### PR TITLE
Enable Jep454Tests for valhalla builds

### DIFF
--- a/test/functional/Java22andUp/playlist.xml
+++ b/test/functional/Java22andUp/playlist.xml
@@ -23,12 +23,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_DownCall</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18583</comment>
-				<testflag>VTSTANDARD</testflag>
-			</disable>
-		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \
@@ -55,12 +49,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_DownCall_HeapArray</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18583</comment>
-				<testflag>VTSTANDARD</testflag>
-			</disable>
-		</disables>
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>Mode501</variation>
@@ -93,12 +81,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<test>
 		<testCaseName>Jep454Tests_testLinkerFfi_UpCall</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/18583</comment>
-				<testflag>VTSTANDARD</testflag>
-			</disable>
-		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			--enable-native-access=ALL-UNNAMED \
 			-Dforeign.restricted=permit \


### PR DESCRIPTION
These tests were previously disabled due to the valuetypes extensions repository being out of date.

The tests are now passing https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/44071/

Fixes: https://github.com/eclipse-openj9/openj9/issues/18583

fyi @JasonFengJ9 