### PR TITLE
Fix JDK11 Windows compilation error

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -4085,9 +4085,9 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 			char *errMsg = errBuf;
 			int bufSize = sizeof(errBuf);
 			const char *portMsg =
-#if defined(WIN32)
+#if defined(WIN32) && (JAVA_SPEC_VERSION >= 17)
 				!attemptedLoad ? "" :
-#endif /* defined(WIN32) */
+#endif /* defined(WIN32) && (JAVA_SPEC_VERSION >= 17) */
 				j9error_last_error_message();
 			const char *space = ('\0' == *portMsg) ? "" : " ";
 			bufSize = jio_snprintf(errMsg, bufSize, "Failed to load library (\"%s\")%s%s", libName, space, portMsg);


### PR DESCRIPTION
Fix JDK11 Windows compilation error

```
01:10:58.774  c:\workspace\openjdk-build\workspace\build\src\openj9\runtime\j9vm\jvm.c(4089): error C2065: 'attemptedLoad': undeclared identifier
01:10:58.774  make[6]: *** [runtime/j9vm/CMakeFiles/jvm.dir/build.make:176: runtime/j9vm/CMakeFiles/jvm.dir/jvm.c.obj] Error 2
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>