### PR TITLE
Limit the number of startup hints in SCC

### DIFF
--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -6957,3 +6957,36 @@ J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMMUTEX.explanation=The system is unable
 J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMMUTEX.system_action=The JVM terminates, unless you have specified the nonfatal option with "-Xshareclasses:nonfatal", in which case the JVM attempts to start up without using Shared Classes.
 J9NLS_SHRC_SHRINIT_FAILURE_CREATE_ROMTORAMMUTEX.user_response=System is running low on memory resource for the JVM to start up properly. Check system memory configuration. If the situation persists, contact your service representative.
 # END NON-TRANSLATABLE
+
+J9NLS_SHRC_SHRINIT_HELPTEXT_EXTRA_STARTUPHINTS_EQUALS=Adjust the number of additional startup hints allowed to be stored into the shared classes cache to <number>.
+# START NON-TRANSLATABLE
+J9NLS_SHRC_SHRINIT_HELPTEXT_EXTRA_STARTUPHINTS_EQUALS.explanation=NOTAG
+J9NLS_SHRC_SHRINIT_HELPTEXT_EXTRA_STARTUPHINTS_EQUALS.system_action=
+J9NLS_SHRC_SHRINIT_HELPTEXT_EXTRA_STARTUPHINTS_EQUALS.user_response=
+# END NON-TRANSLATABLE
+
+J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM=Invalid parameter passed to option \"%s\". 
+# START NON-TRANSLATABLE
+J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM.sample_input_1=extraStartupHints=
+J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM.explanation=An incorrect parameter has been used in the command-line option
+J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM.system_action=The JVM terminates.
+J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM.user_response=Correct or remove the invalid command-line option and rerun.
+# END NON-TRANSLATABLE
+
+J9NLS_SHRC_CC_EXTRA_STARTUPHINTS_SET=The number of additional startup hints that can be stored into the shared cache is set to %u.
+# START NON-TRANSLATABLE
+J9NLS_SHRC_CC_EXTRA_STARTUPHINTS_SET.sample_input_1=64
+J9NLS_SHRC_CC_EXTRA_STARTUPHINTS_SET.explanation=The number of additional startup hints allowed to be stored to the shared classes cache has been adjusted.
+J9NLS_SHRC_CC_EXTRA_STARTUPHINTS_SET.system_action=The JVM continues.
+J9NLS_SHRC_CC_EXTRA_STARTUPHINTS_SET.user_response=No action required. This message is for information only.
+# END NON-TRANSLATABLE
+
+J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS=additional startup hints allowed    %*.c= %u
+# START NON-TRANSLATABLE
+J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS.sample_input_1=0
+J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS.sample_input_2=
+J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS.sample_input_3=8
+J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS.explanation=NOTAG
+J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS.system_action=
+J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS.user_response=
+# END NON-TRANSLATABLE

--- a/runtime/nls/shrc/j9shr.nls
+++ b/runtime/nls/shrc/j9shr.nls
@@ -6965,7 +6965,7 @@ J9NLS_SHRC_SHRINIT_HELPTEXT_EXTRA_STARTUPHINTS_EQUALS.system_action=
 J9NLS_SHRC_SHRINIT_HELPTEXT_EXTRA_STARTUPHINTS_EQUALS.user_response=
 # END NON-TRANSLATABLE
 
