### PR TITLE
(0.48) Ensure JIT/AOT code is not invalidated post-restore under `-XX:+DebugOnRestore`

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3026,6 +3026,17 @@ J9::Options::fePostProcessAOT(void * base)
 bool
 J9::Options::isFSDNeeded(J9JavaVM *javaVM, J9HookInterface **vmHooks)
    {
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+   J9VMThread * vmThread = javaVM->internalVMFunctions->currentVMThread(javaVM);
+   if (javaVM->internalVMFunctions->isCheckpointAllowed(vmThread))
+      {
+      if (javaVM->internalVMFunctions->isDebugOnRestoreEnabled(vmThread))
+         {
+         return false;
+         }
+      }
+#endif
+
    return
 #if defined(J9VM_JIT_FULL_SPEED_DEBUG)
       (javaVM->requiredDebugAttributes & J9VM_DEBUG_ATTRIBUTE_CAN_ACCESS_LOCALS) ||

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -737,8 +737,10 @@ J9::OptionsPostRestore::postProcessInternalCompilerOptions()
    TR::Options::FSDInitStatus fsdStatus = TR::Options::resetFSD(vm, _vmThread, doAOT);
    disableAOT = !doAOT;
 
-   if (fsdStatus != TR::Options::FSDInitStatus::FSDInit_NotInitialized)
+   if (!_compInfo->getCRRuntime()->isFSDEnabled()
+       && fsdStatus == TR::Options::FSDInitStatus::FSDInit_Initialized)
       {
+      _compInfo->getCRRuntime()->setFSDEnabled(true);
       invalidateAll = true;
       disableAOT = true;
       }

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -126,6 +126,10 @@
 #include "runtime/MetricsServer.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+#include "runtime/CRRuntime.hpp"
+#endif
+
 extern "C" int32_t encodeCount(int32_t count);
 
 extern "C" {
@@ -2046,6 +2050,9 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
 #endif
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
+   if (compInfo->getCRRuntime())
+      compInfo->getCRRuntime()->cacheEventsStatus();
+
    bool debugOnRestoreEnabled = javaVM->internalVMFunctions->isDebugOnRestoreEnabled(curThread);
 
    /* If the JVM is in CRIU mode and checkpointing is allowed, then the JIT should be

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -91,7 +91,20 @@ TR::CRRuntime::CRRuntime(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo) 
    _forcedRecomps(),
    _impMethodForCR(),
    _proactiveCompEnv(),
-   _jniMethodAddr()
+   _jniMethodAddr(),
+   _vmMethodTraceEnabled(false),
+   _vmExceptionEventsHooked(false),
+   _fsdEnabled(false)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   _canPerformRemoteCompilationInCRIUMode = false;
+   _remoteCompilationRequestedAtBootstrap = false;
+   _remoteCompilationExplicitlyDisabledAtBootstrap = false;
+#endif
+   }
+
+void
+TR::CRRuntime::cacheEventsStatus()
    {
    // TR::CompilationInfo is initialized in the JIT_INITIALIZED bootstrap
    // stage, whereas J9_EXTENDED_RUNTIME_METHOD_TRACE_ENABLED is set in the
@@ -109,11 +122,7 @@ TR::CRRuntime::CRRuntime(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo) 
         || J9_EVENT_IS_RESERVED(jitConfig->javaVM->hookInterface, J9HOOK_VM_EXCEPTION_THROW);
    _vmExceptionEventsHooked = exceptionCatchEventHooked || exceptionThrowEventHooked;
 
-#if defined(J9VM_OPT_JITSERVER)
-   _canPerformRemoteCompilationInCRIUMode = false;
-   _remoteCompilationRequestedAtBootstrap = false;
-   _remoteCompilationExplicitlyDisabledAtBootstrap = false;
-#endif
+   _fsdEnabled = J9::Options::_fsdInitStatus == J9::Options::FSDInit_Initialized;
    }
 
 void

--- a/runtime/compiler/runtime/CRRuntime.hpp
+++ b/runtime/compiler/runtime/CRRuntime.hpp
@@ -69,6 +69,13 @@ class CRRuntime
 
    CRRuntime(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
 
+   /**
+    * @brief Cache the status of JVMTI events such as exception throw/catch
+    *        as well as whether method trace and FSD were enabled
+    *        pre-checkpoint.
+    */
+   void cacheEventsStatus();
+
    /* The CR Monitor (Checkpoint/Restore Monitor) must always be acquired with
     * Comp Monitor in hand. If waiting on the CR Monitor, the Comp Monitor
     * should be released. After being notified, the CR Monitor should be
@@ -107,6 +114,9 @@ class CRRuntime
 
    void setVMExceptionEventsHooked(bool trace) { _vmExceptionEventsHooked = trace; }
    bool isVMExceptionEventsHooked()            { return _vmExceptionEventsHooked;  }
+
+   void setFSDEnabled(bool trace) { _fsdEnabled = trace; }
+   bool isFSDEnabled()            { return _fsdEnabled;  }
 
 #if defined(J9VM_OPT_JITSERVER)
    bool canPerformRemoteCompilationInCRIUMode()                   { return _canPerformRemoteCompilationInCRIUMode;       }
@@ -422,6 +432,7 @@ class CRRuntime
 
    bool _vmMethodTraceEnabled;
    bool _vmExceptionEventsHooked;
+   bool _fsdEnabled;
 
 #if defined(J9VM_OPT_JITSERVER)
    bool _canPerformRemoteCompilationInCRIUMode;


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/19754 adds VM Support for Debug On Restore. As the code stands, this will result in the JIT invalidating all code post-restore because it is unable to distinguish between FSD mode caused by the VM or the user.

This PR fixes this by adding the following changes:
* Cache the status of certain runtime events
* Return early from isFSDNeeded under `-XX:+DebugOnRestore`

Depends on https://github.com/eclipse-openj9/openj9/pull/20191