### PR TITLE
Clean up references to old opcodes

### DIFF
--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4927,7 +4927,7 @@ TR_J9ByteCodeIlGenerator::runMacro(TR::SymbolReference * symRef)
                push(array);
                loadConstant(TR::iconst, i);
                push(arg);
-               storeArrayElement(arg->getDataType()); // TODO:JSR292: use isstore for char arguments
+               storeArrayElement(arg->getDataType()); // TODO:JSR292: use sstorei for char arguments
                }
             argShepherd->removeAllChildren();
             push(array);

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -1375,13 +1375,13 @@ while the direct access code looks like
     iloadi
       aiadd
 We will replace b2i and bloadi by c2iu and icload for Unsafe.getChar, by
-s2i and isload for Unsafe.getShort, and by bu2i and bloadi for Unsafe.getBoolean
+s2i and sloadi for Unsafe.getShort, and by bu2i and bloadi for Unsafe.getBoolean
 
 For Unsafe.putByte and Unsafe.putBoolean, we generate
    bstorei
      i2b
        <some load node>
-We replace i2b and bstorei by i2c and icstore for Unsafe.getChar, and by i2s and isstore for
+We replace i2b and bstorei by i2c and icstore for Unsafe.getChar, and by i2s and sstorei for
 Unsafe.getShort.
 */
 

--- a/runtime/compiler/optimizer/J9Simplifier.cpp
+++ b/runtime/compiler/optimizer/J9Simplifier.cpp
@@ -1034,7 +1034,7 @@ J9::Simplifier::simplifyi2sPatterns(TR::Node *node)
    if (firstChild->getOpCodeValue() == TR::ior && 
        firstChild->getReferenceCount() == 1 &&
        (address = getOrOfTwoConsecutiveBytes(firstChild)) &&
-       performTransformation(comp(), "%sconvert ior to isload node [" POINTER_PRINTF_FORMAT "]\n", optDetailString(), node))
+       performTransformation(comp(), "%sconvert ior to sloadi node [" POINTER_PRINTF_FORMAT "]\n", optDetailString(), node))
       {
       TR::Node::recreate(node, TR::sloadi);
       node->setSymbolReference(getSymRefTab()->findOrCreateUnsafeSymbolRef(TR::Int16));


### PR DESCRIPTION
The old opcodes had the letter i as a prefix if the operation was indirect. Those opcodes were renamed to use the letter i as a suffix instead.

This commit cleans up the references to the old opcodes from isload/isstore to sloadi/sstorei 

Related: #19489