### PR TITLE
Track loaded classes with valid class chains

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -292,6 +292,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/control/rossa.cpp \
     compiler/env/ClassLoaderTable.cpp \
     compiler/env/CpuUtilization.cpp \
+    compiler/env/DependencyTable.cpp \
     compiler/env/FilePointer.cpp \
     compiler/env/J2IThunk.cpp \
     compiler/env/J9ArithEnv.cpp \

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -393,7 +393,9 @@ const char * J9::Options::_externalOptionStrings[J9::ExternalOptions::TR_NumExte
    "-XX:+JITServerHealthProbes",          // = 74
    "-XX:-JITServerHealthProbes",          // = 75
    "-XX:JITServerHealthProbePort=",       // = 76
-   // TR_NumExternalOptions                  = 77
+   "-XX:+TrackAOTDependencies",           // = 77
+   "-XX:-TrackAOTDependencies"            // = 78
+   // TR_NumExternalOptions                  = 79
    };
 
 //************************************************************************
@@ -2601,6 +2603,13 @@ J9::Options::fePreProcess(void * base)
          {
          compInfo->getPersistentInfo()->setLateSCCDisclaimTime(((uint64_t) disclaimMs) * 1000000);
          }
+      }
+
+   int32_t xxEnableTrackAOTDependenciesArgIndex  = FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXplusTrackAOTDependencies], 0);
+   int32_t xxDisableTrackAOTDependenciesArgIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, J9::Options::_externalOptionStrings[J9::ExternalOptions::XXminusTrackAOTDependencies], 0);
+   if (xxEnableTrackAOTDependenciesArgIndex > xxDisableTrackAOTDependenciesArgIndex)
+      {
+      compInfo->getPersistentInfo()->setTrackAOTDependencies(true);
       }
 
   /* Using traps on z/OS for NullPointerException and ArrayIndexOutOfBound checks instead of the

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -130,7 +130,9 @@ enum ExternalOptions
    XXplusHealthProbes                          = 74,
    XXminusHealthProbes                         = 75,
    XXJITServerHealthProbePortOption            = 76,
-   TR_NumExternalOptions                       = 77
+   XXplusTrackAOTDependencies                  = 77,
+   XXminusTrackAOTDependencies                 = 78,
+   TR_NumExternalOptions                       = 79
    };
 
 class OMR_EXTENSIBLE Options : public OMR::OptionsConnector

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -180,6 +180,8 @@ J9::OptionsPostRestore::iterateOverExternalOptions()
          case J9::ExternalOptions::XXplusHealthProbes:
          case J9::ExternalOptions::XXminusHealthProbes:
          case J9::ExternalOptions::XXJITServerHealthProbePortOption:
+         case J9::ExternalOptions::XXplusTrackAOTDependencies:
+         case J9::ExternalOptions::XXminusTrackAOTDependencies:
             {
             // do nothing, consume them to prevent errors
             FIND_AND_CONSUME_RESTORE_ARG(OPTIONAL_LIST_MATCH, optString, 0);

--- a/runtime/compiler/env/CMakeLists.txt
+++ b/runtime/compiler/env/CMakeLists.txt
@@ -31,6 +31,7 @@ j9jit_files(
 	env/CHTable.cpp
 	env/ClassLoaderTable.cpp
 	env/CpuUtilization.cpp
+	env/DependencyTable.cpp
 	env/FilePointer.cpp
 	env/J2IThunk.cpp
 	env/J9ArithEnv.cpp
@@ -68,4 +69,3 @@ if(J9VM_OPT_JITSERVER)
 		env/VMJ9Server.cpp
 	)
 endif()
-

--- a/runtime/compiler/env/DependencyTable.cpp
+++ b/runtime/compiler/env/DependencyTable.cpp
@@ -1,0 +1,232 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+
+#include "control/CompilationThread.hpp"
+#include "env/DependencyTable.hpp"
+#include "env/J9SharedCache.hpp"
+#include "env/PersistentCHTable.hpp"
+
+#if !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
+
+TR_AOTDependencyTable::TR_AOTDependencyTable(TR_J9SharedCache *sharedCache) :
+   _isActive(true),
+   _sharedCache(sharedCache),
+   _tableMonitor(TR::Monitor::create("JIT-AOTDependencyTableMonitor")),
+   _offsetMap(decltype(_offsetMap)::allocator_type(TR::Compiler->persistentAllocator()))
+   { }
+
+void
+TR_AOTDependencyTable::classLoadEvent(TR_OpaqueClassBlock *clazz, bool isClassLoad, bool isClassInitialization)
+   {
+   auto ramClass = (J9Class *)clazz;
+
+   uintptr_t classOffset = TR_SharedCache::INVALID_ROM_CLASS_OFFSET;
+   if (!_sharedCache->isClassInSharedCache(clazz, &classOffset))
+      return;
+
+   // We only need to check if clazz matches its cached version on load; on
+   // initialization, it will be in the _offsetMap if it did match.
+   if (isClassLoad && !_sharedCache->classMatchesCachedVersion(ramClass, NULL))
+      return;
+
+   OMR::CriticalSection cs(_tableMonitor);
+   if (!isActive())
+      return;
+
+   try
+      {
+      classLoadEventAtOffset(ramClass, classOffset, isClassLoad, isClassInitialization);
+      }
+   catch (std::exception&)
+      {
+      deactivateTable();
+      }
+   }
+
+void
+TR_AOTDependencyTable::classLoadEventAtOffset(J9Class *ramClass, uintptr_t offset, bool isClassLoad, bool isClassInitialization)
+   {
+   auto entry = getOffsetEntry(offset, isClassLoad);
+   TR_ASSERT(entry || !isClassLoad, "Class %p offset %lu initialized without loading");
+
+   if (isClassLoad)
+      entry->_loadedClasses.insert(ramClass);
+   }
+
+OffsetEntry *
+TR_AOTDependencyTable::getOffsetEntry(uintptr_t offset, bool create)
+   {
+   auto it = _offsetMap.find(offset);
+   if (it != _offsetMap.end())
+      return &it->second;
+
+   if (create)
+      {
+      PersistentUnorderedSet<J9Class *> loadedClasses(PersistentUnorderedSet<J9Class *>::allocator_type(TR::Compiler->persistentAllocator()));
+      return &(*_offsetMap.insert(it, {offset, {loadedClasses}})).second;
+      }
+
+   return NULL;
+   }
+
+void
+TR_AOTDependencyTable::invalidateUnloadedClass(TR_OpaqueClassBlock *clazz)
+   {
+   uintptr_t classOffset = TR_SharedCache::INVALID_ROM_CLASS_OFFSET;
+   if (!_sharedCache->isClassInSharedCache(clazz, &classOffset))
+      return;
+
+
+   OMR::CriticalSection cs(_tableMonitor);
+   if (!isActive())
+      return;
+
+   invalidateClassAtOffset((J9Class *)clazz, classOffset);
+   }
+
+bool
+TR_AOTDependencyTable::invalidateClassAtOffset(J9Class *ramClass, uintptr_t romClassOffset)
+   {
+   auto entry = getOffsetEntry(romClassOffset, false);
+   if (entry)
+      {
+      entry->_loadedClasses.erase(ramClass);
+      if (entry->_loadedClasses.empty())
+         _offsetMap.erase(romClassOffset);
+      return true;
+      }
+   return false;
+   }
+
+// If an entry exists for a class, remove it. Otherwise, if we should
+// revalidate, add an entry if the class has a valid chain.
+void
+TR_AOTDependencyTable::recheckSubclass(J9Class *ramClass, uintptr_t offset, bool shouldRevalidate)
+   {
+   if (invalidateClassAtOffset(ramClass, offset))
+      return;
+
+   if (shouldRevalidate && _sharedCache->classMatchesCachedVersion(ramClass, NULL))
+      {
+      bool initialized = J9ClassInitSucceeded == ramClass->initializeStatus;
+      classLoadEventAtOffset(ramClass, offset, true, initialized);
+      }
+   }
+
+// In a class redefinition event, an old class is replaced by a fresh class. If
+// the ROM class offset changed as a result, it and all its subclasses that
+// formerly had valid chains will now be guaranteed not to match, so the entries
+// for these must be removed. If the new offset is valid, any class that didn't
+// have an entry should be rechecked.
+void
+TR_AOTDependencyTable::invalidateRedefinedClass(TR_PersistentCHTable *table, TR_J9VMBase *fej9, TR_OpaqueClassBlock *oldClass, TR_OpaqueClassBlock *freshClass)
+   {
+   uintptr_t freshClassOffset = TR_SharedCache::INVALID_ROM_CLASS_OFFSET;
+   uintptr_t oldClassOffset = TR_SharedCache::INVALID_ROM_CLASS_OFFSET;
+   if (!_sharedCache->isClassInSharedCache(freshClass, &freshClassOffset) && !_sharedCache->isClassInSharedCache(oldClass, &oldClassOffset))
+      return;
+
+   if (oldClassOffset == freshClassOffset)
+      {
+      OMR::CriticalSection cs(_tableMonitor);
+      if (!isActive())
+         return;
+
+      try
+         {
+         // If the offset is unchanged and the old class was tracked, the new
+         // class will have a valid chain as well, so we only need to swap the
+         // old and fresh class pointers.
+         if (invalidateClassAtOffset((J9Class *)oldClass, oldClassOffset))
+            {
+            auto freshRamClass = (J9Class *)freshClass;
+            bool initialized = J9ClassInitSucceeded == freshRamClass->initializeStatus;
+            classLoadEventAtOffset(freshRamClass, freshClassOffset, true, initialized);
+            }
+         }
+      catch (std::exception&)
+         {
+         deactivateTable();
+         }
+
+      return;
+      }
+
+   bool revalidateUntrackedClasses = freshClassOffset != TR_SharedCache::INVALID_ROM_CLASS_OFFSET;
+
+   TR_PersistentClassInfo *classInfo = table->findClassInfo(oldClass);
+   TR_PersistentCHTable::ClassList classList(TR::Compiler->persistentAllocator());
+
+   table->collectAllSubClasses(classInfo, classList, fej9);
+   classList.push_front(classInfo);
+
+   OMR::CriticalSection cs(_tableMonitor);
+   if (!isActive())
+      return;
+
+   try
+      {
+      for (auto iter = classList.begin(); iter != classList.end(); iter++)
+         {
+         auto clazz = (J9Class *)(*iter)->getClassId();
+         uintptr_t offset = TR_SharedCache::INVALID_ROM_CLASS_OFFSET;
+         if (!_sharedCache->isClassInSharedCache(clazz, &offset))
+            continue;
+         recheckSubclass(clazz, offset, revalidateUntrackedClasses);
+         }
+      }
+   catch (std::exception&)
+      {
+      deactivateTable();
+      }
+   }
+
+TR_OpaqueClassBlock *
+TR_AOTDependencyTable::findClassCandidate(uintptr_t romClassOffset)
+   {
+   OMR::CriticalSection cs(_tableMonitor);
+
+   if (!isActive())
+      return NULL;
+
+   auto it = _offsetMap.find(romClassOffset);
+   if (it == _offsetMap.end())
+      return NULL;
+
+   for (const auto& clazz: it->second._loadedClasses)
+      {
+      if (J9ClassInitSucceeded == clazz->initializeStatus)
+         return (TR_OpaqueClassBlock *)clazz;
+      }
+
+   return NULL;
+   }
+
+void
+TR_AOTDependencyTable::deactivateTable()
+   {
+   _offsetMap.clear();
+   setInactive();
+   }
+
+#endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */

