### PR TITLE
Set dummy resolved method flag in findOrCreateHandleMethodSymbol()

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -482,6 +482,8 @@ J9::SymbolReferenceTable::findOrCreateHandleMethodSymbol(TR::ResolvedMethodSymbo
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    TR_ResolvedMethod  * method = owningMethodSymbol->getResolvedMethod()->getResolvedHandleMethod(comp(), cpIndex, unresolvedInCP, isInvokeCacheAppendixNull);
    TR::SymbolReference * symRef = findOrCreateMethodSymbol(owningMethodSymbol->getResolvedMethodIndex(), cpIndex, method, TR::MethodSymbol::Static);
+   if (*unresolvedInCP)
+      symRef->getSymbol()->setDummyResolvedMethod(); // linkToStatic is a dummy TR_ResolvedMethod
 #else
    TR_ResolvedMethod  * method = owningMethodSymbol->getResolvedMethod()->getResolvedHandleMethod(comp(), cpIndex, unresolvedInCP);
    TR::SymbolReference * symRef = findOrCreateMethodSymbol(owningMethodSymbol->getResolvedMethodIndex(), cpIndex, method, TR::MethodSymbol::ComputedVirtual);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3342,8 +3342,6 @@ TR_J9ByteCodeIlGenerator::genInvokeHandle(int32_t cpIndex)
    bool isUnresolved = false;
    bool isInvokeCacheAppendixNull = false;
    TR::SymbolReference * targetMethodSymRef = symRefTab()->findOrCreateHandleMethodSymbol(_methodSymbol, cpIndex, &isUnresolved, &isInvokeCacheAppendixNull);
-   if (isUnresolved)
-      targetMethodSymRef->getSymbol()->setDummyResolvedMethod(); // linkToStatic is a dummy TR_ResolvedMethod
    TR::SymbolReference *methodTypeTableEntrySymRef = symRefTab()->findOrCreateMethodTypeTableEntrySymbol(_methodSymbol, cpIndex);
    TR_ResolvedJ9Method* owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
    uintptr_t * invokeCacheArray = (uintptr_t *) owningMethod->methodTypeTableEntryAddress(cpIndex);


### PR DESCRIPTION
...instead of in the caller.

This method is also called from `stashArgumentsForOSR()`, which neglected to set the flag. Because the flag wasn't set, the symbol reference was available for reuse, and it would be reused even if the `invokehandle` instruction became resolved before `genInvokeHandle()`. In that case, `genInvokeHandle()` would see `isUnresolved=false`, so it would push only the appendix (if non-null), but then it would get the dummy `linkToStatic` symbol reference, which expects more arguments.

This flag is now set in `findOrCreateHandleMethodSymbol()`. There's no reason to allow a caller to forget to set the flag.