### PR TITLE
Fix calculareOffsetFromIndex for OffHeap

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -2188,7 +2188,17 @@ TR::Node * J9::TransformUtil::calculateOffsetFromIndexInContiguousArrayWithEleme
       shift = checkNonNegativePowerOfTwo(elementStride);
       }
 
-   int32_t headerSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
+   int32_t headerSize;
+#if defined(J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION)
+   if (TR::Compiler->om.isOffHeapAllocationEnabled())
+      {
+      headerSize = 0;
+      }
+   else
+#endif /* J9VM_GC_ENABLE_SPARSE_HEAP_ALLOCATION */
+      {
+      headerSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
+      }
 
    TR::Node * offset = index;
 


### PR DESCRIPTION
UnsafeFastPath generates the wrong tree when inlining the `JITHelpers.getByteFromArrayByIndex()` call in `String.hashCodeImplCompressed()` as it uses `calculateOffsetFromIndexInContiguousArray()` which adds the header-size to the trees [1]. This fix prevent inserting the header-size addition if OffHeap is in use.

[1]
Before
```
n25n        aload  java/lang/String.helpers Lcom/ibm/jit/JITHelpers;[#409  notAccessed final Static] (obj1) [flags 0xa0307 0x0 ]  [    0x70ed200b5040] bci=[-1,22,3136] rc=3 vc=4 vn=- li=- udi=- nc=0
n29n        icall  com/ibm/jit/JITHelpers.getByteFromArrayByIndex(Ljava/lang/Object;I)B[#413  final virtual Method -512] [flags 0x20500 0x0 ] ()  [    0x7c78f8765180] bci=[-1,31,3136] rc=2 vc=0 vn=- li>
n26n          aload  java/lang/String.helpers Lcom/ibm/jit/JITHelpers;[#409  final Static] (obj1) [flags 0xa0307 0x0 ]  [    0x7c78f8765090] bci=[-1,25,3136] rc=1 vc=0 vn=- li=- udi=- nc=0
n27n          aload  value<parm 0 [B>[#403  Parm] [flags 0x40000107 0x0 ]                     [    0x7c78f87650e0] bci=[-1,28,3136] rc=1 vc=0 vn=- li=- udi=- nc=0
n28n          iload  i<auto slot 5>[#408  Auto] [flags 0x3 0x0 ]                              [    0x7c78f8765130] bci=[-1,29,3136] rc=1 vc=0 vn=- li=- udi=- nc=0 vn=- li=- udi=- nc=1
n32n        icall  com/ibm/jit/JITHelpers.byteToCharUnsigned(B)C[#416  final virtual Method -488] [flags 0x20500 0x0 ]  [    0x7c78f8765270] bci=[-1,34,3136] rc=2 vc=0 vn=- li=- udi=- nc=2
n25n          ==>aload
n29n          ==>icall
```

```
n77n      treetop                                                                             [    0x7c78f87e07d0] bci=[-1,31,3136] rc=0 vc=0 vn=- li=- udi=- nc=1
n29n        b2i                                                                               [    0x7c78f8765180] bci=[-1,31,3136] rc=3 vc=0 vn=- li=- udi=- nc=1
n76n          bloadi  <unsafe shadow sym>[#417  Shadow] [flags 0x80000601 0x100 ]             [    0x7c78f87e0780] bci=[-1,31,3136] rc=1 vc=0 vn=- li=- udi=- nc=1
n75n            aladd (internalPtr )                                                          [    0x7c78f87e0730] bci=[-1,28,3136] rc=1 vc=0 vn=- li=- udi=- nc=2 flg=0x8000
n74n              aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x7c78f87e06e0] bci=[-1,28,3136] rc=1 vc=0 vn=- li=- udi=- nc=1 flg=0x8000
n27n                ==>aload
n73n              ladd                                                                        [    0x7c78f87e0690] bci=[-1,29,3136] rc=1 vc=0 vn=- li=- udi=- nc=2
n71n                lmul                                                                      [    0x7c78f87e05f0] bci=[-1,29,3136] rc=1 vc=0 vn=- li=- udi=- nc=2
n69n                  i2l                                                                     [    0x7c78f87e0550] bci=[-1,29,3136] rc=1 vc=0 vn=- li=- udi=- nc=1
n28n                    ==>iload
n70n                  lconst 1 (highWordZero X!=0 X>=0 )                                      [    0x7c78f87e05a0] bci=[-1,0,3133] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x4104
n72n                lconst 16 (highWordZero X!=0 X>=0 )                                       [    0x7c78f87e0640] bci=[-1,0,3133] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x4104
```

After fix
```
n101n     treetop                                                                             [    0x70ed20150f50] bci=[-1,31,3136] rc=0 vc=0 vn=- li=- udi=- nc=1
n29n        b2i                                                                               [    0x70ed200b5180] bci=[-1,31,3136] rc=4 vc=4 vn=- li=- udi=- nc=1
n100n         bloadi  <unsafe shadow sym>[#422  Shadow] [flags 0x80000601 0x100 ]             [    0x70ed20150f00] bci=[-1,31,3136] rc=1 vc=0 vn=- li=- udi=- nc=1
n99n            aladd (internalPtr )                                                          [    0x70ed20150eb0] bci=[-1,28,3136] rc=1 vc=0 vn=- li=- udi=- nc=2 flg=0x8000
n98n              aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x70ed20150e60] bci=[-1,28,3136] rc=1 vc=0 vn=- li=- udi=- nc=1 flg=0x8000
n27n                ==>aload
n97n              lmul                                                                        [    0x70ed20150e10] bci=[-1,29,3136] rc=1 vc=0 vn=- li=- udi=- nc=2
n95n                i2l                                                                       [    0x70ed20150d70] bci=[-1,29,3136] rc=1 vc=0 vn=- li=- udi=- nc=1
n28n                  ==>iload
n96n                lconst 1 (highWordZero X!=0 X>=0 )                                        [    0x70ed20150dc0] bci=[-1,0,3133] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x4104
```