### PR TITLE
Fix bound JITServer port reporting

### DIFF
--- a/runtime/compiler/runtime/Listener.cpp
+++ b/runtime/compiler/runtime/Listener.cpp
@@ -172,7 +172,7 @@ openCommunicationSocket(uint32_t port, uint32_t &boundPort)
          close(sockfd);
          return retCode;
          }
-      boundPort = sock_desc.sin_port;
+      boundPort = ntohs(sock_desc.sin_port);
       }
    else
       {


### PR DESCRIPTION
The port in sockaddr (see man 7 ip) is stored in network order, so needs to be converted to host order to be used elsewhere.