### PR TITLE
Remove some methods from recognized methods

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -505,13 +505,9 @@
    sun_io_ByteToCharSingleByte_JITintrinsicConvert,
    sun_nio_cs_ISO_8859_1_Encoder_encodeArrayLoop,
    sun_nio_cs_ISO_8859_1_Encoder_encodeISOArray,
-   sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1,
    sun_nio_cs_US_ASCII_Encoder_encodeASCII,
    sun_nio_cs_US_ASCII_Decoder_decodeASCII,
-   sun_nio_cs_ext_SBCS_Encoder_encodeSBCS,
-   sun_nio_cs_ext_SBCS_Decoder_decodeSBCS,
    sun_nio_cs_UTF_8_Decoder_decodeUTF_8,
-   sun_nio_cs_UTF_8_Encoder_encodeUTF_8,
    sun_nio_cs_ext_IBM1388_Encoder_encodeArrayLoop,
 
    sun_nio_cs_UTF16_Encoder_encodeUTF16Big,

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -441,13 +441,9 @@ J9::Compilation::isConverterMethod(TR::RecognizedMethod rm)
       case TR::sun_nio_cs_ISO_8859_1_Encoder_encodeISOArray:
       case TR::java_lang_StringCoding_implEncodeISOArray:
       case TR::java_lang_String_decodeUTF8_UTF16:
-      case TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1:
       case TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII:
       case TR::java_lang_StringCoding_implEncodeAsciiArray:
       case TR::sun_nio_cs_US_ASCII_Decoder_decodeASCII:
-      case TR::sun_nio_cs_ext_SBCS_Encoder_encodeSBCS:
-      case TR::sun_nio_cs_ext_SBCS_Decoder_decodeSBCS:
-      case TR::sun_nio_cs_UTF_8_Encoder_encodeUTF_8:
       case TR::sun_nio_cs_UTF_8_Decoder_decodeUTF_8:
       case TR::sun_nio_cs_UTF16_Encoder_encodeUTF16Big:
       case TR::sun_nio_cs_UTF16_Encoder_encodeUTF16Little:
@@ -479,23 +475,13 @@ J9::Compilation::canTransformConverterMethod(TR::RecognizedMethod rm)
       case TR::java_lang_StringCoding_implEncodeISOArray:
          return genTRxx || self()->cg()->getSupportsArrayTranslateTRTO255() || self()->cg()->getSupportsArrayTranslateTRTO() || genSIMD;
 
-      case TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1:
-         return genTRxx || self()->cg()->getSupportsArrayTranslateTROTNoBreak() || genSIMD;
-
       case TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII:
       case TR::java_lang_StringCoding_implEncodeAsciiArray:
-      case TR::sun_nio_cs_UTF_8_Encoder_encodeUTF_8:
          return genTRxx || self()->cg()->getSupportsArrayTranslateTRTO() || genSIMD;
 
       case TR::sun_nio_cs_US_ASCII_Decoder_decodeASCII:
       case TR::sun_nio_cs_UTF_8_Decoder_decodeUTF_8:
          return genTRxx || self()->cg()->getSupportsArrayTranslateTROT() || genSIMD;
-
-      case TR::sun_nio_cs_ext_SBCS_Encoder_encodeSBCS:
-         return genTRxx && self()->cg()->getSupportsTestCharComparisonControl();
-
-      case TR::sun_nio_cs_ext_SBCS_Decoder_decodeSBCS:
-         return genTRxx;
 
       // devinmp: I'm not sure whether these could be transformed in AOT, but
       // they haven't been so far.

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3775,12 +3775,8 @@ void TR_ResolvedJ9Method::construct()
       {
       {x(TR::sun_nio_cs_ISO_8859_1_Encoder_encodeArrayLoop,       "encodeArrayLoop", "(Ljava/nio/CharBuffer;Ljava/nio/ByteBuffer;)Ljava/nio/charset/CoderResult;")},
       {x(TR::sun_nio_cs_ISO_8859_1_Encoder_encodeISOArray,        "encodeISOArray",         "([CI[BII)I")},
-      {x(TR::sun_nio_cs_ISO_8859_1_Decoder_decodeISO8859_1,       "decodeISO8859_1",      "([BII[CI)I")},
       {x(TR::sun_nio_cs_US_ASCII_Encoder_encodeASCII,             "encodeASCII",             "([CII[BI)I")},
       {x(TR::sun_nio_cs_US_ASCII_Decoder_decodeASCII,             "decodeASCII",             "([BII[CI)I")},
-      {x(TR::sun_nio_cs_ext_SBCS_Encoder_encodeSBCS,              "encodeSBCS",              "([CII[BI[B)I")},
-      {x(TR::sun_nio_cs_ext_SBCS_Decoder_decodeSBCS,              "decodeSBCS",           "([BII[CI[C)I")},
-      {x(TR::sun_nio_cs_UTF_8_Encoder_encodeUTF_8,                "encodeUTF_8",     "([CII[BI)I")},
       {x(TR::sun_nio_cs_UTF_8_Decoder_decodeUTF_8,                "decodeUTF_8",          "([BII[CI)I")},
       {x(TR::sun_nio_cs_UTF16_Encoder_encodeUTF16Big,             "encodeUTF16Big",       "([CII[BI)I")},
       {x(TR::sun_nio_cs_UTF16_Encoder_encodeUTF16Little,          "encodeUTF16Little",    "([CII[BI)I")},
@@ -4210,8 +4206,6 @@ void TR_ResolvedJ9Method::construct()
       { "java/util/GregorianCalendar", GregorianCalendarMethods },
       { "sun/nio/cs/US_ASCII$Encoder", EncodeMethods },
       { "sun/nio/cs/US_ASCII$Decoder", EncodeMethods },
-      { "sun/nio/cs/ext/SBCS_Encoder", EncodeMethods },
-      { "sun/nio/cs/ext/SBCS_Decoder", EncodeMethods },
       { "java/lang/invoke/FoldHandle", FoldHandleMethods },
       { "java/lang/ref/SoftReference", JavaLangRefSoftReferenceMethods },
       { 0 }


### PR DESCRIPTION
These methods no longer exist in the Java class library.

- sun/nio/cs/ISO_8859_1$Decoder.decodeISO8859_1()
- sun/nio/cs/UTF_8$Encoder.encodeUTF_8()
- sun/nio/cs/ext/SBCS_Encoder.encodeSBCS()
- sun/nio/cs/ext/SBCS_Decoder.decodeSBCS()