### PR TITLE
Allow JITServer to ignore line number requests

### DIFF
--- a/doc/compiler/jitserver/Problem.md
+++ b/doc/compiler/jitserver/Problem.md
@@ -67,7 +67,10 @@ because you often need to find the failing method and look at its trace log to f
 but by a series of them, which makes debugging even harder.
 
 Tracing method compilation is the same as for non-JITServer - use `-Xjit:{<method_name_regex>}(traceFull,log=<log_name>)` in the client options and both client
-and server will produce trace logs. Passing options for limit files and other tracing options also works in the same way.
+and server will produce trace logs. Passing options for limit files and other tracing options also works in the same way. In some cases (when the method is very large
+and compiled at a high optimization level) having the server generate these logs will slow down method compilation enough that timing-sensitive bugs will happen less frequently.
+If that happens, consider setting the environment variable `TR_JITServerShouldIgnoreLineNumbers=1` at the server. This has the downside of suppressing the line numbers in
+all the generated logs, but the resulting reduction in network overhead can improve the compilation times of traced methods enough to be worth it.
 
 To find if a problem is happening at the client side due to JITServer-specific issues in compiled code, remote compilation of the identified methods can be excluded by specifying `-Xjit:remoteCompileExclude={<method_name_regex>}`. Passing this option at the client side ensures that only local compilations will be performed on methods matching the specified regex pattern.
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1726,6 +1726,10 @@ TR_J9ServerVM::getStringHashCode(TR::Compilation *comp, uintptr_t* stringLocatio
 int32_t
 TR_J9ServerVM::getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *method, int32_t bcIndex)
    {
+   static bool ignoreLineNumbers = feGetEnv("TR_JITServerShouldIgnoreLineNumbers") != NULL;
+   if (ignoreLineNumbers)
+      return -1;
+
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_getLineNumberForMethodAndByteCodeIndex, method, bcIndex);
    return std::get<0>(stream->read<int32_t>());


### PR DESCRIPTION
The method getLineNumberForMethodAndByteCodeIndex, in the base VM frontend, is supposed to retrieve the line number corresponding to a method and byte codex index from the method's associated ROM method. At the server, these line numbers are not directly accessible, so the server must request this information from the client whenever that method is called.

These line numbers appear to be used only when generating compilation logs. The most notable use of this method for that purpose is in dumping IL trees - for every line of this dump, this method will be called. Even this network overhead is not usually significant. However, if the method being compiled at the server is very large, at a high optimization level, and has many trace options enabled, these line number messages can slow the compilation significantly. This can make some test failures more difficult to reproduce, if they are timing-sensitive.

The environment variable TR_JITServerShouldIgnoreLineNumbers will, if set in the server environment, cause the server to skip consulting the client for line numbers, and instead return -1 from this method always. This results in a moderate decrease in remote compilation time in the scenario outlined above, and can improve test failure reproducibility. Compilations of large methods will still be much slower at high optimization and trace levels, however, so this won't necessarily solve the issue fully.