### PR TITLE
Pull cuda image from nvcr

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -828,7 +828,7 @@ def create_docker_image_locally()
         echo 'ARG image
             ARG cuda_ver=12.2.0
             ARG cuda_distro=ubi8
-            FROM nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
+            FROM nvcr.io/nvidia/cuda:${cuda_ver}-devel-${cuda_distro} as cuda
             FROM $image
             RUN mkdir -p /usr/local/cuda/nvvm
             COPY --from=cuda /usr/local/cuda/include         /usr/local/cuda/include


### PR DESCRIPTION
In the event we are rate-limited or restricted from pulling from DockerHub, this should work around the problem by pulling from Nvidia's site.

Issue runtimes/automation/122