### PR TITLE
Cache Client's Reflect Class Pointers at JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2885,6 +2885,41 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, knownObjectTableDumpInfoList);
          }
          break;
+      case MessageType::KnownObjectTable_getJ9Class:
+         {
+         TR::KnownObjectTable::Index knotIndex =
+            std::get<0>(client->getRecvData<TR::KnownObjectTable::Index>());
+
+         uintptr_t j9class = 0;
+            {
+            TR::VMAccessCriticalSection getJ9ClassFromKnownObjectIndex(fe);
+
+            uintptr_t javaLangClass = knot->getPointer(knotIndex);
+            j9class = (uintptr_t)fe->getInt64Field(javaLangClass, "vmRef");
+            }
+
+         client->write(response, j9class);
+         }
+         break;
+      case MessageType::KnownObjectTable_getVectorBitSize:
+         {
+         TR::KnownObjectTable::Index knotIndex =
+            std::get<0>(client->getRecvData<TR::KnownObjectTable::Index>());
+
+         int32_t vectorBitSize = 0;
+            {
+            TR::VMAccessCriticalSection getVBSFromKnownObjectIndex(fe);
+
+            uintptr_t vectorSpeciesLocation = knot->getPointer(knotIndex);
+            uintptr_t vectorShapeLocation = fe->getReferenceField(vectorSpeciesLocation,
+                                                            "vectorShape",
+                                                            "Ljdk/incubator/vector/VectorShape;");
+            vectorBitSize = fe->getInt32Field(vectorShapeLocation, "vectorBitSize");
+            }
+
+         client->write(response, vectorBitSize);
+         }
+         break;
       case MessageType::AOTCache_getROMClassBatch:
          {
          auto recv = client->getRecvData<std::vector<J9Class *>>();

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -555,6 +555,16 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
 #else
          vmInfo._isNonPortableRestoreMode = false;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+         vmInfo._voidReflectClassPtr = javaVM->voidReflectClass;
+         vmInfo._booleanReflectClassPtr = javaVM->booleanReflectClass;
+         vmInfo._charReflectClassPtr = javaVM->charReflectClass;
+         vmInfo._floatReflectClassPtr = javaVM->floatReflectClass;
+         vmInfo._doubleReflectClassPtr = javaVM->doubleReflectClass;
+         vmInfo._byteReflectClassPtr = javaVM->byteReflectClass;
+         vmInfo._shortReflectClassPtr = javaVM->shortReflectClass;
+         vmInfo._intReflectClassPtr = javaVM->intReflectClass;
+         vmInfo._longReflectClassPtr = javaVM->longReflectClass;
+
          client->write(response, vmInfo, listOfCacheDescriptors, comp->getPersistentInfo()->getJITServerAOTCacheName());
          }
          break;
@@ -2885,20 +2895,20 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, knownObjectTableDumpInfoList);
          }
          break;
-      case MessageType::KnownObjectTable_getJ9Class:
+      case MessageType::KnownObjectTable_getOpaqueClass:
          {
          TR::KnownObjectTable::Index knotIndex =
             std::get<0>(client->getRecvData<TR::KnownObjectTable::Index>());
 
-         uintptr_t j9class = 0;
+         uintptr_t clazz = 0;
             {
             TR::VMAccessCriticalSection getJ9ClassFromKnownObjectIndex(fe);
 
             uintptr_t javaLangClass = knot->getPointer(knotIndex);
-            j9class = (uintptr_t)fe->getInt64Field(javaLangClass, "vmRef");
+            clazz = (uintptr_t)fe->getInt64Field(javaLangClass, "vmRef");
             }
 
-         client->write(response, j9class);
+         client->write(response, clazz);
          }
          break;
       case MessageType::KnownObjectTable_getVectorBitSize:

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1307,11 +1307,13 @@ TR_J9VMBase::getReferenceElement(uintptr_t objectPointer, intptr_t elementIndex)
    return (uintptr_t)J9JAVAARRAYOFOBJECT_LOAD(vmThread(), objectPointer, elementIndex);
    }
 
