### PR TITLE
Always profile switches in interpreter profiler

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -4377,7 +4377,8 @@ UDATA TR_IProfiler::parseBuffer(J9VMThread * vmThread, const U_8* dataStart, UDA
             cursor += sizeof(switchOperand);
 
             data = switchOperand;
-            addSample = (profileFlag && !isClassLoadPhase) || TR::Options::_profileAllTheTime;
+            // switches are rare compared to branches, so we can afford to profile them all
+            addSample = true;
 
 
             //bytecodeType = SWITCH_BYTECODE;


### PR DESCRIPTION
Before this commit, the interpreter profiler was not collecting data on switches during 'classLoadPhase'. This was done to reduce the overhead of interpreter profiler. However, we have seen cases where, for some methods compiled during 'classLoadPhase' there is no profiling data for some hot switches, making the compiler to infer the wrong block frequencies.
This commit always collects information for switches. We can afford to do so because:
1. Typically switches are not that frequently executed compared to branches
2. When using the shared class cache (SCC), IProfiler is turned off during start-up, relying on profiling info stored in SCC in the cold run.