### PR TITLE
Exclude cmdLineTester_criu_jitserverAcrossCheckpoint for jdk8

### DIFF
--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -254,6 +254,9 @@
 		<impls>
 			<impl>openj9</impl>
 		</impls>
+		<versions>
+			<version>11+</version>
+		</versions>
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_criu_jitserverPostRestore</testCaseName>


### PR DESCRIPTION
related:https://github.com/eclipse-openj9/openj9/issues/20243