### PR TITLE
Add runtime helpers for JProfilingValue

### DIFF
--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -461,6 +461,16 @@ void J9FASTCALL jProfile64BitValue(uint64_t value, TR_HashTableProfilerInfo<uint
    table->addKey(value);
    }
 
+void J9FASTCALL jProfile32BitValueLowOpt(uint32_t value, TR_HashTableProfilerInfo<uint32_t> *table)
+   {
+   table->updateFrequency(value);
+   }
+
+void J9FASTCALL jProfile64BitValueLowOpt(uint64_t value, TR_HashTableProfilerInfo<uint64_t> *table)
+   {
+   table->updateFrequency(value);
+   }
+
 }
 
 extern "C" {
@@ -1227,6 +1237,8 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_Helper);
    SET_CONST(TR_jProfile32BitValue,             (void *)jProfile32BitValue);
    SET_CONST(TR_jProfile64BitValue,             (void *)jProfile64BitValue);
+   SET_CONST(TR_jProfile32BitValueLowOpt        (void *)jProfile32BitValueLowOpt);
+   SET_CONST(TR_jProfile64BitValueLowOpt        (void *)jProfile64BitValueLowOpt);
 #elif defined(TR_HOST_X86)
    SET(TR_jitProfileWarmCompilePICAddress,      (void *)_jitProfileWarmCompilePICAddress, TR_CHelper);
    SET(TR_jitProfileAddress,                    (void *)_jitProfileAddress,               TR_CHelper);
@@ -1238,9 +1250,13 @@ void initializeJitRuntimeHelperTable(char isSMP)
 #if defined(TR_HOST_64BIT)
    SET(TR_jProfile32BitValue,                   (void *)jProfile32BitValueWrapper,        TR_CHelper);
    SET(TR_jProfile64BitValue,                   (void *)jProfile64BitValueWrapper,        TR_CHelper);
+   SET(TR_jProfile32BitValueLowOpt,             (void *)jProfile32BitValueLowOptWrapper,  TR_CHelper);
+   SET(TR_jProfile64BitValueLowOpt,             (void *)jProfile64BitValueLowOptWrapper,  TR_CHelper);
 #else
    SET(TR_jProfile32BitValue,                   (void *)jProfile32BitValue,        TR_CHelper);
    SET(TR_jProfile64BitValue,                   (void *)jProfile64BitValue,        TR_CHelper);
+   SET(TR_jProfile32BitValueLowOpt,             (void *)jProfile32BitValueLowOpt,  TR_CHelper);
+   SET(TR_jProfile64BitValueLowOpt,             (void *)jProfile64BitValueLowOpt,  TR_CHelper);
 #endif
 #else
    SET(TR_jitProfileWarmCompilePICAddress,      (void *)_jitProfileWarmCompilePICAddress, TR_Helper);
@@ -1250,8 +1266,10 @@ void initializeJitRuntimeHelperTable(char isSMP)
    SET(TR_jitProfileBigDecimalValue,            (void *)_jitProfileBigDecimalValue,       TR_Helper);
    SET(TR_jitProfileStringValue,                (void *)_jitProfileStringValue,           TR_Helper);
    SET(TR_jitProfileParseBuffer,                (void *)_jitProfileParseBuffer,           TR_Helper);
-   SET(TR_jProfile32BitValue,                   (void *)jProfile32BitValue,              TR_Helper);
-   SET(TR_jProfile64BitValue,                   (void *)jProfile64BitValue,              TR_Helper);
+   SET(TR_jProfile32BitValue,                   (void *)jProfile32BitValue,               TR_Helper);
+   SET(TR_jProfile64BitValue,                   (void *)jProfile64BitValue,               TR_Helper);
+   SET(TR_jProfile32BitValueLowOpt,             (void *)jProfile32BitValueLowOpt,         TR_Helper);
+   SET(TR_jProfile64BitValueLowOpt,             (void *)jProfile64BitValueLowOpt,         TR_Helper);
 #endif
 
 #if defined(J9ZOS390)

--- a/runtime/compiler/x/runtime/X86Codert.nasm
+++ b/runtime/compiler/x/runtime/X86Codert.nasm
@@ -142,8 +142,12 @@ segment .text
 %ifdef TR_HOST_64BIT
         DECLARE_GLOBAL jProfile32BitValueWrapper
         DECLARE_GLOBAL jProfile64BitValueWrapper
+        DECLARE_GLOBAL jProfile32BitValueWrapperLowOpt
+        DECLARE_GLOBAL jProfile64BitValueWrapperLowOpt
         DECLARE_EXTERN jProfile32BitValue
         DECLARE_EXTERN jProfile64BitValue
+        DECLARE_EXTERN jProfile32BitValueLowOpt
+        DECLARE_EXTERN jProfile64BitValueLowOpt
 %endif
 
         align 16
@@ -652,12 +656,29 @@ jProfile32BitValueWrapper:
         mov _rsp, [_rbp+J9TR_VMThread_sp]                 ; restore java stack pointer
         ret
 
+jProfile32BitValueWrapperLowOpt:
+        ; Called directly from jitted code, _rbp is vmthread
+        mov [_rbp+J9TR_VMThread_sp], _rsp                 ; Store current java stack pointer to vmthread
+        mov _rsp, [_rbp+J9TR_VMThread_machineSP]          ; switch to c stack
+        CallHelper jProfile32BitValueLowOpt
+        mov _rsp, [_rbp+J9TR_VMThread_sp]                 ; restore java stack pointer
+        ret
+
         align 16
 jProfile64BitValueWrapper:
         ; Called directly from jitted code, _rbp is vmthread
         mov [_rbp+J9TR_VMThread_sp], _rsp                 ; Store current java stack pointer to vmthread
         mov _rsp, [_rbp+J9TR_VMThread_machineSP]          ; switch to c stack
         CallHelper jProfile64BitValue
+        mov _rsp, [_rbp+J9TR_VMThread_sp]                 ; restore java stack pointer
+        ret
+
+        align 16
+jProfile64BitValueWrapperLowOpt:
+        ; Called directly from jitted code, _rbp is vmthread
+        mov [_rbp+J9TR_VMThread_sp], _rsp                 ; Store current java stack pointer to vmthread
+        mov _rsp, [_rbp+J9TR_VMThread_machineSP]          ; switch to c stack
+        CallHelper jProfile64BitValueLowOpt
         mov _rsp, [_rbp+J9TR_VMThread_sp]                 ; restore java stack pointer
         ret
 %endif


### PR DESCRIPTION
For low level optimizations, having a value profiling trees could be hurtful for runtime performance. This commit adds new helper to increment the counter frequency or other frequency in the Value Profiling table to be called by JIT compiled code at runtime.