### PR TITLE
Remove DDR uses of J9ClassIsPrimitiveValueType

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
@@ -77,7 +77,6 @@ J9JavaAccessFlags.J9StaticFieldRefTypeObject = 0
 J9JavaAccessFlags.J9StaticFieldRefTypeShort = 0
 
 J9JavaClassFlags.J9ClassIsFlattened = 0
-J9JavaClassFlags.J9ClassIsPrimitiveValueType = 0
 J9JavaClassFlags.J9ClassIsValueType = 0
 J9JavaClassFlags.J9ClassLargestAlignmentConstraintDouble = 0
 J9JavaClassFlags.J9ClassLargestAlignmentConstraintReference = 0

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
@@ -235,11 +235,6 @@ public class ValueTypeHelper {
 		}
 
 		@Override
-		public boolean isJ9ClassAPrimitiveValueType(J9ClassPointer clazz) throws CorruptDataException {
-			return clazz.classFlags().allBitsIn(J9JavaClassFlags.J9ClassIsPrimitiveValueType);
-		}
-
-		@Override
 		public boolean isFieldInClassFlattened(J9ClassPointer clazz, J9ROMFieldShapePointer fieldShape) throws CorruptDataException {
 			boolean result = false;
 
@@ -404,17 +399,6 @@ public class ValueTypeHelper {
 	 * @throws CorruptDataException
 	 */
 	public boolean isJ9ClassAValueType(J9ClassPointer clazz) throws CorruptDataException {
-		return false;
-	}
-
-	/**
-	 * Queries if J9Class is a primitive value type
-	 *
-	 * @param clazz clazz to query
-	 * @return true if class is a primitive value type, false otherwise
-	 * @throws CorruptDataException
-	 */
-	public boolean isJ9ClassAPrimitiveValueType(J9ClassPointer clazz) throws CorruptDataException {
 		return false;
 	}
 


### PR DESCRIPTION
Related to https://github.com/eclipse-openj9/openj9/issues/18157