### PR TITLE
Update identityHashCode() in System.java for Value type

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1101,6 +1101,11 @@ public static int identityHashCode(Object anObject) {
 	if (anObject == null) {
 		return 0;
 	}
+/*[IF INLINE-TYPES]*/
+	if (anObject.getClass().isValue()) {
+		return J9VMInternals.valueHashCode(anObject);
+	}
+/*[ENDIF] INLINE-TYPES */
 	return J9VMInternals.fastIdentityHashCode(anObject);
 }
 


### PR DESCRIPTION
System.IdentityHashCode() should always return the same hash as Object.hashCode(), no matter the object is VT or not.