### PR TITLE
Disable use of method handle for core reflection in JDK21

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -749,6 +749,10 @@ private static void ensureProperties(boolean isInitialization) {
 	initializedProperties.put("native.encoding", platformEncoding); //$NON-NLS-1$
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
+	/*[IF JAVA_SPEC_VERSION == 21]*/
+	initializedProperties.putIfAbsent("jdk.reflect.useDirectMethodHandle", "false");
+	/*[ENDIF] JAVA_SPEC_VERSION == 21 */
+
 	/*[IF (JAVA_SPEC_VERSION >= 21) & (PLATFORM-mz31 | PLATFORM-mz64)]*/
 	initializedProperties.put("com.ibm.autocvt", zOSAutoConvert); //$NON-NLS-1$
 	/*[ENDIF] (JAVA_SPEC_VERSION >= 21) & (PLATFORM-mz31 | PLATFORM-mz64) */

--- a/test/functional/cmdline_options_testresources/src_90/com/ibm/j9/getcallerclass/ReflectionMHTests.java
+++ b/test/functional/cmdline_options_testresources/src_90/com/ibm/j9/getcallerclass/ReflectionMHTests.java
@@ -62,7 +62,9 @@ public class ReflectionMHTests {
 			cls = (Class<?>) method.invoke(null, new Object[0]);
 
 			boolean isClassNameExpected;
-			if (VersionCheck.major() >= 18) {
+			if ((VersionCheck.major() >= 18)
+					&& (Boolean.getBoolean("jdk.reflect.useDirectMethodHandle") || (VersionCheck.major() != 21))
+			) {
 				isClassNameExpected = isSecurityFrameOrInjectedInvoker(cls);
 			} else {
 				isClassNameExpected = (cls == ReflectionMHTests.class);


### PR DESCRIPTION
In JEP 416, core reflection was re-implemented with Method Handles with the purpose of simplifying adding new language features. While analyzing performance of workload based on large enterprise based application, I observed that this was causing visible performance degradation. Disabling the use of direct method handles for reflection calls while we are working on improving the performance with direct method handles.