### PR TITLE
Tag jar/keystore files as binary

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -21,6 +21,9 @@
 # Binary files
 *.blob binary
 *.gif binary
+*.jar binary
 *.jpg binary
 *.png binary
 *.zip binary
+test/functional/cmdLineTests/URLClassLoaderTests/SignedSealed/benKeyStore binary
+test/functional/cmdLineTests/URLClassLoaderTests/SignedSealed/benKeyStore.forMVS binary


### PR DESCRIPTION
This PR fixes functional compilation issues seen due to improper tagging of jar/war/keystore files on JDK21. Hence tagging these extension files as binary.

Verification : Grinder_CR/22174