### PR TITLE
Update OpenSSL 3.0.15 to include the fix for CVE-2024-9143

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -133,7 +133,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-branch=openssl-3.0.15'
+  extra_getsource_options: '-openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.0.15+CVEs1'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
https://openssl-library.org/news/secadv/20241016.txt

https://github.com/ibmruntimes/openssl/releases/tag/openssl-3.0.15%2BCVEs1