### PR TITLE
Revert changes that disables use of Method Handle for core reflection

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -748,10 +748,6 @@ private static void ensureProperties(boolean isInitialization) {
 	initializedProperties.put("native.encoding", platformEncoding); //$NON-NLS-1$
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
-	/*[IF JAVA_SPEC_VERSION == 21]*/
-	initializedProperties.putIfAbsent("jdk.reflect.useDirectMethodHandle", "false");
-	/*[ENDIF] JAVA_SPEC_VERSION == 21 */
-
 	/*[IF (JAVA_SPEC_VERSION >= 21) & (PLATFORM-mz31 | PLATFORM-mz64)]*/
 	initializedProperties.put("com.ibm.autocvt", zOSAutoConvert); //$NON-NLS-1$
 	/*[ENDIF] (JAVA_SPEC_VERSION >= 21) & (PLATFORM-mz31 | PLATFORM-mz64) */

--- a/test/functional/cmdline_options_testresources/src_90/com/ibm/j9/getcallerclass/ReflectionMHTests.java
+++ b/test/functional/cmdline_options_testresources/src_90/com/ibm/j9/getcallerclass/ReflectionMHTests.java
@@ -62,9 +62,7 @@ public class ReflectionMHTests {
 			cls = (Class<?>) method.invoke(null, new Object[0]);
 
 			boolean isClassNameExpected;
-			if ((VersionCheck.major() >= 18)
-					&& (Boolean.getBoolean("jdk.reflect.useDirectMethodHandle") || (VersionCheck.major() != 21))
-			) {
+			if (VersionCheck.major() >= 18) {
 				isClassNameExpected = isSecurityFrameOrInjectedInvoker(cls);
 			} else {
 				isClassNameExpected = (cls == ReflectionMHTests.class);


### PR DESCRIPTION
Given that switching to old reflection was causing a functional issue
when trying to use Virtual Thread, I am opening up this PR to revert it
back. See https://github.com/eclipse-openj9/openj9/issues/20200 for more
details.

Reverts https://github.com/eclipse-openj9/openj9/pull/20159