### PR TITLE
Fix retrieval of switch IProfiler info from SCC

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -781,7 +781,7 @@ bool isSpecialOrStatic(U_8 byteCode)
 static void
 getSwitchSegmentDataAndCount(uint64_t segment, uint32_t *segmentData, uint32_t *segmentCount)
    {
-   // each segment is 2 bytes long and contains
+   // each segment is 8 bytes long and contains
    // switch data   count
    // | 0000000 | 00000000 |
    *segmentData = (uint32_t)((segment >> 32) & 0xFFFFFFFF);
@@ -1527,7 +1527,7 @@ TR_IProfiler::profilingSample (TR_OpaqueMethodBlock *method, uint32_t byteCodeIn
 #ifdef PERSISTENCE_VERBOSE
                fprintf(stderr, "Entry from SCC\n");
 #endif
-               if (!entry->getData())
+               if (!entry->hasData())
                   {
                   _STATS_persistedIPReadHadBadData++;
                   }
@@ -1580,9 +1580,9 @@ TR_IProfiler::profilingSample (TR_OpaqueMethodBlock *method, uint32_t byteCodeIn
       if (!preferHashtableData)
          {
          // If I don't have data in IProfiler HT, choose the persistent source
-         if(!currentEntry || (currentEntry->getData() == (uintptr_t)NULL))
+         if(!currentEntry || !currentEntry->hasData())
             {
-            if (persistentEntry && (persistentEntry->getData()))
+            if (persistentEntry && persistentEntry->hasData())
                {
                _STATS_IPEntryChoosePersistent++;
                currentEntry = findOrCreateEntry(bcHash(pc), pc, true);
@@ -1593,7 +1593,7 @@ TR_IProfiler::profilingSample (TR_OpaqueMethodBlock *method, uint32_t byteCodeIn
                }
             }
          // If I don't have relevant data in the SCC, choose the data from IProfiler HT
-         else if(!persistentEntry || (persistentEntry->getData() == (uintptr_t)NULL))
+         else if(!persistentEntry || !persistentEntry->hasData())
             {
             // Remember that we already looked into the SCC for this PC
             currentEntry->setPersistentEntryRead();


### PR DESCRIPTION
The code that retrieves IProfiler info from the shared class cache (SCC) first does a check to see whether the data stored is valid. This check is done against `entry->getData()`, but for switches this always returns 0. As a consequence the JVM is never able to retrieve switch IProfiler data from SCC.

This commit adds a new virtual call, `hasData()`, which will be tested instead of `getData()`.
The reason we cannot use `getData()` directly, is that the switch data uses 32 bytes, exceeding the size returned by `getData()` which is only 8 bytes (for 64-bit architectures).