### PR TITLE
(0.46.1) Disable TLH prefetching for portable AOT code

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2176,15 +2176,21 @@ void J9::Options::preProcessTLHPrefetch(J9JavaVM *vm)
 #elif defined(TR_HOST_ARM64)
    preferTLHPrefetch = true;
 #else // TR_HOST_X86
-   preferTLHPrefetch =
-      (TR::Compiler->target.cpu.isGenuineIntel() &&
-       TR::Compiler->target.cpu.isAtMost(OMR_PROCESSOR_X86_INTEL_BROADWELL)) ||
-      !TR::Compiler->target.cpu.isGenuineIntel();
+   preferTLHPrefetch = !TR::Compiler->target.cpu.isGenuineIntel() ||
+       TR::Compiler->target.cpu.isAtMost(OMR_PROCESSOR_X86_INTEL_BROADWELL);
 
    // Disable TM on x86 because we cannot tell whether a Haswell chip supports
    // TM or not, plus it's killing the performance on dayTrader3
    self()->setOption(TR_DisableTM);
 #endif
+   // For portable AOT code we want to disable TLH prefetch
+   if (preferTLHPrefetch &&
+       J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE) &&
+       self() == TR::Options::getAOTCmdLineOptions()
+      )
+      {
+      preferTLHPrefetch = false;
+      }
 
    IDATA notlhPrefetch = FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XnotlhPrefetch], 0);
    IDATA tlhPrefetch = FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XtlhPrefetch], 0);

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -938,7 +938,7 @@ TR_RelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
    if (TR::Options::getCmdLineOptions()->getOption(TR_DisableTraps))
       featureFlags |= TR_FeatureFlag_DisableTraps;
 
-   if (TR::Options::getCmdLineOptions()->getOption(TR_TLHPrefetch))
+   if (TR::Options::getAOTCmdLineOptions()->getOption(TR_TLHPrefetch))
       featureFlags |= TR_FeatureFlag_TLHPrefetch;
 
    if (TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines())


### PR DESCRIPTION
Current code for x86 disables TLH prefething globally for Intel CPUs newer than Broadwell architecture and enables it globally for Broadwell or older CPUs.
If a container image is generated on a newer architecture, then TLH prefetch will be off and this information is written into the AOT header for the shared class cache embedded in the container. If that container image is run on an older architecture, the JVM will set TLH prefetch off, and the AOT compatibility check will fail, rendering the embedded AOT code useless.

This commit disables TLH prefething for portable AOT code.