### PR TITLE
Correct "null restricted" to null-restricted

### DIFF
--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -129,7 +129,7 @@ public:
     *    the criteria that NO field is of
     *    - type double (D) or float (F)
     *    - nullable-class/interface type
-    *    - null restricted class type that are not both flattened and recursively
+    *    - null-restricted class type that are not both flattened and recursively
     *      compatible for direct memory comparison
     *
     *  \param clazz

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -68,7 +68,7 @@ public:
    bool areValueTypesEnabled();
 
    /**
-    * @brief Whether or not flattenable value object (aka null restricted) type is enabled
+    * @brief Whether or not flattenable value object (aka null-restricted) type is enabled
     */
    bool areFlattenableValueTypesEnabled();
 

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1273,7 +1273,7 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                      flagsForTransform.set(ValueTypesHelperCallTransform::RequiresStoreCheck);
                      }
 
-                   // If the value being stored is NULL and the destination array component is null restricted in runtime,
+                   // If the value being stored is NULL and the destination array component is null-restricted at runtime,
                    // a NPE is expected to throw. Therefore, when the array component type is not known to be identity type
                    // in compilation time, a NULLCHK on store value is required
                    if ((isCompTypePrimVT != TR_no) &&
@@ -2971,7 +2971,7 @@ TR_YesNoMaybe
 J9::ValuePropagation::isArrayCompTypePrimitiveValueType(TR::VPConstraint *arrayConstraint)
    {
    if (!TR::Compiler->om.areValueTypesEnabled() ||
-       !TR::Compiler->om.areFlattenableValueTypesEnabled()) // Only null restricted or primitive value type are flattenable
+       !TR::Compiler->om.areFlattenableValueTypesEnabled()) // Only null-restricted or primitive value type are flattenable
       {
       return TR_no;
       }

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2709,11 +2709,11 @@ BOOLEAN
 valueTypeCapableAcmp(J9VMThread *currentThread, j9object_t lhs, j9object_t rhs);
 
 /**
- * Determines if null restricted attribute is set on a field or not.
+ * Determines if null-restricted attribute is set on a field or not.
  *
  * @param[in] field The field to be checked
  *
- * @return TRUE if the field has null restricted attribute set, FALSE otherwise
+ * @return TRUE if the field has null-restricted attribute set, FALSE otherwise
  */
 BOOLEAN
 isFieldNullRestricted(J9ROMFieldShape *field);
@@ -2817,7 +2817,7 @@ getFlattenableFieldOffset(J9Class *fieldOwner, J9ROMFieldShape *field);
 
 /**
  * Returns if a field is flattened. `J9_IS_J9CLASS_FLATTENED` will be deprecated.
- * This helper assumes field is null restricted.
+ * This helper assumes field is null-restricted.
  *
  * @param[in] fieldOwner the J9class that defines the field
  * @param[in] field romfieldshape of the field
@@ -2829,7 +2829,7 @@ isFlattenableFieldFlattened(J9Class *fieldOwner, J9ROMFieldShape *field);
 
 /**
  * Returns the type of an instance field. `J9_IS_J9CLASS_FLATTENED` will be deprecated.
- * This helper assumes field is null restricted.
+ * This helper assumes field is null-restricted.
  *
  * @param[in] fieldOwner the J9class that defines the field
  * @param[in] field romfieldshape of the field
@@ -2841,7 +2841,7 @@ getFlattenableFieldType(J9Class *fieldOwner, J9ROMFieldShape *field);
 
 /**
  * Returns the size of an instance field. `J9_VALUETYPE_FLATTENED_SIZE` will be deprecated.
- * This helper assumes field is null restricted.
+ * This helper assumes field is null-restricted.
  *
  * @param[in] currentThread thread token
  * @param[in] fieldOwner the J9class that defines the field
@@ -2865,7 +2865,7 @@ arrayElementSize(J9ArrayClass* arrayClass);
 
 /**
  * Performs a getfield operation on an object. Handles flattened and non-flattened cases.
- * This helper assumes that the cpIndex points to a resolved null restricted fieldRef. This helper
+ * This helper assumes that the cpIndex points to a resolved null-restricted fieldRef. This helper
  * also assumes that the cpIndex points to an instance field.
  *
  * @param currentThread thread token
@@ -2895,7 +2895,7 @@ cloneValueType(J9VMThread *currentThread, J9Class *receiverClass, j9object_t ori
 
 /**
  * Performs a putfield operation on an object. Handles flattened and non-flattened cases.
- * This helper assumes that the cpIndex points to a resolved null restricted fieldRef. This helper
+ * This helper assumes that the cpIndex points to a resolved null-restricted fieldRef. This helper
  * also assumes that the cpIndex points to an instance field.
  *
  * @param currentThread thread token

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8591,9 +8591,9 @@ retry:
 			}
 		}
 
-		/* In the future Valhalla checkcast needs to throw exception on
-		 * null restricted checkedType if obj is null,
-		 * see issue https://github.com/eclipse-openj9/openj9/issues/19764
+		/* In the future, Valhalla checkcast must throw an exception on
+		 * null-restricted checkedType if object is null.
+		 * See issue https://github.com/eclipse-openj9/openj9/issues/19764.
 		 */
 
 		_pc += 3;

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -190,11 +190,11 @@ public:
 	}
 
 	/**
-	 * Determines if null restricted attribute is set on a field or not.
+	 * Determines if null-restricted attribute is set on a field or not.
 	 *
 	 * @param[in] field The field to be checked
 	 *
-	 * @return TRUE if the field has null restricted attribute set, FALSE otherwise
+	 * @return TRUE if the field has null-restricted attribute set, FALSE otherwise
 	 */
 	static VMINLINE bool
 	isFieldNullRestricted(J9ROMFieldShape *field)

