### PR TITLE
Changes some uses of nullptr to NULL

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5546,7 +5546,7 @@ TR_J9MethodBase::isUnsafeCAS(TR::Compilation * c)
     * The TR::Compilation parameter "c" is sometimes null. But, it is needed to perform a platform target check.
     * So, if it is null, this code goes and gets comp.
     */
-   if (nullptr == c)
+   if (NULL == c)
       {
       c = TR::comp();
       }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9533,7 +9533,7 @@ static TR::Register* inlineCompareAndSwapObjectNative(TR::Node* node, TR::CodeGe
    TR::Register* offset   = cg->evaluate(offsetNode);
    TR::Register* oldValue = cg->evaluate(oldValueNode);
    TR::Register* newValue = cg->evaluate(newValueNode);
-   TR::Register* result   = isExchange ? nullptr : cg->allocateRegister();
+   TR::Register* result   = isExchange ? NULL : cg->allocateRegister();
    TR::Register* EAX      = cg->allocateRegister();
    TR::Register* tmp      = cg->allocateRegister();
 


### PR DESCRIPTION
`nullptr` is not supported by some supported compilers. So some uses of `nullptr` are now changed to use `NULL` instead.