### PR TITLE
Set log file in TR_Debug at client

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3757,6 +3757,10 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
          if (compiler->getOption(TR_JITServerFollowRemoteCompileWithLocalCompile) && compilationSequenceNumber)
             {
             compiler->getOptions()->setLogFileForClientOptions(compilationSequenceNumber);
+            auto logFile = compiler->getOptions()->getLogFile();
+            auto debug = compiler->getDebug();
+            if (logFile && debug)
+               debug->setFile(logFile);
             bool compileWithoutVMAccess = !compiler->getOption(TR_DisableNoVMAccess);
             if (compileWithoutVMAccess)
                {


### PR DESCRIPTION
When a client recompiles a method locally following a remote compilation (enabled with the
enableJITServerFollowRemoteCompileWithLocalCompile option) it must set up a local log file for compilation traces if necessary. Previously, it would only set this log file explicitly in the TR::Compilation object itself; the _file in the TR_Debug object for the compilation would not be set. Since the TR_Debug would have been created already during the prior remote compilation with a NULL _file, this had the effect of suppressing the compilation traces coming from systems that used that _file for output and not the _logFile in the TR::Compilation itself.

The file in the TR_Debug object for the compilation is now set explicitly.