### PR TITLE
Updates to IProfiler branch data collection

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -969,29 +969,27 @@ TR_IProfiler::addSampleData(TR_IPBytecodeHashTableEntry *entry, uintptr_t data, 
 
          if (data)
             {
-            if (((entry->getData()) & 0xFFFF0000)==0xFFFF0000)
+            uintptr_t existingData = entry->getData();
+            if ((existingData & 0xFFFF0000) == 0xFFFF0000)
                {
-               size_t data = entry->getData();
-               data >>= 1;
-               data &= 0x7FFF7FFF;
-
-               entry->setData(data);
+               // Overflow detected; divide both counters by 2
+               existingData >>= 1;
+               existingData &= 0x7FFF7FFF;
                }
 
-            entry->setData(entry->getData() + (1<<16));
+            entry->setData(existingData + (1<<16));
             }
          else
             {
-            if (((entry->getData()) & 0x0000FFFF)==0x0000FFFF)
+            uintptr_t existingData = entry->getData();
+            if ((existingData & 0x0000FFFF) == 0x0000FFFF)
                {
-               size_t data = entry->getData();
-               data >>= 1;
-               data &= 0x7FFF7FFF;
-
-               entry->setData(data);
+               // Overflow detected; divide both counters by 2
+               existingData >>= 1;
+               existingData &= 0x7FFF7FFF;
                }
 
-            entry->setData(entry->getData()+1);
+            entry->setData(existingData + 1);
             }
          return true;
       case JBinvokestatic:


### PR DESCRIPTION
Collection of IProfiler data is done without any form of synchornization due to the high overhead of IProfiler. Thus, we should try to minimize all windows of opportunities for races to appear.
The profiling data for a branch is just a 32-bit entity which encodes two 16-bit counters (taken and not-taken). If incrementing one of these counters would cause an overflow, we will divide both counters by 2 and only then increment the desired counter. This operation is complex and cannot be done atomically without a lock.
In order to minimize the race conditions, this commit reads the value of the 32-bit word containing the 2 counters and performs all the desired operations on this copy of the data before writing it back. Since reading and writing a 32-bit aligned word is atomic on most modern architectures, the possibility of storing inconsistent data is decreased.