### PR TITLE
Add storage, retrieval of AOT method dependencies

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -181,7 +181,7 @@ class CompilationInfoPerThreadBase
                               bool canDoRelocatableCompile,
                               bool eligibleForRelocatableCompile,
                               TR_RelocationRuntime *reloRuntime);
-   const void* findAotBodyInSCC(J9VMThread *vmThread, const J9ROMMethod *romMethod);
+   static const void* findAotBodyInSCC(J9VMThread *vmThread, const J9ROMMethod *romMethod);
 
 #if defined(J9VM_OPT_SHARED_CLASSES) && defined(J9VM_INTERP_AOT_RUNTIME_SUPPORT)
    TR_MethodMetaData *installAotCachedMethod(

--- a/runtime/compiler/env/J9SharedCache.cpp
+++ b/runtime/compiler/env/J9SharedCache.cpp
@@ -25,6 +25,7 @@
 #include <algorithm>
 #include "j9cfg.h"
 #include "control/CompilationRuntime.hpp"
+#include "control/CompilationThread.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
 #include "compile/ResolvedMethod.hpp"
@@ -74,6 +75,10 @@
 // Used by TR_J9SharedCache::rememberClass() to communicate that a class has not been recorded in the SCC but could have been recorded.
 #define COULD_CREATE_CLASS_CHAIN 1
 static_assert(TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET != COULD_CREATE_CLASS_CHAIN, "These values must be distinct");
+
+static const char dependencyKeyPrefix[] = "MethodDependencies:";
+static const size_t dependencyKeyPrefixLength = sizeof(dependencyKeyPrefix) - 1; // exclude NULL terminator
+static const size_t dependencyKeyBufferLength = sizeof(dependencyKeyPrefix) + 16;
 
 TR_J9SharedCache::TR_J9SharedCacheDisabledReason TR_J9SharedCache::_sharedCacheState = TR_J9SharedCache::UNINITIALIZED;
 TR_YesNoMaybe TR_J9SharedCache::_sharedCacheDisabledBecauseFull = TR_maybe;
@@ -1539,6 +1544,81 @@ TR_J9SharedCache::storeWellKnownClasses(J9VMThread *vmThread, uintptr_t *classCh
    dataDescriptor.flags = 0;
 
    return storeSharedData(vmThread, key, &dataDescriptor);
+   }
+
+void
+TR_J9SharedCache::buildAOTMethodDependenciesKey(uintptr_t offset, char *buffer, size_t &keyLength)
+   {
+   auto cursor = buffer;
+
+   memcpy(cursor, dependencyKeyPrefix, dependencyKeyPrefixLength);
+   cursor += dependencyKeyPrefixLength;
+
+   convertUnsignedOffsetToASCII(offset, cursor);
+   keyLength = (cursor - buffer) + _numDigitsForCacheOffsets + 1; // NULL terminator not included in _numDigitsForCacheOffsets
+   }
+
+const void *
+TR_J9SharedCache::storeAOTMethodDependencies(J9VMThread *vmThread,
+                                             TR_OpaqueMethodBlock *method,
+                                             TR_OpaqueClassBlock *definingClass,
+                                             uintptr_t *methodDependencies,
+                                             size_t methodDependenciesSize)
+   {
+   LOG(1, "storeAOTMethodDependencies class %p method %p\n", definingClass, method);
+   uintptr_t methodOffset = 0;
+   if (!isMethodInSharedCache(method, definingClass, &methodOffset))
+      return NULL;
+
+   LOG(3, "\toffset %lu\n", methodOffset);
+
+   char key[dependencyKeyBufferLength];
+   size_t keyLength = 0;
+   buildAOTMethodDependenciesKey(methodOffset, key, keyLength);
+
+   LOG(3, "\tkey created: %.*s\n", keyLength, key);
+
+   J9SharedDataDescriptor dataDescriptor;
+   dataDescriptor.address = (uint8_t *)methodDependencies;
+   dataDescriptor.length = methodDependenciesSize * sizeof(methodDependencies[0]);
+   dataDescriptor.type = J9SHR_DATA_TYPE_JITHINT;
+   dataDescriptor.flags = 0;
+
+   return storeSharedData(vmThread, key, &dataDescriptor);
+   }
+
+bool
+TR_J9SharedCache::methodHasAOTBodyWithDependencies(J9VMThread *vmThread, J9ROMMethod *method, const uintptr_t * &methodDependencies)
+   {
+   methodDependencies = NULL;
+#if defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
+   char key[dependencyKeyBufferLength];
+   uintptr_t methodOffset = INVALID_ROM_METHOD_OFFSET;
+   if (!isROMMethodInSharedCache(method, &methodOffset))
+      return false;
+
+   auto aotBody = TR::CompilationInfoPerThreadBase::findAotBodyInSCC(vmThread, method);
+   if (!aotBody)
+      return false;
+
+   auto dataCacheHeader = static_cast<const J9JITDataCacheHeader *>(aotBody);
+   auto aotMethodHeader = (TR_AOTMethodHeader *)(dataCacheHeader + 1); // skip the data cache header to get to the AOT method header
+   if (!(aotMethodHeader->flags & TR_AOTMethodHeader_TracksDependencies))
+      return false;
+
+   size_t keyLength = 0;
+   buildAOTMethodDependenciesKey(methodOffset, key, keyLength);
+
+   J9SharedDataDescriptor dataDescriptor;
+   dataDescriptor.address = NULL;
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
+
+   if (sharedCacheConfig()->findSharedData(vmThread, key, keyLength, J9SHR_DATA_TYPE_JITHINT, FALSE, &dataDescriptor, NULL) > 0)
+      methodDependencies = (uintptr_t *)dataDescriptor.address;
+   return true;
+#else
+   return false;
+#endif /*  defined(J9VM_OPT_SHARED_CLASSES) && (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64)) */
    }
 
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -418,6 +418,40 @@ public:
     */
    static void buildWellKnownClassesSCCKey(char *buffer, size_t size, unsigned int includedClasses);
 
+    /**
+    * \brief Store the dependencies of an AOT method in the SCC
+    *
+    * The dependencies of an AOT method are encoded as an array of uintptr_t values. The first entry is the number
+    * of elements in the entire array. The subsequent entries are encoded offsets to the class chains of classes that
+    * need to be loaded or initialized before the compiled body can be loaded. If the class must be initialized, the
+    * entry will be the offset itself (which necessarily has a set low bit), and if the class only needs to be loaded
+    * it will be the offset with the low bit cleared.    *
+    *
+    * \param[in] vmThread VM thread
+    * \param[in] methodDependencies The dependencies of the AOT compilation
+    * \param[in] methodDependenciesSize The number of elements in methodDependencies
+    * \return Pointer to the method dependencies in the local SCC, or INVALID_CLASS_CHAIN_OFFSET if the method
+    *         dependencies could not be stored
+    */
+   virtual const void *storeAOTMethodDependencies(J9VMThread *vmThread, TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass,
+                                                  uintptr_t *methodDependencies, size_t methodDependenciesSize);
+
+    /**
+    * \brief Check if the given method has a compiled body in the SCC that tracked its dependencies
+    *
+    * This method also returns the dependencies of the method if they were
+    * stored in the local SCC. Note that if the method has zero dependencies
+    * then we skip storing the dependency chain in the SCC entirely. If this is
+    * the case, methodHasAOTBodyWithDependencies will return true and also
+    * return NULL through methodDependencies.
+    *
+    * \param[in] vmThread VM thread
+    * \param[in] method J9ROMMethod to check
+    * \param[out] methodDependencies The dependencies of compiled body associated to method if they were stored in the SCC
+    * \return Whether or not the method has a body in the SCC that was compiled with dependency tracking
+    */
+   virtual bool methodHasAOTBodyWithDependencies(J9VMThread *vmThread, J9ROMMethod *method, const uintptr_t * &methodDependencies);
+
    enum TR_J9SharedCacheDisabledReason
       {
       UNINITIALIZED,
@@ -488,6 +522,16 @@ protected:
     * \return True if the pointer points into the shared cache, false otherwise.
     */
    bool isROMStructureInSharedCache(void *romStructure, uintptr_t *cacheOffset = NULL);
+
+   /**
+    * \brief Fill the given buffer of size at least dependencyKeyBufferLength with the method dependency key
+    *        corresponding to the given ROM method offset.
+    *
+    * \param[in] offset The offset to the ROM method
+    * \param[out] buffer The buffer to fill with the SCC key
+    * \param[out] keyLength The length of the resulting key, including NULL terminator.
+    */
+   void buildAOTMethodDependenciesKey(uintptr_t offset, char *buffer, size_t &keyLength);
 
 private:
    // This class is intended to be a POD; keep it simple.
@@ -714,6 +758,9 @@ public:
    static TR_YesNoMaybe isSharedCacheDisabledBecauseFull(TR::CompilationInfo *compInfo) { TR_ASSERT_FATAL(false, "called"); return TR_no;}
    static void setStoreSharedDataFailedLength(UDATA length) { TR_ASSERT_FATAL(false, "called"); }
 
+   virtual bool methodHasAOTBodyWithDependencies(J9VMThread *vmThread, J9ROMMethod *method, const uintptr_t * &methodDependencies) override
+      { TR_ASSERT_FATAL(false, "called"); return false; }
+
    virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) override;
 
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList() override;
@@ -812,6 +859,9 @@ public:
    virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL) override { TR_ASSERT_FATAL(false, "called"); return false; }
    virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) override { TR_ASSERT_FATAL(false, "called"); return 0; }
    virtual const void *storeSharedData(J9VMThread *vmThread, const char *key, const J9SharedDataDescriptor *descriptor) override { TR_ASSERT_FATAL(false, "called"); return NULL; }
