### PR TITLE
Distinguish why AOT is disabled post-restore

### DIFF
--- a/runtime/compiler/control/OptionsPostRestore.hpp
+++ b/runtime/compiler/control/OptionsPostRestore.hpp
@@ -119,8 +119,11 @@ class OptionsPostRestore
 
    /**
     * \brief Helper method to disable further AOT compilation.
+    *
+    * \param disabledPreCheckpoint bool to indicate whther AOT was disable post
+    *                              restore or pre checkpoint.
     */
-   void disableAOTCompilation();
+   void disableAOTCompilation(bool disabledPreCheckpoint = false);
 
    /**
     * \brief Helper method to perform tasks prior to processing

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -431,3 +431,10 @@ J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.sample_input_1=-XX:codecachetotalMaxRAMPe
 J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.sample_input_2=0.8
 J9NLS_JIT_OPTIONS_PERCENT_OUT_OF_RANGE.sample_input_3=25
 # END NON-TRANSLATABLE
+
+J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT=AOT load and compilation disabled pre-checkpoint and post-restore.
+# START NON-TRANSLATABLE
+J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.explanation=The JVM was running in a mode pre-checkpoint that prevents AOT load and compilation.
+J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.user_response=Remove any (pre-checkpoint) option that would have resulted in this behaviour.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
Post-Restore, the `AOT load and compilation disabled post restore.` can be printed out either because AOT was disabled due to options/factors pre-checkpoint or options/factors post-restore. This PR adds a new NLS message to distinguish between these two scenarios.

https://github.com/eclipse-openj9/openj9/issues/20233