### PR TITLE
Check for VarHandle's MethodType table only when necessary

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5200,7 +5200,7 @@ TR_J9VMBase::getMethodHandleTableEntryIndex(TR::Compilation *comp, TR::KnownObje
                                  "methodTypeTable",
                                  "[Ljava/lang/invoke/MethodType;");
 #endif // JAVA_SPEC_VERSION <= 17
-   if (!mhTable || !mtTable) return result;
+   if (!mhTable) return result;
 
 #if JAVA_SPEC_VERSION >= 17
    // if the VarHandle has invokeExact behaviour, then the MethodType in
@@ -5212,6 +5212,7 @@ TR_J9VMBase::getMethodHandleTableEntryIndex(TR::Compilation *comp, TR::KnownObje
    int32_t varHandleHasInvokeExactBehaviour = getInt32FieldAt(varHandleObj, varHandleExactFieldOffset);
    if (varHandleHasInvokeExactBehaviour)
       {
+      if (!mtTable) return result;
       int32_t mtEntryIndex = getInt32Field(accessDescriptorObj, "type");
       uintptr_t methodTypeTableEntryObj = getReferenceElement(mtTable, mtEntryIndex);
       if (!methodTypeTableEntryObj) return result;


### PR DESCRIPTION
A `VarHandle` can be initialized such that its access mode method invocation behaves like a `MethodHandle.invokeExact` invocation. We can check if this is the case by checking whether the `VarHandle.exact` field was set to true. In such a case, an additional check is necessary, where we need to verify whether `AccessDescriptor.symbolicMethodTypeExact` field matches the corresponding entry in the `MethodType` table, failing which the JIT should abort trying to lookup the `MethodHandle` table.

The `MethodType` table would only be initialized for a `VarHandle` if the `VarHandle.exact` field was initialized as true. Therefore, by moving the check for whether the `MethodType` table is valid to occur only after we confirm that the `VarHandle` has `invokeExact` behaviour, we prevent prematurely aborting the MH entry lookup in `getMethodHandleTableEntryIndex` when the MT table is not initialized.