### PR TITLE
Footprint Improvements under `-XX:+DebugOnRestore`

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4268,61 +4268,6 @@ static void jitHookAboutToRunMain(J9HookInterface * * hook, UDATA eventNum, void
    }
 
 
-#if defined(J9VM_INTERP_PROFILING_BYTECODES)
-// Below, options and jitConfig are guaranteed to be not null
-void printIprofilerStats(TR::Options *options, J9JITConfig * jitConfig, TR_IProfiler *iProfiler)
-   {
-   if (!options->getOption(TR_DisableInterpreterProfiling))
-      {
-      PORT_ACCESS_FROM_JITCONFIG(jitConfig);
-      if (TR::Options::getCmdLineOptions()->getOption(TR_VerboseInterpreterProfiling))
-         {
-         j9tty_printf(PORTLIB, "VM shutdown event received.\n");
-         j9tty_printf(PORTLIB, "Total events: %d\n", TEST_events);
-         j9tty_printf(PORTLIB, "Total records: %d\n", TEST_records);
-         j9tty_printf(PORTLIB, "Total method persistence opportunities: %d\n", TR_IProfiler::_STATS_methodPersistenceAttempts);
-         j9tty_printf(PORTLIB, "Total jitprofile entries: %d\n", TR_IProfiler::_STATS_methodPersisted);
-         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted due to locked entry:                %d\n", TR_IProfiler::_STATS_abortedPersistence);
-         j9tty_printf(PORTLIB, "Total IProfiler persistence failed:                                     %d\n", TR_IProfiler::_STATS_persistError);
-         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because SCC full:                   %d\n", TR_IProfiler::_STATS_methodNotPersisted_SCCfull);
-         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because ROM class in not in SCC:    %d\n", TR_IProfiler::_STATS_methodNotPersisted_classNotInSCC);
-         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted due to other reasons:               %d\n", TR_IProfiler::_STATS_methodNotPersisted_other);
-         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because already stored:             %d\n", TR_IProfiler::_STATS_methodNotPersisted_alreadyStored);
-         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because nothing needs to be stored: %d\n", TR_IProfiler::_STATS_methodNotPersisted_noEntries);
-         j9tty_printf(PORTLIB, "Total IProfiler persisted delayed:                                      %d\n", TR_IProfiler::_STATS_methodNotPersisted_delayed);
-         j9tty_printf(PORTLIB, "Total records persisted:                        %d\n", TR_IProfiler::_STATS_entriesPersisted);
-         j9tty_printf(PORTLIB, "Total records not persisted_NotInSCC:           %d\n", TR_IProfiler::_STATS_entriesNotPersisted_NotInSCC);
-         j9tty_printf(PORTLIB, "Total records not persisted_unloaded:           %d\n", TR_IProfiler::_STATS_entriesNotPersisted_Unloaded);
-         j9tty_printf(PORTLIB, "Total records not persisted_noInfo in bc table: %d\n", TR_IProfiler::_STATS_entriesNotPersisted_NoInfo);
-         j9tty_printf(PORTLIB, "Total records not persisted_Other:              %d\n", TR_IProfiler::_STATS_entriesNotPersisted_Other);
-         j9tty_printf(PORTLIB, "IP Total Persistent Read Failed Attempts:          %d\n", TR_IProfiler::_STATS_persistedIPReadFail);
-
-         j9tty_printf(PORTLIB, "IP Total Persistent Reads with Bad Data:           %d\n", TR_IProfiler::_STATS_persistedIPReadHadBadData);
-         j9tty_printf(PORTLIB, "IP Total Persistent Read Success:                  %d\n", TR_IProfiler::_STATS_persistedIPReadSuccess);
-         j9tty_printf(PORTLIB, "IP Total Persistent vs Current Data Differ:        %d\n", TR_IProfiler::_STATS_persistedAndCurrentIPDataDiffer);
-         j9tty_printf(PORTLIB, "IP Total Persistent vs Current Data Match:         %d\n", TR_IProfiler::_STATS_persistedAndCurrentIPDataMatch);
-         j9tty_printf(PORTLIB, "IP Total Current Read Fail:                        %d\n", TR_IProfiler::_STATS_currentIPReadFail);
-         j9tty_printf(PORTLIB, "IP Total Current Read Success:                     %d\n", TR_IProfiler::_STATS_currentIPReadSuccess);
-         j9tty_printf(PORTLIB, "IP Total Current Read Bad Data:                    %d\n", TR_IProfiler::_STATS_currentIPReadHadBadData);
-         j9tty_printf(PORTLIB, "Total records read: %d\n", TR_IProfiler::_STATS_IPEntryRead);
-         j9tty_printf(PORTLIB, "Total records choose persistent: %d\n", TR_IProfiler::_STATS_IPEntryChoosePersistent);
-         }
-      if (TR_IProfiler::_STATS_abortedPersistence > 0)
-         {
-         TR_ASSERT(TR_IProfiler::_STATS_methodPersisted / TR_IProfiler::_STATS_abortedPersistence > 20 ||
-            TR_IProfiler::_STATS_methodPersisted < 200,
-            "too many aborted persistence attempts due to locked entries (%d aborted, %d total methods persisted)",
-            TR_IProfiler::_STATS_abortedPersistence, TR_IProfiler::_STATS_methodPersisted);
-         }
-      if (TR::Options::getCmdLineOptions()->getOption(TR_EnableNewAllocationProfiling))
-         iProfiler->printAllocationReport();
-      if (TEST_verbose || TR::Options::getCmdLineOptions()->getOption(TR_VerboseInterpreterProfiling))
-         iProfiler->outputStats();
-      }
-   }
-#endif
-
-
 /// JIT cleanup code
 void JitShutdown(J9JITConfig * jitConfig)
    {
@@ -4365,7 +4310,7 @@ void JitShutdown(J9JITConfig * jitConfig)
    // so the fact that this option is true doesn't mean that IProfiler structures were not allocated
    if (options /* && !options->getOption(TR_DisableInterpreterProfiling) */ && iProfiler)
       {
-      printIprofilerStats(options, jitConfig, iProfiler);
+      printIprofilerStats(options, jitConfig, iProfiler, "Shutdown");
       // Prevent the interpreter to accumulate more info
       // stopInterpreterProfiling is stronger than turnOff... because it prevents the reactivation
       // by setting TR_DisableInterpreterProfiling option to false
@@ -7760,6 +7705,58 @@ int32_t waitJITServerTermination(J9JITConfig *jitConfig)
 } /* extern "C" */
 
 #if defined(J9VM_INTERP_PROFILING_BYTECODES)
+// Below, options and jitConfig are guaranteed to be not null
+void printIprofilerStats(TR::Options *options, J9JITConfig * jitConfig, TR_IProfiler *iProfiler, const char *event)
+   {
+   if (!options->getOption(TR_DisableInterpreterProfiling))
+      {
+      PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+      if (options->getOption(TR_VerboseInterpreterProfiling))
+         {
+         j9tty_printf(PORTLIB, "VM %s event received.\n", event);
+         j9tty_printf(PORTLIB, "Total events: %d\n", TEST_events);
+         j9tty_printf(PORTLIB, "Total records: %d\n", TEST_records);
+         j9tty_printf(PORTLIB, "Total method persistence opportunities: %d\n", TR_IProfiler::_STATS_methodPersistenceAttempts);
+         j9tty_printf(PORTLIB, "Total jitprofile entries: %d\n", TR_IProfiler::_STATS_methodPersisted);
+         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted due to locked entry:                %d\n", TR_IProfiler::_STATS_abortedPersistence);
+         j9tty_printf(PORTLIB, "Total IProfiler persistence failed:                                     %d\n", TR_IProfiler::_STATS_persistError);
+         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because SCC full:                   %d\n", TR_IProfiler::_STATS_methodNotPersisted_SCCfull);
+         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because ROM class in not in SCC:    %d\n", TR_IProfiler::_STATS_methodNotPersisted_classNotInSCC);
+         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted due to other reasons:               %d\n", TR_IProfiler::_STATS_methodNotPersisted_other);
+         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because already stored:             %d\n", TR_IProfiler::_STATS_methodNotPersisted_alreadyStored);
+         j9tty_printf(PORTLIB, "Total IProfiler persistence aborted because nothing needs to be stored: %d\n", TR_IProfiler::_STATS_methodNotPersisted_noEntries);
+         j9tty_printf(PORTLIB, "Total IProfiler persisted delayed:                                      %d\n", TR_IProfiler::_STATS_methodNotPersisted_delayed);
+         j9tty_printf(PORTLIB, "Total records persisted:                        %d\n", TR_IProfiler::_STATS_entriesPersisted);
+         j9tty_printf(PORTLIB, "Total records not persisted_NotInSCC:           %d\n", TR_IProfiler::_STATS_entriesNotPersisted_NotInSCC);
+         j9tty_printf(PORTLIB, "Total records not persisted_unloaded:           %d\n", TR_IProfiler::_STATS_entriesNotPersisted_Unloaded);
+         j9tty_printf(PORTLIB, "Total records not persisted_noInfo in bc table: %d\n", TR_IProfiler::_STATS_entriesNotPersisted_NoInfo);
+         j9tty_printf(PORTLIB, "Total records not persisted_Other:              %d\n", TR_IProfiler::_STATS_entriesNotPersisted_Other);
+         j9tty_printf(PORTLIB, "IP Total Persistent Read Failed Attempts:          %d\n", TR_IProfiler::_STATS_persistedIPReadFail);
+
+         j9tty_printf(PORTLIB, "IP Total Persistent Reads with Bad Data:           %d\n", TR_IProfiler::_STATS_persistedIPReadHadBadData);
+         j9tty_printf(PORTLIB, "IP Total Persistent Read Success:                  %d\n", TR_IProfiler::_STATS_persistedIPReadSuccess);
+         j9tty_printf(PORTLIB, "IP Total Persistent vs Current Data Differ:        %d\n", TR_IProfiler::_STATS_persistedAndCurrentIPDataDiffer);
+         j9tty_printf(PORTLIB, "IP Total Persistent vs Current Data Match:         %d\n", TR_IProfiler::_STATS_persistedAndCurrentIPDataMatch);
+         j9tty_printf(PORTLIB, "IP Total Current Read Fail:                        %d\n", TR_IProfiler::_STATS_currentIPReadFail);
+         j9tty_printf(PORTLIB, "IP Total Current Read Success:                     %d\n", TR_IProfiler::_STATS_currentIPReadSuccess);
+         j9tty_printf(PORTLIB, "IP Total Current Read Bad Data:                    %d\n", TR_IProfiler::_STATS_currentIPReadHadBadData);
+         j9tty_printf(PORTLIB, "Total records read: %d\n", TR_IProfiler::_STATS_IPEntryRead);
+         j9tty_printf(PORTLIB, "Total records choose persistent: %d\n", TR_IProfiler::_STATS_IPEntryChoosePersistent);
+         }
+      if (TR_IProfiler::_STATS_abortedPersistence > 0)
+         {
+         TR_ASSERT(TR_IProfiler::_STATS_methodPersisted / TR_IProfiler::_STATS_abortedPersistence > 20 ||
+            TR_IProfiler::_STATS_methodPersisted < 200,
+            "too many aborted persistence attempts due to locked entries (%d aborted, %d total methods persisted)",
+            TR_IProfiler::_STATS_abortedPersistence, TR_IProfiler::_STATS_methodPersisted);
+         }
+      if (options->getOption(TR_EnableNewAllocationProfiling))
+         iProfiler->printAllocationReport();
+      if (TEST_verbose || options->getOption(TR_VerboseInterpreterProfiling))
+         iProfiler->outputStats();
+      }
+   }
+
 void turnOffInterpreterProfiling(J9JITConfig *jitConfig)
    {
    // Turn off interpreter profiling

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -224,6 +224,7 @@ int32_t J9::Options::_waitTimeToExitStartupMode = DEFAULT_WAIT_TIME_TO_EXIT_STAR
 int32_t J9::Options::_waitTimeToGCR = 10000; // ms
 int32_t J9::Options::_waitTimeToStartIProfiler = 1000; // ms
 int32_t J9::Options::_compilationDelayTime = 0; // sec; 0 means disabled
+int32_t J9::Options::_delayBeforeStateChange = 500; // ms
 
 int32_t J9::Options::_invocationThresholdToTriggerLowPriComp = 250;
 
@@ -938,6 +939,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_dataCacheQuantumSize, 0, "F%d", NOT_IN_SUBSET},
    {"datatotal=",              "C<nnn>\ttotal data memory limit, in KB",
         TR::Options::setJitConfigNumericValue, offsetof(J9JITConfig, dataCacheTotalKB), 0, "F%d (KB)"},
+   {"delayBeforeStateChange=",                 "M<nnn>\tTime (ms) after restore before allowing the JIT to change states.",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_delayBeforeStateChange, 0, "F%d", NOT_IN_SUBSET},
    {"disableIProfilerClassUnloadThreshold=",      "R<nnn>\tNumber of classes that can be unloaded before we disable the IProfiler",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_disableIProfilerClassUnloadThreshold, 0, "F%d", NOT_IN_SUBSET},
    {"dltPostponeThreshold=",      "M<nnn>\tNumber of dlt attempts inv. count for a method is seen not advancing",

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -183,6 +183,7 @@ int32_t J9::Options::_iProfilerMethodHashTableSize = 32707; // 32707 could be an
 int32_t J9::Options::_IprofilerOffSubtractionFactor = 500;
 int32_t J9::Options::_IprofilerOffDivisionFactor = 16;
 
+int32_t J9::Options::_IprofilerPreCheckpointDropRate = 0;
 
 
 int32_t J9::Options::_maxIprofilingCount = TR_DEFAULT_INITIAL_COUNT; // 3000
@@ -1055,6 +1056,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_IprofilerOffDivisionFactor, 0, "F%d", NOT_IN_SUBSET},
    {"iprofilerOffSubtractionFactor=", "O<nnn>\tCounts Subtraction factor when IProfiler is Off",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_IprofilerOffSubtractionFactor, 0, "F%d", NOT_IN_SUBSET},
+   {"iprofilerPreCheckpointDropRate=", "O<nnn>\tPercent*10 of buffers to drop precheckpoint",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_IprofilerPreCheckpointDropRate, 0, "F%d", NOT_IN_SUBSET},
    {"iprofilerSamplesBeforeTurningOff=", "O<nnn>\tnumber of interpreter profiling samples "
                                 "needs to be taken after the profiling starts going off to completely turn it off. "
                                 "Specify a very large value to disable this optimization",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -296,6 +296,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _IprofilerOffSubtractionFactor;
    static int32_t _IprofilerOffDivisionFactor;
 
+   static int32_t _IprofilerPreCheckpointDropRate;
+
    static int32_t _LoopyMethodSubtractionFactor;
    static int32_t _LoopyMethodDivisionFactor;
 

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -400,6 +400,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _waitTimeToGCR;
    static int32_t _waitTimeToStartIProfiler;
    static int32_t _compilationDelayTime;
+   static int32_t _delayBeforeStateChange;
 
    static int32_t _invocationThresholdToTriggerLowPriComp; // we trigger an LPQ comp req only if the method
                                                            // was invoked at least this many times

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -679,6 +679,18 @@ TR::CRRuntime::prepareForCheckpoint()
       }
 
    setReadyForCheckpointRestore();
+
+   char * printPersistentMem = feGetEnv("TR_PrintPersistentMem");
+   if (printPersistentMem)
+      {
+      if (trPersistentMemory)
+         trPersistentMemory->printMemStats();
+      }
+
+   printIprofilerStats(TR::Options::getCmdLineOptions(),
+                       _jitConfig,
+                       TR_J9VMBase::get(_jitConfig, NULL)->getIProfiler(),
+                       "Checkpoint");
    }
 
    if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseCheckpointRestore))

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -90,7 +90,8 @@ TR::CRRuntime::CRRuntime(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo) 
    _failedComps(),
    _forcedRecomps(),
    _impMethodForCR(),
