### PR TITLE
Update to openssl 3.0.15

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -138,7 +138,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.0.14+CVEs1'
+  extra_getsource_options: '-openssl-branch=openssl-3.0.15'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
To include fix for CVE-2024-6119.
See https://github.com/openssl/openssl/blob/openssl-3.0/CHANGES.md#changes-between-3014-and-3015-3-sep-2024.