### PR TITLE
(0.47.0) Disable TLH prefetching for portable AOT code

### DIFF
--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -938,7 +938,7 @@ TR_RelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
    if (TR::Options::getCmdLineOptions()->getOption(TR_DisableTraps))
       featureFlags |= TR_FeatureFlag_DisableTraps;
 
-   if (TR::Options::getCmdLineOptions()->getOption(TR_TLHPrefetch))
+   if (TR::Options::getAOTCmdLineOptions()->getOption(TR_TLHPrefetch))
       featureFlags |= TR_FeatureFlag_TLHPrefetch;
 
    if (TR::CodeCacheManager::instance()->codeCacheConfig().needsMethodTrampolines())


### PR DESCRIPTION
Current code for x86 disables TLH prefething globally for Intel CPUs newer than Broadwell architecture and enables it globally for Broadwell or older CPUs.
If a container image is generated on a newer architecture, then TLH prefetch will be off and this information is written into the AOT header for the shared class cache embedded in the container. If that container image is run on an older architecture, the JVM will set TLH prefetch off, and the AOT compatibility check will fail, rendering the embedded AOT code useless.

This commit disables TLH prefething for portable AOT code.