### PR TITLE
Add AOT (w/ SVM) support for unresolved invokeHandle/invokeDynamic dispatch

### DIFF
--- a/doc/compiler/aot/RelocationRecords.md
+++ b/doc/compiler/aot/RelocationRecords.md
@@ -140,3 +140,4 @@ exact type of the API class for each relocation kind can be found in
 |`TR_ValidateDynamicMethodFromCallsiteIndex`|Validates an unresolved dynamic method from callsite index.|
 |`TR_ValidateHandleMethodFromCPIndex`|Validates an unresolved handle method from CP index.|
 |`TR_CallsiteTableEntryAddress`|Relocates the callsite table entry address.|
+|`TR_MethodTypeTableEntryAddress`|Relocates the method type table entry address.|

--- a/doc/compiler/aot/RelocationRecords.md
+++ b/doc/compiler/aot/RelocationRecords.md
@@ -138,3 +138,4 @@ exact type of the API class for each relocation kind can be found in
 |`TR_StartPC`|Relocates the startPC of the method being compiled. Only implemented and used on Power.|
 |`TR_MethodEnterExitHookAddress`|Relocates the address of the method enter or exit hook.|
 |`TR_ValidateDynamicMethodFromCallsiteIndex`|Validates an unresolved dynamic method from callsite index.|
+|`TR_ValidateHandleMethodFromCPIndex`|Validates an unresolved handle method from CP index.|

--- a/doc/compiler/aot/RelocationRecords.md
+++ b/doc/compiler/aot/RelocationRecords.md
@@ -139,3 +139,4 @@ exact type of the API class for each relocation kind can be found in
 |`TR_MethodEnterExitHookAddress`|Relocates the address of the method enter or exit hook.|
 |`TR_ValidateDynamicMethodFromCallsiteIndex`|Validates an unresolved dynamic method from callsite index.|
 |`TR_ValidateHandleMethodFromCPIndex`|Validates an unresolved handle method from CP index.|
+|`TR_CallsiteTableEntryAddress`|Relocates the callsite table entry address.|

--- a/doc/compiler/aot/RelocationRecords.md
+++ b/doc/compiler/aot/RelocationRecords.md
@@ -137,3 +137,4 @@ exact type of the API class for each relocation kind can be found in
 |`TR_CatchBlockCounter`|Relocates the address of the catch block counter in the `TR_PersistentMethodInfo` of the method being compiled.|
 |`TR_StartPC`|Relocates the startPC of the method being compiled. Only implemented and used on Power.|
 |`TR_MethodEnterExitHookAddress`|Relocates the address of the method enter or exit hook.|
+|`TR_ValidateDynamicMethodFromCallsiteIndex`|Validates an unresolved dynamic method from callsite index.|

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1391,6 +1391,21 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+      case TR_CallsiteTableEntryAddress:
+         {
+         auto *cteaRecord = reinterpret_cast<TR_RelocationRecordCallsiteTableEntryAddress *>(reloRecord);
+
+         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(relocation->getTargetAddress());
+         uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
+
+         TR_OpaqueMethodBlock *method = symRef->getOwningMethod(comp)->getNonPersistentIdentifier();
+
+         cteaRecord->setReloFlags(reloTarget, flags);
+         cteaRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(method));
+         cteaRecord->setCallsiteIndex(reloTarget, symRef->getSymbol()->getStaticSymbol()->getCallSiteIndex());
+         }
+         break;
+
       default:
          TR_ASSERT(false, "Unknown relo type %d!\n", kind);
          comp->failCompilation<J9::AOTRelocationRecordGenerationFailure>("Unknown relo type %d!\n", kind);
@@ -2368,6 +2383,22 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
                      hmciRecord->cpIndex(reloTarget),
                      hmciRecord->signatureLength(reloTarget),
                      hmciRecord->signatureOffsetInSCC(reloTarget));
+            }
+         }
+         break;
+
+      case TR_CallsiteTableEntryAddress:
+         {
+         auto *cteaRecord = reinterpret_cast<TR_RelocationRecordCallsiteTableEntryAddress *>(reloRecord);
+
+         self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
+         if (isVerbose)
+            {
+            traceMsg(
+               self()->comp(),
+               "\n Callsite Table Entry Address: methodID=%d, callsiteIndex=%d ",
+               (uint32_t)cteaRecord->methodID(reloTarget),
+               cteaRecord->callsiteIndex(reloTarget));
             }
          }
          break;

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1256,7 +1256,9 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
 
          TR::DebugCounterReloData *counterReloData = counter->getReloData();
 
-         uintptr_t offsetOfNameString = fej9->sharedCache()->rememberDebugCounterName(counter->getName());
+         const char * name = counter->getName();
+         uintptr_t length = strlen(name) + 1; // +1 for the \0 terminator
+         uintptr_t offsetOfNameString = fej9->sharedCache()->storeStringToSCC(name, length);
          uint8_t flags = counterReloData->_seqKind;
 
          dcRecord->setReloFlags(reloTarget, flags);

--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1406,6 +1406,22 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          }
          break;
 
+
+      case TR_MethodTypeTableEntryAddress:
+         {
+         auto *mteaRecord = reinterpret_cast<TR_RelocationRecordMethodTypeTableEntryAddress *>(reloRecord);
+
+         TR::SymbolReference *symRef = reinterpret_cast<TR::SymbolReference *>(relocation->getTargetAddress());
+         uint8_t flags = static_cast<uint8_t>(reinterpret_cast<uintptr_t>(relocation->getTargetAddress2()));
+
+         TR_OpaqueMethodBlock *method = symRef->getOwningMethod(comp)->getNonPersistentIdentifier();
+
+         mteaRecord->setReloFlags(reloTarget, flags);
+         mteaRecord->setMethodID(reloTarget, symValManager->getSymbolIDFromValue(method));
+         mteaRecord->setCpIndex(reloTarget, symRef->getSymbol()->getStaticSymbol()->getMethodTypeIndex());
+         }
+         break;
+
       default:
          TR_ASSERT(false, "Unknown relo type %d!\n", kind);
          comp->failCompilation<J9::AOTRelocationRecordGenerationFailure>("Unknown relo type %d!\n", kind);
@@ -2399,6 +2415,22 @@ J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool isVerbose
                "\n Callsite Table Entry Address: methodID=%d, callsiteIndex=%d ",
                (uint32_t)cteaRecord->methodID(reloTarget),
                cteaRecord->callsiteIndex(reloTarget));
