### PR TITLE
Avoid vTableSlot assertion at JITServer client

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6491,7 +6491,6 @@ TR_ResolvedJ9Method::vTableSlot(U_32 cpIndex)
    {
    TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
    //UDATA vTableSlot = ((J9RAMVirtualMethodRef *)literals())[cpIndex].methodIndexAndArgCount >> 8;
-   TR_ASSERT(_vTableSlot, "vTableSlot called for unresolved method");
    return _vTableSlot;
    }
 


### PR DESCRIPTION
The `TR_ResolvedJ9Method::vTableSlot()` would formerly assert that the `_vTableSlot` of the resolved method was not zero before returning its value. This is not particularly helpful, as none of the existing code assumes that the `vTableSlot()` will be valid when calling this method, and there are certain kinds of resolved methods that may legitimately have a `_vTableSlot` of zero.

This assert would (unnecessarily) fire in particular in the handling of the `ResolvedMethod_getMultipleResolvedMethods` message at a JITServer client. Removing it eliminates the resulting crash in debug/prod-with-assumes builds.

Fixes: https://github.com/eclipse-openj9/openj9/issues/19983