-   _proactiveCompEnv()
+   _proactiveCompEnv(),
+   _restoreTime(0)
    {
    // TR::CompilationInfo is initialized in the JIT_INITIALIZED bootstrap
    // stage, whereas J9_EXTENDED_RUNTIME_METHOD_TRACE_ENABLED is set in the
@@ -606,7 +607,7 @@ TR::CRRuntime::resumeJITThreadsForRestore(J9VMThread *vmThread)
 void
 TR::CRRuntime::resetStartTime()
    {
-   PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
+   PORT_ACCESS_FROM_JAVAVM(getJITConfig()->javaVM);
    TR::PersistentInfo *persistentInfo = getCompInfo()->getPersistentInfo();
 
    if (TR::Options::isAnyVerboseOptionSet())
@@ -619,6 +620,8 @@ TR::CRRuntime::resetStartTime()
    if (TR::Options::isAnyVerboseOptionSet())
       TR_VerboseLog::writeLineLocked(TR_Vlog_CHECKPOINT_RESTORE, "Reset start and elapsed time: startTime=%6u, elapsedTime=%6u",
                                        (uint32_t)persistentInfo->getStartTime(), (uint32_t)persistentInfo->getElapsedTime());
+
+   _restoreTime = persistentInfo->getElapsedTime();
    }
 
 void
@@ -760,6 +763,13 @@ TR::CRRuntime::recompileMethodsCompiledPreCheckpoint()
       setCRRuntimeThreadLifetimeState(TR_CRRuntimeThreadLifetimeStates::CR_THR_TRIGGER_RECOMP);
       getCRRuntimeMonitor()->notifyAll();
       }
