### PR TITLE
Remove method TR_J9VMBase::findOrCreateClassAndDepthFlagsSymbolRef

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1292,12 +1292,6 @@ J9::SymbolReferenceTable::findOrCreateClassFlagsSymbolRef()
 
 
 TR::SymbolReference *
-J9::SymbolReferenceTable::findOrCreateClassAndDepthFlagsSymbolRef()
-   {
-   return self()->findOrCreateClassDepthAndFlagsSymbolRef();
-   }
-
-TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateClassDepthAndFlagsSymbolRef()
    {
    if (!element(isClassDepthAndFlagsSymbol))

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -242,7 +242,6 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateInstanceDescriptionSymbolRef();
    TR::SymbolReference * findOrCreateDescriptionWordFromPtrSymbolRef();
    TR::SymbolReference * findOrCreateClassFlagsSymbolRef();
-   TR::SymbolReference * findOrCreateClassAndDepthFlagsSymbolRef();
    TR::SymbolReference * findOrCreateClassDepthAndFlagsSymbolRef();
    TR::SymbolReference * findOrCreateArrayComponentTypeAsPrimitiveSymbolRef();
    TR::SymbolReference * findOrCreateMethodTypeCheckSymbolRef(TR::ResolvedMethodSymbol * owningMethodSymbol);


### PR DESCRIPTION
A method named `findOrCreateClassDepthAndFlagsSymbolRef` was introduced to `TR_J9VMBase` by a previous commit to correct the typo in the name of the method, `findOrCreateClassAndDepthFlagsSymbolRef`.  That change kept the old method due to upstream uses in `J9_PROJECT_SPECIFIC` code in OMR.

This change replaces a call to `findOrCreateClassAndDepthFlagsSymbolRef` that was recently introduced with a call to
`TR_J9VMBase::testIsClassArrayType` instead, to hide the manipulation of the `classDepthAndFlags` field.

As that was the last remaining use of
`findOrCreateClassAndDepthFlagsSymbolRef`, this change also removes the now obsolete method from `TR_J9VMBase`.

This is follow on to pull request #19558 which first introduced `TR_J9VMBase::findOrCreateClassDepthAndFlagsSymbolRef` to replace `TR_J9VMBase::findOrCreateClassAndDepthFlagsSymbolRef`.