### PR TITLE
(0.48) Fix x86 assembly source issues with gcc 13

### DIFF
--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -93,7 +93,6 @@ define({SHORT_JMP},{short})
 
 define({FILE_START},{
 	.intel_syntax noprefix
-	.arch pentium4
 	.text
 })
 
@@ -111,7 +110,9 @@ define({START_PROC},{
 	GLOBAL_SYMBOL($1):
 })
 
-define({FILE_END})
+define({FILE_END},{ifdef({LINUX},{
+	.section .note.GNU-stack,"",@progbits
+})})
 
 define({END_PROC},{
 END_$1:


### PR DESCRIPTION
* remove ".arch" directive
* add .section .note.GNU-stack,"",@progbits at end of file

This is a replay of #20278 and #20284 for the 0.48 release.