### PR TITLE
Prevent repeated comp requests when code caches are full

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -457,7 +457,8 @@ public:
    static bool canRelocateMethod(TR::Compilation * comp);
    static int computeCompilationThreadPriority(J9JavaVM *vm);
    static void *compilationEnd(J9VMThread *context, TR::IlGeneratorMethodDetails & details, J9JITConfig *jitConfig, void * startPC,
-                               void *oldStartPC, TR_FrontEnd *vm=0, TR_MethodToBeCompiled *entry=NULL, TR::Compilation *comp=NULL);
+                               void *oldStartPC, bool preventFutureMethodCountingOnFailure = true, TR_FrontEnd *vm=0,
+                               TR_MethodToBeCompiled *entry=NULL, TR::Compilation *comp=NULL);
 #if defined(J9VM_OPT_JITSERVER)
    static JITServer::ServerStream *getStream();
 #endif /* defined(J9VM_OPT_JITSERVER) */


### PR DESCRIPTION
For large applications, the code caches can become full, preventing further JIT compilation. Compilation requests issued by the invocation counting mechanism of the interpreter will be rejected early by the JIT, before having the chance of being queued for compilation. Ideally, once a method has been rejected once, it will not be sent again for compilation. Currently this is not happening due to the circumstances described in https://github.com/eclipse-openj9/openj9/issues/20448

This commit will prevent an interpreted method to be sent repeatedly for JIT compilation if compilation is disabled (because of code/data caches becoming full or because of a user specified command line option).

Fixes: https://github.com/eclipse-openj9/openj9/issues/20448