### PR TITLE
Remove unused cpIndex parameter of vTableSlot(), virtualCallSelector()

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1771,7 +1771,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                case TR_ResolvedMethodType::VirtualFromCP:
                   {
                   resolvedMethod = static_cast<TR_ResolvedJ9Method *>(owningMethod->getResolvedPossiblyPrivateVirtualMethod(comp, cpIndex, true, &unresolvedInCP));
-                  vTableOffset = resolvedMethod ? resolvedMethod->vTableSlot(cpIndex) : 0;
+                  vTableOffset = resolvedMethod ? resolvedMethod->vTableSlot() : 0;
                   break;
                   }
                case TR_ResolvedMethodType::Static:
@@ -1787,7 +1787,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                case TR_ResolvedMethodType::ImproperInterface:
                   {
                   resolvedMethod = static_cast<TR_ResolvedJ9Method *>(owningMethod->getResolvedImproperInterfaceMethod(comp, cpIndex));
-                  vTableOffset = resolvedMethod ? resolvedMethod->vTableSlot(cpIndex) : 0;
+                  vTableOffset = resolvedMethod ? resolvedMethod->vTableSlot() : 0;
                   break;
                   }
                default:

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1024,15 +1024,6 @@ TR_ResolvedRelocatableJ9Method::TR_ResolvedRelocatableJ9Method(TR_OpaqueMethodBl
          setRecognizedMethod(TR::unknownMethod);
          }
       }
-
-
-   }
-
-int32_t
-TR_ResolvedRelocatableJ9Method::virtualCallSelector(U_32 cpIndex)
-   {
-   return TR_ResolvedJ9Method::virtualCallSelector(cpIndex);
-   //return -1;
    }
 
 bool
@@ -5487,9 +5478,9 @@ TR_ResolvedJ9Method::getExistingJittedBodyInfo()
    }
 
 int32_t
-TR_ResolvedJ9Method::virtualCallSelector(U_32 cpIndex)
+TR_ResolvedJ9Method::virtualCallSelector()
    {
-   return -(int32_t)(vTableSlot(cpIndex) - TR::Compiler->vm.getInterpreterVTableOffset());
+   return -(int32_t)(vTableSlot() - TR::Compiler->vm.getInterpreterVTableOffset());
    }
 
 bool
@@ -6487,10 +6478,8 @@ TR_ResolvedJ9Method::startAddressForJNIMethod(TR::Compilation * comp)
    }
 
 U_32
-TR_ResolvedJ9Method::vTableSlot(U_32 cpIndex)
+TR_ResolvedJ9Method::vTableSlot()
    {
-   TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
-   //UDATA vTableSlot = ((J9RAMVirtualMethodRef *)literals())[cpIndex].methodIndexAndArgCount >> 8;
    return _vTableSlot;
    }
 

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -441,7 +441,7 @@ public:
    virtual uint32_t                classCPIndexOfMethod(uint32_t methodCPIndex);
    virtual void * &                addressOfClassOfMethod();
 
-   virtual uint32_t                vTableSlot(uint32_t);
+   virtual uint32_t                vTableSlot();
 
    virtual bool                    isCompilable(TR_Memory *);
 
@@ -474,7 +474,7 @@ public:
    virtual bool                    virtualMethodIsOverridden();
    virtual void                    setVirtualMethodIsOverridden();
    virtual void *                  addressContainingIsOverriddenBit();
-   virtual int32_t                 virtualCallSelector(uint32_t cpIndex);
+   virtual int32_t                 virtualCallSelector();
 
    virtual int32_t                 exceptionData(int32_t exceptionNumber, int32_t * startIndex, int32_t * endIndex, int32_t * catchType);
    virtual uint32_t                numberOfExceptionHandlers();
@@ -611,7 +611,6 @@ public:
 
    virtual TR_OpaqueClassBlock * definingClassFromCPFieldRef(TR::Compilation *comp, int32_t cpIndex, bool isStatic, TR_OpaqueClassBlock** fromResolvedJ9Method = NULL);
 
-   virtual int32_t                 virtualCallSelector(uint32_t cpIndex);
    virtual char *                  fieldSignatureChars(int32_t cpIndex, int32_t & len);
    virtual char *                  staticSignatureChars(int32_t cpIndex, int32_t & len);
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1591,7 +1591,7 @@ InterpreterEmulator::visitInvokevirtual()
          {
          TR_J9MutableCallSite *inlinerMcs = new (comp()->trHeapMemory()) TR_J9MutableCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
                                                       callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
-                                                      (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex, _currentCallMethod,
+                                                      -1, cpIndex, _currentCallMethod,
                                                       resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                       _recursionDepth, allconsts);
          if (_currentCallMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeBasic)
@@ -1621,7 +1621,7 @@ InterpreterEmulator::visitInvokevirtual()
          {
          callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(_calltarget->_calleeMethod, callNodeTreeTop, parent,
                                                                         callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
-                                                                        (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex, _currentCallMethod,
+                                                                        (int32_t) _currentCallMethod->virtualCallSelector(), cpIndex, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                                                                         _recursionDepth, allconsts);
 
@@ -1736,7 +1736,7 @@ InterpreterEmulator::visitInvokestatic()
          {
          TR_J9MutableCallSite *mcs = new (comp()->trHeapMemory()) TR_J9MutableCallSite( _calltarget->_calleeMethod, callNodeTreeTop,   parent,
                callNode, interfaceMethod, receiverClass,
-               (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex, _currentCallMethod,
+               -1, cpIndex, _currentCallMethod,
                resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
                _recursionDepth, allconsts);
          if (mcsIndex != TR::KnownObjectTable::UNKNOWN)
@@ -1751,7 +1751,7 @@ InterpreterEmulator::visitInvokestatic()
          int32_t noCPIndex = -1; // The method is not referenced via the constant pool
          callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(
                _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
-               interfaceMethod, receiverClass, (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), noCPIndex,
+               interfaceMethod, receiverClass, (int32_t) _currentCallMethod->virtualCallSelector(), noCPIndex,
                _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
                *_newBCInfo, comp(), _recursionDepth, allconsts);
          }
@@ -1817,7 +1817,7 @@ InterpreterEmulator::visitInvokeinterface()
       {
       callsite = new (comp()->trHeapMemory()) TR_J9VirtualCallSite(
          _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
-         interfaceMethod, _currentCallMethod->classOfMethod(), (int32_t) _currentCallMethod->virtualCallSelector(cpIndex), cpIndex,
+         interfaceMethod, _currentCallMethod->classOfMethod(), (int32_t) _currentCallMethod->virtualCallSelector(), cpIndex,
          _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
          *_newBCInfo, comp(), _recursionDepth, allconsts);
       }


### PR DESCRIPTION
...in `TR_ResolvedMethod`.

Additionally:

- Delete commented code in `vTableSlot()`.

- Remove `TR_ResolvedRelocatableJ9Method::virtualCallSelector()`. This override just forwarded to the base implementation.

- Stop using `virtualCallSelector()` to determine the vtable slot to pass to the constructor when instantiating `TR_J9MutableCallSite`. Instead just pass -1 like we do for other call sites that don't use the slot.