### PR TITLE
Remove JVM_VirtualThreadHideFrames() from Java 24+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -428,8 +428,12 @@ if(JAVA_SPEC_VERSION LESS 20)
 else()
 	jvm_add_exports(jvm
 		JVM_GetClassFileVersion
-		JVM_VirtualThreadHideFrames
 	)
+	if(JAVA_SPEC_VERSION LESS 24)
+		jvm_add_exports(jvm
+			JVM_VirtualThreadHideFrames
+		)
+	endif()
 endif()
 
 if(NOT JAVA_SPEC_VERSION LESS 21)

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -449,7 +449,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<exports group="jdk20">
 		<!-- Additions for Java 20 (General) -->
 		<export name="JVM_GetClassFileVersion"/>
-		<export name="JVM_VirtualThreadHideFrames"/>
+		<export name="JVM_VirtualThreadHideFrames">
+			<exclude-if condition="spec.java24"/>
+		</export>
 	</exports>
 
 	<exports group="jdk21">

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -584,15 +584,17 @@ JVM_GetClassFileVersion(JNIEnv *env, jclass cls)
 
 	return version;
 }
+#endif /* JAVA_SPEC_VERSION >= 20 */
 
+#if (20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 23)
 JNIEXPORT void JNICALL
 JVM_VirtualThreadHideFrames(
 		JNIEnv *env,
-#if JAVA_SPEC_VERSION >= 23
+#if JAVA_SPEC_VERSION == 23
 		jclass clz,
-#else /* JAVA_SPEC_VERSION >= 23 */
+#else /* JAVA_SPEC_VERSION == 23 */
 		jobject vthread,
-#endif /* JAVA_SPEC_VERSION >= 23 */
+#endif /* JAVA_SPEC_VERSION == 23 */
 		jboolean hide)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
@@ -625,7 +627,7 @@ JVM_VirtualThreadHideFrames(
 
 	vmFuncs->internalExitVMToJNI(currentThread);
 }
-#endif /* JAVA_SPEC_VERSION >= 20 */
+#endif /* (20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 23) */
 
 #if JAVA_SPEC_VERSION >= 21
 JNIEXPORT jboolean JNICALL

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -3849,11 +3849,11 @@ jvmtiHookVmDumpEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void
 }
 
 /**
- * Check if a JVMTI event should be dispatched by checking the flag set by
- * notifyJvmtiHideFrames() and the presence of the JvmtiMountTransition
- * annotation.
+ * Check if a JVMTI event should be dispatched by checking the flag set
+ * by VM_VMHelpers::virtualThreadHideFrames() and the presence of the
+ * JvmtiMountTransition annotation.
  *
- * Note that the method should only be checked for Method Entry and Method Exit event.
+ * Note that the method should only be checked for Method Entry and Method Exit events.
  *
  * @param currentThread the current thread to be checked
  * @param method the method to be checked

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -412,7 +412,7 @@ _IF([JAVA_SPEC_VERSION >= 20],
 	[_X(JVM_GetClassFileVersion, JNICALL, false, jint, JNIEnv *env, jclass cls)])
 _IF([(20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 23)],
 	[_X(JVM_VirtualThreadHideFrames, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
-_IF([JAVA_SPEC_VERSION >= 23],
+_IF([JAVA_SPEC_VERSION == 23],
 	[_X(JVM_VirtualThreadHideFrames, JNICALL, false, void, JNIEnv *env, jclass clz, jboolean hide)])
 _IF([JAVA_SPEC_VERSION >= 21],
 	[_X(JVM_IsForeignLinkerSupported, JNICALL, false, jboolean, void)])


### PR DESCRIPTION
Removed upstream by:
* [8343132: Remove temporary transitions from Virtual thread implementation](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/4f96a8ecd7af92122394cada0c74d8504fe1f4c9)