### PR TITLE
Use the dependency table as class loader fallback

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -391,6 +391,9 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    // fails serialization by setting _aotCacheStore to false if we are not ignoring the client's SCC, and otherwise
    // fails the compilation entirely.
    void addThunkRecord(const AOTCacheThunkRecord *record);
+#else
+   bool isDeserializedAOTMethod() const { return false; }
+   bool ignoringLocalSCC() const { return false; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }

--- a/runtime/compiler/env/DependencyTable.cpp
+++ b/runtime/compiler/env/DependencyTable.cpp
@@ -47,7 +47,7 @@ TR_AOTDependencyTable::classLoadEvent(TR_OpaqueClassBlock *clazz, bool isClassLo
 
    // We only need to check if clazz matches its cached version on load; on
    // initialization, it will be in the _offsetMap if it did match.
-   if (isClassLoad && !_sharedCache->classMatchesCachedVersion(ramClass, NULL))
+   if (isClassLoad && (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET == _sharedCache->rememberClass(ramClass)))
       return;
 
    OMR::CriticalSection cs(_tableMonitor);
@@ -127,7 +127,7 @@ TR_AOTDependencyTable::recheckSubclass(J9Class *ramClass, uintptr_t offset, bool
    if (invalidateClassAtOffset(ramClass, offset))
       return;
 
-   if (shouldRevalidate && _sharedCache->classMatchesCachedVersion(ramClass, NULL))
+   if (shouldRevalidate && (TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != _sharedCache->rememberClass(ramClass)))
       {
       bool initialized = J9ClassInitSucceeded == ramClass->initializeStatus;
       classLoadEventAtOffset(ramClass, offset, true, initialized);

--- a/runtime/compiler/env/DependencyTable.cpp
+++ b/runtime/compiler/env/DependencyTable.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 
+#include "compile/Compilation.hpp"
 #include "control/CompilationThread.hpp"
 #include "env/DependencyTable.hpp"
 #include "env/J9SharedCache.hpp"
@@ -202,8 +203,14 @@ TR_AOTDependencyTable::invalidateRedefinedClass(TR_PersistentCHTable *table, TR_
    }
 
 TR_OpaqueClassBlock *
-TR_AOTDependencyTable::findClassCandidate(uintptr_t romClassOffset)
+TR_AOTDependencyTable::findCandidateFromChainOffset(TR::Compilation *comp, uintptr_t chainOffset)
    {
+   if (comp->isDeserializedAOTMethod() || comp->ignoringLocalSCC())
+      return NULL;
+
+   void *chain = _sharedCache->pointerFromOffsetInSharedCache(chainOffset);
+   uintptr_t romClassOffset = _sharedCache->startingROMClassOffsetOfClassChain(chain);
+
    OMR::CriticalSection cs(_tableMonitor);
 
    if (!isActive())

--- a/runtime/compiler/env/DependencyTable.hpp
+++ b/runtime/compiler/env/DependencyTable.hpp
@@ -80,9 +80,9 @@ public:
    // Invalidate a redefined class
    void invalidateRedefinedClass(TR_PersistentCHTable *table, TR_J9VMBase *fej9, TR_OpaqueClassBlock *oldClass, TR_OpaqueClassBlock *freshClass);
 
-   // Given a ROM class offset, return an initialized class with a valid class
-   // chain starting with that offset.
-   TR_OpaqueClassBlock *findClassCandidate(uintptr_t offset);
+   // Given a class chain offset in the local SCC, return an initialized class
+   // with a valid class chain starting with that offset.
+   TR_OpaqueClassBlock *findCandidateFromChainOffset(TR::Compilation *comp, uintptr_t chainOffset);
 
 private:
    bool isActive() const { return _isActive; }

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -981,11 +981,16 @@ TR_J9SharedCache::isPtrToROMClassesSectionInSharedCache(void *ptr, uintptr_t *ca
 J9ROMClass *
 TR_J9SharedCache::startingROMClassOfClassChain(UDATA *classChain)
    {
-   UDATA lengthInBytes = classChain[0];
-   TR_ASSERT_FATAL(lengthInBytes >= 2 * sizeof (UDATA), "class chain is too short!");
+   return romClassFromOffsetInSharedCache(startingROMClassOffsetOfClassChain(classChain));
+   }
 
-   UDATA romClassOffset = classChain[1];
-   return romClassFromOffsetInSharedCache(romClassOffset);
+uintptr_t
+TR_J9SharedCache::startingROMClassOffsetOfClassChain(void *chain)
+   {
+   auto classChain = (uintptr_t *)chain;
+   uintptr_t lengthInBytes = classChain[0];
+   TR_ASSERT_FATAL(lengthInBytes >= 2 * sizeof (UDATA), "class chain is too short!");
+   return classChain[1];
    }
 
 // convert an offset into a string of 8 characters

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -369,6 +369,8 @@ public:
 
    J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
 
+   uintptr_t startingROMClassOffsetOfClassChain(void *chain);
+
    virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL);
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -23,6 +23,7 @@
 #include <string.h>
 #include "env/VMJ9.h"
 #include "env/ClassLoaderTable.hpp"
+#include "env/DependencyTable.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "exceptions/AOTFailure.hpp"
@@ -850,7 +851,7 @@ TR::SymbolValidationManager::addStaticClassFromCPRecord(TR_OpaqueClassBlock *cla
    SVM_ASSERT_ALREADY_VALIDATED(this, beholder);
    if (skipFieldRefClassRecord(clazz, beholder, cpIndex))
        return true;
-    else
+   else
       return addClassRecord(clazz, new (_region) StaticClassFromCPRecord(clazz, beholder, cpIndex));
    }
 
@@ -1210,7 +1211,7 @@ TR::SymbolValidationManager::validateClassByNameRecord(uint16_t classID, uint16_
 
 bool
 TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, void *classChainIdentifyingLoader,
-                                                         void *classChainForClassBeingValidated)
+                                                         void *classChainForClassBeingValidated, uintptr_t classChainOffsetForClassBeingValidated)
    {
    J9ClassLoader *classLoader = (J9ClassLoader *)_fej9->sharedCache()->lookupClassLoaderAssociatedWithClassChain(classChainIdentifyingLoader);
    if (classLoader == NULL)
@@ -1219,6 +1220,11 @@ TR::SymbolValidationManager::validateProfiledClassRecord(uint16_t classID, void 
    TR_OpaqueClassBlock *clazz = _fej9->sharedCache()->lookupClassFromChainAndLoader(
       static_cast<uintptr_t *>(classChainForClassBeingValidated), classLoader, _comp
    );
+   if (!clazz)
+      {
+      if (auto dependencyTable = _fej9->_compInfo->getPersistentInfo()->getAOTDependencyTable())
+         clazz = dependencyTable->findCandidateFromChainOffset(_comp, classChainOffsetForClassBeingValidated);
+      }
    return validateSymbol(classID, clazz);
    }
 

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -796,7 +796,7 @@ public:
 
 
    bool validateClassByNameRecord(uint16_t classID, uint16_t beholderID, uintptr_t *classChain);
-   bool validateProfiledClassRecord(uint16_t classID, void *classChainIdentifyingLoader, void *classChainForClassBeingValidated);
+   bool validateProfiledClassRecord(uint16_t classID, void *classChainIdentifyingLoader, void *classChainForClassBeingValidated, uintptr_t classChainOffsetForClassBeingValidated);
    bool validateClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);
    bool validateDefiningClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex, bool isStatic);
    bool validateStaticClassFromCPRecord(uint16_t classID, uint16_t beholderID, uint32_t cpIndex);


### PR DESCRIPTION
The dependency table tracks currently-loaded RAM classes with valid class chains by their offset, so it can be used as a fallback during relocation if a class cannot be found in its associated loader or if the loader itself cannot be found.

Related: https://github.com/eclipse-openj9/openj9/issues/20529