### PR TITLE
(0.48) Acquire class table mutex 048 release

### DIFF
--- a/runtime/codert_vm/CodertVMHelpers.cpp
+++ b/runtime/codert_vm/CodertVMHelpers.cpp
@@ -207,6 +207,8 @@ jitMethodTranslated(J9VMThread *currentThread, J9Method *method, void *jitStartA
 			}
 			UDATA initialClassDepth = VM_VMHelpers::getClassDepth(currentClass);
 			void *j2jAddress = VM_VMHelpers::jitToJitStartAddress(jitStartAddress);
+
+			omrthread_monitor_enter(vm->classTableMutex);
 			do {
 				J9VTableHeader* vTableHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(currentClass);
 
@@ -228,6 +230,7 @@ jitMethodTranslated(J9VMThread *currentThread, J9Method *method, void *jitStartA
 				}
 				currentClass = currentClass->subclassTraversalLink;
 			} while (VM_VMHelpers::getClassDepth(currentClass) > initialClassDepth);
+			omrthread_monitor_exit(vm->classTableMutex);
 		}
 	}
 }


### PR DESCRIPTION
Back port #20327

Acquire classTableMutex when traversing sub class links

Fixes: https://github.com/eclipse-openj9/openj9/issues/20257