### PR TITLE
Attempt to reload the library in case of UnsatisfiedLinkError

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1152,10 +1152,30 @@ public static void loadLibrary(String libName) {
 		smngr.checkLink(libName);
 	}
 /*[IF JAVA_SPEC_VERSION >= 15]*/
-	ClassLoader.loadLibrary(getCallerClass(), libName);
+	Class<?> callerClass = getCallerClass();
 /*[ELSE]*/
-	ClassLoader.loadLibraryWithClassLoader(libName, ClassLoader.callerClassLoader());
+	ClassLoader callerClassLoader = ClassLoader.callerClassLoader();
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+	try {
+/*[IF JAVA_SPEC_VERSION >= 15]*/
+		ClassLoader.loadLibrary(callerClass, libName);
+/*[ELSE]*/
+		ClassLoader.loadLibraryWithClassLoader(libName, callerClassLoader);
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+	} catch (UnsatisfiedLinkError ule) {
+		String errorMessage = ule.getMessage();
+		if ((errorMessage != null) && errorMessage.contains("already loaded in another classloader")) { //$NON-NLS-1$
+			// attempt to unload the classloader, and retry
+			gc();
+/*[IF JAVA_SPEC_VERSION >= 15]*/
+			ClassLoader.loadLibrary(callerClass, libName);
+/*[ELSE]*/
+			ClassLoader.loadLibraryWithClassLoader(libName, callerClassLoader);
+/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+		} else {
+			throw ule;
+		}
+	}
 }
 
 /**


### PR DESCRIPTION
Attempt to reload the library in case of `UnsatisfiedLinkError`

When an `UnsatisfiedLinkError` is thrown because the library was already loaded in another classloader, run `gc()` to unload the unreachable classloaders, and reload the library again.

Java 8/11 `UnsatisfiedLinkError` message `already loaded in another classloader` is from
https://github.com/eclipse-openj9/openj9/blob/0027b8193413e99fd9747ddbd84750ffc14ba4d1/runtime/vm/vmbootlib.c#L518-L519

Java 17+ is from https://github.com/ibmruntimes/openj9-openjdk-jdk17/blob/4a311794a42998359c859814c645398be928e19a/src/java.base/share/classes/jdk/internal/loader/NativeLibraries.java#L206-L209
```
            // cannot be loaded by other class loaders
            if (loadedLibraryNames.contains(name)) {
                throw new UnsatisfiedLinkError("Native Library " + name +
                        " already loaded in another classloader");
            }
```

closes https://github.com/eclipse-openj9/openj9/issues/19978

Signed-off-by: Jason Feng <fengj@ca.ibm.com>