### PR TITLE
CRIU sets J9VM_CRIU_IS_JDWP_ENABLED according to event EI_VM_RESTORE

### DIFF
--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -904,6 +904,17 @@ processEvent(J9JVMTIEnv* j9env, jint event, J9HookRedirectorFunction redirectorF
 			return redirectorFunction(vmHook, J9HOOK_VM_CRIU_CHECKPOINT, jvmtiHookVMCheckpoint, OMR_GET_CALLSITE(), j9env);
 
 		case J9JVMTI_EVENT_OPENJ9_VM_RESTORE:
+			if (hookRegister == redirectorFunction) {
+				/* This occurs when jdk.jdwp.agent/share/native/libjdwp/debugInit.c:DEF_Agent_OnLoad()
+				 * enables extension event EI_VM_RESTORE and set callback cbEarlyVMRestore().
+				 * It indicates a JDWP agent is being loaded and enabled.
+				 * This covers following cases:
+				 *   -Xrunjdwp:transport=dt_socket,server=y,suspend=n
+				 *   -agentlib:jdwp=transport=dt_socket,server=y,suspend=n
+				 *   -agentpath:/path/to/libjdwp.so=transport=dt_socket,server=y,suspend=n
+				 */
+				j9env->vm->checkpointState.flags |= J9VM_CRIU_IS_JDWP_ENABLED;
+			}
 			return redirectorFunction(vmHook, J9HOOK_VM_CRIU_RESTORE, jvmtiHookVMRestore, OMR_GET_CALLSITE(), j9env);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4039,16 +4039,8 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 		}
 	}
 
-	{
-		if ((FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, MAPOPT_AGENTLIB_JDWP_EQUALS, NULL) >= 0)
-			|| (FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, MAPOPT_XRUNJDWP, NULL) >= 0)
-		) {
-			vm->checkpointState.flags |= J9VM_CRIU_IS_JDWP_ENABLED;
-		}
-		memset(vm->checkpointState.javaDebugThreads, 0, sizeof(vm->checkpointState.javaDebugThreads));
-		vm->checkpointState.javaDebugThreadCount = 0;
-	}
-
+	memset(vm->checkpointState.javaDebugThreads, 0, sizeof(vm->checkpointState.javaDebugThreads));
+	vm->checkpointState.javaDebugThreadCount = 0;
 	vm->checkpointState.lastRestoreTimeInNanoseconds = -1;
 	vm->checkpointState.processRestoreStartTimeInNanoseconds = -1;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */


### PR DESCRIPTION
`CRIU` sets `J9VM_CRIU_IS_JDWP_ENABLED` according to event `EI_VM_RESTORE`

`J9JVMTI_EVENT_OPENJ9_VM_RESTORE` registration only occurs  when `jdk.jdwp.agent/share/native/libjdwp/debugInit.c:DEF_Agent_OnLoad()` enables extension event `EI_VM_RESTORE` and set callback `cbEarlyVMRestore()`. It indicates a `JDWP` agent is being loaded and enabled.
This covers following cases:
```
  -Xrunjdwp:transport=dt_socket,server=y,suspend=n
  -agentlib:jdwp=transport=dt_socket,server=y,suspend=n
  -agentpath:/path/to/libjdwp.so=transport=dt_socket,server=y,suspend=n
```

closes https://github.com/eclipse-openj9/openj9/issues/20204

Signed-off-by: Jason Feng <fengj@ca.ibm.com>