### PR TITLE
Add support for VirtualThreadSchedulerMXBean

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -40,6 +40,11 @@ import com.sun.management.internal.ExtendedHotSpotDiagnostic;
 import com.sun.management.HotSpotDiagnosticMXBean;
 /*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+import com.sun.management.internal.VirtualThreadSchedulerImpls;
+import jdk.management.VirtualThreadSchedulerMXBean;
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+
 /**
  * This class implements the service-provider interface to make OpenJ9-specific
  * MXBeans available. These beans are either in addition to the basic set or
@@ -117,6 +122,12 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.addInterface(HotSpotDiagnosticMXBean.class)
 			.register(allComponents);
 		/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
+
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		ComponentBuilder.create("jdk.management:type=VirtualThreadScheduler", VirtualThreadSchedulerImpls.create()) //$NON-NLS-1$
+			.addInterface(VirtualThreadSchedulerMXBean.class)
+			.register(allComponents);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 		// register beans with zero or more instances
 


### PR DESCRIPTION
New MXBean added upstream in:
* [8338890: Add monitoring/management interface for the virtual thread scheduler](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/7abcfe079c167845df4ee854b451a6319470aee1)

Fixes: https://github.com/eclipse-openj9/openj9/issues/20352