### PR TITLE
(0.47.0) Fall back to out-of-line call to StringUTF16.toBytes

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -288,7 +288,7 @@ void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::Tr
    // The implementation of java.lang.StringUTF16.toBytes(char[],int,int) will
    // throw a NegativeArraySizeException or OutOfMemoryError if the specified
    // length is outside the range [0,0x3fffffff].  In order to avoid deciding
-   // which to throw in the IL, fallback to the out-of-line call if the length
+   // which to throw in the IL, fall back to the out-of-line call if the length
    // is negative or too great.  Otherwise, create the byte array and copy the
    // input char array to it with java.lang.String.decompressedArrayCopy
    //
@@ -337,7 +337,7 @@ void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::Tr
    //                                                |    |
    //                      +------------------------------+
    //                      |                         |
-   // fallBackPathBlock    V (freq 0) (cold)         |
+   // fallbackPathBlock    V (freq 0) (cold)         |
    // +----------------------------------------+     |
    // | astore result                          |     |
    // |   acall  java/lang/StringUTF16.toBytes |     |
@@ -416,7 +416,7 @@ void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_toBytes(TR::Tr
    // Then split the inline version of the code into its own block
    TR::Block *fallThroughPathBlock = ifCmpBlock->split(newByteArraryTreeTop, cfg, true /* fixUpCommoning */, true /* copyExceptionSuccessors */);
 
-   // Then split the fall-back, out-of-line call into its own block
+   // Then split the fallback, out-of-line call into its own block
    TR::Block *fallbackPathBlock = fallThroughPathBlock->split(fallbackTreeTop, cfg, true /* fixUpCommoning */, true /* copyExceptionSuccessors */);
 
    // Then split again at the original call TreeTop to create the tail block


### PR DESCRIPTION
The implementation of `StringUTF16.toBytes` will throw a `NegativeArraySizeException` if the specified array length is negative or an `OutOfMemoryError` if the length is 2^30 or greater.  The IL for the inline implementation that the JIT compiler generates for that recognized method could throw a `NegativeArraySizeException` in situations where the actual implementation would throw an `OutOfMemoryError`.

This change calls the actual implementation if the array length is outside the range [0,0x3fffffff] to ensure that the behaviour is always as expected in exceptional situations.

Port of pull request #19953 to v0.47.0-release branch for issue #19309