### PR TITLE
Valhalla still requires JVM_VirtualThreadHideFrames

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -483,5 +483,6 @@ if(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		JVM_IsImplicitlyConstructibleClass
 		JVM_IsNullRestrictedArray
 		JVM_NewNullRestrictedArray
+		JVM_VirtualThreadHideFrames
 	)
 endif()

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -334,6 +334,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<export name="JVM_NewNullRestrictedArray">
 			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
 		</export>
+		<export name="JVM_VirtualThreadHideFrames">
+			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
+		</export>
 	</exports>
 
 	<exports group="jdk11">

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -586,15 +586,15 @@ JVM_GetClassFileVersion(JNIEnv *env, jclass cls)
 }
 #endif /* JAVA_SPEC_VERSION >= 20 */
 
-#if (20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 23)
+#if ((20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 23)) || defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 JNIEXPORT void JNICALL
 JVM_VirtualThreadHideFrames(
 		JNIEnv *env,
-#if JAVA_SPEC_VERSION == 23
+#if (JAVA_SPEC_VERSION == 23) || defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		jclass clz,
-#else /* JAVA_SPEC_VERSION == 23 */
+#else /* (JAVA_SPEC_VERSION == 23) || defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		jobject vthread,
-#endif /* JAVA_SPEC_VERSION == 23 */
+#endif /* (JAVA_SPEC_VERSION == 23) || defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		jboolean hide)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
@@ -627,7 +627,7 @@ JVM_VirtualThreadHideFrames(
 
 	vmFuncs->internalExitVMToJNI(currentThread);
 }
-#endif /* (20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 23) */
+#endif /* ((20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION <= 23)) || defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 #if JAVA_SPEC_VERSION >= 21
 JNIEXPORT jboolean JNICALL

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -412,7 +412,7 @@ _IF([JAVA_SPEC_VERSION >= 20],
 	[_X(JVM_GetClassFileVersion, JNICALL, false, jint, JNIEnv *env, jclass cls)])
 _IF([(20 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 23)],
 	[_X(JVM_VirtualThreadHideFrames, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
-_IF([JAVA_SPEC_VERSION == 23],
+_IF([(JAVA_SPEC_VERSION == 23) || defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_VirtualThreadHideFrames, JNICALL, false, void, JNIEnv *env, jclass clz, jboolean hide)])
 _IF([JAVA_SPEC_VERSION >= 21],
 	[_X(JVM_IsForeignLinkerSupported, JNICALL, false, jboolean, void)])


### PR DESCRIPTION
Valhalla still requires `JVM_VirtualThreadHideFrames`

Valhalla extension repo is behind OpenJDK latest update, and still requires `JVM_VirtualThreadHideFrames`.

This addresses [JDKnext_x86-64_linux_valhalla_Nightly](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Build_JDKnext_x86-64_linux_valhalla_Nightly/1589/consoleFull) compilation failure:
```
20:29:57  /usr/local/gcc11/lib/gcc/x86_64-pc-linux-gnu/11.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/build/linux-x86_64-server-release/support/native/java.base/libjava/VirtualThread.o:(.data.rel+0x70): undefined reference to `JVM_VirtualThreadHideFrames'
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>