### PR TITLE
Set TR_ResolvedMethod vtable slot to zero for private invokevirtual

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6860,6 +6860,14 @@ TR_ResolvedJ9Method::getResolvedPossiblyPrivateVirtualMethod(TR::Compilation * c
          TR_AOTInliningStats *aotStats = NULL;
          if (comp->getOption(TR_EnableAOTStats))
             aotStats = & (((TR_JitPrivateConfig *)_fe->_jitConfig->privateConfig)->aotStats->virtualMethods);
+
+         if (isInvokePrivateVTableOffset(vTableOffset))
+            {
+            // This method is private and therefore not in the vtable, so pass
+            // zero as the vtable slot when creating the TR_ResolvedMethod.
+            vTableOffset = 0;
+            }
+
          if (createResolvedMethod)
             resolvedMethod = createResolvedMethodFromJ9Method(comp, cpIndex, vTableOffset, ramMethod, unresolvedInCP, aotStats);
          }


### PR DESCRIPTION
...for consistency with other private methods and generally other methods that don't appear in the vtable. Previously the vtable slot would have been `J9VTABLE_INVOKE_PRIVATE_OFFSET`.