### PR TITLE
(4.7.0) Ensure that J9JITGPRSpillArea is available

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/AuxFieldInfo29.dat
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/AuxFieldInfo29.dat
@@ -214,6 +214,7 @@ J9JITFrame.returnPC = required
 J9JITHashTable.buckets = required
 J9JITHashTable.end = required
 J9JITHashTable.start = required
+J9JITGPRSpillArea.unused = void*
 J9JITStackAtlas.internalPointerMap = required
 J9JITStackAtlas.localBaseOffset = required
 J9JITStackAtlas.numberOfMapBytes = required


### PR DESCRIPTION
Cherry-pick https://github.com/eclipse-openj9/openj9/pull/20097 for the 0.47.0 release.