### PR TITLE
Support JEP 486: Permanently Disable the Security Manager

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -35,6 +35,7 @@
 
 K002c=Access\ denied\ {0}
 K002d=Access\ denied\ {0} due to untrusted AccessControlContext since {1} is denied
+K002e=checking\ permissions\ is\ not\ supported
 
 K0053=Package\ {0}\ already\ defined.
 K0056=Already\ destroyed

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -290,14 +290,12 @@ final class Access implements JavaLangAccess {
 		return classLoader.createOrGetClassLoaderValueMap();
 	}
 
+/*[IF (JAVA_SPEC_VERSION >= 11) & (JAVA_SPEC_VERSION < 24)]*/
 	@SuppressWarnings("removal")
 	public void invalidatePackageAccessCache() {
-/*[IF JAVA_SPEC_VERSION >= 10]*/
-		java.lang.SecurityManager.invalidatePackageAccessCache();
-/*[ELSE] JAVA_SPEC_VERSION >= 10 */
-		return;
-/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
+		SecurityManager.invalidatePackageAccessCache();
 	}
+/*[ENDIF] (JAVA_SPEC_VERSION >= 11) & (JAVA_SPEC_VERSION < 24) */
 
 	public Class<?> defineClass(ClassLoader classLoader, String className, byte[] classRep, ProtectionDomain protectionDomain, String str) {
 		ClassLoader targetClassLoader = (null == classLoader) ? ClassLoader.bootstrapClassLoader : classLoader;
@@ -352,10 +350,12 @@ final class Access implements JavaLangAccess {
 		return ml.getServicesCatalog();
 	}
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	public void addNonExportedPackages(ModuleLayer ml) {
 		SecurityManager.addNonExportedPackages(ml);
 	}
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	public List<Method> getDeclaredPublicMethods(Class<?> clz, String name, Class<?>... types) {
 		return clz.getDeclaredPublicMethods(name, types);
@@ -542,11 +542,6 @@ final class Access implements JavaLangAccess {
 	}
 
 	@Override
-	public boolean allowSecurityManager() {
-		return System.allowSecurityManager();
-	}
-
-	@Override
 	public int getCharsLatin1(long i, int index, byte[] buf) {
 		return StringLatin1.getChars(i, index, buf);
 	}
@@ -562,6 +557,11 @@ final class Access implements JavaLangAccess {
 	}
 
 /*[IF JAVA_SPEC_VERSION < 24]*/
+	@Override
+	public boolean allowSecurityManager() {
+		return System.allowSecurityManager();
+	}
+
 	@Override
 	public long stringConcatHelperPrepend(long indexCoder, byte[] buf, String value) {
 		return StringConcatHelper.prepend(indexCoder, buf, value);

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1298,11 +1298,11 @@ static void initSecurityManager(ClassLoader applicationClassLoader) {
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
-/*[IF JAVA_SPEC_VERSION >= 23]*/
+/*[IF JAVA_SPEC_VERSION == 23]*/
 static boolean allowSecurityManager() {
 	return !throwUOEFromSetSM;
 }
-/*[ENDIF] JAVA_SPEC_VERSION >= 23 */
+/*[ENDIF] JAVA_SPEC_VERSION == 23 */
 
 /**
  * Sets the active security manager. Note that once

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -22,6 +22,7 @@
  */
 package java.security;
 
+import com.ibm.oti.util.Msg;
 import java.io.IOException;
 import java.io.StreamTokenizer;
 import java.io.StringReader;
@@ -496,6 +497,7 @@ static Permission[] combinePermObjs(Permission[] checked, Permission[] toBeCombi
 	return (Permission[]) combineObjs(false, checked, toBeCombined, start, len, justCombine);
 }
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 /**
  * Perform ProtectionDomain.implies(permission) with known ProtectionDomain objects already implied
  *
@@ -661,7 +663,7 @@ static boolean checkPermissionWithCache(
 				}
 			}
 			/*[MSG "K002c", "Access denied {0}"]*/
-			throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002c", perm), perm); //$NON-NLS-1$
+			throw new AccessControlException(Msg.getString("K002c", perm), perm); //$NON-NLS-1$
 		}
 	}
 	if (null != accCurrent
@@ -697,6 +699,7 @@ static boolean checkPermissionWithCache(
 	}
 	return true;
 }
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 /**
  * Helper to print debug information for checkPermission().
@@ -730,6 +733,10 @@ private boolean debugHelper(Permission perm) {
  *                  if perm is null
  */
 public void checkPermission(Permission perm) throws AccessControlException {
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	/*[MSG "K002e", "checking permissions is not supported"]*/
+	throw new AccessControlException(Msg.getString("K002e")); //$NON-NLS-1$
+/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	if (perm == null) throw new NullPointerException();
 	if (null != context && (STATE_AUTHORIZED != authorizeState) && containPrivilegedContext && null != System.getSecurityManager()) {
 		// only check SecurityPermission "createAccessControlContext" when context is not null, not authorized and containPrivilegedContext.
@@ -743,7 +750,7 @@ public void checkPermission(Permission perm) throws AccessControlException {
 		}
 		if (STATE_NOT_AUTHORIZED == authorizeState) {
 			/*[MSG "K002d", "Access denied {0} due to untrusted AccessControlContext since {1} is denied"]*/
-			throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002d", perm, SecurityConstants.CREATE_ACC_PERMISSION), perm); //$NON-NLS-1$
+			throw new AccessControlException(Msg.getString("K002d", perm, SecurityConstants.CREATE_ACC_PERMISSION), perm); //$NON-NLS-1$
 		}
 	}
 
@@ -752,6 +759,7 @@ public void checkPermission(Permission perm) throws AccessControlException {
 		debug = debugHelper(perm);
 	}
 	checkPermissionWithCache(perm, null, this.context, debug ? DEBUG_ENABLED | DEBUG_ACCESS_DENIED : DEBUG_DISABLED, this.doPrivilegedAcc,this.isLimitedContext, this.limitedPerms, this.nextStackAcc, new AccessCache());
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
 /**

--- a/jcl/src/java.base/share/classes/java/security/AccessController.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessController.java
@@ -22,6 +22,7 @@
  */
 package java.security;
 
+import com.ibm.oti.util.Msg;
 import sun.security.util.SecurityConstants;
 
 /*[IF JAVA_SPEC_VERSION >= 9]
@@ -47,6 +48,11 @@ public final class AccessController {
 		// Initialize vm-internal caches
 		initializeInternal();
 	}
+
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	private static AccessControlContext ACC_NO_PERM = new AccessControlContext(
+			new ProtectionDomain[] { new ProtectionDomain(null, null) });
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 	static final int OBJS_INDEX_ACC = 0;
 	static final int OBJS_INDEX_PDS = 1;
@@ -179,13 +185,14 @@ private static void throwACE(boolean debug, Permission perm, ProtectionDomain pD
 	}
 	if (createACCdenied) {
 		/*[MSG "K002d", "Access denied {0} due to untrusted AccessControlContext since {1} is denied"]*/
-		throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002d", perm, SecurityConstants.CREATE_ACC_PERMISSION), perm); //$NON-NLS-1$
+		throw new AccessControlException(Msg.getString("K002d", perm, SecurityConstants.CREATE_ACC_PERMISSION), perm); //$NON-NLS-1$
 	} else {
 		/*[MSG "K002c", "Access denied {0}"]*/
-		throw new AccessControlException(com.ibm.oti.util.Msg.getString("K002c", perm), perm); //$NON-NLS-1$
+		throw new AccessControlException(Msg.getString("K002c", perm), perm); //$NON-NLS-1$
 	}
 }
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 /**
  * Helper method to check whether the running program is allowed to access the resource
  * being guarded by the given Permission argument
@@ -268,6 +275,7 @@ private static boolean checkPermissionHelper(Permission perm, AccessControlConte
 	}
 	return limitedPermImplied;
 }
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 /**
  * Helper to print debug stack information for checkPermission().
@@ -368,6 +376,10 @@ private static boolean debugHelperJEP140(Object[] objects, Permission perm) {
  *              NullPointerException if perm is null
  */
 public static void checkPermission(Permission perm) throws AccessControlException {
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	/*[MSG "K002e", "checking permissions is not supported"]*/
+	throw new AccessControlException(Msg.getString("K002e")); //$NON-NLS-1$
+/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	if (perm == null) {
 		throw new NullPointerException();
 	}
@@ -421,6 +433,7 @@ public static void checkPermission(Permission perm) throws AccessControlExceptio
 		System.err.println("access allowed " + perm); //$NON-NLS-1$
 		DebugRecursionDetection.getTlDebug().remove();
 	}
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
 /**
@@ -452,7 +465,11 @@ private static void keepalive(Permission... perms) {
  * @see         AccessControlContext
  */
 public static AccessControlContext getContext() {
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	return ACC_NO_PERM;
+/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	return getContextHelper(false);
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
 /**

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -1423,11 +1423,13 @@ Java_java_security_AccessController_getAccSnapshot(JNIEnv* env, jclass jsAccessC
 	if (NULL != vmThread->currentException) {
 		goto _walkStateUninitialized;
 	}
+#if JAVA_SPEC_VERSION < 24
 	/* AccessControlContext is allocated in the same space as the thread, so no exception can occur */
 	contextObject = vmThread->threadObject;
 	if (NULL != contextObject) {
 		contextObject = J9VMJAVALANGTHREAD_INHERITEDACCESSCONTROLCONTEXT(vmThread, contextObject);
 	}
+#endif /* JAVA_SPEC_VERSION < 24 */
 	/* Walk the stack, caching the constant pools of the frames. */
 	walkState.skipCount = startingFrame + 1; /* skip this JNI frame as well */
 	walkState.userData1 = STACK_WALK_STATE_MAGIC;	/* set to NULL when a limited doPrivileged frame is discovered */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -231,7 +231,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<!-- Common field references shared between OpenJ9 and OpenJDK Thread. -->
 	<fieldref class="java/lang/Thread" name="contextClassLoader" signature="Ljava/lang/ClassLoader;"/>
-	<fieldref class="java/lang/Thread" name="inheritedAccessControlContext" signature="Ljava/security/AccessControlContext;"/>
+	<fieldref class="java/lang/Thread" name="inheritedAccessControlContext" signature="Ljava/security/AccessControlContext;" versions="8-23"/>
 	<fieldref class="java/lang/Thread" name="name" signature="Ljava/lang/String;"/>
 	<fieldref class="java/lang/Thread" name="parkBlocker" signature="Ljava/lang/Object;"/>
 	<fieldref class="java/lang/Thread" name="tid" signature="J"/>


### PR DESCRIPTION
Support JEP 486: Permanently Disable the Security Manager

JDK24 removes the following:
```
SecurityManager.invalidatePackageAccessCache();
SecurityManager.addNonExportedPackages(ml);
Access.allowSecurityManager();
Throw new AccessControlException() for
AccessControlContext.checkPermission() and
AccessController.javaAccessController.checkPermission();
AccessController.getContext() returns NO_PERMISSIONS_ACC;
Thread.inheritedAccessControlContext.
```

Originally included
* https://github.com/eclipse-openj9/openj9/pull/20566

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/886

Related to https://github.com/eclipse-openj9/openj9/issues/20563

Signed-off-by: Jason Feng <fengj@ca.ibm.com>