### PR TITLE
Update verbose GC for off-heap

### DIFF
--- a/runtime/gc_stats/CopyForwardStats.hpp
+++ b/runtime/gc_stats/CopyForwardStats.hpp
@@ -74,6 +74,10 @@ public:
 	uintptr_t _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
 	uintptr_t _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	uintptr_t _offHeapRegionsCleared; /**< The number of sparse heap allocated regions that have been cleared during marking */
+	uintptr_t _offHeapRegionCandidates; /**< The number of sparse heap allocated regions that have been visited during marking */
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
 	uint64_t _cycleStartTime; /**< The start time of a copy forward cycle */
 
@@ -111,6 +115,10 @@ public:
 		_doubleMappedArrayletsCleared = 0;
 		_doubleMappedArrayletsCandidates = 0;
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+		_offHeapRegionsCleared = 0;
+		_offHeapRegionCandidates = 0;
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	}
 	
 	/**
@@ -140,6 +148,10 @@ public:
 		_doubleMappedArrayletsCleared += stats->_doubleMappedArrayletsCleared;
 		_doubleMappedArrayletsCandidates += stats->_doubleMappedArrayletsCandidates;
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+		_offHeapRegionsCleared += stats->_offHeapRegionsCleared;
+		_offHeapRegionCandidates += stats->_offHeapRegionCandidates;
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	}
 
 	MM_CopyForwardStats() :
@@ -161,6 +173,10 @@ public:
 		, _doubleMappedArrayletsCleared(0)
 		, _doubleMappedArrayletsCandidates(0)
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+		, _offHeapRegionsCleared(0)
+		, _offHeapRegionCandidates(0)
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	{}
 };
 

--- a/runtime/gc_stats/MarkVLHGCStats.hpp
+++ b/runtime/gc_stats/MarkVLHGCStats.hpp
@@ -78,6 +78,10 @@ public:
 	uintptr_t _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
 	uintptr_t _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */	
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	uintptr_t _offHeapRegionsCleared; /**< The number of or sparse heap allocated regions that have been cleared during marking */
+	uintptr_t _offHeapRegionCandidates; /**< The number of or sparse heap allocated regions that have been visited during marking */
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	uintptr_t _splitArraysProcessed; /**< The number of array chunks (not counting parts smaller than the split size) processed by this thread */
@@ -118,6 +122,10 @@ public:
 		_doubleMappedArrayletsCleared = 0;
 		_doubleMappedArrayletsCandidates = 0;
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */	
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+		_offHeapRegionsCleared = 0;
+		_offHeapRegionCandidates = 0;
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		_splitArraysProcessed = 0;
@@ -156,6 +164,10 @@ public:
 		_doubleMappedArrayletsCleared += statsToMerge->_doubleMappedArrayletsCleared;
 		_doubleMappedArrayletsCandidates += statsToMerge->_doubleMappedArrayletsCandidates;
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */	
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+		_offHeapRegionsCleared += statsToMerge->_offHeapRegionsCleared;
+		_offHeapRegionCandidates += statsToMerge->_offHeapRegionCandidates;
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
 		_concurrentGCThreadsCPUStartTimeSum += statsToMerge->_concurrentGCThreadsCPUStartTimeSum;
 		_concurrentGCThreadsCPUEndTimeSum += statsToMerge->_concurrentGCThreadsCPUEndTimeSum;
@@ -187,6 +199,10 @@ public:
 		,_doubleMappedArrayletsCleared(0)
 		,_doubleMappedArrayletsCandidates(0)
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+		,_offHeapRegionsCleared(0)
+		,_offHeapRegionCandidates(0)
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		,_splitArraysProcessed(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.cpp
@@ -30,6 +30,10 @@
 #include "EnvironmentBase.hpp"
 #include "GCExtensions.hpp"
 #include "MarkVLHGCStats.hpp"
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+#include "SparseAddressOrderedFixedSizeDataPool.hpp"
+#include "SparseVirtualMemory.hpp"
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 #include "ReferenceStats.hpp"
 #include "VerboseManager.hpp"
 #include "VerboseWriterChain.hpp"
@@ -282,6 +286,16 @@ MM_VerboseHandlerOutputVLHGC::outputContinuationInfo(MM_EnvironmentBase *env, UD
 	}
 }
 
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+void
+MM_VerboseHandlerOutputVLHGC::outputOffHeapInfo(MM_EnvironmentBase *env, UDATA indent, UDATA offHeapRegionCandidates, UDATA offHeapRegionsCleared)
+{
+	if (0 != offHeapRegionCandidates) {
+		_manager->getWriterChain()->formatAndOutput(env, indent, "<offheap candidates=\"%zu\" cleared=\"%zu\" />", offHeapRegionCandidates, offHeapRegionsCleared);
+	}
+}
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+
 void
 MM_VerboseHandlerOutputVLHGC::outputContinuationObjectInfo(MM_EnvironmentBase *env, uintptr_t indent)
 {
@@ -347,7 +361,14 @@ MM_VerboseHandlerOutputVLHGC::outputMemoryInfoInnerStanza(MM_EnvironmentBase *en
 				stats->_edenFreeHeapSize, stats->_edenHeapSize,
 				((UDATA)(((U_64)stats->_edenFreeHeapSize*100) / (U_64)stats->_edenHeapSize)));
 	}