+
+   virtual bool methodHasAOTBodyWithDependencies(J9VMThread *vmThread, J9ROMMethod *method, const uintptr_t * &methodDependencies) override
+      { TR_ASSERT_FATAL(false, "called"); return false; }
 
    virtual J9SharedClassCacheDescriptor *getCacheDescriptorList() override { TR_ASSERT_FATAL(false, "called"); return NULL; }
 

--- a/runtime/compiler/runtime/J9Runtime.hpp
+++ b/runtime/compiler/runtime/J9Runtime.hpp
@@ -199,6 +199,7 @@ typedef struct TR_AOTMethodHeader {
 #define TR_AOTMethodHeader_UsesOSR                                   0x00000200
 #define TR_AOTMethodHeader_MethodTracingEnabled                      0x00000400
 #define TR_AOTMethodHeader_UsesFSD                                   0x00000800
+#define TR_AOTMethodHeader_TracksDependencies                        0x00001000
 
 
 typedef struct TR_AOTInliningStats


### PR DESCRIPTION
When the dependencies of compiled AOT method bodies are tracked, they will be stored in the SCC as arrays of uintptr_t values, with the first entry being the length of the array, and the subsequent entries being encoded class chain offsets. The low bit of the class chain offset will be cleared if the corresponding class merely needs to be loaded before the compiled method body in the SCC can be loaded.

This infrastructure is currently unused.

Related: https://github.com/eclipse-openj9/openj9/issues/20529