### PR TITLE
Fix build break in JDK8,11 due to undefined targetMethodFromMemberName

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1926,7 +1926,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          TR_ResolvedJ9Method *owningMethod = std::get<0>(recv);
          uintptr_t * invokeCacheArray = std::get<1>(recv);
 
-         bool isInvokeCacheAppendixNull;
+         bool isInvokeCacheAppendixNull = false;
          TR_OpaqueMethodBlock *targetMethod = owningMethod->getTargetMethodFromMemberName(invokeCacheArray, &isInvokeCacheAppendixNull);
 
          client->write(response, targetMethod, isInvokeCacheAppendixNull);

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6997,14 +6997,19 @@ TR_ResolvedJ9Method::handleUnresolvedVirtualMethodInCP(int32_t cpIndex, bool * u
 TR_OpaqueMethodBlock *
 TR_ResolvedJ9Method::getTargetMethodFromMemberName(uintptr_t * invokeCacheArray, bool * isInvokeCacheAppendixNull)
    {
+   TR_OpaqueMethodBlock *targetJ9MethodBlock = NULL;
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    TR::VMAccessCriticalSection getTargetMethodCS(fej9());
-   TR_OpaqueMethodBlock *targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) fej9()->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayMemberNameIndex));
+   targetJ9MethodBlock = fej9()->targetMethodFromMemberName((uintptr_t) fej9()->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayMemberNameIndex));
    // if the callSite table entry / method type table entry is resolved,
    // we can check if the appendix object is null,
    // in which case the appendix object must not be pushed to stack
    auto appendixObject = fej9()->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayAppendixIndex);
    if (isInvokeCacheAppendixNull && !appendixObject)
       *isInvokeCacheAppendixNull = true;
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
    return targetJ9MethodBlock;
    }
 

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1580,6 +1580,7 @@ TR::SymbolValidationManager::validateDynamicMethodFromCallsiteIndex(uint16_t met
    {
    bool valid = false;
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    TR_OpaqueMethodBlock *caller = getMethodFromID(callerID);
    TR_ResolvedMethod *resolvedCaller = _fej9->createResolvedMethod(_trMemory, caller, NULL);
 
@@ -1614,6 +1615,7 @@ TR::SymbolValidationManager::validateDynamicMethodFromCallsiteIndex(uint16_t met
             && (methodIndex == _fej9->getMethodIndexInClass(targetMethodClass, targetMethod));
          }
       }
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
    return valid;
    }
@@ -1628,6 +1630,7 @@ TR::SymbolValidationManager::validateHandleMethodFromCPIndex(uint16_t methodID,
    {
    bool valid = false;
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    TR_OpaqueMethodBlock *caller = getMethodFromID(callerID);
    TR_ResolvedMethod *resolvedCaller = _fej9->createResolvedMethod(_trMemory, caller, NULL);
 
@@ -1659,6 +1662,7 @@ TR::SymbolValidationManager::validateHandleMethodFromCPIndex(uint16_t methodID,
          // bytecodes are the same.
          && (methodIndex == _fej9->getMethodIndexInClass(targetMethodClass, targetMethod));
       }
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
    return valid;
    }


### PR DESCRIPTION
This PR fixes a build break in JDK8 and JDK11 introduced by https://github.com/eclipse-openj9/openj9/pull/20373 which occurred because `J9VM_OPT_OPENJDK_METHODHANDLE` is not defined. 