### PR TITLE
Force inline AbstractMemorySegmentImpl.reinterpret for getCallerClass optimization

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1169,6 +1169,7 @@
    java_lang_invoke_VarHandleByteArrayAsX_ByteBufferHandle_method,
 
    jdk_internal_foreign_layout_ValueLayouts_AbstractValueLayout_accessHandle,
+   jdk_internal_foreign_AbstractMemorySegmentImpl_reinterpret,
    java_lang_foreign_MemorySegment_method,
 
    // Clone and Deep Copy

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4030,6 +4030,12 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod},
       };
 
+   static X AbstractMemorySegmentImplMethods [] =
+      {
+      {  TR::jdk_internal_foreign_AbstractMemorySegmentImpl_reinterpret, 11, "reinterpret", (int16_t)-1, "*"},
+      {  TR::unknownMethod},
+      };
+
    static X ArraysSupportMethods [] =
       {
       {x(TR::jdk_internal_util_ArraysSupport_vectorizedMismatch, "vectorizedMismatch", "(Ljava/lang/Object;JLjava/lang/Object;JII)I")},
@@ -4343,6 +4349,7 @@ void TR_ResolvedJ9Method::construct()
       { "java/util/concurrent/atomic/AtomicIntegerArray", JavaUtilConcurrentAtomicIntegerArrayMethods },
       { "java/util/concurrent/ConcurrentHashMap$TreeBin", JavaUtilConcurrentConcurrentHashMapTreeBinMethods },
       { "java/io/ObjectInputStream$BlockDataInputStream", ObjectInputStream_BlockDataInputStreamMethods },
+      { "jdk/internal/foreign/AbstractMemorySegmentImpl", AbstractMemorySegmentImplMethods },
       { 0 }
       };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -366,6 +366,9 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_lang_Class_newInstance:
       case TR::jdk_internal_util_Preconditions_checkIndex:
 
+      // AbstractMemorySegmentImpl.reinterpret methods call Reflection.getCallerClass
+      case TR::jdk_internal_foreign_AbstractMemorySegmentImpl_reinterpret:
+
       // we rely on inlining compareAndSwap so we see the inner native call and can special case it
       case TR::com_ibm_jit_JITHelpers_compareAndSwapIntInObject:
       case TR::com_ibm_jit_JITHelpers_compareAndSwapLongInObject:


### PR DESCRIPTION
AbstractMemorySegmentImpl.reinterpret methods contain calls to
Reflection.getCallerClass. Optimization of getCallerClass requires
the caller to be inlined. Otherwise, we would end up using the
JNI helper which performs a very expensive stackwalk to obtain
the caller class.

Issue: #20270