### PR TITLE
Reset trampoline pointers to top of space (0.49)

### DIFF
--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -749,8 +749,10 @@ J9::CodeCache::resetTrampolines()
       }
 
    //reset the trampoline marks back to their starting positions
-   _trampolineAllocationMark = _trampolineBase;
-   _trampolineReservationMark = _trampolineBase;
+   // Note that permanent trampolines are allocated from _tempTrampolineBase downwards
+   // see initialize in OMRCodeCache.cpp
+   _trampolineAllocationMark = _tempTrampolineBase;
+   _trampolineReservationMark = _tempTrampolineBase;
 
    OMR::CodeCacheTempTrampolineSyncBlock *syncBlock;
    if (!_tempTrampolinesMax)


### PR DESCRIPTION
Backport of https://github.com/eclipse-openj9/openj9/pull/20614 for v0.49.0-release

