### PR TITLE
Fix fieldAlignment check for AtomicLong on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3267,8 +3267,8 @@ J9::Z::CodeGenerator::checkFieldAlignmentForAtomicLong()
    int32_t fieldNameLen = 5;
    const char * fieldSig = "J";
    int32_t fieldSigLen = 1;
-   int32_t intOrBoolOffset = self()->fe()->getObjectHeaderSizeInBytes() + self()->fej9()->getInstanceFieldOffset(classBlock, fieldName, fieldNameLen, fieldSig, fieldSigLen);
-   return (intOrBoolOffset & 0x3) == 0;
+   int32_t longOffset = self()->fe()->getObjectHeaderSizeInBytes() + self()->fej9()->getInstanceFieldOffset(classBlock, fieldName, fieldNameLen, fieldSig, fieldSigLen);
+   return (longOffset & 0x7) == 0;
    }
 
 


### PR DESCRIPTION
"value" field for in AtomicLong is of type "long" and therefore should be aligned to 8-byte boundary.

checkFieldAlignmentForAtomicLong was incorrectly checking that the offset of the field is a multiple of 4 instead of a multiple of 8.

This PR fixes that.

addresses https://github.com/eclipse-openj9/openj9/issues/20235