### PR TITLE
Add and support JNI_VERSION_24 for Java 24+

### DIFF
--- a/runtime/include/jni.h.m4
+++ b/runtime/include/jni.h.m4
@@ -53,11 +53,12 @@ extern "C" {
 #define JNI_VERSION_1_4 0x00010004
 #define JNI_VERSION_1_6 0x00010006
 #define JNI_VERSION_1_8 0x00010008
-ifelse(eval(JAVA_SPEC_VERSION >=  9), 1, `#define JNI_VERSION_9   0x00090000', `dnl')
-ifelse(eval(JAVA_SPEC_VERSION >= 10), 1, `#define JNI_VERSION_10  0x000A0000', `dnl')
-ifelse(eval(JAVA_SPEC_VERSION >= 19), 1, `#define JNI_VERSION_19  0x00130000', `dnl')
-ifelse(eval(JAVA_SPEC_VERSION >= 20), 1, `#define JNI_VERSION_20  0x00140000', `dnl')
-ifelse(eval(JAVA_SPEC_VERSION >= 21), 1, `#define JNI_VERSION_21  0x00150000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >=  9), 1, `#define JNI_VERSION_9  0x00090000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 10), 1, `#define JNI_VERSION_10 0x000A0000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 19), 1, `#define JNI_VERSION_19 0x00130000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 20), 1, `#define JNI_VERSION_20 0x00140000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 21), 1, `#define JNI_VERSION_21 0x00150000', `dnl')
+ifelse(eval(JAVA_SPEC_VERSION >= 24), 1, `#define JNI_VERSION_24 0x00180000', `dnl')
 
 #define JVMEXT_VERSION_1_1 0x7E010001
 

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1679,6 +1679,9 @@ JVM_IsSupportedJNIVersion(jint version)
 #if JAVA_SPEC_VERSION >= 21
 	case JNI_VERSION_21:
 #endif /* JAVA_SPEC_VERSION >= 21 */
+#if JAVA_SPEC_VERSION >= 24
+	case JNI_VERSION_24:
+#endif /* JAVA_SPEC_VERSION >= 24 */
 		return JNI_TRUE;
 
 	default:

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2571,6 +2571,9 @@ jint JNICALL JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 #if JAVA_SPEC_VERSION >= 21
 	case JNI_VERSION_21:
 #endif /* JAVA_SPEC_VERSION >= 21 */
+#if JAVA_SPEC_VERSION >= 24
+	case JNI_VERSION_24:
+#endif /* JAVA_SPEC_VERSION >= 24 */
 		return JNI_OK;
 	}
 

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -938,6 +938,9 @@ JNI_GetDefaultJavaVMInitArgs(void *vm_args)
 #if JAVA_SPEC_VERSION >= 21
 		case JNI_VERSION_21:
 #endif /* JAVA_SPEC_VERSION >= 21 */
+#if JAVA_SPEC_VERSION >= 24
+		case JNI_VERSION_24:
+#endif /* JAVA_SPEC_VERSION >= 24 */
 			return JNI_OK;
 		default:
 			break;

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -396,7 +396,9 @@ getObjectClass(JNIEnv *env, jobject obj)
 jint JNICALL
 getVersion(JNIEnv *env)
 {
-#if JAVA_SPEC_VERSION >= 21
+#if JAVA_SPEC_VERSION >= 24
+	return JNI_VERSION_24;
+#elif JAVA_SPEC_VERSION >= 21
 	return JNI_VERSION_21;
 #elif JAVA_SPEC_VERSION >= 20
 	return JNI_VERSION_20;

--- a/runtime/vm/jvminitcommon.c
+++ b/runtime/vm/jvminitcommon.c
@@ -155,6 +155,9 @@ jniVersionIsValid(UDATA jniVersion)
 #if JAVA_SPEC_VERSION >= 21
 	case JNI_VERSION_21:
 #endif /* JAVA_SPEC_VERSION >= 21 */
+#if JAVA_SPEC_VERSION >= 24
+	case JNI_VERSION_24:
+#endif /* JAVA_SPEC_VERSION >= 24 */
 		return JNI_TRUE;
 	default:
 		return JNI_FALSE;


### PR DESCRIPTION
See also [openjdk](https://github.com/ibmruntimes/openj9-openjdk-jdk/blob/76f4981979e23822e3c1caaae3037c1e15942418/src/java.base/share/native/include/jni.h#L2005).