### PR TITLE
Include <unordered_set> only for JITServer platforms

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -20,11 +20,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-#include <string>
-#include <unordered_set>
-
 #include <algorithm>
 #include <limits.h>
+#if defined(J9VM_OPT_JITSERVER)
+#include <string>
+#include <unordered_set>
+#endif
 #ifdef LINUX
 #include <malloc.h>
 #endif // LINUX


### PR DESCRIPTION
unordered_set was introduced in c++-11 standard.
Platforms that support JITServer code add a compiler option to provide support for c++-11 standard.
This commit protects the inclusion of the unordered_set header file with `#if defined(J9VM_OPT_JITSERVER)`