### PR TITLE
Fix null restricted array related issues for value types

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -483,6 +483,9 @@
    LastVectorMethod = LastVectorIntrinsicMethod,
 
    java_lang_reflect_Array_getLength,
+   jdk_internal_value_ValueClass_newArrayInstance,
+   jdk_internal_value_ValueClass_newNullRestrictedArray,
+   jdk_internal_value_NullRestrictedCheckedType_of,
    java_lang_reflect_Method_invoke,
    java_util_Arrays_fill,
    java_util_Arrays_equals,

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -617,6 +617,12 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getArrayClassFromComponentClass(clazz));
          }
          break;
+      case MessageType::VM_getNullRestrictedArrayClassFromComponentClass:
+         {
+         auto clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
+         client->write(response, fe->getNullRestrictedArrayClassFromComponentClass(clazz));
+         }
+         break;
       case MessageType::VM_matchRAMclassFromROMclass:
          {
          J9ROMClass *clazz = std::get<0>(client->getRecvData<J9ROMClass *>());

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -969,6 +969,7 @@ JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Cl
    classInfoStruct._classNameIdentifyingLoader = std::get<22>(classInfoTuple);
    classInfoStruct._arrayElementSize = std::get<23>(classInfoTuple);
    classInfoStruct._defaultValueSlotAddress = std::get<24>(classInfoTuple);
+   classInfoStruct._nullRestrictedArrayClass = std::get<26>(classInfoTuple);
 
    auto result = clientSessionData->getROMClassMap().insert({ clazz, classInfoStruct });
 
@@ -1031,6 +1032,7 @@ JITServerHelpers::packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, T
    TR_OpaqueClassBlock *hostClass = fe->convertClassPtrToClassOffset(clazz->hostClass);
    TR_OpaqueClassBlock *componentClass = fe->getComponentClassFromArrayClass((TR_OpaqueClassBlock *)clazz);
    TR_OpaqueClassBlock *arrayClass = fe->getArrayClassFromComponentClass((TR_OpaqueClassBlock *)clazz);
+   TR_OpaqueClassBlock *nullRestrictedArrayClass = fe->getNullRestrictedArrayClassFromComponentClass((TR_OpaqueClassBlock *)clazz);
    uintptr_t totalInstanceSize = clazz->totalInstanceSize;
    uintptr_t cp = fe->getConstantPoolFromClass((TR_OpaqueClassBlock *)clazz);
    uintptr_t classFlags = fe->getClassFlagsValue((TR_OpaqueClassBlock *)clazz);
@@ -1082,7 +1084,7 @@ JITServerHelpers::packRemoteROMClassInfo(J9Class *clazz, J9VMThread *vmThread, T
       classHasFinalFields, classDepthAndFlags, classInitialized, byteOffsetToLockword, leafComponentClass,
       classLoader, hostClass, componentClass, arrayClass, totalInstanceSize, clazz->romClass,
       cp, classFlags, classChainOffsetIdentifyingLoader, origROMMethods, classNameIdentifyingLoader, arrayElementSize,
-      defaultValueSlotAddress, romClassHash
+      defaultValueSlotAddress, romClassHash, nullRestrictedArrayClass
    );
    }
 
@@ -1260,6 +1262,9 @@ JITServerHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo,
          break;
       case CLASSINFO_DEFAULT_VALUE_SLOT_ADDRESS:
          *(j9object_t **)data = classInfo._defaultValueSlotAddress;
+         break;
+      case CLASSINFO_NULLRESTRICTED_ARRAY_CLASS :
+         *(TR_OpaqueClassBlock **)data = classInfo._nullRestrictedArrayClass;
          break;
       default:
          TR_ASSERT(false, "Class Info not supported %u\n", dataType);

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -57,6 +57,7 @@ public:
       CLASSINFO_CLASS_CHAIN_OFFSET_IDENTIFYING_LOADER,
       CLASSINFO_ARRAY_ELEMENT_SIZE,
       CLASSINFO_DEFAULT_VALUE_SLOT_ADDRESS,
+      CLASSINFO_NULLRESTRICTED_ARRAY_CLASS,
       };
 
    // NOTE: when adding new elements to this tuple, add them to the end,
@@ -88,7 +89,8 @@ public:
       std::string,                       // 22: _classNameIdentifyingLoader
       int32_t,                           // 23: _arrayElementSize
       j9object_t *,                      // 24: _defaultValueSlotAddress
