### PR TITLE
Treat single CPU as if -XnoConcurrentMark were set

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2842,9 +2842,12 @@ configurateGCWithPolicyAndOptionsStandard(MM_EnvironmentBase *env)
 MM_Configuration *
 configurateGCWithPolicyAndOptions(OMR_VM* omrVM)
 {
+	J9JavaVM *vm = (J9JavaVM*) omrVM->_language_vm;
+	PORT_ACCESS_FROM_JAVAVM(vm);
 	MM_Configuration *result = NULL;
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(omrVM);
 	MM_EnvironmentBase env(omrVM);
+	bool ccMark = false;
 
 	switch(extensions->configurationOptions._gcPolicy) {
 	case gc_policy_optthruput:
@@ -2866,8 +2869,9 @@ configurateGCWithPolicyAndOptions(OMR_VM* omrVM)
 	case gc_policy_gencon:
 		extensions->gcModeString = "-Xgcpolicy:gencon";
 		omrVM->gcPolicy = J9_GC_POLICY_GENCON;
+		ccMark = (1 != j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_TARGET));
 		/* scavenge, concurrentMark, noConcurrentSweep, loa */
-		setDefaultConfigOptions(extensions, true, true, false, true);
+		setDefaultConfigOptions(extensions, true, ccMark, false, true);
 		result = configurateGCWithPolicyAndOptionsStandard(&env);
 		break;
 


### PR DESCRIPTION
It is the 2nd time I am doing this. Previously, it was reverted due to a performance regression due to incompatible AOT code. In fact, AOT code (generated on running multiple CPUs) are actually compatible. So, SCC loading check is changed to accommodate this specific combination.

Previous commit message: There is little expected benefit with concurrentmark if you are running on a single-CPU machine/environment. On the other hand, you could gain some benefits with noConcurrentMark: 1) no interference from background marking thread; 2) shorter write-barrier path-length: for certain workloads, this provides substantial performance benefits (e.g. Spark TPC-DS q72 in particular).