### PR TITLE
Remove CRIU required in cmdLineTester_criu_jitserverAcrossCheckpoint

### DIFF
--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -243,7 +243,6 @@
 			<platformRequirements>os.linux,^arch.arm,bits.64,os.linux.cent.8+</platformRequirements>
 		</platformRequirementsList>
 		<features>
-			<feature>CRIU:required</feature>
 			<feature>JITAAS:nonapplicable</feature>
 		</features>
 		<levels>


### PR DESCRIPTION
related:https://github.ibm.com/runtimes/backlog/issues/1525