### PR TITLE
Remove functions no longer used by Java 24+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -78,7 +78,6 @@ jvm_add_exports(jvm
 	_JVM_GetClassAccessFlags@8
 	_JVM_GetClassAnnotations@8
 	_JVM_GetClassConstantPool@8
-	_JVM_GetClassContext@4
 	_JVM_GetClassLoader@8
 	_JVM_GetClassSignature@8
 	_JVM_GetEnclosingMethodInfo@8
@@ -464,7 +463,11 @@ if(NOT JAVA_SPEC_VERSION LESS 23)
 	)
 endif()
 
-if(NOT JAVA_SPEC_VERSION LESS 24)
+if(JAVA_SPEC_VERSION LESS 24)
+	jvm_add_exports(jvm
+		_JVM_GetClassContext@4
+	)
+else()
 	jvm_add_exports(jvm
 		JVM_IsContainerized
 		JVM_IsStaticallyLinked

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1152,14 +1152,14 @@ JVM_GetDeclaringClass(jint arg0, jint arg1)
 }
 
 
-
+#if JAVA_SPEC_VERSION < 24
 jobject JNICALL
 JVM_GetInheritedAccessControlContext(jint arg0, jint arg1)
 {
 	assert(!"JVM_GetInheritedAccessControlContext() stubbed!");
 	return NULL;
 }
-
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 
 /**
@@ -1350,11 +1350,13 @@ JVM_GetProtectionDomain(jint arg0, jint arg1)
 	return NULL;
 }
 
+#if JAVA_SPEC_VERSION < 24
 jobject JNICALL
-JVM_GetStackAccessControlContext(JNIEnv* env, jclass java_security_AccessController)
+JVM_GetStackAccessControlContext(JNIEnv *env, jclass java_security_AccessController)
 {
 	return NULL;
 }
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 jint JNICALL
 JVM_GetStackTraceDepth(JNIEnv* env, jobject throwable)

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -75,7 +75,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<export name="_JVM_GetClassAccessFlags@8" />
 		<export name="_JVM_GetClassAnnotations@8" />
 		<export name="_JVM_GetClassConstantPool@8" />
-		<export name="_JVM_GetClassContext@4" />
+		<export name="_JVM_GetClassContext@4">
+			<exclude-if condition="spec.java24"/>
+		</export>
 		<export name="_JVM_GetClassLoader@8" />
 		<export name="_JVM_GetClassName@8">
 			<exclude-if condition="spec.java11"/>

--- a/runtime/j9vm/vmi.c
+++ b/runtime/j9vm/vmi.c
@@ -106,14 +106,14 @@ JVM_GetClassAccessFlags(JNIEnv * env, jclass clazzRef)
 	return g_VMI->JVM_GetClassAccessFlags(env, clazzRef);
 }
 
-
+#if JAVA_SPEC_VERSION < 24
 jobject JNICALL
 JVM_GetClassContext(JNIEnv *env)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetClassContext(env);
 }
-
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 void JNICALL
 JVM_Halt(jint exitCode)

--- a/runtime/oti/sunvmi_api.h
+++ b/runtime/oti/sunvmi_api.h
@@ -54,7 +54,9 @@ typedef jobject (JNICALL *JVM_GetCallerClass_Type)(JNIEnv *env);
 typedef jobject (JNICALL *JVM_GetCallerClass_Type)(JNIEnv *env, jint depth);
 #endif /* JAVA_SPEC_VERSION >= 11 */
 typedef jint (JNICALL *JVM_GetClassAccessFlags_Type)(JNIEnv * env, jclass clazzRef);
+#if JAVA_SPEC_VERSION < 24
 typedef jobject (JNICALL *JVM_GetClassContext_Type)(JNIEnv *env);
+#endif /* JAVA_SPEC_VERSION < 24 */
 typedef jobject (JNICALL *JVM_GetClassLoader_Type)(JNIEnv *env, jobject obj);
 
 
