### PR TITLE
(0.49) Add j9gc_get_cumulative_class_unloading_stats()

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -251,6 +251,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 #endif /* J9VM_GC_OBJECT_ACCESS_BARRIER */
 	j9gc_get_bytes_allocated_by_thread,
 	j9gc_get_cumulative_bytes_allocated_by_thread,
+	j9gc_get_cumulative_class_unloading_stats,
 	j9mm_iterate_all_ownable_synchronizer_objects,
 	j9mm_iterate_all_continuation_objects,
 	ownableSynchronizerObjectCreated,

--- a/runtime/gc_base/ClassLoaderManager.cpp
+++ b/runtime/gc_base/ClassLoaderManager.cpp
@@ -365,9 +365,7 @@ MM_ClassLoaderManager::cleanUpClassLoadersStart(MM_EnvironmentBase *env, J9Class
 		TRIGGER_J9HOOK_VM_CLASS_LOADERS_UNLOAD(_javaVM->hookInterface, vmThread, classLoaderUnloadList);
 	}
 
-	classUnloadStats->_classesUnloadedCount = classUnloadCount;
-	classUnloadStats->_classLoaderUnloadedCount = classLoaderUnloadCount;
-	classUnloadStats->_anonymousClassesUnloadedCount = anonymousClassUnloadCount;
+	classUnloadStats->updateUnloadedCounters(anonymousClassUnloadCount, classUnloadCount, classLoaderUnloadCount);
 
 	/* Ensure that the vm has an accurate number of currently loaded anonymous classes  */
 	_javaVM->anonClassCount -= anonymousClassUnloadCount;

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -293,6 +293,7 @@ extern BOOLEAN j9gc_stringHashEqualFn (void *leftKey, void *rightKey, void *user
 /* modronapi.cpp */
 extern J9_CFUNC UDATA j9gc_get_bytes_allocated_by_thread(J9VMThread* vmThread);
 extern J9_CFUNC BOOLEAN j9gc_get_cumulative_bytes_allocated_by_thread(J9VMThread *vmThread, UDATA *cumulativeValue);
+extern J9_CFUNC BOOLEAN j9gc_get_cumulative_class_unloading_stats(J9VMThread *vmThread, UDATA *anonymous, UDATA *classes, UDATA *classloaders);
 
 #ifdef __cplusplus
 }

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -979,6 +979,20 @@ j9gc_get_cumulative_bytes_allocated_by_thread(J9VMThread *vmThread, UDATA *cumul
 }
 
 /**
+ * @param[in] vmThread the vmThread we are querying about
+ * @param[out] anonymous cumulative value pointer for unloaded anonymous classes
+ * @param[out] classes cumulative value pointer for unloaded classes (including anonymous)
+ * @param[out] classloaders cumulative value pointer for unloaded classesloaders
+ */
+BOOLEAN
+j9gc_get_cumulative_class_unloading_stats(J9VMThread *vmThread, UDATA *anonymous, UDATA *classes, UDATA *classloaders)
+{
+	MM_GCExtensions *ext = MM_GCExtensions::getExtensions(vmThread->javaVM);
+	ext->globalGCStats.classUnloadStats.getUnloadedCountersCumulative(anonymous, classes, classloaders);
+	return true;
+}
+
+/**
  * Return information about the total CPU time consumed by GC threads, as well
  * as the number of GC threads. The time for the main and worker threads is
  * reported separately, with the worker threads returned as a total.

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -615,9 +615,8 @@ MM_MetronomeDelegate::updateClassUnloadStats(MM_EnvironmentBase *env, UDATA clas
 	MM_ClassUnloadStats *classUnloadStats = &_extensions->globalGCStats.classUnloadStats;
 
 	/* TODO CRGTMP move global stats into super class implementation once it is created */
-	classUnloadStats->_classesUnloadedCount = classUnloadCount;
-	classUnloadStats->_anonymousClassesUnloadedCount = anonymousClassUnloadCount;
-	classUnloadStats->_classLoaderUnloadedCount = classLoaderUnloadCount;
+	classUnloadStats->updateUnloadedCounters(anonymousClassUnloadCount, classUnloadCount, classLoaderUnloadCount);
+
 
 	/* Record increment stats */
 	_extensions->globalGCStats.metronomeStats.classesUnloadedCount = classUnloadCount;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4801,6 +4801,7 @@ typedef struct J9MemoryManagerFunctions {
 #endif /* defined(J9VM_GC_OBJECT_ACCESS_BARRIER) */
 	UDATA  ( *j9gc_get_bytes_allocated_by_thread)(struct J9VMThread *vmThread) ;
 	BOOLEAN ( *j9gc_get_cumulative_bytes_allocated_by_thread)(struct J9VMThread *vmThread, UDATA *cumulativeValue) ;
+	BOOLEAN ( *j9gc_get_cumulative_class_unloading_stats)(struct J9VMThread *vmThread, UDATA *anonumous, UDATA *classes, UDATA *classloaders) ;
 
 	jvmtiIterationControl  ( *j9mm_iterate_all_ownable_synchronizer_objects)(struct J9VMThread *vmThread, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl (*func)(struct J9VMThread *vmThread, struct J9MM_IterateObjectDescriptor *object, void *userData), void *userData) ;
 	jvmtiIterationControl  ( *j9mm_iterate_all_continuation_objects)(struct J9VMThread *vmThread, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl (*func)(struct J9VMThread *vmThread, struct J9MM_IterateObjectDescriptor *object, void *userData), void *userData) ;


### PR DESCRIPTION
Add external GC function to report cumulative class unloading stats. Use general API to update counters in class unloading stats.