### PR TITLE
Guard jvmtitests newly added header includes to J9ZOS only

### DIFF
--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp003.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp003.c
@@ -22,7 +22,9 @@
 
 #include "jvmti_test.h"
 #include <string.h>
+#if defined(J9ZOS390)
 #include <strings.h>
+#endif /* defined(J9ZOS390) */
 
 static agentEnv * env;
 static jmethodID catchMethod = NULL;

--- a/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp005.c
+++ b/runtime/tests/jvmtitests/src/com/ibm/jvmti/tests/decompResolveFrame/decomp005.c
@@ -22,7 +22,9 @@
 
 #include "jvmti_test.h"
 #include <string.h>
+#if defined(J9ZOS390)
 #include <strings.h>
+#endif /* defined(J9ZOS390) */
 
 static agentEnv * env;
 static int imse = 0;


### PR DESCRIPTION
Have draft PR ready here @r30shah 
Double checking right now the below, before I remove it from draft:
- full vm open-xl build
- java 8 build (would like more insight on what all platforms we should verify here to minimize surprises later)