### PR TITLE
Nullable array class cannot be cast to null-restricted

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -648,13 +648,22 @@ cacheCastable:
 							/* check the [[O -> [[O case.  Don't allow [[I -> [[O */
 							if (instanceArity == castArity) {
 								J9Class *instanceClassLeafComponent = ((J9ArrayClass*)instanceClass)->leafComponentType;
-								if (J9CLASS_IS_MIXED(instanceClassLeafComponent)) {
-									/* we know arities are the same, so skip directly to the terminal case */
-									instanceClass = instanceClassLeafComponent;
-									castClass = castClassLeafComponent;
-									didRetry = true;
-									goto retry;
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+								if (J9_IS_J9ARRAYCLASS_NULL_RESTRICTED(instanceClass)
+									|| !J9_IS_J9ARRAYCLASS_NULL_RESTRICTED(castClass)
+								) {
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+									if (J9CLASS_IS_MIXED(instanceClassLeafComponent)) {
+										/* we know arities are the same, so skip directly to the terminal case */
+										instanceClass = instanceClassLeafComponent;
+										castClass = castClassLeafComponent;
+										didRetry = true;
+										goto retry;
+									}
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 								}
+								/* else fail since a nullable array class cannot be cast to a null-restricted class */
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 							}
 							/* else the arity of the instance wasn't high enough, so we fail */
 						}

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -2291,6 +2291,17 @@ public class ValueTypeTests {
 		checkCastRefClassOnNull.invoke();
 	}
 
+	@Test(priority=1)
+	static public void testClassIsInstanceNullableArrays() throws Throwable {
+		ValueTypePoint2D[] nonNullableArray = (ValueTypePoint2D[]) ValueClass.newNullRestrictedArray(ValueTypePoint2D.class, 1);
+		ValueTypePoint2D[] nullableArray = new ValueTypePoint2D[1];
+
+		assertTrue(nonNullableArray.getClass().isInstance(nonNullableArray));
+		assertTrue(nullableArray.getClass().isInstance(nullableArray));
+		assertFalse(nonNullableArray.getClass().isInstance(nullableArray));
+		assertTrue(nullableArray.getClass().isInstance(nonNullableArray));
+	}
+
 	/*
 	 * Maintain a buffer of flattened arrays with long-aligned valuetypes while keeping a certain amount of classes alive at any
 	 * single time. This forces the GC to unload the classes.


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/20305