### PR TITLE
AArch64: Inline StringUTF16.compress([CI[BII)I

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -99,6 +99,11 @@ J9::ARM64::CodeGenerator::initialize()
       {
       cg->setSupportsInlineStringLatin1Inflate();
       }
+   static bool disableInlineStringUTF16CompressCharArray = feGetEnv("TR_disableInlineStringUTF16CompressCharArray") != NULL;
+   if ((!TR::Compiler->om.canGenerateArraylets()) && (!disableInlineStringUTF16CompressCharArray) && !TR::Compiler->om.isOffHeapAllocationEnabled())
+      {
+      cg->setSupportsInlineStringUTF16CompressCharArray();
+      }
    if (comp->fej9()->hasFixedFrameC_CallingConvention())
       cg->setHasFixedFrameC_CallingConvention();
    }

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -472,6 +472,16 @@ public:
    void setSupportsInlineStringLatin1Inflate() { _j9Flags.set(SupportsInlineStringLatin1Inflate); }
 
    /** \brief
+   *    Determines whether the code generator supports inlining of java/lang/StringUTF16.compress([CI[BII)
+   */
+   bool getSupportsInlineStringUTF16CompressCharArray() { return _j9Flags.testAny(SupportsInlineStringUTF16CompressCharArray); }
+
+   /** \brief
+   *    The code generator supports inlining of java/lang/StringUTF16.compress([CI[BII)
+   */
+   void setSupportsInlineStringUTF16CompressCharArray() { _j9Flags.set(SupportsInlineStringUTF16CompressCharArray); }
+
+   /** \brief
    *    Determines whether the code generator supports inlining of java_util_concurrent_ConcurrentLinkedQueue_tm*
    *    methods
    */
@@ -677,6 +687,7 @@ private:
       SavesNonVolatileGPRsForGC                           = 0x00000800,
       SupportsInlineVectorizedMismatch                    = 0x00001000,
       SupportsInlineVectorizedHashCode                    = 0x00002000,
+      SupportsInlineStringUTF16CompressCharArray          = 0x00004000, /*! codegen inlining of Java StringUTF16.compress([CI[BII) */
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -240,6 +240,7 @@
    java_lang_StringUTF16_compareCodePointCI,
    java_lang_StringUTF16_compareToCIImpl,
    java_lang_StringUTF16_compareValues,
+   java_lang_StringUTF16_compress_charArray,
    java_lang_StringUTF16_getChar,
    java_lang_StringUTF16_indexOf,
    java_lang_StringUTF16_indexOfCharUnsafe,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3236,6 +3236,7 @@ void TR_ResolvedJ9Method::construct()
       { x(TR::java_lang_StringUTF16_compareCodePointCI,                       "compareCodePointCI", "(II)I")},
       { x(TR::java_lang_StringUTF16_compareToCIImpl,                          "compareToCIImpl",    "([BII[BII)I")},
       { x(TR::java_lang_StringUTF16_compareValues,                            "compareValues",      "([B[BII)I")},
+      { x(TR::java_lang_StringUTF16_compress_charArray,                       "compress",           "([CI[BII)I")},
       { x(TR::java_lang_StringUTF16_getChar,                                  "getChar",            "([BI)C")},
       { x(TR::java_lang_StringUTF16_indexOf,                                  "indexOf",            "([BI[BII)I")},
       { x(TR::java_lang_StringUTF16_indexOfCharUnsafe,                        "indexOfCharUnsafe",  "([BIII)I")},

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5518,6 +5518,14 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
             return true;
             }
          break;
+#if JAVA_SPEC_VERSION >= 11
+      case TR::java_lang_StringUTF16_compress_charArray:
+         if (comp->cg()->getSupportsInlineStringUTF16CompressCharArray())
+            {
+            return true;
+            }
+         break;
+#endif /* JAVA_SPEC_VERSION >= 11 */
       default:
          break;
       }


### PR DESCRIPTION
This commit recognizes StringUTF16.compress([CI[BII)I, and generates inlined code for AArch64.