-TR_arrayTypeCode TR_J9VMBase::getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz)
+TR_arrayTypeCode
+TR_J9VMBase::getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz)
    {
    TR_ASSERT(isPrimitiveClass(clazz), "Expect primitive class in TR_J9VMBase::getPrimitiveArrayType");
 
    J9Class* j9clazz = (J9Class*)clazz;
+
    if (j9clazz == jitConfig->javaVM->booleanReflectClass)
       return atype_boolean;
    else if (j9clazz == jitConfig->javaVM->charReflectClass)
@@ -1333,6 +1335,31 @@ TR_arrayTypeCode TR_J9VMBase::getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* cla
       TR_ASSERT(false, "TR_arrayTypeCode is not defined for the j9clazz");
       return (TR_arrayTypeCode)0;
       }
+   }
+
+TR::DataType
+TR_J9VMBase::getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz)
+   {
+   J9Class *j9class = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
+   if (!j9class)
+      return TR::NoType;
+
+   J9JavaVM *vm = getJ9JITConfig()->javaVM;
+
+   if (j9class == vm->floatReflectClass)
+      return TR::Float;
+   else if (j9class == vm->doubleReflectClass)
+      return TR::Double;
+   else if (j9class == vm->byteReflectClass)
+      return TR::Int8;
+   else if (j9class == vm->shortReflectClass)
+      return TR::Int16;
+   else if (j9class == vm->intReflectClass)
+      return TR::Int32;
+   else if (j9class == vm->longReflectClass)
+      return TR::Int64;
+   else
+      return TR::NoType;
    }
 
 TR_OpaqueClassBlock *

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -669,6 +669,7 @@ public:
 
    virtual TR_OpaqueClassBlock *getClassFromJavaLangClass(uintptr_t objectPointer);
    virtual TR_arrayTypeCode    getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz);
+   virtual TR::DataType        getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz);
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool callSiteVettedForAOT=false) { return 0; }
    virtual TR_OpaqueClassBlock * getByteArrayClass();
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2616,6 +2616,65 @@ TR_J9ServerVM::isOffHeapAllocationEnabled()
    return vmInfo->_isOffHeapAllocationEnabled;
    }
 
+
+TR_arrayTypeCode
+TR_J9ServerVM::getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz)
+   {
+   TR_ASSERT(isPrimitiveClass(clazz), "Expect primitive class in TR_J9VMBase::getPrimitiveArrayType");
+
+   J9Class* j9clazz = (J9Class*)clazz;
+
+   auto stream = _compInfoPT->getStream();
+   auto vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+   if (j9clazz == vmInfo->_booleanReflectClassPtr)
+      return atype_boolean;
+   else if (j9clazz == vmInfo->_charReflectClassPtr)
+      return atype_char;
+   else if (j9clazz == vmInfo->_floatReflectClassPtr)
+      return atype_float;
+   else if (j9clazz == vmInfo->_doubleReflectClassPtr)
+      return atype_double;
+   else if (j9clazz == vmInfo->_byteReflectClassPtr)
+      return atype_byte;
+   else if (j9clazz == vmInfo->_shortReflectClassPtr)
+      return atype_short;
+   else if (j9clazz == vmInfo->_intReflectClassPtr)
+      return atype_int;
+   else if (j9clazz == vmInfo->_longReflectClassPtr)
+      return atype_long;
+   else
+      {
+      TR_ASSERT(false, "TR_arrayTypeCode is not defined for the j9clazz");
+      return (TR_arrayTypeCode)0;
+      }
+   }
+
+TR::DataType
+TR_J9ServerVM::getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz)
+   {
+   J9Class *j9class = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
+
+   if (!j9class) return TR::NoType;
+
+   auto vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(_compInfoPT->getStream());
+
+   if (j9class == vmInfo->_floatReflectClassPtr)
+      return TR::Float;
+   else if (j9class == vmInfo->_doubleReflectClassPtr)
+      return TR::Double;
+   else if (j9class == vmInfo->_byteReflectClassPtr)
+      return TR::Int8;
+   else if (j9class == vmInfo->_shortReflectClassPtr)
+      return TR::Int16;
+   else if (j9class == vmInfo->_intReflectClassPtr)
+      return TR::Int32;
+   else if (j9class == vmInfo->_longReflectClassPtr)
+      return TR::Int64;
+   else
+      return TR::NoType;
+   }
+
+
 bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -265,6 +265,9 @@ public:
    virtual bool isIndexableDataAddrPresent() override;
    virtual bool isOffHeapAllocationEnabled() override;
 
