### PR TITLE
Remove Unnecessary Assertion in removeHCRGuards

### DIFF
--- a/runtime/compiler/optimizer/OSRGuardInsertion.cpp
+++ b/runtime/compiler/optimizer/OSRGuardInsertion.cpp
@@ -348,7 +348,6 @@ void TR_OSRGuardInsertion::removeHCRGuards(TR_BitVector &fearGeneratingNodes, TR
       if (!node->isTheVirtualGuardForAGuardedInlinedCall()) { continue; }
       TR_VirtualGuard *guardInfo = comp()->findVirtualGuardInfo(node);
       TR_ASSERT(guardInfo, "we expect to get virtual guard info in HCRGuardRemoval!");
-      TR_ASSERT(!guardInfo->getByteCodeInfo().isInvalidByteCodeIndex(), "we expect to get valid bytecode info for a virtual guard!");
 
       if (!guardAnalysis || guardAnalysis->_blockAnalysisInfo[cursor->getNextBlock()->getNumber()]->isEmpty())
          {


### PR DESCRIPTION
The assertion "!guardInfo->getByteCodeInfo().isInvalidByteCodeIndex()" is obsolete and not needed since the function does not actual access a ByteCodeInfo anywhere. It fails incorrectly when a "TR_SideEffectGuard" is encountered.