### PR TITLE
valhalla enable methods for latest openjdk updates

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -85,10 +85,10 @@ import sun.reflect.ConstantPool;
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
-/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
+/*[IF JAVA_SPEC_VERSION >= 24]*/
 import java.util.concurrent.Executor;
 import jdk.internal.loader.NativeLibraries;
-/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 /**
  * Helper class to allow privileged access to classes
@@ -833,7 +833,6 @@ final class Access implements JavaLangAccess {
 		return new StringConcatHelper.Concat1(constants);
 	}
 
-/*[IF !INLINE-TYPES]*/
 	@Override
 	public String concat(String prefix, Object value, String suffix) {
 		return StringConcatHelper.concat(prefix, value, suffix);
@@ -863,7 +862,6 @@ final class Access implements JavaLangAccess {
 	public Executor virtualThreadDefaultScheduler() {
 		return VirtualThread.defaultScheduler();
 	}
-/*[ENDIF] !INLINE-TYPES */
 /*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2947,12 +2947,12 @@ public Package getPackage() {
 	}
 }
 
-/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
+/*[IF JAVA_SPEC_VERSION >= 24]*/
 @SuppressWarnings("unchecked")
 static <T> Class<T> getPrimitiveClass(String name)
-/*[ELSE] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
+/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 static Class<?> getPrimitiveClass(String name)
-/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 {
 	Class<?> type;
 
@@ -2998,11 +2998,11 @@ static Class<?> getPrimitiveClass(String name)
 		type = array.getClass().getComponentType();
 	}
 
-	/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
+	/*[IF JAVA_SPEC_VERSION >= 24]*/
 	return (Class<T>) type;
-	/*[ELSE] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
+	/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	return type;
-	/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
 /**

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -40,10 +40,10 @@ import com.sun.management.internal.ExtendedHotSpotDiagnostic;
 import com.sun.management.HotSpotDiagnosticMXBean;
 /*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
-/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
+/*[IF JAVA_SPEC_VERSION >= 24]*/
 import com.sun.management.internal.VirtualThreadSchedulerImpls;
 import jdk.management.VirtualThreadSchedulerMXBean;
-/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 /**
  * This class implements the service-provider interface to make OpenJ9-specific
@@ -123,11 +123,11 @@ public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBea
 			.register(allComponents);
 		/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
-		/*[IF (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES]*/
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
 		ComponentBuilder.create("jdk.management:type=VirtualThreadScheduler", VirtualThreadSchedulerImpls.create()) //$NON-NLS-1$
 			.addInterface(VirtualThreadSchedulerMXBean.class)
 			.register(allComponents);
-		/*[ENDIF] (JAVA_SPEC_VERSION >= 24) & !INLINE-TYPES */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 		// register beans with zero or more instances
 


### PR DESCRIPTION
valhalla enable methods for latest openjdk updates

After merging latest openjdk updates, these methods need to be enabled for valhalla.

A personal build [JDKnext_x86-64_linux_valhalla](https://hyc-runtimes-jenkins.swg-devops.com/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/1985/) passed.
However, https://github.com/eclipse-openj9/openj9/issues/20372 still fails so it needs further investigation.

Required by 
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/16

closes https://github.com/eclipse-openj9/openj9/issues/20381



Signed-off-by: Jason Feng <fengj@ca.ibm.com>