-      std::string                        // 25: optional hash of packedROMClass
+      std::string,                       // 25: optional hash of packedROMClass
+      TR_OpaqueClassBlock *              // 26: _nullRestrictedArrayClass
       >;
 
    // Packs a ROMClass to be transferred to the server.

--- a/runtime/compiler/env/J9ClassEnv.cpp
+++ b/runtime/compiler/env/J9ClassEnv.cpp
@@ -903,6 +903,29 @@ J9::ClassEnv::isValueBasedOrValueTypeClass(TR_OpaqueClassBlock *clazz)
    }
 
 bool
+J9::ClassEnv::isArrayNullRestricted(TR::Compilation *comp,TR_OpaqueClassBlock *arrayClass)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (auto stream = comp->getStream())
+      {
+      uintptr_t classFlags = 0;
+      JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)arrayClass, TR::compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_FLAGS, (void *)&classFlags);
+#ifdef DEBUG
+      stream->write(JITServer::MessageType::ClassEnv_classFlagsValue, clazz);
+      uintptr_t classFlagsRemote = std::get<0>(stream->read<uintptr_t>());
+      // Check that class flags from remote call is equal to the cached ones
+      classFlags = classFlags & J9ClassArrayIsNullRestricted;
+      classFlagsRemote = classFlagsRemote & J9ClassArrayIsNullRestricted;
+      TR_ASSERT_FATAL(classFlags == classFlagsRemote, "remote call class flags is not equal to cached class flags");
+#endif
+      return J9_ARE_ALL_BITS_SET(classFlags, J9ClassArrayIsNullRestricted);
+      }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+   J9ArrayClass *j9class = reinterpret_cast<J9ArrayClass*>(arrayClass);
+   return J9_IS_J9ARRAYCLASS_NULL_RESTRICTED(j9class);
+   }
+
+bool
 J9::ClassEnv::classHasIdentity(TR_OpaqueClassBlock *clazz)
    {
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/J9ClassEnv.hpp
+++ b/runtime/compiler/env/J9ClassEnv.hpp
@@ -96,6 +96,7 @@ public:
    bool isPrimitiveValueTypeClass(TR_OpaqueClassBlock *);
    bool isValueTypeClassFlattened(TR_OpaqueClassBlock *clazz);
    bool isValueBasedOrValueTypeClass(TR_OpaqueClassBlock *);
+   bool isArrayNullRestricted(TR::Compilation *comp, TR_OpaqueClassBlock *arrayClass);
 
    /** \brief
     *    Returns the size of the flattened array element

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1559,6 +1559,16 @@ public:
 
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);
+   /** \brief
+     *     Retrieves the nullRestrictedArrayClass from the array component class.
+     *
+     *  \param componentClass
+     *     The array component class
+     *
+     *  \return
+     *     A pointer to nullRestrictedArrayClass if it exists, otherwise NULL
+     */
+   virtual TR_OpaqueClassBlock * getNullRestrictedArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);
    virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual int32_t               getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz);
    virtual TR_OpaqueClassBlock * getClassFromSignature(const char * sig, int32_t length, TR_ResolvedMethod *method, bool isVettedForAOT=false);
@@ -1685,6 +1695,16 @@ public:
    virtual bool               isPrimitiveClass(TR_OpaqueClassBlock *clazz);
    virtual TR_OpaqueClassBlock * getComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);
+   /** \brief
+     *     Retrieves the nullRestrictedArrayClass from the array component class.
+     *
+     *  \param componentClass
+     *     The array component class
+     *
+     *  \return
+     *     A pointer to nullRestrictedArrayClass if it exists, otherwise NULL
+     */
+   virtual TR_OpaqueClassBlock * getNullRestrictedArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass);
    virtual TR_OpaqueClassBlock * getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock * arrayClass);
    virtual TR_OpaqueClassBlock * getBaseComponentClass(TR_OpaqueClassBlock * clazz, int32_t & numDims);
    virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -126,6 +126,16 @@ public:
    virtual bool isCloneable(TR_OpaqueClassBlock *clazzPointer) override;
    virtual bool canAllocateInlineClass(TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock * getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;
+   /** \brief
+     *     Retrieves the nullRestrictedArrayClass from the array component class.
+     *
+     *  \param componentClass
+     *     The array component class
+     *
+     *  \return
+     *     A pointer to nullRestrictedArrayClass if it exists, otherwise NULL
+     */
+   virtual TR_OpaqueClassBlock * getNullRestrictedArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;
    virtual J9Class * matchRAMclassFromROMclass(J9ROMClass *clazz, TR::Compilation *comp) override;
    virtual int32_t * getCurrentLocalsMapForDLT(TR::Compilation *comp) override;
    virtual uintptr_t getReferenceFieldAt(uintptr_t objectPointer, uintptr_t offsetFromHeader) override;
@@ -345,6 +355,16 @@ public:
    virtual bool isPrimitiveClass(TR_OpaqueClassBlock *clazzPointer) override;
    virtual TR_OpaqueClassBlock *getComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass) override;
    virtual TR_OpaqueClassBlock *getArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;
