### PR TITLE
Set java.lang.reflect.Field flags for value types

### DIFF
--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -759,6 +759,9 @@ createField(struct J9VMThread *vmThread, jfieldID fieldID)
 	j9object_t fieldObject = NULL;
 	J9Class *jlrFieldClass = J9VMJAVALANGREFLECTFIELD(vmThread->javaVM);
 	UDATA initStatus;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	U_32 fieldFlags = 0; /* used to calculate value of Field.flags in value type builds */
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 	if (NULL == jlrFieldClass) {
 		return NULL;
@@ -837,9 +840,20 @@ createField(struct J9VMThread *vmThread, jfieldID fieldID)
 			|| J9ROMCLASS_IS_RECORD(j9FieldID->declaringClass->romClass)
 			|| J9ROMCLASS_IS_HIDDEN(j9FieldID->declaringClass->romClass)
 		) {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			fieldFlags |= TRUST_FINAL;
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			J9VMJAVALANGREFLECTFIELD_SET_TRUSTEDFINAL(vmThread, fieldObject, JNI_TRUE);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		}
 	}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	if (J9ROMFIELD_IS_NULL_RESTRICTED(j9FieldID->field)) {
+		fieldFlags |= NULL_RESTRICTED;
+	}
+	/* alias is "int flags;" in value types */
+	J9VMJAVALANGREFLECTFIELD_SET_TRUSTEDFINAL(vmThread, fieldObject, fieldFlags);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
 	return fieldObject;

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -950,6 +950,12 @@ extern "C" {
 #define PREVIEW_MINOR_VERSION 65535
 #define J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(classfileOrRomClass) (((classfileOrRomClass)->majorVersion >= VALUE_TYPES_MAJOR_VERSION) && (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion))
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+/* Constants for java.lang.reflect.Field flags */
+#define TRUST_FINAL 0x10
+#define NULL_RESTRICTED 0x20
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES)*/
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
The value types java.lang.reflect.Field replaces the trustedFinal boolean with a flags int. Set TRUSTED_ACCESS and
NULL_RESTRICTED flags.

Fixes: https://github.com/eclipse-openj9/openj9/issues/20372

edit: I ran a personal build to confirm that sanity tests with a valhalla build will pass with this change https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/24974/