### PR TITLE
(v0.48.0) Fix testXXArgumentTesting

### DIFF
--- a/test/functional/cmdLineTests/xxargtest/XXArgumentTesting.xml
+++ b/test/functional/cmdLineTests/xxargtest/XXArgumentTesting.xml
@@ -25,53 +25,6 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 <suite id="XXArgumentTesting.xml" timeout="1000">
 
-	<test id="Ensure -XXnosuballoc32bitmem is recognized on all platforms">
-		<command>$EXE$ -Xcompressedrefs -XXnosuballoc32bitmem -version</command>
-		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
-		<output regex="no" type="failure">Command-line option unrecognised</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
-	</test>
-
-	<exec command="rm -f testjavacore.txt" quiet="false"/>
-
-	<test id="Generate a javacore without -XXnosuballoc32bitmem">
-		<command>$EXE$ -Xcompressedrefs -Xdump:java:events=vmstop,file=testjavacore.txt -version</command>
-		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
-		<output regex="no" type="failure">Command-line option unrecognised</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	</test>
-	
-	<test id="Verify that the sub allocator memory is listed in the javacore">
-		<command>cat testjavacore.txt</command>				
-		<output type="success" caseSensitive="no" regex="no">32bit allocation regions</output>
-	</test>
-	
-	<exec command="rm -f testjavacore.txt" quiet="false"/>
-	
-	<test id="Generate a javacore with -XXnosuballoc32bitmem">
-		<command>$EXE$ -Xcompressedrefs -XXnosuballoc32bitmem -Xdump:java:events=vmstop,file=testjavacore.txt -version</command>
-		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
-		<output regex="no" type="failure">Command-line option unrecognised</output>
-		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
-		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
-	</test>
-	
-	<test id="Verify that the sub allocator memory is not listed in the javacore on z/OS. All other platforms should use the sub-allocator when -XXnosuballoc32bitmem is used.">
-		<command>cat testjavacore.txt</command>				
-		<output type="success" caseSensitive="no" regex="no">Javacore filename</output>
-		<output type="failure" caseSensitive="no" regex="no" platforms="zos_390-64_cmprssptrs.*">32bit allocation regions</output>		
-	</test>
-	
-	<test id="Verify -XX:MaxHeapSize -XX:InitialHeapSize -XX:ThreadStackSize">
-		<command>$EXE$ -XX:MaxHeapSize=234m -XX:InitialHeapSize=11m -verbose:sizes -version</command>				
-		<output type="success" caseSensitive="no" regex="no">OpenJ9</output>
-		<output type="required" caseSensitive="no" regex="no">-Xmx234M</output>
-		<output type="required" caseSensitive="no" regex="no">-Xms11M</output>
-	</test>
-	
 	<test id="Verify -XX:+PrintFlagsFinal">
 		<command>$EXE$ -XX:+PrintFlagsFinal -version</command>
 		<output type="success" caseSensitive="no" regex="no">[Global flags]</output>

--- a/test/functional/cmdLineTests/xxargtest/XXArgumentTesting_j9.xml
+++ b/test/functional/cmdLineTests/xxargtest/XXArgumentTesting_j9.xml
@@ -25,6 +25,53 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 <suite id="XXArgumentTesting.xml" timeout="1000">
 
+	<test id="Ensure -XXnosuballoc32bitmem is recognized on all platforms">
+		<command>$EXE$ -Xcompressedrefs -XXnosuballoc32bitmem -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output regex="no" type="failure">Command-line option unrecognised</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<exec command="rm -f testjavacore.txt" quiet="false"/>
+
+	<test id="Generate a javacore without -XXnosuballoc32bitmem">
+		<command>$EXE$ -Xcompressedrefs -Xdump:java:events=vmstop,file=testjavacore.txt -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output regex="no" type="failure">Command-line option unrecognised</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+	</test>
+
+	<test id="Verify that the sub allocator memory is listed in the javacore">
+		<command>cat testjavacore.txt</command>
+		<output type="success" caseSensitive="no" regex="no">32bit allocation regions</output>
+	</test>
+
+	<exec command="rm -f testjavacore.txt" quiet="false"/>
+
+	<test id="Generate a javacore with -XXnosuballoc32bitmem">
+		<command>$EXE$ -Xcompressedrefs -XXnosuballoc32bitmem -Xdump:java:events=vmstop,file=testjavacore.txt -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+		<output regex="no" type="failure">Command-line option unrecognised</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>
+	</test>
+
+	<test id="Verify that the sub allocator memory is not listed in the javacore on z/OS. All other platforms should use the sub-allocator when -XXnosuballoc32bitmem is used.">
+		<command>cat testjavacore.txt</command>
+		<output type="success" caseSensitive="no" regex="no">Javacore filename</output>
+		<output type="failure" caseSensitive="no" regex="no" platforms="zos_390-64_cmprssptrs.*">32bit allocation regions</output>
+	</test>
+
+	<test id="Verify -XX:MaxHeapSize -XX:InitialHeapSize -XX:ThreadStackSize">
+		<command>$EXE$ -XX:MaxHeapSize=234m -XX:InitialHeapSize=11m -verbose:sizes -version</command>
+		<output type="success" caseSensitive="no" regex="no">OpenJ9</output>
+		<output type="required" caseSensitive="no" regex="no">-Xmx234M</output>
+		<output type="required" caseSensitive="no" regex="no">-Xms11M</output>
+	</test>
+
 	<test id="Verify single/rightmost -XX:+UseCompressedOops overrides earlier -XX:-UseCompressedOops or -Xnocompressedrefs (based on mode options)">
 		<command>$EXE$ -XX:+UseCompressedOops -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Compressed References</output>

--- a/test/functional/cmdLineTests/xxargtest/playlist.xml
+++ b/test/functional/cmdLineTests/xxargtest/playlist.xml
@@ -28,7 +28,8 @@
 			<variation>Mode150</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) -DEXE=$(SQ)$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) \
-	-config $(Q)$(TEST_RESROOT)$(D)XXArgumentTesting.xml$(Q); \
+	-config $(Q)$(TEST_RESROOT)$(D)XXArgumentTesting.xml$(Q) \
+	-nonZeroExitWhenError; \
 	$(TEST_STATUS)</command>
 		<levels>
 			<level>sanity</level>


### PR DESCRIPTION
Cherry-pick 4a6636a98f561cba48425d88357af63fa0460030

Move j9 specific subtests to XXArgumentTesting_j9

Issues: #19966