### PR TITLE
Don't use <fieldalias> for java/lang/reflect/Field.flags

### DIFF
--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -834,7 +834,7 @@ createField(struct J9VMThread *vmThread, jfieldID fieldID)
 	J9VMJAVALANGREFLECTFIELD_SET_CLAZZ(vmThread, fieldObject, J9VM_J9CLASS_TO_HEAPCLASS(j9FieldID->declaringClass));
 	J9VMJAVALANGREFLECTFIELD_SET_MODIFIERS(vmThread, fieldObject, j9FieldID->field->modifiers & CFR_FIELD_ACCESS_MASK);
 #if JAVA_SPEC_VERSION >= 15
-	/* trust that static final fields and final record or hidden class fields will not be modified. */
+	/* Trust that static final fields and final record or hidden class fields will not be modified. */
 	if (J9_ARE_ALL_BITS_SET(j9FieldID->field->modifiers, J9AccFinal)) {
 		if (J9_ARE_ALL_BITS_SET(j9FieldID->field->modifiers, J9AccStatic)
 			|| J9ROMCLASS_IS_RECORD(j9FieldID->declaringClass->romClass)
@@ -851,8 +851,8 @@ createField(struct J9VMThread *vmThread, jfieldID fieldID)
 	if (J9ROMFIELD_IS_NULL_RESTRICTED(j9FieldID->field)) {
 		fieldFlags |= NULL_RESTRICTED;
 	}
-	/* alias is "int flags;" in value types */
-	J9VMJAVALANGREFLECTFIELD_SET_TRUSTEDFINAL(vmThread, fieldObject, fieldFlags);
+	/* Field is "int flags;" in value types. */
+	J9VMJAVALANGREFLECTFIELD_SET_FLAGS(vmThread, fieldObject, fieldFlags);
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #endif /* JAVA_SPEC_VERSION >= 15 */
 

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -283,9 +283,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/reflect/Field" name="type" signature="Ljava/lang/Class;"/>
 	<fieldref class="java/lang/reflect/Field" name="signature" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/reflect/Field" name="modifiers" signature="I"/>
-	<fieldref class="java/lang/reflect/Field" name="trustedFinal" signature="Z" versions="15-">
-		<fieldalias name="flags" signature="I" flags="opt_valhallaValueTypes"/>
-	</fieldref>
+	<fieldref class="java/lang/reflect/Field" name="trustedFinal" signature="Z" versions="15-" flags="!opt_valhallaValueTypes"/>
+	<fieldref class="java/lang/reflect/Field" name="flags" signature="I" flags="opt_valhallaValueTypes"/>
 	<fieldref class="java/lang/reflect/Field" name="annotations" signature="[B"/>
 	<fieldref class="java/lang/reflect/Field" name="slot" signature="I"/>
 	<fieldref class="java/lang/reflect/Field" name="clazz" signature="Ljava/lang/Class;"/>


### PR DESCRIPTION
The fields `Field.flags` and `Field.trustedFinal` are related, but have different types, making it inappropriate to treat them as aliases.

Fixes: #20580.