### PR TITLE
JDK24: Permanently Disable the Security Manager

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -482,6 +482,8 @@ K0A02="Bootstrap method returned null."
 K0B00="The Security Manager is deprecated and will be removed in a future release"
 K0B01="Library name must not contain a file path: {0}"
 K0B02="Enabling a SecurityManager currently unsupported when -XX:+EnableCRIUSupport is specified"
+K0B03="Setting a Security Manager is not supported"
+K0B04="A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported."
 
 #java.lang.Throwable
 K0C00="Non-standard List class not permitted in suppressedExceptions serial stream"

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -3204,7 +3204,9 @@ static final native Class<?> getStackClass(int depth);
  * array of not more than maxDepth Classes representing the classes of
  * running methods on the stack (including native methods).  Frames
  * representing the VM implementation of java.lang.reflect are not included
- * in the list.  If stopAtPrivileged is true, the walk will terminate at any
+ * in the list.
+/*[IF JAVA_SPEC_VERSION < 24]
+ * If stopAtPrivileged is true, the walk will terminate at any
  * frame running one of the following methods:
  *
  * <code><ul>
@@ -3215,6 +3217,7 @@ static final native Class<?> getStackClass(int depth);
  * </ul></code>
  *
  * If one of the doPrivileged methods is found, the walk terminate and that frame is NOT included in the returned array.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  *
  * Notes: <ul>
  * 	 <li> This method operates on the defining classes of methods on stack.
@@ -3225,7 +3228,11 @@ static final native Class<?> getStackClass(int depth);
  *</ul>
  *
  * @param 		maxDepth			maximum depth to walk the stack, -1 for the entire stack
+/*[IF JAVA_SPEC_VERSION >= 24]
+ * @param 		stopAtPrivileged	has no effect
+/*[ELSE] JAVA_SPEC_VERSION >= 24
  * @param 		stopAtPrivileged	stop at privileged classes
+/*[ENDIF] JAVA_SPEC_VERSION >= 24
  * @return		the array of the most recent classes on the stack
  */
 @CallerSensitive

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1264,6 +1264,20 @@ static void checkTmpDir() {
 }
 
 /*[IF JAVA_SPEC_VERSION >= 9]*/
