### PR TITLE
Remove Class.asNullRestrictedType

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2643,15 +2643,6 @@ public native boolean isValue();
  * @return	true if receiver is an identity class, and false otherwise.
  */
 public native boolean isIdentity();
-
-/**
- * Returns the Null-Restricted type of this class.
- *
- * @return Null-Restricted class
- */
-public Class<?> asNullRestrictedType() {
-	return this;
-}
 /*[ENDIF] INLINE-TYPES */
 
 /**


### PR DESCRIPTION
This method has been removed from the latest valuetypes extensions repository.

Fixes: https://github.com/eclipse-openj9/openj9/issues/13695