### PR TITLE
Update j9vmtest for off-heap feature

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/unsafe/UnsafeCopyMemoryTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/unsafe/UnsafeCopyMemoryTest.java
@@ -390,7 +390,12 @@ public class UnsafeCopyMemoryTest {
 			Array.setByte(array, i, (byte)(i % Byte.SIZE));	
 		}
 
-		for (long arrayOffset = baseOffset ; arrayOffset < (baseOffset + maxNumBytes) ; arrayOffset = arrayOffset * 11 - 1 ) {
+		/*
+			For off-heap eanbled case initial arrayOffset would be 0 (baseOffset=0),
+			cause the next arrayOffset in loop become to negative (arrayOffset*11-1),
+			update logic for the next arrayOffset to avoid negative offset test case.
+		*/
+		for (long arrayOffset = baseOffset; arrayOffset < (baseOffset + maxNumBytes); arrayOffset = ((arrayOffset==0) ? 16 : arrayOffset) * 11 - 1 ) {
 			long maxNumBytesLeft = ((baseOffset + maxNumBytes) - arrayOffset) ;
 			for (long numBytesToCopy = 1 ; numBytesToCopy < maxNumBytesLeft ; numBytesToCopy = (numBytesToCopy + 1) * numBytesToCopy) {
 				long memoryPointer = myUnsafe.allocateMemory(maxNumBytes);


### PR DESCRIPTION
In TestUnsafeCopyMemory.testCopyLargeArrayIntoRawMemory(), arrayBaseOffset has been used to generate the arbitrary arrayOffsets for copy, the original test assume that arrayBaseOffset is positive number( array header size), but for off-heap enabled case arrayBaseOffset =0, which could cause negative offset for testing copy(trigger exceptions), update the test code to avoid negative offset for copying.