--- a/runtime/compiler/env/DependencyTable.hpp
+++ b/runtime/compiler/env/DependencyTable.hpp
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef DEPENDENCYTABLE_INCL
+#define DEPENDENCYTABLE_INCL
+
+#include "env/J9PersistentInfo.hpp"
+#include "env/PersistentCollections.hpp"
+#include "env/VMJ9.h"
+
+class TR_J9SharedCache;
+
+#if defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
+
+class TR_AOTDependencyTable
+   {
+public:
+   void classLoadEvent(TR_OpaqueClassBlock *ramClass, bool isClassLoad, bool isClassInitialization) {}
+   void invalidateUnloadedClass(TR_OpaqueClassBlock *ramClass) {}
+   void invalidateRedefinedClass(TR_PersistentCHTable *table, TR_J9VMBase *fej9, TR_OpaqueClassBlock *oldClass, TR_OpaqueClassBlock *freshClass) {}
+   TR_OpaqueClassBlock *findClassCandidate(uintptr_t offset) { return NULL; }
+   };
+
+#else
+
+struct OffsetEntry
+   {
+   PersistentUnorderedSet<J9Class *> _loadedClasses;
+   };
+
+/**
+ * \brief Tracking AOT load dependencies
+ *
+ * The dependency table maintains a map from ROM class offsets to loaded
+ * J9Classes with that offset and a valid stored class chain. (There is at most
+ * one chain with a particular first ROM class offset, so any two such classes
+ * must have identical chains). The class chains of these classes must have been
+ * shared when they were loaded in order to be tracked.
+ *
+ * The dependency table starts active, if the option is enabled. The public
+ * methods of this class responsible for updating the table will catch
+ * exceptions thrown internally and deactivate the table in response.
+ * (Only failures to allocate are possible).
+ *
+ * In future it will also track pending AOT loads so the counts of their
+ * associated RAM methods can be reduced when all of their AOT load dependencies
+ * have been satisfied.
+ */
+class TR_AOTDependencyTable
+   {
+public:
+   TR_PERSISTENT_ALLOC(TR_Memory::PersistentCHTable)
+   TR_AOTDependencyTable(TR_J9SharedCache *sharedCache);
+   // Update the table in response to a class load or initialization event. The
+   // isClassInitialization parameter is currently unused.
+   void classLoadEvent(TR_OpaqueClassBlock *ramClass, bool isClassLoad, bool isClassInitialization);
+
+   // Invalidate an unloaded class
+   void invalidateUnloadedClass(TR_OpaqueClassBlock *ramClass);
+
+   // Invalidate a redefined class
+   void invalidateRedefinedClass(TR_PersistentCHTable *table, TR_J9VMBase *fej9, TR_OpaqueClassBlock *oldClass, TR_OpaqueClassBlock *freshClass);
+
+   // Given a ROM class offset, return an initialized class with a valid class
+   // chain starting with that offset.
+   TR_OpaqueClassBlock *findClassCandidate(uintptr_t offset);
+
+private:
+   bool isActive() const { return _isActive; }
+   void setInactive() { _isActive = false; }
+   // Deallocate the internal structures of the table and mark the table as
+   // inactive. Must be called with the _tableMonitor in hand.
+   void deactivateTable();
+
+   void classLoadEventAtOffset(J9Class *ramClass, uintptr_t offset, bool isClassLoad, bool isClassInitialization);
+   // Invalidate a class with a particular ROM class offset. Returns false if
+   // the class wasn't tracked.
+   bool invalidateClassAtOffset(J9Class *ramClass, uintptr_t romClassOffset);
+   void recheckSubclass(J9Class *ramClass, uintptr_t offset, bool shouldRevalidate);
+   OffsetEntry *getOffsetEntry(uintptr_t offset, bool create);
+
+   // Initially true, and set to false if there is a failure to allocate.
+   bool _isActive;
+
+   TR_J9SharedCache *_sharedCache;
+   TR::Monitor *const _tableMonitor;
+
+   // A map from ROM class offsets to offset entries. The _loadedClasses of
+   // those entries will contain classes with a valid class chain in the SCC
+   // corresponding to that offset. Having the key be the ROM class offset
+   // avoids the need to recreate the class chain to consult this map; this
+   // works because there can be at most one class chain in the SCC whose entry
+   // is a particular ROM class offset.
+   PersistentUnorderedMap<uintptr_t, OffsetEntry> _offsetMap;
+   };
+
+#endif /* defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
+#endif