+   }
+
+bool
+TR::CRRuntime::allowStateChange()
+   {
+   TR::PersistentInfo *persistentInfo = getCompInfo()->getPersistentInfo();
+   return (_restoreTime != 0) && ((persistentInfo->getElapsedTime() - _restoreTime) > TR::Options::_delayBeforeStateChange);
    }
 
 void

--- a/runtime/compiler/runtime/CRRuntime.hpp
+++ b/runtime/compiler/runtime/CRRuntime.hpp
@@ -182,6 +182,13 @@ class CRRuntime
     */
    void recompileMethodsCompiledPreCheckpoint();
 
+   /**
+    * @brief Determine whether it's ok for the JIT to change states.
+    *
+    * @return true if ok to chnage states, false otherwise.
+    */
+   bool allowStateChange();
+
    private:
 
    class TR_MemoizedComp : public TR_Link0<TR_MemoizedComp>
@@ -395,6 +402,8 @@ class CRRuntime
    bool _remoteCompilationRequestedAtBootstrap;
    bool _remoteCompilationExplicitlyDisabledAtBootstrap;
 #endif
+
+   uint64_t _restoreTime;
    };
 
 } // namespace TR

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -598,7 +598,7 @@ TR_IProfiler::TR_IProfiler(J9JITConfig *jitConfig)
    : _isIProfilingEnabled(true),
      _valueProfileMethod(NULL), _lightHashTableMonitor(0), _allowedToGiveInlinedInformation(true),
      _globalAllocationCount (0), _maxCallFrequency(0), _iprofilerThread(0), _iprofilerOSThread(NULL),
