### PR TITLE
Extend CAS alignment error to Little Endian

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -5976,7 +5976,7 @@ public final class Unsafe {
 	 * memory blocks
 	 */
 	private void compareAndExchange16BitsOffsetChecks(long offset) {
-		if ((IS_BIG_ENDIAN) && (BYTE_OFFSET_MASK == (BYTE_OFFSET_MASK & offset))) {
+		if (BYTE_OFFSET_MASK == (BYTE_OFFSET_MASK & offset)) {
 			/*[MSG "K0700", "Update spans the word, not supported"]*/
 			throw new IllegalArgumentException(com.ibm.oti.util.Msg.getString("K0700")); //$NON-NLS-1$
 		}


### PR DESCRIPTION
`compareAndExchange16BitsOffsetChecks` is used by 16 bit compare and exchange operations to check to see if the 16 bits cross a 32 bit boundary which is not supported.

This check was previously only enabled under Big Endian but the problem can occur under Little Endian as well.

The check has been updated to apply to Little Endian to prevent incorrect behavior.

Example test case (tested on X and LE Power):
```
import java.lang.reflect.Field;
import jdk.internal.misc.Unsafe;

public class UnsafeIntrinsicTest {

    private Unsafe unsafe;
    private long shortArrayBaseOffset;

    UnsafeIntrinsicTest() {
        unsafe = Unsafe.getUnsafe();
        try {
            shortArrayBaseOffset = unsafe.arrayBaseOffset(short[].class);
        } catch (Exception e) {
            System.out.println("Missing field offset");
            System.exit(0);
        }
    }

    public static void main (String[] args) {
        UnsafeIntrinsicTest t = new UnsafeIntrinsicTest();

        for (int i = 0; i < 15; i++) {
            t.runTest(false);
        }
        t.runTest(true);
    }

    protected void runTest(boolean printFlag) {
        short shortExResult = (short)0;
        short[] testShortArray = new short[16];
        for (int i = 0; i < testShortArray.length; i++) {
            testShortArray[i] = (short) (i + 1);
        }

        if (printFlag) {
            for (int i = 0; i < testShortArray.length; i++) {
                System.out.printf("%d ", testShortArray[i]);
            }
            System.out.printf("\n");
        }

        shortExResult = unsafe.compareAndExchangeShort(testShortArray, shortArrayBaseOffset+3, (short)0, (short)100);

        if (printFlag) {
            System.out.printf("shortExResult: %d\n", shortExResult);
            for (int i = 0; i < testShortArray.length; i++) {
                System.out.printf("%d ", testShortArray[i]);
            }
            System.out.printf("\n");
        }
    }
}
```
Output:
```
java --add-exports java.base/jdk.internal.misc=ALL-UNNAMED -Xint -XX:-EnableHCR -Xshareclasses:none -Xnoaot -Xdump:none UnsafeIntrinsicTest
1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16
shortExResult: 0
1 25602 3 4 5 6 7 8 9 10 11 12 13 14 15 16
```
The call to `compareAndExchangeShort` is looking for a short of `0x0000` to replace with 100 (`0x0064`). There is no `0x0000` in the array to the operation should not go through. But, it ends up finding a match on the 4th byte in the array and only modifies that one byte. So the 2 (in memory: `0x02 0x00`) becomes 25602 (in memory: `0x02 0x64`) when it shouldn't.