### PR TITLE
Revert "CRIU disable tests on ppc64le platform temporarily"

### DIFF
--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -71,12 +71,6 @@
 			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
@@ -119,12 +113,6 @@
 			<variation>-XX:+DebugOnRestore -Xjit</variation>
 			<variation>-XX:+DebugOnRestore -Xjit:count=0</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
@@ -204,12 +192,6 @@
 			<variation>-XX:+DebugOnRestore -Xjit</variation>
 			<variation>-XX:+DebugOnRestore -Xjit:count=0</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			TR_Options=$(Q)disableSuffixLogs$(Q) \
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
@@ -244,12 +226,6 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
 			then \
@@ -294,12 +270,6 @@
 			<variation>-Xjit:vlog=vlog</variation>
 			<variation>-XX:+JVMPortableRestoreMode</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			if [ -x $(Q)$(TEST_JDK_BIN)$(D)jitserver$(Q) ]; \
 			then \
@@ -344,12 +314,6 @@
 			<variation>-Xgcpolicy:optthruput</variation>
 			<variation>-Xgcpolicy:optavgpause</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
@@ -387,12 +351,6 @@
 			<variation>-Xgcpolicy:optthruput</variation>
 			<variation>-Xgcpolicy:optavgpause</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
@@ -430,12 +388,6 @@
 			<variation>-Xgcpolicy:optthruput</variation>
 			<variation>-Xgcpolicy:optavgpause</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
@@ -473,12 +425,6 @@
 			<variation>-Xgcpolicy:optthruput</variation>
 			<variation>-Xgcpolicy:optavgpause</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			TR_Options=$(Q)exclude={org/openj9/criu/TimeChangeTest.nanoTimeInt()J},dontInline={org/openj9/criu/TimeChangeTest.nanoTimeInt()J|org/openj9/criu/TimeChangeTest.nanoTimeJit()J},{org/openj9/criu/TimeChangeTest.nanoTimeJit()J}(count=1)$(Q) \
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
@@ -515,12 +461,6 @@
 			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-XX:+JVMPortableRestoreMode</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
@@ -558,12 +498,6 @@
 			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-Xjit:count=0 -XX:+CRIURestoreNonPortableMode</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
@@ -599,12 +533,6 @@
 		<variations>
 			<variation>-XX:+CRIURestoreNonPortableMode -Denable.j9internal.checkpoint.security.api.debug=true</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuSecurityScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \
@@ -637,12 +565,6 @@
 		<variations>
 			<variation>-Denable.j9internal.checkpoint.security.api.debug=true</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)criuRandomScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \

--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -150,12 +150,6 @@
 			<variation>-Xgcpolicy:gencon -Xgcthreads1</variation>
 			<variation>-XX:+DebugOnRestore</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18468</comment>
-				<platform>ppc64le.*</platform>
-			</disable>
-		</disables>
 		<command>
 			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
 			-DSCRIPPATH=$(TEST_RESROOT)$(D)cracScript.sh -DTEST_RESROOT=$(TEST_RESROOT) \


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#18469

related: https://github.com/eclipse-openj9/openj9/issues/18468