### PR TITLE
Valhalla still uses static Class<?> getPrimitiveClass(String name)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2947,12 +2947,12 @@ public Package getPackage() {
 	}
 }
 
-/*[IF JAVA_SPEC_VERSION >= 24]*/
+/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
 @SuppressWarnings("unchecked")
 static <T> Class<T> getPrimitiveClass(String name)
-/*[ELSE] JAVA_SPEC_VERSION >= 24 */
+/*[ELSE] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
 static Class<?> getPrimitiveClass(String name)
-/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
 {
 	Class<?> type;
 
@@ -2998,11 +2998,11 @@ static Class<?> getPrimitiveClass(String name)
 		type = array.getClass().getComponentType();
 	}
 
-	/*[IF JAVA_SPEC_VERSION >= 24]*/
+	/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
 	return (Class<T>) type;
-	/*[ELSE] JAVA_SPEC_VERSION >= 24 */
+	/*[ELSE] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
 	return type;
-	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+	/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
 }
 
 /**


### PR DESCRIPTION
Valhalla still uses `static Class<?> getPrimitiveClass(String name)`

Valhalla extension repo has no latest openjdk change to use `static <T> Class<T> getPrimitiveClass(String name)`.

This fixes [JDKnext_x86-64_linux_valhalla_Nightly](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Build_JDKnext_x86-64_linux_valhalla_Nightly/1585/consoleFull) compilation error:
```
21:08:31  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/src/java.base/share/classes/java/lang/Short.java:83: error: incompatible types: Class<Object> cannot be converted to Class<Short>
21:08:31      public static final Class<Short>    TYPE = (Class<Short>) Class.getPrimitiveClass("short");
21:08:31                                                                                       ^
21:08:31  Note: Some input files additionally use or override a deprecated API.
21:08:31  Note: Some input files additionally use or override a deprecated API that is marked for removal.
21:08:31  Note: Some input files additionally use unchecked or unsafe operations.
21:08:31  9 errors
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>