-     _workingBufferTail(NULL), _numOutstandingBuffers(0), _numRequests(1), _numRequestsSkipped(0),
+     _workingBufferTail(NULL), _numOutstandingBuffers(0), _numRequests(1), _numRequestsDropped(0), _numRequestsSkipped(0),
      _numRequestsHandedToIProfilerThread(0), _iprofilerMonitor(NULL),
      _crtProfilingBuffer(NULL), _iprofilerNumRecords(0), _numMethodHashEntries(0),
      _iprofilerThreadLifetimeState(TR_IprofilerThreadLifetimeStates::IPROF_THR_NOT_CREATED)
@@ -2613,6 +2613,7 @@ TR_IProfiler::outputStats()
    if (options && !options->getOption(TR_DisableIProfilerThread))
       {
       fprintf(stderr, "IProfiler: Number of buffers to be processed           =%" OMR_PRIu64 "\n", _numRequests);
+      fprintf(stderr, "IProfiler: Number of buffers to be dropped             =%" OMR_PRIu64 "\n", _numRequestsDropped);
       fprintf(stderr, "IProfiler: Number of buffers discarded                 =%" OMR_PRIu64 "\n", _numRequestsSkipped);
       fprintf(stderr, "IProfiler: Number of buffers handed to iprofiler thread=%" OMR_PRIu64 "\n", _numRequestsHandedToIProfilerThread);
       }
