### PR TITLE
Remove flattening flag from nullable arrays

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -335,6 +335,10 @@ static const struct { \
 #define J9CLASS_UNPADDED_INSTANCE_SIZE(clazz) J9_VALUETYPE_FLATTENED_SIZE(clazz)
 #define J9_IS_J9CLASS_ALLOW_DEFAULT_VALUE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassAllowsInitialDefaultValue)
 #define J9_IS_J9CLASS_PRIMITIVE_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsPrimitiveValueType)
+/**
+ * This macro can only be used to determine vm flattening for a J9ArrayClass.
+ * For non-array classes use J9_IS_FIELD_FLATTENED.
+ */
 #define J9_IS_J9CLASS_FLATTENED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsFlattened)
 
 #define J9ROMFIELD_IS_NULL_RESTRICTED(romField)	J9_ARE_ALL_BITS_SET((romField)->modifiers, J9FieldFlagIsNullRestricted)

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1234,9 +1234,13 @@ obj:
 						}
 					} else if (J9_IS_J9CLASS_FLATTENED(srcClazz)
 						|| J9_IS_J9CLASS_FLATTENED(destClazz)
-						|| J9_IS_J9CLASS_ALLOW_DEFAULT_VALUE(destComponentClass)
+						|| J9_IS_J9ARRAYCLASS_NULL_RESTRICTED(destClazz)
 					) {
-						/* VM_ArrayCopyHelpers::referenceArrayCopy cannot handle flattened arrays or null elements being copied into arrays of primitive value types, so for those cases use copyFlattenableArray instead */
+						/* VM_ArrayCopyHelpers::referenceArrayCopy cannot handle
+						 * flattened arrays or null elements being copied into
+						 * arrays of null-restricted value types, so for those
+						 * cases use copyFlattenableArray instead.
+						 */
 						updateVMStruct(REGISTER_ARGS);
 						I_32 value = VM_ValueTypeHelpers::copyFlattenableArray(_currentThread, _objectAccessBarrier, _objectAllocate, srcObject, destObject, srcStart, destStart, elementCount);
 						VMStructHasBeenUpdated(REGISTER_ARGS);

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3451,16 +3451,13 @@ fail:
 					 * elements may be flattened arrays.
 					 */
 					U_32 arrayFlags = J9ClassLargestAlignmentConstraintReference | J9ClassLargestAlignmentConstraintDouble;
-					if (J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING)) {
-						/* TODO restrict this flag to be set only for null-restricted
-						 * arrays once value type command line tests are updated.
-						 */
-						arrayFlags |= J9ClassIsFlattened;
-					}
-					ramArrayClass->classFlags |= (elementClass->classFlags & arrayFlags);
 					if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_CLASS_OPTION_NULL_RESTRICTED_ARRAY)) {
+						if (J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING)) {
+							arrayFlags |= J9ClassIsFlattened;
+						}
 						ramArrayClass->classFlags |= J9ClassArrayIsNullRestricted;
 					}
+					ramArrayClass->classFlags |= (elementClass->classFlags & arrayFlags);
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 					arity = 1;
 					leafComponentType = elementClass;

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeSystemArraycopyTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeSystemArraycopyTests.java
@@ -60,9 +60,10 @@ public class ValueTypeSystemArraycopyTests {
 	}
 
 	@ImplicitlyConstructible