+   /** \brief
+     *     Retrieves the nullRestrictedArrayClass from the array component class.
+     *
+     *  \param componentClass
+     *     The array component class
+     *
+     *  \return
+     *     A pointer to nullRestrictedArrayClass if it exists, otherwise NULL
+     */
+   virtual TR_OpaqueClassBlock * getNullRestrictedArrayClassFromComponentClass(TR_OpaqueClassBlock *componentClass) override;
    virtual TR_OpaqueClassBlock *getLeafComponentClassFromArrayClass(TR_OpaqueClassBlock *arrayClass) override;
    virtual TR_OpaqueClassBlock *getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t & numDims) override;
    virtual TR_OpaqueClassBlock *getClassFromNewArrayType(int32_t arrayType) override;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3847,6 +3847,19 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod}
       };
 
+   static X ValueClassMethods[] =
+      {
+      {x(TR::jdk_internal_value_ValueClass_newArrayInstance, "newArrayInstance", "(Ljdk/internal/value/CheckedType;I)[Ljava/lang/Object;")},
+      {x(TR::jdk_internal_value_ValueClass_newNullRestrictedArray, "newNullRestrictedArray", "(Ljava/lang/Class;I)[Ljava/lang/Object;")},
+      {  TR::unknownMethod}
+      };
+
+   static X NullRestrictedCheckedTypeMethods[] =
+      {
+      {x(TR::jdk_internal_value_NullRestrictedCheckedType_of, "of", "(Ljava/lang/Class;)Ljdk/internal/value/NullRestrictedCheckedType;")},
+      {  TR::unknownMethod}
+      };
+
    static X SpreadHandleMethods[] =
       {
       {x(TR::java_lang_invoke_SpreadHandle_numArgsToPassThrough,  "numArgsToPassThrough",   "()I")},
@@ -4183,6 +4196,7 @@ void TR_ResolvedJ9Method::construct()
       { "sun/nio/cs/ISO_8859_1$Decoder", EncodeMethods },
       { "java/io/ByteArrayOutputStream", ByteArrayOutputStreamMethods },
       { "java/lang/ScopedValue$Carrier", ScopedValueMethods },
+      { "jdk/internal/value/ValueClass", ValueClassMethods },
       { 0 }
       };
 
@@ -4311,6 +4325,7 @@ void TR_ResolvedJ9Method::construct()
       {
       { "java/lang/invoke/ConvertHandle$FilterHelpers", ConvertHandleFilterHelpersMethods },
       { "java/lang/invoke/DirectMethodHandle$Accessor", DirectMethodHandleAccessorMethods },
+      { "jdk/internal/value/NullRestrictedCheckedType", NullRestrictedCheckedTypeMethods },
       { 0 }
       };
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 68; // ID: +/QzEedP8cjGovxgYECy
+   static const uint16_t MINOR_NUMBER = 69; // ID: SMN6DXY0b2X1Z76N9825
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -122,6 +122,7 @@ const char *messageNames[] =
    "VM_classInitIsFinished",
    "VM_getClassFromNewArrayType",
    "VM_getArrayClassFromComponentClass",
+   "VM_getNullRestrictedArrayClassFromComponentClass",
    "VM_matchRAMclassFromROMclass",
    "VM_getInt32FieldAt",
    "VM_getInt64FieldAt",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -131,6 +131,7 @@ enum MessageType : uint16_t
    VM_classInitIsFinished,
    VM_getClassFromNewArrayType,
    VM_getArrayClassFromComponentClass,
+   VM_getNullRestrictedArrayClassFromComponentClass,
    VM_matchRAMclassFromROMclass,
    VM_getInt32FieldAt,
    VM_getInt64FieldAt,

