### PR TITLE
Remove unused method layoutContiguousArraylet()

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.hpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.hpp
@@ -58,12 +58,6 @@ public:
 	 */
 private:
 	/**
-	 * For contiguous arraylet all data is subsumed into the spine.
-	 * @return initialized arraylet spine with its arraylet pointers initialized.
-	 */
-	MMINLINE J9IndexableObject *layoutContiguousArraylet(MM_EnvironmentBase *env, J9IndexableObject *spine);
-
-	/**
 	 * For non-contiguous arraylet (i.e. discontiguous and hybrid), perform separate allocations
 	 * for spine and leaf data. The spine and attached leaves may move as each leaf is allocated
 	 * is GC is allowed. The final location of the spine is returned.


### PR DESCRIPTION
Method MM_IndexableObjectAllocationModel::layoutContiguousArraylet() is not used and can be removed