### PR TITLE
Reset queued methods on cache flush

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -275,7 +275,9 @@ jitResetAllMethods(J9VMThread *currentThread)
 
 		while (methodCount != 0) {
 			UDATA extra = (UDATA)method->extra;
-			if (0 == (extra & J9_STARTPC_NOT_TRANSLATED)) {
+			// NB methods that have been queued but not yet compiled must also be reset, but the constant
+			// used (-5) will not match the first part of this test.
+			if (0 == (extra & J9_STARTPC_NOT_TRANSLATED) || (extra == J9_JIT_QUEUED_FOR_COMPILATION)) {
 				/* Do not reset JIT INLs (currently in FSD there are no compiled JNI natives) */
 				if (0 == (J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers & J9AccNative)) {
 					J9JITExceptionTable *metaData = vm->jitConfig->jitGetExceptionTableFromPC(currentThread, extra);


### PR DESCRIPTION
When running under FSD, class redefinition results in all methods being unloaded from the class cache and the compilation queues are emptied. This is partly accomplished by jitResetAllMethods in decomp.cpp, however it misses those methods that have been queued but not yet compiled. The result is that after class redef a subset of methods will never be recompiled, with a potentially significant impact on performance. This change ensures that queued methods also have their status reset.