### PR TITLE
J9ClassHasIdentity should not be set for interfaces

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -323,6 +323,8 @@ static const struct { \
 #define J9_CLASS_DISALLOWS_LOCKING_FLAGS (J9ClassIsValueType | J9ClassIsValueBased)
 #define J9_CLASS_ALLOWS_LOCKING(clazz) J9_ARE_NO_BITS_SET((clazz)->classFlags, J9_CLASS_DISALLOWS_LOCKING_FLAGS)
 #define J9_IS_J9CLASS_VALUEBASED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsValueBased)
+/* Identity classes are not value types or interfaces. */
+#define J9_IS_J9CLASS_IDENTITY(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassHasIdentity)
 #ifdef J9VM_OPT_VALHALLA_VALUE_TYPES
 #define J9_IS_J9CLASS_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsValueType)
 #else /* J9VM_OPT_VALHALLA_VALUE_TYPES */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2925,8 +2925,7 @@ done:
 	inlClassIsIdentity(REGISTER_ARGS_LIST)
 	{
 		J9Class *receiverClazz = J9VM_J9CLASS_FROM_HEAPCLASS(_currentThread, *(j9object_t*)_sp);
-		bool isValue = J9ROMCLASS_IS_VALUE(receiverClazz->romClass);
-		returnSingleFromINL(REGISTER_ARGS, (isValue ? 0 : 1), 1);
+		returnSingleFromINL(REGISTER_ARGS, J9_IS_J9CLASS_IDENTITY(receiverClazz), 1);
 		return EXECUTE_BYTECODE;
 	}
 

--- a/runtime/vm/FastJNI_java_lang_Class.cpp
+++ b/runtime/vm/FastJNI_java_lang_Class.cpp
@@ -137,8 +137,7 @@ jboolean JNICALL
 Fast_java_lang_Class_isIdentity(J9VMThread *currentThread, j9object_t classObject)
 {
 	J9Class *receiverClazz = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, classObject);
-	bool isValue = J9ROMCLASS_IS_VALUE(receiverClazz->romClass);
-	return isValue ? JNI_FALSE : JNI_TRUE;
+	return J9_IS_J9CLASS_IDENTITY(receiverClazz) ? JNI_TRUE : JNI_FALSE;
 }
 
 /* java.lang.Class: private native int getClassFileVersion0(); */

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2300,7 +2300,7 @@ nativeOOM:
 			classFlags |= J9ClassIsValueType;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 			/* superclass can be NULL if primitive classes are changed to value typess in the future. */
-			if ((NULL != superclass) && J9_ARE_ALL_BITS_SET(superclass->classFlags, J9ClassHasIdentity)) {
+			if ((NULL != superclass) && J9_IS_J9CLASS_IDENTITY(superclass)) {
 				J9UTF8 *superclassName = J9ROMCLASS_SUPERCLASSNAME(romClass);
 				if (!J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(superclassName), J9UTF8_LENGTH(superclassName), "java/lang/Object")) {
 					J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
@@ -2332,7 +2332,8 @@ nativeOOM:
 			}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
-		} else {
+		} else if (!(J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass) && J9ROMCLASS_IS_INTERFACE(romClass))) {
+			/* All classes before value type version are identity. */
 			classFlags |= J9ClassHasIdentity;
 		}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -2820,6 +2820,7 @@ public class ValueTypeTests {
 	@Test(priority=1)
 	static public void testIsValueClassOnInterface() throws Throwable {
 		assertFalse(TestInterface.class.isValue());
+		assertFalse(TestInterface.class.isIdentity());
 	}
 
 	private interface TestInterface {


### PR DESCRIPTION
- Don't set J9ClassHasIdentity for interfaces
- Update Object.isIdentity to match ri

Discussed with @a7ehuo and we decided the clearest meaning for J9ClassHasIdentity is to exclude interfaces fyi @hangshao0 