### PR TITLE
Use indent size rather than buffer for printing bytecodes

### DIFF
--- a/runtime/compiler/runtime/MetaDataDebug.cpp
+++ b/runtime/compiler/runtime/MetaDataDebug.cpp
@@ -546,7 +546,7 @@ extern "C" void jitBytecodePrintFunction(void *userData, char *format, ...)
    }
 
 void
-TR_Debug::printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, char * indent)
+TR_Debug::printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, size_t *indentLen)
    {
 #if defined(J9VM_OPT_JITSERVER)
    if (_comp->isOutOfProcessCompilation() || _comp->isRemoteCompilation())
@@ -558,14 +558,13 @@ TR_Debug::printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, c
       void *bcPrintFunc = (void *)jitBytecodePrintFunction;
       if (parentStackIndex == -1)
          {
-         sprintf(indent, " \\\\");
-         trfprintf(_file, "%s %s\n", indent, _comp->getCurrentMethod()->signature(comp()->trMemory(), heapAlloc));
+         trfprintf(_file, " \\\\ %s\n", _comp->getCurrentMethod()->signature(comp()->trMemory(), heapAlloc));
          ramMethod = (J9Method *)_comp->getCurrentMethod()->resolvedMethodAddress();
          }
       else
          {
          TR_InlinedCallSite & site = _comp->getInlinedCallSite(parentStackIndex);
-         printByteCodeStack(site._byteCodeInfo.getCallerIndex(), site._byteCodeInfo.getByteCodeIndex(), indent);
+         printByteCodeStack(site._byteCodeInfo.getCallerIndex(), site._byteCodeInfo.getByteCodeIndex(), indentLen);
          ramMethod = (J9Method *)site._methodInfo;
          }
 
@@ -575,11 +574,12 @@ TR_Debug::printByteCodeStack(int32_t parentStackIndex, uint16_t byteCodeIndex, c
          uint32_t flags = BCT_BigEndianOutput;
       #endif
 
+      trfprintf(_file, " \\\\");
       j9bcutil_dumpBytecodes(((TR_J9VMBase *)_comp->fej9())->_portLibrary,
                              J9_CLASS_FROM_METHOD(ramMethod)->romClass,
                              J9_BYTECODE_START_FROM_RAM_METHOD(ramMethod),
-                             byteCodeIndex, byteCodeIndex, flags, bcPrintFunc, this, indent);
-      sprintf(indent, "%s   ", indent);
+                             byteCodeIndex, byteCodeIndex, flags, bcPrintFunc, this, *indentLen);
+      *indentLen += 3;
       }
    }
 

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -147,7 +147,7 @@ JVM_GetExtendedNPEMessage(JNIEnv *env, jthrowable throwableObj)
 #else /* defined(J9VM_ENV_LITTLE_ENDIAN) */
 				flags |= BCT_BigEndianOutput;
 #endif /* defined(J9VM_ENV_LITTLE_ENDIAN) */
-				j9bcutil_dumpBytecodes(PORTLIB, userData.romClass, bytecodes, 0, userData.bytecodeOffset, flags, (void *)cfdumpBytecodePrintFunction, PORTLIB, "");
+				j9bcutil_dumpBytecodes(PORTLIB, userData.romClass, bytecodes, 0, userData.bytecodeOffset, flags, (void *)cfdumpBytecodePrintFunction, PORTLIB, 0);
 			}
 #endif /* defined(DEBUG_BCV) */
 			npeMsgData.npePC = userData.bytecodeOffset;

--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -136,7 +136,7 @@ IDATA dumpBytecodes(J9PortLibrary * portLib, J9ROMClass * romClass, J9ROMMethod 
 */
 IDATA j9bcutil_dumpBytecodes(J9PortLibrary * portLib, J9ROMClass * romClass,
 							 U_8 * bytecodes, UDATA walkStartPC, UDATA walkEndPC,
-							 UDATA flags, void *printFunction, void *userData, char *indent);
+							 UDATA flags, void *printFunction, void *userData, UDATA indentLen);
 
 
 /* ---------------- binarysup.c ---------------- */

--- a/runtime/util/bcdump.c
+++ b/runtime/util/bcdump.c
@@ -47,7 +47,7 @@ static void cfdumpBytecodePrintFunction (void *userData, char *format, ...);
 
 IDATA j9bcutil_dumpBytecodes(J9PortLibrary * portLib, J9ROMClass * romClass,
 							 U_8 * bytecodes, UDATA walkStartPC, UDATA walkEndPC,
-							 UDATA flags, void *printFunction, void *userData, char *indent)
+							 UDATA flags, void *printFunction, void *userData, UDATA indentLen)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 	DISASSEMBLY_PRINT_FN outputFunction = (DISASSEMBLY_PRINT_FN) printFunction;
@@ -166,7 +166,7 @@ IDATA j9bcutil_dumpBytecodes(J9PortLibrary * portLib, J9ROMClass * romClass,
 			}
 		}
 		_GETNEXT_U8(bc, bcIndex);
-		outputFunction(userData, "%s%5i %s ", indent, pc, JavaBCNames[bc]);
+		outputFunction(userData, "%*s%5i %s ", indentLen, "", pc, JavaBCNames[bc]);
 		start = pc;
 		pc++;
 		switch (bc) {
@@ -569,7 +569,7 @@ IDATA dumpBytecodes(J9PortLibrary * portLib, J9ROMClass * romClass, J9ROMMethod 
 	return j9bcutil_dumpBytecodes(portLib, romClass,
 								  J9_BYTECODE_START_FROM_ROM_METHOD(romMethod), 0,
 								  length - 1, flags,
-								  (void *) cfdumpBytecodePrintFunction, portLib, "");
+								  (void *) cfdumpBytecodePrintFunction, portLib, 0);
 }
 
 


### PR DESCRIPTION
Codependent on https://github.com/eclipse-omr/omr/pull/7555