### PR TITLE
Remove incorrect assertion

### DIFF
--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -6792,7 +6792,6 @@ U_32
 SH_CompositeCacheImpl::getExtraStartupHints(void) const
 {
 	if (!_started) {
-		Trc_SHR_Assert_ShouldNeverHappen();
 		return 0;
 	}
 	return _theca->extraStartupHints;


### PR DESCRIPTION
It is possible that we could call getExtraStartupHints() during startup.

Fixes #20370