### PR TITLE
Client Request Cached Methods List from JIT Server

### DIFF
--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 69; // ID: SMN6DXY0b2X1Z76N9825
+   static const uint16_t MINOR_NUMBER = 70; // ID:5nbb7nhW+R7OABuv+aRm
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -259,6 +259,8 @@ const char *messageNames[] =
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
    "AOTCache_getROMClassBatch",
+   "AOTCacheMap_request",
+   "AOTCacheMap_reply"
    };
 
    static_assert(sizeof(messageNames) / sizeof(messageNames[0]) == MessageType_MAXTYPE,

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -286,6 +286,9 @@ enum MessageType : uint16_t
 
    AOTCache_getROMClassBatch,
 
+   AOTCacheMap_request,
+   AOTCacheMap_reply,
+
    MessageType_MAXTYPE
    };
    extern const char *messageNames[];

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -179,6 +179,11 @@ public:
             {
             return getArgsRaw<T...>(_cMsg);
             }
+         case MessageType::AOTCacheMap_request:
+            {
+            std::string cacheName = std::get<0>(getArgsRaw<std::string>(_cMsg));
+            throw StreamAotCacheMapRequest(cacheName);
+            }
          default:
             {
             throw StreamMessageTypeMismatch(MessageType::compilationRequest, _cMsg.type());

--- a/runtime/compiler/net/StreamExceptions.hpp
+++ b/runtime/compiler/net/StreamExceptions.hpp
@@ -81,6 +81,25 @@ private:
    uint64_t _clientId;
    };
 
+
+class StreamAotCacheMapRequest: public virtual std::exception
+   {
+public:
+   StreamAotCacheMapRequest(std::string cacheName) : _cacheName(cacheName)
+      {
+      }
+   virtual const char* what() const throw()
+      {
+      return "Requesting AOT cache content";
+      }
+   const std::string& getCacheName() const
+      {
+      return _cacheName;
+      }
+private:
+   const std::string _cacheName;
+   };
+
 class StreamOOO : public virtual std::exception
    {
    public:

--- a/runtime/compiler/runtime/JITServerAOTCache.cpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.cpp
@@ -20,6 +20,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
+#include <string.h>
+#include <string>
 #include <cstdio> // for rename()
 #include "control/CompilationRuntime.hpp"
 #include "env/J9SegmentProvider.hpp"
@@ -415,22 +417,26 @@ AOTCacheThunkRecord::create(uintptr_t id, const uint8_t *signature, uint32_t sig
 
 
 SerializedAOTMethod::SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
-                                         TR_Hotness optLevel, uintptr_t aotHeaderId, size_t numRecords,
-                                         const void *code, size_t codeSize, const void *data, size_t dataSize) :
-   _size(size(numRecords, codeSize, dataSize)),
+                                         TR_Hotness optLevel, uintptr_t aotHeaderId,
+                                         size_t numRecords,
+                                         const void *code, size_t codeSize,
+                                         const void *data, size_t dataSize,
+                                         const char *signature, size_t signatureSize) :
+   _size(size(numRecords, codeSize, dataSize, signatureSize)),
    _definingClassChainId(definingClassChainId), _index(index),
    _optLevel(optLevel), _aotHeaderId(aotHeaderId),
-   _numRecords(numRecords), _codeSize(codeSize), _dataSize(dataSize)
+   _numRecords(numRecords), _codeSize(codeSize), _dataSize(dataSize), _signatureSize(signatureSize)
    {
    memcpy((void *)this->code(), code, codeSize);
    memcpy((void *)this->data(), data, dataSize);
+   memcpy((void *)this->signature(), signature, signatureSize);
    }
 
 SerializedAOTMethod::SerializedAOTMethod() :
    _size(0),
    _definingClassChainId(0), _index(0),
    _optLevel(TR_Hotness::numHotnessLevels), _aotHeaderId(0),
-   _numRecords(0), _codeSize(0), _dataSize(0)
+   _numRecords(0), _codeSize(0), _dataSize(0), _signatureSize(0)
    {
    }
 
@@ -444,13 +450,18 @@ SerializedAOTMethod::isValidHeader(const JITServerAOTCacheReadContext &context) 
           context._aotHeaderRecords[aotHeaderId()];
    }
 
-CachedAOTMethod::CachedAOTMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
-                                 TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
+CachedAOTMethod::CachedAOTMethod(const AOTCacheClassChainRecord *definingClassChainRecord,
+                                 uint32_t index,
+                                 TR_Hotness optLevel,
+                                 const AOTCacheAOTHeaderRecord *aotHeaderRecord,
                                  const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
-                                 const void *code, size_t codeSize, const void *data, size_t dataSize) :
+                                 const void *code, size_t codeSize,
+                                 const void *data, size_t dataSize,
+                                 const char *signature, size_t signatureSize) :
    _nextRecord(NULL),
    _data(definingClassChainRecord->data().id(), index, optLevel,
-         aotHeaderRecord->data().id(), records.size(), code, codeSize, data, dataSize),
+         aotHeaderRecord->data().id(), records.size(), code, codeSize, data, dataSize,
+         signature, signatureSize),
    _definingClassChainRecord(definingClassChainRecord)
    {
    for (size_t i = 0; i < records.size(); ++i)
@@ -471,11 +482,15 @@ CachedAOTMethod *
 CachedAOTMethod::create(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
                         TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
                         const Vector<std::pair<const AOTCacheRecord *, uintptr_t>> &records,
-                        const void *code, size_t codeSize, const void *data, size_t dataSize)
+                        const void *code, size_t codeSize,
+                        const void *data, size_t dataSize,
+                        const char * signature)
    {
-   void *ptr = AOTCacheRecord::allocate(size(records.size(), codeSize, dataSize));
+   size_t signatureSize = strlen(signature);
+   void *ptr = AOTCacheRecord::allocate(size(records.size(), codeSize, dataSize, signatureSize));
    return new (ptr) CachedAOTMethod(definingClassChainRecord, index, optLevel, aotHeaderRecord,
-                                    records, code, codeSize, data, dataSize);
+                                    records, code, codeSize, data, dataSize,
+                                    signature, signatureSize);
    }
 
 bool
