### PR TITLE
Fix "statement has no effect" with J9CLASS_DEPTH()

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -1463,7 +1463,7 @@ Java_java_lang_invoke_MethodHandleNatives_getMembers(
 					UDATA classDepth = 0;
 					if (J9_ARE_ANY_BITS_SET(matchFlags, MN_SEARCH_SUPERCLASSES)) {
 						/* walk superclasses */
-						J9CLASS_DEPTH(defClass);
+						classDepth = J9CLASS_DEPTH(defClass);
 					}
 					J9Class *currentClass = defClass;
 
@@ -1568,7 +1568,7 @@ Java_java_lang_invoke_MethodHandleNatives_getMembers(
 					UDATA classDepth = 0;
 					if (J9_ARE_ANY_BITS_SET(matchFlags, MN_SEARCH_SUPERCLASSES)) {
 						/* walk superclasses */
-						J9CLASS_DEPTH(defClass);
+						classDepth = J9CLASS_DEPTH(defClass);
 					}
 					J9Class *currentClass = defClass;
 


### PR DESCRIPTION
This commit fixes build errors with J9CLASS_DEPTH() in java_lang_invoke_MethodHandleNatives.cpp.

Fixes: #20170