### PR TITLE
WIP - Feature request: Print actual String arguments with Xtrace

### DIFF
--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -477,10 +477,21 @@ traceMethodArgObject(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 		J9Class* clazz = J9OBJECT_CLAZZ(thr, object);
 		J9ROMClass * romClass = clazz->romClass;
 		J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
+		J9JavaVM *vm = thr->javaVM;
 
-		/* TODO: handle arrays */
+		if (clazz == J9VMJAVALANGSTRING_OR_NULL(vm)) {
+			/* string arg */
+			char stringArgBuffer[J9_ARRAY_DIMENSION_LIMIT];
 
-		j9str_printf(PORTLIB, cursor, length, "%.*s@%p", (U_32)J9UTF8_LENGTH(className), J9UTF8_DATA(className), object);
+			J9InternalVMFunctions const * const vmFuncs = thr->javaVM->internalVMFunctions;
+			char *stringArgUTF8 = vmFuncs->copyStringToUTF8WithMemAlloc(thr, object, J9_STR_NULL_TERMINATE_RESULT, "  ", 2, stringArgBuffer, J9_ARRAY_DIMENSION_LIMIT, NULL);
+			j9str_printf(PORTLIB, cursor, length, "%.*s@%.*s", (U_32)J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(stringArgUTF8), J9UTF8_DATA(stringArgUTF8));
+		}
+		else
+		{
+			/* TODO: handle arrays */
+			j9str_printf(PORTLIB, cursor, length, "%.*s@%p", (U_32)J9UTF8_LENGTH(className), J9UTF8_DATA(className), object);
+		}
 	}
 }
 

--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -486,9 +486,7 @@ traceMethodArgObject(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 			J9InternalVMFunctions const * const vmFuncs = thr->javaVM->internalVMFunctions;
 			char *stringArgUTF8 = vmFuncs->copyStringToUTF8WithMemAlloc(thr, object, J9_STR_NULL_TERMINATE_RESULT, "  ", 2, stringArgBuffer, J9_ARRAY_DIMENSION_LIMIT, NULL);
 			j9str_printf(PORTLIB, cursor, length, "%.*s@%.*s", (U_32)J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(stringArgUTF8), J9UTF8_DATA(stringArgUTF8));
-		}
-		else
-		{
+		} else {
 			/* TODO: handle arrays */
 			j9str_printf(PORTLIB, cursor, length, "%.*s@%p", (U_32)J9UTF8_LENGTH(className), J9UTF8_DATA(className), object);
 		}


### PR DESCRIPTION
The changes reflect the feature request [#16416](https://github.com/eclipse-openj9/openj9/issues/16416).

Instead of printing the memory address for string arguments, print the actual string at max of 255 characters.

Closes: [#16416](https://github.com/eclipse-openj9/openj9/issues/16416)
Signed-off-by: Nick Kamal <nick.kamal@ibm.com>