### PR TITLE
[FFI] Fix the issue with the struct FF/DD in upcall on z/OS

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
@@ -312,8 +312,11 @@ final class LayoutStrPreprocessor {
 		/* Prefix "#" to denote the start of this layout string in the case of downcall. */
 		if (isDownCall) {
 			targetLayoutStr.append('#').append(1);
+			targetLayoutStr.append('[').append(elementLayoutStrs).append(']');
+		} else {
+			/* '{' and '}' are intended for a union in upcall. */
+			targetLayoutStr.append('{').append(elementLayoutStrs).append('}');
 		}
-		targetLayoutStr.append('[').append(elementLayoutStrs).append(']');
 
 		return targetLayoutStr;
 	}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6286,6 +6286,11 @@ typedef struct J9JavaVM {
 /* Intended to compute the composition type from every 8 bytes of the composition type array */
 #define J9_FFI_UPCALL_COMPOSITION_TYPE_DWORD_SIZE 8
 
+/* Intended to compare the layout for struct {float, float} or its variants in upcall. */
+#define J9_FFI_UPCALL_STRUCT_FF_SIZE 8
+/* Intended to compare the layout for struct {double, double} or its variants in upcall. */
+#define J9_FFI_UPCALL_STRUCT_DD_SIZE 16
+
 typedef struct J9UpcallSigType {
 	U_8 type;
 	U_32 sizeInByte:24;


### PR DESCRIPTION
[FFI] Fix the issue with the struct FF/DD in upcall on z/OS

The changes resolve the issue with the register mapping for the
struct FF/DD or its variants in upcall on z/OS by categorizing
them into ALL_SP/ALL_DP placed on FPRs while other non-complex
type are categorized into AGGREGATE_OTHER placed on GPRs.

Fixes: #19952

Signed-off-by: ChengJin01 <jincheng@ca.ibm.com>