### PR TITLE
NPE extended message RTV_SEND case should assign classSig a value

### DIFF
--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -1605,21 +1605,29 @@ simulateStack(J9NPEMessageData *npeMsgData)
 		case RTV_SEND: {
 			J9UTF8 *classSig = NULL;
 
+			Trc_VM_simulateStack_RTVSEND_bcIndex(vmThread, currentBytecode, bcIndex);
 			if (JBinvokeinterface2 == currentBytecode) {
-				/* Set to point to JBinvokeinterface */
+				/* Set to point to JBinvokeinterface. */
 				bcIndex += 2;
+				Trc_VM_simulateStack_RTVSEND_bcIndex2(vmThread, bcIndex);
 			}
 			UDATA index = PARAM_16(bcIndex, 1);
+			Trc_VM_simulateStack_RTVSEND_index(vmThread, index);
 			if (JBinvokestaticsplit == currentBytecode) {
 				index = *(U_16 *)(J9ROMCLASS_STATICSPLITMETHODREFINDEXES(romClass) + index);
+				Trc_VM_simulateStack_RTVSEND_JBinvokestaticsplit_index(vmThread, index);
 			} else if (JBinvokespecialsplit == currentBytecode) {
 				index = *(U_16 *)(J9ROMCLASS_SPECIALSPLITMETHODREFINDEXES(romClass) + index);
-			} else if (JBinvokedynamic == currentBytecode) {
+				Trc_VM_simulateStack_RTVSEND_JBinvokespecialsplit_index(vmThread, index);
+			}
+			if (JBinvokedynamic == currentBytecode) {
 				J9SRP *callSiteData = (J9SRP *) J9ROMCLASS_CALLSITEDATA(romClass);
 				classSig = ((J9UTF8 *) (J9ROMNAMEANDSIGNATURE_SIGNATURE(SRP_PTR_GET(callSiteData + index, J9ROMNameAndSignature*))));
+				Trc_VM_simulateStack_RTVSEND_JBinvokedynamic_classSig(vmThread, J9UTF8_LENGTH(classSig), J9UTF8_DATA(classSig));
 			} else {
 				J9ROMConstantPoolItem *info = &constantPool[index];
 				classSig = ((J9UTF8 *) (J9ROMNAMEANDSIGNATURE_SIGNATURE(J9ROMMETHODREF_NAMEANDSIGNATURE((J9ROMMethodRef *) info))));
+				Trc_VM_simulateStack_RTVSEND_others_classSig(vmThread, J9UTF8_LENGTH(classSig), J9UTF8_DATA(classSig));
 			}
 			stackTop -= getSendSlotsFromSignature(J9UTF8_DATA(classSig));
 

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -986,3 +986,11 @@ TraceException=Trc_VM_jfr_ErrorWritingChunk Overhead=1 Level=1 Template="Error w
 TraceEvent=Trc_VM_VMInitStages_isDebugOnRestoreEnabled NoEnv Overhead=1 Level=3 Template="VMInitStages(ABOUT_TO_BOOTSTRAP) isDebugOnRestoreEnabled returns TRUE"
 TraceEvent=Trc_VM_hookAboutToBootstrapEvent_debugModeRequested Overhead=1 Level=3 Template="hookAboutToBootstrapEvent() debugModeRequested is TRUE"
 TraceEvent=Trc_VM_mustReportEnterStepOrBreakpoint_hookedOrReserved NoEnv Overhead=1 Level=5 Template="mustReportEnterStepOrBreakpoint() hookedOrReserved(%zu)"
+
+TraceEvent=Trc_VM_simulateStack_RTVSEND_bcIndex Overhead=1 Level=5 Template="simulateStack RTV_SEND starts currentBytecode(%zu) bcIndex(%p)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_bcIndex2 Overhead=1 Level=5 Template="simulateStack RTV_SEND bcIndex2(%p)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_index Overhead=1 Level=5 Template="simulateStack RTV_SEND index(%zu)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_JBinvokestaticsplit_index Overhead=1 Level=3 Template="simulateStack RTV_SEND JBinvokestaticsplit index(%zu)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_JBinvokespecialsplit_index Overhead=1 Level=3 Template="simulateStack RTV_SEND JBinvokespecialsplit index(%zu)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_JBinvokedynamic_classSig Overhead=1 Level=5 Template="simulateStack RTV_SEND JBinvokedynamic classSig(%.*s)"
+TraceEvent=Trc_VM_simulateStack_RTVSEND_others_classSig Overhead=1 Level=5 Template="simulateStack RTV_SEND others classSig(%.*s)"


### PR DESCRIPTION
NPE extended message `RTV_SEND` case should assign `classSig` a value

In `simulateStack()` `RTV_SEND` case, `classSig` should always be assigned a value instead of using the initial `NULL`.

This matches the verifier code https://github.com/eclipse-openj9/openj9/blob/bd36b1da7b46660e9f7c38b312150b248678ee14/runtime/bcverify/bcverify.c#L1717-L1722

This fixed [a user-raised segmentation error](https://ibm-cloud.slack.com/archives/C59HR9D5X/p1729590804796459) (~more tests are still running~ no failure occurred)
```
2024-10-22T09:39:45.196210938Z ----------- Stack Backtrace -----------
2024-10-22T09:39:45.211754265Z getSendSlotsFromSignature+0x10 (0x00007FAFE1ADEF50 [libj9vm29.so+0x1a7f50])
2024-10-22T09:39:45.211754265Z getNPEMessage+0x12ce (0x00007FAFE19753EE [libj9vm29.so+0x3e3ee])
2024-10-22T09:39:45.211754265Z JVM_GetExtendedNPEMessage+0x151 (0x00007FAFE1EEF8D1 [libjvm.so+0x1e8d1])
2024-10-22T09:39:45.211754265Z ffi_call_unix64+0x52 (0x00007FAFE1B447EA [libj9vm29.so+0x20d7ea])
2024-10-22T09:39:45.211754265Z ffi_call_int+0x1a1 (0x00007FAFE1B43981 [libj9vm29.so+0x20c981])
2024-10-22T09:39:45.211754265Z _ZN32VM_BytecodeInterpreterCompressed3runEP10J9VMThread+0x111d8 (0x00007FAFE19EAE58 [libj9vm29.so+0xb3e58])
2024-10-22T09:39:45.211754265Z bytecodeLoopCompressed+0xca (0x00007FAFE19D9C6A [libj9vm29.so+0xa2c6a])
2024-10-22T09:39:45.211754265Z  (0x00007FAFE1AD0A52 [libj9vm29.so+0x199a52])
2024-10-22T09:39:45.211754265Z ---------------------------------------
```
It seems related to 
* https://github.com/eclipse-openj9/openj9/issues/17349
though the error wasn't reproduced consistently.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>