### PR TITLE
Fix array and memory segment access in VectorAPIExpansion

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -643,7 +643,22 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *  \return
    *     Address node
    */
-   static TR::Node *generateAddressNode(TR::Compilation *comp, TR::Node *array, TR::Node *arrayIndex, int32_t elementSize);
+   static TR::Node *generateArrayElementAddressNode(TR::Compilation *comp, TR::Node *array, TR::Node *arrayIndex, int32_t elementSize);
+
+
+  /** \brief
+   *     Generates address node based on the base node and offset
+   *
+   * \param base
+   *     Node pointing to the base of the array or memory segment
+   *
+   *  \param offset
+   *     Offset from the base
+   *
+   *  \return
+   *     Address node
+   */
+   static TR::Node *generateAddressNode(TR::Node *base, TR::Node *offset);
 
 
   /** \brief


### PR DESCRIPTION
- we should not add array header to the address but use base address and offset provided by the intrinsic, whether it's array or segment