-J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM=Invalid parameter passed to option \"%s\". 
+J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM=Invalid parameter passed to option \"%s\".
 # START NON-TRANSLATABLE
 J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM.sample_input_1=extraStartupHints=
 J9NLS_SHRC_SHRINIT_OPTION_INVALID_PARAM.explanation=An incorrect parameter has been used in the command-line option

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1221,6 +1221,7 @@ typedef struct J9SharedClassJavacoreDataDescriptor {
 	UDATA startupHintBytes;
 	UDATA nattach;
 	UDATA currentOSPageSize; /* memory page size of the current running OS */
+	U_32 extraStartupHints;
 } J9SharedClassJavacoreDataDescriptor;
 
 typedef struct J9SharedStringFarm {
@@ -1354,6 +1355,7 @@ typedef struct J9SharedCacheAPI {
 #if defined(J9VM_OPT_JITSERVER)
 	U_8 usingJITServerAOTCacheLayer;
 #endif /* defined(J9VM_OPT_JITSERVER) */
+	I_32 newStartupHints;
 } J9SharedCacheAPI;
 
 typedef struct J9SharedClassConfig {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1271,7 +1271,7 @@ typedef struct J9SharedCacheHeader {
 	J9WSRP corruptFlagPtr;
 	J9SRP sharedStringHead;
 	J9SRP sharedStringTail;
-	J9SRP unused1;
+	U_32 extraStartupHints; /* Number of addtional startup hints allowed to be stored into the shared cache */
 	U_32 totalSharedStringNodes;
 	U_32 totalSharedStringWeight;
 	U_32 readWriteFlags;

--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -184,6 +184,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 		vm->sharedCacheAPI->minJIT = -1;
 		vm->sharedCacheAPI->maxJIT = -1;
 		vm->sharedCacheAPI->layer = -1;
+		vm->sharedCacheAPI->newStartupHints = -1;
 		if (index >= 0) {
 			/* -Xshareclasses is specified */
 			char optionsBuffer[SHR_SUBOPT_BUFLEN];

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -7122,4 +7122,3 @@ SH_CacheMap::setExtraStartupHints(J9VMThread* currentThread)
 	CACHEMAP_TRACE1(J9SHR_VERBOSEFLAG_ENABLE_VERBOSE_DEFAULT, J9NLS_INFO, J9NLS_SHRC_CC_EXTRA_STARTUPHINTS_SET, val);
 	_ccHead->exitWriteMutex(currentThread, fnName);
 }
-

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -5058,7 +5058,11 @@ SH_CacheMap::printCacheStatsTopLayerStatsHelper(J9VMThread* currentThread, UDATA
 	if (J9_ARE_ALL_BITS_SET(runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_DETAILED_STATS)) {
 		CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_SUMMARY_METADATA_STARTADDRESS, javacoreData->metadataStart);
 		CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_RUNTIME_FLAGS, javacoreData->runtimeFlags);
+		CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS, javacoreData->extraStartupHints);
 		CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_CACHE_GEN, javacoreData->cacheGen);
+	} else if (J9_ARE_ALL_BITS_SET(showFlags, PRINTSTATS_SHOW_STARTUPHINT)) {
+		CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_STARTUP_HINTS, javacoreData->extraStartupHints);
+		j9tty_printf(_portlib, "\n");
 	}
 
 	CACHEMAP_FMTPRINT1(J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_SHRC_CM_PRINTSTATS_CACHE_LAYER, javacoreData->topLayer);
@@ -7103,3 +7107,19 @@ SH_CacheMap::getDataFromByteDataWrapper(const ByteDataWrapper* bdw)
 	}
 	return ret;
 }
+
+void
+SH_CacheMap::setExtraStartupHints(J9VMThread* currentThread)
+{
+	PORT_ACCESS_FROM_PORT(_portlib);
+	const char* fnName = "setExtraStartupHints";
+	U_32 val = (U_32)currentThread->javaVM->sharedCacheAPI->newStartupHints;
+	if (_ccHead->enterWriteMutex(currentThread, false, fnName) != 0) {
+		CACHEMAP_TRACE(J9SHR_VERBOSEFLAG_ENABLE_VERBOSE_DEFAULT, J9NLS_ERROR, J9NLS_SHRC_CM_FAILED_ENTER_WRITE_MUTEX);
+		return;
+	}
+	_ccHead->setExtraStartupHints(currentThread, val);
+	CACHEMAP_TRACE1(J9SHR_VERBOSEFLAG_ENABLE_VERBOSE_DEFAULT, J9NLS_INFO, J9NLS_SHRC_CC_EXTRA_STARTUPHINTS_SET, val);
+	_ccHead->exitWriteMutex(currentThread, fnName);
+}
+

--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -281,6 +281,8 @@ public:
 	
 	bool isAddressInCache(const void *address, UDATA length, bool includeHeaderReadWriteArea, bool useCcHeadOnly) const;
 
+	void setExtraStartupHints(J9VMThread* currentThread);
+
 private:
 	SH_CompositeCacheImpl* _cc;					/* current cache */
 

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -38,6 +38,7 @@
 #include "CompositeCacheImpl.hpp"
 
 #define SEMSUFFIX "SHSEM"
+#define DEFAULT_STARTUPHINTS 64
 
 /**
  * CACHE AREAS
@@ -157,6 +158,7 @@ SH_CompositeCacheImpl::SH_SharedCacheHeaderInit::init(BlockPtr data, U_32 len, I
 	ca->writerCount = 0;
 	ca->softMaxBytes = softMaxBytes;
 	ca->cacheFullFlags = 0;
+	ca->extraStartupHints = DEFAULT_STARTUPHINTS;
 	ca->unused8 = 0;
 	ca->unused9 = 0;
 	ca->unused10 = 0;
@@ -6784,3 +6786,31 @@ SH_CompositeCacheImpl::updateMsyncRuntimeFlags(void)
 	}
 }
 #endif /* defined(J9VM_OPT_SHR_MSYNC_SUPPORT) */
