### PR TITLE
romToRam cache follow up

### DIFF
--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2643,9 +2643,9 @@ recreateRAMClasses(J9VMThread * currentThread, J9HashTable * classHashTable, J9H
 		if (!fastHCR) {
 			vmFuncs->hashClassTableDelete(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
 			if ((NULL != vm->sharedClassConfig) && (NULL != vm->sharedClassConfig->romToRamHashTable)) {
-				omrthread_rwmutex_enter_write(vm->sharedClassConfig->romToRamHashTableMutex);
 				RomToRamEntry entry;
 				entry.ramClass = originalRAMClass;
+				omrthread_rwmutex_enter_write(vm->sharedClassConfig->romToRamHashTableMutex);
 				hashTableRemove(vm->sharedClassConfig->romToRamHashTable, &entry);
 				omrthread_rwmutex_exit_write(vm->sharedClassConfig->romToRamHashTableMutex);
 			}


### PR DESCRIPTION
- Declare variables first in romToRam entry removal
- Correctly free romToRam hash table and mutex

https://github.com/eclipse-openj9/openj9/pull/20169#discussion_r1766925674

Port to 0.48: https://github.com/eclipse-openj9/openj9/pull/20197