--- a/runtime/compiler/env/J9PersistentInfo.hpp
+++ b/runtime/compiler/env/J9PersistentInfo.hpp
@@ -42,6 +42,7 @@ class TR_FrontEnd;
 class TR_PersistentMemory;
 class TR_PersistentCHTable;
 class TR_PersistentClassLoaderTable;
+class TR_AOTDependencyTable;
 class TR_MHJ2IThunkTable;
 namespace J9 { class Options; }
 
@@ -159,6 +160,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
          _gpuInitMonitor(NULL),
          _runtimeInstrumentationEnabled(false),
          _runtimeInstrumentationRecompilationEnabled(false),
+         _aotDependencyTable(NULL),
+         _trackAOTDependencies(false),
 #if defined(J9VM_OPT_JITSERVER)
          _JITServerAddress("localhost"),
          _JITServerPort(38400),
@@ -185,6 +188,9 @@ class PersistentInfo : public OMR::PersistentInfoConnector
 
    void setPersistentClassLoaderTable(TR_PersistentClassLoaderTable *table) { _persistentClassLoaderTable = table; }
    TR_PersistentClassLoaderTable *getPersistentClassLoaderTable() { return _persistentClassLoaderTable; }
+
+   void setAOTDependencyTable(TR_AOTDependencyTable *table) { _aotDependencyTable = table; }
+   TR_AOTDependencyTable *getAOTDependencyTable() const { return _aotDependencyTable; }
 
    TR_OpaqueClassBlock **getVisitedSuperClasses() { return _visitedSuperClasses; }
    void clearVisitedSuperClasses() { _tooManySuperClasses = false; _numVisitedSuperClasses = 0; }
