### PR TITLE
Fix array lists walk in ClassLoaderClasses Iterator

### DIFF
--- a/runtime/gc_structs/ClassLoaderClassesIterator.hpp
+++ b/runtime/gc_structs/ClassLoaderClassesIterator.hpp
@@ -120,6 +120,17 @@ private:
 	 */
 	J9Class *nextArrayClass();
 	
+	/**
+	 * Initialize array class walk state machine.
+	 */
+	MMINLINE void
+	initArrayClassWalk()
+	{
+		_startingClass = _nextClass;
+		_arrayState = STATE_VALUETYPEARRAY;
+		_iterateArrayClazz = NULL;
+	}
+
 protected:
 	
 public:


### PR DESCRIPTION
- Do proper initialization of state machine before use it for walk.
- Move check that list is switched to super Classloader to proper place to cancel walk on individual list, not for all lists.

relates to https://github.com/eclipse-openj9/openj9/issues/20150