### PR TITLE
Update disabled functional/Valhalla tests

### DIFF
--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/NullRestrictedTypeOptTests.java
@@ -365,6 +365,10 @@ public class NullRestrictedTypeOptTests {
 		}
 	}
 
+	/* This test cannot be expressed without lw5 level javac.
+	 * The test will be enabled when tests are migrated to src_lw5.
+	 * https://github.com/eclipse-openj9/openj9/issues/20268
+	 */
 	@Test(enabled = false)
 	static public void testStoreNullValueToNullRestrictedInstanceField() throws Throwable {
 		TestStoreToNullRestrictedField storeFieldObj = new TestStoreToNullRestrictedField();
@@ -379,6 +383,10 @@ public class NullRestrictedTypeOptTests {
 		Assert.fail("Expect a NullPointerException. No exception or wrong kind of exception thrown");
 	}
 
+	/* This test cannot be expressed without lw5 level javac.
+	 * The test will be enabled when tests are migrated to src_lw5.
+	 * https://github.com/eclipse-openj9/openj9/issues/20268
+	 */
 	@Test(enabled = false)
 	static public void testStoreNullValueToNullRestrictedStaticField() throws Throwable {
 		TestStoreToNullRestrictedField.replaceStaticField(new PrimPair(1, 2));
@@ -392,6 +400,10 @@ public class NullRestrictedTypeOptTests {
 		Assert.fail("Expect a NullPointerException. No exception or wrong kind of exception thrown");
 	}
 
+	/* This test cannot be expressed without lw5 level javac.
+	 * The test will be enabled when tests are migrated to src_lw5.
+	 * https://github.com/eclipse-openj9/openj9/issues/20268
+	 */
 	@Test(enabled = false)
 	static public void testWithFieldStoreToNullRestrictedField() throws Throwable {
 		TestWithFieldStoreToNullRestrictedField withFieldObj = new TestWithFieldStoreToNullRestrictedField(new PrimPair(1, 2));

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -1051,7 +1051,7 @@ public class ValueTypeGenerator extends ClassLoader {
 		return generator.defineClass(name, bytes, 0, bytes.length);
 	}
 	
-	public static Class<?> generateIllegalValueClassWithSychMethods(String name, String[] fields) throws Throwable {
+	public static Class<?> generateIllegalValueClassWithSynchMethods(String name, String[] fields) throws Throwable {
 		ClassConfiguration classConfig = new ClassConfiguration(name, fields);
 		classConfig.setHasNonStaticSynchronizedMethods(true);
 		byte[] bytes = generateClass(classConfig);

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -978,19 +978,16 @@ public class ValueTypeTests {
 	}
 
 
-	@Test(enabled=false, priority=2)
-	static public void testSynchMethodsOnValueTypes() throws Throwable {
+	/* The non-static synchronized method case is covered by
+	 * ValueTypeTests.testValueTypeHasSynchMethods.
+	 */
+	@Test(priority=2)
+	static public void testStaticSynchMethodsOnValueTypes() throws Throwable {
 		int x = 1;
 		int y = 1;
 		Object valueType = makePoint2D.invoke(x, y);
-		MethodHandle syncMethod = lookup.findVirtual(point2DClass, "synchronizedMethodReturnInt", MethodType.methodType(int.class));
 		MethodHandle staticSyncMethod = lookup.findStatic(point2DClass, "staticSynchronizedMethodReturnInt", MethodType.methodType(int.class));
-		
-		try {
-			syncMethod.invoke(valueType);
-			Assert.fail("should throw exception. Synchronized methods cannot be used with ValueType");
-		} catch (IllegalMonitorStateException e) {}
-		
+
 		try {
 			staticSyncMethod.invoke();
 		} catch (IllegalMonitorStateException e) {

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -2256,6 +2256,9 @@ public class ValueTypeTests {
 	}
 
 	/*
+	 * Re-enable when CheckedType support is available.
+	 * https://github.com/eclipse-openj9/openj9/issues/19764
+	 *
 	 * Ensure that casting null to a value type class will throw a null pointer exception
 	 * This test is disabled since the latest spec from
 	 * https://cr.openjdk.org/~dlsmith/jep401/jep401-20230519/specs/types-cleanup-jvms.html

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -2796,9 +2796,9 @@ public class ValueTypeTests {
 	}
 
 	@Test(priority=1, expectedExceptions=ClassFormatError.class)
-	static public void testValueTypeHasSychMethods() throws Throwable {
+	static public void testValueTypeHasSynchMethods() throws Throwable {
 		String[] fields = {"longField:J"};
-		Class<?> valueClass = ValueTypeGenerator.generateIllegalValueClassWithSychMethods("testValueTypeHasSychMethods", fields);
+		Class<?> valueClass = ValueTypeGenerator.generateIllegalValueClassWithSynchMethods("testValueTypeHasSynchMethods", fields);
 	}
 
 	@Test(priority = 1)


### PR DESCRIPTION
This change along with https://github.com/eclipse-openj9/openj9/pull/20473 enables all the disabled tests in ValueTypeTests or associates them with an issue. The change includes:
- Commenting that testCheckCastNullRestrictedTypeOnNull will be enabled with https://github.com/eclipse-openj9/openj9/issues/19764
- Correcting the spelling of sych to synch
- Enabling and updating testSynchMethodsOnValueTypes which was not previously associated with an issue. Since the time this tests was disabled it has become illegal to use synchronized methods that are not static. This is tested in testValueTypeHasSynchMethods. This change removes the part of testSynchMethodsOnValueTypes that attempts to verify a synchronized instance method and renames the test to testStaticSynchMethodsOnValueTypes.
- Add a comment to disabled NullRestrictedTypeOptTests explaining that they cannot be enabled until we migrate to lw5 tests.