+   virtual TR_arrayTypeCode       getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz) override;
+   virtual TR::DataType           getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz) override;
+
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
    bool checkCHTableIfClassInfoExistsAndHasBeenExtended(TR_OpaqueClassBlock *clazz, bool &bClassHasBeenExtended);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 71; // ID:1QMsN16q0acJzn1qRQHY
+   static const uint16_t MINOR_NUMBER = 72; // ID: PB545sJS3QOBXIIPV5JZ
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -259,6 +259,8 @@ const char *messageNames[] =
    "KnownObjectTable_createSymRefWithKnownObject",
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
+   "KnownObjectTable_getJ9Class",
+   "KnownObjectTable_getVectorBitSize",
    "AOTCache_getROMClassBatch",
    "AOTCacheMap_request",
    "AOTCacheMap_reply"

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -259,7 +259,7 @@ const char *messageNames[] =
    "KnownObjectTable_createSymRefWithKnownObject",
    "KnownObjectTable_getReferenceField",
    "KnownObjectTable_getKnownObjectTableDumpInfo",
-   "KnownObjectTable_getJ9Class",
+   "KnownObjectTable_getOpaqueClass",
    "KnownObjectTable_getVectorBitSize",
    "AOTCache_getROMClassBatch",
    "AOTCacheMap_request",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -284,11 +284,16 @@ enum MessageType : uint16_t
    KnownObjectTable_createSymRefWithKnownObject,
    KnownObjectTable_getReferenceField,
    KnownObjectTable_getKnownObjectTableDumpInfo,
+   // for getting a J9Class from KnownObjectTable
+   KnownObjectTable_getJ9Class,
+   // for getting a vectorBitSize from KnownObjectTable
+   KnownObjectTable_getVectorBitSize,
 
    AOTCache_getROMClassBatch,
 
    AOTCacheMap_request,
    AOTCacheMap_reply,
+
 
    MessageType_MAXTYPE
    };

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -285,7 +285,7 @@ enum MessageType : uint16_t
    KnownObjectTable_getReferenceField,
    KnownObjectTable_getKnownObjectTableDumpInfo,
    // for getting a J9Class from KnownObjectTable