+            }
+         }
+         break;
+
+      case TR_MethodTypeTableEntryAddress:
+         {
+         auto *mteaRecord = reinterpret_cast<TR_RelocationRecordMethodTypeTableEntryAddress *>(reloRecord);
+
+         self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
+         if (isVerbose)
+            {
+            traceMsg(
+               self()->comp(),
+               "\n Method Type Table Entry Address: methodID=%d, cpIndex=%d ",
+                     (uint32_t)mteaRecord->methodID(reloTarget),
+                     mteaRecord->cpIndex(reloTarget));
             }
          }
          break;

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -627,9 +627,17 @@ TR::CompilationInfo::isMethodIneligibleForAot(J9Method *method)
    const J9ROMClass *romClass = J9_CLASS_FROM_METHOD(method)->romClass;
    J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 
-   // Don't AOT-compile anything in j/l/i for now
-   if (strncmp(utf8Data(className), "java/lang/invoke/", sizeof("java/lang/invoke/") - 1) == 0)
-      return true;
+   bool disableJLI = true;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   disableJLI = !TR::Options::getAOTCmdLineOptions()->getOption(TR_EnableMHRelocatableCompile);
+#endif
+
+   if (disableJLI)
+      {
+      // Don't AOT-compile anything in j/l/i for now
+      if (strncmp(utf8Data(className), "java/lang/invoke/", sizeof("java/lang/invoke/") - 1) == 0)
+         return true;
+      }
 
    if (J9UTF8_LENGTH(className) == 36 &&
       0 == memcmp(utf8Data(className), "com/ibm/rmi/io/FastPathForCollocated", 36))

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8961,8 +8961,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                // Disable AOT w/ SVM during startup
                if (jitConfig->javaVM->phase != J9VM_PHASE_NOT_STARTUP)
                   {
-                  static char *dontDisableSVMDuringStartup = feGetEnv("TR_DontDisableSVMDuringStartup");
-                  if (!dontDisableSVMDuringStartup)
+                  if (TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableSVMDuringStartup))
                      options->setOption(TR_UseSymbolValidationManager, false);
                   }
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2751,6 +2751,7 @@ J9::Options::fePreProcess(void * base)
 
 #if (defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_POWER)) && defined(TR_TARGET_64BIT)
    self()->setOption(TR_EnableSymbolValidationManager);
+   self()->setOption(TR_DisableSVMDuringStartup);
 #endif
 
    // Forcing inlining of unrecognized intrinsics needs more performance investigation

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -1034,7 +1034,7 @@ TR_J9SharedCache::rememberClass(J9Class *clazz, const AOTCacheClassChainRecord *
    }
 
 UDATA
-TR_J9SharedCache::rememberDebugCounterName(const char *name)
+TR_J9SharedCache::storeStringToSCC(const char *string, uintptr_t length)
    {
    UDATA offset = 0;
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
@@ -1042,8 +1042,8 @@ TR_J9SharedCache::rememberDebugCounterName(const char *name)
    J9VMThread *vmThread = fej9->getCurrentVMThread();
 
    J9SharedDataDescriptor dataDescriptor;
-   dataDescriptor.address = (U_8*)name;
-   dataDescriptor.length  = (strlen(name) + 1); // +1 for the \0 terminator
+   dataDescriptor.address = (U_8*)string;
+   dataDescriptor.length  = length;
    dataDescriptor.type    = J9SHR_DATA_TYPE_JITHINT;
    dataDescriptor.flags   = J9SHRDATA_NOT_INDEXED;
 
@@ -1060,13 +1060,13 @@ TR_J9SharedCache::rememberDebugCounterName(const char *name)
    }
 
 const char *
-TR_J9SharedCache::getDebugCounterName(UDATA offset)
+TR_J9SharedCache::getStringFromSCC(UDATA offset)
    {
-   const char *name = (offset != (UDATA)-1) ? (const char *)pointerFromOffsetInSharedCache(offset) : NULL;
+   const char *string = (offset != (UDATA)-1) ? (const char *)pointerFromOffsetInSharedCache(offset) : NULL;
 
    //printf("\ngetDebugCounterName: Tried to find %p, name=%s (%p)\n", offset, (name ? name : ""), name);
 
-   return name;
+   return string;
    }
 
 bool

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -195,8 +195,8 @@ public:
    virtual uintptr_t rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
                                     bool create = true);
 
-   virtual UDATA rememberDebugCounterName(const char *name);
-   virtual const char *getDebugCounterName(UDATA offset);
+   virtual UDATA storeStringToSCC(const char *string, uintptr_t length);
+   virtual const char *getStringFromSCC(UDATA offset);
 
    virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL);
    virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *classPtr, UDATA *chainData=NULL)
@@ -659,8 +659,8 @@ public:
    virtual uintptr_t rememberClass(J9Class *clazz, const AOTCacheClassChainRecord **classChainRecord = NULL,
                                    bool create = true) override;
 
-   virtual UDATA rememberDebugCounterName(const char *name) override { TR_ASSERT_FATAL(false, "called"); return 0;}
-   virtual const char *getDebugCounterName(UDATA offset) override { TR_ASSERT_FATAL(false, "called"); return NULL;}
+   virtual UDATA storeStringToSCC(const char *string, uintptr_t length) override { TR_ASSERT_FATAL(false, "called"); return 0;}
+   virtual const char *getStringFromSCC(UDATA offset) override { TR_ASSERT_FATAL(false, "called"); return NULL;}
 
    virtual bool isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset = NULL) override;
    virtual bool isMethodInSharedCache(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass, uintptr_t *cacheOffset = NULL) override;
@@ -765,8 +765,8 @@ public:
                                    bool create = true) override
       { TR_ASSERT_FATAL(false, "called"); return TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET; }
 
-   virtual UDATA rememberDebugCounterName(const char *name) override { TR_ASSERT_FATAL(false, "called"); return 0; }
-   virtual const char *getDebugCounterName(UDATA offset) override { TR_ASSERT_FATAL(false, "called"); return NULL; }
+   virtual UDATA storeStringToSCC(const char *string, uintptr_t length) override { TR_ASSERT_FATAL(false, "called"); return 0; }
+   virtual const char *getStringFromSCC(UDATA offset) override { TR_ASSERT_FATAL(false, "called"); return NULL; }
 
    virtual bool isPointerInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL) override { TR_ASSERT_FATAL(false, "called"); return false; }
    virtual bool isOffsetInSharedCache(uintptr_t encoded_offset, void *ptr = NULL) override { TR_ASSERT_FATAL(false, "called"); return false; }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8896,7 +8896,7 @@ TR_J9SharedCacheVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vett
    }
 
 TR_OpaqueMethodBlock *
