### PR TITLE
(0.46.1) Update to openssl 3.0.15

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -133,7 +133,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.0.14+CVEs1'
+  extra_getsource_options: '-openssl-branch=openssl-3.0.15'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Cherry-pick https://github.com/eclipse-openj9/openj9/pull/20098 for the 0.46.1 release.