+
+U_32
+SH_CompositeCacheImpl::getExtraStartupHints(void) const
+{
+	if (!_started) {
+		Trc_SHR_Assert_ShouldNeverHappen();
+		return 0;
+	}
+	return _theca->extraStartupHints;
+}
+
+void
+SH_CompositeCacheImpl::setExtraStartupHints(J9VMThread* currentThread, U_32 val)
+{
+	if (!_started) {
+		Trc_SHR_Assert_ShouldNeverHappen();
+		return;
+	}
+	if (_readOnlyOSCache) {
+		Trc_SHR_Assert_ShouldNeverHappen();
+		return;
+	}
+	Trc_SHR_Assert_True(hasWriteMutex(currentThread));
+	_theca->extraStartupHints = val;
+	Trc_SHR_CC_setExtraStartupHints_Event(currentThread, val);
+}
+
+

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -6813,5 +6813,3 @@ SH_CompositeCacheImpl::setExtraStartupHints(J9VMThread* currentThread, U_32 val)
 	_theca->extraStartupHints = val;
 	Trc_SHR_CC_setExtraStartupHints_Event(currentThread, val);
 }
-
-

--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -4490,6 +4490,7 @@ SH_CompositeCacheImpl::getJavacoreData(J9JavaVM *vm, J9SharedClassJavacoreDataDe
 		descriptor->maxJIT = _theca->maxJIT;
 		descriptor->softMaxBytes = (UDATA)((U_32)-1 == _theca->softMaxBytes ? descriptor->cacheSize : _theca->softMaxBytes);
 		descriptor->currentOSPageSize = getOSPageSize();
+		descriptor->extraStartupHints = getExtraStartupHints();
 #if defined(J9VM_OPT_JITSERVER)
 		descriptor->usingJITServerAOTCacheLayer = vm->sharedCacheAPI->usingJITServerAOTCacheLayer;
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -397,6 +397,10 @@ public:
 	
 	bool hasReadMutex(J9VMThread* currentThread) const;
 
+	U_32 getExtraStartupHints(void) const;
+	
+	void setExtraStartupHints(J9VMThread* currentThread, U_32 val);
+
 private:
 	J9SharedClassConfig* _sharedClassConfig;
 	SH_OSCache* _oscache;

--- a/runtime/shared_common/CompositeCacheImpl.hpp
+++ b/runtime/shared_common/CompositeCacheImpl.hpp
@@ -398,7 +398,7 @@ public:
 	bool hasReadMutex(J9VMThread* currentThread) const;
 
 	U_32 getExtraStartupHints(void) const;
-	
+
 	void setExtraStartupHints(J9VMThread* currentThread, U_32 val);
 
 private:
@@ -585,4 +585,3 @@ private:
 };
 
 #endif /* !defined(COMPOSITECACHEIMPL_H_INCLUDED) */
-

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -3006,3 +3006,5 @@ TraceEvent=Trc_SHR_OSC_Mmap_startup_jitserverlayergooddelete NoEnv Overhead=1 Le
 TraceException=Trc_SHR_OSC_Mmap_startup_jitserverlayerbaddelete NoEnv Overhead=1 Level=1 Template="SH_OSCachemmap::startup: deleteCacheFile failed for cache path name = %s, file handle %zd"
 
 TraceEvent=Trc_SHR_CC_OSPAGE_SIZE_MISMATCH_V1 Overhead=1 Level=1 Template="Mismatch in layer %d composite cache osPageSize value. CompositeCache = %p, _theca->osPageSize = %zu, _osPageSize = %zu, _theca->roundedPagesFlag is %u, _readOnlyOSCache is %d"
+TraceEvent=Trc_SHR_CC_setExtraStartupHints_Event Overhead=1 Level=6 Template="CC setExtraStartupHints: set extraStartupHints in the header to %u"
+TraceEvent=Trc_SHR_CM_storeSharedData_NoMoreStartupHintsAllowed Overhead=1 Level=1 Template="CM storeSharedData: No more startup hints are allowed to be stored"

