### PR TITLE
Mark TR_J9VMServer virtual methods with override

### DIFF
--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -252,8 +252,8 @@ public:
    virtual bool inSnapshotMode() override;
    virtual bool isSnapshotModeEnabled() override;
    virtual bool isPortableRestoreModeEnabled() override;
-   virtual bool isIndexableDataAddrPresent();
-   virtual bool isOffHeapAllocationEnabled();
+   virtual bool isIndexableDataAddrPresent() override;
+   virtual bool isOffHeapAllocationEnabled() override;
 
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);


### PR DESCRIPTION
The isIndexableDataAdrPresent() and isOffHeapAlocationEnabled() methods override the TR_J9VMBase implementations. They are now marked with override; a compilation error results without it with clang in the default configuration (with -Werror).