@@ -4186,6 +4187,20 @@ UDATA TR_IProfiler::parseBuffer(J9VMThread * vmThread, const U_8* dataStart, UDA
       return 0;
       }
 
+   J9JavaVM *javaVM = _compInfo->getJITConfig()->javaVM;
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread) && javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+      {
+      int32_t dropRate = (int32_t)((((float)(_numRequestsDropped + _numRequestsSkipped)) / ((float)_numRequests)) * 1000);
+      if (TR::Options::_IprofilerPreCheckpointDropRate >= 1000 || dropRate <= TR::Options::_IprofilerPreCheckpointDropRate)
+         {
+         _numRequestsDropped++;
+         return 0;
+         }
+      }
+#endif
+
    if (numUnloadedClasses > 0)
       ratio = numLoadedClasses/numUnloadedClasses;
 
@@ -4200,8 +4215,6 @@ UDATA TR_IProfiler::parseBuffer(J9VMThread * vmThread, const U_8* dataStart, UDA
       }
 
    bool isClassLoadPhase = _compInfo->getPersistentInfo()->isClassLoadingPhase();
-
-   J9JavaVM * javaVM = _compInfo->getJITConfig()->javaVM;
 
    int32_t skipCountMain = 20+(rand()%10); // TODO: Use the main TR_RandomGenerator from jitconfig?
    int32_t skipCount = skipCountMain;

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -734,6 +734,7 @@ private:
    TR::Monitor                    *_iprofilerMonitor;
    volatile int32_t                _numOutstandingBuffers;
    uint64_t                        _numRequests;
+   uint64_t                        _numRequestsDropped;
    uint64_t                        _numRequestsSkipped;
    uint64_t                        _numRequestsHandedToIProfilerThread;
    uint64_t                        _iprofilerNumRecords; // info stats only

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -74,6 +74,7 @@
 
 class TR_BlockFrequencyInfo;
 namespace TR { class CompilationInfo; }
+namespace TR { class Options; }
 class TR_FrontEnd;
 class TR_IPBCDataPointer;
 class TR_IPBCDataCallGraph;
@@ -781,6 +782,7 @@ private:
    static int32_t                  _STATS_IPEntryChoosePersistent;
    };
 
+void printIprofilerStats(TR::Options *options, J9JITConfig * jitConfig, TR_IProfiler *iProfiler, const char *event);
 void turnOffInterpreterProfiling(J9JITConfig *jitConfig);
 
 #endif


### PR DESCRIPTION
This PR adds a few improvements under `-XX:+DebugOnRestore`:
* Add verbose output at checkpoint
* Drop IProfier buffers precheckpoint
* Delay JVM phase change post-restore