### PR TITLE
Update doPrivilegedWithCombinerHelper function

### DIFF
--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -1088,21 +1088,17 @@ public static <T> T doPrivilegedWithCombiner(PrivilegedExceptionAction<T> action
 /**
  * Helper method to construct an AccessControlContext for doPrivilegedWithCombiner methods.
  *
- * @param   context an AccessControlContext, if it is null, use getContextHelper() to construct a context.
+ * @param   acc an AccessControlContext, if it is null, use getContextHelper() to construct a context.
  *
  * @return  An AccessControlContext to be applied to the doPrivileged(action, context, perms).
  */
 @CallerSensitive
-private static AccessControlContext doPrivilegedWithCombinerHelper(AccessControlContext context) {
+private static AccessControlContext doPrivilegedWithCombinerHelper(AccessControlContext acc) {
 	ProtectionDomain domain = getCallerPD(2);
-	ProtectionDomain[] pdArray = (domain == null) ? null : new ProtectionDomain[] { domain };
-	AccessControlContext fixedContext = new AccessControlContext(context, pdArray, getNewAuthorizedState(context, domain));
-	if (context == null) {
-		AccessControlContext parentContext = getContextHelper(true);
-		fixedContext.domainCombiner = parentContext.domainCombiner;
-		fixedContext.nextStackAcc = parentContext;
-	}
-	return fixedContext;
+	ProtectionDomain[] context = (domain == null) ? null : new ProtectionDomain[] { domain };
+	AccessControlContext parentAcc = getContextHelper(acc == null);
+
+	return new AccessControlContext(context, parentAcc, acc, getNewAuthorizedState(acc, domain));
 }
 /*[ENDIF] JAVA_SPEC_VERSION < 24 */
 


### PR DESCRIPTION
When we try to invoke doPrivilegedWithCombiner function to
perform a privileged action under an existing context
environment, we are used to construct a new context but ignore
the parent context.

We should take consideration of a combination of the current
and parent context, rather than just choose either the current
or the parent.

This patch solves the failed case in issue https://github.com/eclipse-openj9/openj9/issues/19499.