### PR TITLE
Fix stackwalker calculation of object displacement for Offheap

### DIFF
--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -1403,10 +1403,6 @@ void walkJITFrameSlotsForInternalPointers(J9StackWalkState * walkState,  U_8 ** 
       J9Object ** currPinningArrayCursor = (J9Object **) (((U_8 *) walkState->bp) + (offsetOfFirstInternalPtr + (((U_16) currPinningArrayIndex * sizeof(UDATA)))));
       J9Object *oldPinningArrayAddress = *((J9Object **) currPinningArrayCursor);
       J9Object * newPinningArrayAddress;
-      void *oldDataAddr = 0, *newDataAddr = 0;
-      if (offHeapAllocationEnabled && oldPinningArrayAddress)
-         oldDataAddr = walkState->walkThread->javaVM->memoryManagerFunctions->j9gc_objaccess_getArrayObjectDataAddress(walkState->walkThread, (J9IndexableObject*)oldPinningArrayAddress);
-      IDATA displacement = 0;
 
 
 #ifdef J9VM_INTERP_STACKWALK_TRACING
@@ -1414,13 +1410,12 @@ void walkJITFrameSlotsForInternalPointers(J9StackWalkState * walkState,  U_8 ** 
 #endif
       walkState->objectSlotWalkFunction(walkState->walkThread, walkState, currPinningArrayCursor, currPinningArrayCursor);
       newPinningArrayAddress = *((J9Object **) currPinningArrayCursor);
-      if (offHeapAllocationEnabled && newPinningArrayAddress)
-         {
-         newDataAddr = walkState->walkThread->javaVM->memoryManagerFunctions->j9gc_objaccess_getArrayObjectDataAddress(walkState->walkThread, (J9IndexableObject*)newPinningArrayAddress);
-         displacement = (IDATA) (((UDATA)newDataAddr) - ((UDATA)oldDataAddr));
-         }
-      else
-         displacement = (IDATA) (((UDATA)newPinningArrayAddress) - ((UDATA)oldPinningArrayAddress));
+
+      IDATA displacement = 0;
+
+      if (newPinningArrayAddress)
+         displacement = walkState->walkThread->javaVM->memoryManagerFunctions->j9gc_objaccess_indexableDataDisplacement(walkState->walkThread, (J9IndexableObject*)oldPinningArrayAddress, (J9IndexableObject*)newPinningArrayAddress);
+
       ++(walkState->slotIndex);
 
 #ifdef J9VM_INTERP_STACKWALK_TRACING


### PR DESCRIPTION
In `walkJITFrameSlotsForInternalPointers()`, a displacement of data is calculated between an array object before and after it is moved. Currently, when offheap is enabled, this displacement is calculated as the difference between the dataAddr pointers of the new and old locations. However, because the src object may be overwritten during sliding object movement, it is not safe to read its contents, such as the dataAddr pointer.

Thus, this contribution modifies how the stackwalker calculates displacement when offheap allocation is enabled such that:
- If the array data is adjacent to the array header (i.e.: `dataAddr == pinningArrayAddr + sizeofHeader`), calculate the displacement as `dst - src`
- Otherwise, set displacement to 0

Depends on https://github.com/eclipse-openj9/openj9/pull/20564