### PR TITLE
Client Request Cached Methods List from JIT Server

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -24,6 +24,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#include <vector>
+#include <string>
+
 #ifdef WINDOWS
 // Undefine the winsockapi because winsock2 defines it. Removes warnings.
 #if defined(_WINSOCKAPI_) && !defined(_WINSOCK2API_)
@@ -1917,6 +1920,56 @@ onLoadInternal(
    return 0;
    }
 
+#if defined(J9VM_OPT_JITSERVER)
+static int32_t J9THREAD_PROC fetchServerCachedAOTMethods(void * entryarg)
+   {
+   J9JITConfig *jitConfig = (J9JITConfig *) entryarg;
+   J9JavaVM *vm = jitConfig->javaVM;
+   TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
+   TR::PersistentInfo *persistentInfo = compInfo->getPersistentInfo();
+
+   j9thread_t osThread = (j9thread_t) vm->serverAOTQueryThread;
+   J9VMThread *vmThread = NULL;
+
+   int rc = vm->internalVMFunctions->internalAttachCurrentThread(vm, &vmThread, NULL,
+                              J9_PRIVATE_FLAGS_DAEMON_THREAD | J9_PRIVATE_FLAGS_NO_OBJECT |
+                              J9_PRIVATE_FLAGS_SYSTEM_THREAD | J9_PRIVATE_FLAGS_ATTACHED_THREAD,
+                              osThread);
+
+   if (rc != JNI_OK)
+   {
+      return rc;
+   }
+
+   JITServer::ClientStream *client =
+      new (PERSISTENT_NEW) JITServer::ClientStream(persistentInfo);
+
+   client->write(JITServer::MessageType::AOTCacheMap_request,
+                  persistentInfo->getJITServerAOTCacheName());
+
+   client->read();
+   auto result = client->getRecvData<std::vector<std::string>>();
+
+   std::vector<std::string> cachedMethods = std::get<0>(result);
+
+   if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+      TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "Received %d methods",
+                                     cachedMethods.size());
+
+   std::unordered_set<std::string> *serverAOTMethodSet =
+      new (PERSISTENT_NEW) std::unordered_set<std::string>(cachedMethods.begin(),
+                                                            cachedMethods.end());
+
+   client->~ClientStream();
+   TR_Memory::jitPersistentFree(client);
+
+   vm->serverAOTMethodSet = (UDATA) serverAOTMethodSet;
+   vm->internalVMFunctions->DetachCurrentThread((JavaVM *) vm);
+   j9thread_exit(NULL);
+
+   return 0;
+   }
+#endif // J9VM_OPT_JITSERVER
 
 extern "C" int32_t
 aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
@@ -2184,6 +2237,43 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
    UT_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(javaVM));
    Trc_JIT_VMInitStages_Event1(curThread);
    Trc_JIT_portableSharedCache_enabled_or_disabled(curThread, J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE) ? 1 : 0);
+
+#if defined(J9VM_OPT_JITSERVER)
+   jitConfig->javaVM->serverAOTMethodSet = 0;
+   if (TR::Options::getCmdLineOptions()->getOption(TR_RequestJITServerCachedMethods))
+      {
+      // Ask the server for its cached methods
+      if (compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::CLIENT)
+         {
+         if (JITServerHelpers::isServerAvailable())
+            {
+            if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                                             "Asking the server for its cached methods");
+
+            IDATA result = javaVM->internalVMFunctions->createThreadWithCategory(
+               (omrthread_t *) &(jitConfig->javaVM->serverAOTQueryThread),
+               javaVM->defaultOSStackSize,
+               J9THREAD_PRIORITY_NORMAL,
+               0,
+               &fetchServerCachedAOTMethods,
+               (void *) jitConfig,
+               J9THREAD_CATEGORY_SYSTEM_JIT_THREAD
+            );
+
+            if (result != J9THREAD_SUCCESS)
+               {
+               jitConfig->javaVM->serverAOTMethodSet = 0;
+               if (TR::Options::getVerboseOption(TR_VerboseJITServer))
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                                                "Query thread not created");
+               }
+            }
+         }
+      }
+#endif // J9VM_OPT_JITSERVER
+
+
    return 0;
    }
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -257,6 +257,8 @@ const char *messageNames[] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
    "AOTCache_getROMClassBatch",
+   "AOTCacheMap_request",
+   "AOTCacheMap_reply"
    };
 
    static_assert(sizeof(messageNames) / sizeof(messageNames[0]) == MessageType_MAXTYPE,

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -284,6 +284,9 @@ enum MessageType : uint16_t
 
    AOTCache_getROMClassBatch,
 
+   AOTCacheMap_request,
+   AOTCacheMap_reply,
+
    MessageType_MAXTYPE
    };
    extern const char *messageNames[];

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -179,6 +179,11 @@ public:
             {
             return getArgsRaw<T...>(_cMsg);
             }
+         case MessageType::AOTCacheMap_request:
+            {
+            std::string cacheName = std::get<0>(getArgsRaw<std::string>(_cMsg));
+            throw StreamAotCacheMapRequest(cacheName);
+            }
          default:
             {
             throw StreamMessageTypeMismatch(MessageType::compilationRequest, _cMsg.type());

--- a/runtime/compiler/net/StreamExceptions.hpp
+++ b/runtime/compiler/net/StreamExceptions.hpp
@@ -81,6 +81,25 @@ private:
    uint64_t _clientId;
    };
 
