### PR TITLE
Prevent Assertion Fail Caused by Incorrect numDeps

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -8132,7 +8132,10 @@ J9::X86::TreeEvaluator::VMnewEvaluator(
       }
 
    // 1 == vmThread
-   int32_t numDeps = 1;
+   int32_t numDeps = 2;
+
+   if (useRepInstruction)
+      numDeps += 2;
 
    if (sizeReg)
       numDeps++;


### PR DESCRIPTION
Changed the numDeps parameter so that it is always greater or equal to the number of post conditions added. Avoiding the assertion `TR_ASSERT(newCursor <= _numPostConditions, "Too many dependencies");` being triggered.