### PR TITLE
Reset trampoline pointers to top of space

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -749,8 +749,10 @@ J9::CodeCache::resetTrampolines()
       }
 
    //reset the trampoline marks back to their starting positions
-   _trampolineAllocationMark = _trampolineBase;
-   _trampolineReservationMark = _trampolineBase;
+   // Note that permanent trampolines are allocated from _tempTrampolineBase downwards
+   // see initialize in OMRCodeCache.cpp
+   _trampolineAllocationMark = _tempTrampolineBase;
+   _trampolineReservationMark = _tempTrampolineBase;
 
    OMR::CodeCacheTempTrampolineSyncBlock *syncBlock;
    if (!_tempTrampolinesMax)


### PR DESCRIPTION
After flushing the code cache under FSD there is a call to resetTrampolines. The _trampolineAllocationMark and _trampolineReservationMark need to be reset to their starting positions but were incorrectly set to the end of the trampoline space. As a result all active segments at the time of the cache flush are marked as full (assuming a platform that uses trampolines). This can be seen by taking a JIT verbose log with option `codecache` which will show

CODECACHE:  CodeCache 00007E759000C660 marked as full in reserveSpaceForTrampoline