### PR TITLE
Add flag isVirtualLargeObjectHeapEnabled in J9VMThread and J9JavaVM

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2962,6 +2962,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 #if defined(J9VM_ENV_DATA64)
 	vm->isIndexableDualHeaderShapeEnabled = TRUE;
 	vm->isIndexableDataAddrPresent = FALSE;
+	vm->isVirtualLargeObjectHeapEnabled = FALSE;
 #endif /* defined(J9VM_ENV_DATA64) */
 
 	/* enable estimateFragmentation for all GCs as default for java, but not the estimated result would not affect concurrentgc kickoff by default */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5480,6 +5480,7 @@ typedef struct J9VMThread {
 	UDATA discontiguousIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
 	UDATA isIndexableDataAddrPresent;
+	BOOLEAN isVirtualLargeObjectHeapEnabled;
 #endif /* defined(J9VM_ENV_DATA64) */
 	void* gpInfo;
 	void* jitVMwithThreadInfo;
@@ -6033,6 +6034,7 @@ typedef struct J9JavaVM {
 	UDATA discontiguousIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
 	UDATA isIndexableDataAddrPresent;
+	BOOLEAN isVirtualLargeObjectHeapEnabled;
 	BOOLEAN isIndexableDualHeaderShapeEnabled;
 #endif /* defined(J9VM_ENV_DATA64) */
 	struct J9VMThread* exclusiveVMAccessQueueHead;

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -197,6 +197,7 @@ allocateVMThread(J9JavaVM *vm, omrthread_t osThread, UDATA privateFlags, void *m
 	newThread->unsafeIndexableHeaderSize = vm->unsafeIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
 	newThread->isIndexableDataAddrPresent = vm->isIndexableDataAddrPresent;
+	newThread->isVirtualLargeObjectHeapEnabled = vm->isVirtualLargeObjectHeapEnabled;
 #endif /* defined(J9VM_ENV_DATA64) */
 
 	newThread->privateFlags = privateFlags;


### PR DESCRIPTION
 - cache flag isVirtualLargeObjectHeapEnabled in both J9VMThread and J9JavaVM.
 - initialize both isVirtualLargeObjectHeapEnabled flags.