### PR TITLE
CRIU adds @NotCheckpointSafe at ClassLoader.getClassLoadingLock()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -72,6 +72,10 @@ import jdk.internal.loader.NativeLibrary;
 import jdk.internal.reflect.CallerSensitiveAdapter;
 /*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
+/*[IF CRIU_SUPPORT]*/
+import openj9.internal.criu.NotCheckpointSafe;
+/*[ENDIF] CRIU_SUPPORT*/
+
 /**
  * ClassLoaders are used to dynamically load, link and install
  * classes into a running image.
@@ -1460,6 +1464,9 @@ private static boolean registerAsParallelCapable(Class<?> callerCls) {
  * @see			java.lang.ClassLoader
  *
  */
+/*[IF CRIU_SUPPORT]*/
+@NotCheckpointSafe
+/*[ENDIF] CRIU_SUPPORT */
 protected Object getClassLoadingLock(final String className) {
 	Object lock = this;
 	if (isParallelCapable)	{


### PR DESCRIPTION
CRIU adds `@NotCheckpointSafe` at `ClassLoader.getClassLoadingLock()`

This is expected to address 
```
[err] openj9.internal.criu.JVMRestoreException: Blocking operation is not allowed in CRIU single thread mode.
[err]   at java.base/java.lang.ClassLoader.getClassLoadingLock(ClassLoader.java:1270)
[err]   at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:837)
[err]   at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:825)
[err]   at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
[err]   at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:1093)
[err]   at com.ibm.ws.kernel.internal.classloader.JarFileClassLoader._loadClass(JarFileClassLoader.java:172)
[err]   at com.ibm.ws.kernel.internal.classloader.BootstrapChildFirstJarClassloader.loadClass(BootstrapChildFirstJarClassloader.java:83)
[err]   at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:1093)
[err]   at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:446)
[err]   at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:416)
[err]   at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:168)
[err]   at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:1093)
[err]   at io.openliberty.checkpoint.internal.criu.CheckpointFailedException$Type.$values(CheckpointFailedException.java:24)
[err]   at io.openliberty.checkpoint.internal.criu.CheckpointFailedException$Type.<clinit>(CheckpointFailedException.java:24)
[err]   at io.openliberty.checkpoint.internal.CheckpointImpl.failedRestore(CheckpointImpl.java:618)
[err]   at io.openliberty.checkpoint.internal.CheckpointImpl.callHooks(CheckpointImpl.java:581)
[err]   at io.openliberty.checkpoint.internal.CheckpointImpl.restore(CheckpointImpl.java:611)
[err]   at io.openliberty.checkpoint.internal.CheckpointImpl.lambda$checkpoint$15(CheckpointImpl.java:397)
[err]   at java.base/openj9.internal.criu.InternalCRIUSupport.lambda$registerCheckpointHookHelper$2(InternalCRIUSupport.java:796)
[err]   at java.base/openj9.internal.criu.J9InternalCheckpointHookAPI$J9InternalCheckpointHook.runHook(J9InternalCheckpointHookAPI.java:143)
[err]   at java.base/openj9.internal.criu.J9InternalCheckpointHookAPI.runHooks(J9InternalCheckpointHookAPI.java:98)
[err]   at java.base/openj9.internal.criu.J9InternalCheckpointHookAPI.runPostRestoreHooksSingleThread(J9InternalCheckpointHookAPI.java:115)
[err]   at java.base/openj9.internal.criu.InternalCRIUSupport.checkpointJVMImpl(Native Method)
[err]   at java.base/openj9.internal.criu.InternalCRIUSupport.checkpointJVM(InternalCRIUSupport.java:997)
[err]   at openj9.criu/org.eclipse.openj9.criu.CRIUSupport.checkpointJVM(CRIUSupport.java:530)
[err]   at io.openliberty.checkpoint.internal.openj9.ExecuteCRIU_OpenJ9.dump(ExecuteCRIU_OpenJ9.java:55)
[err]   at io.openliberty.checkpoint.internal.CheckpointImpl.checkpoint(CheckpointImpl.java:396)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>