### PR TITLE
Ignore class loading errors in LoadableDescriptors

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2061,6 +2061,8 @@ loadFlattenableFieldValueClasses(J9VMThread *currentThread, J9ClassLoader *class
 					loadableDescriptorLength,
 					classLoader,
 					classPreloadFlags & ~J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+			/* Ignore exceptions that may have been set from failed class loading. */
+			currentThread->currentException = NULL;
 		}
 	}
 done:


### PR DESCRIPTION
Ignore ClassCircularityError created by LoadableDescriptors lists. I encountered this error when trying to enable migrated value classes https://github.com/eclipse-openj9/openj9/issues/20386

Related to https://github.com/eclipse-openj9/openj9/issues/19119

```
class Test {
        public static void main(String[] args) throws Throwable {
                Circ c = new Circ();
        }
}

value class Circ {
        static Circ2 c2;
        /* LoadableDescriptors list contains Circ2 */
}

value class Circ2 {
        static Circ c;
        /* LoadableDescriptors list contains Circ */
}
```