@@ -95,7 +97,9 @@ JNIEXPORT jobject JNICALL JVM_GetCallerClass_Impl(JNIEnv *env, jint depth);
 JNIEXPORT jobject JNICALL JVM_NewInstanceFromConstructor_Impl(JNIEnv * env, jobject c, jobjectArray args);
 JNIEXPORT jobject JNICALL JVM_InvokeMethod_Impl(JNIEnv * env, jobject method, jobject obj, jobjectArray args);
 JNIEXPORT jint JNICALL JVM_GetClassAccessFlags_Impl(JNIEnv * env, jclass clazzRef);
+#if JAVA_SPEC_VERSION < 24
 JNIEXPORT jobject JNICALL JVM_GetClassContext_Impl(JNIEnv *env);
+#endif /* JAVA_SPEC_VERSION < 24 */
 JNIEXPORT void JNICALL JVM_Halt_Impl(jint exitCode);
 JNIEXPORT void JNICALL JVM_GCNoCompact_Impl(void);
 JNIEXPORT void JNICALL JVM_GC_Impl(void);
@@ -118,7 +122,7 @@ JNIEXPORT jobjectArray JNICALL JVM_GetMethodParameters_Impl(JNIEnv *env, jobject
 
 
 
-/* 
+/*
  * Structure which contains all of the VMI functions.
  */
 typedef struct SunVMI {
@@ -130,7 +134,9 @@ typedef struct SunVMI {
 	JVM_GCNoCompact_Type JVM_GCNoCompact;
 	JVM_GetCallerClass_Type JVM_GetCallerClass;
 	JVM_GetClassAccessFlags_Type JVM_GetClassAccessFlags;
+#if JAVA_SPEC_VERSION < 24
 	JVM_GetClassContext_Type JVM_GetClassContext;
+#endif /* JAVA_SPEC_VERSION < 24 */
 	JVM_GetClassLoader_Type JVM_GetClassLoader;
 	JVM_GetSystemPackage_Type JVM_GetSystemPackage;
 	JVM_GetSystemPackages_Type JVM_GetSystemPackages;

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -64,7 +64,8 @@ _IF([JAVA_SPEC_VERSION < 11],
 _X(JVM_GetClassAccessFlags,JNICALL,true,jint,JNIEnv *env, jclass clazzRef)
 _X(JVM_GetClassAnnotations,JNICALL,true,jbyteArray,JNIEnv *env, jclass target)
 _X(JVM_GetClassConstantPool,JNICALL,true,jobject,JNIEnv *env, jclass target)
-_X(JVM_GetClassContext,JNICALL,true,jobject,JNIEnv *env)
+_IF([JAVA_SPEC_VERSION < 24],
+	[_X(JVM_GetClassContext,JNICALL,true,jobject,JNIEnv *env)])
 _X(JVM_GetClassLoader,JNICALL,true,jobject,JNIEnv *env, jobject obj)
 _IF([JAVA_SPEC_VERSION < 11],
 	[_X(JVM_GetClassName,JNICALL,true,jstring, JNIEnv *env, jclass theClass)],
@@ -168,10 +169,12 @@ _X(JVM_GetClassSigners,JNICALL,true,jobject,jint arg0, jint arg1)
 _X(JVM_GetComponentType,JNICALL,true,jobject,JNIEnv *env, jclass cls)
 _X(JVM_GetDeclaredClasses,JNICALL,true,jobject,jint arg0, jint arg1)
 _X(JVM_GetDeclaringClass,JNICALL,true,jobject,jint arg0, jint arg1)
-_X(JVM_GetInheritedAccessControlContext,JNICALL,true,jobject,jint arg0, jint arg1)
+_IF([JAVA_SPEC_VERSION < 24],
+	[_X(JVM_GetInheritedAccessControlContext,JNICALL,true,jobject,jint arg0, jint arg1)])
 _X(JVM_GetPrimitiveArrayElement,JNICALL,true,jvalue,JNIEnv *env, jobject arr, jint index, jint wCode)
 _X(JVM_GetProtectionDomain,JNICALL,true,jobject,jint arg0, jint arg1)
-_X(JVM_GetStackAccessControlContext,JNICALL,true,jobject,JNIEnv *env, jclass java_security_AccessController)
+_IF([JAVA_SPEC_VERSION < 24],
+	[_X(JVM_GetStackAccessControlContext,JNICALL,true,jobject,JNIEnv *env, jclass java_security_AccessController)])
 _X(JVM_GetStackTraceDepth,JNICALL,true,jint,JNIEnv *env, jobject throwable)
 _X(JVM_GetStackTraceElement,JNICALL,true,jobject,JNIEnv *env, jobject throwable, jint index)
 _X(JVM_HoldsLock,JNICALL,true,jobject,jint arg0, jint arg1, jint arg2)

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -472,17 +472,18 @@ initializeReflectionGlobalsHook(J9HookInterface** hookInterface, UDATA eventNum,
 }
 
 
+#if JAVA_SPEC_VERSION < 24
 /**
  * JVM_GetClassContext
  */
 JNIEXPORT jobject JNICALL
 JVM_GetClassContext_Impl(JNIEnv *env)
 {
-	J9VMThread * vmThread = (J9VMThread *) env;
+	J9VMThread *vmThread = (J9VMThread *)env;
 	J9JavaVM *vm = vmThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9StackWalkState walkState;
-	jobject classCtx;
+	jobject classCtx = NULL;
 
 	Trc_SunVMI_GetClassContext_Entry(env);
 
@@ -493,20 +494,20 @@ JVM_GetClassContext_Impl(JNIEnv *env)
 
 	/* calculate length of class context */
 	walkState.skipCount = 1;
-	walkState.userData1 = (void *) 0;
-	walkState.userData2 = (void *) NULL;
+	walkState.userData1 = (void *)0;
+	walkState.userData2 = (void *)NULL;
 
 	vmFuncs->internalEnterVMFromJNI(vmThread);
 	vm->walkStackFrames(vmThread, &walkState);
 	vmFuncs->internalExitVMToJNI(vmThread);
 
 	classCtx = (*env)->NewObjectArray(env, (jsize)(UDATA) walkState.userData1, VM.jlClass, 0);
-	if (classCtx) {
+	if (NULL != classCtx) {
 		/* fill in class context elements */
 		walkState.skipCount = 1;
-		walkState.userData1 = (void *) 0;
+		walkState.userData1 = (void *)0;
 		vmFuncs->internalEnterVMFromJNI(vmThread);
-		walkState.userData2 = *((j9object_t*) classCtx);
+		walkState.userData2 = *(j9object_t *)classCtx;
 		vm->walkStackFrames(vmThread, &walkState);
 		vmFuncs->internalExitVMToJNI(vmThread);
 	}
@@ -515,6 +516,7 @@ JVM_GetClassContext_Impl(JNIEnv *env)
 
 	return classCtx;
 }
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 
 JNIEXPORT void JNICALL
@@ -1256,7 +1258,9 @@ static SunVMI VMIFunctionTable = {
 		JVM_GCNoCompact_Impl,
 		JVM_GetCallerClass_Impl,
 		JVM_GetClassAccessFlags_Impl,
+#if JAVA_SPEC_VERSION < 24
 		JVM_GetClassContext_Impl,
+#endif /* JAVA_SPEC_VERSION < 24 */
 		JVM_GetClassLoader_Impl,
 		JVM_GetSystemPackage_Impl,
 		JVM_GetSystemPackages_Impl,
@@ -1274,7 +1278,7 @@ static SunVMI VMIFunctionTable = {
 		JVM_GetFieldTypeAnnotations_Impl,
 		JVM_GetMethodTypeAnnotations_Impl,
 		JVM_GetMethodParameters_Impl
-		};
+};
 
 
 /**


### PR DESCRIPTION
These functions are not needed for Java 24+:
- `jobjectArray JVM_GetClassContext(JNIEnv *);`
- `jobject      JVM_GetInheritedAccessControlContext(JNIEnv *, jclass);`
- `jobject      JVM_GetStackAccessControlContext(JNIEnv *, jclass);`

See upstream changes:
- [8338411: Implement JEP 486: Permanently Disable the Security Manager](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/95daf5dd71a529a0f8f9498812566cec7a92237a)
- [8341916: Remove ProtectionDomain related hotspot code and tests](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/d429ce5e29cba2deabbb41dd27fa22c74cefc9b0)