### PR TITLE
Adjust IProfiler locked entry assert

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4160,8 +4160,9 @@ void JitShutdown(J9JITConfig * jitConfig)
       if (!options->getOption(TR_DisableIProfilerThread))
          iProfiler->stopIProfilerThread();
 #ifdef DEBUG
-      uint32_t lockedEntries = iProfiler->releaseAllEntries();
-      TR_ASSERT(lockedEntries == 0, "some entries were still locked on shutdown");
+      uint32_t unexpectedLockedEntries = 0;
+      iProfiler->releaseAllEntries(unexpectedLockedEntries);
+      TR_ASSERT(unexpectedLockedEntries == 0, "some entries were still locked on shutdown");
 #endif
       // Dump all IProfiler related to virtual/interface invokes and instanceof/checkcasts
       // to track possible performance issues

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -565,7 +565,9 @@ public:
    void setupEntriesInHashTable(TR_IProfiler *ip);
 
    TR_IPMethodHashTableEntry *findOrCreateMethodEntry(J9Method *, J9Method *, bool addIt, uint32_t pcIndex =  ~0);
-   uint32_t releaseAllEntries();
+   // Returns the number of entries released, and also stores the number of
+   // entries that were not expected to be locked in unexpectedLockedEntries
+   uint32_t releaseAllEntries(uint32_t &unexpectedLockedEntries);
    uint32_t countEntries();
    void advanceEpochForHistoryBuffer() { _readSampleRequestsHistory->advanceEpoch(); }
    uint32_t getReadSampleFailureRate() const { return _readSampleRequestsHistory->getReadSampleFailureRate(); }


### PR DESCRIPTION
The TR_IProfiler::releaseAllEntries() function is used with DEBUG to check that all entries in the IProfiler _bcHashTable are unlocked at JVM exit. This function now compensates for a known race condition in TR_IProfiler::findOrCreateEntry() by also reporting the number of locked entries it encounters that were likely not a result of that race condition, so it can be asserted instead that that total is zero.

Fixes: https://github.com/eclipse-openj9/openj9/issues/20344