--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -76,14 +76,14 @@ class ValuePropagation : public OMR::ValuePropagation
    virtual TR_YesNoMaybe isValue(TR::VPConstraint *constraint, TR_OpaqueClassBlock *& clazz);
 
    /**
-    * Determine whether the component type of an array is, or might be, a primitive value
-    * type.
+    * Determine whether the array is, or might be, null-restricted
+    *
     * \param arrayConstraint The \ref TR::VPConstraint type constraint for the array reference
-    * \returns \c TR_yes if the array's component type is definitely a primitive value type;\n
-    *          \c TR_no if it is definitely not a primitive value type; or\n
+    * \returns \c TR_yes if the array is definitely a null-restricted array;\n
+    *          \c TR_no if it is definitely not a null-restricted array; or\n
     *          \c TR_maybe otherwise.
     */
-   virtual TR_YesNoMaybe isArrayCompTypePrimitiveValueType(TR::VPConstraint *arrayConstraint);
+   virtual TR_YesNoMaybe isArrayNullRestricted(TR::VPConstraint *arrayConstraint);
 
    /**
     * \brief

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -413,6 +413,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _aotCacheClassRecord(NULL),
    _arrayElementSize(0),
    _defaultValueSlotAddress(NULL),
+   _nullRestrictedArrayClass(NULL),
    _classOfStaticCache(decltype(_classOfStaticCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _constantClassPoolCache(decltype(_constantClassPoolCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _fieldAttributesCache(decltype(_fieldAttributesCache)::allocator_type(persistentMemory->_persistentAllocator.get())),

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -203,6 +203,7 @@ public:
       TR_OpaqueClassBlock *_hostClass;
       TR_OpaqueClassBlock *_componentClass; // caching the componentType of the J9ArrayClass
       TR_OpaqueClassBlock *_arrayClass;
+      TR_OpaqueClassBlock *_nullRestrictedArrayClass;
       uintptr_t _totalInstanceSize;
       J9ConstantPool *_constantPool;
       uintptr_t _classFlags;

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1252,7 +1252,12 @@ TR::SymbolValidationManager::validateArrayClassFromComponentClassRecord(uint16_t
    if (isDefinedID(componentClassID))
       {
       TR_OpaqueClassBlock *componentClass = getClassFromID(componentClassID);
-      return validateSymbol(arrayClassID, _fej9->getArrayClassFromComponentClass(componentClass));
+      if (validateSymbol(arrayClassID, _fej9->getArrayClassFromComponentClass(componentClass)))
+         return true;
+
+      TR_OpaqueClassBlock *nullRestrictedArray = TR::Compiler->om.areFlattenableValueTypesEnabled() ?
+                                                   _fej9->getNullRestrictedArrayClassFromComponentClass(componentClass) : NULL;
+      return nullRestrictedArray ? validateSymbol(arrayClassID, nullRestrictedArray) : false;
       }
    else
       {

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1255,8 +1255,7 @@ TR::SymbolValidationManager::validateArrayClassFromComponentClassRecord(uint16_t
       if (validateSymbol(arrayClassID, _fej9->getArrayClassFromComponentClass(componentClass)))
          return true;
 
-      TR_OpaqueClassBlock *nullRestrictedArray = TR::Compiler->om.areFlattenableValueTypesEnabled() ?
-                                                   _fej9->getNullRestrictedArrayClassFromComponentClass(componentClass) : NULL;
+      TR_OpaqueClassBlock *nullRestrictedArray = _fej9->getNullRestrictedArrayClassFromComponentClass(componentClass);
       return nullRestrictedArray ? validateSymbol(arrayClassID, nullRestrictedArray) : false;
       }
    else


### PR DESCRIPTION
(1) Add utility methods for null restricted arrays
(2) Fix null restricted array related issues
- Add recognized method  `jdk/internal/value/ValueClass.newArrayInstance`
- Add VP fixed class constraint if `ValueClass.newArrayInstance` creates null restricted array
- Rename `isArrayCompTypePrimitiveValueType` to `isArrayNullRestricted` to reflect the updated logic
- Update `isArrayNullRestricted` on how to determine whether or not an array is a null restricted array
- Disable transformation based on type hint which is no longer sufficient enough to decide whether or not the array is null restricted or not
- If flattenable arrays are enabled, do not create fixed class constraint for parm array class based on signature since both nullable and null restricted arrays share the same signature

**Depends on** 
- [x] https://github.com/eclipse-openj9/openj9/pull/20132
- [x] https://github.com/eclipse-openj9/openj9/pull/20139
- [x] https://github.com/eclipse-openj9/openj9/pull/19995
- [x] https://github.com/eclipse-openj9/openj9/pull/20086
- [ ] https://github.com/eclipse/omr/pull/7452

Related: #19913, #19914, #19708