### PR TITLE
Fix "storing the address of local variable" in trcmain.c

### DIFF
--- a/runtime/rastrace/trcmain.c
+++ b/runtime/rastrace/trcmain.c
@@ -1053,6 +1053,7 @@ initializeTrace(UtThreadData **thr, void **gbl,
 			} else {
 				/* the old utGlobal is still in use */
 				UT_DBGOUT(1, ("<UT> Error, utGlobal already in use.\n"));
+				*thr = NULL;
 				return OMR_ERROR_INTERNAL;
 			}
 		}


### PR DESCRIPTION
This commit fixes a build error with runtime/rastrace/trcmain.c.

Fixes: #20171