-TR_J9SharedCacheVM::getMethodFromClass(TR_OpaqueClassBlock * methodClass, char * methodName, char * signature, TR_OpaqueClassBlock *callingClass)
+TR_J9SharedCacheVM::getMethodFromClass(TR_OpaqueClassBlock * methodClass, const char * methodName, const char * signature, TR_OpaqueClassBlock *callingClass)
    {
    TR_OpaqueMethodBlock* omb = this->TR_J9VM::getMethodFromClass(methodClass, methodName, signature, callingClass);
    if (omb)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1666,7 +1666,7 @@ public:
    virtual bool               hasFinalizer(TR_OpaqueClassBlock * classPointer);
    virtual uintptr_t         getClassDepthAndFlagsValue(TR_OpaqueClassBlock * classPointer);
    virtual uintptr_t         getClassFlagsValue(TR_OpaqueClassBlock * classPointer);
-   virtual TR_OpaqueMethodBlock * getMethodFromClass(TR_OpaqueClassBlock *, char *, char *, TR_OpaqueClassBlock * = NULL);
+   virtual TR_OpaqueMethodBlock * getMethodFromClass(TR_OpaqueClassBlock *, const char *, const char *, TR_OpaqueClassBlock * = NULL);
    virtual bool               isPrimitiveClass(TR_OpaqueClassBlock *clazz);
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7076,6 +7076,16 @@ TR_ResolvedJ9Method::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpInde
       int32_t signatureLength;
       char * linkToStaticSignature = _fe->getSignatureForLinkToStaticForInvokeHandle(comp, signature, signatureLength);
       result = _fe->createResolvedMethodWithSignature(comp->trMemory(), dummyInvoke, NULL, linkToStaticSignature, signatureLength, this);
+
+      if (comp->compileRelocatableCode())
+         {
+         TR_ASSERT_FATAL(comp->getOption(TR_UseSymbolValidationManager), "invokeHandle not supported without SVM!\n");
+         comp->getSymbolValidationManager()->addHandleMethodFromCPIndex(
+            result->getNonPersistentIdentifier(),
+            cp(),
+            cpIndex,
+            static_cast<TR_ResolvedJ9Method *>(result)->_signature);
+         }
       }
 #else
 

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7003,6 +7003,16 @@ TR_ResolvedJ9Method::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callS
       int32_t signatureLength;
       char * linkToStaticSignature = _fe->getSignatureForLinkToStaticForInvokeDynamic(comp, signature, signatureLength);
       result = _fe->createResolvedMethodWithSignature(comp->trMemory(), dummyInvoke, NULL, linkToStaticSignature, signatureLength, this);
+
+      if (comp->compileRelocatableCode())
+         {
+         TR_ASSERT_FATAL(comp->getOption(TR_UseSymbolValidationManager), "invokeDynamic not supported without SVM!\n");
+         comp->getSymbolValidationManager()->addDynamicMethodFromCallsiteIndex(
+            result->getNonPersistentIdentifier(),
+            cp(),
+            callSiteIndex,
+            static_cast<TR_ResolvedJ9Method *>(result)->_signature);
+         }
       }
 #else
    TR_OpaqueMethodBlock *dummyInvokeExact = _fe->getMethodFromName("java/lang/invoke/MethodHandle", "invokeExact", JSR292_invokeExactSig);

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -604,6 +604,8 @@ public:
    virtual bool                    isUnresolvedMethodType(int32_t cpIndex);
    virtual void *                  methodHandleConstant(int32_t cpIndex);
    virtual bool                    isUnresolvedMethodHandle(int32_t cpIndex);
+   virtual bool                    isUnresolvedCallSiteTableEntry(int32_t callSiteIndex) { return true; }
+   virtual bool                    isUnresolvedMethodTypeTableEntry(int32_t cpIndex) { return true; }
 
    virtual bool                    fieldAttributes ( TR::Compilation *, int32_t cpIndex, uint32_t * fieldOffset, TR::DataType * type, bool * volatileP, bool * isFinal, bool *isPrivate, bool isStore, bool * unresolvedInCP, bool needsAOTValidation);
 

--- a/runtime/compiler/il/J9StaticSymbol_inlines.hpp
+++ b/runtime/compiler/il/J9StaticSymbol_inlines.hpp
@@ -50,6 +50,9 @@ J9::StaticSymbol::makeCallSiteTableEntry(int32_t callSiteIndex)
    TR_ASSERT(self()->getDataType() == TR::Address, "CallSiteTableEntries have historically had TR::Address as data type");
    _callSiteIndex = callSiteIndex;
    self()->setCallSiteTableEntry();
+
+   // Needed so that the relo infra does not think this is a static field address
+   self()->setNotDataAddress();
    }
 
 

--- a/runtime/compiler/il/J9StaticSymbol_inlines.hpp
+++ b/runtime/compiler/il/J9StaticSymbol_inlines.hpp
@@ -42,6 +42,9 @@ J9::StaticSymbol::makeMethodTypeTableEntry(int32_t methodTypeIndex)
    TR_ASSERT(self()->getDataType() == TR::Address, "MethodTypeTableEntries have historically had TR::Address as data type");
    _methodTypeIndex = methodTypeIndex;
    self()->setMethodTypeTableEntry();
