### PR TITLE
JDK24 adds Access new APIs

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -85,6 +85,9 @@ import sun.reflect.ConstantPool;
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
+/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
+import jdk.internal.loader.NativeLibraries;
+/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
 
 /**
  * Helper class to allow privileged access to classes
@@ -829,10 +832,27 @@ final class Access implements JavaLangAccess {
 		return new StringConcatHelper.Concat1(constants);
 	}
 
+/*[IF !INLINE-TYPES]*/
 	@Override
 	public String concat(String prefix, Object value, String suffix) {
 		return StringConcatHelper.concat(prefix, value, suffix);
 	}
+
+	@Override
+	public int countNonZeroAscii(String string) {
+		return StringCoding.countNonZeroAscii(string);
+	}
+
+	@Override
+	public NativeLibraries nativeLibrariesFor(ClassLoader loader) {
+		return ClassLoader.nativeLibrariesFor(loader);
+	}
+
+	@Override
+	public byte stringInitCoder() {
+		return String.COMPACT_STRINGS ? String.LATIN1 : String.UTF16;
+	}
+/*[ENDIF] !INLINE-TYPES */
 /*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -2587,4 +2587,10 @@ static void checkClassLoaderPermission(ClassLoader classLoader, Class<?> caller)
 	}
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+static NativeLibraries nativeLibrariesFor(ClassLoader loader) {
+	return (loader == null) ? BootLoader.getNativeLibraries() : loader.nativelibs;
+}
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }


### PR DESCRIPTION
JDK24 adds Access new APIs

```
Access.countNonZeroAscii(String string);
Access.nativeLibrariesFor(ClassLoader loader);
Access.stringInitCoder();
```

This resolves JDK next compilation error:
```
01:47:13  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:70: error: Access is not abstract and does not override abstract method nativeLibrariesFor(ClassLoader) in JavaLangAccess
01:47:13  final class Access implements JavaLangAccess {
```


Signed-off-by: Jason Feng <fengj@ca.ibm.com>