### PR TITLE
Always create nullable array before null-restricted

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -362,6 +362,7 @@ static const struct { \
 #define J9_IS_NULL_RESTRICTED_FIELD_FLATTENED(fieldClazz, romFieldShape) FALSE
 #define J9_VALUETYPE_FLATTENED_SIZE(clazz)((UDATA) 0) /* It is not possible for this macro to be used since we always check J9_IS_J9CLASS_FLATTENED before ever using it. */
 #define J9_IS_J9ARRAYCLASS_NULL_RESTRICTED(clazz) FALSE
+#define J9CLASS_GET_NULLRESTRICTED_ARRAY(clazz) NULL
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #define IS_REF_OR_VAL_SIGNATURE(firstChar) ('L' == (firstChar))
 

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2404,18 +2404,14 @@ nativeOOM:
 			if (J9ROMCLASS_IS_ARRAY(romClass)) {
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 				if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_CLASS_OPTION_NULL_RESTRICTED_ARRAY)) {
+					((J9ArrayClass *)state->ramClass)->companionArray = elementClass->arrayClass;
 					elementClass->nullRestrictedArrayClass = state->ramClass;
+					((J9ArrayClass *)elementClass->arrayClass)->companionArray = elementClass->nullRestrictedArrayClass;
 				} else
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 				{
 					((J9ArrayClass *)elementClass)->arrayClass = state->ramClass;
 				}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-				if ((NULL != elementClass->nullRestrictedArrayClass) && (NULL != elementClass->arrayClass)) {
-					((J9ArrayClass *)elementClass->arrayClass)->companionArray = elementClass->nullRestrictedArrayClass;
-					((J9ArrayClass *)elementClass->nullRestrictedArrayClass)->companionArray = elementClass->arrayClass;
-				}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 				/* Assigning into the arrayClass field creates an implicit reference to the class from its class loader */
 				javaVM->memoryManagerFunctions->j9gc_objaccess_postStoreClassToClassLoader(vmThread, classLoader, state->ramClass);
 			}


### PR DESCRIPTION
Always create a nullable array before a null-restricted array to better align with JIT assumptions that the nullable array should exist. See discussion https://github.com/eclipse-openj9/openj9/issues/19914#issuecomment-2311388833

I also defined J9CLASS_GET_NULLRESTRICTED_ARRAY outside of J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES for JIT use https://github.com/eclipse-openj9/openj9/pull/20112#discussion_r1750553860

fyi @a7ehuo 

Related to https://github.com/eclipse-openj9/openj9/issues/17340