### PR TITLE
Protect <string>/<vector> includes with #ifdef

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -23,9 +23,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
+#if defined(J9VM_OPT_JITSERVER)
 #include <vector>
 #include <string>
+#endif /* defined(J9VM_OPT_JITSERVER) */
 
 #ifdef WINDOWS
 // Undefine the winsockapi because winsock2 defines it. Removes warnings.


### PR DESCRIPTION
PR #20129 added two includes (for "string" and "vector") that are only needed for JITServer specific code. Thus the two includes should be protected by `#if defined(J9VM_OPT_JITSERVER)`