-	public value static class SomeValueClass implements SomeInterface {
+	public static value class SomeValueClass implements SomeInterface {
 		double val1;
 		long val2;
+		@NullRestricted
 		SomeValueClass2 val3;
 		int val4;
 
@@ -74,37 +75,12 @@ public class ValueTypeSystemArraycopyTests {
 		}
 	}
 
-	public static class SomeValueClass2 implements SomeInterface {
+	@ImplicitlyConstructible
+	public static value class SomeValueClass2 implements SomeInterface {
 		long val1;
 		double val2;
 
 		SomeValueClass2(int i) {
-			this.val1 = (long)(i*5);
-			this.val2 = (double)(i*6);
-		}
-	}
-
-	@ImplicitlyConstructible
-	public static value class SomePrimitiveValueClass implements SomeInterface {
-		double val1;
-		long val2;
-		SomePrimitiveValueClass2 val3;
-		int val4;
-
-		SomePrimitiveValueClass(int i) {
-			this.val1 = (double)i;
-			this.val2 = (long)(i*2);
-			this.val3 = new SomePrimitiveValueClass2(i*3);
-			this.val4 = i*4;
-		}
-	}
-
-	@ImplicitlyConstructible
-	public static value class SomePrimitiveValueClass2 implements SomeInterface {
-		long val1;
-		double val2;
-
-		SomePrimitiveValueClass2(int i) {
 			this.val1 = (long)(i*5);
 			this.val2 = (double)(i*6);
 		}
@@ -116,11 +92,6 @@ public class ValueTypeSystemArraycopyTests {
 	public static SomeIdentityClass[] idArraySrc = new SomeIdentityClass[ARRAY_SIZE];
 	public static SomeValueClass[] vtArrayDst = new SomeValueClass[ARRAY_SIZE];
 	public static SomeValueClass[] vtArraySrc = new SomeValueClass[ARRAY_SIZE];
-	public static SomePrimitiveValueClass[] primitiveVtArrayDst =
-		(SomePrimitiveValueClass[])ValueClass.newNullRestrictedArray(SomePrimitiveValueClass.class, ARRAY_SIZE);
-	public static SomePrimitiveValueClass[] primitiveVtArraySrc =
-			(SomePrimitiveValueClass[])ValueClass.newNullRestrictedArray(SomePrimitiveValueClass.class, ARRAY_SIZE);
-	/* These arrays should be used instead of primitiveVTArrayDst/Src once javac supports null-restricted classes. */
 	public static SomeValueClass[] nullRestrictedVtArraySrc =
 		(SomeValueClass[])ValueClass.newNullRestrictedArray(SomeValueClass.class, ARRAY_SIZE);
 	public static SomeValueClass[] nullRestrictedVtArrayDst =
@@ -129,15 +100,17 @@ public class ValueTypeSystemArraycopyTests {
 	public static SomeInterface[] ifIdArraySrc = new SomeIdentityClass[ARRAY_SIZE];
 	public static SomeInterface[] ifVtArrayDst = new SomeValueClass[ARRAY_SIZE];
 	public static SomeInterface[] ifVtArraySrc = new SomeValueClass[ARRAY_SIZE];
-	public static SomeInterface[] ifPrimitiveVtArrayDst = new SomePrimitiveValueClass[ARRAY_SIZE];
-	public static SomeInterface[] ifPrimitiveVtArraySrc = new SomePrimitiveValueClass[ARRAY_SIZE];
+	public static SomeInterface[] ifNullRestrictedVtArrayDst =
+		(SomeValueClass[])ValueClass.newNullRestrictedArray(SomeValueClass.class, ARRAY_SIZE);
+	public static SomeInterface[] ifNullRestrictedVtArraySrc =
+		(SomeValueClass[])ValueClass.newNullRestrictedArray(SomeValueClass.class, ARRAY_SIZE);
 	public static SomeInterface[] ifArray1 = new SomeInterface[ARRAY_SIZE];
 	public static SomeInterface[] ifArray2 = new SomeInterface[ARRAY_SIZE];
 	public static SomeInterface[] ifArray3 = new SomeInterface[ARRAY_SIZE];
 
 	public static SomeIdentityClass[] idArrayDstCheckForException = new SomeIdentityClass[ARRAY_SIZE];
-	public static SomePrimitiveValueClass[] primitiveVtArrayDstCheckForException =
-		(SomePrimitiveValueClass[])ValueClass.newNullRestrictedArray(SomePrimitiveValueClass.class, ARRAY_SIZE);
+	public static SomeValueClass[] nullRestrictedVtArrayDstCheckForException =
+		(SomeValueClass[])ValueClass.newNullRestrictedArray(SomeValueClass.class, ARRAY_SIZE);
 
 	static private void initArrays() {
 		for (int i=0; i < ARRAY_SIZE; i++) {
@@ -148,8 +121,8 @@ public class ValueTypeSystemArraycopyTests {
 			vtArrayDst[i] = new SomeValueClass(i*3);
 			vtArraySrc[i] = new SomeValueClass(i*4);
 
-			primitiveVtArrayDst[i] = new SomePrimitiveValueClass(i*5);
-			primitiveVtArraySrc[i] = new SomePrimitiveValueClass(i*6);
+			nullRestrictedVtArrayDst[i] = new SomeValueClass(i*5);
+			nullRestrictedVtArraySrc[i] = new SomeValueClass(i*6);
 
 			ifIdArrayDst[i] = new SomeIdentityClass(i*7);
 			ifIdArraySrc[i] = new SomeIdentityClass(i*8);
@@ -157,15 +130,12 @@ public class ValueTypeSystemArraycopyTests {
 			ifVtArrayDst[i] = new SomeValueClass(i*9);
 			ifVtArraySrc[i] = new SomeValueClass(i*10);
 
-			ifPrimitiveVtArrayDst[i] = new SomePrimitiveValueClass(i*11);
-			ifPrimitiveVtArraySrc[i] = new SomePrimitiveValueClass(i*12);
+			ifNullRestrictedVtArrayDst[i] = new SomeValueClass(i*11);
+			ifNullRestrictedVtArraySrc[i] = new SomeValueClass(i*12);
 
 			ifArray1[i] = new SomeIdentityClass(i*13);
 			ifArray2[i] = new SomeValueClass(i*14);
-			ifArray3[i] = new SomePrimitiveValueClass(i*15);
-
-			nullRestrictedVtArrayDst[i] = new SomeValueClass(i*16);
-			nullRestrictedVtArraySrc[i] = new SomeValueClass(i*17);
+			ifArray3[i] = new SomeValueClass(i*15);
 		}
 	}
 
@@ -175,29 +145,29 @@ public class ValueTypeSystemArraycopyTests {
 				ifArray3[i] = null;
 			}
 			else {
-				ifArray3[i] = new SomePrimitiveValueClass(i*30);
+				ifArray3[i] = new SomeValueClass(i*30);
 			}
 
-			primitiveVtArrayDst[i] = new SomePrimitiveValueClass(i*5);
-			primitiveVtArrayDstCheckForException[i] = primitiveVtArrayDst[i];
+			nullRestrictedVtArrayDst[i] = new SomeValueClass(i*5);
+			nullRestrictedVtArrayDstCheckForException[i] = nullRestrictedVtArrayDst[i];
 		}
 	}
 
 	static private void initArraysForArrayStoreChkExceptionTest() {
 		for (int i=0; i < ARRAY_SIZE; i++) {
 			if (i >= ARRAY_SIZE/2) {
-				ifArray1[i] = new SomePrimitiveValueClass(i*13);
+				ifArray1[i] = new SomeValueClass(i*13);
 				ifArray3[i] = new SomeIdentityClass(i*30);
 			}
 			else {
 				ifArray1[i] = new SomeIdentityClass(i*13);
-				ifArray3[i] = new SomePrimitiveValueClass(i*30);
+				ifArray3[i] = new SomeValueClass(i*30);
 			}
 
 			idArrayDst[i] = new SomeIdentityClass(i);
 			idArrayDstCheckForException[i] = idArrayDst[i];
-			primitiveVtArrayDst[i] = new SomePrimitiveValueClass(i*5);
-			primitiveVtArrayDstCheckForException[i] = primitiveVtArrayDst[i];
+			nullRestrictedVtArrayDst[i] = new SomeValueClass(i*5);
+			nullRestrictedVtArrayDstCheckForException[i] = nullRestrictedVtArrayDst[i];
 		}
 	}
 
@@ -220,9 +190,9 @@ public class ValueTypeSystemArraycopyTests {
 		}
 	}
 
-	static private void checkPVTArrayAfterException(int index) {
-		for (int i=index; i < primitiveVtArrayDst.length; ++i) {
-			assertEquals(primitiveVtArrayDst[i], primitiveVtArrayDstCheckForException[i]);
+	static private void checkNullRestrictedVTArrayAfterException(int index) {
+		for (int i=index; i < nullRestrictedVtArrayDst.length; ++i) {
+			assertEquals(nullRestrictedVtArrayDst[i], nullRestrictedVtArrayDstCheckForException[i]);
 		}
 	}
 
@@ -253,18 +223,6 @@ public class ValueTypeSystemArraycopyTests {
 	}
 
 	static private void testIFVT(SomeInterface[] src, SomeValueClass[] dst) {
-		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
-	}
-
-	static private void testPVTPVT(SomePrimitiveValueClass[] src, SomePrimitiveValueClass[] dst) {
-		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
-	}
-
-	static private void testPVTIF(SomePrimitiveValueClass[] src, SomeInterface[] dst) {
-		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
-	}
-
-	static private void testIFPVT(SomeInterface[] src, SomePrimitiveValueClass[] dst) {
 		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
 	}
 
@@ -324,38 +282,12 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(src, dst);
 	}
 
-	static private void testPVTOBJ(SomePrimitiveValueClass[] src) {
-
-		Object[] dst = new Object[ARRAY_SIZE];
-
-		for (int i=0; i < ARRAY_SIZE; i++) {
-			dst[i] = new SomePrimitiveValueClass(i*20);
-		}
-
-		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
-
-		checkResults(src, dst);
-	}
-
-	static private void testOBJPVT(SomePrimitiveValueClass[] dst) {
-
-		Object[] src = new Object[ARRAY_SIZE];
-
-		for (int i=0; i < ARRAY_SIZE; i++) {
-			src[i] = new SomePrimitiveValueClass(i*21);
-		}
-
-		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
-
-		checkResults(src, dst);
-	}
-
 	static private void testIFOBJ(SomeInterface[] src) {
 
 		Object[] dst = new Object[ARRAY_SIZE];
 
 		for (int i=0; i < ARRAY_SIZE; i++) {
-			dst[i] = new SomePrimitiveValueClass(i*22);
+			dst[i] = new SomeValueClass(i*22);
 		}
 
 		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
@@ -368,7 +300,7 @@ public class ValueTypeSystemArraycopyTests {
 		Object[] src = new Object[ARRAY_SIZE];
 
 		for (int i=0; i < ARRAY_SIZE; i++) {
-			src[i] = new SomePrimitiveValueClass(i*23);
+			src[i] = new SomeValueClass(i*23);
 		}
 
 		System.arraycopy(src, 0, dst, 0, ARRAY_SIZE);
@@ -456,36 +388,36 @@ public class ValueTypeSystemArraycopyTests {
 	static public void testSystemArrayCopy7() throws Throwable {
 
 		initArrays();
-		testPVTPVT(primitiveVtArraySrc, primitiveVtArrayDst); // Fist invocation (Interpreter)
+		testVTVT(nullRestrictedVtArraySrc, nullRestrictedVtArrayDst); // Fist invocation (Interpreter)
 
 		initArrays();
-		testPVTPVT(primitiveVtArraySrc, primitiveVtArrayDst);
+		testVTVT(nullRestrictedVtArraySrc, nullRestrictedVtArrayDst);
 
-		checkResults(primitiveVtArraySrc, primitiveVtArrayDst);
+		checkResults(nullRestrictedVtArraySrc, nullRestrictedVtArrayDst);
 	}
 
 	@Test(priority=1)
 	static public void testSystemArrayCopy8() throws Throwable {
 
 		initArrays();
-		testPVTIF(primitiveVtArraySrc, ifPrimitiveVtArrayDst); // Fist invocation (Interpreter)
+		testVTIF(nullRestrictedVtArraySrc, ifNullRestrictedVtArrayDst); // Fist invocation (Interpreter)
 
 		initArrays();
-		testPVTIF(primitiveVtArraySrc, ifPrimitiveVtArrayDst);
+		testVTIF(nullRestrictedVtArraySrc, ifNullRestrictedVtArrayDst);
 
-		checkResults(primitiveVtArraySrc, ifPrimitiveVtArrayDst);
+		checkResults(nullRestrictedVtArraySrc, ifNullRestrictedVtArrayDst);
 	}
 
 	@Test(priority=1)
 	static public void testSystemArrayCopy9() throws Throwable {
 
 		initArrays();
-		testIFPVT(ifPrimitiveVtArraySrc, primitiveVtArrayDst); // Fist invocation (Interpreter)
+		testIFVT(ifNullRestrictedVtArraySrc, nullRestrictedVtArrayDst); // Fist invocation (Interpreter)
 
 		initArrays();
-		testIFPVT(ifPrimitiveVtArraySrc, primitiveVtArrayDst);
+		testIFVT(ifNullRestrictedVtArraySrc, nullRestrictedVtArrayDst);
 
-		checkResults(ifPrimitiveVtArraySrc, primitiveVtArrayDst);
+		checkResults(ifNullRestrictedVtArraySrc, nullRestrictedVtArrayDst);
 	}
 
 
@@ -504,8 +436,8 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(ifVtArraySrc, ifVtArrayDst);
 
 		initArrays();
-		testIFIF(ifPrimitiveVtArraySrc, ifPrimitiveVtArrayDst);
-		checkResults(ifPrimitiveVtArraySrc, ifPrimitiveVtArrayDst);
+		testIFIF(ifNullRestrictedVtArraySrc, ifNullRestrictedVtArrayDst);
+		checkResults(ifNullRestrictedVtArraySrc, ifNullRestrictedVtArrayDst);
 
 		initArrays();
 		testIFIF(ifArray1, ifIdArrayDst);
@@ -524,12 +456,12 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(ifVtArraySrc, ifArray2);
 
 		initArrays();
-		testIFIF(ifArray3, ifPrimitiveVtArrayDst);
-		checkResults(ifArray3, ifPrimitiveVtArrayDst);
+		testIFIF(ifArray3, ifNullRestrictedVtArrayDst);
+		checkResults(ifArray3, ifNullRestrictedVtArrayDst);
 
 		initArrays();
-		testIFIF(ifPrimitiveVtArraySrc, ifArray3);
-		checkResults(ifPrimitiveVtArraySrc, ifArray3);
+		testIFIF(ifNullRestrictedVtArraySrc, ifArray3);
+		checkResults(ifNullRestrictedVtArraySrc, ifArray3);
 	}
 
 	@Test(priority=1)
@@ -576,40 +508,40 @@ public class ValueTypeSystemArraycopyTests {
 	static public void testSystemArrayCopy15() throws Throwable {
 
 		initArrays();
-		testPVTOBJ(primitiveVtArraySrc); // Fist invocation (Interpreter)
+		testVTOBJ(nullRestrictedVtArraySrc); // Fist invocation (Interpreter)
 
 		initArrays();
-		testPVTOBJ(primitiveVtArraySrc);
+		testVTOBJ(nullRestrictedVtArraySrc);
 	}
 
 	@Test(priority=1)
 	static public void testSystemArrayCopy16() throws Throwable {
 
 		initArrays();
-		testOBJPVT(primitiveVtArrayDst); // Fist invocation (Interpreter)
+		testOBJVT(nullRestrictedVtArrayDst); // Fist invocation (Interpreter)
 
 		initArrays();
-		testOBJPVT(primitiveVtArrayDst);
+		testOBJVT(nullRestrictedVtArrayDst);
 	}
 
 	@Test(priority=1)
 	static public void testSystemArrayCopy17() throws Throwable {
 
 		initArrays();
-		testIFOBJ(ifPrimitiveVtArraySrc); // Fist invocation (Interpreter)
+		testIFOBJ(ifNullRestrictedVtArraySrc); // Fist invocation (Interpreter)
 
 		initArrays();
-		testIFOBJ(ifPrimitiveVtArraySrc);
+		testIFOBJ(ifNullRestrictedVtArraySrc);
 	}
 
 	@Test(priority=1)
 	static public void testSystemArrayCopy18() throws Throwable {
 
 		initArrays();
-		testOBJIF(ifPrimitiveVtArrayDst); // Fist invocation (Interpreter)
+		testOBJIF(ifNullRestrictedVtArrayDst); // Fist invocation (Interpreter)
 
 		initArrays();
-		testOBJIF(ifPrimitiveVtArrayDst);
+		testOBJIF(ifNullRestrictedVtArrayDst);
 	}
 
 	@Test(priority=1)
@@ -627,8 +559,8 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(ifVtArraySrc, ifVtArrayDst);
 
 		initArrays();
-		testOBJOBJ(ifPrimitiveVtArraySrc, ifPrimitiveVtArrayDst);
-		checkResults(ifPrimitiveVtArraySrc, ifPrimitiveVtArrayDst);
+		testOBJOBJ(ifNullRestrictedVtArraySrc, ifNullRestrictedVtArrayDst);
+		checkResults(ifNullRestrictedVtArraySrc, ifNullRestrictedVtArrayDst);
 
 		initArrays();
 		testOBJOBJ(ifArray1, ifIdArrayDst);
@@ -647,12 +579,12 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(ifVtArraySrc, ifArray2);
 
 		initArrays();
-		testOBJOBJ(ifArray3, ifPrimitiveVtArrayDst);
-		checkResults(ifArray3, ifPrimitiveVtArrayDst);
+		testOBJOBJ(ifArray3, ifNullRestrictedVtArrayDst);
+		checkResults(ifArray3, ifNullRestrictedVtArrayDst);
 
 		initArrays();
-		testOBJOBJ(ifPrimitiveVtArraySrc, ifArray3);
-		checkResults(ifPrimitiveVtArraySrc, ifArray3);
+		testOBJOBJ(ifNullRestrictedVtArraySrc, ifArray3);
+		checkResults(ifNullRestrictedVtArraySrc, ifArray3);
 	}
 
 	@Test(priority=1)
@@ -677,10 +609,10 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(src, ifVtArrayDst);
 
 		for (int i=0; i < ARRAY_SIZE; i++) {
-			src[i] = new SomePrimitiveValueClass(i*25);
+			src[i] = new SomeValueClass(i*25);
 		}
-		testOBJOBJ(src, ifPrimitiveVtArrayDst);
-		checkResults(src, ifPrimitiveVtArrayDst);
+		testOBJOBJ(src, ifNullRestrictedVtArrayDst);
+		checkResults(src, ifNullRestrictedVtArrayDst);
 	}
 
 	@Test(priority=1)
@@ -708,10 +640,10 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(ifVtArraySrc, dst);
 
 		for (int i=0; i < ARRAY_SIZE; i++) {
-			dst[i] = new SomePrimitiveValueClass(i*26);
+			dst[i] = new SomeValueClass(i*26);
 		}
-		testOBJOBJ(ifPrimitiveVtArraySrc, dst);
-		checkResults(ifPrimitiveVtArraySrc, dst);
+		testOBJOBJ(ifNullRestrictedVtArraySrc, dst);
+		checkResults(ifNullRestrictedVtArraySrc, dst);
 	}
 
 	@Test(priority=1)
@@ -719,16 +651,16 @@ public class ValueTypeSystemArraycopyTests {
 
 		try {
 			initArraysForASETest(); // ifArray3[ARRAY_SIZE/2] is NULL
-			testIFPVT(ifArray3, primitiveVtArrayDst);
+			testIFVT(ifArray3, nullRestrictedVtArrayDst);
 		} catch (java.lang.ArrayStoreException ase1) {
 			try {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
-				checkPVTArrayAfterException(ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
+				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 
 				initArraysForASETest();
-				testIFPVT(ifArray3, primitiveVtArrayDst);
+				testIFVT(ifArray3, nullRestrictedVtArrayDst);
 			} catch (java.lang.ArrayStoreException ase2) {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
 				// pass
 				return;
 			}
@@ -742,17 +674,17 @@ public class ValueTypeSystemArraycopyTests {
 
 		try {
 			initArraysForASETest(); // ifArray3[ARRAY_SIZE/2] is NULL
-			testIFIF(ifArray3, primitiveVtArrayDst);
+			testIFIF(ifArray3, nullRestrictedVtArrayDst);
 		} catch (java.lang.ArrayStoreException ase1) {
 			try {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
-				checkPVTArrayAfterException(ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
+				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 
 				initArraysForASETest();
-				testIFIF(ifArray3, primitiveVtArrayDst);
+				testIFIF(ifArray3, nullRestrictedVtArrayDst);
 			} catch (java.lang.ArrayStoreException ase2) {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
-				checkPVTArrayAfterException(ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
+				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 				// pass
 				return;
 			}
@@ -766,17 +698,17 @@ public class ValueTypeSystemArraycopyTests {
 
 		try {
 			initArraysForArrayStoreChkExceptionTest();  // ifArray3[ARRAY_SIZE/2] is SomeIdentityClass
-			testIFPVT(ifArray3, primitiveVtArrayDst);
+			testIFVT(ifArray3, nullRestrictedVtArrayDst);
 		} catch (java.lang.ArrayStoreException ase1) {
 			try {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
-				checkPVTArrayAfterException(ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
+				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 
 				initArraysForArrayStoreChkExceptionTest();
-				testIFPVT(ifArray3, primitiveVtArrayDst);
+				testIFVT(ifArray3, nullRestrictedVtArrayDst);
 			} catch (java.lang.ArrayStoreException ase2) {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
-				checkPVTArrayAfterException(ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
+				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 				// pass
 				return;
 			}
@@ -790,17 +722,17 @@ public class ValueTypeSystemArraycopyTests {
 
 		try {
 			initArraysForArrayStoreChkExceptionTest();  // ifArray3[ARRAY_SIZE/2] is SomeIdentityClass
-			testIFIF(ifArray3, primitiveVtArrayDst);
+			testIFIF(ifArray3, nullRestrictedVtArrayDst);
 		} catch (java.lang.ArrayStoreException ase1) {
 			try {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
-				checkPVTArrayAfterException(ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
+				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 
 				initArraysForArrayStoreChkExceptionTest();
-				testIFIF(ifArray3, primitiveVtArrayDst);
+				testIFIF(ifArray3, nullRestrictedVtArrayDst);
 			} catch (java.lang.ArrayStoreException ase2) {
-				checkResultsPartial(ifArray3, primitiveVtArrayDst, ARRAY_SIZE/2);
-				checkPVTArrayAfterException(ARRAY_SIZE/2);
+				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
+				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 				// pass
 				return;
 			}
@@ -813,7 +745,7 @@ public class ValueTypeSystemArraycopyTests {
 	static public void testSystemArrayCopy26() throws Throwable {
 
 		try {
-			initArraysForArrayStoreChkExceptionTest();  // ifArray1[ARRAY_SIZE/2] is SomePrimitiveValueClass
+			initArraysForArrayStoreChkExceptionTest();  // ifArray1[ARRAY_SIZE/2] is null-restricted SomeValueClass
 			testIFIF(ifArray1, idArrayDst);
 		} catch (java.lang.ArrayStoreException ase1) {
 			try {
@@ -833,21 +765,24 @@ public class ValueTypeSystemArraycopyTests {
 		Assert.fail("Expect a ArrayStoreException. No exception or wrong kind of exception thrown");
 	}
 
-	@Test(priority=1)
+	@Test(priority=1, invocationCount=2)
 	static public void testSystemArrayCopy27() throws Throwable {
 		initArrays();
 		testVTVT(vtArraySrc, nullRestrictedVtArrayDst);
+		checkResults(vtArraySrc, nullRestrictedVtArrayDst);
 	}
 
-	@Test(priority=1)
+	@Test(priority=1, invocationCount=2)
 	static public void testSystemArrayCopy28() throws Throwable {
 		initArrays();
 		testVTVT(nullRestrictedVtArraySrc, vtArrayDst);
+		checkResults(nullRestrictedVtArraySrc, vtArrayDst);
 	}
 
-	@Test(priority=1, expectedExceptions=ArrayStoreException.class)
+	@Test(priority=1, invocationCount=2, expectedExceptions=ArrayStoreException.class)
 	static public void testSystemArrayCopy29() throws Throwable {
 		initArraysToCopyNullToNullRestrictedArray();
 		testVTVT(vtArraySrc, nullRestrictedVtArrayDst);
+		checkResults(vtArraySrc, nullRestrictedVtArrayDst);
 	}
 }

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeUnsafeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeUnsafeTests.java
@@ -23,6 +23,7 @@ package org.openj9.test.lworld;
 
 
 import jdk.internal.misc.Unsafe;
+import jdk.internal.value.ValueClass;
 import jdk.internal.vm.annotation.ImplicitlyConstructible;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -93,10 +94,11 @@ public class ValueTypeUnsafeTests {
 	@BeforeMethod
 	static public void setUp() {
 		vtPoint = new ValueTypePoint2D(new ValueTypeInt(7), new ValueTypeInt(8));
-		vtPointAry = new ValueTypePoint2D[] {
-			new ValueTypePoint2D(new ValueTypeInt(5), new ValueTypeInt(10)),
-			new ValueTypePoint2D(new ValueTypeInt(10), new ValueTypeInt(20))
-		};
+
+		vtPointAry = (ValueTypePoint2D[])ValueClass.newNullRestrictedArray(ValueTypePoint2D.class, 2);
+		vtPointAry[0] = new ValueTypePoint2D(new ValueTypeInt(5), new ValueTypeInt(10));
+		vtPointAry[1] = new ValueTypePoint2D(new ValueTypeInt(10), new ValueTypeInt(20));
+
 		vtPointAryOffset1 = vtPointAryOffset0 + arrayElementSize(vtPointAry);
 		vtIntAry = new ValueTypeInt[] { new ValueTypeInt(1), new ValueTypeInt(2) };
 		vtIntAryOffset1 = vtIntAryOffset0 + arrayElementSize(vtIntAry);


### PR DESCRIPTION
Update ValueTypeUnsafeTests  tests to use flattenable array.
Update ValueTypeSystemArraycopyTests to test System.arrayCopy
between nullable and null-restricted arrays.

Fixes: https://github.com/eclipse-openj9/openj9/issues/20223
Fixes: https://github.com/eclipse-openj9/openj9/issues/20253