### PR TITLE
    Cache Client's Reflect Class Pointers at JITServer     

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -550,6 +550,16 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
 #else
          vmInfo._isNonPortableRestoreMode = false;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+         vmInfo._voidReflectClassPtr = javaVM->voidReflectClass;
+         vmInfo._booleanReflectClassPtr = javaVM->booleanReflectClass;
+         vmInfo._charReflectClassPtr = javaVM->charReflectClass;
+         vmInfo._floatReflectClassPtr = javaVM->floatReflectClass;
+         vmInfo._doubleReflectClassPtr = javaVM->doubleReflectClass;
+         vmInfo._byteReflectClassPtr = javaVM->byteReflectClass;
+         vmInfo._shortReflectClassPtr = javaVM->shortReflectClass;
+         vmInfo._intReflectClassPtr = javaVM->intReflectClass;
+         vmInfo._longReflectClassPtr = javaVM->longReflectClass;
+
          client->write(response, vmInfo, listOfCacheDescriptors, comp->getPersistentInfo()->getJITServerAOTCacheName());
          }
          break;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1307,31 +1307,64 @@ TR_J9VMBase::getReferenceElement(uintptr_t objectPointer, intptr_t elementIndex)
    return (uintptr_t)J9JAVAARRAYOFOBJECT_LOAD(vmThread(), objectPointer, elementIndex);
    }
 
-TR_arrayTypeCode TR_J9VMBase::getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz)
+TR_arrayTypeCode
+TR_J9VMBase::getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz)
    {
    TR_ASSERT(isPrimitiveClass(clazz), "Expect primitive class in TR_J9VMBase::getPrimitiveArrayType");
 
    J9Class* j9clazz = (J9Class*)clazz;
-   if (j9clazz == jitConfig->javaVM->booleanReflectClass)
-      return atype_boolean;
-   else if (j9clazz == jitConfig->javaVM->charReflectClass)
-      return atype_char;
-   else if (j9clazz == jitConfig->javaVM->floatReflectClass)
-      return atype_float;
-   else if (j9clazz == jitConfig->javaVM->doubleReflectClass)
-      return atype_double;
-   else if (j9clazz == jitConfig->javaVM->byteReflectClass)
-      return atype_byte;
-   else if (j9clazz == jitConfig->javaVM->shortReflectClass)
-      return atype_short;
-   else if (j9clazz == jitConfig->javaVM->intReflectClass)
-      return atype_int;
-   else if (j9clazz == jitConfig->javaVM->longReflectClass)
-      return atype_long;
-   else
+#if defined(J9VM_OPT_JITSERVER)
+   if (_compInfo->getPersistentInfo()->getRemoteCompilationMode() == JITServer::SERVER)
+      /* In server mode */
       {
-      TR_ASSERT(false, "TR_arrayTypeCode is not defined for the j9clazz");
-      return (TR_arrayTypeCode)0;
+      auto stream = _compInfoPT->getStream();
+      auto vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+      if (j9clazz == vmInfo->_booleanReflectClassPtr)
+         return atype_boolean;
+      else if (j9clazz == vmInfo->_charReflectClassPtr)
+         return atype_char;
+      else if (j9clazz == vmInfo->_floatReflectClassPtr)
+         return atype_float;
+      else if (j9clazz == vmInfo->_doubleReflectClassPtr)
+         return atype_double;
+      else if (j9clazz == vmInfo->_byteReflectClassPtr)
+         return atype_byte;
+      else if (j9clazz == vmInfo->_shortReflectClassPtr)
+         return atype_short;
+      else if (j9clazz == vmInfo->_intReflectClassPtr)
+         return atype_int;
+      else if (j9clazz == vmInfo->_longReflectClassPtr)
+         return atype_long;
+      else
+         {
+         TR_ASSERT(false, "TR_arrayTypeCode is not defined for the j9clazz");
+         return (TR_arrayTypeCode)0;
+         }
+      }
+   else
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      if (j9clazz == jitConfig->javaVM->booleanReflectClass)
+         return atype_boolean;
+      else if (j9clazz == jitConfig->javaVM->charReflectClass)
+         return atype_char;
+      else if (j9clazz == jitConfig->javaVM->floatReflectClass)
+         return atype_float;
+      else if (j9clazz == jitConfig->javaVM->doubleReflectClass)
+         return atype_double;
+      else if (j9clazz == jitConfig->javaVM->byteReflectClass)
+         return atype_byte;
+      else if (j9clazz == jitConfig->javaVM->shortReflectClass)
+         return atype_short;
+      else if (j9clazz == jitConfig->javaVM->intReflectClass)
+         return atype_int;
+      else if (j9clazz == jitConfig->javaVM->longReflectClass)
+         return atype_long;
+      else
+         {
+         TR_ASSERT(false, "TR_arrayTypeCode is not defined for the j9clazz");
+         return (TR_arrayTypeCode)0;
+         }
       }
    }
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 70; // ID:5nbb7nhW+R7OABuv+aRm
+   static const uint16_t MINOR_NUMBER = 71; // ID: t80Voe+mNpo5+lQvjult
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -258,6 +258,8 @@ const char *messageNames[] =
    "KnownObjectTable_createSymRefWithKnownObject",
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
+   "KnownObjectTable_getJ9Class",
+   "KnownObjectTable_getVectorBitSize",
    "AOTCache_getROMClassBatch",
    "AOTCacheMap_request",
    "AOTCacheMap_reply"

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -283,11 +283,16 @@ enum MessageType : uint16_t
    KnownObjectTable_createSymRefWithKnownObject,
    KnownObjectTable_getReferenceField,
    KnownObjectTable_getKnownObjectTableDumpInfo,
