### PR TITLE
Add openjdk test group to 'sanity' keyword for PR builds

### DIFF
--- a/buildenv/jenkins/common/variables-functions.groovy
+++ b/buildenv/jenkins/common/variables-functions.groovy
@@ -712,7 +712,11 @@ def set_test_targets() {
     if (TESTS_TARGETS != 'none') {
         for (target in TESTS_TARGETS.replaceAll("\\s","").toLowerCase().tokenize(',')) {
             switch (target) {
-                case ["sanity", "extended"]:
+                case ["sanity"]:
+                    TESTS["${target}.functional"] = [:]
+                    TESTS["${target}.openjdk"] = [:]
+                    break
+                case ["extended"]:
                     TESTS["${target}.functional"] = [:]
                     break
                 default:


### PR DESCRIPTION
Run functional and openjdk test buckets for sanity keyword.
Continue to run functional for extended keyword.