### PR TITLE
Add a setting file to control options used in Java16andUp tests

### DIFF
--- a/test/functional/Java16andUp/java16andUpSettings.mk
+++ b/test/functional/Java16andUp/java16andUpSettings.mk
@@ -1,0 +1,29 @@
+##############################################################################
+#  Copyright IBM Corp. and others 2024
+#
+#  This program and the accompanying materials are made available under
+#  the terms of the Eclipse Public License 2.0 which accompanies this
+#  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+#  or the Apache License, Version 2.0 which accompanies this distribution and
+#  is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+#  This Source Code may also be made available under the following
+#  Secondary Licenses when the conditions for such availability set
+#  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+#  General Public License, version 2 with the GNU Classpath
+#  Exception [1] and GNU General Public License, version 2 with the
+#  OpenJDK Assembly Exception [2].
+#
+#  [1] https://www.gnu.org/software/classpath/license.html
+#  [2] https://openjdk.org/legal/assembly-exception.html
+#
+#  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0
+##############################################################################
+
+
+# Turn on --enable-preview when testing a Valhalla build.
+ifeq ($(findstring VTSTANDARD, $(TEST_FLAG)), VTSTANDARD)
+ ENABLE_PREVIEW=--enable-preview
+else
+ ENABLE_PREVIEW=
+endif

--- a/test/functional/Java16andUp/playlist.xml
+++ b/test/functional/Java16andUp/playlist.xml
@@ -21,6 +21,7 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
+	<include>java16andUpSettings.mk</include>
 	<test>
 		<testCaseName>Jep397Tests</testCaseName>
 		<disables>
@@ -55,7 +56,7 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(ENABLE_PREVIEW) $(JVM_OPTIONS) \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			-cp $(Q)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.moduleX$(Q) \
 			-cp $(Q)$(TEST_RESROOT)$(D)module_bin$(D)org.openj9test.modularity.moduleY$(Q) \
@@ -89,7 +90,7 @@
 				<impl>hotspot</impl>
 			</disable>
 		</disables>
-		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		<command>$(JAVA_COMMAND) $(ENABLE_PREVIEW) $(JVM_OPTIONS) \
 			-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testSubClassOfSealedSuperFromDifferentPackageInSameUnnamedModule.xml$(Q) -testnames Jep397Tests_testSubClassOfSealedSuperFromDifferentPackageInSameUnnamedModule \
 			-groups $(TEST_GROUP) \


### PR DESCRIPTION
Add variable `ENABLE_PREVIEW` to enable option `--enable-preview` in
Jep397Tests in Valhalla standard build

Fixes #20575