### PR TITLE
JDK24 requires new JavaLangAccess.ensureNativeAccess()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -496,18 +496,24 @@ final class Access implements JavaLangAccess {
 		return String.join(prefix, suffix, delimiter, elements, size);
 	}
 
-/*[IF JAVA_SPEC_VERSION >= 20]*/
+/*[IF JAVA_SPEC_VERSION >= 24]*/
 	@Override
-/*[IF JAVA_SPEC_VERSION >= 22]*/
-	public void ensureNativeAccess(Module mod, Class<?> clsOwner, String methodName, Class<?> clsCaller) {
-		mod.ensureNativeAccess(clsOwner, methodName, clsCaller);
+	public void ensureNativeAccess(Module module, Class<?> ownerClass, String methodName, Class<?> callerClass, boolean isJNI) {
+		module.ensureNativeAccess(ownerClass, methodName, callerClass, isJNI);
 	}
-/*[ELSE] JAVA_SPEC_VERSION >= 22 */
-	public void ensureNativeAccess(Module mod, Class<?> clsOwner, String methodName) {
-		mod.ensureNativeAccess(clsOwner, methodName);
+/*[ELSEIF JAVA_SPEC_VERSION >= 22]*/
+	@Override
+	public void ensureNativeAccess(Module module, Class<?> ownerClass, String methodName, Class<?> callerClass) {
+		module.ensureNativeAccess(ownerClass, methodName, callerClass);
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
+/*[ELSEIF JAVA_SPEC_VERSION >= 20]*/
+	@Override
+	public void ensureNativeAccess(Module module, Class<?> ownerClass, String methodName) {
+		module.ensureNativeAccess(ownerClass, methodName);
+	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
+/*[IF JAVA_SPEC_VERSION >= 20]*/
 	public void addEnableNativeAccessToAllUnnamed() {
 		Module.implAddEnableNativeAccessToAllUnnamed();
 	}

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -65,6 +65,10 @@ import java.lang.reflect.Field;
 import jdk.internal.util.SystemProps;
 /*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+import java.net.URL;
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+
 /**
  * Class System provides a standard place for programs
  * to find system related information. All System API
@@ -568,6 +572,13 @@ static void initGPUAssist() {
 	GPUAssistHolder.instance = AccessController.doPrivileged(finder);
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
+
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+static URL codeSource(Class<?> callerClass) {
+	CodeSource codeSource = callerClass.getProtectionDomainInternal().getCodeSource();
+	return (codeSource == null) ? null : codeSource.getLocation();
+}
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 /**
  * Sets the value of the static slot "in" in the receiver


### PR DESCRIPTION
JDK24 requires new `JavaLangAccess.ensureNativeAccess()`

Also requires `System.codeSource(Class<?> callerClz)`.

This resolves JDK next abuild compilation failures:
```
00:43:02  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/src/java.base/share/classes/java/lang/Module.java:314: error: cannot find symbol
00:43:02                  URL url = System.codeSource(currentClass);

00:43:02  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:70: error: Access is not abstract and does not override abstract method ensureNativeAccess(Module,Class<?>,String,Class<?>,boolean) in JavaLangAccess
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>