### PR TITLE
Clean up references to old opcodes

### DIFF
--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -1390,12 +1390,12 @@ checkByteToChar(TR::Compilation *comp, TR::Node *iorNode, TR::Node *&inputNode, 
       //       if index is i then inputNode = bloadi child of imul
       //       else fail
       //
-      TR::Node *ibloadNode = imulNode->getFirstChild()->skipConversions();
+      TR::Node *bloadiNode = imulNode->getFirstChild()->skipConversions();
       bool plusOne = false;
       bool matchPattern = false;
-      if (ibloadNode->getOpCodeValue() == TR::bloadi)
+      if (bloadiNode->getOpCodeValue() == TR::bloadi)
          {
-         TR::Node *subNode = ibloadNode->getFirstChild()->getSecondChild();
+         TR::Node *subNode = bloadiNode->getFirstChild()->getSecondChild();
          int32_t hdrSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes() + 1;
          if (subNode->getOpCode().isSub() &&
                subNode->getSecondChild()->getOpCode().isLoadConst())
@@ -1425,7 +1425,7 @@ checkByteToChar(TR::Compilation *comp, TR::Node *iorNode, TR::Node *&inputNode, 
                   {
                   if (!plusOne)
                      {
-                     inputNode = ibloadNode->getFirstChild();
+                     inputNode = bloadiNode->getFirstChild();
                      return true;
                      }
                   else
@@ -5947,13 +5947,13 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
       return false;
       }
 
-   TR::Node *optionalIistore = NULL;
+   TR::Node *optionalIstorei = NULL;
    if (P->getImportantNode(4))
       {
-      TR_CISCNode *optionalCISCIistore = trans->getP2TInLoopIfSingle(P->getImportantNode(4));
-      if (!optionalCISCIistore)
+      TR_CISCNode *optionalCISCIstorei = trans->getP2TInLoopIfSingle(P->getImportantNode(4));
+      if (!optionalCISCIstorei)
          return false;
-      optionalIistore = optionalCISCIistore->getHeadOfTrNode()->duplicateTree();
+      optionalIstorei = optionalCISCIstorei->getHeadOfTrNode()->duplicateTree();
       }
 
    TR::Node * exitVarNode = createLoad(exitVarRepNode);
@@ -6112,11 +6112,11 @@ CISCTransform2ArrayCopySub(TR_CISCTransformer *trans, TR::Node *indexRepNode, TR
       block->append(theOtherVarUpdateTreeTop);
       }
 
-   if (optionalIistore)
+   if (optionalIstorei)
       {
       TR_ASSERT(theOtherVarUpdateNode != NULL, "error!");
-      optionalIistore->setAndIncChild(1, theOtherVarUpdateNode->getChild(0));
-      block->append(TR::TreeTop::create(comp, optionalIistore));
+      optionalIstorei->setAndIncChild(1, theOtherVarUpdateNode->getChild(0));
+      block->append(TR::TreeTop::create(comp, optionalIstorei));
       }
 
    trans->insertAfterNodes(block);

--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1982,7 +1982,7 @@ static TR::TreeTop* generateArraycopyFromSequentialStores(TR::Compilation* comp,
    return treeTop;
    }
 
-static TR::TreeTop* generateArraycopyFromSequentialLoadsDEPRECATED(TR::Compilation* comp, TR::TreeTop* currentTreeTop, TR::Node* ibloadNode)
+static TR::TreeTop* generateArraycopyFromSequentialLoadsDEPRECATED(TR::Compilation* comp, TR::TreeTop* currentTreeTop, TR::Node* bloadiNode)
    {
 
    static const char * disableSeqLoadOpt = feGetEnv("TR_DisableSeqLoadOpt");
@@ -2000,7 +2000,7 @@ static TR::TreeTop* generateArraycopyFromSequentialLoadsDEPRECATED(TR::Compilati
    TR::Node* rootNode;
 
    //checking the number of bytes
-   while ( !((currentNode->getFirstChild() == ibloadNode) && (currentNode->getOpCodeValue() == TR::bu2i)) )
+   while ( !((currentNode->getFirstChild() == bloadiNode) && (currentNode->getOpCodeValue() == TR::bu2i)) )
       {
       if ( (currentNode->getOpCodeValue() == TR::iadd) || (currentNode->getOpCodeValue() == TR::ior))
          {
@@ -2039,7 +2039,7 @@ static TR::TreeTop* generateArraycopyFromSequentialLoadsDEPRECATED(TR::Compilati
 
    // Need to make sure these loads are not under spine checks.
    //
-   if (comp->requiresSpineChecks() && ibloadNode->getReferenceCount() > 1)
+   if (comp->requiresSpineChecks() && bloadiNode->getReferenceCount() > 1)
       {
       TR::TreeTop *tt = currentTreeTop;
       TR::TreeTop *lastTreeTop = currentTreeTop->getEnclosingBlock()->startOfExtendedBlock()->getFirstRealTreeTop()->getPrevTreeTop();
@@ -2054,7 +2054,7 @@ static TR::TreeTop* generateArraycopyFromSequentialLoadsDEPRECATED(TR::Compilati
             node = node->getFirstChild();
             while (node->getOpCode().isConversion())
                node = node->getFirstChild();
-            if (node == ibloadNode)
+            if (node == bloadiNode)
                {
                dumpOptDetails(comp, " Sequential Load to spine checked array not reducible\n");
                return currentTreeTop;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -539,9 +539,9 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
 
    // J9, Z
    //
-   if (comp->target().cpu.isZ() && node->getOpCodeValue() == TR::aloadi && node->isUnneededIALoad())
+   if (comp->target().cpu.isZ() && node->getOpCodeValue() == TR::aloadi && node->isUnneededAloadi())
       {
-      ListIterator<TR_Pair<TR::Node, int32_t> > listIter(&_ialoadUnneeded);
+      ListIterator<TR_Pair<TR::Node, int32_t> > listIter(&_aloadiUnneeded);
       TR_Pair<TR::Node, int32_t> *ptr;
       uintptr_t temp;
       int32_t updatedTemp;
@@ -551,7 +551,7 @@ J9::Z::CodeGenerator::lowerTreeIfNeeded(
          updatedTemp = (int32_t) temp;
          if (ptr->getKey() == node && temp != node->getReferenceCount())
             {
-            node->setUnneededIALoad(false);
+            node->setUnneededAloadi(false);
             break;
             }
          }

--- a/runtime/compiler/z/codegen/J9MemoryReference.cpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.cpp
@@ -275,7 +275,7 @@ J9::Z::MemoryReference::createUnresolvedDataSnippet(TR::Node * node, TR::CodeGen
    }
 
 TR::UnresolvedDataSnippet *
-J9::Z::MemoryReference::createUnresolvedDataSnippetForiaload(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore)
+J9::Z::MemoryReference::createUnresolvedDataSnippetForAloadi(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore)
    {
    // Have to catch the case where, on first glance, a putstatic looks
    // like a 'read' since the unresolved ref is on the aloadi, not the

--- a/runtime/compiler/z/codegen/J9MemoryReference.hpp
+++ b/runtime/compiler/z/codegen/J9MemoryReference.hpp
@@ -94,7 +94,7 @@ public:
    static bool typeNeedsAlignment(TR::Node *node);
 
    TR::UnresolvedDataSnippet * createUnresolvedDataSnippet(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool isStore);
-   TR::UnresolvedDataSnippet * createUnresolvedDataSnippetForiaload(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore);
+   TR::UnresolvedDataSnippet * createUnresolvedDataSnippetForAloadi(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register * tempReg, bool & isStore);
    void createUnresolvedSnippetWithNodeRegister(TR::Node * node, TR::CodeGenerator * cg, TR::SymbolReference * symRef, TR::Register *& writableLiteralPoolRegister);
    void createUnresolvedDataSnippetForBaseNode(TR::CodeGenerator * cg, TR::Register * writableLiteralPoolRegister);
 

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -7649,7 +7649,7 @@ J9::Z::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Node * node, bool n
 
    // determine if an explicit check is needed
    if (cg->getSupportsImplicitNullChecks()
-         && !firstChild->isUnneededIALoad())
+         && !firstChild->isUnneededAloadi())
       {
       if (opCode.isLoadVar()
             || (cg->comp()->target().is64Bit() && opCode.getOpCodeValue()==TR::l2i)


### PR DESCRIPTION
The old opcodes had the letter i as a prefix if the operation was indirect. Those opcodes were renamed to use the letter i as a suffix instead.

This commit cleans up the references to the old opcodes, iiload/iistore ilload/ilstore iaload/iastore ibload/ibstore, to iloadi/istorei lloadi/lstorei aloadi/astorei bloadi/bstorei in the code.

**Depends on** 
- [ ] https://github.com/eclipse-omr/omr/pull/7529

Related: #19489