-
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env->getOmrVM());
+	if (extensions->isVirtualLargeObjectHeapEnabled) {
+		writer->formatAndOutput(env, indent, "<offheap-objects objects=\"%zu\" bytes=\"%zu\" />",
+				extensions->largeObjectVirtualMemory->getSparseDataPool()->getAllocObjectCount(),
+				extensions->largeObjectVirtualMemory->getSparseDataPool()->getFreeListPoolAllocBytes());
+	}
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	if (0 != stats->_arrayletReferenceObjects) {
 		writer->formatAndOutput(env, indent, "<arraylet-reference objects=\"%zu\" leaves=\"%zu\" largest=\"%zu\" />",
 				stats->_arrayletReferenceObjects, stats->_arrayletReferenceLeaves, stats->_largestReferenceArraylet);
@@ -439,6 +460,9 @@ MM_VerboseHandlerOutputVLHGC::handleCopyForwardEnd(J9HookInterface** hook, UDATA
 	}
 	outputRememberedSetClearedInfo(env, irrsStats);
 
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	outputOffHeapInfo(env, 1, copyForwardStats->_offHeapRegionCandidates, copyForwardStats->_offHeapRegionsCleared);
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	outputUnfinalizedInfo(env, 1, copyForwardStats->_unfinalizedCandidates, copyForwardStats->_unfinalizedEnqueued);
 	outputOwnableSynchronizerInfo(env, 1, copyForwardStats->_ownableSynchronizerCandidates, (copyForwardStats->_ownableSynchronizerCandidates-copyForwardStats->_ownableSynchronizerSurvived));
 	outputContinuationInfo(env, 1, copyForwardStats->_continuationCandidates, copyForwardStats->_continuationCleared);
@@ -587,6 +611,9 @@ MM_VerboseHandlerOutputVLHGC::outputMarkSummary(MM_EnvironmentBase *env, const c
 		outputRememberedSetClearedInfo(env, irrsStats);
 	}
 
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	outputOffHeapInfo(env, 1, markStats->_offHeapRegionCandidates, markStats->_offHeapRegionsCleared);
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	outputUnfinalizedInfo(env, 1, markStats->_unfinalizedCandidates, markStats->_unfinalizedEnqueued);
 	outputOwnableSynchronizerInfo(env, 1, markStats->_ownableSynchronizerCandidates, markStats->_ownableSynchronizerCleared);
 	outputContinuationInfo(env, 1, markStats->_continuationCandidates, markStats->_continuationCleared);

--- a/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
+++ b/runtime/gc_verbose_handler_vlhgc/VerboseHandlerOutputVLHGC.hpp
@@ -66,6 +66,17 @@ private:
 	void outputContinuationInfo(MM_EnvironmentBase *env, UDATA indent, UDATA continuationCandidates, UDATA continuationCleared);
 	void outputContinuationObjectInfo(MM_EnvironmentBase *env, uintptr_t indent);
 
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	/**
+	 * Output off-heap processing summary.
+	 * @param env GC thread used for output.
+	 * @param indent base level of indentation for the summary.
+	 * @param offHeapRegionCandidates number of off-heap regions encountered.
+	 * @param offHeapRegionsCleared number of off-heap regions cleared.
+	 */
+	void outputOffHeapInfo(MM_EnvironmentBase *env, UDATA indent, UDATA offHeapRegionCandidates, UDATA offHeapRegionsCleared);
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+
 	/**
 	 * Output reference processing summary.
 	 * @param env GC thread used for output.


### PR DESCRIPTION
 -new outputOffHeapInfo in CopyForward and Mark for balancedGC
  \<offheap candidates="xxx" cleared="xxx" /\>
 - output offheap-objects in MemoryInfo \<offheap-objects objects="xxx" bytes="xxx" /\>