### PR TITLE
Add an unknown thread entry to JFR constant pool

### DIFF
--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -1235,7 +1235,10 @@ VM_JFRConstantPoolTypes::freeThreadNameEntries(void *entry, void *userData)
 	J9VMThread *currentThread = (J9VMThread *)userData;
 	PORT_ACCESS_FROM_VMC(currentThread);
 
-	j9mem_free_memory(tableEntry->javaThreadName);
+	/* Name of the unknown thread entry cannot be freed */
+	if (0 != tableEntry->index) {
+		j9mem_free_memory(tableEntry->javaThreadName);
+	}
 	tableEntry->javaThreadName = NULL;
 
 	return FALSE;

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -45,6 +45,7 @@ J9_DECLARE_CONSTANT_UTF8(nativeMethod, "(nativeMethod)");
 J9_DECLARE_CONSTANT_UTF8(nativeMethodSignature, "()");
 J9_DECLARE_CONSTANT_UTF8(defaultPackage, "(defaultPackage)");
 J9_DECLARE_CONSTANT_UTF8(bootLoaderName, "boostrapClassLoader");
+J9_DECLARE_CONSTANT_UTF8(unknownThread, "unknown thread");
 
 enum JFRStringConstants {
 	DefaultString = 0,
@@ -540,6 +541,21 @@ done:
 			value = jvmInfoProperty->value;
 		}
 		return value;
+	}
+
+	void addUnknownThreadEntry() {
+		ThreadEntry unknownThreadEntry = {0};
+		unknownThreadEntry.vmThread = NULL;
+		unknownThreadEntry.index = 0;
+		unknownThreadEntry.osTID = 0;
+		unknownThreadEntry.javaTID = 0;
+		unknownThreadEntry.javaThreadName = (J9UTF8 *)&unknownThread;
+		unknownThreadEntry.osThreadName = (J9UTF8 *)&unknownThread;
+		unknownThreadEntry.threadGroupIndex = 0;
+
+		ThreadEntry *entry = (ThreadEntry *)hashTableAdd(_threadTable, &unknownThreadEntry);
+		_firstThreadEntry = entry;
+		_previousThreadEntry = entry;
 	}
 
 protected:
@@ -1276,6 +1292,7 @@ done:
 
 		/* Leave index 0 as a NULL entry for unknown notifier thread. */
 		_threadCount += 1;
+		addUnknownThreadEntry();
 
 done:
 		return;


### PR DESCRIPTION
This fixes the error of "Size of check point event doesn't match content" while reading a JFR chunk.