### PR TITLE
Move setmemoryEvaluator() from OMR to Openj9

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.hpp
@@ -74,6 +74,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *conditionalHelperEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *flushEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+   static TR::Register *setmemoryEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *VMcheckcastEvaluator2(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *VMcheckcastEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
The current implementation of `OMR::Power::setmemoryEvaluator()` has some OpenJ9 dependencies (namely when getting the `classDepthAndFlags` from the object's `J9Class` to generate the [runtime array check](https://github.com/eclipse-omr/omr/blob/5be76769e35bd6bd3dfec8c5237fb87d8a5e81b0/compiler/p/codegen/OMRTreeEvaluator.cpp#L6130-L6149)), and is only ever used by OpenJ9 to generate assembly code for `Unsafe.setMemory()`. Thus, to avoid having to re-implement `setmemoryEvaluator()` to eliminate these OpenJ9 dependencies, we will move it over to OpenJ9 instead.

Depends on https://github.com/eclipse-omr/omr/pull/7513