### PR TITLE
Mark receiver objects of an instance method

### DIFF
--- a/runtime/stackmap/localmap.c
+++ b/runtime/stackmap/localmap.c
@@ -478,8 +478,8 @@ j9localmap_LocalBitsForPC(J9PortLibrary * portLib, J9ROMClass * romClass, J9ROMM
 
 	mapAllLocals(portLib, romMethod, (PARALLEL_TYPE *) scratch, pc, resultArrayBase);
 
-	/* Ensure that the receiver is marked for all <init>()V methods */
-	if ((J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccStatic)) && ('<' == J9UTF8_DATA(J9ROMMETHOD_NAME(romMethod))[0])) {
+	/* Ensure that the receiver is marked for all instance methods. */
+	if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccStatic)) {
 		*resultArrayBase |= 1;
 	}
 


### PR DESCRIPTION
Marking the receiver object of an instance method ensures that it
is not collected by the garbage collector (GC) while the instance
method is executing.

If the receiver object is not marked, there is a risk that the GC
might collect it. In such cases, finalization mechanisms, such as
PhantomReferences and Cleaners, could indicate that the object has
been collected while it is still in use. This issue is resolved if
the receiver object is marked during the execution of its instance
method.

Fixes: https://github.com/ibmruntimes/Semeru-Runtimes/issues/93