### PR TITLE
Replace Thread.onSpinWait() with a PAUSE instruction on x86

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -134,6 +134,7 @@
    java_lang_ref_Reference_refersTo,
    java_lang_ref_SoftReference_get,
    java_lang_Thread_currentThread,
+   java_lang_Thread_onSpinWait,
    java_lang_Thread_runWith,
    java_lang_VirtualThread_runWith,
    java_lang_ScopedValue_runWith,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2865,6 +2865,7 @@ void TR_ResolvedJ9Method::construct()
    static X ThreadMethods[] =
       {
       {x(TR::java_lang_Thread_currentThread,     "currentThread",   "()Ljava/lang/Thread;")},
+      {x(TR::java_lang_Thread_onSpinWait,     "onSpinWait",   "()V")},
       {  TR::java_lang_Thread_runWith,       7,  "runWith",         (int16_t)-1, "*"},
       {  TR::unknownMethod}
       };

--- a/runtime/compiler/il/J9Node.cpp
+++ b/runtime/compiler/il/J9Node.cpp
@@ -316,6 +316,13 @@ J9::Node::processJNICall(TR::TreeTop *callNodeTreeTop, TR::ResolvedMethodSymbol 
       return self();
       }
 
+   if (methodSymbol->getRecognizedMethod() == TR::java_lang_Thread_onSpinWait)
+      {
+      static char *disableOSW = feGetEnv("TR_noPauseOnSpinWait");
+      if (!disableOSW)
+         return self();
+      }
+
    if (methodSymbol->canReplaceWithHWInstr())
       return self();
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5486,6 +5486,19 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
             return true;
             }
          break;
+      case TR::java_lang_Thread_onSpinWait:
+         static char *disableOSW = feGetEnv("TR_noPauseOnSpinWait");
+         if (!disableOSW)
+            {
+            static char *printIt = feGetEnv("TR_showPauseOnSpinWait");
+            if (printIt && comp->trace(OMR::inlining))
+               {
+               traceMsg(comp, "suppress inlining onSpinWait : node=%p, %s\n", callNode, comp->signature());
+               }
+
+            return true;
+            }
+         break;
       case TR::sun_misc_Unsafe_allocateInstance:
          // VP transforms this into a plain new if it can get a non-null
          // known object java/lang/Class representing an initialized class

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11702,6 +11702,25 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
 
    switch (symbol->getRecognizedMethod())
       {
+      case TR::java_lang_Thread_onSpinWait:
+         {
+         static char *disableOSW = feGetEnv("TR_noPauseOnSpinWait");
+         if (!disableOSW)
+            {
+            generateInstruction(TR::InstOpCode::PAUSE, node, cg);
+
+            static char *printIt = feGetEnv("TR_showPauseOnSpinWait");
+            if (printIt && comp->getOption(TR_TraceCG))
+               {
+               traceMsg(comp, "insert PAUSE for onSpinWait : node=%p, %s\n", node, comp->signature());
+               }
+
+            return NULL;
+            }
+         else
+            break;
+         }
+
       case TR::java_nio_Bits_keepAlive:
       case TR::java_lang_ref_Reference_reachabilityFence:
          {


### PR DESCRIPTION
Enabled by default.  Disable by setting the `TR_noPauseOnSpinWait` environment variable.