@@ -343,6 +349,9 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    uint8_t _paddingBefore[128];
    int32_t _countForRecompile;
 
+  void setTrackAOTDependencies(bool b) { _trackAOTDependencies = b;}
+  bool getTrackAOTDependencies() const { return _trackAOTDependencies; }
+
 #if defined(J9VM_OPT_JITSERVER)
    static JITServer::RemoteCompilationModes _remoteCompilationMode; // JITServer::NONE, JITServer::CLIENT, JITServer::SERVER
 
@@ -395,6 +404,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
    TR_PersistentCHTable *_persistentCHTable;
 
    TR_PersistentClassLoaderTable *_persistentClassLoaderTable;
+
+   TR_AOTDependencyTable *_aotDependencyTable;
 
    // these fields are RW
 
@@ -468,6 +479,8 @@ class PersistentInfo : public OMR::PersistentInfoConnector
                                    ///< May need adjustment if sampling thread goes to sleep
 
    int32_t _numLoadedClasses; ///< always increasing
+
+   bool _trackAOTDependencies;
 
 #if defined(J9VM_OPT_JITSERVER)
    std::string _JITServerAddress;

--- a/runtime/compiler/env/PersistentCollections.hpp
+++ b/runtime/compiler/env/PersistentCollections.hpp
@@ -23,6 +23,12 @@
 #ifndef PERSISTENT_COLLECTIONS_H
 #define PERSISTENT_COLLECTIONS_H
 
