### PR TITLE
Make j9localmap_DebugLocalBitsForPC the default mapper

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1172,7 +1172,7 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	vm->reserved1_identifier = (void*)J9VM_IDENTIFIER;
 	vm->internalVMFunctions = GLOBAL_TABLE(J9InternalFunctions);
 	vm->portLibrary = portLibrary;
-	vm->localMapFunction = j9localmap_LocalBitsForPC;
+	vm->localMapFunction = j9localmap_DebugLocalBitsForPC;
 
 	vm->internalVMLabels = (J9InternalVMLabels*)-1001;
 	vm->cInterpreter = J9_BUILDER_SYMBOL(cInterpreter);


### PR DESCRIPTION
`j9localmap_LocalBitsForPC` is more aggressive than
`j9localmap_DebugLocalBitsForPC` in the way it analyzes and marks local
variables as object references. Aggressiveness relates to determining
whether a local object is being used at a specific point in the
bytecode execution, and this helps optimize garbage collection and
runtime performance. In contrast, `j9localmap_DebugLocalBitsForPC`
adopts a conservative approach; it overestimates and plays safe by
marking objects alive even if they are not being used.

`j9localmap_DebugLocalBitsForPC` resolves the issue seen in
https://github.com/ibmruntimes/Semeru-Runtimes/issues/93.

We have run the following benchmarks: Liberty DT8/DT10 Startup &
Footprint, JRuby and Nashorn. No performance difference is seen between
`j9localmap_DebugLocalBitsForPC` and `j9localmap_LocalBitsForPC`. 

Since there are no side-effects of `j9localmap_DebugLocalBitsForPC`,
this PR makes it OpenJ9's default mapper.