### PR TITLE
Remove old ReferenceType error handling for value types

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -2118,14 +2118,6 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 					errorCode = J9NLS_CFR_ERR_CATCH_NOT_CLASS__ID;
 					goto _errorFound;
 				}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-				if (CFR_CONSTANT_Class == cpBase[value].tag) {
-					if (bcvIsReferenceTypeDescriptor(&cpBase[cpBase[value].slot1])) {
-						errorCode = J9NLS_CFR_ERR_CATCH_IS_REFERENCETYPE_DESCRIPTOR__ID;
-						goto _errorFound;
-					}
-				}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 			}
 					
 			if(checkAttributes(portLib, classfile, code->attributes, code->attributesCount, segment, -1, code->codeLength, flags)) {
@@ -2145,12 +2137,6 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 					errorCode = J9NLS_CFR_ERR_EXCEPTION_NOT_CLASS__ID;
 					goto _errorFound;
 				}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-				if (bcvIsReferenceTypeDescriptor(&cpBase[cpBase[value].slot1])) {
-					errorCode = J9NLS_CFR_ERR_EXCEPTION_IS_REFERENCETYPE_DESCRIPTOR__ID;
-					goto _errorFound;
-				}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 			}
 			break;
 
@@ -2289,13 +2275,6 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 					errorCode = J9NLS_CFR_ERR_INNER_CLASS_NOT_CLASS__ID;
 					goto _errorFound;
 				}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-				classInfoUtf8 = &cpBase[cpBase[value].slot1];
-				if (bcvIsReferenceTypeDescriptor(classInfoUtf8)) {
-					errorCode = J9NLS_CFR_ERR_INNER_CLASS_REFERENCETYPE__ID;
-					goto _errorFound;
-				}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 				/* Check class name integrity? */
 
 				innerClassArrayIndexTable[value] = j;
@@ -2319,15 +2298,9 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 						errorCode = J9NLS_CFR_ERR_OUTER_CLASS_UTF8_ZERO_LENGTH__ID;
 						goto _errorFound;
 					}
-					/* Capture the error if the outer_class_info_index points to an array class or other referencetype descriptor */
-					if (
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-						bcvIsReferenceTypeDescriptor(classInfoUtf8)
-#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-						('[' == classInfoUtf8->bytes[0])
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-					) {
-						errorCode = J9NLS_CFR_ERR_OUTER_CLASS_REFERENCETYPE_DESCRIPTOR__ID;
+					/* Capture the error if the outer_class_info_index points to an array class */
+					if ('[' == classInfoUtf8->bytes[0]) {
+						errorCode = J9NLS_CFR_ERR_OUTER_CLASS_BAD_ARRAY_CLASS__ID;
 						goto _errorFound;
 					}
 				}
@@ -2402,12 +2375,6 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 				errorCode = J9NLS_CFR_ERR_ENCLOSING_METHOD_CLASS_INDEX_NOT_CLASS__ID;
 				goto _errorFound;
 			}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-			if (bcvIsReferenceTypeDescriptor(&cpBase[cpBase[value].slot1])) {
-				errorCode = J9NLS_CFR_ERR_ENCLOSING_METHOD_CLASS_INDEX_IS_REFERENCETYPE__ID;
-				goto _errorFound;
-			}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 			value = enclosing->methodIndex;
 			if(value >= cpCount) {
@@ -2657,12 +2624,6 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 				errorCode = J9NLS_CFR_ERR_BAD_NEST_HOST_INDEX__ID;
 				goto _errorFound;
 			}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-			if (bcvIsReferenceTypeDescriptor(&cpBase[cpBase[value].slot1])) {
-				errorCode = J9NLS_CFR_ERR_NEST_HOST_INVALID_REFERENCETYPE_DESCRIPTOR__ID;
-				goto _errorFound;
-			}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 			break;
 
 		case CFR_ATTRIBUTE_NestMembers: {
@@ -2677,12 +2638,6 @@ checkAttributes(J9PortLibrary* portLib, J9CfrClassFile* classfile, J9CfrAttribut
 					errorCode = J9NLS_CFR_ERR_NEST_MEMBERS_NAME_NOT_CONSTANT_CLASS__ID;
 					goto _errorFound;
 				}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-				if (bcvIsReferenceTypeDescriptor(&cpBase[cpBase[value].slot1])) {
-					errorCode = J9NLS_CFR_ERR_NEST_MEMBER_INVALID_REFERENCETYPE_DESCRIPTOR__ID;
-					goto _errorFound;
-				}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 			}
 			break;
 		}
@@ -2849,14 +2804,6 @@ checkClass(J9PortLibrary *portLib, J9CfrClassFile* classfile, U_8* segment, U_32
 			offset = endOfConstantPool + 2;
 			goto _errorFound;
 		}
