### PR TITLE
AArch64: Implement arrayTranslateTRTO

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -596,6 +596,7 @@ JIT_HELPER(__forwardArrayCopy);
 JIT_HELPER(__backwardArrayCopy);
 JIT_HELPER(_patchGCRHelper);
 JIT_HELPER(_fieldWatchHelper);
+JIT_HELPER(__arrayTranslateTRTO);
 JIT_HELPER(__arrayTranslateTRTO255);
 
 #elif defined(TR_HOST_S390)
@@ -1581,6 +1582,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
 #else
    SET(TR_ARM64fieldWatchHelper,                  (void *) 0,                                TR_Helper);
 #endif
+   SET(TR_ARM64arrayTranslateTRTO,                (void *) __arrayTranslateTRTO,             TR_Helper);
    SET(TR_ARM64arrayTranslateTRTO255,             (void *) __arrayTranslateTRTO255,          TR_Helper);
 
 #elif defined(TR_HOST_S390)


### PR DESCRIPTION
This commit implements arraytranslateTRTO (ASCII conversion) for AArch64.