### PR TITLE
Refactor a few CRIU APIs to take J9JavaVM* instead of J9VMThread*

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2478,8 +2478,8 @@ bool TR::CompilationInfo::shouldRetryCompilation(J9VMThread *vmThread, TR_Method
    else if (entry->_compErrCode != compilationOK)
       {
       J9JavaVM *javaVM = compInfo->getJITConfig()->javaVM;
-      if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread)
-          && javaVM->internalVMFunctions->isCheckpointAllowed(vmThread)
+      if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM)
+          && javaVM->internalVMFunctions->isCheckpointAllowed(javaVM)
           && !compInfo->getCRRuntime()->isCheckpointInProgress()
           && !compInfo->isInShutdownMode())
          {
@@ -7219,7 +7219,7 @@ TR::CompilationInfoPerThreadBase::cannotPerformRemoteComp(
    {
    return
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-          (_jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread) && !_compInfo.getCRRuntime()->canPerformRemoteCompilationInCRIUMode()) ||
+          (_jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(_jitConfig->javaVM) && !_compInfo.getCRRuntime()->canPerformRemoteCompilationInCRIUMode()) ||
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
           !JITServer::ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)) ||
           (!JITServerHelpers::isServerAvailable() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))) ||
@@ -8993,7 +8993,7 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                           vm->isAOT_DEPRECATED_DO_NOT_USE() || // AOT compilations
 #if defined(J9VM_OPT_CRIU_SUPPORT)
                           (jitConfig->javaVM->internalVMFunctions->isNonPortableRestoreMode(vmThread) &&
-                          jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread)) ||
+                          jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM)) ||
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
                           TR::Options::getAggressivityLevel() == TR::Options::TR_AggresivenessLevel::AGGRESSIVE_THROUGHPUT;
                   if (enableExpensiveOptsAtWarm)
