### PR TITLE
Rename IS_REF_OR_VAL_SIGNATURE to IS_CLASS_SIGNATURE

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ArgBits.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ArgBits.java
@@ -50,7 +50,7 @@ public class ArgBits
 		/* Parse the signature inside the ()'s */
 		char thisChar;
 		while ((thisChar = signature.charAt(++stringPtr)) != ')') {
-			if ((thisChar == '[') || J9ClassHelper.isRefOrValSignature(thisChar)) {
+			if ((thisChar == '[') || J9ClassHelper.isClassSignature(thisChar)) {
 				/* Mark a bit for objects or arrays */
 				resultArray[writePtr] |= argBit;
 				
@@ -59,7 +59,7 @@ public class ArgBits
 					stringPtr++;
 				}
 
-				if (J9ClassHelper.isRefOrValSignature(thisChar)) {
+				if (J9ClassHelper.isClassSignature(thisChar)) {
 					/* Walk past the name of the object class */
 					while ((thisChar = signature.charAt(stringPtr)) != ';') {
 						stringPtr++;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/SendSlot.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/SendSlot.java
@@ -48,7 +48,7 @@ public class SendSlot
 				/* skip all '['s */
 				for (i++; J9UTF8Helper.stringValue(signature).charAt(i) == '['; i++);
 				char charAti = J9UTF8Helper.stringValue(signature).charAt(i);
-				if (J9ClassHelper.isRefOrValSignature(charAti)) {
+				if (J9ClassHelper.isClassSignature(charAti)) {
 					/* FALL THRU */
 				} else {
 					sendArgs = sendArgs.add(1);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/StackMap.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackmap/StackMap.java
@@ -502,7 +502,7 @@ public class StackMap
 						utf8Signature = J9ROMFieldRefPointer.cast(pool.add(index)).nameAndSignature().signature();
 						
 						signature = J9UTF8Helper.stringValue(utf8Signature).charAt(0);
-						if (J9ClassHelper.isRefOrValSignature(signature) || (signature == '[')) {
+						if (J9ClassHelper.isClassSignature(signature) || (signature == '[')) {
 							PUSH(OBJ);
 						} else {
 							PUSH(INT);
@@ -515,7 +515,7 @@ public class StackMap
 						utf8Signature = J9ROMFieldRefPointer.cast(pool.add(index)).nameAndSignature().signature();
 						
 						signature = J9UTF8Helper.stringValue(utf8Signature).charAt(0);
-						if (J9ClassHelper.isRefOrValSignature(signature) || (signature == '[')) {
+						if (J9ClassHelper.isClassSignature(signature) || (signature == '[')) {
 							PUSH(OBJ);
 						} else {
 							PUSH(INT);
@@ -574,7 +574,7 @@ public class StackMap
 							while (args[i] == '[') {
 								i += 1;
 							}
-							if (J9ClassHelper.isRefOrValSignature(args[i])) {
+							if (J9ClassHelper.isClassSignature(args[i])) {
 								do {
 									i += 1;
 								} while (args[i] != ';');
@@ -583,7 +583,7 @@ public class StackMap
 
 						signature = args[i + 1];
 						if (signature != 'V') {
-							if (J9ClassHelper.isRefOrValSignature(signature) || (signature == '[')) {
+							if (J9ClassHelper.isClassSignature(signature) || (signature == '[')) {
 								PUSH(OBJ);
 							} else {
 								PUSH(INT);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
@@ -533,7 +533,7 @@ public class J9ClassHelper
 	 * @param firstChar the first character of the signature being checked
 	 * @return true if the character indicates the beginning of a reference or value signature, false otherwise
 	 */
-	public static boolean isRefOrValSignature(char firstChar) {
+	public static boolean isClassSignature(char firstChar) {
 		return firstChar == 'L';
 	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassHelper.java
@@ -528,7 +528,7 @@ public class J9ClassHelper
 
 	/**
 	 * Queries if a given char is the first character of a reference or value type signature.
-	 * Equivalent to J9's IS_REF_OR_VAL_SIGNATURE macro.
+	 * Equivalent to J9's IS_CLASS_SIGNATURE macro.
 	 *
 	 * @param firstChar the first character of the signature being checked
 	 * @return true if the character indicates the beginning of a reference or value signature, false otherwise

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassLoaderHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/J9ClassLoaderHelper.java
@@ -70,7 +70,7 @@ public class J9ClassLoaderHelper
 		
 		int arity = calculateClassArity(signature);
 
-		if ((arity > 0) && !J9ClassHelper.isRefOrValSignature(signature.charAt(arity))) {
+		if ((arity > 0) && !J9ClassHelper.isClassSignature(signature.charAt(arity))) {
 			return PRIMITIVE_TO_CLASS.get(signature.charAt(arity));			
 		} else {		
 			while (classIterator.hasNext()) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaClass.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/view/dtfj/java/DTFJJavaClass.java
@@ -327,7 +327,7 @@ public class DTFJJavaClass implements JavaClass {
 					J9ArrayClassPointer arrayClass = J9ArrayClassPointer.cast(j9class);
 					
 					// Any multi-dimensional array is an object array, as is any single dimensional array with an object type (i.e. [Lwhatever; or [Qwhatever;).
-					if (arrayClass.arity().gt(1) || J9ClassHelper.isRefOrValSignature(getName().charAt(1))) {
+					if (arrayClass.arity().gt(1) || J9ClassHelper.isClassSignature(getName().charAt(1))) {
 						isObjectArray = true;
 					} else {
 						isObjectArray = false;

--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -377,7 +377,7 @@ ClassFileOracle::walkFields()
 					markStringAsReferenced(constantValueIndex);
 				}
 			}
-			if ((IS_REF_OR_VAL_SIGNATURE(fieldChar))
+			if ((IS_CLASS_SIGNATURE(fieldChar))
 				|| ('[' == fieldChar)
 			) {
 				_objectStaticCount++;
@@ -427,7 +427,7 @@ ClassFileOracle::walkFields()
 					}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 					if (containsKnownAnnotation(foundAnnotations, NULLRESTRICTED_ANNOTATION)) {
-						if (!IS_REF_OR_VAL_SIGNATURE(fieldChar)) {
+						if (!IS_CLASS_SIGNATURE(fieldChar)) {
 							if ('[' == fieldChar) {
 								throwGenericErrorWithCustomMsg(J9NLS_CFR_NO_NULLRESTRICTED_IN_ARRAYFIELD__ID, fieldIndex);
 							} else { /* primitive type */
@@ -458,7 +458,7 @@ ClassFileOracle::walkFields()
 			case CFR_ATTRIBUTE_NullRestricted:
 				/* JVMS: There must not be a NullRestricted attribute in the attributes table of a field_info
 				 * structure whose descriptor_index references a primitive type or an array type.*/
-				if (!IS_REF_OR_VAL_SIGNATURE(fieldChar)) {
+				if (!IS_CLASS_SIGNATURE(fieldChar)) {
 					if ('[' == fieldChar) {
 						throwGenericErrorWithCustomMsg(J9NLS_CFR_NO_NULLRESTRICTED_IN_ARRAYFIELD__ID, fieldIndex);
 					} else { /* primitive type */

--- a/runtime/bcutil/ClassFileWriter.cpp
+++ b/runtime/bcutil/ClassFileWriter.cpp
@@ -1338,7 +1338,7 @@ ClassFileWriter::computeArgsCount(U_16 methodRefIndex)
 			while ((index < count) && ('[' == sig[index])) {
 				index += 1;
 			}
-			if (!IS_REF_OR_VAL_SIGNATURE(sig[index])) {
+			if (!IS_CLASS_SIGNATURE(sig[index])) {
 				break;
 			}
 			/* fall through */

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -2221,7 +2221,7 @@ ROMClassWriter::writeNativeSignature(Cursor *cursor, U_8 *methodDescriptor, U_8 
 		} else {
 			cursor->writeU8(nativeArgCharConversion[methodDescriptor[index] - 'A'], Cursor::GENERIC);
 		}
-		if (IS_REF_OR_VAL_SIGNATURE(methodDescriptor[index])) {
+		if (IS_CLASS_SIGNATURE(methodDescriptor[index])) {
 			while (';' != methodDescriptor[index]) {
 				++index;
 			}

--- a/runtime/bcutil/jsrinliner.c
+++ b/runtime/bcutil/jsrinliner.c
@@ -1159,11 +1159,11 @@ _nextBranch:
 					stackError |= popStack (jsrData);
 					if (args[step] == '[') {
 						while (args[++step] == '[');
-						if (!IS_REF_OR_VAL_SIGNATURE(args[step])) {
+						if (!IS_CLASS_SIGNATURE(args[step])) {
 							continue;
 						}
 					}
-					if (IS_REF_OR_VAL_SIGNATURE(args[step])) {
+					if (IS_CLASS_SIGNATURE(args[step])) {
 						while (args[++step] != ';');
 						continue;
 					}

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -2628,11 +2628,11 @@ j9rtv_verifyArguments (J9BytecodeVerificationData *verifyData, J9UTF8 * utf8stri
 		}
 
 		/* Object or array */
-		if (IS_REF_OR_VAL_SIGNATURE(*signature) || arity) {
+		if (IS_CLASS_SIGNATURE(*signature) || arity) {
 			IDATA reasonCode = 0;
 
 			/* Object array */
-			if (IS_REF_OR_VAL_SIGNATURE(*signature)) {
+			if (IS_CLASS_SIGNATURE(*signature)) {
 				signature++;
 				string = signature;	/* remember the start of the string */
 				while (*signature++ != ';');

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -812,7 +812,7 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 			break;
 
 		case CFR_BC_areturn:
-			if (!IS_REF_OR_VAL_SIGNATURE(sigChar) && (sigChar != '[')) {
+			if (!IS_CLASS_SIGNATURE(sigChar) && (sigChar != '[')) {
 				/* fail, modify the bytecode to be incompatible in the second pass of verification */
 				if (sigChar != 'V') {
 					*(bcIndex - 1) = CFR_BC_return;

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -282,7 +282,7 @@ buildStackFromMethodSignature( J9BytecodeVerificationData *verifyData, UDATA **s
 			arity++;
 		}
 
-		if (IS_REF_OR_VAL_SIGNATURE(args[i])) {
+		if (IS_CLASS_SIGNATURE(args[i])) {
 			U_8 *string;
 			U_16 length = 0;
 
@@ -684,7 +684,7 @@ static UDATA *
 pushType(J9BytecodeVerificationData *verifyData, U_8 * signature, UDATA * stackTop)
 {
 	if (*signature != 'V') {
-		if ((*signature == '[') || IS_REF_OR_VAL_SIGNATURE(*signature)) {
+		if ((*signature == '[') || IS_CLASS_SIGNATURE(*signature)) {
 			PUSH(parseObjectOrArrayName(verifyData, signature));
 		} else {
 			UDATA baseType = (UDATA) argTypeCharConversion[*signature - 'A'];
@@ -1197,7 +1197,7 @@ parseObjectOrArrayName(J9BytecodeVerificationData *verifyData, U_8 *signature)
 		signature++;
 	}
 	arity = (UDATA) (signature - string);
-	if (IS_REF_OR_VAL_SIGNATURE(*signature)) {
+	if (IS_CLASS_SIGNATURE(*signature)) {
 		U_16 length = 0;
 		UDATA classIndex = 0;
 

--- a/runtime/gc_check/CheckEngine.cpp
+++ b/runtime/gc_check/CheckEngine.cpp
@@ -877,7 +877,7 @@ GC_CheckEngine::checkClassStatics(J9JavaVM* vm, J9Class* clazz)
 				J9UTF8* sigUTF = J9ROMFIELDSHAPE_SIGNATURE(romFieldCursor);
 
 				/* interested in objects and all kinds of arrays */
-				if ((IS_REF_OR_VAL_SIGNATURE(J9UTF8_DATA(sigUTF)[0]))
+				if ((IS_CLASS_SIGNATURE(J9UTF8_DATA(sigUTF)[0]))
 					|| ('[' == J9UTF8_DATA(sigUTF)[0])
 				) {
 					numberOfReferences += 1;
@@ -897,7 +897,7 @@ GC_CheckEngine::checkClassStatics(J9JavaVM* vm, J9Class* clazz)
 						U_8* toSearchString = J9UTF8_DATA(sigUTF);
 						UDATA toSearchLength = J9UTF8_LENGTH(sigUTF);
 
-						if (IS_REF_OR_VAL_SIGNATURE(toSearchString[0])) {
+						if (IS_CLASS_SIGNATURE(toSearchString[0])) {
 							/*  Convert signature to class name:
 							 *  Entering 'L' as well as closing ';' must be removed to get a proper class name
 							 */

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -345,7 +345,7 @@ accessCheckFieldSignature(J9VMThread *currentThread, J9Class* lookupClass, UDATA
 			sigOffset += 1;
 		}
 	
-		if (IS_REF_OR_VAL_SIGNATURE(lookupSigData[sigOffset])) {
+		if (IS_CLASS_SIGNATURE(lookupSigData[sigOffset])) {
 			BOOLEAN isVirtual = (0 == (((J9ROMFieldShape*)romField)->modifiers & J9AccStatic));
 			j9object_t argsArray = J9VMJAVALANGINVOKEMETHODTYPE_PTYPES(currentThread, methodType);
 			U_32 numParameters = J9INDEXABLEOBJECT_SIZE(currentThread, argsArray);
@@ -433,7 +433,7 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 			endIndex = index;
 
 			/* If this entry is a class type, we need to do a classloader check on it */
-			if (IS_REF_OR_VAL_SIGNATURE(lookupSigData[index])) {
+			if (IS_CLASS_SIGNATURE(lookupSigData[index])) {
 				index += 1;
 
 				clazz = J9JAVAARRAYOFOBJECT_LOAD(currentThread, argsArray, i);
@@ -462,7 +462,7 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 		while ('[' == lookupSigData[index]) {
 			index += 1;
 		}
-		if(IS_REF_OR_VAL_SIGNATURE(lookupSigData[index])) {
+		if(IS_CLASS_SIGNATURE(lookupSigData[index])) {
 			J9Class *returnRamClass = NULL;
 			/* Grab the MethodType returnType */
 			clazz = J9VMJAVALANGINVOKEMETHODTYPE_RTYPE(currentThread, methodType);

--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -1281,7 +1281,7 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(
 							while ('[' == J9UTF8_DATA(signature)[sigOffset]) {
 								sigOffset += 1;
 							}
-							if (IS_REF_OR_VAL_SIGNATURE(J9UTF8_DATA(signature)[sigOffset])) {
+							if (IS_CLASS_SIGNATURE(J9UTF8_DATA(signature)[sigOffset])) {
 								sigOffset += 1;
 								omrthread_monitor_enter(vm->classTableMutex);
 								UDATA clConstraintResult = verifyData->checkClassLoadingConstraintForNameFunction(

--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -51,7 +51,7 @@ accessCheckFieldType(J9VMThread *currentThread, J9Class* lookupClass, J9Class* t
 	if (NULL != verifyData) {
 		U_8 *lookupSigData = J9UTF8_DATA(lookupSig);
 		/* Only check reference types (not primitive types) */
-		if (IS_REF_OR_VAL_SIGNATURE(*lookupSigData)) {
+		if (IS_CLASS_SIGNATURE(*lookupSigData)) {
 			J9ClassLoader *lookupClassloader = lookupClass->classLoader;
 			J9ClassLoader *typeClassloader = type->classLoader;
 			if (typeClassloader != lookupClassloader) {

--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -247,7 +247,7 @@ computeArgCount(J9ROMMethod *method)
 			while ((index < count) && ('[' == bytes[index])) {
 				index += 1;
 			}
-			if (!IS_REF_OR_VAL_SIGNATURE(bytes[index])) {
+			if (!IS_CLASS_SIGNATURE(bytes[index])) {
 				break;
 			}
 			/* fall through */
@@ -537,7 +537,7 @@ getArgCountFromSignature(J9UTF8* signature)
 			i++;
 		}
 		/* skip class name */
-		if (IS_REF_OR_VAL_SIGNATURE(sigData[i])) {
+		if (IS_CLASS_SIGNATURE(sigData[i])) {
 			while (';' != sigData[i]) {
 				i++;
 			}

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -2457,7 +2457,7 @@ jniCheckObjectArg(const char* function, JNIEnv* env, jobject aJobject, char* sig
 		while (*sigArgs == '[') {
 			sigArgs++;
 		}
-		if (IS_REF_OR_VAL_SIGNATURE(*sigArgs)) {
+		if (IS_CLASS_SIGNATURE(*sigArgs)) {
 			while (*sigArgs != ';') {
 				sigArgs++;
 			}

--- a/runtime/jvmti/jvmtiHelpers.cpp
+++ b/runtime/jvmti/jvmtiHelpers.cpp
@@ -671,7 +671,7 @@ skipSignature(U_8 ** pUtfData)
 
 	/* Skip to the end of Object type signatures */
 
-	if (IS_REF_OR_VAL_SIGNATURE(utfChar)) {
+	if (IS_CLASS_SIGNATURE(utfChar)) {
 		do {
 			utfChar = nextUTFChar(pUtfData);
 		} while (utfChar != ';');

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -359,7 +359,7 @@ static const struct { \
 #define J9_IS_J9ARRAYCLASS_NULL_RESTRICTED(clazz) FALSE
 #define J9CLASS_GET_NULLRESTRICTED_ARRAY(clazz) NULL
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-#define IS_REF_OR_VAL_SIGNATURE(firstChar) ('L' == (firstChar))
+#define IS_CLASS_SIGNATURE(firstChar) ('L' == (firstChar))
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 #define J9_IS_CRIU_OR_CRAC_CHECKPOINT_ENABLED(vm) (J9_ARE_ANY_BITS_SET(vm->checkpointState.flags, J9VM_CRAC_IS_CHECKPOINT_ENABLED | J9VM_CRIU_IS_CHECKPOINT_ENABLED))

--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -500,7 +500,7 @@ traceMethodArguments(J9VMThread* thr, J9UTF8* signature, UDATA* arg0EA, char* bu
 			while (*sigChar == '[') {
 				sigChar++;
 			}
-			if (IS_REF_OR_VAL_SIGNATURE(*sigChar)) {
+			if (IS_CLASS_SIGNATURE(*sigChar)) {
 				while (*sigChar != ';') {
 					sigChar++;
 				}

--- a/runtime/stackmap/debuglocalmap.c
+++ b/runtime/stackmap/debuglocalmap.c
@@ -662,7 +662,7 @@ validateLocalSlot(J9VMThread *currentThread, J9Method *ramMethod, U_32 offsetPC,
 					break;
 			}
 		} else {
-			if ((slotSignature == '[') || IS_REF_OR_VAL_SIGNATURE(slotSignature)) {
+			if ((slotSignature == '[') || IS_CLASS_SIGNATURE(slotSignature)) {
 				if ((localMap[slot / 32] & (1 << (slot % 32))) == 0) {
 					rc = J9_SLOT_VALIDATE_ERROR_LOCAL_MAP_MISMATCH;
 				}

--- a/runtime/util/argbits.c
+++ b/runtime/util/argbits.c
@@ -40,12 +40,12 @@ argBitsFromSignature(U_8 * signature, U_32 * resultArrayBase, UDATA resultArrayS
 	
 	/* Parse the signature inside the ()'s */
 	while (*(++signature) != ')') {
-		if ((*signature == '[') || IS_REF_OR_VAL_SIGNATURE(*signature)) {
+		if ((*signature == '[') || IS_CLASS_SIGNATURE(*signature)) {
 			*resultArrayBase |= argBit;
 			while (*signature == '[') {
 				signature++;
 			}
-			if (IS_REF_OR_VAL_SIGNATURE(*signature)) {
+			if (IS_CLASS_SIGNATURE(*signature)) {
 				while (*signature != ';') {
 					signature++;
 				}

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -518,7 +518,7 @@ iterateToNextArgument(U_32 sigIndex, U_32 sigLength, U_8* sigData)
 	if (sigIndex >= sigLength) return sigIndex;
 
 	/* check for object */
-	if (IS_REF_OR_VAL_SIGNATURE(sigData[sigIndex])) {
+	if (IS_CLASS_SIGNATURE(sigData[sigIndex])) {
 		while ((sigIndex < sigLength) && (';' != sigData[sigIndex])) {
 			sigIndex += 1;
 		}

--- a/runtime/verbose/errormessagehelper.c
+++ b/runtime/verbose/errormessagehelper.c
@@ -882,7 +882,7 @@ mapDataTypeToUTF8String(J9UTF8Ref* dataType, StackMapFrame* stackMapFrame, Metho
 			dataType->bytes = methodInfo->signature.bytes + typeValue;
 			dataType->length = typeLength;
 			/* Ignore 'L' and ';' to get the full string of argument in signature */
-			if (IS_REF_OR_VAL_SIGNATURE(*dataType->bytes)) {
+			if (IS_CLASS_SIGNATURE(*dataType->bytes)) {
 				dataType->bytes += 1;
 				dataType->length -= 2;
 			}

--- a/runtime/verutil/sigverify.c
+++ b/runtime/verutil/sigverify.c
@@ -195,7 +195,7 @@ checkSignatureInlined (U_8* signatureBytes, UDATA signatureLength, UDATA *curren
 		}
 	}
 
-	if (IS_REF_OR_VAL_SIGNATURE(*cursor)) {
+	if (IS_CLASS_SIGNATURE(*cursor)) {
 		IDATA bytesConsumed = 0;
 
 		cursor += 1; /* skip the 'L' */

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -108,7 +108,7 @@ internalFindArrayClass(J9VMThread* vmThread, J9Module *j9module, UDATA arity, U_
 		/* the first level of arity is already present in the array class */
 		arity -= 1;
 
-	} else if (IS_REF_OR_VAL_SIGNATURE(firstChar) && lastChar == ';') {
+	} else if (IS_CLASS_SIGNATURE(firstChar) && lastChar == ';') {
 
 		name += arity + 1; /* 1 for 'L' */
 		length -= arity + 2; /* 2 for 'L and ';' */

--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -258,7 +258,7 @@ convertMethodSignature(J9VMThread *vmThread, J9UTF8 *methodSig)
 				i += 1;
 			}
 			const char *elementType = NULL;
-			if (IS_REF_OR_VAL_SIGNATURE(string[i])) {
+			if (IS_CLASS_SIGNATURE(string[i])) {
 				i += 1;
 
 				UDATA objSize = 0;

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -589,7 +589,7 @@ UDATA JNICALL pushArguments(J9VMThread *vmThread, J9Method* method, void *args) 
 				break;
 			case ')':
 				vmThread->sp = sp;
-				return (IS_REF_OR_VAL_SIGNATURE(*sigChar) || *sigChar == '[') ? J9_SSF_RETURNS_OBJECT : 0;
+				return (IS_CLASS_SIGNATURE(*sigChar) || *sigChar == '[') ? J9_SSF_RETURNS_OBJECT : 0;
 		}
 	}
 }

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -250,7 +250,7 @@ findFieldSignatureClass(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA field
 	if ('[' == J9UTF8_DATA(signature)[0]) {
 		resolvedClass = internalFindClassUTF8(vmStruct, J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 	} else {
-		Assert_VM_true(IS_REF_OR_VAL_SIGNATURE(J9UTF8_DATA(signature)[0]));
+		Assert_VM_true(IS_CLASS_SIGNATURE(J9UTF8_DATA(signature)[0]));
 		/* skip fieldSignature's L and ; to have only CLASSNAME required for internalFindClassUTF8 */
 		resolvedClass = internalFindClassUTF8(vmStruct, &J9UTF8_DATA(signature)[1], J9UTF8_LENGTH(signature)-2, classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 	}


### PR DESCRIPTION
- Rename IS_REF_OR_VAL_SIGNATURE to IS_CLASS_SIGNATURE
- Rename isRefOrValSignature to isClassSignature

These names refer to ReferenceType from an old value types specification draft which is no longer in use https://cr.openjdk.org/~dlsmith/jep401/jep401-20211220/specs/primitive-classes-jvms.html#jvms-4.3.2. Rename these to reflect the current meaning.

Related to https://github.com/eclipse-openj9/openj9/issues/18157