### PR TITLE
Unhide compressed refs logic from Unsafe CAS codegen

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -652,11 +652,12 @@ J9::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node *parent, TR::TreeTop *tre
       {
       // J9
       //
-      // Hiding compressedref logic from CodeGen doesn't seem a good practise, the evaluator always need the uncompressedref node for write barrier,
-      // therefore, this part is deprecated. It'll be removed once P and Z update their corresponding evaluators.
+      // Hiding compressedref logic from CodeGen isn't a good practice, and the evaluator still needs the uncompressedref node for write barriers.
+      // Therefore, this part is deprecated. It can only be activated on X, P or Z with the TR_UseOldCompareAndSwapObject envvar.
       static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
       static bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
-      if (self()->comp()->useCompressedPointers() && ((UseOldCompareAndSwapObject && (self()->comp()->target().cpu.isARM64() || !disableCASInlining)) || !(self()->comp()->target().cpu.isX86() || self()->comp()->target().cpu.isARM64())))
+      if (((self()->comp()->target().cpu.isX86() && !disableCASInlining) || self()->comp()->target().cpu.isPower() || self()->comp()->target().cpu.isZ()) &&
+          self()->comp()->useCompressedPointers() && UseOldCompareAndSwapObject)
          {
          TR::MethodSymbol *methodSymbol = parent->getSymbol()->castToMethodSymbol();
          static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -652,12 +652,22 @@ J9::CodeGenerator::lowerTreesPreChildrenVisit(TR::Node *parent, TR::TreeTop *tre
       {
       // J9
       //
-      // Hiding compressedref logic from CodeGen isn't a good practice, and the evaluator still needs the uncompressedref node for write barriers.
-      // Therefore, this part is deprecated. It can only be activated on X, P or Z with the TR_UseOldCompareAndSwapObject envvar.
-      static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
+      /* Hiding compressedref logic from CodeGen isn't a good practice, and the evaluator still needs the uncompressedref node for write barriers.
+       * Therefore, this part is deprecated. It can only be activated on X, P or Z with the TR_UseOldCompareAndSwapObject envvar.
+       *
+       * If TR_DisableCAEIntrinsic is set to disable inlining of compareAndExchange, compressedref logic will not be hidden for compareAndExchange
+       * calls even if TR_UseOldCompareAndSwapObject is set. The reason is that TR_DisableCAEIntrinsic takes priority over TR_UseOldCompareAndSwapObject
+       * so neither the old nor new version of the inlined compareAndExchange are used and the non-inlined version expects that the compressedrefs are
+       * not hidden.
+       *
+       * Similarly, TR_DisableCASInlining (which is only supported on X) can be used to disable inlining on both compareAndSwap and compareAndExchange.
+       * This also takes priority over TR_UseOldCompareAndSwapObject. Once again, the compressedrefs logic will not be hidden since it is expected by
+       * the non-inlined version.
+       */
+      static bool useOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
       static bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
       if (((self()->comp()->target().cpu.isX86() && !disableCASInlining) || self()->comp()->target().cpu.isPower() || self()->comp()->target().cpu.isZ()) &&
-          self()->comp()->useCompressedPointers() && UseOldCompareAndSwapObject)
+          self()->comp()->useCompressedPointers() && useOldCompareAndSwapObject)
          {
          TR::MethodSymbol *methodSymbol = parent->getSymbol()->castToMethodSymbol();
          static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -8313,8 +8313,8 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       }
 
 
-   static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
-   if (!UseOldCompareAndSwapObject &&
+   static bool useOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
+   if (!useOldCompareAndSwapObject &&
        comp->target().is64Bit() &&
        (TR::Compiler->om.compressedReferenceShiftOffset() != 0) &&
        ((oldVNode->getOpCodeValue() != TR::aconst) || (oldVNode->getAddress() != 0)))
@@ -8329,7 +8329,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
 
    TR::Node *translatedNode = newVNode;
    bool bumpedRefCount = false;
-   if (UseOldCompareAndSwapObject && comp->useCompressedPointers() && (newVNode->getDataType() != TR::Address))
+   if (useOldCompareAndSwapObject && comp->useCompressedPointers() && (newVNode->getDataType() != TR::Address))
       {
       bool useShiftedOffsets = (TR::Compiler->om.compressedReferenceShiftOffset() != 0);
 
@@ -8355,7 +8355,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
          }
       }
 
-   if (!UseOldCompareAndSwapObject)
+   if (!useOldCompareAndSwapObject)
       {
       uncompressedNewVReg = cg->evaluate(newVNode);
       if (comp->target().is64Bit() &&
@@ -8479,7 +8479,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       TR::addDependency(conditions, objReg, TR::RealRegister::gr3, TR_GPR, cg);
       TR::Register *wrtbarSrcReg;
 
-      if (!UseOldCompareAndSwapObject)
+      if (!useOldCompareAndSwapObject)
          {
          if (uncompressedNewVReg != newVReg)
             {
@@ -8539,7 +8539,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       TR::addDependency(conditions, objReg, TR::RealRegister::gr3, TR_GPR, cg);
       TR::Register *wrtbarSrcReg;
 
-      if (!UseOldCompareAndSwapObject)
+      if (!useOldCompareAndSwapObject)
          {
          if (newVReg != uncompressedNewVReg)
             {
@@ -8625,7 +8625,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       TR::addDependency(conditions, temp1Reg, TR::RealRegister::NoReg, TR_GPR, cg);
       conditions->getPostConditions()->getRegisterDependency(1)->setExcludeGPR0();
 
-      if (!UseOldCompareAndSwapObject)
+      if (!useOldCompareAndSwapObject)
          {
          if (newVReg != uncompressedNewVReg)
             {
@@ -8664,7 +8664,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       TR::addDependency(conditions, objReg, TR::RealRegister::NoReg, TR_GPR, cg);
       conditions->getPostConditions()->getRegisterDependency(0)->setExcludeGPR0();
       TR::addDependency(conditions, offsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
-      if (!UseOldCompareAndSwapObject)
+      if (!useOldCompareAndSwapObject)
          {
          if (newVReg != uncompressedNewVReg)
             TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
@@ -8690,7 +8690,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
 
    generateDepLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
 
-   if (!UseOldCompareAndSwapObject)
+   if (!useOldCompareAndSwapObject)
       {
       cg->stopUsingRegister(oldVReg);
       }

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -2487,14 +2487,14 @@ static TR::Register *genDecompressPointerNonNull2RegsWithTempReg(TR::CodeGenerat
       }
    }
 
-static void genCompressPointerWithTempReg(TR::CodeGenerator *cg, TR::Node *node, TR::Register *ptrReg, TR::Register *tempReg, TR::Register *condReg = NULL, bool nullCheck = true)
+static void genCompressPointerWithTempReg(TR::CodeGenerator *cg, TR::Node *node, TR::Register *tempReg, TR::Register *ptrReg, TR::Register *condReg = NULL, bool nullCheck = true)
    {
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (cg->comp()->fe());
    int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
 
    if (shiftAmount != 0)
       {
-      generateShiftRightLogicalImmediateLong(cg, node, ptrReg, ptrReg, shiftAmount);
+      generateShiftRightLogicalImmediateLong(cg, node, tempReg, ptrReg, shiftAmount);
       }
    }
 
@@ -8274,13 +8274,12 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
    {
    TR::Compilation *comp = cg->comp();
    TR_J9VMBase *fej9 = (TR_J9VMBase *) (comp->fe());
-   TR::Register *objReg, *offsetReg, *oldVReg, *newVReg, *resultReg, *cndReg;
+   TR::Register *objReg, *offsetReg, *oldVReg, *newVReg, *uncompressedNewVReg, *resultReg, *cndReg;
    TR::Node *firstChild, *objNode, *offsetNode, *oldVNode, *newVNode;
    TR::RegisterDependencyConditions *conditions;
    TR::LabelSymbol *doneLabel, *storeLabel, *wrtBarEndLabel;
    intptr_t offsetValue;
    bool freeOffsetReg;
-   bool needDup = false;
 
    auto gcMode = TR::Compiler->om.writeBarrierType();
    bool doWrtBar = (gcMode == gc_modron_wrtbar_satb || gcMode == gc_modron_wrtbar_oldcheck || gcMode == gc_modron_wrtbar_cardmark_and_oldcheck || gcMode == gc_modron_wrtbar_always
@@ -8313,11 +8312,24 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
          offsetReg = offsetReg->getLowOrder();
       }
 
-   oldVReg = cg->evaluate(oldVNode);
+
+   static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
+   if (!UseOldCompareAndSwapObject &&
+       comp->target().is64Bit() &&
+       (TR::Compiler->om.compressedReferenceShiftOffset() != 0) &&
+       ((oldVNode->getOpCodeValue() != TR::aconst) || (oldVNode->getAddress() != 0)))
+      {
+      oldVReg = cg->gprClobberEvaluate(oldVNode);
+      genCompressPointer(cg, node, oldVReg);
+      }
+   else
+      {
+      oldVReg = cg->evaluate(oldVNode);
+      }
 
    TR::Node *translatedNode = newVNode;
    bool bumpedRefCount = false;
-   if (comp->useCompressedPointers() && (newVNode->getDataType() != TR::Address))
+   if (UseOldCompareAndSwapObject && comp->useCompressedPointers() && (newVNode->getDataType() != TR::Address))
       {
       bool useShiftedOffsets = (TR::Compiler->om.compressedReferenceShiftOffset() != 0);
 
@@ -8343,12 +8355,31 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
          }
       }
 
-   newVReg = cg->evaluate(newVNode);
+   if (!UseOldCompareAndSwapObject)
+      {
+      uncompressedNewVReg = cg->evaluate(newVNode);
+      if (comp->target().is64Bit() &&
+          (TR::Compiler->om.compressedReferenceShiftOffset() != 0) &&
+          ((newVNode->getOpCodeValue() != TR::aconst) || (newVNode->getAddress() != 0)))
+         {
+         newVReg = cg->allocateRegister();
+         genCompressPointerWithTempReg(cg, node, newVReg, uncompressedNewVReg);
+         }
+      else
+         {
+         newVReg = uncompressedNewVReg;
+         }
+      }
+   else
+      {
+      newVReg = cg->evaluate(newVNode);
+      uncompressedNewVReg = nullptr;
+      }
+
    if (objReg == newVReg)
       {
       newVReg = cg->allocateCollectedReferenceRegister();
       generateTrg1Src1Instruction(cg, TR::InstOpCode::mr, node, newVReg, objReg);
-      needDup = true;
       }
    cndReg = cg->allocateRegister(TR_CCR);
    doneLabel = generateLabelSymbol(cg);
@@ -8447,16 +8478,29 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       TR::Register *temp1Reg = cg->allocateRegister(), *temp2Reg = cg->allocateRegister(), *temp3Reg, *temp4Reg = cg->allocateRegister();
       TR::addDependency(conditions, objReg, TR::RealRegister::gr3, TR_GPR, cg);
       TR::Register *wrtbarSrcReg;
-      if (translatedNode != newVNode)
+
+      if (!UseOldCompareAndSwapObject)
          {
-         TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
-         TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::gr4, TR_GPR, cg);
-         wrtbarSrcReg = translatedNode->getRegister();
+         if (uncompressedNewVReg != newVReg)
+            {
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+            }
+         TR::addDependency(conditions, uncompressedNewVReg, TR::RealRegister::gr4, TR_GPR, cg);
+         wrtbarSrcReg = uncompressedNewVReg;
          }
       else
          {
-         TR::addDependency(conditions, newVReg, TR::RealRegister::gr4, TR_GPR, cg);
-         wrtbarSrcReg = newVReg;
+         if (translatedNode != newVNode)
+            {
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+            TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::gr4, TR_GPR, cg);
+            wrtbarSrcReg = translatedNode->getRegister();
+            }
+         else
+            {
+            TR::addDependency(conditions, newVReg, TR::RealRegister::gr4, TR_GPR, cg);
+            wrtbarSrcReg = newVReg;
+            }
          }
 
       TR::addDependency(conditions, temp1Reg, TR::RealRegister::gr11, TR_GPR, cg);
@@ -8493,21 +8537,44 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       {
       TR::Register *temp1Reg = cg->allocateRegister(), *temp2Reg;
       TR::addDependency(conditions, objReg, TR::RealRegister::gr3, TR_GPR, cg);
+      TR::Register *wrtbarSrcReg;
 
-      if (newVReg != translatedNode->getRegister())
+      if (!UseOldCompareAndSwapObject)
          {
-         TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+         if (newVReg != uncompressedNewVReg)
+            {
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+            }
+
          if (comp->getOptions()->realTimeGC())
-            TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::gr5, TR_GPR, cg);
+            {
+            TR::addDependency(conditions, uncompressedNewVReg, TR::RealRegister::gr5, TR_GPR, cg);
+            }
          else
-            TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::gr4, TR_GPR, cg);
+            {
+            TR::addDependency(conditions, uncompressedNewVReg, TR::RealRegister::gr4, TR_GPR, cg);
+            }
+
+         wrtbarSrcReg = uncompressedNewVReg;
          }
       else
          {
-         if (comp->getOptions()->realTimeGC())
-            TR::addDependency(conditions, newVReg, TR::RealRegister::gr5, TR_GPR, cg);
+         if (newVReg != translatedNode->getRegister())
+            {
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+            if (comp->getOptions()->realTimeGC())
+               TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::gr5, TR_GPR, cg);
+            else
+               TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::gr4, TR_GPR, cg);
+            }
          else
-            TR::addDependency(conditions, newVReg, TR::RealRegister::gr4, TR_GPR, cg);
+            {
+            if (comp->getOptions()->realTimeGC())
+               TR::addDependency(conditions, newVReg, TR::RealRegister::gr5, TR_GPR, cg);
+            else
+               TR::addDependency(conditions, newVReg, TR::RealRegister::gr4, TR_GPR, cg);
+            }
+         wrtbarSrcReg = translatedNode->getRegister();
          }
 
       TR::addDependency(conditions, temp1Reg, TR::RealRegister::NoReg, TR_GPR, cg);
@@ -8540,7 +8607,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
          generateTrg1Src2Instruction(cg, TR::InstOpCode::add, node, dstAddrReg, objReg, offsetReg);
          }
 
-      VMnonNullSrcWrtBarCardCheckEvaluator(node, comp->useCompressedPointers() ? translatedNode->getRegister() : newVReg, objReg, cndReg, temp1Reg, temp2Reg, dstAddrReg, NULL,
+      VMnonNullSrcWrtBarCardCheckEvaluator(node, comp->useCompressedPointers() ? wrtbarSrcReg : newVReg, objReg, cndReg, temp1Reg, temp2Reg, dstAddrReg, NULL,
             wrtBarEndLabel, conditions, comp->useCompressedPointers(), cg);
 
       if (comp->getOptions()->realTimeGC())
@@ -8557,9 +8624,21 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       conditions->getPostConditions()->getRegisterDependency(0)->setExcludeGPR0();
       TR::addDependency(conditions, temp1Reg, TR::RealRegister::NoReg, TR_GPR, cg);
       conditions->getPostConditions()->getRegisterDependency(1)->setExcludeGPR0();
-      if (newVReg != translatedNode->getRegister())
-         TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
-      TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
+
+      if (!UseOldCompareAndSwapObject)
+         {
+         if (newVReg != uncompressedNewVReg)
+            {
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+            }
+         TR::addDependency(conditions, uncompressedNewVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+         }
+      else
+         {
+         if (newVReg != translatedNode->getRegister())
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+         TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
+         }
 
       TR::addDependency(conditions, temp2Reg, TR::RealRegister::NoReg, TR_GPR, cg);
       TR::addDependency(conditions, offsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
@@ -8585,9 +8664,18 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
       TR::addDependency(conditions, objReg, TR::RealRegister::NoReg, TR_GPR, cg);
       conditions->getPostConditions()->getRegisterDependency(0)->setExcludeGPR0();
       TR::addDependency(conditions, offsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
-      if (newVReg != translatedNode->getRegister())
-         TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
-      TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
+      if (!UseOldCompareAndSwapObject)
+         {
+         if (newVReg != uncompressedNewVReg)
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+         TR::addDependency(conditions, uncompressedNewVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+         }
+      else
+         {
+         if (newVReg != translatedNode->getRegister())
+            TR::addDependency(conditions, newVReg, TR::RealRegister::NoReg, TR_GPR, cg);
+         TR::addDependency(conditions, translatedNode->getRegister(), TR::RealRegister::NoReg, TR_GPR, cg);
+         }
       }
 
    generateLabelInstruction(cg, TR::InstOpCode::label, node, storeLabel);
@@ -8602,10 +8690,14 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
 
    generateDepLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, conditions);
 
-   if (needDup)
-      cg->stopUsingRegister(newVReg);
+   if (!UseOldCompareAndSwapObject)
+      {
+      cg->stopUsingRegister(oldVReg);
+      }
 
+   cg->stopUsingRegister(newVReg);
    cg->stopUsingRegister(cndReg);
+
    cg->recursivelyDecReferenceCount(firstChild);
    cg->decReferenceCount(objNode);
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -10089,10 +10089,10 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
             break;
          case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
             {
-            static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
+            static bool useOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
             if (node->isSafeForCGToFastPathUnsafeCall())
                {
-               if (UseOldCompareAndSwapObject)
+               if (useOldCompareAndSwapObject)
                   return inlineCompareAndSwapNative(node, TR::Compiler->om.sizeofReferenceField(), true, false, cg);
                else
                   {
@@ -10117,10 +10117,10 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
          case TR::jdk_internal_misc_Unsafe_compareAndExchangeObject:
          case TR::jdk_internal_misc_Unsafe_compareAndExchangeReference:
             {
-            static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
+            static bool useOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
             if (!disableCAEIntrinsic && node->isSafeForCGToFastPathUnsafeCall())
                {
-               if (UseOldCompareAndSwapObject)
+               if (useOldCompareAndSwapObject)
                   return inlineCompareAndSwapNative(node, TR::Compiler->om.sizeofReferenceField(), true, true, cg);
                else
                   {

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -11952,7 +11952,7 @@ TR::Register*
 J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic casOp, bool isObj, bool isExchange)
    {
    TR::Register *scratchReg = NULL;
-   TR::Register *objReg, *oldVReg, *newVReg, *decompressedValueRegister;
+   TR::Register *objReg = NULL, *oldVReg = NULL, *newVReg = NULL, *decompressedValueRegister = NULL;
    TR::Register *resultReg = isExchange ? NULL : cg->allocateRegister();
    TR::MemoryReference* casMemRef = NULL;
 
@@ -11969,10 +11969,10 @@ J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *
    // compression sequence.
    bool isValueCompressedReference = false;
 
-   static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
+   static bool useOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
 
    TR::Node* decompressedValueNode = newVNode;
-   if (UseOldCompareAndSwapObject && isObj && comp->useCompressedPointers() && decompressedValueNode->getOpCodeValue() == TR::l2i)
+   if (useOldCompareAndSwapObject && isObj && comp->useCompressedPointers() && decompressedValueNode->getOpCodeValue() == TR::l2i)
       {
       // Pattern match the sequence:
       //
@@ -12027,7 +12027,7 @@ J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *
       {
       decompressedValueRegister = cg->evaluate(decompressedValueNode);
       }
-   else if (!UseOldCompareAndSwapObject &&
+   else if (!useOldCompareAndSwapObject &&
             isObj &&
             comp->target().is64Bit() &&
             (TR::Compiler->om.compressedReferenceShiftOffset() != 0))

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -11952,7 +11952,7 @@ TR::Register*
 J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *cg, TR::InstOpCode::Mnemonic casOp, bool isObj, bool isExchange)
    {
    TR::Register *scratchReg = NULL;
-   TR::Register *objReg, *oldVReg, *newVReg;
+   TR::Register *objReg, *oldVReg, *newVReg, *decompressedValueRegister;
    TR::Register *resultReg = isExchange ? NULL : cg->allocateRegister();
    TR::MemoryReference* casMemRef = NULL;
 
@@ -11969,9 +11969,10 @@ J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *
    // compression sequence.
    bool isValueCompressedReference = false;
 
-   TR::Node* decompressedValueNode = newVNode;
+   static bool UseOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
 
-   if (isObj && comp->useCompressedPointers() && decompressedValueNode->getOpCodeValue() == TR::l2i)
+   TR::Node* decompressedValueNode = newVNode;
+   if (UseOldCompareAndSwapObject && isObj && comp->useCompressedPointers() && decompressedValueNode->getOpCodeValue() == TR::l2i)
       {
       // Pattern match the sequence:
       //
@@ -12020,14 +12021,28 @@ J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *
    oldVReg = cg->gprClobberEvaluate(oldVNode);  //  CS oldReg, newReg, OFF(objReg)
    newVReg = cg->evaluate(newVNode);                    //    oldReg is clobbered
 
-   TR::Register* decompressedValueRegister = newVReg;
+   decompressedValueRegister = newVReg;
 
    if (isValueCompressedReference)
       {
       decompressedValueRegister = cg->evaluate(decompressedValueNode);
       }
+   else if (!UseOldCompareAndSwapObject &&
+            isObj &&
+            comp->target().is64Bit() &&
+            (TR::Compiler->om.compressedReferenceShiftOffset() != 0))
+      {
+      if ((oldVNode->getOpCodeValue() != TR::aconst) || (oldVNode->getAddress() != 0))
+         {
+         generateRSInstruction(cg, TR::InstOpCode::SRLG, node, oldVReg, oldVReg, TR::Compiler->om.compressedReferenceShiftOffset());
+         }
 
-   bool needsDup = false;
+      if ((newVNode->getOpCodeValue() != TR::aconst) || (newVNode->getAddress() != 0))
+         {
+         newVReg = cg->allocateRegister();
+         generateRSInstruction(cg, TR::InstOpCode::SRLG, node, newVReg, decompressedValueRegister, TR::Compiler->om.compressedReferenceShiftOffset());
+         }
+      }
 
    if (objReg == newVReg)
       {
@@ -12036,8 +12051,6 @@ J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *
       generateRRInstruction(cg, TR::InstOpCode::getLoadRegOpCode(), node, newVReg, objReg);
       if (!isValueCompressedReference)
          decompressedValueRegister = newVReg;
-
-      needsDup = true;
       }
 
    if (!isExchange)
@@ -12188,10 +12201,8 @@ J9::Z::TreeEvaluator::VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *
       cg->stopUsingRegister(oldVReg);
       }
 
-   if (needsDup)
-      {
-      cg->stopUsingRegister(newVReg);
-      }
+   cg->stopUsingRegister(newVReg);
+
    if (scratchReg)
       {
       cg->stopUsingRegister(scratchReg);


### PR DESCRIPTION
Disables code on Power and Z that hides compressedrefs logic from the fast path code generation for the following recognized methods:
`sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z`
`jdk_internal_misc_Unsafe_compareAndExchangeObject`
`jdk_internal_misc_Unsafe_compareAndExchangeReference`

Fast path code generation for those recognized methods is updated to handle compressedrefs.

Original behavior can be restored by setting the `TR_UseOldCompareAndSwapObject` environment variable. This behavior matches the X implementation which has already disabled the compressedrefs hiding logic when the envvar is not set.