### PR TITLE
Use ExceptionCheck() instead of ExceptionOccurred() where appropriate

### DIFF
--- a/runtime/jcl/common/jcltrace.c
+++ b/runtime/jcl/common/jcltrace.c
@@ -464,7 +464,7 @@ extractAndProcessFormatStrings(JNIEnv *env, jarray templates, char ***const form
 
 	*tracePointCount = (*env)->GetArrayLength(env, templates);
 
-	if (NULL != (*env)->ExceptionOccurred(env)) {
+	if ((*env)->ExceptionCheck(env)) {
 		return 1;
 	}
 
@@ -493,7 +493,7 @@ extractAndProcessFormatStrings(JNIEnv *env, jarray templates, char ***const form
 		jobject thisString = (*env)->GetObjectArrayElement(env, templates, (jsize)i);
 		const char *jniStringCharacters = NULL;
 
-		if (NULL != (*env)->ExceptionOccurred(env)) {
+		if ((*env)->ExceptionCheck(env)) {
 			rc = 3;
 			goto fail;
 		}

--- a/runtime/jvmti/jvmtiModules.c
+++ b/runtime/jvmti/jvmtiModules.c
@@ -137,7 +137,7 @@ addModuleExportsOrOpens(jvmtiEnv* jvmtiEnv, jobject fromModule, const char* pkgN
 										!exports,
 										JNI_TRUE);
 			}
-			if ((*env)->ExceptionOccurred(env)) {
+			if ((*env)->ExceptionCheck(env)) {
 				rc = JVMTI_ERROR_INTERNAL;
 			}
 		}
@@ -399,7 +399,7 @@ jvmtiAddModuleReads(jvmtiEnv* jvmtiEnv, jobject fromModule, jobject toModule)
 				vm->addReads = addReads;
 			}
 			(*env)->CallObjectMethod(env, fromModule, vm->addReads, toModule, JNI_TRUE);
-			if ((*env)->ExceptionOccurred(env)) {
+			if ((*env)->ExceptionCheck(env)) {
 				rc = JVMTI_ERROR_INTERNAL;
 			}
 		}
@@ -509,7 +509,7 @@ jvmtiAddModuleUses(jvmtiEnv* jvmtiEnv, jobject module, jclass service)
 				vm->addUses = addUses;
 			}
 			(*env)->CallObjectMethod(env, module, vm->addUses, service);
-			if ((*env)->ExceptionOccurred(env)) {
+			if ((*env)->ExceptionCheck(env)) {
 				rc = JVMTI_ERROR_INTERNAL;
 			}
 		}

--- a/runtime/jvmti/jvmtiThread.cpp
+++ b/runtime/jvmti/jvmtiThread.cpp
@@ -510,7 +510,7 @@ done:
 
 			jniEnv->CallObjectMethod(thread, vm->vThreadInterrupt);
 
-			if (jniEnv->ExceptionOccurred()) {
+			if (jniEnv->ExceptionCheck()) {
 				rc = JVMTI_ERROR_INTERNAL;
 			}
 		}

--- a/runtime/vm/classloadersearch.c
+++ b/runtime/vm/classloadersearch.c
@@ -254,7 +254,7 @@ addZipToLoader(J9JavaVM * vm, const char * filename, J9ClassLoader * classLoader
 				vmModule = (*env)->CallStaticObjectMethod(env, jimModules, loadModule, moduleNameString);
 				(*env)->DeleteLocalRef(env, vmModule);
 				(*env)->DeleteLocalRef(env, moduleNameString);
-				if ((*env)->ExceptionOccurred(env)) {
+				if ((*env)->ExceptionCheck(env)) {
 					rc = CLS_ERROR_INTERNAL;
 					goto cleanup;
 				}


### PR DESCRIPTION
Avoid the expense of creating a JNI reference when it's not needed.