--- a/test/functional/Valhalla/src_lw5/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
+++ b/test/functional/Valhalla/src_lw5/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
@@ -172,8 +172,8 @@ public class NullRestrictedTypeOptTests {
 		}
 	}
 
-	/* A value class with an implicit constructor (eligible to be null restricted)
-	 * with null restricted value class fields.
+	/* A value class with an implicit constructor (eligible to be null-restricted)
+	 * with null-restricted value class fields.
 	 */
 	public value static class NestedFlattenablePair {
 		public final FlattenablePair! p1;

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -193,7 +193,7 @@ public class ValueTypeTests {
 
 	/* fields */
 	static String typeWithSingleAlignmentFields[] = {
-		"tri:LTriangle2D;:NR", /* NR means null restricted */
+		"tri:LTriangle2D;:NR", /* NR means null-restricted */
 		"point:LPoint2D;:NR",
 		"line:LFlattenedLine2D;:NR",
 		"i:LValueInt;:NR",
@@ -1817,7 +1817,7 @@ public class ValueTypeTests {
 	 * Create a value type and read the fields before
 	 * they are set. The test should Verify that the
 	 * flattenable fields are set to the default values.
-	 * NULL should never be observed for null restricted fields.
+	 * NULL should never be observed for null-restricted fields.
 	 */
 	@Test(priority=4)
 	static public void testDefaultValues() throws Throwable {
@@ -2275,7 +2275,7 @@ public class ValueTypeTests {
 	 * Ensure that casting null to a value type class will throw a null pointer exception
 	 * This test is disabled since the latest spec from
 	 * https://cr.openjdk.org/~dlsmith/jep401/jep401-20230519/specs/types-cleanup-jvms.html
-	 * no longer requires null check on the objectref for null restricted value type class
+	 * no longer requires null check on the objectref for null-restricted value type class
 	 */
 	@Test(enabled=false, priority=1, expectedExceptions=NullPointerException.class)
 	static public void testCheckCastNullRestrictedTypeOnNull() throws Throwable {


### PR DESCRIPTION
Corrects all cases of "null restricted" that are not fixed in https://github.com/eclipse-openj9/openj9/pull/19911