### PR TITLE
(0.48) Fix overflow issues

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -789,8 +789,12 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 			j9array_t array = (j9array_t)J9_JNI_UNWRAP_REFERENCE(packageArray);
 			j9object_t stringObject = J9JAVAARRAYOFOBJECT_LOAD(currentThread, array, pkgIndex);
 			if (NULL != stringObject) {
-				UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject) + 1;
-				char *packageName = (char*)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+				UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject);
+				char *packageName = NULL;
+				if (utfLength < UDATA_MAX) {
+					utfLength += 1;
+					packageName = (char *)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+				}
 				if (NULL == packageName) {
 					oom = TRUE;
 					break;
@@ -992,8 +996,12 @@ JVM_AddModuleExports(JNIEnv * env, jobject fromModule, const char *package, jobj
 #if JAVA_SPEC_VERSION >= 15
 	if (NULL != packageObj) {
 		j9object_t stringObject = J9_JNI_UNWRAP_REFERENCE(packageObj);
-		UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject) + 1;
-		char* packageName = (char *)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+		UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject);
+		char *packageName = NULL;
+		if (utfLength < UDATA_MAX) {
+			utfLength += 1;
+			packageName = (char *)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+		}
 		if (NULL == packageName) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
@@ -1066,8 +1074,12 @@ JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, const char *package)
 #if JAVA_SPEC_VERSION >= 15
 	if (NULL != packageObj) {
 		j9object_t stringObject = J9_JNI_UNWRAP_REFERENCE(packageObj);
-		UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject) + 1;
-		char* packageName = (char *)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+		UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject);
+		char *packageName = NULL;
+		if (utfLength < UDATA_MAX) {
+			utfLength += 1;
+			packageName = (char *)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+		}
 		if (NULL == packageName) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;
