### PR TITLE
Remove unused variable on AIX in rasdump.c

### DIFF
--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -647,9 +647,11 @@ void
 J9RASCheckDump(J9JavaVM* javaVM)
 {
 #if defined(LINUX) || defined(AIXPPC)
-	IDATA rc;
-	U_64 limit;
+	IDATA rc = 0;
+	U_64 limit = 0;
+#if defined(LINUX)
 	IDATA fd = -1;
+#endif /* defined(LINUX) */
 
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 


### PR DESCRIPTION
```
openj9/runtime/vm/rasdump.c:652:8: warning: unused variable 'fd'
[-Wunused-variable]
14:20:44    652 |         IDATA fd = -1;
14:20:44        |               ^~
```