+
+class StreamAotCacheMapRequest: public virtual std::exception
+   {
+public:
+   StreamAotCacheMapRequest(std::string cacheName) : _cacheName(cacheName)
+      {
+      }
+   virtual const char* what() const throw()
+      {
+      return "Requesting AOT cache content";
+      }
+   std::string getCacheName() const
+      {
+      return _cacheName;
+      }
+private:
+   std::string _cacheName;
+   };
+
 class StreamOOO : public virtual std::exception
    {
    public:

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -371,10 +371,14 @@ public:
    AOTCacheRecord **records() { return (AOTCacheRecord **)_data.end(); }
 
    static const char *getRecordName() { return "cached AOT method"; }
-   static CachedAOTMethod *create(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
-                                  TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+   static CachedAOTMethod *create(const AOTCacheClassChainRecord *definingClassChainRecord,
+                                  uint32_t index,
+                                  TR_Hotness optLevel,
+                                  const AOTCacheAOTHeaderRecord *aotHeaderRecord,
                                   const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
-                                  const void *code, size_t codeSize, const void *data, size_t dataSize);
+                                  const void *code, size_t codeSize,
+                                  const void *data, size_t dataSize,
+                                  const char *signature, size_t signatureSize);
 
    CachedAOTMethod *getNextRecord() const { return _nextRecord; }
    void setNextRecord(CachedAOTMethod *record) { _nextRecord = record; }
@@ -387,18 +391,20 @@ private:
    CachedAOTMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
                    TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
                    const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
-                   const void *code, size_t codeSize, const void *data, size_t dataSize);
+                   const void *code, size_t codeSize, const void *data, size_t dataSize,
+                   const char *signature, size_t signatureSize);
    CachedAOTMethod(const JITServerAOTCacheReadContext &context, const SerializedAOTMethod &header);
 
    SerializedAOTMethod *dataAddr() { return &_data; }
 
-   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize)
+   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize, size_t signatureSize)
       {
-      return offsetof(CachedAOTMethod, _data) + SerializedAOTMethod::size(numRecords, codeSize, dataSize) +
+      return offsetof(CachedAOTMethod, _data) +
+             SerializedAOTMethod::size(numRecords, codeSize, dataSize, signatureSize) +
              numRecords * sizeof(AOTCacheRecord *);
       }
 
-   static size_t size(const SerializedAOTMethod &header) { return size(header.numRecords(), header.codeSize(), header.dataSize()); }
+   static size_t size(const SerializedAOTMethod &header) { return size(header.numRecords(), header.codeSize(), header.dataSize(), header.signatureSize()); }
 
    bool setSubrecordPointers(const JITServerAOTCacheReadContext &context);
 
@@ -516,6 +522,8 @@ public:
       @return true if the in-memory cache is better than the one on file, false otherwise
    */
    bool isAOTCacheBetterThanSnapshot(const std::string &cacheFileName, size_t numExtraMethods);
+
+   CachedAOTMethod *getCachedMethodHead() { return _cachedMethodHead; }
 
 private:
    static StringKey getRecordKey(const AOTCacheClassLoaderRecord *record)

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -362,11 +362,15 @@ public:
    size_t numRecords() const { return _numRecords; }
    size_t codeSize() const { return _codeSize; }
    size_t dataSize() const { return _dataSize; }
+   size_t signatureSize() const { return _signatureSize; }
    const SerializedSCCOffset *offsets() const { return (const SerializedSCCOffset *)_varSizedData; }
    SerializedSCCOffset *offsets() { return (SerializedSCCOffset *)_varSizedData; }
    const uint8_t *code() const { return (const uint8_t *)(offsets() + _numRecords); }
    const uint8_t *data() const { return code() + _codeSize; }
    uint8_t *data() { return (uint8_t *)(code() + _codeSize); }
+
+   const char *signature() const { return (char *)(data() + _dataSize); }
+
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
 
    static SerializedAOTMethod *get(std::string &str)
@@ -382,13 +386,15 @@ private:
 
    SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
                        TR_Hotness optLevel, uintptr_t aotHeaderId, size_t numRecords,
-                       const void *code, size_t codeSize, const void *data, size_t dataSize);
+                       const void *code, size_t codeSize,
+                       const void *data, size_t dataSize,
+                       const char *signature, size_t signatureSize);
    SerializedAOTMethod();
 
-   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize)
+   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize, size_t signatureSize)
       {
       return sizeof(SerializedAOTMethod) + numRecords * sizeof(SerializedSCCOffset) +
-             OMR::alignNoCheck(codeSize + dataSize, sizeof(size_t));
+             OMR::alignNoCheck(codeSize + dataSize + signatureSize, sizeof(size_t));
       }
 
    bool isValidHeader(const JITServerAOTCacheReadContext &context) const;
@@ -404,7 +410,12 @@ private:
    const size_t _numRecords;
    const size_t _codeSize;
    const size_t _dataSize;
-   // Layout: SerializedSCCOffset offsets[_numRecords], uint8_t code[_codeSize], uint8_t data[_dataSize]
+
+   const size_t _signatureSize;
+   // Layout: SerializedSCCOffset offsets[_numRecords]
+   //         uint8_t             code[_codeSize]
+   //         uint8_t             data[_dataSize]
+   //         char*               signature[_signatureSize]
    uint8_t _varSizedData[];
    };
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6159,6 +6159,9 @@ typedef struct J9JavaVM {
 	UDATA closeScopeNotifyCount;
 #endif /* JAVA_SPEC_VERSION >= 22 */
 	UDATA unsafeIndexableHeaderSize;
+
+	UDATA serverAOTMethodSet;
+	UDATA serverAOTQueryThread;
 } J9JavaVM;
 
 #define J9JFR_SAMPLER_STATE_UNINITIALIZED 0


### PR DESCRIPTION
Added an option that makes the client request a list of cached methods from the server on bootstrap, and set the count for those methods as scount to improve rampup