### PR TITLE
JDK24 adds JVM_IsStaticallyLinked(void)

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -463,6 +463,7 @@ endif()
 if(NOT JAVA_SPEC_VERSION LESS 24)
 	jvm_add_exports(jvm
 		JVM_IsContainerized
+		JVM_IsStaticallyLinked
 	)
 endif()
 

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -476,5 +476,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<exports group="jdk24">
 		<!-- Additions for Java 24 (General) -->
 		<export name="JVM_IsContainerized"/>
+		<export name="JVM_IsStaticallyLinked"/>
 	</exports>
 </exportlists>

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -829,6 +829,18 @@ JVM_IsContainerized(void)
 
 	return isContainerized;
 }
+
+/**
+ * @brief Determine if the JVM is statically linked, always returns JNI_FALSE.
+ *
+ * @return JNI_FALSE
+ */
+JNIEXPORT jboolean JNICALL
+JVM_IsStaticallyLinked(void)
+{
+	/* OpenJDK removed static builds using --enable-static-build. */
+	return JNI_FALSE;
+}
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
 } /* extern "C" */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -444,3 +444,5 @@ _IF([JAVA_SPEC_VERSION >= 23],
 	[_X(JVM_GetCDSConfigStatus, JNICALL, false, jint, void)])
 _IF([JAVA_SPEC_VERSION >= 24],
 	[_X(JVM_IsContainerized, JNICALL, false, jboolean, void)])
+_IF([JAVA_SPEC_VERSION >= 24],
+	[_X(JVM_IsStaticallyLinked, JNICALL, false, jboolean, void)])


### PR DESCRIPTION
JDK24 adds `JVM_IsStaticallyLinked(void)`

Support [[JDK-8333301] Remove static builds using --enable-static-build](https://bugs.openjdk.org/browse/JDK-8333301?page=com.atlassian.jira.plugin.system.issuetabpanels%3Aworklog-tabpanel)

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/836

Signed-off-by: Jason Feng <fengj@ca.ibm.com>