### PR TITLE
Print actual string arguments with -Xtrace (part 2)

### DIFF
--- a/runtime/oti/j9trace.h
+++ b/runtime/oti/j9trace.h
@@ -63,11 +63,18 @@ typedef struct RasGlobalStorage {
 	void *  traceMethodTable;
 	int     stackdepth;
 	unsigned int    stackCompressionLevel;
+	unsigned int    maxStringLength;
 	ConfigureTraceFunction configureTraceEngine;
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	CRIURestoreInitializeTrace criuRestoreInitializeTrace;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 } RasGlobalStorage;
+
+/*
+ * Default and maximum values for RasGlobalStorage.maxStringLength.
+ */
+#define RAS_MAX_STRING_LENGTH_DEFAULT  32
+#define RAS_MAX_STRING_LENGTH_LIMIT   128
 
 #define RAS_GLOBAL(x) ((RasGlobalStorage *)thr->javaVM->j9rasGlobalStorage)->x 
 

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -1570,7 +1570,8 @@ J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 				/* RAS init may happen in either dump or trace */
 				vm->j9rasGlobalStorage = j9mem_allocate_memory(sizeof(RasGlobalStorage), OMRMEM_CATEGORY_VM);
 				if (vm->j9rasGlobalStorage != NULL) {
-					memset (vm->j9rasGlobalStorage, '\0', sizeof(RasGlobalStorage));
+					memset(vm->j9rasGlobalStorage, '\0', sizeof(RasGlobalStorage));
+					RAS_GLOBAL_FROM_JAVAVM(maxStringLength, vm) = RAS_MAX_STRING_LENGTH_DEFAULT;
 				}
 			}
 			break;

--- a/runtime/rastrace/j9rastrace.h
+++ b/runtime/rastrace/j9rastrace.h
@@ -54,6 +54,7 @@ extern "C" {
 #define RAS_STACKDEPTH_KEYWORD          "STACKDEPTH"
 #define RAS_SLEEPTIME_KEYWORD           "SLEEPTIME"
 #define RAS_COMPRESSION_LEVEL_KEYWORD   "STACKCOMPRESSIONLEVEL"
+#define RAS_MAX_STRING_LENGTH_KEYWORD   "MAXSTRINGLENGTH"
 
 /*
  * ======================================================================
@@ -128,8 +129,9 @@ void rasTriggerMethod(J9VMThread *thr, J9Method *mb, I_32 entry, const TriggerPh
 BOOLEAN matchMethod (RasMethodTable * methodTable, J9Method *method);
 omr_error_t processTriggerMethodClause(OMR_VMThread *, char *, BOOLEAN atRuntime);
 void doTriggerActionJstacktrace(OMR_VMThread *thr);
-omr_error_t setStackDepth(J9JavaVM *thr, const char * value, BOOLEAN atRuntime);
-omr_error_t setStackCompressionLevel(J9JavaVM * vm, const char *str, BOOLEAN atRuntime);
+omr_error_t setStackDepth(J9JavaVM *thr, const char *value, BOOLEAN atRuntime);
+omr_error_t setStackCompressionLevel(J9JavaVM *vm, const char *str, BOOLEAN atRuntime);
+omr_error_t setMaxStringLength(J9JavaVM *vm, const char *str, BOOLEAN atRuntime);
 
 /*
  * =============================================================================

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -117,9 +117,10 @@ const struct traceOption TRACE_OPTIONS[] =
 	{RAS_METHODS_KEYWORD, FALSE, setMethod},
 	{RAS_STACKDEPTH_KEYWORD, TRUE, setStackDepth},
 	{RAS_COMPRESSION_LEVEL_KEYWORD, TRUE, setStackCompressionLevel},
+	{RAS_MAX_STRING_LENGTH_KEYWORD, FALSE, setMaxStringLength},
 };
 
-#define NUMBER_OF_TRACE_OPTIONS ( sizeof(TRACE_OPTIONS) / sizeof(struct traceOption))
+#define NUMBER_OF_TRACE_OPTIONS (sizeof(TRACE_OPTIONS) / sizeof(struct traceOption))
 
 /**
  * The list of trigger actions defined by J9VM passed to the


### PR DESCRIPTION
The changes reflect the feature request https://github.com/eclipse-openj9/openj9/issues/16416.

Adding cmdline option to specify string argument length.
-Xtrace:maxstringlength=[0-128]
maxstringlength takes an unsigned integer value from 0 to 128
If maxstringlength = 0 or unspecified, default to address printing.
Other invalid inputs result in the input error.

There will be subsequent PR for tests (part 3).

Signed-off-by: Nick Kamal <<nick.kamal@ibm.com>>