@@ -1090,9 +1105,11 @@ JITServerAOTCache::createAndStoreThunk(const uint8_t *signature, uint32_t signat
 bool
 JITServerAOTCache::storeMethod(const AOTCacheClassChainRecord *definingClassChainRecord, uint32_t index,
                                TR_Hotness optLevel, const AOTCacheAOTHeaderRecord *aotHeaderRecord,
-                               const Vector<std::pair<const AOTCacheRecord *, uintptr_t/*reloDataOffset*/>> &records,
+                               const Vector<std::pair<const AOTCacheRecord *,
+                               uintptr_t/*reloDataOffset*/>> &records,
                                const void *code, size_t codeSize, const void *data, size_t dataSize,
-                               const char *signature, uint64_t clientUID, const CachedAOTMethod *&methodRecord)
+                               const char *signature, uint64_t clientUID,
+                               const CachedAOTMethod *&methodRecord)
    {
    uintptr_t definingClassId = definingClassChainRecord->records()[0]->data().id();
    const char *levelName = TR::Compilation::getHotnessName(optLevel);
@@ -1125,7 +1142,8 @@ JITServerAOTCache::storeMethod(const AOTCacheClassChainRecord *definingClassChai
       }
 
    auto method = CachedAOTMethod::create(definingClassChainRecord, index, optLevel, aotHeaderRecord,
-                                         records, code, codeSize, data, dataSize);
+                                         records, code, codeSize, data, dataSize,
+                                         signature);
    methodRecord = method;
    addToMap(_cachedMethodMap, _cachedMethodHead, _cachedMethodTail, it, key, method);
 

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -362,11 +362,15 @@ public:
    size_t numRecords() const { return _numRecords; }
    size_t codeSize() const { return _codeSize; }
    size_t dataSize() const { return _dataSize; }
+   size_t signatureSize() const { return _signatureSize; }
    const SerializedSCCOffset *offsets() const { return (const SerializedSCCOffset *)_varSizedData; }
    SerializedSCCOffset *offsets() { return (SerializedSCCOffset *)_varSizedData; }
    const uint8_t *code() const { return (const uint8_t *)(offsets() + _numRecords); }
    const uint8_t *data() const { return code() + _codeSize; }
    uint8_t *data() { return (uint8_t *)(code() + _codeSize); }
+
+   const char *signature() const { return (char *)(data() + _dataSize); }
+
    const uint8_t *end() const { return (const uint8_t *)this + size(); }
 
    static SerializedAOTMethod *get(std::string &str)
@@ -382,13 +386,15 @@ private:
 
    SerializedAOTMethod(uintptr_t definingClassChainId, uint32_t index,
                        TR_Hotness optLevel, uintptr_t aotHeaderId, size_t numRecords,
-                       const void *code, size_t codeSize, const void *data, size_t dataSize);
+                       const void *code, size_t codeSize,
+                       const void *data, size_t dataSize,
+                       const char *signature, size_t signatureSize);
    SerializedAOTMethod();
 
-   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize)
+   static size_t size(size_t numRecords, size_t codeSize, size_t dataSize, size_t signatureSize)
       {
       return sizeof(SerializedAOTMethod) + numRecords * sizeof(SerializedSCCOffset) +
-             OMR::alignNoCheck(codeSize + dataSize, sizeof(size_t));
+             OMR::alignNoCheck(codeSize + dataSize + signatureSize, sizeof(size_t));
       }
 
    bool isValidHeader(const JITServerAOTCacheReadContext &context) const;
@@ -404,7 +410,12 @@ private:
    const size_t _numRecords;
    const size_t _codeSize;
    const size_t _dataSize;
-   // Layout: SerializedSCCOffset offsets[_numRecords], uint8_t code[_codeSize], uint8_t data[_dataSize]
+
+   const size_t _signatureSize;
+   // Layout: SerializedSCCOffset offsets[_numRecords]
+   //         uint8_t             code[_codeSize]
+   //         uint8_t             data[_dataSize]
+   //         char*               signature[_signatureSize]
    uint8_t _varSizedData[];
    };
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4291,6 +4291,10 @@ typedef struct J9JITConfig {
 	uint64_t serverUID;
 #endif /* J9VM_OPT_JITSERVER */
 	void (*jitAddNewLowToHighRSSRegion)(const char *name, uint8_t *start, uint32_t size, size_t pageSize);
+#if defined(J9VM_OPT_JITSERVER)
+	void *serverAOTMethodSet;
+	UDATA serverAOTQueryThread;
+#endif // J9VM_OPT_JITSERVER
 } J9JITConfig;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)


### PR DESCRIPTION
Added an option that makes the client request a list of cached methods from the server on bootstrap, and set the count for those methods as scount to improve rampup

Depends on https://github.com/eclipse/omr/pull/7458