### PR TITLE
Correct outdated linkToVirtual() J2I-avoidance transformation comment

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -286,11 +286,8 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
     *     Transforms java/lang/MethodHandle.linkToVirtual when the MemberName object (last arg) is not a known object.
     *     linkToVirtual is a VM INL call that would construct the call frame for the target virtual method invocation.
     *     This would be the case even if the method to be invoked is compiled, resulting in j2i and i2j transitions.
-    *     This transformation creates an alternate conditional paths for such invocations to avoid j2i transitions. In most
-    *     cases, the JITHelper method dispatchVirtual will be used to dispatch to the vtable entry for the method directly.
-    *     For private virtual methods (vtable index 0), dispatchVirtual cannot be used as there are no vtable entries for those
-    *     methods, so instead the call will be treated as a linkToStatic call, as the target method can be obtained from the
-    *     MemberName object.
+    *     The JITHelper method dispatchVirtual will be used to dispatch to the vtable entry for the method directly
+    *     and thereby avoid the transitions.
     *
     *  \param treetop
     *     the TreeTop anchoring the call node


### PR DESCRIPTION
This method no longer generates any control flow. Instead it generates an unconditional virtual dispatch using `dispatchVirtual()`. Update the doc comment for consistency with 425a1f1da0, 830016e675, and fc9e39d53f.