### PR TITLE
Update jfr time calculations

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -360,7 +360,7 @@ typedef struct J9JFRBuffer {
 /* JFR event structures */
 
 #define J9JFR_EVENT_COMMON_FIELDS \
-	I_64 startTime; \
+	I_64 startTicks; \
 	UDATA eventType; \
 	struct J9VMThread *vmThread;
 
@@ -5635,6 +5635,8 @@ typedef struct JFRState {
 	IDATA blobFileDescriptor;
 	void *jfrWriter;
 	UDATA jfrChunkCount;
+	I_64 chunkStartTime;
+	I_64 chunkStartTicks;
 	void *constantEvents;
 	BOOLEAN isConstantEventsInitialized;
 	omrthread_monitor_t isConstantEventsInitializedMutex;

--- a/runtime/vm/JFRChunkWriter.cpp
+++ b/runtime/vm/JFRChunkWriter.cpp
@@ -49,13 +49,13 @@ VM_JFRChunkWriter::writeJFRHeader()
 	_bufferWriter->writeU64(_bufferWriter->getFileOffsetFromStart(_metadataOffset)); // 24
 
 	/* start time */
-	_bufferWriter->writeU64(VM_JFRUtils::getCurrentTimeNanos(privatePortLibrary, _buildResult)); // 32
+	_bufferWriter->writeU64(_vm->jfrState.chunkStartTime); // 32
 
 	/* duration */
 	_bufferWriter->writeU64(0); // 40
 
 	/* start ticks */
-	_bufferWriter->writeU64(0); // 48
+	_bufferWriter->writeU64(_vm->jfrState.chunkStartTicks); // 48
 
 	/* ticks per second - 1000_000_000 ticks per second means that we are reporting nanosecond timestamps */
 	_bufferWriter->writeU64(1000000000); // 56
@@ -138,7 +138,7 @@ VM_JFRChunkWriter::writeCheckpointEventHeader(CheckpointTypeMask typeMask, U_32 
 	_bufferWriter->writeU8(EventCheckpoint);
 
 	/* start time */
-	_bufferWriter->writeLEB128(VM_JFRUtils::getCurrentTimeNanos(privatePortLibrary, _buildResult));
+	_bufferWriter->writeLEB128(j9time_nano_time());
 
 	/* duration */
 	_bufferWriter->writeLEB128((U_64)0);
@@ -649,7 +649,7 @@ VM_JFRChunkWriter::writeJVMInformationEvent()
 	_bufferWriter->writeLEB128(JVMInformationID);
 
 	/* write start time */
-	_bufferWriter->writeLEB128(j9time_current_time_millis());
+	_bufferWriter->writeLEB128(j9time_nano_time());
 
 	/* write JVM name */
 	writeStringLiteral(jvmInfo->jvmName);
@@ -687,7 +687,7 @@ VM_JFRChunkWriter::writePhysicalMemoryEvent()
 	_bufferWriter->writeLEB128(PhysicalMemoryID);
 
 	/* write start time */
-	_bufferWriter->writeLEB128(j9time_current_time_millis());
+	_bufferWriter->writeLEB128(j9time_nano_time());
 
 	J9MemoryInfo memInfo = {0};
 	I_32 rc = j9sysinfo_get_memory_info(&memInfo);
@@ -717,7 +717,7 @@ VM_JFRChunkWriter::writeCPUInformationEvent()
 	_bufferWriter->writeLEB128(CPUInformationID);
 
 	/* write start time */
-	_bufferWriter->writeLEB128(j9time_current_time_millis());
+	_bufferWriter->writeLEB128(j9time_nano_time());
 
 	/* write CPU type */
 	writeStringLiteral(cpuInfo->cpu);
@@ -752,7 +752,7 @@ VM_JFRChunkWriter::writeVirtualizationInformationEvent()
 	_bufferWriter->writeLEB128(VirtualizationInformationID);
 
 	/* write start time */
-	_bufferWriter->writeLEB128(j9time_current_time_millis());
+	_bufferWriter->writeLEB128(j9time_nano_time());
 
 	/* write virtualization name */
 	writeStringLiteral(virtualizationInfo->name);
@@ -775,7 +775,7 @@ VM_JFRChunkWriter::writeOSInformationEvent()
 	_bufferWriter->writeLEB128(OSInformationID);
 
 	/* write start time */
-	_bufferWriter->writeLEB128(j9time_current_time_millis());
+	_bufferWriter->writeLEB128(j9time_nano_time());
 
 	/* write OS version */
 	writeStringLiteral(osInfo->osVersion);
@@ -800,7 +800,7 @@ VM_JFRChunkWriter::writeInitialSystemPropertyEvents(J9JavaVM *vm)
 		_bufferWriter->writeLEB128(InitialSystemPropertyID);
 
 		/* write start time */
-		_bufferWriter->writeLEB128(j9time_current_time_millis());
+		_bufferWriter->writeLEB128(j9time_nano_time());
 
 		/* write key */
 		writeStringLiteral(property->name);

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -159,7 +159,7 @@ struct StackFrame {
 
 struct ExecutionSampleEntry {
 	J9VMThread *vmThread;
-	I_64 time;
+	I_64 ticks;
 	ThreadState state;
 	U_32 stackTraceIndex;
 	U_32 threadIndex;
@@ -167,7 +167,7 @@ struct ExecutionSampleEntry {
 };
 
 struct ThreadStartEntry {
-	I_64 time;
+	I_64 ticks;
 	U_32 stackTraceIndex;
 	U_32 threadIndex;
 	U_32 eventThreadIndex;
@@ -175,13 +175,13 @@ struct ThreadStartEntry {
 };
 
 struct ThreadEndEntry {
-	I_64 time;
+	I_64 ticks;
 	U_32 threadIndex;
 	U_32 eventThreadIndex;
 };
 
 struct ThreadSleepEntry {
-	I_64 time;
+	I_64 ticks;
 	I_64 duration;
 	I_64 sleepTime;
 	U_32 threadIndex;
@@ -191,7 +191,7 @@ struct ThreadSleepEntry {
 
 struct StackTraceEntry {
 	J9VMThread *vmThread;
-	I_64 time;
+	I_64 ticks;
 	U_32 numOfFrames;
 	U_32 index;
 	StackFrame *frames;
@@ -417,7 +417,7 @@ private:
 
 	U_32 addThreadGroupEntry(j9object_t threadGroup);
 
-	U_32 addStackTraceEntry(J9VMThread *vmThread, I_64 time, U_32 numOfFrames);
+	U_32 addStackTraceEntry(J9VMThread *vmThread, I_64 ticks, U_32 numOfFrames);
 
 	void printMergedStringTables();
 
@@ -726,7 +726,7 @@ public:
 
 		iterateStackTraceImpl(_currentThread, (j9object_t*)walkStateCache, &stackTraceCallback, this, FALSE, FALSE, numberOfFrames, FALSE);
 
-		index = addStackTraceEntry(walkThread, VM_JFRUtils::getCurrentTimeNanos(privatePortLibrary, _buildResult), _currentFrameCount);
+		index = addStackTraceEntry(walkThread, j9time_nano_time(), _currentFrameCount);
 		_stackFrameCount += expandedStackTraceCount;
 		_currentStackFrameBuffer = NULL;
 


### PR DESCRIPTION
JFR timestamps are calculated in the following manner.

timestamp = chunkStartTime + (jfrTicks - chunkStartTicks)

The reason the data seemed sensible is because we always made the chunkStartTicks zero in the chunk header, so the relative difference in the millisecond time entries made some sense, but this was incorrect.