### PR TITLE
Don't use Offheap APIs for 32 bit

### DIFF
--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -276,9 +276,12 @@ MM_VLHGCAccessBarrier::indexableDataDisplacement(J9VMThread *vmThread, J9Indexab
 {
 	IDATA displacement = 0;
 
+#if defined(J9VM_ENV_DATA64)
 	Assert_MM_true(vmThread->isVirtualLargeObjectHeapEnabled);
 	/* Adjacency check against dst object since src object may be overwritten during sliding compaction. */
-	if (_extensions->indexableObjectModel.isDataAdjacentToHeader(dst)) {
+	if (_extensions->indexableObjectModel.isDataAdjacentToHeader(dst))
+#endif /* defined(J9VM_ENV_DATA64) */
+	{
 		displacement = MM_ObjectAccessBarrier::indexableDataDisplacement(vmThread, src, dst);
 	}
 	return displacement;


### PR DESCRIPTION
A couple of Offheap APIs are guarded with 64 bit compile flag.

A more accurate fix would be to guard them with Offheap specific build flag (and do not compile the whole dir for 32bit), but it would require more complex changes.