### PR TITLE
Remove no-op disable of -Winvalid-offsetof in J9Options

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -60,21 +60,7 @@
 #include "j9jitnls.h"
 #endif
 
-#if defined(__clang__)
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Winvalid-offsetof"
-#elif defined(__GNUC__) || defined(__GNUG__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Winvalid-offsetof"
-#endif
-
 #define SET_OPTION_BIT(x)   TR::Options::setBit,   offsetof(OMR::Options,_options[(x)&TR_OWM]), ((x)&~TR_OWM)
-
-#if defined(__clang__)
-#pragma clang diagnostic pop
-#elif defined(__GNUC__) || defined(__GNUG__)
-#pragma GCC diagnostic pop
-#endif
 
 //Default code cache total max memory percentage set to 25% of physical RAM for low memory systems
 #define CODECACHE_DEFAULT_MAXRAMPERCENTAGE 25


### PR DESCRIPTION
Revert part of a change to add GCC and Clang directives disabling `-Winvalid-offsetof` warnings in `J90ptions`, `kca_offsets_generator`, and `J9ValueProfiler`, because there was no warning in `J9Options`

Partially reverts #18313