@@ -1306,8 +1318,12 @@ JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, const char *p
 #if JAVA_SPEC_VERSION >= 15
 	if (NULL != packageObj) {
 		j9object_t stringObject = J9_JNI_UNWRAP_REFERENCE(packageObj);
-		UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject) + 1;
-		char* packageName = (char *)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+		UDATA utfLength = vmFuncs->getStringUTF8Length(currentThread, stringObject);
+		char *packageName = NULL;
+		if (utfLength < UDATA_MAX) {
+			utfLength += 1;
+			packageName = (char *)j9mem_allocate_memory(utfLength, OMRMEM_CATEGORY_VM);
+		}
 		if (NULL == packageName) {
 			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 			goto done;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3587,6 +3587,8 @@ typedef struct J9UTF8 {
 #pragma warning(pop)
 #endif /* defined(_MSC_VER) */
 
+#define J9UTF8_MAX_LENGTH U_16_MAX
+
 typedef struct J9ROMClass {
 	U_32 romSize;
 	U_32 singleScalarStaticCount;
@@ -4803,7 +4805,8 @@ typedef struct J9InternalVMFunctions {
 	struct J9Class*  ( *internalFindKnownClass)(struct J9VMThread *currentThread, UDATA index, UDATA flags) ;
 	struct J9Class*  ( *resolveKnownClass)(struct J9JavaVM * vm, UDATA index) ;
 	UDATA  ( *computeHashForUTF8)(const U_8 * string, UDATA size) ;
-	IDATA  ( *getStringUTF8Length)(struct J9VMThread *vmThread, j9object_t string) ;
+	UDATA  ( *getStringUTF8Length)(struct J9VMThread *vmThread, j9object_t string) ;
+	U_64  ( *getStringUTF8LengthTruncated)(struct J9VMThread *vmThread, j9object_t string, U_64 maxLength) ;
 	void  ( *acquireExclusiveVMAccess)(struct J9VMThread * vmThread) ;
 	void  ( *releaseExclusiveVMAccess)(struct J9VMThread * vmThread) ;
 	void  ( *internalReleaseVMAccess)(struct J9VMThread * currentThread) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3580,13 +3580,30 @@ copyStringToUTF8Helper(J9VMThread *vmThread, j9object_t string, UDATA stringFlag
 
 
 /**
-* @brief
-* @param *vm
-* @param *string
-* @return IDATA
-*/
-IDATA
-getStringUTF8Length(J9VMThread *vmThread,j9object_t string);
+ * @brief Find the length of the string object when it is converted to UTF-8.
+ *
+ * Note: On 32-bit platforms, the length may be truncated.
+ *
+ * @param vm a pointer to J9JavaVM
+ * @param string a string object
+ *
+ * @return the length of the string in UTF-8
+ */
+UDATA
+getStringUTF8Length(J9VMThread *vmThread, j9object_t string);
+
+/**
+ * @brief Find the length of the string object when it is converted to UTF-8, but truncate it
+ * using maxLength as the upper bound.
+ *
+ * @param vm a pointer to J9JavaVM
+ * @param string a string object
+ * @param maxLength the upper bound of the length used for truncation
+ *
+ * @return the length of the string in UTF-8
+ */
+U_64
+getStringUTF8LengthTruncated(J9VMThread *vmThread, j9object_t string, U_64 maxLength);
 
 
 /**

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -75,6 +75,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	resolveKnownClass,
 	computeHashForUTF8,
 	getStringUTF8Length,
+	getStringUTF8LengthTruncated,
 	acquireExclusiveVMAccess,
 	releaseExclusiveVMAccess,
 	internalReleaseVMAccess,

--- a/runtime/vm/jnimisc.cpp
+++ b/runtime/vm/jnimisc.cpp
@@ -827,7 +827,7 @@ getStringUTFLength(JNIEnv *env, jstring string)
 	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
 	j9object_t stringObject = J9_JNI_UNWRAP_REFERENCE(string);
 
-	UDATA utfLength = getStringUTF8Length(currentThread, stringObject);
+	U_64 utfLength = getStringUTF8LengthTruncated(currentThread, stringObject, INT32_MAX);
 	VM_VMAccess::inlineExitVMToJNI(currentThread);
 	return (jsize)utfLength;
 }
@@ -838,14 +838,17 @@ getStringUTFCharsImpl(JNIEnv *env, jstring string, jboolean *isCopy, jboolean en
 	J9VMThread *currentThread = (J9VMThread*)env;
 	VM_VMAccess::inlineEnterVMFromJNI(currentThread);
 	j9object_t stringObject = J9_JNI_UNWRAP_REFERENCE(string);
-	/* Add 1 for null terminator */
-	UDATA utfLength = getStringUTF8Length(currentThread, stringObject) + 1;
 
+	UDATA utfLength = getStringUTF8Length(currentThread, stringObject);
 	U_8 *utfChars = NULL;
-	if (ensureMem32) {
-		utfChars = (U_8*)jniArrayAllocateMemory32FromThread(currentThread, utfLength);
-	} else {
-		utfChars = (U_8*)jniArrayAllocateMemoryFromThread(currentThread, utfLength);
+	if (utfLength < UDATA_MAX) {
+		/* Add 1 for a null terminator. */
+		utfLength += 1;
+		if (ensureMem32) {
+			utfChars = (U_8 *)jniArrayAllocateMemory32FromThread(currentThread, utfLength);
+		} else {
+			utfChars = (U_8 *)jniArrayAllocateMemoryFromThread(currentThread, utfLength);
+		}
 	}
 
 	if (NULL == utfChars) {


### PR DESCRIPTION
Backport of https://github.com/eclipse-openj9/openj9/pull/20362

### Background

See https://bugs.openjdk.org/browse/JDK-8338709 and https://bugs.openjdk.org/browse/JDK-8328877.

### Implementation

Truncate length while evaluating length of a `UTF-8` string

   - On 32-bit systems, the length is truncated to `UDATA_MAX`.
   - For JNI `getStringUTFLength`, the length is truncated to `INT32_MAX`.

Add restrictions while copying a string to `UTF-8` to avoid overflow

- The length is restricted to `UDATA_MAX` to accommodate memory allocation
functions, which take a `UDATA` as the input parameter for length.
- The data is stopped from being written to the `UTF-8` buffer if its
length will be exceeded.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>