### PR TITLE
Remove Server VM Access Request in VectorAPIExpansion.cpp

### DIFF
--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 70; // ID:5nbb7nhW+R7OABuv+aRm
+   static const uint16_t MINOR_NUMBER = 71; // ID: t80Voe+mNpo5+lQvjult
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -258,6 +258,8 @@ const char *messageNames[] =
    "KnownObjectTable_createSymRefWithKnownObject",
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
+   "KnownObjectTable_getJ9Class",
+   "KnownObjectTable_getVectorBitSize",
    "AOTCache_getROMClassBatch",
    "AOTCacheMap_request",
    "AOTCacheMap_reply"

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -283,11 +283,16 @@ enum MessageType : uint16_t
    KnownObjectTable_createSymRefWithKnownObject,
    KnownObjectTable_getReferenceField,
    KnownObjectTable_getKnownObjectTableDumpInfo,
+   // for getting a J9Class from KnownObjectTable
+   KnownObjectTable_getJ9Class,
+   // for getting a vectorBitSize from KnownObjectTable
+   KnownObjectTable_getVectorBitSize,
 
    AOTCache_getROMClassBatch,
 
    AOTCacheMap_request,
    AOTCacheMap_reply,
+
 
    MessageType_MAXTYPE
    };


### PR DESCRIPTION
The server should make a specific request to the client in getJ9ClassFromClassNode() and getVectorSizeFromVectorSpecies(), instead of requesting a pointer from the KnownObjectTable as that requires VM Access and will cause a fatal assertion fail at J9KnownObjectTable.cpp:207.