### PR TITLE
resolves the fill of space due to docker images pile up

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -817,7 +817,13 @@ def _build_all() {
 // TODO: remove this workaround when https://github.com/adoptium/infrastructure/issues/3597 resolved. related: infra 9292
 def create_docker_image_locally()
 {
-    new_image_name=DOCKER_IMAGE.split(':')[0]+'_cuda'
+    new_image_name = DOCKER_IMAGE.split(':')[0] + '_cuda'
+    // check and return if image is already exists on node
+    CUDA_DOCKER_IMAGE_ID = get_docker_image_id(new_image_name)
+    if (CUDA_DOCKER_IMAGE_ID) {
+        DOCKER_IMAGE = new_image_name
+        return
+    }
     sh '''
         echo 'ARG image
             ARG cuda_ver=12.2.0


### PR DESCRIPTION
It checks for `centos7_build_image_cuda` image existance on the node locally and only create it when can not find the image on it. related: #infra-9829

Signed-off-by: mahdi@ibm.com