### PR TITLE
Check option TR_DisableIProfilerThread instead of iprofiler thread pr…

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -3425,8 +3425,7 @@ bool J9::Options::feLatePostProcess(void * base, TR::OptionSet * optionSet)
    // The exploitation of idle time is done by a tracking mechanism done
    // on the IProfiler thread. If this thread does not exist, then we
    // must turn this feature off to avoid allocating a useless hashtable
-   TR_IProfiler *iProfiler = vm->getIProfiler();
-   if (!iProfiler || !iProfiler->getIProfilerThread())
+   if (self()->getOption(TR_DisableIProfilerThread))
       self()->setOption(TR_UseIdleTime, false);
 
    // If NoResumableTrapHandler is set, disable packed decimal intrinsics inlining because


### PR DESCRIPTION
…esence

In `TR_Options::feLatePostProcess()` we want to disable the `TR_UseIdleTime` option bit if we don't want to run with an IProfiler thread. Currently this is done by checking the presence of the Iprofiler thread. The problem is that the IProfiler thread is created much later so our query will always return `false`.
This commit replaces the check on the IProfiler thread with a check on the `TR_DisableIProfilerThread` option bit.