### PR TITLE
Clean up references to old opcodes

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -7397,7 +7397,7 @@ J9::ARM64::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node *node, boo
             {
             needExplicitCheck = false;
 
-            // If the child is an arraylength which has been reduced to an iiload,
+            // If the child is an arraylength which has been reduced to an iloadi,
             // and is only going to be used immediately in a BNDCHK, combine the checks.
             //
             TR::TreeTop *nextTreeTop = cg->getCurrentEvaluationTreeTop()->getNextTreeTop();
@@ -7808,7 +7808,7 @@ J9::ARM64::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node, TR::CodeGe
       TR_ASSERT(
             arrayLengthChild->getOpCode().isConversion() || arrayLengthChild->getOpCodeValue() == TR::iloadi || arrayLengthChild->getOpCodeValue() == TR::iload
                   || arrayLengthChild->getOpCodeValue() == TR::iRegLoad || arrayLengthChild->getOpCode().isLoadConst(),
-            "Expecting array length child under BNDCHKwithSpineCHK to be a conversion, iiload, iload, iRegLoad or iconst");
+            "Expecting array length child under BNDCHKwithSpineCHK to be a conversion, iloadi, iload, iRegLoad or iconst");
 
       arrayLengthReg = arrayLengthChild->getRegister();
 

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -257,11 +257,11 @@ J9::CodeGenerator::lowerCompressedRefs(
     and compression:
     compress = actual - heap_base
 
-    iaload f      l2a
+    aloadi f      l2a
       aload O       ladd
                       lshl
                         i2l
-                          iiload f
+                          iloadi f
                             aload O
                         iconst shftKonst
                       lconst HB
@@ -269,11 +269,11 @@ J9::CodeGenerator::lowerCompressedRefs(
     -or- if the field is known to be null
     l2a
       i2l
-        iiload f
+        iloadi f
           aload O
 
 
-    iastore f     iistore f
+    astorei f     istorei f
       aload O       aload O
       value         l2i
                       lshr
@@ -284,7 +284,7 @@ J9::CodeGenerator::lowerCompressedRefs(
                         iconst shftKonst
 
     -or- if the field is known to be null
-    iistore f
+    istorei f
       aload O
       l2i
         a2l      <- nop on most platforms
@@ -297,16 +297,16 @@ J9::CodeGenerator::lowerCompressedRefs(
     compress = actual - heapBase + shadowBase = actual + disp
     actual = compress - disp
 
-    iaload f     i2a
+    aloadi f     i2a
        aload O      isub
-                      iiload f
+                      iloadi f
                        aload O
                       iconst HB
 
-    iastore f    iistore f
+    astorei f    istorei f
        aload O      aload O
                    iushr            // iushr only there to distinguish between
-                     iadd           // real iistores with iadds as the value
+                     iadd           // real istoreis with iadds as the value
                        a2i
                          value
                        iconst HB

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7537,10 +7537,10 @@ TR_J9VM::transformJavaLangClassIsArrayOrIsPrimitive(TR::Compilation * comp, TR::
    //   i2b                      <= callNode
    //     ishr                   <= shiftNode
    //       iand                 <= andNode
-   //         iiload             <= isArrayField
-   //           iaload
+   //         iloadi             <= isArrayField
+   //           aloadi
    // if (generateClassesOnHeap())
-   //             iaload
+   //             aloadi
    // endif
    //               aload <parm 1> <= vftField
    //         iconst <andMask>   <= andConstNode

--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -2789,7 +2789,7 @@ TR_CISCTransformer::renumberDagId(TR_CISCGraph *graph, int32_t tempMaxDagId, int
    //  2L isub        [] [40 41]
    //  2L aiadd       [] [39 42]
    //  0L bconst 1    [] []
-   //  2L ibstore     [] [43 44]
+   //  2L bstorei     [] [43 44]
    //  2L iadd        [] [40 22]
    //  2L istore      [] [46 4]
    //  2L ificmpge    [] [4 6]

--- a/runtime/compiler/optimizer/IdiomRecognition.hpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.hpp
@@ -66,15 +66,15 @@ typedef enum
    TR_ahconst,          // constant for array header
    TR_variableORconst,
    TR_quasiConst,       // Currently, variable or constant or arraylength
-   TR_quasiConst2,      // Currently, variable or constant, arraylength, or *iiload* (for non-array)
-                        // We shouldn't use it in an idiom including iistore to *non-array* variable.
+   TR_quasiConst2,      // Currently, variable or constant, arraylength, or *iloadi* (for non-array)
+                        // We shouldn't use it in an idiom including istorei to *non-array* variable.
    TR_iaddORisub,       // addition or subtraction
    TR_conversion,       // all data conversions, such as b2i, c2i, i2l, ...
    TR_ifcmpall,         // all if instructions
    TR_ishrall,          // ishr and iushr
    TR_bitop1,           // AND, OR, and XOR
    TR_arrayindex,       // variable or addition
-   TR_arraybase,        // variable or iaload
+   TR_arraybase,        // variable or aloadi
    TR_inbload,          // indirect non-byte load
    TR_inbstore,         // indirect non-byte store
    TR_indload,          // indirect load

--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -747,7 +747,7 @@ IANDSpecialNodeTransformer(TR_CISCTransformer *trans)
 static void
 findIndexLoad(TR::Node *aiaddNode, TR::Node *&index1, TR::Node *&index2, TR::Node *&topLevelIndex)
    {
-   // iiload
+   // iloadi
    //      aiadd              <-- aiaddNode
    //           aload
    //           isub
@@ -757,7 +757,7 @@ findIndexLoad(TR::Node *aiaddNode, TR::Node *&index1, TR::Node *&index2, TR::Nod
    //              iconst -16
    //
    // -or-
-   // iiload
+   // iloadi
    //      aiadd
    //           aload
    //           isub
@@ -765,7 +765,7 @@ findIndexLoad(TR::Node *aiaddNode, TR::Node *&index1, TR::Node *&index2, TR::Nod
    //              iconst
    //
    // -or-
-   // iiload
+   // iloadi
    //      aiadd              <-- aiaddNode
    //           aload
    //           isub
@@ -777,7 +777,7 @@ findIndexLoad(TR::Node *aiaddNode, TR::Node *&index1, TR::Node *&index2, TR::Nod
    //              iconst -16
    //
    // -or-
-   // iiload
+   // iloadi
    //      aiadd
    //           aload
    //           isub
@@ -1348,7 +1348,7 @@ checkByteToChar(TR::Compilation *comp, TR::Node *iorNode, TR::Node *&inputNode, 
    //   ior
    //     imul
    //        bu2i
-   //          ibload #261  Shadow[<array-shadow>]
+   //          bloadi #261  Shadow[<array-shadow>]
    //            aiadd   <flags:"0x8000" (internalPtr )/>
    //              aload #523  Auto[<temp slot 10>]
    //              isub
@@ -1356,7 +1356,7 @@ checkByteToChar(TR::Compilation *comp, TR::Node *iorNode, TR::Node *&inputNode, 
    //                iconst -17
    //        iconst 256
    //      bu2i
-   //        ibload #261  Shadow[<array-shadow>]
+   //        bloadi #261  Shadow[<array-shadow>]
    //          aiadd   <flags:"0x8000" (internalPtr )/>
    //            ==>aload at #523
    //            isub
@@ -1384,10 +1384,10 @@ checkByteToChar(TR::Compilation *comp, TR::Node *iorNode, TR::Node *&inputNode, 
       {
       // find the index to be either i, i+1
       // if (le)
-      //       if index is i+1 then inputNode = other ibload of the ior
+      //       if index is i+1 then inputNode = other bloadi of the ior
       //       else fail
       // if (be)
-      //       if index is i then inputNode = ibload child of imul
+      //       if index is i then inputNode = bloadi child of imul
       //       else fail
       //
       TR::Node *ibloadNode = imulNode->getFirstChild()->skipConversions();
@@ -5825,7 +5825,7 @@ namespace
 //        ImportantNode(1) - array store
 //        ImportantNode(2) - the size of elements (NULL for the byte array)
 //        ImportantNode(3) - exit if node
-//        ImportantNode(4) - optional iistore
+//        ImportantNode(4) - optional istorei
 //*****************************************************************************************
 static bool
 CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR::Node *dstIndexRepNode,

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1366,19 +1366,19 @@ The functions used to construct the trees for all the cases outlined above are a
 Note that in case (2), i.e., when the conversion is needed, we generate code like the
 following for the "direct access with conversion" for Unsafe.getByte
     b2i
-      ibload
+      bloadi
         aiadd
 while the direct access code looks like
-    iiload
+    iloadi
       aiadd
-We will replace b2i and ibload by c2iu and icload for Unsafe.getChar, by
-s2i and isload for Unsafe.getShort, and by bu2i and ibload for Unsafe.getBoolean
+We will replace b2i and bloadi by c2iu and icload for Unsafe.getChar, by
+s2i and isload for Unsafe.getShort, and by bu2i and bloadi for Unsafe.getBoolean
 
 For Unsafe.putByte and Unsafe.putBoolean, we generate
-   ibstore
+   bstorei
      i2b
        <some load node>
-We replace i2b and ibstore by i2c and icstore for Unsafe.getChar, and by i2s and isstore for
+We replace i2b and bstorei by i2c and icstore for Unsafe.getChar, and by i2s and isstore for
 Unsafe.getShort.
 */
 

--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -748,7 +748,7 @@ J9::Simplifier::simplifyiOrPatterns(TR::Node *node)
    //   ior
    //     imul
    //       bu2i
-   //         ibload #245[0x107AF564] Shadow[<Unsafe shadow sym>]
+   //         bloadi #245[0x107AF564] Shadow[<Unsafe shadow sym>]
    //           isub
    //             l2i
    //               lload #202[0x107A1050] Parm[<parm 1 J>]
@@ -757,20 +757,20 @@ J9::Simplifier::simplifyiOrPatterns(TR::Node *node)
    //     ior
    //       imul
    //         bu2i
-   //           ibload #245[0x107AF564] Shadow[<Unsafe shadow sym>]
+   //           bloadi #245[0x107AF564] Shadow[<Unsafe shadow sym>]
    //             isub
    //               ==>l2i at [0x107AE8F4]
    //               iconst -3
    //         iconst 16777216
    //       imul
    //         bu2i
-   //           ibload #245[0x107AF564] Shadow[<Unsafe shadow sym>]
+   //           bloadi #245[0x107AF564] Shadow[<Unsafe shadow sym>]
    //             isub
    //               ==>l2i at [0x107AE8F4]
    //               iconst -2
    //         iconst 65536
    //   bu2i
-   //     ibload #245[0x107AF564] Shadow[<Unsafe shadow sym>]
+   //     bloadi #245[0x107AF564] Shadow[<Unsafe shadow sym>]
    //       ==>l2i at [0x107AE8F4]
    //
 
@@ -792,7 +792,7 @@ J9::Simplifier::simplifyiOrPatterns(TR::Node *node)
       if ((addr = getUnsafeBaseAddr(byte2, -1)) && addr == byte1 &&
           (addr = getUnsafeBaseAddr(byte3, -2)) && addr == byte1 &&
           (addr = getUnsafeBaseAddr(byte4, -3)) && addr == byte1 &&
-          performTransformation(comp(), "%sconvert ior to iiload node [" POINTER_PRINTF_FORMAT "]\n", optDetailString(), node))
+          performTransformation(comp(), "%sconvert ior to iloadi node [" POINTER_PRINTF_FORMAT "]\n", optDetailString(), node))
          {
          TR::Node::recreate(node, TR::iloadi);
          node->setNumChildren(1);
@@ -986,11 +986,11 @@ J9::Simplifier::getOrOfTwoConsecutiveBytes(TR::Node * ior)
    // ior
    //   imul
    //     b2i
-   //       ibload #231[0x10D06670] Shadow[unknown field]
+   //       bloadi #231[0x10D06670] Shadow[unknown field]
    //         address
    //     iconst 256
    //   bu2i
-   //     ibload #231[0x10D06670] Shadow[unknown field]
+   //     bloadi #231[0x10D06670] Shadow[unknown field]
    //       isub
    //         ==>address
    //         iconst -1
@@ -999,13 +999,13 @@ J9::Simplifier::getOrOfTwoConsecutiveBytes(TR::Node * ior)
    // ior
    //   imul
    //     b2i
-   //       ibload #231[0x10D06670] Shadow[unknown field]
+   //       bloadi #231[0x10D06670] Shadow[unknown field]
    //         isub
    //           address
    //           iconst -1
    //     iconst 256
    //   bu2i
-   //     ibload #231[0x10D06670] Shadow[unknown field]
+   //     bloadi #231[0x10D06670] Shadow[unknown field]
    //       ==>address
    //
    TR::Node *byte1, *byte2, *temp, *addr;

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1866,7 +1866,7 @@ TR::Node* TR_arraycopySequentialStores::constValNode()
 // Transform a set of sequential stores into increasing storage from an integral type into
 // an arraycopy call
 // Order varies depending if on Big Endian or Little Endian target hardware
-// ibstore <array element>
+// bstorei <array element>
 //   aiadd
 //     aload <arr>
 //     isub
@@ -1939,7 +1939,7 @@ static TR::TreeTop* generateArraycopyFromSequentialStores(TR::Compilation* comp,
    symRef->setOffset(arraycopy.getTreeTop()->getNode()->getSymbolReference()->getOffset());
 
    //
-   // delete the ibstore trees and replace them with a new, improved iXstore tree
+   // delete the bstorei trees and replace them with a new, improved iXstore tree
    //
    arraycopy.removeTrees(symRef);
 
@@ -3229,7 +3229,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
    //traceMsg(comp, " First store in sequence %p Load Ref:%p Number of bytes: %d. Offset range:%d to %d. Byte Value:%d\n", istoreNode, arrayset.getALoadRef(), numBytes, arrayset.getBaseOffset(), arrayset.getBaseOffset() + numBytes - 1, arrayset.getConstant());
 
    //
-   // break the iistore trees into tree_tops of the aload and const
+   // break the istorei trees into tree_tops of the aload and const
    // so that it can be subsequently deleted by simplifier phase
    //
    TR_arraysetSequentialStores arraysetUpdate = TR_arraysetSequentialStores(comp);
@@ -3324,7 +3324,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
       TR::Node *topNode = TR::Node::create(TR::treetop, 1, arraysetNode);
       arraysetTreeTop = TR::TreeTop::create(comp, topNode);
 
-      // delete all the old iistore trees by eliminating them from the tree list
+      // delete all the old istorei trees by eliminating them from the tree list
       prevTreeTop->join(arraysetTreeTop);
       arraysetTreeTop->join(curTreeTop);
       }
@@ -3332,7 +3332,7 @@ static TR::TreeTop* generateArraysetFromSequentialStores(TR::Compilation* comp, 
       {
       TR_ASSERT((numBytes <= 8), "Number of bytes is more than expected\n");
       //
-      // delete the ibstore trees and replace them with a new, improved iXstore tree
+      // delete the bstorei trees and replace them with a new, improved iXstore tree
       //
       //dumpOptDetails(comp, " Remove trees %p to %p\n", istoreTreeTop->getNode(), curTreeTop->getNode());
       //TR::TreeTop::removeDeadTrees(comp, istoreTreeTop, curTreeTop);
@@ -4108,7 +4108,7 @@ TR_SequentialStoreSimplifier::optDetailString() const throw()
 /*
  * Seen in atmstac0.cbl after removing the reassociation opts from Simplifier:
  *
- * [0x2A0A5874]   ibstore #182[id=42:"WS-ATM-ACCT-ENTRY-USED-F"][0x29201614]  Shadow[<refined-array-shadow>] <intPrec=2>
+ * [0x2A0A5874]   bstorei #182[id=42:"WS-ATM-ACCT-ENTRY-USED-F"][0x29201614]  Shadow[<refined-array-shadow>] <intPrec=2>
  *                  ==>aiadd at [0x2A0A561C]
  * [0x2A0A58B4]     buconst -16 <intPrec=2>    <flags:"0x204" (X!=0 X<=0 )/>
  * [0x2A0A5A94]   astore #201[id=305:"Subscr-AddrTemp"][0x2A08552C]  Auto[<auto slot 84>]

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -2603,7 +2603,7 @@ TR::Register *J9::Power::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *no
       TR_ASSERT(
             arrayLengthChild->getOpCode().isConversion() || arrayLengthChild->getOpCodeValue() == TR::iloadi || arrayLengthChild->getOpCodeValue() == TR::iload
                   || arrayLengthChild->getOpCodeValue() == TR::iRegLoad || arrayLengthChild->getOpCode().isLoadConst(),
-            "Expecting array length child under BNDCHKwithSpineCHK to be a conversion, iiload, iload, iRegLoad or iconst");
+            "Expecting array length child under BNDCHKwithSpineCHK to be a conversion, iloadi, iload, iRegLoad or iconst");
 
       TR::Register *condReg = srm->findOrCreateScratchRegister(TR_CCR);
 
@@ -6963,7 +6963,7 @@ static bool simpleReadMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::Node *o
    // look for the special case of a read monitor sequence that protects
    // a single fixed-point load, ie:
    //   monenter (object)
-   //   a simple form of iaload or iiload
+   //   a simple form of aloadi or iloadi
    //   monexit (object)
 
    // note: before we make the following checks it is important that the
@@ -7026,8 +7026,8 @@ static bool simpleReadMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::Node *o
       return false;
       }
    // possible TODO: expand the complexity of loads we can handle
-   // iaload and iiload are indirect and have a child
-   // if we don't need to evaluate that child then the iaload or iiload
+   // aloadi and iloadi are indirect and have a child
+   // if we don't need to evaluate that child then the aloadi or iloadi
    // consists of a single hardware instruction and satisfies our current
    // constraint of simple
    if (!nextTopNode->getFirstChild()->getRegister())
@@ -7152,7 +7152,7 @@ static bool simpleReadMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::Node *o
    TR::addDependency(conditions, offsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
    TR::addDependency(conditions, cndReg, TR::RealRegister::cr0, TR_CCR, cg);
 
-   // the following code is derived from the iaload and iiload evaluators
+   // the following code is derived from the aloadi and iloadi evaluators
    TR::Register *loadResultReg;
    OMR::Power::NodeMemoryReference tempMR;
    if (nextTopNode->getOpCodeValue() == TR::aloadi)
@@ -7184,7 +7184,7 @@ static bool simpleReadMonitor(TR::Node *node, TR::CodeGenerator *cg, TR::Node *o
       tempMR = TR::LoadStoreHandler::generateSimpleLoadMemoryReference(cg, nextTopNode, 4);
       loadOpCode = TR::InstOpCode::lwz;
       }
-   // end of code derived from the iaload and iiload evaluators
+   // end of code derived from the aloadi and iloadi evaluators
 
    TR::addDependency(conditions, loadResultReg, TR::RealRegister::NoReg, TR_GPR, cg);
    if (tempMR.getMemoryReference()->getBaseRegister() != objReg)

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -2149,7 +2149,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(
          {
          needExplicitCheck = false;
 
-         // If the child is an arraylength which has been reduced to an iiload,
+         // If the child is an arraylength which has been reduced to an iloadi,
          // and is only going to be used immediately in a bound check then combine the checks.
          //
          TR::TreeTop *nextTreeTop = cg->getCurrentEvaluationTreeTop()->getNextTreeTop();
@@ -2210,7 +2210,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(
          //
          needLateEvaluation = false;
 
-         // at this point, firstChild is the raw iiload (created by lowerTrees) and
+         // at this point, firstChild is the raw iloadi (created by lowerTrees) and
          // reference is the aload of the object. node->getFirstChild is the
          // l2a sequence; as a result, firstChild's refCount will always be 1
          // and node->getFirstChild's refCount will be at least 2 (one under the nullchk

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -388,17 +388,17 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
       // Looking for trees that look like this:
 
       // BNDCHK / BNDCHKwithSpineCHK
-      //   iiload
+      //   iloadi
       //     ==>aRegLoad
-      //   iiload
+      //   iloadi
       //     ==>aRegLoad
 
-      // iaload
+      // aloadi
       //   aiadd    <=====  You are here
       //     ==>aRegLoad
       //     isub
       //       imul   <=== Find this node and anchor it up above the BNDCHK
-      //         ==>iiload
+      //         ==>iloadi
       //         iconst 4
       //       iconst -16
 
@@ -423,7 +423,7 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
          {
          // The general tree that we are matching is:
          //  aladd        <=====  You are here
-         //    ==>iaload
+         //    ==>aloadi
          //    lsub
          //      lmul     <=====  Find this node and anchor it up above the ArrayStoreCHK
          //        i2l
@@ -433,7 +433,7 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
          //  arrayheader isub/lsub, we will see a tree as such:
          //
          //  aladd (internal ptr)       <=====  You are here
-         //    ==>iaload
+         //    ==>aloadi
          //    lshl     <=====  Find this node and anchor it up above the ArrayStoreCHK
          //      i2l
          //        ==>iRegLoad
@@ -460,7 +460,7 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
          {
          // The general tree that we are matching is:
          //  aladd        <=====  You are here
-         //    ==>iaload
+         //    ==>aloadi
          //    lsub
          //      lmul     <=====  Find this node and anchor it up above the BNDCHK
          //        i2l
@@ -470,7 +470,7 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
          //  arrayheader isub/lsub, we will see a tree as such:
          //
          //  aladd (internal ptr)       <=====  You are here
-         //    ==>iaload
+         //    ==>aloadi
          //    lshl     <=====  Find this node and anchor it up above the BNDCHK
          //      i2l
          //        ==>iRegLoad
@@ -512,7 +512,7 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
 
    // J9, Z
    //
-   // On zseries, convert aconst to iaload of aconst 0 and move it to its own new treetop
+   // On zseries, convert aconst to aloadi of aconst 0 and move it to its own new treetop
    if (comp->target().cpu.isZ() && !self()->profiledPointersRequireRelocation() &&
          node->getOpCodeValue() == TR::aconst && node->isClassUnloadingConst())
       {

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -278,8 +278,8 @@ TR::UnresolvedDataSnippet *
 J9::Z::MemoryReference::createUnresolvedDataSnippetForiaload(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore)
    {
    // Have to catch the case where, on first glance, a putstatic looks
-   // like a 'read' since the unresolved ref is on the iaload, not the
-   // iistore. The 'right' fix is to set a bit on the sym instead
+   // like a 'read' since the unresolved ref is on the aloadi, not the
+   // istorei. The 'right' fix is to set a bit on the sym instead
    //
    TR::Node * rootNode = cg->getCurrentEvaluationTreeTop()->getNode();
    if (rootNode->getOpCode().isResolveCheck() &&

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -5217,7 +5217,7 @@ J9::Z::TreeEvaluator::DIVCHKEvaluator(TR::Node * node, TR::CodeGenerator * cg)
       // [0x000002000752262c] (  1)      iand   <flags:"0x1100" (X>=0 cannotOverflow )/>
       //                      (  3)        ==>icall at [0x00000200075223f8] (in GPR_0049)   <flags:"0x30" (arithmeticPreference invalid8BitGlobalRegister)/>
       // [0x00000200075225f4] (  1)        iconst 0x7fffffff   <flags:"0x104" (X!=0 X>=0 )/>
-      // [0x00000200075228cc] (  1)      iiload #251[0x000002000745c940]+12  Shadow[<array-size>]   <flags:"0x1100" (X>=0 cannotOverflow )/>
+      // [0x00000200075228cc] (  1)      iloadi #251[0x000002000745c940]+12  Shadow[<array-size>]   <flags:"0x1100" (X>=0 cannotOverflow )/>
       // [0x00000200074665d0] (  1)        l2a
       // [0x000002000745c908] (  1)          lshl   <flags:"0x800" (compressionSequence )/>
       //                      (  2)            ==>iu2l at [0x000002000745c8d0] (in GPR_0072)   <flags:"0x4" (X!=0 )/>
@@ -7613,7 +7613,7 @@ J9::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node * node, bool n
 
    // NULLCHK has a special case with compressed pointers.
    // In the scenario where the first child is TR::l2a, the
-   // node to be null checked is not the iiload, but its child.
+   // node to be null checked is not the iloadi, but its child.
    // i.e. aload, aRegLoad, etc.
    if (comp->useCompressedPointers()
          && firstChild->getOpCodeValue() == TR::l2a)
@@ -7672,7 +7672,7 @@ J9::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node * node, bool n
             // the generation of the explicit check below.
             needLateEvaluation = false;
 
-            // at this point, n is the raw iiload (created by lowerTrees) and
+            // at this point, n is the raw iloadi (created by lowerTrees) and
             // reference is the aload of the object. node->getFirstChild is the
             // l2a sequence; as a result, n's refCount will always be 1
             // and node->getFirstChild's refCount will be at least 2 (one under the nullchk
@@ -7690,7 +7690,7 @@ J9::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node * node, bool n
             {
             needExplicitCheck = false;
 
-            // If the child is an arraylength which has been reduced to an iiload,
+            // If the child is an arraylength which has been reduced to an iloadi,
             // and is only going to be used immediately in a BNDCHK, combine the checks.
             //
             TR::TreeTop *nextTreeTop = cg->getCurrentEvaluationTreeTop()->getNextTreeTop();


### PR DESCRIPTION
The old opcodes had the letter i as a prefix if the operation was indirect. Those opcodes were renamed to use the letter as a suffix instead.

This commit cleans up the references to the old opcodes, iiload/iistore ilload/ilstore iaload/iastore ibload/ibstore, to iloadi/istorei lloadi/lstorei aloadi/astorei bloadi/bstorei in the code comments and trace messages

Related: eclipse-openj9/openj9#19489