+// Some of these container types are unsupported on certain XLC/C++ build
+// configurations
+#if defined(__IBMCPP__) && !defined(__IBMCPP_TR1__)
+#define PERSISTENT_COLLECTIONS_UNSUPPORTED
+#else
+
 #include <list>
 #include <unordered_map>
 #include <unordered_set>
@@ -130,4 +136,5 @@ namespace std
    }
 
 
+#endif /* defined(__IBMCPP__) && !defined(__IBMCPP_TR1__) */
 #endif /* PERSISTENT_COLLECTIONS_H */

--- a/runtime/compiler/env/SharedCache.hpp
+++ b/runtime/compiler/env/SharedCache.hpp
@@ -84,6 +84,8 @@ public:
    // and related methods.
    static const uintptr_t INVALID_ROM_METHOD_OFFSET = 1;
 
+   static const uintptr_t INVALID_ROM_CLASS_OFFSET = 1;
+
 private:
 
    TR_PersistentClassLoaderTable *_persistentClassLoaderTable;


### PR DESCRIPTION
The new TR_AOTDependencyTable tracks all loaded classes whose class chains match what is stored in the local SCC. In future, it will also be responsible for tracking potential AOT loads; it will use this offset map to detect when all the dependencies of the stored AOT compilation have been satisfied and reduce the count of the associated method to induce a load in response.

This class tracking is disabled by default. It can be controlled with the option -XX:[+|-]TrackAOTDependencies.

Related: https://github.com/eclipse-openj9/openj9/issues/20529