--- a/runtime/shared_common/shrinit.h
+++ b/runtime/shared_common/shrinit.h
@@ -198,6 +198,7 @@ typedef struct J9SharedClassesOptions {
 #define OPTION_MAP31 "map31"
 #define OPTION_TEST_DOUBLE_PAGESIZE "testDoublePageSize"
 #define OPTION_TEST_HALF_PAGESIZE "testHalfPageSize"
+#define OPTION_EXTRA_STARTUPHINTS_EQUALS "extraStartupHints="
 
 /* public options for printallstats= and printstats=  */
 #define SUB_OPTION_PRINTSTATS_ALL "all"
@@ -279,6 +280,7 @@ typedef struct J9SharedClassesOptions {
 #define RESULT_DO_PRINT_TOP_LAYER_STATS 53
 #define RESULT_DO_PRINT_TOP_LAYER_STATS_EQUALS 54
 #define RESULT_DO_ADD_RUNTIMEFLAG2 55
+#define RESULT_DO_SET_EXTRA_STARTUPHINTS 56
 
 #define PARSE_TYPE_EXACT 1
 #define PARSE_TYPE_STARTSWITH 2
@@ -311,6 +313,7 @@ typedef struct J9SharedClassesOptions {
 #define HELPTEXT_ADJUST_MINJITDATA_EQUALS OPTION_ADJUST_MINJITDATA_EQUALS"<size>"
 #define HELPTEXT_ADJUST_MAXJITDATA_EQUALS OPTION_ADJUST_MAXJITDATA_EQUALS"<size>"
 #define HELPTEXT_LAYER_EQUALS OPTION_LAYER_EQUALS "<number>"
+#define HELPTEXT_OPTION_EXTRA_STARTUPHINTS_EQUALS OPTION_EXTRA_STARTUPHINTS_EQUALS"<number>"
 
 #define HELPTEXT_NEWLINE {"", 0, 0, 0, 0}
 

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -976,7 +976,7 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-	
+
 	<test id="Test 208-c: use option extraStartupHints=0 to prevent more startup hints to be stored" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,extraStartupHints=0</command>
 		<output type="success" caseSensitive="yes" regex="no">JVMSHRC864I The number of additional startup hints that can be stored into the shared cache is set to 0</output>
@@ -995,7 +995,7 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-	
+
 	<test id="Test 208-e: Check no more new startup hints are stored" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,printStats=startuphint</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">STARTUP HINTS KEY:</output>
@@ -1009,7 +1009,7 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-	
+
 	<test id="Test 208-f: use option extraStartupHints=32 to allow more startup hints to be stored" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,extraStartupHints=32</command>
 		<output type="success" caseSensitive="yes" regex="no">JVMSHRC864I The number of additional startup hints that can be stored into the shared cache is set to 32</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -967,6 +967,8 @@
 		<command>$JAVA_EXE$ $currentMode$,printStats=startuphint</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">STARTUP HINTS KEY:</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 1</output>
+		<!--  DEFAULT_STARTUPHINTS is 64, so there are 63 more startup hints that can be stored into this cache -->
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">additional startup hints allowed[\s]*= 63</output>
 
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Startup hint bytes[\s]*= 0</output>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 0</output>
@@ -974,9 +976,51 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
+	
+	<test id="Test 208-c: use option extraStartupHints=0 to prevent more startup hints to be stored" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,extraStartupHints=0</command>
+		<output type="success" caseSensitive="yes" regex="no">JVMSHRC864I The number of additional startup hints that can be stored into the shared cache is set to 0</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
 
 	<!-- Since running Hanoi with -Xjit option does not store the startup hint to the shared chache, we use -Xint here -->
-	<test id="Test 208-c: Run the test again with a different argument" timeout="600" runPath=".">
+	<test id="Test 208-d: Run the test again with a different argument" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$ -Xint $CP_HANOI$ $PROGRAM_HANOI_2$</command>
+		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 208-e: Check no more new startup hints are stored" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,printStats=startuphint</command>
+		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">STARTUP HINTS KEY:</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 1</output>
+		<!--  DEFAULT_STARTUPHINTS is 64, so there are 63 more startup hints that can be stored into this cache -->
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">additional startup hints allowed[\s]*= 0</output>
+
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Startup hint bytes[\s]*= 0</output>
+		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 0</output>
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+	
+	<test id="Test 208-f: use option extraStartupHints=32 to allow more startup hints to be stored" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,extraStartupHints=32</command>
+		<output type="success" caseSensitive="yes" regex="no">JVMSHRC864I The number of additional startup hints that can be stored into the shared cache is set to 32</output>
+
+		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
+		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
+		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
+	</test>
+
+	<!-- Since running Hanoi with -Xjit option does not store the startup hint to the shared chache, we use -Xint here -->
+	<test id="Test 208-g: Run the test again with a different argument" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$ -Xint $CP_HANOI$ $PROGRAM_HANOI_2$</command>
 		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
 
@@ -985,10 +1029,11 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 
-	<test id="Test 208-d: Make sure -Xshareclasses:printStats=startuphint still works properly for another test" timeout="600" runPath=".">
+	<test id="Test 208-h: Make sure new startup hints are stored into the cache" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,printStats=startuphint</command>
 		<output type="success" caseSensitive="yes" regex="yes" javaUtilPattern="yes">STARTUP HINTS KEY:</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 2</output>
+		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">additional startup hints allowed[\s]*= 31</output>
 
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Startup hint bytes[\s]*= 0</output>
 		<output type="failure" caseSensitive="yes" regex="yes" javaUtilPattern="yes"># Startup hints[\s]*= 0</output>


### PR DESCRIPTION
1. Add a new field in the cache header which is the number of additional
startup hints that are allowed to be stored to the SCC.
2. Add a CML option to adjust this number.
3. Add test cases.

Fixes: https://github.com/eclipse-openj9/openj9/issues/19308