### PR TITLE
Add array annotation to provide better type information for j/l/O fields

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3965,6 +3965,13 @@ TR_J9VMBase::isIntrinsicCandidate(TR_ResolvedMethod *method)
                                                   (J9Method*)method->getPersistentIdentifier());
    }
 
+bool
+TR_J9VMBase::isPrimitiveArray(J9Class *fieldClass, int cpIndex)
+   {
+   TR_ASSERT_FATAL(fieldClass, "fieldClass must not be NULL");
+   return jitIsPrimitiveArray(vmThread(), fieldClass, cpIndex);
+   }
+
 // Creates a node to initialize the local object flags field
 //
 TR::Node *

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1055,6 +1055,8 @@ public:
    virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp);
    virtual bool isStable(J9Class *fieldClass, int cpIndex);
 
+   virtual bool isPrimitiveArray(J9Class *fieldClass, int cpIndex);
+
    /*
     * \brief
     *    tell whether a method was annotated as @ForceInline.

--- a/runtime/jit_vm/cthelpers.cpp
+++ b/runtime/jit_vm/cthelpers.cpp
@@ -47,6 +47,8 @@ J9_DECLARE_CONSTANT_UTF8(ojdk_forceInline, "Ljava/lang/invoke/ForceInline;");
 J9_DECLARE_CONSTANT_UTF8(ojdk_dontInline, "Ljava/lang/invoke/DontInline;");
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
+J9_DECLARE_CONSTANT_UTF8(ojdk_isPrimitiveArray, "Ljdk/internal/vm/annotation/IsPrimitiveArray;");
+
 void*
 jitGetCountingSendTarget(J9VMThread *vmThread, J9Method *ramMethod)
 {
@@ -271,6 +273,12 @@ jitIsMethodTaggedWithChangesCurrentThread(J9VMThread *currentThread, J9Method *m
 #else /* JAVA_SPEC_VERSION >= 21 */
 	return FALSE;
 #endif /* JAVA_SPEC_VERSION >= 21 */
+}
+
+BOOLEAN
+jitIsPrimitiveArray(J9VMThread *currentThread, J9Class *clazz, UDATA cpIndex)
+{
+	return fieldContainsRuntimeAnnotation(currentThread, clazz, cpIndex, (J9UTF8 *)&ojdk_isPrimitiveArray);
 }
 
 } /* extern "C" */

--- a/runtime/oti/j9protos.h
+++ b/runtime/oti/j9protos.h
@@ -1134,6 +1134,7 @@ extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithForceInline(J9VMThread *currentThre
 extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithDontInline(J9VMThread *currentThread, J9Method *method);
 extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithIntrinsicCandidate(J9VMThread *currentThread, J9Method *method);
 extern J9_CFUNC BOOLEAN jitIsMethodTaggedWithChangesCurrentThread(J9VMThread *currentThread, J9Method *method);
+extern J9_CFUNC BOOLEAN jitIsPrimitiveArray(J9VMThread *currentThread, J9Class *clazz, UDATA cpIndex);
 
 typedef struct J9MethodFromSignatureWalkState {
 	const char *className;


### PR DESCRIPTION
Java doesn't have a supertype for arrays; the only alternative is to use `java/lang/Object`. This PR introduces a field annotation that can be used to tell the runtime that such fields actually point to an array, thereby allowing the JIT compiler to better optimize code that refers to such fields.