### PR TITLE
(0.48) Update classloader when cached rom to ram entry is found

### DIFF
--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -258,6 +258,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 		omrthread_rwmutex_exit_read(config->romToRamHashTableMutex);
 		if (NULL != resultEntry) {
 			ret = resultEntry->ramClass;
+			*resultClassLoader = ret->classLoader;
 			goto done;
 		}
 


### PR DESCRIPTION
Port from https://github.com/eclipse-openj9/openj9/pull/20371
Fixes: https://github.com/eclipse-openj9/openj9/issues/20368