### PR TITLE
Change Class.isAssignableFrom to use CHelper instead of JNI call on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3800,6 +3800,11 @@ J9::Z::CodeGenerator::inlineDirectCall(
       ReduceSynchronizedFieldLoad::inlineSynchronizedFieldLoad(node, cg);
       return true;
       }
+   else if (node->getSymbolReference()->getReferenceNumber() == TR_checkAssignable)
+      {
+      resultReg = TR::TreeEvaluator::inlineCheckAssignableFromEvaluator(node, cg);
+      return true;
+      }
 
    static const char * enableTRTRE = feGetEnv("TR_enableTRTRE");
    static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -225,6 +225,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *resolveAndNULLCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *evaluateNULLCHKWithPossibleResolve(TR::Node *node, bool needResolution, TR::CodeGenerator *cg);
    static float interpreterProfilingInstanceOfOrCheckCastTopProb(TR::CodeGenerator * cg, TR::Node * node);
+   static TR::Register *inlineCheckAssignableFromEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
    /**
     * \brief

--- a/runtime/compiler/z/codegen/S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390CHelperLinkage.cpp
@@ -250,6 +250,18 @@ class RealRegisterManager
    TR::CodeGenerator*   _cg;
    };
 
+bool J9::Z::CHelperLinkage::getIsFastPathOnly(TR::Node * callNode)
+   {
+   auto opCode = callNode->getOpCodeValue();
+   if (opCode == TR::instanceof)
+      {
+      return true;
+      }
+
+   TR::SymbolReference * ref = callNode->getSymbolReference();
+   return ref == cg()->comp()->getSymRefTab()->findOrCreateRuntimeHelper(TR_checkAssignable);
+   }
+
 /**   \brief Build a JIT helper call.
  *    \details
  *    It generates sequence that prepares parameters for the JIT helper function and generate a helper call.
@@ -264,7 +276,7 @@ TR::Register * J9::Z::CHelperLinkage::buildDirectDispatch(TR::Node * callNode, T
    RealRegisterManager RealRegisters(cg());
    bool isHelperCallWithinICF = deps != NULL;
    // TODO: Currently only jitInstanceOf is fast path helper. Need to modify following condition if we add support for other fast path only helpers
-   bool isFastPathOnly = callNode->getOpCodeValue() == TR::instanceof;
+   bool isFastPathOnly = getIsFastPathOnly(callNode);
    traceMsg(comp(),"%s: Internal Control Flow in OOL : %s\n",callNode->getOpCode().getName(),isHelperCallWithinICF  ? "true" : "false" );
    for (int i = TR::RealRegister::FirstGPR; i < TR::RealRegister::NumRegisters; i++)
       {

--- a/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
+++ b/runtime/compiler/z/codegen/S390CHelperLinkage.hpp
@@ -39,6 +39,7 @@ class CHelperLinkage : public TR::Linkage
    uint32_t _preservedRegisterMapForGC;
    TR::RealRegister::RegNum _methodMetaDataRegister;
    TR::RealRegister::RegNum _returnAddressRegister;
+   bool getIsFastPathOnly(TR::Node * callNode);
 	// Following Regs are needed only in the case of zOS.
 #if defined(J9ZOS390)
 	TR::RealRegister::RegNum _DSAPointerRegister;


### PR DESCRIPTION
Calls to Class.isAssignableFrom will now use CHelper instead of a JNI call.

note: as discussed (@r30shah ), this change is not enabled yet on Z. It will be enabled when the inlined tests are added to `checkAssignabeEvaluator`.
[vmfarm sanity check for this branch](https://hyc-runtimes-jenkins.swg-devops.com/job/jvm.29.personal/34447/)

The following tests were run on a branch with the change enabled:
[vmfarm](https://hyc-runtimes-jenkins.swg-devops.com/job/jvm.29.personal/34474/)
[personal s390x](https://hyc-runtimes-jenkins.swg-devops.com/job/Pipeline-Build-Test-Personal/25034/)
[personal s390x (unstable re-run)](https://hyc-runtimes-jenkins.swg-devops.com/job/Pipeline-Build-Test-Personal/25047/)