+
+   // Needed so that the relo infra does not think this is a static field address
+   self()->setNotDataAddress();
    }
 
 inline void

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3196,15 +3196,13 @@ static char *suffixedName(char *baseName, char typeSuffix, char *buf, int32_t bu
 void
 TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
    {
-   if (comp()->compileRelocatableCode())
-      {
-      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 0");
-      }
-
    if (comp()->getOption(TR_FullSpeedDebug) && !isPeekingMethod())
       comp()->failCompilation<J9::FSDHasInvokeHandle>("FSD_HAS_INVOKEHANDLE 0");
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
-
+   if (comp()->compileRelocatableCode() && (!comp()->getOption(TR_EnableMHRelocatableCompile) || !comp()->getOption(TR_UseSymbolValidationManager)))
+      {
+      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 0");
+      }
    // Call generated when call site table entry is resolved:
    // -----------------------------------------------------
    // call <target method obtained from memberName object>
@@ -3259,6 +3257,10 @@ TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
    TR::Node* callNode = genInvokeDirect(targetMethodSymRef);
 
 #else
+   if (comp()->compileRelocatableCode())
+      {
+      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 0");
+      }
 
    TR::SymbolReference *symRef = symRefTab()->findOrCreateDynamicMethodSymbol(_methodSymbol, callSiteIndex);
 
@@ -3292,14 +3294,13 @@ TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
 TR::Node *
 TR_J9ByteCodeIlGenerator::genInvokeHandle(int32_t cpIndex)
    {
-   if (comp()->compileRelocatableCode())
-      {
-      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 1");
-      }
-
    if (comp()->getOption(TR_FullSpeedDebug) && !isPeekingMethod())
       comp()->failCompilation<J9::FSDHasInvokeHandle>("FSD_HAS_INVOKEHANDLE 1");
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   if (comp()->compileRelocatableCode() && (!comp()->getOption(TR_EnableMHRelocatableCompile) || !comp()->getOption(TR_UseSymbolValidationManager)))
+      {
+      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 1");
+      }
    // Call generated when methodType table entry is resolved:
    // -----------------------------------------------------
    // call <target method obtained from memberName object>
@@ -3357,6 +3358,10 @@ TR_J9ByteCodeIlGenerator::genInvokeHandle(int32_t cpIndex)
    TR::Node* callNode = genInvokeDirect(targetMethodSymRef);
 
 #else
+   if (comp()->compileRelocatableCode())
+      {
+      comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 1");
+      }
 
    TR::SymbolReference * invokeExactSymRef = symRefTab()->findOrCreateHandleMethodSymbol(_methodSymbol, cpIndex);
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 65; // ID: YxVkiLqD7B1LhYMv58y8
+   static const uint16_t MINOR_NUMBER = 66; // ID: Smx17vPdRk39t3iUpE0Y
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -313,6 +313,7 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
       case TR_DataAddress:
       case TR_DebugCounter:
       case TR_MethodEnterExitHookAddress:
+      case TR_CallsiteTableEntryAddress:
          return true;
       default:
          return false;

--- a/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
+++ b/runtime/compiler/p/runtime/PPCRelocationTarget.cpp
@@ -314,6 +314,7 @@ TR_PPC32RelocationTarget::isOrderedPairRelocation(TR_RelocationRecord *reloRecor
       case TR_DebugCounter:
       case TR_MethodEnterExitHookAddress:
       case TR_CallsiteTableEntryAddress:
+      case TR_MethodTypeTableEntryAddress:
          return true;
       default:
          return false;

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -421,6 +421,12 @@ struct TR_RelocationRecordMethodEnterExitHookAddressBinaryTemplate : public TR_R
    uint8_t _isEnterHookAddr;
    };
 
+struct TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   int32_t _callsiteIndex;
+   };
+
 // END OF BINARY TEMPLATES
 
 uint8_t
@@ -859,6 +865,9 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
          break;
       case TR_MethodEnterExitHookAddress:
          reloRecord = new (storage) TR_RelocationRecordMethodEnterExitHookAddress(reloRuntime, record);
+         break;
+      case TR_CallsiteTableEntryAddress:
+         reloRecord = new (storage) TR_RelocationRecordCallsiteTableEntryAddress(reloRuntime, record);
          break;
       default:
          // TODO: error condition
@@ -6778,6 +6787,74 @@ TR_RelocationRecordMethodEnterExitHookAddress::applyRelocation(TR_RelocationRunt
    return TR_RelocationErrorCode::relocationOK;
    }
 
+// TR_RelocationRecordCallsiteTableEntryAddress
+void
+TR_RelocationRecordCallsiteTableEntryAddress::print(TR_RelocationRuntime *reloRuntime)
+   {
+   TR_RelocationTarget *reloTarget = reloRuntime->reloTarget();
+   TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
+   TR_RelocationRecord::print(reloRuntime);
+   reloLogger->printf("\tmethodID %d\n", methodID(reloTarget));
+   reloLogger->printf("\tcallsiteIndex %d\n", callsiteIndex(reloTarget));
+   }
+
+void
+TR_RelocationRecordCallsiteTableEntryAddress::setMethodID(TR_RelocationTarget *reloTarget, uint16_t methodID)
+   {
+   reloTarget->storeUnsigned16b(methodID, (uint8_t *) &((TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate *)_record)->_methodID);
+   }
+
+uint16_t
+TR_RelocationRecordCallsiteTableEntryAddress::methodID(TR_RelocationTarget *reloTarget)
+   {
+   return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate *)_record)->_methodID);
+   }
+
+void
+TR_RelocationRecordCallsiteTableEntryAddress::setCallsiteIndex(TR_RelocationTarget *reloTarget, int32_t callsiteIndex)
+   {
+   reloTarget->storeSigned32b(callsiteIndex, (uint8_t *) &((TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate *)_record)->_callsiteIndex);
+   }
+
+int32_t
+TR_RelocationRecordCallsiteTableEntryAddress::callsiteIndex(TR_RelocationTarget *reloTarget)
+   {
+   return reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate *)_record)->_callsiteIndex);
+   }
+
+void
+TR_RelocationRecordCallsiteTableEntryAddress::preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget)
+   {
+   TR_RelocationRecordCallsiteTableEntryAddressPrivateData *reloPrivateData = &(privateData()->callsiteTableEntryAddr);
+
+   TR_OpaqueMethodBlock *method = reloRuntime->comp()->getSymbolValidationManager()->getMethodFromID(methodID(reloTarget));
+   TR_ResolvedMethod *resolvedMethod = reloRuntime->fej9()->createResolvedMethod(reloRuntime->trMemory(), method, NULL);
+
+   reloPrivateData->_callsiteTableEntryAddress = resolvedMethod->callSiteTableEntryAddress(callsiteIndex(reloTarget));
+   }
+
+TR_RelocationErrorCode
+TR_RelocationRecordCallsiteTableEntryAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   TR_RelocationRecordCallsiteTableEntryAddressPrivateData *reloPrivateData = &(privateData()->callsiteTableEntryAddr);
+   void *callsiteTableEntryAddr = reloPrivateData->_callsiteTableEntryAddress;
+
+   reloTarget->storeAddressSequence((uint8_t *)callsiteTableEntryAddr, reloLocation, reloFlags(reloTarget));
+
+   return TR_RelocationErrorCode::relocationOK;
+   }
+
+TR_RelocationErrorCode
+TR_RelocationRecordCallsiteTableEntryAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
+   {
+   TR_RelocationRecordCallsiteTableEntryAddressPrivateData *reloPrivateData = &(privateData()->callsiteTableEntryAddr);
+   void *callsiteTableEntryAddr = reloPrivateData->_callsiteTableEntryAddress;
+
+   reloTarget->storeAddress((uint8_t *)callsiteTableEntryAddr, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
+
+   return TR_RelocationErrorCode::relocationOK;
+   }
+
 // The _relocationRecordHeaderSizeTable table should be the last thing in this file
 uint32_t TR_RelocationRecord::_relocationRecordHeaderSizeTable[TR_NumExternalRelocationKinds] =
    {
@@ -6899,5 +6976,6 @@ uint32_t TR_RelocationRecord::_relocationRecordHeaderSizeTable[TR_NumExternalRel
    sizeof(TR_RelocationRecordMethodEnterExitHookAddressBinaryTemplate),              // TR_MethodEnterExitHookAddress                   = 115
    sizeof(TR_RelocationRecordValidateDynamicMethodFromCallsiteIndexBinaryTemplate),  // TR_ValidateDynamicMethodFromCallsiteIndex       = 116
    sizeof(TR_RelocationRecordValidateHandleMethodFromCPIndexBinaryTemplate),         // TR_ValidateHandleMethodFromCPIndex              = 117
+   sizeof(TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate),               // TR_CallsiteTableEntryAddress                    = 118
    };
 // The _relocationRecordHeaderSizeTable table should be the last thing in this file

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -6056,7 +6056,7 @@ TR_RelocationRecordDebugCounter::preparePrivateData(TR_RelocationRuntime *reloRu
    reloPrivateData->_staticDelta = staticDelta(reloTarget);
 
    UDATA offset                  = offsetOfNameString(reloTarget);
-   reloPrivateData->_name        =  reloRuntime->fej9()->sharedCache()->getDebugCounterName(offset);
+   reloPrivateData->_name        =  reloRuntime->fej9()->sharedCache()->getStringFromSCC(offset);
    }
 
 TR_RelocationErrorCode

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -427,6 +427,12 @@ struct TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate : public TR_Re
    int32_t _callsiteIndex;
    };
 
+struct TR_RelocationRecordMethodTypeTableEntryAddressBinaryTemplate : public TR_RelocationRecordBinaryTemplate
+   {
+   uint16_t _methodID;
+   int32_t _cpIndex;
+   };
+
 // END OF BINARY TEMPLATES
 
 uint8_t
@@ -868,6 +874,9 @@ TR_RelocationRecord::create(TR_RelocationRecord *storage, TR_RelocationRuntime *
          break;
       case TR_CallsiteTableEntryAddress:
          reloRecord = new (storage) TR_RelocationRecordCallsiteTableEntryAddress(reloRuntime, record);
+         break;
+      case TR_MethodTypeTableEntryAddress:
+         reloRecord = new (storage) TR_RelocationRecordMethodTypeTableEntryAddress(reloRuntime, record);
          break;
       default:
          // TODO: error condition
@@ -6855,6 +6864,74 @@ TR_RelocationRecordCallsiteTableEntryAddress::applyRelocation(TR_RelocationRunti
    return TR_RelocationErrorCode::relocationOK;
    }
 
+// TR_RelocationRecordMethodTypeTableEntryAddress
+void
+TR_RelocationRecordMethodTypeTableEntryAddress::print(TR_RelocationRuntime *reloRuntime)
+   {
+   TR_RelocationTarget *reloTarget = reloRuntime->reloTarget();
+   TR_RelocationRuntimeLogger *reloLogger = reloRuntime->reloLogger();
+   TR_RelocationRecord::print(reloRuntime);
+   reloLogger->printf("\tmethodID %d\n", methodID(reloTarget));
+   reloLogger->printf("\tcpIndex %d\n", cpIndex(reloTarget));
+   }
+
+void
+TR_RelocationRecordMethodTypeTableEntryAddress::setMethodID(TR_RelocationTarget *reloTarget, uint16_t methodID)
+   {
+   reloTarget->storeUnsigned16b(methodID, (uint8_t *) &((TR_RelocationRecordMethodTypeTableEntryAddressBinaryTemplate *)_record)->_methodID);
+   }
+
+uint16_t
+TR_RelocationRecordMethodTypeTableEntryAddress::methodID(TR_RelocationTarget *reloTarget)
+   {
+   return reloTarget->loadUnsigned16b((uint8_t *) &((TR_RelocationRecordMethodTypeTableEntryAddressBinaryTemplate *)_record)->_methodID);
+   }
+
+void
+TR_RelocationRecordMethodTypeTableEntryAddress::setCpIndex(TR_RelocationTarget *reloTarget, int32_t cpIndex)
+   {
+   reloTarget->storeSigned32b(cpIndex, (uint8_t *) &((TR_RelocationRecordMethodTypeTableEntryAddressBinaryTemplate *)_record)->_cpIndex);
+   }
+
+int32_t
+TR_RelocationRecordMethodTypeTableEntryAddress::cpIndex(TR_RelocationTarget *reloTarget)
+   {
+   return reloTarget->loadSigned32b((uint8_t *) &((TR_RelocationRecordMethodTypeTableEntryAddressBinaryTemplate *)_record)->_cpIndex);
+   }
+
+void
+TR_RelocationRecordMethodTypeTableEntryAddress::preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget)
+   {
+   TR_RelocationRecordMethodTypeTableEntryAddressPrivateData *reloPrivateData = &(privateData()->methodTypeTableEntryAddr);
+
+   TR_OpaqueMethodBlock *method = reloRuntime->comp()->getSymbolValidationManager()->getMethodFromID(methodID(reloTarget));
+   TR_ResolvedMethod *resolvedMethod = reloRuntime->fej9()->createResolvedMethod(reloRuntime->trMemory(), method, NULL);
+
+   reloPrivateData->_methodTypeTableEntryAddress = resolvedMethod->methodTypeTableEntryAddress(cpIndex(reloTarget));
+   }
+
+TR_RelocationErrorCode
+TR_RelocationRecordMethodTypeTableEntryAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation)
+   {
+   TR_RelocationRecordMethodTypeTableEntryAddressPrivateData *reloPrivateData = &(privateData()->methodTypeTableEntryAddr);
+   void *methodTypeTableEntryAddr = reloPrivateData->_methodTypeTableEntryAddress;
+
+   reloTarget->storeAddressSequence((uint8_t *)methodTypeTableEntryAddr, reloLocation, reloFlags(reloTarget));
+
+   return TR_RelocationErrorCode::relocationOK;
+   }
+
+TR_RelocationErrorCode
+TR_RelocationRecordMethodTypeTableEntryAddress::applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow)
+   {
+   TR_RelocationRecordMethodTypeTableEntryAddressPrivateData *reloPrivateData = &(privateData()->methodTypeTableEntryAddr);
+   void *methodTypeTableEntryAddr = reloPrivateData->_methodTypeTableEntryAddress;
+
+   reloTarget->storeAddress((uint8_t *)methodTypeTableEntryAddr, reloLocationHigh, reloLocationLow, reloFlags(reloTarget));
+
+   return TR_RelocationErrorCode::relocationOK;
+   }
+
 // The _relocationRecordHeaderSizeTable table should be the last thing in this file
 uint32_t TR_RelocationRecord::_relocationRecordHeaderSizeTable[TR_NumExternalRelocationKinds] =
    {
@@ -6977,5 +7054,6 @@ uint32_t TR_RelocationRecord::_relocationRecordHeaderSizeTable[TR_NumExternalRel
    sizeof(TR_RelocationRecordValidateDynamicMethodFromCallsiteIndexBinaryTemplate),  // TR_ValidateDynamicMethodFromCallsiteIndex       = 116
    sizeof(TR_RelocationRecordValidateHandleMethodFromCPIndexBinaryTemplate),         // TR_ValidateHandleMethodFromCPIndex              = 117
    sizeof(TR_RelocationRecordCallsiteTableEntryAddressBinaryTemplate),               // TR_CallsiteTableEntryAddress                    = 118
+   sizeof(TR_RelocationRecordMethodTypeTableEntryAddressBinaryTemplate),             // TR_MethodTypeTableEntryAddress                  = 119
    };
 // The _relocationRecordHeaderSizeTable table should be the last thing in this file

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1538,6 +1538,34 @@ class TR_RelocationRecordValidateMethodFromClassAndSig : public TR_RelocationRec
       uintptr_t romMethodOffsetInSCC(TR_RelocationTarget *reloTarget);
    };
 