@@ -10585,8 +10585,8 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                {
                jitMethodTranslated(vmThread, method, startPC);
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-               if (jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread)
-                   && jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread)
+               if (jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM)
+                   && jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
                    && (!compInfo->getCRRuntime()->isCheckpointInProgress() || comp->getOption(TR_FullSpeedDebug)))
                   {
                   if (comp->getRecompilationInfo() && comp->getRecompilationInfo()->getJittedBodyInfo())

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -440,8 +440,8 @@ static void jitHookInitializeSendTarget(J9HookInterface * * hook, UDATA eventNum
       {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
       bool cpAllowedAndDebugOnRestoreEnabled
-         = jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread)
-           && jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread);
+         = jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
+           && jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
       bool sccCounts =
@@ -1397,8 +1397,8 @@ static void jitMethodSampleInterrupt(J9VMThread* vmThread, IDATA handlerKey, voi
           && !compInfo->getCRRuntime()->shouldSuspendThreadsForCheckpoint()
 
           /* Don't sample methods for recompilation pre-checkpoint if Debug On Restore is enabled */
-          && (!jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread)
-              || !jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+          && (!jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM)
+              || !jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM))
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
           && !compInfo->getPersistentInfo()->getDisableFurtherCompilation())
          {
@@ -1456,8 +1456,8 @@ static void jitMethodSampleInterrupt(J9VMThread* vmThread, IDATA handlerKey, voi
           && !compInfo->getCRRuntime()->shouldSuspendThreadsForCheckpoint()
 
           /* Don't sample methods for recompilation pre-checkpoint if Debug On Restore is enabled */
-          && (!jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread)
-              || !jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+          && (!jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM)
+              || !jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM))
 #endif
           && !compInfo->getPersistentInfo()->getDisableFurtherCompilation())
          {
@@ -4182,7 +4182,7 @@ void JitShutdown(J9JITConfig * jitConfig)
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-   if (jitConfig->javaVM->internalVMFunctions->isCRaCorCRIUSupportEnabled(vmThread))
+   if (jitConfig->javaVM->internalVMFunctions->isCRaCorCRIUSupportEnabled(jitConfig->javaVM))
       {
       compInfo->getCRRuntime()->stopCRRuntimeThread();
       }
@@ -4957,7 +4957,7 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
        TR::Options::getCmdLineOptions()->getOption(TR_NoIProfilerDuringStartupPhase) &&
        interpreterProfilingState == IPROFILING_STATE_OFF
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-       && (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(compInfo->getSamplerThread())
+       && (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
            || compInfo->getCRRuntime()->allowStateChange())
 #endif
       )
@@ -5025,7 +5025,7 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
 #endif
                if (crtElapsedTime - lastTimeInStartupMode > waitTime
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-                   && (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(compInfo->getSamplerThread())
+                   && (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
                        || compInfo->getCRRuntime()->allowStateChange())
 #endif
                   )
@@ -5045,7 +5045,7 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
             // is implemented above in the IF block
             if (persistentInfo->getExternalStartupEndedSignal()
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-                && (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(compInfo->getSamplerThread())
+                && (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
                     || compInfo->getCRRuntime()->allowStateChange())
 #endif
                )
@@ -5073,7 +5073,7 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
                else
                   {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-                  if (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(compInfo->getSamplerThread())
+                  if (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
                       || compInfo->getCRRuntime()->allowStateChange())
 #endif
                      {
@@ -5094,7 +5094,7 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
             else
                {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-               if (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(compInfo->getSamplerThread())
+               if (!jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
                    || compInfo->getCRRuntime()->allowStateChange())
 #endif
                   {
@@ -6430,7 +6430,7 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
          crtTime += samplingPeriod;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-         if (vm->internalVMFunctions->isCheckpointAllowed(samplerThread))
+         if (vm->internalVMFunctions->isCheckpointAllowed(vm))
             {
             /* It's ok to not acquire the comp monitor here. Even if at this
              * point a checkpoint isn't in progress but later it is, the
@@ -6446,7 +6446,7 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
             if (compInfo->getCRRuntime()->shouldSuspendThreadsForCheckpoint())
                suspendSamplerThreadForCheckpoint(samplerThread,jitConfig, compInfo);
             }
-         else if (vm->internalVMFunctions->isDebugOnRestoreEnabled(samplerThread))
+         else if (vm->internalVMFunctions->isDebugOnRestoreEnabled(vm))
             {
             if (!forcedRecompilations && jitConfig->javaVM->phase == J9VM_PHASE_NOT_STARTUP)
                {
@@ -6778,7 +6778,7 @@ static int32_t J9THREAD_PROC samplerThreadProc(void * entryarg)
 
             // compute jit state
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-            if (!jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(samplerThread))
+            if (!jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM))
 #endif
                {
                jitStateLogic(jitConfig, compInfo, diffTime); // Update JIT state before going to sleep
@@ -7235,8 +7235,6 @@ int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm)
    J9HookInterface * * gcHooks = javaVM->memoryManagerFunctions->j9gc_get_hook_interface(javaVM);
    J9HookInterface * * gcOmrHooks = javaVM->memoryManagerFunctions->j9gc_get_omr_hook_interface(javaVM->omrVM);
 
-   J9VMThread *vmThread = javaVM->internalVMFunctions->currentVMThread(javaVM);
-
    PORT_ACCESS_FROM_JAVAVM(javaVM);
 
    if (TR::Options::getCmdLineOptions()->getOption(TR_noJitDuringBootstrap) ||
@@ -7393,7 +7391,7 @@ int32_t setUpHooks(J9JavaVM * javaVM, J9JITConfig * jitConfig, TR_FrontEnd * vm)
 #endif // if defined (J9VM_INTERP_PROFILING_BYTECODES)
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-      if (jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+      if (jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM))
          {
          compInfo->getCRRuntime()->startCRRuntimeThread(javaVM);
          }

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2428,7 +2428,7 @@ bool J9::Options::preProcessJitServer(J9JavaVM *vm, J9JITConfig *jitConfig)
          // Enable JITServer client mode if
          // 1) CRIU support is enabled
          // 2) client mode is not explicitly disabled
-         bool implicitClientMode = ifuncs->isCRaCorCRIUSupportEnabled(currentThread) && !useJitServerExplicitlyDisabled;
+         bool implicitClientMode = ifuncs->isCRaCorCRIUSupportEnabled(vm) && !useJitServerExplicitlyDisabled;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
          if (useJitServerExplicitlySpecified
@@ -3034,10 +3034,9 @@ bool
 J9::Options::isFSDNeeded(J9JavaVM *javaVM, J9HookInterface **vmHooks)
    {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-   J9VMThread * vmThread = javaVM->internalVMFunctions->currentVMThread(javaVM);
-   if (javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+   if (javaVM->internalVMFunctions->isCheckpointAllowed(javaVM))
       {
-      if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+      if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM))
          {
          return false;
          }
@@ -3110,7 +3109,6 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    J9JITConfig * jitConfig = (J9JITConfig*)base;
    J9JavaVM * javaVM = jitConfig->javaVM;
    J9HookInterface * * vmHooks = javaVM->internalVMFunctions->getVMHookInterface(javaVM);
-   J9VMThread * vmThread = javaVM->internalVMFunctions->currentVMThread(javaVM);
 
    TR_J9VMBase * vm = TR_J9VMBase::get(jitConfig, 0);
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
@@ -3146,7 +3144,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
       }
 #if defined(J9VM_OPT_CRIU_SUPPORT)
    else if (fsdStatus == FSDInitStatus::FSDInit_NotInitialized
-            && javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+            && javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM))
       {
       self()->setOption(TR_FullSpeedDebug);
       self()->setOption(TR_DisableDirectToJNI);
@@ -3340,7 +3338,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
             }
          }
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-      else if (!javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+      else if (!javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM))
 #else
       else
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
@@ -3837,8 +3835,8 @@ J9::Options::resetFSD(J9JavaVM *vm, J9VMThread *vmThread, bool &doAOT)
    TR_ASSERT_FATAL (fsdStatusJIT == fsdStatusAOT, "fsdStatusJIT=%d != fsdStatusAOT=%d!\n", fsdStatusJIT, fsdStatusAOT);
 
    if (fsdStatusJIT == TR::Options::FSDInitStatus::FSDInit_NotInitialized
-       && !vm->internalVMFunctions->isCheckpointAllowed(vmThread)
-       && vm->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+       && !vm->internalVMFunctions->isCheckpointAllowed(vm)
+       && vm->internalVMFunctions->isDebugOnRestoreEnabled(vm))
       {
       getCmdLineOptions()->setFSDOptionsForAll(false);
       getAOTCmdLineOptions()->setFSDOptionsForAll(false);

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1613,7 +1613,7 @@ onLoadInternal(
 #endif // defined(J9VM_OPT_JITSERVER)
       {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-      if (javaVM->internalVMFunctions->isCheckpointAllowed(curThread))
+      if (javaVM->internalVMFunctions->isCheckpointAllowed(javaVM))
          {
          if (TR::Options::_numAllocatedCompilationThreads > maxNumberOfCodeCaches)
             {
@@ -2053,7 +2053,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
    if (compInfo->getCRRuntime())
       compInfo->getCRRuntime()->cacheEventsStatus();
 
-   bool debugOnRestoreEnabled = javaVM->internalVMFunctions->isDebugOnRestoreEnabled(curThread);
+   bool debugOnRestoreEnabled = javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM);
 
    /* If the JVM is in CRIU mode and checkpointing is allowed, then the JIT should be
     * limited to the same processor features as those used in Portable AOT mode. This

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -817,8 +817,8 @@ TR_J9VMBase::TR_J9VMBase(
 #if defined(J9VM_OPT_CRIU_SUPPORT)
       || (vmThread
           && jitConfig->javaVM->sharedClassConfig
-          && jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread)
-          && jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+          && jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(jitConfig->javaVM)
+          && jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(jitConfig->javaVM))
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
       )
       // shared classes and AOT must be enabled, or we should be on the JITServer with remote AOT enabled
@@ -9666,7 +9666,8 @@ bool
 TR_J9VMBase::inSnapshotMode()
    {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-   return getJ9JITConfig()->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread());
+   J9JavaVM *javaVM = getJ9JITConfig()->javaVM;
+   return javaVM->internalVMFunctions->isCheckpointAllowed(javaVM);
 #else /* defined(J9VM_OPT_CRIU_SUPPORT) */
    return false;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
@@ -9686,7 +9687,8 @@ bool
 TR_J9VMBase::isSnapshotModeEnabled()
    {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-   return getJ9JITConfig()->javaVM->internalVMFunctions->isCRaCorCRIUSupportEnabled(vmThread());
+   J9JavaVM *javaVM = getJ9JITConfig()->javaVM;
+   return javaVM->internalVMFunctions->isCRaCorCRIUSupportEnabled(javaVM);
 #else /* defined(J9VM_OPT_CRIU_SUPPORT) */
    return false;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -371,7 +371,7 @@ void
 TR::CRRuntime::setupEnvForProactiveCompilation(J9JavaVM *javaVM, J9VMThread *vmThread, TR_J9VMBase *fej9)
    {
    /* Proactive compilation should not be FSD compiles */
-   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM))
       {
       TR::Options::getCmdLineOptions()->setFSDOptionsForAll(false);
       TR::Options::getAOTCmdLineOptions()->setFSDOptionsForAll(false);
@@ -395,7 +395,7 @@ void
 TR::CRRuntime::teardownEnvForProactiveCompilation(J9JavaVM *javaVM, J9VMThread *vmThread, TR_J9VMBase *fej9)
    {
    /* Proactive compilation should not be FSD compiles */
-   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM))
       {
       TR::Options::getCmdLineOptions()->setFSDOptionsForAll(true);
       TR::Options::getAOTCmdLineOptions()->setFSDOptionsForAll(true);
@@ -619,8 +619,8 @@ void
 TR::CRRuntime::resumeJITThreadsForRestore(J9VMThread *vmThread)
    {
    // Allow heuristics to turn on the IProfiler
-   if (_jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread)
-       && !_jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+   if (_jitConfig->javaVM->internalVMFunctions->isDebugOnRestoreEnabled(_jitConfig->javaVM)
+       && !_jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(_jitConfig->javaVM))
       {
       turnOffInterpreterProfiling(_jitConfig);
       TR::Options::getCmdLineOptions()->setOption(TR_NoIProfilerDuringStartupPhase);

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -4087,7 +4087,8 @@ TR_IProfiler::processWorkingQueue()
          {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
          // Check if the IProfiler Thread should be suspended for checkpoint
-         if (_compInfo->getJITConfig()->javaVM->internalVMFunctions->isCheckpointAllowed(_iprofilerThread))
+         J9JavaVM *javaVM = _compInfo->getJITConfig()->javaVM;
+         if (javaVM->internalVMFunctions->isCheckpointAllowed(javaVM))
             {
             // The monitors must be acquired in the right order, therefore
             // release the IProfiler monitor prior to attempting to suspend
@@ -4190,7 +4191,7 @@ UDATA TR_IProfiler::parseBuffer(J9VMThread * vmThread, const U_8* dataStart, UDA
    J9JavaVM *javaVM = _compInfo->getJITConfig()->javaVM;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread) && javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+   if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(javaVM) && javaVM->internalVMFunctions->isCheckpointAllowed(javaVM))
       {
       int32_t dropRate = (int32_t)((((float)(_numRequestsDropped + _numRequestsSkipped)) / ((float)_numRequests)) * 1000);
       if (TR::Options::_IprofilerPreCheckpointDropRate >= 1000 || dropRate <= TR::Options::_IprofilerPreCheckpointDropRate)

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3038,7 +3038,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 				extensions->concurrentScavengerHWSupport = hwSupported
 					&& !extensions->softwareRangeCheckReadBarrierForced
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-					&& !vm->internalVMFunctions->isCRaCorCRIUSupportEnabled_VM(vm)
+					&& !vm->internalVMFunctions->isCRaCorCRIUSupportEnabled(vm)
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 					&& !J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE);
 			}

--- a/runtime/gc_modron_startup/mmparseXgcpolicy.cpp
+++ b/runtime/gc_modron_startup/mmparseXgcpolicy.cpp
@@ -85,7 +85,7 @@ isMetronomeGCPolicySupported(MM_GCExtensions *extensions)
 {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	J9JavaVM *vm = extensions->getJavaVM();
-	if (vm->internalVMFunctions->isCRaCorCRIUSupportEnabled_VM(vm)) {
+	if (vm->internalVMFunctions->isCRaCorCRIUSupportEnabled(vm)) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU, "metronome");
 		return false;
@@ -107,7 +107,7 @@ isBalancedGCPolicySupported(MM_GCExtensions *extensions)
 {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	J9JavaVM *vm = extensions->getJavaVM();
-	if (vm->internalVMFunctions->isCRaCorCRIUSupportEnabled_VM(vm)) {
+	if (vm->internalVMFunctions->isCRaCorCRIUSupportEnabled(vm)) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_POLICY_NOT_SUPPOURTED_CRIU, "balanced");
 		return false;

--- a/runtime/jcl/common/criu.cpp
+++ b/runtime/jcl/common/criu.cpp
@@ -57,10 +57,10 @@ Java_openj9_internal_criu_InternalCRIUSupport_getProcessRestoreStartTimeImpl(JNI
 jboolean JNICALL
 Java_openj9_internal_criu_InternalCRIUSupport_isCheckpointAllowedImpl(JNIEnv *env, jclass unused)
 {
-	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = ((J9VMThread *)env)->javaVM;
 	jboolean res = JNI_FALSE;
 
-	if (currentThread->javaVM->internalVMFunctions->isCheckpointAllowed(currentThread)) {
+	if (vm->internalVMFunctions->isCheckpointAllowed(vm)) {
 		res = JNI_TRUE;
 	}
 

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -464,7 +464,7 @@ jobject getPropertyList(JNIEnv *env)
 	 * https://github.com/eclipse-openj9/openj9/issues/15800
 	 */
 	result = -1;
-	if (!vmFuncs->isCheckpointAllowed(currentThread))
+	if (!vmFuncs->isCheckpointAllowed(javaVM))
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	{
 		result = j9sysinfo_get_username(username, USERNAME_LENGTH);

--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -97,7 +97,8 @@ jobject getPlatformPropertyList(JNIEnv *env, const char *strings[], int propInde
 	char home[EsMaxPath] = {0};
 	char *homeAlloc = NULL;
 	J9VMThread *currentThread = (J9VMThread*)env;
-	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
 	/* Hard coded file/path separators and other values */
 
@@ -158,7 +159,7 @@ jobject getPlatformPropertyList(JNIEnv *env, const char *strings[], int propInde
 	/* Skip getpwuid if a checkpoint can be taken.
 	 * https://github.com/eclipse-openj9/openj9/issues/15800
 	 */
-	if (!vmFuncs->isCheckpointAllowed(currentThread))
+	if (!vmFuncs->isCheckpointAllowed(vm))
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 	{
 		/*[PR 101939] user.home not set correctly when j9 invoked via execve(x,y,null) */

--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -547,11 +547,10 @@ mapCapabilitiesToEvents(J9JVMTIEnv * j9env, jvmtiCapabilities * capabilities, J9
 	IDATA rc = 0;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-	J9JavaVM * vm = j9env->vm;
-	J9VMThread *mainThread = vm->mainThread;
+	J9JavaVM *vm = j9env->vm;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	BOOLEAN skipHookReserve = vmFuncs->isCheckpointAllowed(mainThread)
-			&& vmFuncs->isDebugOnRestoreEnabled(mainThread);
+	BOOLEAN skipHookReserve = vmFuncs->isCheckpointAllowed(vm)
+			&& vmFuncs->isDebugOnRestoreEnabled(vm);
 	/* Skip J9HookReserve for the events required by JDWP agent pre-checkpoint when DebugOnRestore is enabled,
 	 * these events will be registered post-restore if a JDWP agent is specified in the restore option file,
 	 * otherwise they are going to be unregistered by J9HookUnregister() which only clears J9HOOK_FLAG_HOOKED,

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -2047,7 +2047,7 @@ hookGlobalEvents(J9JVMTIData * jvmtiData)
 	}
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-	if (vm->internalVMFunctions->isDebugOnRestoreEnabled(vm->mainThread)) {
+	if (vm->internalVMFunctions->isDebugOnRestoreEnabled(vm)) {
 		if ((*vmHook)->J9HookRegisterWithCallSite(vmHook, J9HOOK_TAG_AGENT_ID | J9HOOK_VM_PREPARING_FOR_RESTORE, jvmtiHookVMRestoreCRIUInit, OMR_GET_CALLSITE(), jvmtiData, J9HOOK_AGENTID_FIRST)) {
 			return 1;
 		}

--- a/runtime/jvmti/jvmtiStartup.c
+++ b/runtime/jvmti/jvmtiStartup.c
@@ -168,8 +168,8 @@ createAgentLibraryWithOption(J9JavaVM *vm, J9VMInitArgs *argsList, IDATA agentIn
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 		if ((JNI_OK == result)
 			&& (isXrunjdwp || (0 == strncmp(JDWP_AGENT, optionsPtr, libraryLength)))
-			&& (vm->internalVMFunctions->isDebugOnRestoreEnabled(vm->mainThread))
-		){
+			&& (vm->internalVMFunctions->isDebugOnRestoreEnabled(vm))
+		) {
 			*isJDWPagent = TRUE;
 		}
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
@@ -381,7 +381,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 			 * Adding capabilities is required before checkpoint if JIT is enabled.
 			 * Following code can be removed when JIT allows capabilities to be added after restore.
 			 */
-			if (vm->internalVMFunctions->isDebugOnRestoreEnabled(vm->mainThread)) {
+			if (vm->internalVMFunctions->isDebugOnRestoreEnabled(vm)) {
 				Trc_JVMTI_criuAddCapabilities_invoked();
 				/* ignore the failure, it won't cause a problem if JDWP is not enabled later */
 				criuAddCapabilities(vm, NULL != vm->jitConfig);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5152,14 +5152,13 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	BOOLEAN (*jvmCheckpointHooks)(struct J9VMThread *currentThread);
 	BOOLEAN (*jvmRestoreHooks)(struct J9VMThread *currentThread);
-	BOOLEAN (*isCRaCorCRIUSupportEnabled)(struct J9VMThread *currentThread);
-	BOOLEAN (*isCRaCorCRIUSupportEnabled_VM)(struct J9JavaVM *vm);
+	BOOLEAN (*isCRaCorCRIUSupportEnabled)(struct J9JavaVM *vm);
 	BOOLEAN (*isCRIUSupportEnabled)(struct J9VMThread *currentThread);
 	BOOLEAN (*enableCRIUSecProvider)(struct J9VMThread *currentThread);
-	BOOLEAN (*isCheckpointAllowed)(struct J9VMThread *currentThread);
+	BOOLEAN (*isCheckpointAllowed)(struct J9JavaVM *vm);
 	BOOLEAN (*isNonPortableRestoreMode)(struct J9VMThread *currentThread);
 	BOOLEAN (*isJVMInPortableRestoreMode)(struct J9VMThread *currentThread);
-	BOOLEAN (*isDebugOnRestoreEnabled)(struct J9VMThread *currentThread);
+	BOOLEAN (*isDebugOnRestoreEnabled)(struct J9JavaVM *vm);
 	void (*setRequiredGhostFileLimit)(struct J9VMThread *currentThread, U_32 ghostFileLimit);
 	BOOLEAN (*runInternalJVMCheckpointHooks)(struct J9VMThread *currentThread, const char **nlsMsgFormat);
 	BOOLEAN (*runInternalJVMRestoreHooks)(struct J9VMThread *currentThread, const char **nlsMsgFormat);

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -514,21 +514,11 @@ internalCreateRAMClassFromROMClass(J9VMThread *vmThread, J9ClassLoader *classLoa
  * @brief Queries if CRaC or CRIU support is enabled. By default support
  * is not enabled, it can be enabled with -XX:CRaCCheckpointTo or -XX:+EnableCRIUSupport.
  *
- * @param currentThread vmthread token
- * @return TRUE if enabled, FALSE otherwise
- */
-BOOLEAN
-isCRaCorCRIUSupportEnabled(J9VMThread *currentThread);
-
-/**
- * @brief Queries if CRaC or CRIU support is enabled. By default support
- * is not enabled, it can be enabled with -XX:CRaCCheckpointTo or -XX:+EnableCRIUSupport.
- *
  * @param vm javaVM token
  * @return TRUE if enabled, FALSE otherwise
  */
 BOOLEAN
-isCRaCorCRIUSupportEnabled_VM(J9JavaVM *vm);
+isCRaCorCRIUSupportEnabled(J9JavaVM *vm);
 
 /**
  * @brief Queries if CRIU support is enabled. By default support
@@ -557,11 +547,11 @@ enableCRIUSecProvider(J9VMThread *currentThread);
  * will not be permitted after the JVM has been restored from a checkpoint
  * (checkpoint once mode).
  *
- * @param currentThread vmthread token
+ * @param vm javaVM token
  * @return TRUE if permitted, FALSE otherwise
  */
 BOOLEAN
-isCheckpointAllowed(J9VMThread *currentThread);
+isCheckpointAllowed(J9JavaVM *vm);
 
 /**
  * @brief Queries if non-portable restore mode (specified via
@@ -593,9 +583,12 @@ isJVMInPortableRestoreMode(J9VMThread *currentThread);
  * -XX:+DebugOnRestore) is supported. If so, the JVM
  * will run in FSD mode pre-checkpoint and will transition out
  * FSD mode on restore (unless debug is specified post restore).
+ *
+ * @param vm javaVM token
+ * @return TRUE if enabled, FALSE otherwise
  */
 BOOLEAN
-isDebugOnRestoreEnabled(J9VMThread *currentThread);
+isDebugOnRestoreEnabled(J9JavaVM *vm);
 
 /**
  * @brief Sets the maximum size for the CRIU ghost files.

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -2675,8 +2675,7 @@ sysinfoGetUserNameHelper(J9JavaVM *vm, UDATA verboseFlags, char *buffer, UDATA l
 	} else if (rc < 0) {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 		/* Skip j9sysinfo_get_username if a checkpoint can be taken. */
-		J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-		if (!vmFuncs->isCheckpointAllowed(vmFuncs->currentVMThread(vm)))
+		if (!vm->internalVMFunctions->isCheckpointAllowed(vm))
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 		{
 			rc = j9sysinfo_get_username(buffer, length);

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -113,7 +113,7 @@ jvmRestoreHooks(J9VMThread *currentThread)
 	nas.name = (J9UTF8 *)&runPostRestoreHooks_name;
 	nas.signature = (J9UTF8 *)&runPostRestoreHooks_sig;
 
-	Assert_VM_true(isCRaCorCRIUSupportEnabled_VM(vm));
+	Assert_VM_true(isCRaCorCRIUSupportEnabled(vm));
 
 	/* make sure Java hooks are the last thing run before restore */
 	runStaticMethod(currentThread, J9UTF8_DATA(&j9InternalCheckpointHookAPI_name), &nas, 0, NULL);
@@ -126,13 +126,7 @@ jvmRestoreHooks(J9VMThread *currentThread)
 }
 
 BOOLEAN
-isCRaCorCRIUSupportEnabled(J9VMThread *currentThread)
-{
-	return isCRaCorCRIUSupportEnabled_VM(currentThread->javaVM);
-}
-
-BOOLEAN
-isCRaCorCRIUSupportEnabled_VM(J9JavaVM *vm)
+isCRaCorCRIUSupportEnabled(J9JavaVM *vm)
 {
 	return J9_IS_CRIU_OR_CRAC_CHECKPOINT_ENABLED(vm);
 }
@@ -144,12 +138,12 @@ isCRIUSupportEnabled(J9VMThread *currentThread)
 }
 
 BOOLEAN
-isCheckpointAllowed(J9VMThread *currentThread)
+isCheckpointAllowed(J9JavaVM *vm)
 {
 	BOOLEAN result = FALSE;
 
-	if (isCRaCorCRIUSupportEnabled(currentThread)) {
-		result = J9_ARE_ALL_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_IS_CHECKPOINT_ALLOWED);
+	if (isCRaCorCRIUSupportEnabled(vm)) {
+		result = J9_ARE_ALL_BITS_SET(vm->checkpointState.flags, J9VM_CRIU_IS_CHECKPOINT_ALLOWED);
 	}
 
 	return result;
@@ -159,9 +153,10 @@ BOOLEAN
 enableCRIUSecProvider(J9VMThread *currentThread)
 {
 	BOOLEAN result = FALSE;
+	J9JavaVM *vm = currentThread->javaVM;
 
-	if (isCRaCorCRIUSupportEnabled(currentThread)) {
-		result = J9_ARE_ANY_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_ENABLE_CRIU_SEC_PROVIDER);
+	if (isCRaCorCRIUSupportEnabled(vm)) {
+		result = J9_ARE_ANY_BITS_SET(vm->checkpointState.flags, J9VM_CRIU_ENABLE_CRIU_SEC_PROVIDER);
 	}
 
 	return result;
@@ -176,15 +171,16 @@ isNonPortableRestoreMode(J9VMThread *currentThread)
 BOOLEAN
 isJVMInPortableRestoreMode(J9VMThread *currentThread)
 {
-	return (!isNonPortableRestoreMode(currentThread) || J9_ARE_ALL_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_IS_PORTABLE_JVM_RESTORE_MODE)) && isCRaCorCRIUSupportEnabled(currentThread);
+	J9JavaVM *vm = currentThread->javaVM;
+	return (!isNonPortableRestoreMode(currentThread) || J9_ARE_ALL_BITS_SET(vm->checkpointState.flags, J9VM_CRIU_IS_PORTABLE_JVM_RESTORE_MODE)) && isCRaCorCRIUSupportEnabled(vm);
 }
 
 BOOLEAN
-isDebugOnRestoreEnabled(J9VMThread *currentThread)
+isDebugOnRestoreEnabled(J9JavaVM *vm)
 {
-	return J9_ARE_NO_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_IS_JDWP_ENABLED)
-			&& J9_ARE_ALL_BITS_SET(currentThread->javaVM->checkpointState.flags, J9VM_CRIU_SUPPORT_DEBUG_ON_RESTORE)
-			&& isCRaCorCRIUSupportEnabled(currentThread);
+	return J9_ARE_NO_BITS_SET(vm->checkpointState.flags, J9VM_CRIU_IS_JDWP_ENABLED)
+			&& J9_ARE_ALL_BITS_SET(vm->checkpointState.flags, J9VM_CRIU_SUPPORT_DEBUG_ON_RESTORE)
+			&& isCRaCorCRIUSupportEnabled(vm);
 }
 
 void
@@ -1499,7 +1495,7 @@ checkTransitionToDebugInterpreter(J9VMThread *currentThread)
 			 * The transition to the debug interpreter currently only works with -Xint,
 			 * and the null check for vm->jitConfig will be removed when the jit changes are completed.
 			 */
-			if (isDebugOnRestoreEnabled(currentThread) && (NULL == vm->jitConfig)) {
+			if (isDebugOnRestoreEnabled(vm) && (NULL == vm->jitConfig)) {
 				transitionToDebugInterpreter(vm);
 			} else {
 				result = FALSE;
@@ -1547,7 +1543,7 @@ criuCheckpointJVMImpl(JNIEnv *env,
 
 	vm->checkpointState.checkpointThread = currentThread;
 
-	if (isCheckpointAllowed(currentThread) && setupCRIU) {
+	if (isCheckpointAllowed(vm) && setupCRIU) {
 #if defined(LINUX)
 		j9object_t cpDir = NULL;
 		j9object_t log = NULL;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -409,7 +409,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jvmCheckpointHooks,
 	jvmRestoreHooks,
 	isCRaCorCRIUSupportEnabled,
-	isCRaCorCRIUSupportEnabled_VM,
 	isCRIUSupportEnabled,
 	enableCRIUSecProvider,
 	isCheckpointAllowed,

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2986,7 +2986,7 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 			}
 #endif /* defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-			if (isDebugOnRestoreEnabled(vm->mainThread)) {
+			if (isDebugOnRestoreEnabled(vm)) {
 				Trc_VM_VMInitStages_isDebugOnRestoreEnabled();
 				/* enable jvmtiCapabilities.can_get_source_debug_extension */
 				vm->requiredDebugAttributes |= J9VM_DEBUG_ATTRIBUTE_SOURCE_DEBUG_EXTENSION;

--- a/runtime/vm/lookuphelper.c
+++ b/runtime/vm/lookuphelper.c
@@ -35,7 +35,7 @@ mustReportEnterStepOrBreakpoint(J9JavaVM *vm)
 	UDATA hookedOrReserved = 0;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-	if (isDebugOnRestoreEnabled(vm->mainThread)) {
+	if (isDebugOnRestoreEnabled(vm)) {
 		hookedOrReserved = J9_EVENT_IS_HOOKED_OR_RESERVED(vm->hookInterface, J9HOOK_VM_METHOD_ENTER)
 			|| J9_EVENT_IS_HOOKED_OR_RESERVED(vm->hookInterface, J9HOOK_VM_METHOD_RETURN)
 			|| J9_EVENT_IS_HOOKED_OR_RESERVED(vm->hookInterface, J9HOOK_VM_SINGLE_STEP)

--- a/runtime/vm/vmhook.c
+++ b/runtime/vm/vmhook.c
@@ -144,7 +144,7 @@ hookAboutToBootstrapEvent(J9HookInterface **hook, UDATA eventNum, void *voidEven
 	}
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-	if (isDebugOnRestoreEnabled(vmThread)) {
+	if (isDebugOnRestoreEnabled(vm)) {
 		debugModeRequested = J9_EVENT_IS_HOOKED_OR_RESERVED(vm->hookInterface, J9HOOK_VM_METHOD_ENTER)
 			|| J9_EVENT_IS_HOOKED_OR_RESERVED(vm->hookInterface, J9HOOK_VM_METHOD_RETURN)
 			|| J9_EVENT_IS_HOOKED_OR_RESERVED(vm->hookInterface, J9HOOK_VM_FRAME_POP)


### PR DESCRIPTION
Refactor a few CRIU APIs to take `J9JavaVM*` instead of `J9VMThread*`

The currentThread passed into `isCRaCorCRIUSupportEnabled(J9VMThread*)`, `isCheckpointAllowed(J9VMThread*)` and
`isDebugOnRestoreEnabled(J9VMThread*)` are just for redirection of `currentThread->javaVM`, changed the APIs to take `J9JavaVM*` directly.

Related to 
* https://github.com/eclipse-openj9/openj9/pull/20202#discussion_r1768809654

Note: there are other CRIU APIs that could also take `J9JavaVM*` instead of `J9VMThread*`, only those related to https://github.com/eclipse-openj9/openj9/pull/20202 are refactored here.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>