+/**
+ * Initialize the security manager according
+ * to the java.security.manager system property.
+ * @param applicationClassLoader
+ * @throws Error
+/*[IF JAVA_SPEC_VERSION >= 24]
+ *  if the user attempts to enable the security manager
+/*[ELSE] JAVA_SPEC_VERSION >= 24
+ *  if the security manager could not be initialized
+/*[ENDIF] JAVA_SPEC_VERSION >= 24
+ */
+/*[IF JAVA_SPEC_VERSION < 24]*/
+@SuppressWarnings("removal")
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 static void initSecurityManager(ClassLoader applicationClassLoader) {
 	/*[IF JAVA_SPEC_VERSION >= 24]*/
 	boolean throwErrorOnInit = false;

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1265,6 +1265,9 @@ static void checkTmpDir() {
 
 /*[IF JAVA_SPEC_VERSION >= 9]*/
 static void initSecurityManager(ClassLoader applicationClassLoader) {
+	/*[IF JAVA_SPEC_VERSION >= 24]*/
+	boolean throwErrorOnInit = false;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	String javaSecurityManager = internalGetProperties().getProperty("java.security.manager"); //$NON-NLS-1$
 	if (null == javaSecurityManager) {
 		/*[IF JAVA_SPEC_VERSION >= 18]*/
@@ -1273,7 +1276,11 @@ static void initSecurityManager(ClassLoader applicationClassLoader) {
 		/* Do nothing. */
 		/*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 	} else if ("allow".equals(javaSecurityManager)) { //$NON-NLS-1$
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		throwErrorOnInit = true;
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		/* Do nothing. */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	} else if ("disallow".equals(javaSecurityManager)) { //$NON-NLS-1$
 		/*[IF JAVA_SPEC_VERSION > 11]*/
 		throwUOEFromSetSM = true;
@@ -1281,6 +1288,9 @@ static void initSecurityManager(ClassLoader applicationClassLoader) {
 		/* Do nothing. */
 		/*[ENDIF] JAVA_SPEC_VERSION > 11 */
 	} else {
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		throwErrorOnInit = true;
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		/*[IF JAVA_SPEC_VERSION >= 17]*/
 		initialErr.println("WARNING: A command line option has enabled the Security Manager"); //$NON-NLS-1$
 		initialErr.println("WARNING: The Security Manager is deprecated and will be removed in a future release"); //$NON-NLS-1$
@@ -1297,7 +1307,14 @@ static void initSecurityManager(ClassLoader applicationClassLoader) {
 				throw new Error(Msg.getString("K0631", e.toString()), e); //$NON-NLS-1$
 			}
 		}
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
+	/*[IF JAVA_SPEC_VERSION >= 24]*/
+	if (throwErrorOnInit) {
+		/*[MSG "K0B04", "A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported."]*/
+		throw new Error(Msg.getString("K0B04")); //$NON-NLS-1$
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
@@ -1315,17 +1332,25 @@ static boolean allowSecurityManager() {
  *
  * @param		s			the new security manager
  *
+/*[IF JAVA_SPEC_VERSION >= 24]
+ * @throws		UnsupportedOperationException	always
+/*[ELSE] JAVA_SPEC_VERSION >= 24
  * @throws		SecurityException 	if the security manager has already been set and its checkPermission method doesn't allow it to be replaced.
 /*[IF JAVA_SPEC_VERSION > 11]
  * @throws		UnsupportedOperationException 	if s is non-null and a special token "disallow" has been set for system property "java.security.manager"
  * 												which indicates that a security manager is not allowed to be set dynamically.
 /*[ENDIF] JAVA_SPEC_VERSION > 11
+/*[ENDIF] JAVA_SPEC_VERSION >= 24
  */
 /*[IF JAVA_SPEC_VERSION >= 17]*/
 @Deprecated(since="17", forRemoval=true)
 @CallerSensitive
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public static void setSecurityManager(final SecurityManager s) {
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	/*[MSG "K0B03", "Setting a Security Manager is not supported"]*/
+	throw new UnsupportedOperationException(Msg.getString("K0B03")); //$NON-NLS-1$
+/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 /*[IF CRIU_SUPPORT]*/
 	if (openj9.internal.criu.InternalCRIUSupport.isCRIUSupportEnabled()) {
 		/*[MSG "K0B02", "Enabling a SecurityManager currently unsupported when -XX:+EnableCRIUSupport is specified"]*/
@@ -1403,6 +1428,7 @@ public static void setSecurityManager(final SecurityManager s) {
 		currentSecurity.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetSecurityManager);
 	}
 	security = s;
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
 /**

--- a/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
+++ b/jcl/src/java.base/share/classes/java/security/AccessControlContext.java
@@ -726,6 +726,13 @@ private boolean debugHelper(Permission perm) {
 }
 
 /**
+/*[IF JAVA_SPEC_VERSION >= 24]
+ * Throws java.security.AccessControlException
+ *
+ * @param       perm is ignored
+ * @exception	java.security.AccessControlException
+ * 					is always thrown
+/*[ELSE] JAVA_SPEC_VERSION >= 24
  * Checks if the permission <code>perm</code> is allowed in this context.
  * All ProtectionDomains must grant the permission for it to be granted.
  *
@@ -735,6 +742,7 @@ private boolean debugHelper(Permission perm) {
  *                  thrown when perm is not granted.
  * @exception   NullPointerException
  *                  if perm is null
+/*[ENDIF] JAVA_SPEC_VERSION >= 24
  */
 public void checkPermission(Permission perm) throws AccessControlException {
 /*[IF JAVA_SPEC_VERSION >= 24]*/
@@ -946,6 +954,7 @@ ProtectionDomain[] getContext() {
 	return context;
 }
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 /*
  * Added to resolve: S6907662, CVE-2010-4465: System clipboard should ensure access restrictions
  * Called internally from java.security.ProtectionDomain
@@ -959,6 +968,7 @@ AccessControlContext(ProtectionDomain[] domains, AccessControlContext acc) {
 		this.domainCombiner = acc.domainCombiner;
 	}
 }
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 /*
  * Added to resolve: S6907662, CVE-2010-4465: System clipboard should ensure access restrictions

--- a/runtime/jcl/CMakeLists.txt
+++ b/runtime/jcl/CMakeLists.txt
@@ -106,7 +106,6 @@ target_link_libraries(jclse
 
 target_sources(jclse
 	PRIVATE
-		${CMAKE_CURRENT_SOURCE_DIR}/common/acccont.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/annparser.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/attach.c
 		${CMAKE_CURRENT_SOURCE_DIR}/common/bootstrp.c
@@ -236,6 +235,10 @@ if(NOT JAVA_SPEC_VERSION LESS 19)
 		PRIVATE
 			${CMAKE_CURRENT_SOURCE_DIR}/common/jdk_internal_vm_Continuation.cpp
 	)
+endif()
+
+if(JAVA_SPEC_VERSION LESS 24)
+	target_sources(jclse PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/common/acccont.c)
 endif()
 
 if(J9VM_OPT_JFR)

--- a/runtime/jcl/common/java_lang_Class.h
+++ b/runtime/jcl/common/java_lang_Class.h
@@ -25,11 +25,13 @@
 /* @ddr_namespace: default */
 #include "j9.h"
 
+#if JAVA_SPEC_VERSION < 24
 typedef struct DoPrivilegedMethodArgs {
 	UDATA frameCounter;		/* the frame just walked */
 	j9object_t accControlContext;	/* arg0EA[-1] - AccessControlContext */
 	j9object_t permissions;	/* arg0EA[-2] - Limited permission array */
 	struct DoPrivilegedMethodArgs* next;	/* next DoPrivilegedMethodArgs structure */
 } DoPrivilegedMethodArgs;
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 #endif	/* java_lang_Class_h */

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -376,7 +376,6 @@ omr_add_exports(jclse
 	Java_java_lang_reflect_Proxy_defineClassImpl
 	Java_java_security_AccessController_getAccSnapshot
 	Java_java_security_AccessController_getCallerPD
-	Java_java_security_AccessController_initializeInternal
 	Java_java_util_stream_IntPipeline_promoteGPUCompile
 	Java_jdk_internal_misc_Unsafe_allocateDBBMemory
 	Java_jdk_internal_misc_Unsafe_copySwapMemory0
@@ -452,6 +451,12 @@ omr_add_exports(jclse
 	Java_java_lang_Thread_resumeImpl
 	Java_java_lang_Thread_stopImpl
 	Java_java_lang_Thread_suspendImpl
+)
+endif()
+
+if(JAVA_SPEC_VERSION LESS 24)
+omr_add_exports(jclse
+	Java_java_security_AccessController_initializeInternal
 )
 endif()
 

--- a/runtime/jcl/uma/se6_vm-side_natives_exports.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_exports.xml
@@ -257,7 +257,9 @@
 	<export name="Java_java_lang_Thread_setPriorityNoVMAccessImpl" />
 	<export name="Java_java_lang_Thread_setNameImpl" />
 	<export name="Java_java_lang_Thread_yield" />
-	<export name="Java_java_security_AccessController_initializeInternal" />
+	<export name="Java_java_security_AccessController_initializeInternal">
+		<exclude-if condition="spec.java24" />
+	</export>
 	<export name="Java_java_lang_Class_allocateAndFillArray" />
 	<export name="Java_java_lang_Class_getConstructorImpl" />
 	<export name="Java_java_lang_Class_getConstructorsImpl" />

--- a/runtime/jcl/uma/se6_vm-side_natives_objects.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_objects.xml
@@ -24,7 +24,9 @@
 	<object name="java_lang_ref_Finalizer" />
 	<object name="java_lang_ref_Reference" />
 	<object name="reflecthelp" />
-	<object name="acccont" />
+	<object name="acccont">
+		<exclude-if condition="spec.java24"/>
+	</object>
 	<object name="annparser" />
 	<object name="jniidcacheinit" />
 	<object name="bootstrp" />

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5861,10 +5861,12 @@ typedef struct J9JavaVM {
 	/* extensionClassLoader holds the platform class loader in Java 11+ */
 	struct J9ClassLoader* extensionClassLoader;
 	struct J9ClassLoader* applicationClassLoader;
+#if JAVA_SPEC_VERSION < 24
 	UDATA doPrivilegedMethodID1;
 	UDATA doPrivilegedMethodID2;
 	UDATA doPrivilegedWithContextMethodID1;
 	UDATA doPrivilegedWithContextMethodID2;
+#endif /* JAVA_SPEC_VERSION < 24 */
 	void* defaultMemorySpace;
 	j9object_t* systemThreadGroupRef;
 	omrthread_monitor_t classLoaderBlocksMutex;
@@ -6125,8 +6127,10 @@ typedef struct J9JavaVM {
 	omrthread_monitor_t nativeLibraryMonitor;
 	UDATA freePreviousClassLoaders;
 	struct J9ClassLoader* anonClassLoader;
+#if JAVA_SPEC_VERSION < 24
 	UDATA doPrivilegedWithContextPermissionMethodID1;
 	UDATA doPrivilegedWithContextPermissionMethodID2;
+#endif /* JAVA_SPEC_VERSION < 24 */
 	UDATA nativeLibrariesLoadMethodID;
 #if defined(J9VM_INTERP_CUSTOM_SPIN_OPTIONS)
 	struct J9Pool *customSpinOptions;

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -739,8 +739,10 @@ extern J9_CFUNC jclass
 defineClassCommon (JNIEnv *env, jobject classLoaderObject,
 	jstring className, jbyteArray classRep, jint offset, jint length, jobject protectionDomain, UDATA *options, J9Class *hostClass, J9ClassPatchMap *patchMap, BOOLEAN validateName);
 
+#if JAVA_SPEC_VERSION < 24
 /* BBjclNativesCommonAccessController*/
 jboolean JNICALL Java_java_security_AccessController_initializeInternal (JNIEnv *env, jclass thisClz);
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 /* BBjclNativesCommonProxy*/
 jclass JNICALL Java_java_lang_reflect_Proxy_defineClassImpl (JNIEnv * env, jclass recvClass, jobject classLoader, jstring className, jbyteArray classBytes);

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestAttachAPI.java
@@ -37,6 +37,7 @@ import java.util.Properties;
 
 import org.openj9.test.util.PlatformInfo;
 import org.openj9.test.util.StringPrintStream;
+import org.openj9.test.util.VersionCheck;
 import org.testng.AssertJUnit;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -1104,8 +1105,15 @@ public class TestAttachAPI extends AttachApiTest {
 		try {
 			ap.checkGuard(this);
 		} catch (SecurityException unwantedException) {
-			fail("attachperm04: checkGuard: unexpected exception: "
-					+ unwantedException.getMessage());
+			String m = unwantedException.getMessage();
+			if (VersionCheck.major() >= 24
+				&& m.contains("checking permissions is not supported")
+			) {
+				return;
+			} else {
+				fail("attachperm04: checkGuard: unexpected exception: "
+						+ unwantedException.getMessage());
+			}
 		}
 		String testString = ap.toString();
 		assertTrue(

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
@@ -719,10 +719,17 @@ public void test_getDeclaredFieldLjava_lang_String() {
 	}
 */
 
-	try {
-		java.lang.reflect.Field f = System.class.getDeclaredField("security");
-		Assert.fail("java.lang.System.security shoud NOT be accessible via reflection");
-	} catch (NoSuchFieldException e) {
+	/**
+	 * Disable temporarily for Java 24+ until the
+	 * System.security field is removed.
+	 * https://github.com/eclipse-openj9/openj9/issues/20563
+	 */
+	if (VersionCheck.major() < 24) {
+		try {
+			java.lang.reflect.Field f = System.class.getDeclaredField("security");
+			Assert.fail("java.lang.System.security shoud NOT be accessible via reflection");
+		} catch (NoSuchFieldException e) {
+		}
 	}
 
 	try {

--- a/test/functional/cmdLineTests/J9security/playlist.xml
+++ b/test/functional/cmdLineTests/J9security/playlist.xml
@@ -66,7 +66,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,23]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/exclude.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/exclude.xml
@@ -44,4 +44,5 @@
 	<!-- PR 133321 -->
 	<exclude id="JarExtensionsTests.SingleJarInManifest.Verify1" platform="current"><reason>Failure condition was found: [Output match: LOCAL]</reason></exclude>
 	<exclude id="JarExtensionsTests.MultipleJarsInManifests.Verify1" platform="current"><reason>Failure condition was found: [Output match: LOCAL]</reason></exclude>
+	<exclude id="NonExistJarTests.CheckForError1" platform="all"><reason>https://github.com/eclipse-openj9/openj9/issues/20702</reason></exclude>
 </suite>

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -464,6 +464,7 @@
   </test>
   <test id="Test setting SecurityManager via -Djava.security.manager">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$" $OPTION_SET_SECURITYMANAGER$ $MAINCLASS_TEST_SECURITYMANAGER$ setSMCommandOption 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">java/lang/Error: A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported.</output>
     <output type="success" caseSensitive="no" regex="no">UnsupportedOperationException: Enabling a SecurityManager currently unsupported</output>
     <output type="failure" caseSensitive="yes" regex="no">TEST FAILED</output>
     <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>

--- a/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/playlist.xml
@@ -70,7 +70,7 @@
 			<impl>ibm</impl>
 		</impls>
 		<versions>
-			<version>11+</version>
+			<version>[11,23]</version>
 		</versions>
 	</test>
 </playlist>

--- a/test/functional/cmdLineTests/shareClassTests/DataHelperTests/DataHelperTests_SecurityManager.xml
+++ b/test/functional/cmdLineTests/shareClassTests/DataHelperTests/DataHelperTests_SecurityManager.xml
@@ -1,31 +1,31 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 
 <!--
-  Copyright IBM Corp. and others 2016
+Copyright IBM Corp. and others 2024
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
-<suite id="Shared Classes DataCaching Helper API tests">
+<suite id="Shared Classes DataCaching Helper API tests with SecurityManager">
 
-    <variable name="TESTCACHENAME" value="testCache"/>
+	<variable name="TESTCACHENAME" value="testCache"/>
 
 	<!-- Used to set which mode the test cases are run in -->
 	<variable name="currentMode" value="-Xshareclasses:reset,name=$TESTCACHENAME$"/>
@@ -39,9 +39,9 @@
 	<variable name="mode212" value="-Xits50000 -Xshareclasses:reset,name=$TESTCACHENAME$"/>
 	<variable name="mode213" value="-Xshareclasses:reset,name=$TESTCACHENAME$,noReduceStoreContention"/>
 	<variable name="mode214" value="-Xshareclasses:reset,name=$TESTCACHENAME$,modified=context1"/>
-	
+
 	<variable name="currentMode" value="$mode204$"/>
-	
+
 	<!-- set currentMode variable depending on the value of loopIndex -->
 	<if testVariable="SCMODE" testValue="204" resultVariable="currentMode" resultValue="$mode204$"/>
 	<if testVariable="SCMODE" testValue="205" resultVariable="currentMode" resultValue="$mode205$"/>
@@ -59,53 +59,36 @@
 	<echo value="Running tests with command line options: $currentMode$"/>
 	<echo value=""/>
 	<exec command="$JAVA_EXE$ -version" quiet="false"/>
-	
+
 	<variable name="BOOTCP" value=""/>
+	<variable name="SECURITY_ON" value="-Djava.security.policy==java.good.policy -Djava.security.manager"/>
+	<variable name="SECURITY_ON_READONLY_BADPOLICY" value="-Djava.security.policy==java.bad.readonly.policy -Djava.security.manager"/>
+	<variable name="SECURITY_ON_WRITEONLY_BADPOLICY" value="-Djava.security.policy==java.bad.writeonly.policy -Djava.security.manager"/>
 
 	<exec command="$JAVA_EXE$ -Xshareclasses:destroyAll" quiet="false"/>
-	
-	<test id="check the datacaching classloader is ok" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$ $BOOTCP$ -classpath . apitesting.datahelper.DataCachingTest01</command>
+
+	<test id="simple caching of a resource, with security on" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$ $SECURITY_ON$ $BOOTCP$ -classpath . apitesting.datahelper.DataCachingTest02</command>
 		<output type="success" caseSensitive="yes" regex="no">test successful</output>
 		<output type="failure" caseSensitive="no" regex="no">failed</output>
 		<output type="failure" caseSensitive="no" regex="no">exception:</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 
-	<test id="simple caching of a resource" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$ -classpath . apitesting.datahelper.DataCachingTest02</command>
-		<output type="success" caseSensitive="yes" regex="no">test successful</output>
-		<output type="failure" caseSensitive="no" regex="no">failed</output>
-		<output type="failure" caseSensitive="no" regex="no">exception:</output>
+	<test id="simple caching of a resource, with security on but readonly policy" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,verboseHelper $BOOTCP$ -classpath . $SECURITY_ON_READONLY_BADPOLICY$ apitesting.datahelper.DataCachingTest02</command>
+		<output type="success" caseSensitive="yes" regex="no">storeSharedData('fileone.txt',...) has failed!</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-	
-	<test id="caching of multiple resources" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$ $BOOTCP$ -classpath . apitesting.datahelper.DataCachingTest03</command>
-		<output type="success" caseSensitive="yes" regex="no">test successful</output>
-		<output type="failure" caseSensitive="no" regex="no">failed</output>
-		<output type="failure" caseSensitive="no" regex="no">exception:</output>
+
+	<test id="simple caching of a resource, with security on but writeonly policy" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$,verboseHelper $BOOTCP$ -classpath . $SECURITY_ON_WRITEONLY_BADPOLICY$ apitesting.datahelper.DataCachingTest02</command>
+		<output type="success" caseSensitive="yes" regex="no">should have found the resource but no data retrieved</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-	
-	<test id="marking cache entries stale for bytedata resources" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$ $BOOTCP$ -classpath . apitesting.datahelper.DataCachingTest04</command>
-		<output type="success" caseSensitive="yes" regex="no">test successful</output>
-		<output type="failure" caseSensitive="no" regex="no">failed</output>
-		<output type="failure" caseSensitive="no" regex="no">exception:</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
-	</test>
-	
-	<test id="more stale marking" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$ $BOOTCP$ -classpath . apitesting.datahelper.DataCachingTest05</command>
-		<output type="success" caseSensitive="yes" regex="no">test successful</output>
-		<output type="failure" caseSensitive="no" regex="no">failed</output>
-		<output type="failure" caseSensitive="no" regex="no">exception:</output>
-		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
-	</test>
-	
-	<test id="using same token for multiple resources" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$ $BOOTCP$ -classpath . apitesting.datahelper.DataCachingTest06</command>
+
+	<test id="caching of multiple resources, security on" timeout="600" runPath=".">
+		<command>$JAVA_EXE$ $currentMode$ $SECURITY_ON$ $BOOTCP$ -classpath . apitesting.datahelper.DataCachingTest03</command>
 		<output type="success" caseSensitive="yes" regex="no">test successful</output>
 		<output type="failure" caseSensitive="no" regex="no">failed</output>
 		<output type="failure" caseSensitive="no" regex="no">exception:</output>

--- a/test/functional/cmdLineTests/shareClassTests/DataHelperTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/DataHelperTests/playlist.xml
@@ -56,4 +56,41 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_DataHelperTests_SecurityManager</testCaseName>
+		<variations>
+			<variation>Mode110</variation>
+			<variation>Mode610</variation>
+		</variations>
+		<command>cp $(Q)$(TEST_RESROOT)$(D)DataHelperTests.jar$(Q) .; \
+	$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf DataHelperTests.jar; \
+	$(CONVERT_TO_EBCDIC_CMD) \
+	$(CD) $(Q)$(REPORTDIR_NQ)$(D)datacaching$(D)dataone.contents$(Q); $(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) cf dataone.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
+	$(CD) $(Q)$(REPORTDIR_NQ)$(D)datacaching$(D)datatwo.contents$(Q); $(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) cf datatwo.jar *.txt; $(CD) $(Q)..$(D)..$(D)$(Q); \
+	mv $(Q)$(REPORTDIR_NQ)$(D)datacaching$(D)dataone.contents$(D)dataone.jar$(Q) $(Q)$(REPORTDIR_NQ)$(D)datacaching$(Q); \
+	mv $(Q)$(REPORTDIR_NQ)$(D)datacaching$(D)datatwo.contents$(D)datatwo.jar$(Q) $(Q)$(REPORTDIR_NQ)$(D)datacaching$(Q); \
+	$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJAVA_EXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -DCPDL=$(Q)$(P)$(Q) -DSCMODE=204 -DTEST_JVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
+	-jar $(CMDLINETESTER_JAR) \
+	-config $(Q)$(TEST_RESROOT)$(D)DataHelperTests_SecurityManager.xml$(Q) -xids all,$(JDK_VERSION) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+	-nonZeroExitWhenError \
+	-outputLimit 300; \
+	$(TEST_STATUS)</command>
+		<versions>
+			<version>[8,23]</version>
+		</versions>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<features>
+			<feature>AOT:explicit</feature>
+		</features>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/testVars.mk
+++ b/test/functional/testVars.mk
@@ -20,12 +20,15 @@
 #  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
 ##############################################################################
 
+# In JDK24+, java.security.manager the security manager is permanently disabled,
+# attempting to enable it will result in an error.
 # In JDK18+, java.security.manager == null behaves as -Djava.security.manager=disallow.
 # In JDK17-, java.security.manager == null behaves as -Djava.security.manager=allow.
 # For OpenJ9 tests to work as expected, -Djava.security.manager=allow behaviour is
 # needed in JDK18+.
-ifeq ($(filter 8 9 10 11 12 13 14 15 16 17, $(JDK_VERSION)),)
-  export JAVA_SECURITY_MANAGER = -Djava.security.manager=allow
-else
+
+ifeq ($(filter 21 23, $(JDK_VERSION)),)
   export JAVA_SECURITY_MANAGER =
+else
+  export JAVA_SECURITY_MANAGER = -Djava.security.manager=allow
 endif


### PR DESCRIPTION
- Throw an error on initialization if java.security.manager attempts to add a security manager
- configure System.setSecurityManager to always throw an UnsupportedOperationException
- System.getSecurityManager will always return null since a security manager can't be set
- Update java.security.* javadocs
- Exclude unused helper methods in java.security.* including native code
- Exclude unused helper methods and natives in java.lang.Class
- Disable functional tests that rely on a security manager

Related: https://github.com/eclipse-openj9/openj9/issues/20563