### PR TITLE
Stash all invokedynamic and invokehandle arguments for OSR

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -1630,9 +1630,6 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
 
    TR::MethodSymbol *symbol = symRef->getSymbol()->castToMethodSymbol();
    int32_t numArgs = symbol->getMethod()->numberOfExplicitParameters() + (symbol->isStatic() ? 0 : 1);
-   // For OpenJDK MH implementation, some args for invokedynamic/invokehandle (details below)
-   // that are already pushed to stack must not be stashed
-   int32_t numArgsToNotStash = 0;
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    // If the transition target is invokehandle/invokedynamic, the arguments to be
@@ -1671,6 +1668,7 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
    // Notice that we always generate a resolved call, thus we use unresolvedInCP to tell
    // us whether the side table entry is resolved
    //
+   int32_t numArgsToNotStash = 0;
    if (byteCode == J9BCinvokedynamic ||
        byteCode == J9BCinvokehandle)
       {
@@ -1684,10 +1682,10 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
       if (trace())
          traceMsg(comp(), "Original num args for invokedynamic/handle: %d, num args to not stash for OSR: %d, stack size: %d\n", numArgs, numArgsToNotStash, _stack->size());
       }
-#endif
+
    numArgs -= numArgsToNotStash;
-   // For OpenJDK MethodHandle implementation, there may be items on stack that we need to exclude
-   int32_t adjustedStackSize = _stack->size() - numArgsToNotStash;
+#endif
+
    TR_OSRMethodData *osrMethodData =
       comp()->getOSRCompilationData()->findOrCreateOSRMethodData(comp()->getCurrentInlinedSiteIndex(), _methodSymbol);
    osrMethodData->ensureArgInfoAt(_bcIndex, numArgs);
@@ -1696,10 +1694,10 @@ TR_J9ByteCodeIlGenerator::stashArgumentsForOSR(TR_J9ByteCode byteCode)
    // It is necessary to walk the whole stack to determine the slot numbers
    int32_t slot = 0;
    int arg = 0;
-   for (int32_t i = 0; i < adjustedStackSize; ++i)
+   for (int32_t i = 0; i < _stack->size(); ++i)
       {
       TR::Node * n = _stack->element(i);
-      if (adjustedStackSize - numArgs <= i)
+      if (_stack->size() - numArgs <= i)
          {
          TR::SymbolReference * symRef = symRefTab()->findOrCreatePendingPushTemporary(_methodSymbol, slot, getDataType(n));
          osrMethodData->addArgInfo(_bcIndex, arg, symRef->getReferenceNumber());


### PR DESCRIPTION
When stashing arguments for OSR at an `invokedynamic` or `invokehandle` bytecode instruction, the callee usually has an extra parameter (the appendix, if it's non-null). If the call is unresolved, it expects two extra parameters instead (the appendix and a `MemberName`). For the purpose of stashing, these are all ignored because they're not on the stack just prior to running the invoke bytecode instruction. However, in these cases `stashArgumentsForOSR()` has been ignoring the top one or two elements of the stack as well, as though the extra arguments were already pushed. However, they haven't actually been pushed at this point, so we would simply fail to stash the last one or two regular arguments. Failure to stash could cause stack slots to appear falsely to be dead, and they could therefore be left uninitialized after an OSR transition at runtime.

This commit changes `stashArgumentsForOSR()` to use the stack size as-is because the regular arguments are still at the top of the stack.

Also keep `numArgsToNotStash` in the `J9VM_OPT_OPENJDK_METHODHANDLE` `#if`.

Fixes #19369