### PR TITLE
Omit VirtualThreadSchedulerMXBean in builds for valuetypes

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -40,10 +40,10 @@ import com.sun.management.internal.ExtendedHotSpotDiagnostic;
 import com.sun.management.HotSpotDiagnosticMXBean;
 /*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
-/*[IF JAVA_SPEC_VERSION >= 24]*/
+/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
 import com.sun.management.internal.VirtualThreadSchedulerImpls;
 import jdk.management.VirtualThreadSchedulerMXBean;
-/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
 
 /**
  * This class implements the service-provider interface to make OpenJ9-specific
@@ -123,11 +123,11 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.register(allComponents);
 		/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
-		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
 		ComponentBuilder.create("jdk.management:type=VirtualThreadScheduler", VirtualThreadSchedulerImpls.create()) //$NON-NLS-1$
 			.addInterface(VirtualThreadSchedulerMXBean.class)
 			.register(allComponents);
-		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+		/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
 
 		// register beans with zero or more instances
 


### PR DESCRIPTION
Not all the required classes are available in https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes; see https://github.com/eclipse-openj9/openj9/pull/20325#issuecomment-2420102508.