### PR TITLE
X: Remove popcnt specialization

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -882,12 +882,10 @@ extern void TEMPORARY_initJ9X86TreeEvaluatorTable(TR::CodeGenerator *cg)
    tet[TR::ilbit] =                 TR::TreeEvaluator::integerLowestOneBit;
    tet[TR::inolz] =                 TR::TreeEvaluator::integerNumberOfLeadingZeros;
    tet[TR::inotz] =                 TR::TreeEvaluator::integerNumberOfTrailingZeros;
-   tet[TR::ipopcnt] =               TR::TreeEvaluator::integerBitCount;
    tet[TR::lhbit] =                 TR::TreeEvaluator::longHighestOneBit;
    tet[TR::llbit] =                 TR::TreeEvaluator::longLowestOneBit;
    tet[TR::lnolz] =                 TR::TreeEvaluator::longNumberOfLeadingZeros;
    tet[TR::lnotz] =                 TR::TreeEvaluator::longNumberOfTrailingZeros;
-   tet[TR::lpopcnt] =               TR::TreeEvaluator::longBitCount;
    tet[TR::tstart] =                TR::TreeEvaluator::tstartEvaluator;
    tet[TR::tfinish] =               TR::TreeEvaluator::tfinishEvaluator;
    tet[TR::tabort] =                TR::TreeEvaluator::tabortEvaluator;
@@ -3971,51 +3969,6 @@ TR::Register *J9::X86::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, 
       generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, resultLow, maskReg, cg);
       cg->stopUsingRegister(resultHigh);
       cg->stopUsingRegister(maskReg);
-      resultReg = resultLow;
-      }
-   node->setRegister(resultReg);
-   cg->decReferenceCount(child);
-   return resultReg;
-   }
-
-static
-TR::Register *bitCount(TR::Node *node, TR::CodeGenerator *cg, TR::Register *reg, bool is64Bit)
-   {
-   TR::Register *bsfReg = cg->allocateRegister();
-   generateRegRegInstruction(TR::InstOpCode::POPCNTRegReg(is64Bit), node, bsfReg, reg, cg);
-   return bsfReg;
-   }
-
-TR::Register *J9::X86::TreeEvaluator::integerBitCount(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR_ASSERT(node->getNumChildren() == 1, "Node has a wrong number of children (i.e. !=1 )! ");
-   TR::Node* child = node->getFirstChild();
-   TR::Register* inputReg = cg->evaluate(child);
-   TR::Register* resultReg = bitCount(node, cg, inputReg, cg->comp()->target().is64Bit());
-   node->setRegister(resultReg);
-   cg->decReferenceCount(child);
-   return resultReg;
-   }
-
-TR::Register *J9::X86::TreeEvaluator::longBitCount(TR::Node *node, TR::CodeGenerator *cg)
-   {
-   TR_ASSERT(node->getNumChildren() == 1, "Node has a wrong number of children (i.e. !=1 )! ");
-   TR::Node * child = node->getFirstChild();
-   TR::Register * inputReg = cg->evaluate(child);
-   TR::Register * resultReg = NULL;
-   if (cg->comp()->target().is64Bit())
-      {
-      resultReg = bitCount(node, cg, inputReg, true);
-      }
-   else
-      {
-      //add low result and high result together
-      TR::Register * inputHigh = inputReg->getHighOrder();
-      TR::Register * inputLow = inputReg->getLowOrder();
-      TR::Register * resultLow = bitCount(node, cg, inputLow, false);
-      TR::Register * resultHigh = bitCount(node, cg, inputHigh, false);
-      generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, resultLow, resultHigh, cg);
-      cg->stopUsingRegister(resultHigh);
       resultReg = resultLow;
       }
    node->setRegister(resultReg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -72,12 +72,10 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *integerLowestOneBit(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *integerNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *integerNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *integerBitCount(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longHighestOneBit(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longLowestOneBit(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longNumberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *longNumberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg);
-   static TR::Register *longBitCount(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *tstartEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *tabortEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -116,15 +116,6 @@ J9::X86::CPU::getProcessorSignature()
    }
 
 bool
-J9::X86::CPU::hasPopulationCountInstruction()
-   {
-   if ((self()->getX86ProcessorFeatureFlags2() & TR_POPCNT) != 0x00000000)
-      return true;
-   else
-      return false;
-   }
-
-bool
 J9::X86::CPU::isCompatible(const OMRProcessorDesc& processorDescription)
    {
    for (int i = 0; i < OMRPORT_SYSINFO_FEATURES_SIZE; i++)

--- a/runtime/compiler/x/env/J9CPU.hpp
+++ b/runtime/compiler/x/env/J9CPU.hpp
@@ -52,7 +52,7 @@ protected:
 
 public:
 
-   /** 
+   /**
     * @brief A factory method used to construct a CPU object for portable AOT compilations
     * @param[in] omrPortLib : the port library
     * @return TR::CPU
@@ -73,7 +73,6 @@ public:
    uint32_t getProcessorSignature();
 
    bool testOSForSSESupport() { return true; } // VM guarantees SSE/SSE2 are available
-   bool hasPopulationCountInstruction();
 
    bool isCompatible(const OMRProcessorDesc& processorDescription);
 


### PR DESCRIPTION
With `ipopcnt` and `lpopcnt` IL opcodes implemented in OMR, the OpenJ9 specializations are no longer needed.

Depends on https://github.com/eclipse-omr/omr/pull/7553
