### PR TITLE
JDK24 adds JavaLangAccess.stringConcat1()

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -262,7 +262,7 @@
 		<classpathentry kind="src" path="src/openj9.traceformat/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.zosconditionhandling/share/classes"/>
 		<classpathentry kind="lib" path="/binaries/common/ibm/ibmjzos.jar"/>
-		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava23.jar"/>
+		<classpathentry kind="lib" path="/binaries/vm/third/rt-compressed.sunJava24.jar"/>
 		<source path="src"/>
 		<parameter name="macro:define" value="JAVA_SPEC_VERSION=24"/>
 		<parameter name="msg:outputdir" value="java.base/share/classes/com/ibm/oti/util"/>

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -817,5 +817,12 @@ final class Access implements JavaLangAccess {
 	}
 /*[ENDIF] INLINE-TYPES */
 
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	@Override
+	public Object stringConcat1(String[] constants) {
+		return new StringConcatHelper.Concat1(constants);
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 }


### PR DESCRIPTION
`JDK24` adds `JavaLangAccess.stringConcat1()`

Also updated `jpp_configuration.xml` to refer `rt-compressed.sunJava24.jar`.

Resolve JDK next abuild compilation failure https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/611/consoleFull
```
00:10:00  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:70: error: Access is not abstract and does not override abstract method stringConcat1(String[]) in JavaLangAccess
00:10:00  final class Access implements JavaLangAccess {
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>