### PR TITLE
Warnings Cleanup

### DIFF
--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1321,10 +1321,10 @@ TR::SymbolValidationManager::validateDeclaringClassFromFieldOrStaticRecord(uint1
       {
       TR::VMAccessCriticalSection getDeclaringClassFromFieldOrStatic(_fej9);
 
-      int32_t fieldLen;
+      int32_t fieldLen = 0;
       char *field = cpIndex >= 0 ? utf8Data(J9ROMNAMEANDSIGNATURE_NAME(J9ROMFIELDREF_NAMEANDSIGNATURE(&romCPBase[cpIndex])), fieldLen) : 0;
 
-      int32_t sigLen;
+      int32_t sigLen = 0;
       char *sig = cpIndex >= 0 ? utf8Data(J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMFIELDREF_NAMEANDSIGNATURE(&romCPBase[cpIndex])), sigLen) : 0;
 
       _vmThread->javaVM->internalVMFunctions->instanceFieldOffset(

--- a/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.cpp
+++ b/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.cpp
@@ -396,7 +396,7 @@ void InMemoryLoadStoreMarking::clearLoadLists()
    _BCDConditionalCleanLoadList.deleteAll();
    }
 
-char *InMemoryLoadStoreMarking::_TR_NodeListTypeNames[NodeList_NumTypes] =
+const char *InMemoryLoadStoreMarking::_TR_NodeListTypeNames[NodeList_NumTypes] =
    {
    "LoadList",
    "ConditionalCleanLoadList",

--- a/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.hpp
+++ b/runtime/compiler/z/codegen/InMemoryLoadStoreMarking.hpp
@@ -91,15 +91,15 @@ class InMemoryLoadStoreMarking
    void clearAllLists();
    void clearLoadLists();
 
-   static char *getName(TR_NodeListTypes s)
+   static const char *getName(TR_NodeListTypes s)
       {
       if (s < NodeList_NumTypes)
          return _TR_NodeListTypeNames[s];
       else
-         return (char*)"UnknownNodeListType";
+         return "UnknownNodeListType";
       }
 
-   static char *_TR_NodeListTypeNames[NodeList_NumTypes];
+   static const char *_TR_NodeListTypeNames[NodeList_NumTypes];
    };
 
 #endif

--- a/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9BCDTreeEvaluator.cpp
@@ -5522,7 +5522,7 @@ TR::Register *
 J9::Z::TreeEvaluator::pddivremVectorEvaluatorHelper(TR::Node * node, TR::CodeGenerator * cg)
    {
    TR::Register* vTargetReg = NULL;
-   TR::InstOpCode::Mnemonic opCode;
+   TR::InstOpCode::Mnemonic opCode = TR::InstOpCode::bad;
    switch(node->getOpCodeValue())
       {
       case TR::pddiv:

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3263,9 +3263,9 @@ J9::Z::CodeGenerator::checkFieldAlignmentForAtomicLong()
    if (!classBlock)
       return false;
 
-   char* fieldName = "value";
+   const char * fieldName = "value";
    int32_t fieldNameLen = 5;
-   char * fieldSig = "J";
+   const char * fieldSig = "J";
    int32_t fieldSigLen = 1;
    int32_t intOrBoolOffset = self()->fe()->getObjectHeaderSizeInBytes() + self()->fej9()->getInstanceFieldOffset(classBlock, fieldName, fieldNameLen, fieldSig, fieldSigLen);
    return (intOrBoolOffset & 0x3) == 0;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -244,7 +244,7 @@ J9::Z::CodeGenerator::callUsesHelperImplementation(TR::Symbol *sym)
 TR::Linkage *
 J9::Z::CodeGenerator::createLinkage(TR_LinkageConventions lc)
    {
-   TR::Linkage * linkage;
+   TR::Linkage * linkage = NULL;
    switch (lc)
       {
       case TR_CHelper:

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -3533,7 +3533,7 @@ generateTestBitFlag(
       int32_t size,
       uint64_t bitFlag)
    {
-   TR::MemoryReference * tempMR;
+   TR::MemoryReference * tempMR = NULL;
    int shiftForFlag = TR::TreeEvaluator::checkNonNegativePowerOfTwo((int64_t) bitFlag);
    TR_ASSERT(shiftForFlag > 0, "generateTestBitFlag: flag is assumed to be power of 2\n");
 
@@ -3822,7 +3822,7 @@ VMCardCheckEvaluator(
          uintptr_t cardSize = comp->getOptions()->getGcCardSize();
          int32_t shiftValue = TR::TreeEvaluator::checkNonNegativePowerOfTwo((int32_t) cardSize);
 
-         TR::Register * cardOffReg;
+         TR::Register * cardOffReg = NULL;
          TR::Register * mdReg = cg->getMethodMetaDataRealRegister();
 
          if (!clobberDstReg)
@@ -10689,7 +10689,7 @@ J9::Z::TreeEvaluator::VMnewEvaluator(TR::Node * node, TR::CodeGenerator * cg)
    bool isArray = false, isDoubleArray = false;
    bool isVariableLen;
    int32_t litPoolRegTotalUse, temp2RegTotalUse;
-   int32_t elementSize;
+   int32_t elementSize = 0;
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = comp->fej9();
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -5304,6 +5304,8 @@ J9::Z::TreeEvaluator::DIVCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
          case TR::irem:
             iDivRemGenericEvaluator(node->getFirstChild(), cg, false, divisorMr);
             break;
+         default:
+            break;
          }
       divisorMr->stopUsingMemRefRegister(cg);
       }
@@ -11647,6 +11649,8 @@ J9::Z::TreeEvaluator::VMinlineCallEvaluator(TR::Node * node, bool indirect, TR::
             callWasInlined = inlineIsAssignableFrom(node, cg);
             break;
             }
+         default:
+            break;
          }
       }
 
@@ -12457,6 +12461,8 @@ J9::Z::TreeEvaluator::inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int
          delta = (int64_t)-1;
          break;
          }
+      default:
+         break;
       }
 
    //Determine the offset of the value field
@@ -12778,6 +12784,8 @@ J9::Z::TreeEvaluator::inlineAtomicFieldUpdater(TR::Node *node, TR::CodeGenerator
          isArgConstant = true;
       case TR::java_util_concurrent_atomic_AtomicIntegerFieldUpdater_addAndGet:
          isGetAndOp = false;
+         break;
+      default:
          break;
       }
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -5690,7 +5690,7 @@ J9::Z::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node * node, TR::CodeGenerato
       }
 
    bool disableS390CompareAndTrap = comp->getOption(TR_DisableTraps);