+class TR_RelocationRecordValidateDynamicMethodFromCallsiteIndex : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateDynamicMethodFromCallsiteIndex() {}
+      TR_RelocationRecordValidateDynamicMethodFromCallsiteIndex(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual const char *name() { return "TR_RelocationRecordValidateDynamicMethodFromCallsiteIndex"; }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      void setMethodID(TR_RelocationTarget *reloTarget, uint16_t methodID);
+      uint16_t methodID(TR_RelocationTarget *reloTarget);
+
+      void setBeholderID(TR_RelocationTarget *reloTarget, uint16_t beholderID);
+      uint16_t beholderID(TR_RelocationTarget *reloTarget);
+
+      void setCallsiteIndex(TR_RelocationTarget *reloTarget, int32_t callsiteIndex);
+      int32_t callsiteIndex(TR_RelocationTarget *reloTarget);
+
+      void setSignatureLength(TR_RelocationTarget *reloTarget, uint32_t signatureLength);
+      uint32_t signatureLength(TR_RelocationTarget *reloTarget);
+
+      void setSignatureOffsetInSCC(TR_RelocationTarget *reloTarget, uintptr_t signatureOffsetInSCC);
+      uintptr_t signatureOffsetInSCC(TR_RelocationTarget *reloTarget);
+   };
+
 class TR_RelocationRecordValidateStackWalkerMaySkipFrames : public TR_RelocationRecord
    {
    public:

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -1566,6 +1566,34 @@ class TR_RelocationRecordValidateDynamicMethodFromCallsiteIndex : public TR_Relo
       uintptr_t signatureOffsetInSCC(TR_RelocationTarget *reloTarget);
    };
 
