### PR TITLE
Track methods with AOT bodies with dependencies

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -59,6 +59,7 @@
 #include "env/StackMemoryRegion.hpp"
 #include "env/jittypes.h"
 #include "env/ClassTableCriticalSection.hpp"
+#include "env/DependencyTable.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VerboseLog.hpp"
@@ -8252,6 +8253,11 @@ TR::CompilationInfoPerThreadBase::compile(J9VMThread * vmThread,
    UDATA oldState = vmThread->omrVMThread->vmState;
    vmThread->omrVMThread->vmState = J9VMSTATE_JIT | J9VMSTATE_MINOR;
    vmThread->jitMethodToBeCompiled = method;
+
+   // If method is being compiled, then the dependency table no longer needs to
+   // track it. Let the table know.
+   if (auto dependencyTable = getCompilationInfo()->getPersistentInfo()->getAOTDependencyTable())
+      dependencyTable->methodWillBeCompiled(method);
 
    try
       {

--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -526,6 +526,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                   persistentInfo->setAOTDependencyTable(dependencyTable);
                   }
 #endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
+               if (!persistentInfo->getAOTDependencyTable())
+                  persistentInfo->setTrackAOTDependencies(false);
                }
             }
          else

--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -368,6 +368,7 @@ public:
    virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL);
 
    J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
+   uintptr_t startingROMClassOffsetOfClassChain(void *chain);
 
    virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL);
 
@@ -421,11 +422,14 @@ public:
     /**
     * \brief Store the dependencies of an AOT method in the SCC
     *
-    * The dependencies of an AOT method are encoded as an array of uintptr_t values. The first entry is the number
-    * of elements in the entire array. The subsequent entries are encoded offsets to the class chains of classes that
-    * need to be loaded or initialized before the compiled body can be loaded. If the class must be initialized, the
-    * entry will be the offset itself (which necessarily has a set low bit), and if the class only needs to be loaded
-    * it will be the offset with the low bit cleared.    *
+    * The dependencies of an AOT method are encoded as an array of uintptr_t
+    * values. The first entry is the number of entries after the first, the
+    * number of dependencies in the array. The subsequent entries are encoded
+    * offsets to the class chains of classes that need to be loaded or
+    * initialized before the compiled body can be loaded. If the class must be
+    * initialized, the entry will be the offset itself (which necessarily has a
+    * set low bit), and if the class only needs to be loaded it will be the
+    * offset with the low bit cleared.
     *
     * \param[in] vmThread VM thread
     * \param[in] methodDependencies The dependencies of the AOT compilation


### PR DESCRIPTION
When a method is initialized in jitHookInitializeSendTarget, the SCC will be checked to see if it has a stored AOT body that was compiled with tracked dependencies. If it does, and all of them are satisfied, the method will be given an initial count of 0. If not all of the dependencies are satisfied, the method will be tracked by the TR_DependencyTable until the dependencies are satisfied, at which point its count will be set to zero, triggering an AOT load on its next invocation.

Related: https://github.com/eclipse-openj9/openj9/issues/20529