### PR TITLE
Fix a Typo in the Server Query for the Vector API

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -697,7 +697,7 @@ TR_VectorAPIExpansion::getOpaqueClassBlockFromClassNode(TR::Compilation *comp, T
          {
          auto stream = comp->getStream();
          stream->write(JITServer::MessageType::KnownObjectTable_getOpaqueClass,
-                        symRef->getKnownObjectIndex());
+                        knownObjectIndex);
          clazz = (TR_OpaqueClassBlock *)std::get<0>(stream->read<uintptr_t>());
          }
       else


### PR DESCRIPTION
Fix a typo that is causing the client to segfault in server mode; it had never been detected because we were not reaching the Vector API in server mode before.