+class TR_RelocationRecordValidateHandleMethodFromCPIndex : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordValidateHandleMethodFromCPIndex() {}
+      TR_RelocationRecordValidateHandleMethodFromCPIndex(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+      virtual bool isValidationRecord() { return true; }
+      virtual const char *name() { return "TR_RelocationRecordValidateHandleMethodFromCPIndex"; }
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget) {}
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      void setMethodID(TR_RelocationTarget *reloTarget, uint16_t methodID);
+      uint16_t methodID(TR_RelocationTarget *reloTarget);
+
+      void setBeholderID(TR_RelocationTarget *reloTarget, uint16_t beholderID);
+      uint16_t beholderID(TR_RelocationTarget *reloTarget);
+
+      void setCpIndex(TR_RelocationTarget *reloTarget, int32_t cpIndex);
+      int32_t cpIndex(TR_RelocationTarget *reloTarget);
+
+      void setSignatureLength(TR_RelocationTarget *reloTarget, uint32_t signatureLength);
+      uint32_t signatureLength(TR_RelocationTarget *reloTarget);
+
+      void setSignatureOffsetInSCC(TR_RelocationTarget *reloTarget, uintptr_t signatureOffsetInSCC);
+      uintptr_t signatureOffsetInSCC(TR_RelocationTarget *reloTarget);
+   };
+
 class TR_RelocationRecordValidateStackWalkerMaySkipFrames : public TR_RelocationRecord
    {
    public:

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -176,6 +176,11 @@ struct TR_RelocationRecordMethodEnterExitHookAddressPrivateData
    bool _isEnterHookAddr;
    };
 
+struct TR_RelocationRecordCallsiteTableEntryAddressPrivateData
+   {
+   void *_callsiteTableEntryAddress;
+   };
+
 union TR_RelocationRecordPrivateData
    {
    TR_RelocationRecordHelperAddressPrivateData helperAddress;
@@ -195,6 +200,7 @@ union TR_RelocationRecordPrivateData
    TR_RelocationRecordRecompQueuedFlagPrivateData recompQueuedFlag;
    TR_RelocationRecordBreakpointGuardPrivateData breakpointGuard;
    TR_RelocationRecordMethodEnterExitHookAddressPrivateData hookAddress;
+   TR_RelocationRecordCallsiteTableEntryAddressPrivateData callsiteTableEntryAddr;
    };
 
 enum TR_RelocationRecordAction
@@ -2050,6 +2056,27 @@ class TR_RelocationRecordMethodEnterExitHookAddress : public TR_RelocationRecord
 
       void setIsEnterHookAddr(TR_RelocationTarget *reloTarget, bool isEnterHookAddr);
       bool isEnterHookAddr(TR_RelocationTarget *reloTarget);
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+   };
+
+class TR_RelocationRecordCallsiteTableEntryAddress : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordCallsiteTableEntryAddress() {}
+      TR_RelocationRecordCallsiteTableEntryAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual const char *name() { return "TR_RelocationRecordCallsiteTableEntryAddress"; }
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      void setMethodID(TR_RelocationTarget *reloTarget, uint16_t methodID);
+      uint16_t methodID(TR_RelocationTarget *reloTarget);
+
+      void setCallsiteIndex(TR_RelocationTarget *reloTarget, int32_t callsiteIndex);
+      int32_t callsiteIndex(TR_RelocationTarget *reloTarget);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -181,6 +181,11 @@ struct TR_RelocationRecordCallsiteTableEntryAddressPrivateData
    void *_callsiteTableEntryAddress;
    };
 
