### PR TITLE
OffHeap CardMarking using the baseObj instead of dataAddr

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -987,7 +987,8 @@ VMCardCheckEvaluator(
       TR::Register *dstReg,
       TR_ARM64ScratchRegisterManager *srm,
       TR::LabelSymbol *doneLabel,
-      TR::CodeGenerator *cg)
+      TR::CodeGenerator *cg,
+      bool clobberDstReg=false)
    {
    TR::Compilation *comp = cg->comp();
 
@@ -1014,7 +1015,11 @@ VMCardCheckEvaluator(
       cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "wrtbarEvaluator:020VMCardCheckEvaluator:01markThreadActiveCheckDone"), *srm);
       }
 
-   TR::Register *temp2Reg = srm->findOrCreateScratchRegister();
+   TR::Register *temp2Reg;
+   if (clobberDstReg)
+      temp2Reg = dstReg;
+   else
+      temp2Reg = srm->findOrCreateScratchRegister();
       /*
        * Generating code checking whether an object is in heap
        *
@@ -5083,6 +5088,12 @@ static TR::Register *VMinlineCompareAndSwapObject(TR::Node *node, TR::CodeGenera
    oldVNode = node->getChild(3);
    newVNode = node->getChild(4);
 
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+   bool isObjOffHeapDataAddr = (gcMode == gc_modron_wrtbar_cardmark_incremental && TR::Compiler->om.isOffHeapAllocationEnabled() && objNode->isDataAddrPointer());
+   TR::Register *baseObjReg = NULL;
+   if (isObjOffHeapDataAddr)
+      TR::TreeEvaluator::stopUsingCopyReg(objNode->getFirstChild(), baseObjReg, cg);
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
    objReg = cg->evaluate(objNode);
 
    if (offsetNode->getOpCode().isLoadConst() && offsetNode->getRegister() == NULL)
@@ -5253,11 +5264,20 @@ static TR::Register *VMinlineCompareAndSwapObject(TR::Node *node, TR::CodeGenera
             generateCompareBranchInstruction(cg, TR::InstOpCode::cbzx, node, wrtBarSrcReg, doneLabel);
             cg->generateDebugCounter(TR::DebugCounter::debugCounterName(comp, "wrtbarEvaluator:000srcNullChk:NonNull"), *srm);
             }
-         VMCardCheckEvaluator(node, objReg, srm, doneLabel, cg);
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+         if (isObjOffHeapDataAddr)
+            VMCardCheckEvaluator(node, baseObjReg, srm, doneLabel, cg, true);
+         else
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+            VMCardCheckEvaluator(node, objReg, srm, doneLabel, cg);
          }
 
       TR_ARM64ScratchRegisterDependencyConditions scratchDeps;
       scratchDeps.addDependency(cg, objReg, doWrtBar ? TR::RealRegister::x0 : TR::RealRegister::NoReg);
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+      if (isObjOffHeapDataAddr)
+         scratchDeps.addDependency(cg, baseObjReg, TR::RealRegister::NoReg);
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
       scratchDeps.addDependency(cg, wrtBarSrcReg, doWrtBar ? TR::RealRegister::x1 : TR::RealRegister::NoReg);
       if (offsetInReg)
          {

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11073,7 +11073,13 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(
    TR::Register *owningObjectReg;
    TR::Register *tempReg = NULL;
 
-   owningObjectReg = cg->evaluate(destOwningObject);
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+   bool stopUsingCopyBaseReg;
+   if (gcMode == gc_modron_wrtbar_cardmark_incremental && TR::Compiler->om.isOffHeapAllocationEnabled() && destOwningObject->isDataAddrPointer())
+      owningObjectReg = cg->evaluate(destOwningObject->getFirstChild());
+   else
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+      owningObjectReg = cg->evaluate(destOwningObject);
 
    if (doInternalControlFlow)
       {


### PR DESCRIPTION
When evaluating Unsafe.CAS, the card marking uses the dstObj to calculate the card entry to dirty.

With OffHeap the dstObj is a dataAddrPointer load of the baseObj:
```
n85n      NULLCHK on n87n [#32]
n86n        icall  jdk/internal/misc/Unsafe.compareAndSetObject(Ljava/lang/Object;JLjava/lang/Object;Ljava/lang/Object;)Z[#415  final native virtual Method -304]
n87n          aload  java/util/concurrent/ConcurrentHashMap.U Ljdk/internal/misc/Unsafe;[#407  final Static]
n92n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +16] 
n88n            aload  tab<parm 0 [Ljava/util/concurrent/ConcurrentHashMap$Node;>[#403  Parm]
n13n          ladd                                 
n9n             lshl                               
n6n               i2l                              
n5n                 iload  i<parm 1 I>[#404  Parm] 
n7n               iconst 3 (X!=0 X>=0 )            
n12n            i2l                                
n10n              iconst 0 (X==0 X>=0 X<=0 )         
n90n          aload  c<parm 2 Ljava/util/concurrent/ConcurrentHashMap$Node;>[#405  Parm]
n91n          aload  v<parm 3 Ljava/util/concurrent/ConcurrentHashMap$Node;>[#406  Parm]
```

This PR changes that to use the correct baseObj to calculate the card entry to dirty.
The change uses the temp registers to not use more registers for the code sequence.

**TODO**:
- [x] Z
  - [x] ~`inlineConcurrentLinkedQueueTMOffer`~ (Given that the dstObj is not an array, no dataAddr load will be present)
  - [x] ~`inlineConcurrentLinkedQueueTMPoll`~ (Given that the dstObj is not an array, no dataAddr load will be present)
- [x] Confirm that `arraycopyEvaluator` needs the change on all platforms [1].

Depends on https://github.com/eclipse-omr/omr/pull/7562

----

[1]
For arraycopy, currently the optimizer uses the baseObj as the dstObj child, and loads the dataAddr in the dstAddr child. As card marking uses the dstObj child for the card entry calculation, it's correct. I just need to confirm that this is always the case.
```
n60n        arraycopy  java/lang/System.arraycopy(Ljava/lang/Object;ILjava/lang/Object;II)V[#405  unresolved notAccessed static Method] [flags 0x400 0x0 ] (Unsigned forwardArrayCopy noArra>
n58n          aload  <parm 0 [Ljava/lang/Object;>[#403  Parm]                          
n59n          aload  <parm 1 [Ljava/lang/Object;>[#404  Parm]                            
n54n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x78f0fb0e00a0] bci=[-1,0,20] rc=1 vc=33 vn=- li=- udi=- nc=1 fl>
n55n            aload  <parm 0 [Ljava/lang/Object;>[#403  Parm]                
n56n          aloadi  <contiguousArrayDataAddrFieldSymbol>[#352  final Shadow +8] [flags 0x20604 0x0 ] (internalPtr )  [    0x78f0fb0e0140] bci=[-1,2,20] rc=1 vc=33 vn=- li=- udi=- nc=1 fl>
n57n            aload  <parm 1 [Ljava/lang/Object;>[#404  Parm]                         
n53n          lconst 8 (highWordZero X!=0 X>=0 cannotOverflow )             

```