### PR TITLE
Move willBeEvaluatedAsCallByCodeGen from OMR

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -107,6 +107,8 @@ public:
    // See J9::CodeGenerator::guaranteesResolvedVirtualDispatchForSVM
    bool guaranteesResolvedVirtualDispatchForSVM() { return true; }
 
+   bool willBeEvaluatedAsCallByCodeGen(TR::Node *node, TR::Compilation *comp);
+
 private:
    TR::SymbolReference *_nanoTimeTemp;
    };

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9664,8 +9664,8 @@ static TR::Register* inlineCompareAndSwapObjectNative(TR::Node* node, TR::CodeGe
 /** Replaces a call to an Unsafe CAS method with inline instructions.
    @return true if the call was replaced, false if it was not.
 
-   Note that this function must have behaviour consistent with the OMR function
-   willNotInlineCompareAndSwapNative in omr/compiler/x/codegen/OMRCodeGenerator.cpp
+   Note that this function must have behaviour consistent with the function
+   willNotInlineCompareAndSwapNative in openj9/runtime/compiler/x/codegen/J9CodeGenerator.cpp
 */
 static bool
 inlineCompareAndSwapNative(


### PR DESCRIPTION
The OMR `willBeEvaluatedAsCallByCodeGen` implementation for x is almost entirely guarded by the `J9_PROJECT_SPECIFIC` macro. If the macro is not set, it always returns true which is what the default implementation already does. Since this implementation is only meaningful to OpenJ9, it is being moved here.

`willNotInlineCompareAndSwapNative` is only called from this implementation of `willBeEvaluatedAsCallByCodeGen` so it is being moved as well.