### PR TITLE
Define system property jdk.debug from JDK_DEBUG_LEVEL

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1084,7 +1084,14 @@ initializeSystemProperties(J9JavaVM * vm)
 	}
 #endif /* JAVA_SPEC_VERSION >= 23 */
 
-	/* If we get here all is good */
+#if defined(JDK_DEBUG_LEVEL)
+	rc = addSystemProperty(vm, "jdk.debug", JDK_DEBUG_LEVEL, 0);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto fail;
+	}
+#endif /* defined(JDK_DEBUG_LEVEL) */
+
+	/* If we get here, all is good. */
 	rc = J9SYSPROP_ERROR_NONE;
 
 fail:


### PR DESCRIPTION
Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/882 and back-ports.
Fixes: https://github.com/eclipse-openj9/openj9/issues/20534.