### PR TITLE
JDK24 adds JavaLangAccess.concat(String, Object, String)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -828,6 +828,11 @@ final class Access implements JavaLangAccess {
 	public Object stringConcat1(String[] constants) {
 		return new StringConcatHelper.Concat1(constants);
 	}
+
+	@Override
+	public String concat(String prefix, Object value, String suffix) {
+		return StringConcatHelper.concat(prefix, value, suffix);
+	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */


### PR DESCRIPTION
JDK24 adds `JavaLangAccess.concat(String, Object, String)`

Resolve JDK next compilation error:
```
03:42:20  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:70: error: Access is not abstract and does not override abstract method concat(String,Object,String) in JavaLangAccess
03:42:20  final class Access implements JavaLangAccess {
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>