### PR TITLE
Add extra Simplifier & gotoElim passes to warm/hot

### DIFF
--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -345,6 +345,8 @@ static const OptimizationStrategy warmStrategyOpts[] =
 #endif
    { OMR::localCSE,                                  OMR::IfLoopsAndNotProfiling     },
    { OMR::idiomRecognition,                          OMR::IfLoopsAndNotProfiling     },
+   { OMR::treeSimplification                                                    },
+   { OMR::redundantGotoElimination,                  OMR::IfEnabledAndNotJitProfiling     },
    { OMR::blockSplitter                                                         },
    { OMR::treeSimplification                                                    }, // revisit; not really required ?
    { OMR::virtualGuardHeadMerger                                                },
@@ -554,8 +556,9 @@ const OptimizationStrategy hotStrategyOpts[] =
    { OMR::earlyLocalGroup                                                 },
    { OMR::stripMiningGroup,                      OMR::IfLoops                  }, // strip mining in loops
    { OMR::loopReplicator,                        OMR::IfLoops                  }, // tail-duplication in loops
-   { OMR::blockSplitter,                         OMR::IfNews                   }, // treeSimplification + blockSplitter + VP => opportunity for EA
    { OMR::expensiveGlobalValuePropagationGroup                            },
+   { OMR::redundantGotoElimination,              OMR::IfEnabledAndNotJitProfiling     },
+   { OMR::blockSplitter,                         OMR::IfNews                   }, // treeSimplification + blockSplitter + VP => opportunity for EA
    { OMR::localCSE,                              OMR::IfVectorAPI },
    { OMR::loopCanonicalization,                  OMR::IfVectorAPI },
    { OMR::partialRedundancyEliminationGroup,     OMR::IfVectorAPI },


### PR DESCRIPTION
If Simplifier detects trivial conditional branches where the fallthrough
block is a goto block to the branch target it can remove said branches
and leave behind a goto block. The resulting CFG can then potentially
be cleaned up by RedundantGotoElimination. Running these two opts
before BlockSplitter allows these trivial conditional branches to be
completely optimized away before BlockSplitter gets a change to run and
potentially duplicate blocks that hide the opportunity and make it
harder to detect and eliminate later.

This PR inserts Simplifer and RedundantGotoElimination passes before
BlockSplitter and moves all 3 after VP, which typically detects
opportunities that result in dead code, which when removed, results
in the trivial conditional branches that we're interested in.

This PR is made more effective by https://github.com/eclipse/omr/pull/7456.