### PR TITLE
Restrict special handling of MemorySegment methods to only the getters and setters

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -4830,7 +4830,8 @@ void TR_ResolvedJ9Method::construct()
             }
          else if ((classNameLen == 31) && !strncmp(className, "java/lang/foreign/MemorySegment", 31))
             {
-            setRecognizedMethodInfo(TR::java_lang_foreign_MemorySegment_method);
+            if (nameLen >= 3 && (!strncmp(name, "get", 3) || !strncmp(name, "set", 3)))
+               setRecognizedMethodInfo(TR::java_lang_foreign_MemorySegment_method);
             }
 #endif
          else if ((classNameLen >= 59 + 3 && classNameLen <= 59 + 7) && !strncmp(className, "java/lang/invoke/ArrayVarHandle$ArrayVarHandleOperations$Op", 59))

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -847,7 +847,7 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
             if (meth)
                {
                const char * sig = meth->signature(comp()->trMemory());
-               if (sig && !strncmp(sig, "java/lang/foreign/MemorySegment", 31))
+               if (sig && (!strncmp(sig, "java/lang/foreign/MemorySegment.get", 35) || !strncmp(sig, "java/lang/foreign/MemorySegment.set", 35) ))
                   {
                   nph.setNeedsPeekingToTrue();
                   heuristicTrace(tracer(), "Depth %d: invokeinterface call at bc index %d has Signature %s, enabled peeking for caller to fold layout field load necessary for VarHandle operation inlining.", _recursionDepth, i, sig);


### PR DESCRIPTION
This PR does the following:
* Only set RecognizedMethod info for MemorySegment getters and setters, as other MemorySegment methods do not require special handling - the special handling being forced to iterate with state in InterpreterEmulator.
* Restrict peeking of MemorySegment method callers to only the getters and setters.