### PR TITLE
Use findOrFabricateShadowSymbol for Reference.referent in get/refersTo

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -697,25 +697,6 @@ J9::SymbolReferenceTable::findOrCreateArrayClassRomPtrSymbolRef()
    }
 
 
-TR::SymbolReference *
-J9::SymbolReferenceTable::findOrCreateJavaLangReferenceReferentShadowSymbol(
-      TR::ResolvedMethodSymbol * owningMethodSymbol,
-      bool isResolved,
-      TR::DataType type,
-      uint32_t offset, bool isUnresolvedInCP)
-   {
-   TR_ResolvedMethod * owningMethod = owningMethodSymbol->getResolvedMethod();
-
-   TR::SymbolReference * symRef = NULL;
-   symRef = findJavaLangReferenceReferentShadowSymbol(owningMethod, TR::Address, offset);
-   if (!symRef)
-      {
-      symRef = createShadowSymbolWithoutCpIndex(owningMethodSymbol, true, TR::Address, offset, false);
-      }
-   return symRef;
-   }
-
-
 // Right now it only works for private fields or fields that are guaranteed to be accessed only from one class
 // because searchRecognizedField only does a name comparison, t does not work if the field is accessed from a subclass of the expected one
 TR::SymbolReference *

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -136,7 +136,6 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * methodSymRefWithSignature(TR::SymbolReference *original, char *effectiveSignature, int32_t effectiveSignatureLength);
    TR::SymbolReference * findOrCreateTypeCheckArrayStoreSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);
    TR::SymbolReference * findOrCreateArrayClassRomPtrSymbolRef();
-   TR::SymbolReference * findOrCreateJavaLangReferenceReferentShadowSymbol(TR::ResolvedMethodSymbol *, bool , TR::DataType, uint32_t, bool);
    TR::SymbolReference * findOrCreateWriteBarrierStoreGenerationalAndConcurrentMarkSymbolRef(TR::ResolvedMethodSymbol *owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateWriteBarrierStoreRealTimeGCSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = 0);
    TR::SymbolReference * findOrCreateWriteBarrierClassStoreRealTimeGCSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol = 0);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7930,8 +7930,17 @@ TR_J9VM::inlineNativeCall(TR::Compilation * comp, TR::TreeTop * callNodeTreeTop,
                }
 
             // Generate reference symbol
-            TR::SymbolReference * symRefField = comp->getSymRefTab()->findOrCreateJavaLangReferenceReferentShadowSymbol(callerSymRef->getOwningMethodSymbol(comp),
-                                                                                                              true, TR::Address, offset, false);
+            TR::SymbolReference * symRefField =
+               comp->getSymRefTab()->findOrFabricateShadowSymbol(
+                  ReferenceClass,
+                  TR::Address,
+                  offset,
+                  /* isVolatile */ false,
+                  /* isPrivate */ true,
+                  /* isFinal */ false,
+                  REFERENCEFIELD,
+                  REFERENCERETURNTYPE);
+
             if (methodID == TR::java_lang_ref_Reference_getImpl)
                {
                // Generate indirect load of referent into the callNode


### PR DESCRIPTION
When inlining `Reference.getImpl()` or `Reference.refersTo()`, the compiler generates a load of `Reference.referent`. Previously, it would reuse any address-typed shadow symref it could find with the expected offset and owning method. If it did find such a shadow symref representing a field of a different class, it would have incorrect aliasing and likely an incorrect type signature. Now instead the field shadow is fabricated if necessary using `findOrFabricateShadowSymbol()`.