### PR TITLE
Wait up to 1 minute in JITServer test

### DIFF
--- a/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
@@ -334,7 +334,7 @@ public class JITServerTest {
 		p.destroy();
 
 		int waitCount = 0;
-		while (!p.waitFor(PROCESS_DESTROY_WAIT_TIME_MS, TimeUnit.MILLISECONDS) && (waitCount < 6)) {
+		while (!p.waitFor(PROCESS_DESTROY_WAIT_TIME_MS, TimeUnit.MILLISECONDS) && (waitCount < 12)) {
 			waitCount++;
 		}
 


### PR DESCRIPTION
Part of the teardown process in the JITServer tests involves waiting for the server and client to shut down in an orderly fashion. Occasionally this can (legitimately) take longer than 30s for the client, the previous maximum. This causes the test to forcibly destroy the process and mark the test as having failed. We now wait for up to one minute for these processes to finish.