-   KnownObjectTable_getJ9Class,
+   KnownObjectTable_getOpaqueClass,
    // for getting a vectorBitSize from KnownObjectTable
    KnownObjectTable_getVectorBitSize,
 

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -637,12 +637,32 @@ TR_VectorAPIExpansion::getVectorSizeFromVectorSpecies(TR::Node *vectorSpeciesNod
       {
       if (vSpeciesSymRef->hasKnownObjectIndex())
          {
-         TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
-         TR::VMAccessCriticalSection getVectorSizeFromVectorSpeciesSection(fej9);
+         int32_t vectorBitSize = 0;
+#if defined(J9VM_OPT_JITSERVER)
+         if (comp()->isOutOfProcessCompilation()) /* In server mode */
+            {
+            auto stream = comp()->getStream();
+            stream->write(JITServer::MessageType::KnownObjectTable_getVectorBitSize,
+                          vSpeciesSymRef->getKnownObjectIndex());
+            vectorBitSize = std::get<0>(stream->read<int32_t>());
+            }
+         else
+#endif /* defined(J9VM_OPT_JITSERVER) */
+            {
+            TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
 
-         uintptr_t vectorSpeciesLocation = comp()->getKnownObjectTable()->getPointer(vSpeciesSymRef->getKnownObjectIndex());
-         uintptr_t vectorShapeLocation = fej9->getReferenceField(vectorSpeciesLocation, "vectorShape", "Ljdk/incubator/vector/VectorShape;");
-         int32_t vectorBitSize = fej9->getInt32Field(vectorShapeLocation, "vectorBitSize");
+            TR::VMAccessCriticalSection getVectorSizeFromVectorSpeciesSection(fej9);
+
+            uintptr_t vectorSpeciesLocation =
+               comp()->getKnownObjectTable()->getPointer(vSpeciesSymRef->getKnownObjectIndex());
+            uintptr_t vectorShapeLocation =
+               fej9->getReferenceField(vectorSpeciesLocation,
+                                       "vectorShape",
+                                       "Ljdk/incubator/vector/VectorShape;");
+            vectorBitSize = fej9->getInt32Field(vectorShapeLocation, "vectorBitSize");
+            }
+
+
          return (vec_sz_t)vectorBitSize;
          }
       }
@@ -671,12 +691,27 @@ TR_VectorAPIExpansion::getJ9ClassFromClassNode(TR::Compilation *comp, TR::Node *
 
    if (knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
       {
-      TR_J9VMBase *fej9 = comp->fej9();
+      J9Class *j9class = NULL;
+#if defined(J9VM_OPT_JITSERVER)
+      if (comp->isOutOfProcessCompilation()) /* In server mode */
+         {
+         auto stream = comp->getStream();
+         stream->write(JITServer::MessageType::KnownObjectTable_getJ9Class,
+                        symRef->getKnownObjectIndex());
+         j9class = (J9Class *)std::get<0>(stream->read<uintptr_t>());
+         }
+      else
+#endif /* defined(J9VM_OPT_JITSERVER) */
+         {
+         TR_J9VMBase *fej9 = comp->fej9();
 
-      TR::VMAccessCriticalSection getDataTypeFromClassNodeSection(fej9);
+         TR::VMAccessCriticalSection getDataTypeFromClassNodeSection(fej9);
 
-      uintptr_t javaLangClass = comp->getKnownObjectTable()->getPointer(knownObjectIndex);
-      J9Class *j9class = (J9Class *)(intptr_t)fej9->getInt64Field(javaLangClass, "vmRef");
+         uintptr_t javaLangClass =
+            comp->getKnownObjectTable()->getPointer(symRef->getKnownObjectIndex());
+
+         j9class = (J9Class *)(intptr_t)fej9->getInt64Field(javaLangClass, "vmRef");
+         }
 
       return j9class;
       }

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -670,8 +670,8 @@ TR_VectorAPIExpansion::getVectorSizeFromVectorSpecies(TR::Node *vectorSpeciesNod
    }
 
 
-J9Class *
-TR_VectorAPIExpansion::getJ9ClassFromClassNode(TR::Compilation *comp, TR::Node *classNode)
+TR_OpaqueClassBlock *
+TR_VectorAPIExpansion::getOpaqueClassBlockFromClassNode(TR::Compilation *comp, TR::Node *classNode)
    {
    if (!classNode->getOpCode().hasSymbolReference())
       return NULL;
@@ -691,14 +691,14 @@ TR_VectorAPIExpansion::getJ9ClassFromClassNode(TR::Compilation *comp, TR::Node *
 
    if (knownObjectIndex != TR::KnownObjectTable::UNKNOWN)
       {
-      J9Class *j9class = NULL;
+      TR_OpaqueClassBlock *clazz = NULL;
 #if defined(J9VM_OPT_JITSERVER)
       if (comp->isOutOfProcessCompilation()) /* In server mode */
          {
          auto stream = comp->getStream();
-         stream->write(JITServer::MessageType::KnownObjectTable_getJ9Class,
+         stream->write(JITServer::MessageType::KnownObjectTable_getOpaqueClass,
                         symRef->getKnownObjectIndex());
-         j9class = (J9Class *)std::get<0>(stream->read<uintptr_t>());
+         clazz = (TR_OpaqueClassBlock *)std::get<0>(stream->read<uintptr_t>());
          }
       else
 #endif /* defined(J9VM_OPT_JITSERVER) */
@@ -707,13 +707,11 @@ TR_VectorAPIExpansion::getJ9ClassFromClassNode(TR::Compilation *comp, TR::Node *
 
          TR::VMAccessCriticalSection getDataTypeFromClassNodeSection(fej9);
 
-         uintptr_t javaLangClass =
-            comp->getKnownObjectTable()->getPointer(symRef->getKnownObjectIndex());
-
-         j9class = (J9Class *)(intptr_t)fej9->getInt64Field(javaLangClass, "vmRef");
+         uintptr_t javaLangClass = comp->getKnownObjectTable()->getPointer(knownObjectIndex);
+         clazz = (TR_OpaqueClassBlock *)(intptr_t)fej9->getInt64Field(javaLangClass, "vmRef");
          }
 
-      return j9class;
+      return clazz;
       }
 
    return NULL;
@@ -723,38 +721,24 @@ TR_VectorAPIExpansion::getJ9ClassFromClassNode(TR::Compilation *comp, TR::Node *
 TR::DataType
 TR_VectorAPIExpansion::getDataTypeFromClassNode(TR::Compilation *comp, TR::Node *classNode)
    {
-   J9Class *j9class = getJ9ClassFromClassNode(comp, classNode);
+   TR_OpaqueClassBlock *clazz = getOpaqueClassBlockFromClassNode(comp, classNode);
 
-   if (!j9class) return TR::NoType;
+   if (!clazz) return TR::NoType;
 
    TR_J9VMBase *fej9 = comp->fej9();
-   J9JavaVM *vm = fej9->getJ9JITConfig()->javaVM;
-
-   if (j9class == vm->floatReflectClass)
-      return TR::Float;
-   else if (j9class == vm->doubleReflectClass)
-      return TR::Double;
-   else if (j9class == vm->byteReflectClass)
-      return TR::Int8;
-   else if (j9class == vm->shortReflectClass)
-      return TR::Int16;
-   else if (j9class == vm->intReflectClass)
-      return TR::Int32;
-   else if (j9class == vm->longReflectClass)
-      return TR::Int64;
-   else
-      return TR::NoType;
+   return fej9->getClassPrimitiveDataType(clazz);
    }
 
 
 TR_VectorAPIExpansion::vapiObjType
 TR_VectorAPIExpansion::getObjectTypeFromClassNode(TR::Compilation *comp, TR::Node *classNode)
    {
-   J9Class *j9class = getJ9ClassFromClassNode(comp, classNode);
+   TR_OpaqueClassBlock *clazz = getOpaqueClassBlockFromClassNode(comp, classNode);
 
-   if (!j9class) return Unknown;
+   if (!clazz) return Unknown;
 
-   J9UTF8 *className = J9ROMCLASS_CLASSNAME(j9class->romClass);
+   J9ROMClass *romClass = TR::Compiler->cls.romClassOf(clazz);
+   J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
    int32_t length = J9UTF8_LENGTH(className);
    char *classNameChars = (char*)J9UTF8_DATA(className);
 

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -584,7 +584,8 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *  \param classNode
    *     Node that loads \c java/lang/Class
    */
-   static J9Class *getJ9ClassFromClassNode(TR::Compilation *comp, TR::Node *classNode);
+   static TR_OpaqueClassBlock *getOpaqueClassBlockFromClassNode(TR::Compilation *comp,
+                                                                TR::Node *classNode);
 
 
   /** \brief

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -335,6 +335,16 @@ public:
       bool _isPortableRestoreMode;
       bool _isSnapshotModeEnabled;
       bool _isNonPortableRestoreMode;
+      // The reflect class pointers for the server to identify the classes
+      void *_voidReflectClassPtr;
+      void *_booleanReflectClassPtr;
+      void *_charReflectClassPtr;
+      void *_floatReflectClassPtr;
+      void *_doubleReflectClassPtr;
+      void *_byteReflectClassPtr;
+      void *_shortReflectClassPtr;
+      void *_intReflectClassPtr;
+      void *_longReflectClassPtr;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
Cache the reflect class pointer used by the client VM in its VMInfo for the JITServer so the JITServer can identify those classes.

Also ensures that the server will not make vm access requests in the vector API, and that it will not access the inside of any J9Class, but rather uses OpaqueClassBlock and requests information from the appropriate frontend.