+   // for getting a J9Class from KnownObjectTable
+   KnownObjectTable_getJ9Class,
+   // for getting a vectorBitSize from KnownObjectTable
+   KnownObjectTable_getVectorBitSize,
 
    AOTCache_getROMClassBatch,
 
    AOTCacheMap_request,
    AOTCacheMap_reply,
+
 
    MessageType_MAXTYPE
    };

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -718,23 +718,47 @@ TR_VectorAPIExpansion::getDataTypeFromClassNode(TR::Compilation *comp, TR::Node 
 
    if (!j9class) return TR::NoType;
 
-   TR_J9VMBase *fej9 = comp->fej9();
-   J9JavaVM *vm = fej9->getJ9JITConfig()->javaVM;
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp->isOutOfProcessCompilation()) /* In server mode */
+      {
+      auto vmInfo = comp->getClientData()->getOrCacheVMInfo(comp->getStream());
 
-   if (j9class == vm->floatReflectClass)
-      return TR::Float;
-   else if (j9class == vm->doubleReflectClass)
-      return TR::Double;
-   else if (j9class == vm->byteReflectClass)
-      return TR::Int8;
-   else if (j9class == vm->shortReflectClass)
-      return TR::Int16;
-   else if (j9class == vm->intReflectClass)
-      return TR::Int32;
-   else if (j9class == vm->longReflectClass)
-      return TR::Int64;
+      if (j9class == vmInfo->_floatReflectClassPtr)
+         return TR::Float;
+      else if (j9class == vmInfo->_doubleReflectClassPtr)
+         return TR::Double;
+      else if (j9class == vmInfo->_byteReflectClassPtr)
+         return TR::Int8;
+      else if (j9class == vmInfo->_shortReflectClassPtr)
+         return TR::Int16;
+      else if (j9class == vmInfo->_intReflectClassPtr)
+         return TR::Int32;
+      else if (j9class == vmInfo->_longReflectClassPtr)
+         return TR::Int64;
+      else
+         return TR::NoType;
+      }
    else
-      return TR::NoType;
+#endif /* defined(J9VM_OPT_JITSERVER) */
+      {
+      TR_J9VMBase *fej9 = comp->fej9();
+      J9JavaVM *vm = fej9->getJ9JITConfig()->javaVM;
+
+      if (j9class == vm->floatReflectClass)
+         return TR::Float;
+      else if (j9class == vm->doubleReflectClass)
+         return TR::Double;
+      else if (j9class == vm->byteReflectClass)
+         return TR::Int8;
+      else if (j9class == vm->shortReflectClass)
+         return TR::Int16;
+      else if (j9class == vm->intReflectClass)
+         return TR::Int32;
+      else if (j9class == vm->longReflectClass)
+         return TR::Int64;
+      else
+         return TR::NoType;
+      }
    }
 
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -334,6 +334,16 @@ public:
       bool _isPortableRestoreMode;
       bool _isSnapshotModeEnabled;
       bool _isNonPortableRestoreMode;
+      // The reflect class pointers for the server to identify the classes
+      void *_voidReflectClassPtr;
+      void *_booleanReflectClassPtr;
+      void *_charReflectClassPtr;
+      void *_floatReflectClassPtr;
+      void *_doubleReflectClassPtr;
+      void *_byteReflectClassPtr;
+      void *_shortReflectClassPtr;
+      void *_intReflectClassPtr;
+      void *_longReflectClassPtr;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
Cache the reflect class pointer used by the client VM in its VMInfo for the JITServer so the JITServer can identify those classes.
