### PR TITLE
Clean Up VM Access in J9SymbolReferenceTable.cpp

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1571,7 +1571,7 @@ J9::SymbolReferenceTable::findOrCreateStringSymbol(TR::ResolvedMethodSymbol * ow
    else if (!sym->isConstString() &&
             !sym->isNonSpecificConstObject())
       {
-      TR::VMAccessCriticalSection constantCriticalSection(comp()->fej9());
+      // getObjectClassAt will acquire/release VMAccess internally when needed
       TR_OpaqueClassBlock *clazz = comp()->fej9()->getObjectClassAt((uintptr_t)stringConst);
       if (comp()->fej9()->isString(clazz))
          {


### PR DESCRIPTION
Clean up the redundant VM Access critical section before getObjectClassAt(), since TR_J9VMBase::getObjectClassAt() will acquire/release VM Access internally, and
TR_J9ServerVM::getObjectClassAt() will query the client instead.