### PR TITLE
Print actual string arguments with -Xtrace (part 3)

### DIFF
--- a/test/functional/cmdLineTests/xtraceTests/build.xml
+++ b/test/functional/cmdLineTests/xtraceTests/build.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+
+<!--
+  Copyright IBM Corp. and others 2025
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<project name="cmdLineTests" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests xtraceTests
+	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/xtraceTests" />
+	<property name="src" location="." />
+
+	<target name="dist" description="generate the distribution">
+		<copy todir="${DEST}">
+			<fileset dir="${src}" includes="*.xml,*.mk"/>
+		</copy>
+	</target>
+
+	<target name="build" depends="buildCmdLineTestTools">
+		<antcall target="dist" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/xtraceTests/playlist.xml
+++ b/test/functional/cmdLineTests/xtraceTests/playlist.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Copyright IBM Corp. and others 2025
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<include>../variables.mk</include>
+	<test>
+		<testCaseName>xtraceTests</testCaseName>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
+	-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(SQ) \
+	-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)xtraceTests.xml$(Q) \
+	-nonZeroExitWhenError; \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>extended</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/xtraceTests/xtraceTests.xml
+++ b/test/functional/cmdLineTests/xtraceTests/xtraceTests.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+	Copyright IBM Corp. and others 2025
+
+	This program and the accompanying materials are made available under
+	the terms of the Eclipse Public License 2.0 which accompanies this
+	distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+	or the Apache License, Version 2.0 which accompanies this distribution and
+	is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+	This Source Code may also be made available under the following
+	Secondary Licenses when the conditions for such availability set
+	forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+	General Public License, version 2 with the GNU Classpath
+	Exception [1] and GNU General Public License, version 2 with the
+	OpenJDK Assembly Exception [2].
+
+	[1] https://www.gnu.org/software/classpath/license.html
+	[2] https://openjdk.org/legal/assembly-exception.html
+
+	SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="xtrace commandline tests" timeout="120">
+
+	<!-- These tests check -Xtrace is working correctly and error/warning messages are proper. -->
+	<test id="Test 1 - invalid argument - 'a'">
+		<command>$EXE$ -Xtrace:methods={java/lang/String.concat()},maxstringlength='a',print=mt -version</command>
+		<output regex="no" type="success">Trace option unrecognized: -Xtrace:maxstringlength</output>
+		<output regex="no" type="required">Error processing trace option, detail: maxstringlength takes an integer value from 0 to 128</output>
+		<output regex="no" type="required">Error processing trace option, detail: Invalid character(s) encountered in decimal number</output>
+	</test>
+
+	<test id="Test 2 - out of range invalid argument - 129">
+		<command>$EXE$ -Xtrace:methods={java/lang/String.concat()},maxstringlength=129,print=mt -version</command>
+		<output regex="no" type="success">Trace option unrecognized: -Xtrace:maxstringlength</output>
+		<output regex="no" type="required">Error processing trace option, detail: maxstringlength takes an integer value from 0 to 128</output>
+		<output regex="no" type="required">Error processing trace option: -Xtrace:maxstringlength=129</output>
+	</test>
+
+	<test id="Test 3 - valid argument length 1" runPath=".">
+		<command>$EXE$ -Xtrace:methods={java/lang/String.concat()},maxstringlength=1,print=mt -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(.)*method arguments: \(\(String\)"(\w)"\.{3}\)</output>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+	</test>
+
+	<test id="Test 4 - valid argument length" runPath=".">
+		<command>$EXE$ -Xtrace:methods={java/lang/String.concat()},maxstringlength=6,print=mt -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(.)*method arguments: \(\(String\)"(\w{6})"\.{3}\)</output>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+	</test>
+
+	<test id="Test 5 - valid argument zero length - 0">
+		<command>$EXE$ -Xtrace:methods={java/lang/String.concat()},maxstringlength=0,print=mt -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(.)*method arguments: \(\(String\)"([\x00-\x7F]{0,32})"\)</output>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+	</test>
+
+	<test id="Test 6 - no argument">
+		<command>$EXE$ -Xtrace:methods={java/lang/String.concat()},print=mt -version</command>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(.)*method arguments: \(\(String\)"([\x00-\x7F]{0,32})"\)</output>
+		<output type="success" caseSensitive="no" regex="yes" javaUtilPattern="yes">(java|openjdk|semeru) version</output>
+	</test>
+</suite>


### PR DESCRIPTION
The changes reflect the feature request https://github.com/eclipse-openj9/openj9/issues/16416 - part 3

Following part 2 - https://github.com/eclipse-openj9/openj9/pull/20662
cmdline tests for -Xtrace:maxstringlength

Closes: https://github.com/eclipse-openj9/openj9/issues/16416
Signed-off-by: Nick Kamal <<nick.kamal@ibm.com>>