### PR TITLE
Reset JNI Addresses if FSD on restore (0.48)

### DIFF
--- a/runtime/compiler/control/CompileBeforeCheckpoint.cpp
+++ b/runtime/compiler/control/CompileBeforeCheckpoint.cpp
@@ -53,6 +53,12 @@ TR::CompileBeforeCheckpoint::CompileBeforeCheckpoint(TR::Region &region, J9VMThr
 void
 TR::CompileBeforeCheckpoint::queueMethodForCompilationBeforeCheckpoint(J9Method *j9method, bool recomp)
    {
+   /* Do this before releasing the CRRuntime Monitor */
+   if (_compInfo->isJNINative(j9method))
+      {
+      _compInfo->getCRRuntime()->pushJNIAddr(j9method, j9method->extra);
+      }
+
    /* Release CR Runtime Monitor since compileMethod below will acquire the
     * Comp Monitor.
     */

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -530,7 +530,10 @@ J9::OptionsPostRestore::invalidateCompiledMethodsIfNeeded(bool invalidateAll)
       javaVM->internalVMFunctions->allClassesEndDo(&classWalkState);
 
       if (invalidateAll)
+         {
          _compInfo->getCRRuntime()->purgeMemoizedCompilations();
+         _compInfo->getCRRuntime()->resetJNIAddr();
+         }
 
       j9nls_printf(PORTLIB, (UDATA) J9NLS_WARNING, J9NLS_JIT_CHECKPOINT_RESTORE_CODE_INVALIDATED);
       }

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -90,7 +90,8 @@ TR::CRRuntime::CRRuntime(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo) 
    _failedComps(),
    _forcedRecomps(),
    _impMethodForCR(),
-   _proactiveCompEnv()
+   _proactiveCompEnv(),
+   _jniMethodAddr()
    {
    // TR::CompilationInfo is initialized in the JIT_INITIALIZED bootstrap
    // stage, whereas J9_EXTENDED_RUNTIME_METHOD_TRACE_ENABLED is set in the
@@ -163,22 +164,25 @@ TR::CRRuntime::waitOnCRRuntimeMonitor()
    _crRuntimeMonitor->wait();
    }
 
+template<typename T>
 void
-TR::CRRuntime::pushMemoizedCompilation(TR_MemoizedCompilations& list, J9Method *method)
+TR::CRRuntime::pushMemoizedCompilation(TR_MemoizedCompilations& list, J9Method *method, void *data)
    {
-   auto newEntry = new (_compInfo->persistentMemory()) TR_MemoizedComp(method);
+   auto newEntry = new (_compInfo->persistentMemory()) T(method, data);
    if (newEntry)
       list.add(newEntry);
    }
 
 J9Method *
-TR::CRRuntime::popMemoizedCompilation(TR_MemoizedCompilations& list)
+TR::CRRuntime::popMemoizedCompilation(TR_MemoizedCompilations& list, void **data)
    {
    J9Method *method = NULL;
    auto memComp = list.pop();
    if (memComp)
       {
       method = memComp->getMethod();
+      if (data)
+         *data = memComp->getData();
       jitPersistentFree(memComp);
       }
    return method;
@@ -262,6 +266,46 @@ TR::CRRuntime::purgeMemoizedCompilations()
    purgeMemoizedCompilation(_failedComps);
    purgeMemoizedCompilation(_forcedRecomps);
    purgeMemoizedCompilation(_impMethodForCR);
+   }
+
+void
+TR::CRRuntime::pushFailedCompilation(J9Method *method)
+   {
+   pushMemoizedCompilation<TR_MemoizedComp>(_failedComps, method);
+   }
+
+void
+TR::CRRuntime::pushForcedRecompilation(J9Method *method)
+   {
+   pushMemoizedCompilation<TR_MemoizedComp>(_forcedRecomps, method);
+   }
+
+void
+TR::CRRuntime::pushImportantMethodForCR(J9Method *method)
+   {
+   pushMemoizedCompilation<TR_MemoizedComp>(_impMethodForCR, method);
+   }
+
+void
+TR::CRRuntime::pushJNIAddr(J9Method *method, void *addr)
+   {
+   pushMemoizedCompilation<TR_JNIMethodAddr>(_jniMethodAddr, method, addr);
+   }
+
+void
+TR::CRRuntime::resetJNIAddr()
+   {
+   OMR::CriticalSection resetJNI(getCRRuntimeMonitor());
+   while (!_jniMethodAddr.isEmpty())
+      {
+      J9Method *method;
+      void *addr;
+      while ((method = popJNIAddr(&addr)))
+         {
+         TR_ASSERT_FATAL(addr, "JNI Address to be reset cannot be NULL!");
+         _compInfo->setJ9MethodExtra(method, reinterpret_cast<intptr_t>(addr));
+         }
+      }
    }
 
 void


### PR DESCRIPTION
If debug is specified on restore, ensure that any proactively compiled JNI Methods are reset to their original address.

JNI methods are not compiled under FSD, but they are compiled proactively in the checkpoint hook. However, if debug is specified on restore, all proactively compiled methods, except for JNI thunks, get invalidated. Thus, the extra field of the J9Method of a JNI method needs to get reset to whatever the VM initialized them to originally.

This is necessary to ensure an environment that is consistent with FSD mode. The invalidation of proactively compiled non-JNI methods (which are non-FSD bodies) ensure that non-FSD code does not execute post-restore. At the checkpoint hook, only FSD bodies are on the stacks of the threads; although the compiler currently does not reuse these FSD bodies, they will continue to execute on restore until an OSR transition, but this is OK because they are already set up for involuntary OSR. The missing piece was the JNI methods, which this commit addresses.

cherry-pick of https://github.com/eclipse-openj9/openj9/pull/20108 (with a merge conflict fixed).