-
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-		if (bcvIsReferenceTypeDescriptor(&classfile->constantPool[value])) {
-			errorCode = J9NLS_INVALID_REFERENCETYPE_DESCRIPTOR_ON_CLASS__ID;
-			offset = endOfConstantPool + 2;
-			goto _errorFound;
-		}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 	}
 
 	value = classfile->superClass;
@@ -2881,14 +2828,6 @@ checkClass(J9PortLibrary *portLib, J9CfrClassFile* classfile, U_8* segment, U_32
 			offset = endOfConstantPool + 4;
 			goto _errorFound;
 		}
-
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-		if (bcvIsReferenceTypeDescriptor(&classfile->constantPool[superClassInfo->slot1])) {
-			errorCode = J9NLS_INVALID_REFERENCETYPE_DESCRIPTOR_ON_SUPER_CLASS__ID;
-			offset = endOfConstantPool + 4;
-			goto _errorFound;
-		}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 	}
 
 	for (i = 0; i < classfile->interfacesCount; i++) {
@@ -2916,13 +2855,6 @@ checkClass(J9PortLibrary *portLib, J9CfrClassFile* classfile, U_8* segment, U_32
 				goto _errorFound;
 			}
 		}
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-		if (bcvIsReferenceTypeDescriptor(&classfile->constantPool[cpInfo->slot1])) {
-			errorCode = J9NLS_INVALID_REFERENCETYPE_DESCRIPTOR_ON_INTERFACE__ID;
-			offset = endOfConstantPool + 4 + (i << 1);
-			goto _errorFound;
-		}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 	}
 
 	/* Check that interfaces subclass object. */

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -984,12 +984,6 @@ checkBytecodeStructure (J9CfrClassFile * classfile, UDATA methodIndex, UDATA len
 				goto _verifyError;
 			}
 			info = &(classfile->constantPool[classfile->constantPool[index].slot1]);
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-			if ((CFR_BC_new == bc) && bcvIsReferenceTypeDescriptor(info)) {
-				errorType = J9NLS_CFR_ERR_NEW_INVALID_REFERENCETYPE_DESCRIPTOR__ID;
-				goto _verifyError;
-			}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 			break;
 
 		case CFR_BC_newarray:

--- a/runtime/oti/bcverify_api.h
+++ b/runtime/oti/bcverify_api.h
@@ -151,16 +151,6 @@ bcvCheckMethodName (J9CfrConstantPoolInfo * info);
 I_32
 bcvIsInitOrClinit (J9CfrConstantPoolInfo * info);
 
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-/**
-* @brief
-* @param info
-* @return BOOLEAN
-*/
-BOOLEAN
-bcvIsReferenceTypeDescriptor(J9CfrConstantPoolInfo * info);
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
-
 /* ---------------- clconstraints.c ---------------- */
 
 /**

--- a/runtime/verutil/chverify.c
+++ b/runtime/verutil/chverify.c
@@ -181,29 +181,3 @@ I_32
 bcvCheckName (J9CfrConstantPoolInfo * info) {
 	return checkNameImpl(info, FALSE, FALSE, FALSE);
 }
-
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-/**
- * Determines if the info parameter is a referencetype descriptor
- *
- * @param info The J9CfrConstantPoolInfo to check
- * @returns TRUE if info is a referencetype descriptor, FALSE otherwise
- */
-BOOLEAN
-bcvIsReferenceTypeDescriptor(J9CfrConstantPoolInfo * info) {
-	U_32 length = info->slot1;
-	U_8 *bytes = info->bytes;
-	BOOLEAN result = FALSE;
-
-	if (length <= 1) {
-		/* All referencetype descriptors must be more than one character long */
-		result = FALSE;
-	} else if (('[' == bytes[0]) || /* Check if bytes is an ArrayType descriptor */
-		((';' == bytes[length - 1]) && ('L' == bytes[0])) /* Check if bytes is a StandardReferenceType descriptor */
-	) {
-		result = TRUE;
-	}
-
-	return result;
-}
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -251,7 +251,7 @@ findFieldSignatureClass(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA field
 		resolvedClass = internalFindClassUTF8(vmStruct, J9UTF8_DATA(signature), J9UTF8_LENGTH(signature), classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 	} else {
 		Assert_VM_true(IS_REF_OR_VAL_SIGNATURE(J9UTF8_DATA(signature)[0]));
-		/* skip fieldSignature's L/Q and ; to have only CLASSNAME required for internalFindClassUTF8 */
+		/* skip fieldSignature's L and ; to have only CLASSNAME required for internalFindClassUTF8 */
 		resolvedClass = internalFindClassUTF8(vmStruct, &J9UTF8_DATA(signature)[1], J9UTF8_LENGTH(signature)-2, classLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 	}
 


### PR DESCRIPTION
This is from an old value types specification for ReferenceType which is no longer in use https://cr.openjdk.org/~dlsmith/jep401/jep401-20211220/specs/primitive-classes-jvms.html#jvms-4.3.2. 

Related to https://github.com/eclipse-openj9/openj9/issues/18157