### PR TITLE
(0.48) Cache rom to ram mappings for exception backtrace

### DIFF
--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -6943,3 +6943,17 @@ J9NLS_SHRC_CM_PRINTSTATS_PAGESIZEE.explanation=NOTAG
 J9NLS_SHRC_CM_PRINTSTATS_PAGESIZEE.system_action=
 J9NLS_SHRC_CM_PRINTSTATS_PAGESIZEE.user_response=
 # END NON-TRANSLATABLE
+
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMHASHTABLE=Cannot allocate ROM to RAM class hash table in shrinit
+# START NON-TRANSLATABLE
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMHASHTABLE.explanation=The system is unable to obtain sufficient native memory to allocate internal data structures.
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMHASHTABLE.system_action=The JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM attempts to start up without using Shared Classes.
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMHASHTABLE.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
+# END NON-TRANSLATABLE
+
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMMUTEX=Cannot allocate ROM to RAM class mutex in shrinit
+# START NON-TRANSLATABLE
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMMUTEX.explanation=The system is unable to obtain sufficient native memory to allocate internal data structures.
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMMUTEX.system_action=The JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM attempts to start up without using Shared Classes.
+J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMMUTEX.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1415,6 +1415,11 @@ typedef struct J9SharedClassConfig {
 	const char* cacheName;
 	I_8 layer;
 	U_64 readOnlyCacheRuntimeFlags;
+	/* This table is a cache for exceptiondescribe.c:findJ9ClassForROMClass
+	 * and does not contain mappings for every romClass to ramClass.
+	 */
+	struct J9HashTable *romToRamHashTable;
+	omrthread_rwmutex_t romToRamHashTableMutex;
 } J9SharedClassConfig;
 
 typedef struct J9SharedClassPreinitConfig {

--- a/runtime/shared_common/include/SCQueryFunctions.h
+++ b/runtime/shared_common/include/SCQueryFunctions.h
@@ -130,6 +130,18 @@ j9shr_Query_PopulatePreinitConfigDefaults(J9JavaVM *vm, J9SharedClassPreinitConf
 }
 #endif
 
+typedef struct RomToRamEntry {
+	J9Class *ramClass;
+} RomToRamEntry;
+
+typedef struct RomToRamQueryEntry {
+	/* J9ROMClass address | ROM_TO_RAM_QUERY_TAG */
+	J9ROMClass *romClass;
+} RomToRamQueryEntry;
+
+/* Used to tell RomToRamQueryEntry apart from RomToRamEntry. */
+#define ROM_TO_RAM_QUERY_TAG 0x1
+
 #ifdef __cplusplus
 }/*extern "C"*/
 #endif


### PR DESCRIPTION
Create a hash table and access mutex to cache romClass to ramClass mappings from exceptiondescribe.c:findJ9ClassForROMClass. This saves time iterating over multiple class loaders to find a ram class. Entries will be deleted when a class is unloaded or redefined.

Port from https://github.com/eclipse-openj9/openj9/pull/20169