+struct TR_RelocationRecordMethodTypeTableEntryAddressPrivateData
+   {
+   void *_methodTypeTableEntryAddress;
+   };
+
 union TR_RelocationRecordPrivateData
    {
    TR_RelocationRecordHelperAddressPrivateData helperAddress;
@@ -201,6 +206,7 @@ union TR_RelocationRecordPrivateData
    TR_RelocationRecordBreakpointGuardPrivateData breakpointGuard;
    TR_RelocationRecordMethodEnterExitHookAddressPrivateData hookAddress;
    TR_RelocationRecordCallsiteTableEntryAddressPrivateData callsiteTableEntryAddr;
+   TR_RelocationRecordMethodTypeTableEntryAddressPrivateData methodTypeTableEntryAddr;
    };
 
 enum TR_RelocationRecordAction
@@ -2077,6 +2083,27 @@ class TR_RelocationRecordCallsiteTableEntryAddress : public TR_RelocationRecord
 
       void setCallsiteIndex(TR_RelocationTarget *reloTarget, int32_t callsiteIndex);
       int32_t callsiteIndex(TR_RelocationTarget *reloTarget);
+
+      virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
+
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation);
+      virtual TR_RelocationErrorCode applyRelocation(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocationHigh, uint8_t *reloLocationLow);
+   };
+
+class TR_RelocationRecordMethodTypeTableEntryAddress : public TR_RelocationRecord
+   {
+   public:
+      TR_RelocationRecordMethodTypeTableEntryAddress() {}
+      TR_RelocationRecordMethodTypeTableEntryAddress(TR_RelocationRuntime *reloRuntime, TR_RelocationRecordBinaryTemplate *record) : TR_RelocationRecord(reloRuntime, record) {}
+
+      virtual const char *name() { return "TR_RelocationRecordMethodTypeTableEntryAddress"; }
+      virtual void print(TR_RelocationRuntime *reloRuntime);
+
+      void setMethodID(TR_RelocationTarget *reloTarget, uint16_t methodID);
+      uint16_t methodID(TR_RelocationTarget *reloTarget);
+
+      void setCpIndex(TR_RelocationTarget *reloTarget, int32_t cpIndex);
+      int32_t cpIndex(TR_RelocationTarget *reloTarget);
 
       virtual void preparePrivateData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -133,24 +133,25 @@ const char *TR_RelocationRuntime::_reloErrorCodeNames[] =
    "svmValidationFailure",                             // 45
    "wkcValidationFailure",                             // 46
    "methodTracingValidationFailure",                   // 47
+   "dynamicMethodFromcallsiteIndexValidationFailure",  // 48
+   "handleMethodFromcallsiteIndexValidationFailure" ,  // 49
 
-   "classAddressRelocationFailure",                    // 48
-   "inlinedMethodRelocationFailure",                   // 49
-   "symbolFromManagerRelocationFailure",               // 50
-   "thunkRelocationFailure",                           // 51
-   "trampolineRelocationFailure",                      // 52
-   "picTrampolineRelocationFailure",                   // 53
-   "cacheFullRelocationFailure",                       // 54
-   "blockFrequencyRelocationFailure",                  // 55
-   "recompQueuedFlagRelocationFailure",                // 56
-   "debugCounterRelocationFailure",                    // 57
-   "directJNICallRelocationFailure",                   // 58
-   "ramMethodConstRelocationFailure",                  // 59
-   "catchBlockCounterRelocationFailure",               // 60
-   "staticDefaultValueInstanceRelocationFailure",      // 61
+   "classAddressRelocationFailure",                    // 50
+   "inlinedMethodRelocationFailure",                   // 51
+   "symbolFromManagerRelocationFailure",               // 52
+   "thunkRelocationFailure",                           // 53
+   "trampolineRelocationFailure",                      // 54
+   "picTrampolineRelocationFailure",                   // 55
+   "cacheFullRelocationFailure",                       // 56
+   "blockFrequencyRelocationFailure",                  // 57
+   "recompQueuedFlagRelocationFailure",                // 58
+   "debugCounterRelocationFailure",                    // 59
+   "directJNICallRelocationFailure",                   // 60
+   "ramMethodConstRelocationFailure",                  // 61
+   "catchBlockCounterRelocationFailure",               // 62
+   "staticDefaultValueInstanceRelocationFailure",      // 63
 
-   "maxRelocationError"                                // 62
-
+   "maxRelocationError"                                // 64
    };
 
 TR_RelocationRuntime::TR_RelocationRuntime(J9JITConfig *jitCfg)

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -194,23 +194,25 @@ struct TR_RelocationError
       svmValidationFailure                             = (45 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
       wkcValidationFailure                             = (46 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
       methodTracingValidationFailure                   = (47 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      dynamicMethodFromcallsiteIndexValidationFailure  = (48 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
+      handleMethodFromcallsiteIndexValidationFailure   = (49 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::VALIDATION,
 
-      classAddressRelocationFailure                    = (48 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      inlinedMethodRelocationFailure                   = (49 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      symbolFromManagerRelocationFailure               = (50 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      thunkRelocationFailure                           = (51 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      trampolineRelocationFailure                      = (52 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      picTrampolineRelocationFailure                   = (53 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      cacheFullRelocationFailure                       = (54 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      blockFrequencyRelocationFailure                  = (55 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      recompQueuedFlagRelocationFailure                = (56 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      debugCounterRelocationFailure                    = (57 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      directJNICallRelocationFailure                   = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      ramMethodConstRelocationFailure                  = (59 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      catchBlockCounterRelocationFailure               = (60 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
-      staticDefaultValueInstanceRelocationFailure      = (61 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      classAddressRelocationFailure                    = (50 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      inlinedMethodRelocationFailure                   = (51 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      symbolFromManagerRelocationFailure               = (52 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      thunkRelocationFailure                           = (53 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      trampolineRelocationFailure                      = (54 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      picTrampolineRelocationFailure                   = (55 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      cacheFullRelocationFailure                       = (56 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      blockFrequencyRelocationFailure                  = (57 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      recompQueuedFlagRelocationFailure                = (58 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      debugCounterRelocationFailure                    = (59 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      directJNICallRelocationFailure                   = (60 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      ramMethodConstRelocationFailure                  = (61 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      catchBlockCounterRelocationFailure               = (62 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
+      staticDefaultValueInstanceRelocationFailure      = (63 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::RELOCATION,
 
-      maxRelocationError                               = (62 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
+      maxRelocationError                               = (64 << RELO_ERRORCODE_SHIFT) | TR_RelocationErrorCodeType::NO_RELO_ERROR
       };
 
    static uint32_t decode(TR_RelocationErrorCode errorCode) { return static_cast<uint32_t>(errorCode >> RELO_ERRORCODE_SHIFT); }

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -2133,6 +2133,7 @@ bool isOrderedPair(U_8 recordType)
       case TR_DebugCounter:
       case TR_MethodEnterExitHookAddress:
       case TR_CallsiteTableEntryAddress:
+      case TR_MethodTypeTableEntryAddress:
 #endif
          isOrderedPair = true;
          break;

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -2132,6 +2132,7 @@ bool isOrderedPair(U_8 recordType)
       case TR_DataAddress:
       case TR_DebugCounter:
       case TR_MethodEnterExitHookAddress:
+      case TR_CallsiteTableEntryAddress:
 #endif
          isOrderedPair = true;
          break;

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -708,6 +708,26 @@ struct IsClassVisibleRecord : public SymbolValidationRecord
    bool _isVisible;
    };
 
+struct DynamicMethodFromCallsiteIndexRecord : public MethodValidationRecord
+   {
+   DynamicMethodFromCallsiteIndexRecord(TR_OpaqueMethodBlock *method,
+                                       TR_OpaqueClassBlock *beholder,
+                                       int32_t callsiteIndex,
+                                       J9UTF8 *signature)
+      : MethodValidationRecord(TR_ValidateDynamicMethodFromCallsiteIndex, method),
+        _beholder(beholder),
+        _callsiteIndex(callsiteIndex),
+        _signature(signature)
+      {}
+
+   virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_beholder;
+   int32_t _callsiteIndex;
+   J9UTF8 *_signature;
+   };
+
 class SymbolValidationManager
    {
 public:
@@ -787,6 +807,7 @@ public:
                                           TR_OpaqueClassBlock *thisClass,
                                           int32_t vftSlot,
                                           TR_OpaqueMethodBlock *callerMethod);
+   bool addDynamicMethodFromCallsiteIndex(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t callsiteIndex, J9UTF8 *signature);
 
    bool addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, bool skipFrames);
    bool addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized);
@@ -834,6 +855,7 @@ public:
                                                uint16_t thisClassID,
                                                int32_t vftSlot,
                                                uint16_t callerMethodID);
+   bool validateDynamicMethodFromCallsiteIndex(uint16_t methodID, uint16_t beholderID, int32_t callsiteIndex, const char *signature, uint32_t length);
 
    bool validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID, bool couldSkipFrames);
    bool validateClassInfoIsInitializedRecord(uint16_t classID, bool wasInitialized);

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -728,6 +728,26 @@ struct DynamicMethodFromCallsiteIndexRecord : public MethodValidationRecord
    J9UTF8 *_signature;
    };
 
+struct HandleMethodFromCPIndex : public MethodValidationRecord
+   {
+   HandleMethodFromCPIndex(TR_OpaqueMethodBlock *method,
+                           TR_OpaqueClassBlock *beholder,
+                           int32_t cpIndex,
+                           J9UTF8 *signature)
+      : MethodValidationRecord(TR_ValidateHandleMethodFromCPIndex, method),
+        _beholder(beholder),
+        _cpIndex(cpIndex),
+        _signature(signature)
+      {}
+
+   virtual bool isLessThanWithinKind(SymbolValidationRecord *other);
+   virtual void printFields();
+
+   TR_OpaqueClassBlock *_beholder;
+   int32_t _cpIndex;
+   J9UTF8 *_signature;
+   };
+
 class SymbolValidationManager
    {
 public:
@@ -808,6 +828,7 @@ public:
                                           int32_t vftSlot,
                                           TR_OpaqueMethodBlock *callerMethod);
    bool addDynamicMethodFromCallsiteIndex(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t callsiteIndex, J9UTF8 *signature);
+   bool addHandleMethodFromCPIndex(TR_OpaqueMethodBlock *method, J9ConstantPool *cp, int32_t cpIndex, J9UTF8 *signature);
 
    bool addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, bool skipFrames);
    bool addClassInfoIsInitializedRecord(TR_OpaqueClassBlock *clazz, bool isInitialized);
@@ -856,6 +877,7 @@ public:
                                                int32_t vftSlot,
                                                uint16_t callerMethodID);
    bool validateDynamicMethodFromCallsiteIndex(uint16_t methodID, uint16_t beholderID, int32_t callsiteIndex, const char *signature, uint32_t length);
+   bool validateHandleMethodFromCPIndex(uint16_t methodID, uint16_t beholderID, int32_t cpIndex, const char *signature, uint32_t length);
 
    bool validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID, bool couldSkipFrames);
    bool validateClassInfoIsInitializedRecord(uint16_t classID, bool wasInitialized);

--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -260,6 +260,19 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
          line,
          node);
       }
+   else if (_reloType==TR_MethodTypeTableEntryAddress)
+      {
+      cg->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)_symbolReference,
+            NULL,
+            TR_MethodTypeTableEntryAddress,
+            cg),
+         file,
+         line,
+         node);
+      }
    else
       {
       TR_ASSERT(0,"relocation type [%d] not handled yet", _reloType);

--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -247,6 +247,19 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
          line,
          node);
       }
+   else if (_reloType==TR_CallsiteTableEntryAddress)
+      {
+      cg->addExternalRelocation(
+         TR::ExternalRelocation::create(
+            cursor,
+            (uint8_t *)_symbolReference,
+            NULL,
+            TR_CallsiteTableEntryAddress,
+            cg),
+         file,
+         line,
+         node);
+      }
    else
       {
       TR_ASSERT(0,"relocation type [%d] not handled yet", _reloType);


### PR DESCRIPTION
This PR adds AOT (w/ SVM) support for the `invokeHandle`/`invokeDynamic` bytecodes. There are several changes:
* Uses an option to enable/disable the SVM rather than an env var
* Renames `getDebugCounterName` to `getStringFromSCC`
* Adds new `TR_RelocationErrorCode` kinds
* Adds new SVM records to validate dynamic and handle methods
* Adds new relocation records to relocate the Callsite Table Entry and Method Type Table Entry addresses
* Fixes a mismatch in signatures between `TR_J9VMBase::getMethodFromClass` and `TR_J9SharedCacheVM::getMethodFromClass`

It is worth noting that because invokeHandle/invokeDynamic are always treated as unresolved for an AOT compilation, the `TR_CallsiteTableEntryAddress`/`TR_MethodTypeTableEntryAddress` relocations are never generated. Nevertheless, they will be needed for resolved dispatch and are trivial to relocate, so they are included in this PR.

Another important point worth calling to attention is the newly renamed `getStringFromSCC` which is used to store the polymorphic signature of the `linkToStatic` dummy method used in the unresolved dispatch; this API does not deduplicate strings stored to the SCC. Therefore, this API will need some improvement to reduce the risk of filling up with SCC with duplicate strings.

Depends https://github.com/eclipse/omr/pull/7439