-   static const char*disableS390CompareAndBranch = feGetEnv("TR_DISABLES390CompareAndBranch");
+   static const char * disableS390CompareAndBranch = feGetEnv("TR_DISABLES390CompareAndBranch");
    if (cg->getHasResumableTrapHandler() &&
        !disableS390CompareAndTrap &&
        arrayTargetLengthReg != NULL &&
@@ -9544,7 +9544,7 @@ J9::Z::TreeEvaluator::VMmonentEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       lockPreservingReg = cg->allocateRegister();
       conditions->addPostCondition(lockPreservingReg, TR::RealRegister::AssignAny);
       }
-   const char* debugCounterNamePrefix = normalLockWithReservationPreserving? "LockEnt/Preserving": "LockEnt/Normal";
+   const char * debugCounterNamePrefix = normalLockWithReservationPreserving? "LockEnt/Preserving": "LockEnt/Normal";
    // Opcodes:
    bool use64b = true;
    if (cg->comp()->target().is64Bit() && fej9->generateCompressedLockWord())
@@ -12470,7 +12470,7 @@ J9::Z::TreeEvaluator::inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int
    if (!isArray)
       {
       TR_OpaqueClassBlock * bdClass;
-      char *className, *fieldSig;
+      const char * className, * fieldSig;
       int32_t classNameLen, fieldSigLen;
 
       fieldSigLen = 1;
@@ -12761,7 +12761,7 @@ J9::Z::TreeEvaluator::inlineAtomicFieldUpdater(TR::Node *node, TR::CodeGenerator
    bool isGetAndOp = true;
    bool isArgConstant = false;
    int32_t delta = 1;
-   char* className = "java/util/concurrent/atomic/AtomicIntegerFieldUpdater$AtomicIntegerFieldUpdaterImpl";
+   const char * className = "java/util/concurrent/atomic/AtomicIntegerFieldUpdater$AtomicIntegerFieldUpdaterImpl";
    int32_t classNameLen = 83;
 
    switch (currentMethod)

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -201,7 +201,7 @@ TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t 
       *(uint32_t *) cursor = 0xe3000006 + finalCallLength + (rEP << 12) + (rEP << 20);  // LG      rEP,8(,rEP)
       cursor += 4;
       *(uint16_t *) cursor = 0x0004;
-      cursor += 2;sizeof(int16_t);
+      cursor += sizeof(int16_t);
       }
    else
       {

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -50,7 +50,7 @@ TR::S390J9CallSnippet::generateVIThunk(TR::Node * callNode, int32_t argSize, TR:
    // make it double-word aligned
    codeSize = (codeSize + 7) / 8 * 8 + 8; // Additional 4 bytes to hold size of thunk
    uint8_t * thunk, * cursor, * returnValue;
-   TR::SymbolReference *dispatcherSymbol;
+   TR::SymbolReference *dispatcherSymbol = NULL;
 
    if (fej9->storeOffsetToArgumentsInVirtualIndirectThunks())
       thunk = (uint8_t *)comp->trMemory()->allocateMemory(codeSize, heapAlloc);
@@ -151,7 +151,7 @@ TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node * callNode, int32_t 
    TR_MHJ2IThunk      *thunk      = TR_MHJ2IThunk::allocate(codeSize, signature, cg, thunkTable);
    uint8_t          *cursor     = thunk->entryPoint();
 
-   TR::SymbolReference *dispatcherSymbol;
+   TR::SymbolReference *dispatcherSymbol = NULL;
    switch (callNode->getDataType())
       {
       case TR::NoType:

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -3120,6 +3120,8 @@ J9::Z::PrivateLinkage::addSpecialRegDepsForBuildArgs(TR::Node * callNode, TR::Re
       case TR::com_ibm_jit_JITHelpers_dispatchVirtual:
          specialArgReg = getVTableIndexArgumentRegister();
          break;
+      default:
+         break;
       }
 
    if (specialArgReg != TR::RealRegister::NoReg)

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -362,8 +362,8 @@ J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
       {
       if (localCursor->getGCMapIndex() >= 0)
          {
-         TR_IGNode *igNode;
-         if (igNode = cg()->getLocalsIG()->getIGNodeForEntity(localCursor))
+         TR_IGNode *igNode = cg()->getLocalsIG()->getIGNodeForEntity(localCursor);
+         if (NULL != igNode)
             {
             IGNodeColour colour = igNode->getColour();
 
@@ -447,8 +447,8 @@ J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
    for (localCursor = automaticIterator.getFirst(); localCursor; localCursor = automaticIterator.getNext())
       if (localCursor->getGCMapIndex() < 0)
          {
-         TR_IGNode *igNode;
-         if (igNode = cg()->getLocalsIG()->getIGNodeForEntity(localCursor))
+         TR_IGNode *igNode = cg()->getLocalsIG()->getIGNodeForEntity(localCursor);
+         if (NULL != igNode)
             {
             IGNodeColour colour = igNode->getColour();
 
@@ -520,8 +520,8 @@ J9::Z::PrivateLinkage::mapCompactedStack(TR::ResolvedMethodSymbol * method)
    for (localCursor = automaticIterator.getFirst(); localCursor; localCursor = automaticIterator.getNext())
       if (localCursor->getGCMapIndex() < 0)
          {
-         TR_IGNode *igNode;
-         if (igNode = cg()->getLocalsIG()->getIGNodeForEntity(localCursor))
+         TR_IGNode *igNode = igNode = cg()->getLocalsIG()->getIGNodeForEntity(localCursor);
+         if (NULL != igNode)
             {
             IGNodeColour colour = igNode->getColour();
 


### PR DESCRIPTION
Suppresses warnings when building on OpenXL

Warnings:
- uninitialized variables
- C++ 11 ISO does not allow conversion from string literal to char *
- unused statements
- assignments inside if clause
- unhandled enums in switch

R29 build: https://hyc-runtimes-jenkins.swg-devops.com/job/jvm.29.personal/34216/