### PR TITLE
Copy local signature from MethodHandleNatives.resolve

### DIFF
--- a/runtime/bcverify/clconstraints.c
+++ b/runtime/bcverify/clconstraints.c
@@ -32,7 +32,7 @@
 #include "omrlinkedlist.h"
 
 static J9ClassLoadingConstraint* findClassLoadingConstraint (J9VMThread* vmThread, J9ClassLoader* loader, U_8* name, UDATA length);
-static J9ClassLoadingConstraint* registerClassLoadingConstraint (J9VMThread* vmThread, J9ClassLoader* loader, U_8* name, UDATA length, UDATA copyName);
+static J9ClassLoadingConstraint* registerClassLoadingConstraint (J9VMThread* vmThread, J9ClassLoader* loader, U_8* name, UDATA length, BOOLEAN copyName);
 static void validateArgs (J9VMThread* vmThread, J9ClassLoader* loader1, J9ClassLoader* loader2, U_8* name1, U_8* name2, UDATA length);
 static void constrainList (J9ClassLoadingConstraint* constraint, J9Class* clazz);
 static UDATA constraintHashFn(void *key, void *userData);
@@ -71,7 +71,7 @@ validateArgs (J9VMThread* vmThread, J9ClassLoader* loader1, J9ClassLoader* loade
  * return 0 if no class loading constraints have been violated, or non-zero if they have been.
  */
 UDATA 
-j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread* vmThread, J9ClassLoader* loader1, J9ClassLoader* loader2, J9UTF8* sig1, J9UTF8* sig2)
+j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread *vmThread, J9ClassLoader *loader1, J9ClassLoader *loader2, J9UTF8 *sig1, J9UTF8 *sig2, BOOLEAN copySig1)
 {
 	U_32 index = 0, endIndex;
 	U_32 length = J9UTF8_LENGTH(sig1);
@@ -101,8 +101,7 @@ j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread* vmThread, J9ClassLoa
 		while (J9UTF8_DATA(sig1)[endIndex] != ';') {
 			endIndex++;
 		}
-
-		rc = j9bcv_checkClassLoadingConstraintForName (vmThread, loader1, loader2, &J9UTF8_DATA(sig1)[index], &J9UTF8_DATA(sig2)[index], endIndex - index, FALSE);
+		rc = j9bcv_checkClassLoadingConstraintForName (vmThread, loader1, loader2, &J9UTF8_DATA(sig1)[index], &J9UTF8_DATA(sig2)[index], endIndex - index, copySig1, FALSE);
 		if (rc) {
 			break;
 		}
@@ -120,7 +119,7 @@ j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread* vmThread, J9ClassLoa
 /* NOTE: the current thread must own the class table mutex */
 
 UDATA
-j9bcv_checkClassLoadingConstraintForName (J9VMThread* vmThread, J9ClassLoader* loader1, J9ClassLoader* loader2, U_8* name1, U_8* name2, UDATA length, UDATA copyUTFs)
+j9bcv_checkClassLoadingConstraintForName (J9VMThread *vmThread, J9ClassLoader *loader1, J9ClassLoader *loader2, U_8 *name1, U_8 *name2, UDATA length, BOOLEAN copyName1, BOOLEAN copyName2)
 {
 	J9Class *class1;
 	J9Class *class2;
@@ -140,7 +139,7 @@ j9bcv_checkClassLoadingConstraintForName (J9VMThread* vmThread, J9ClassLoader* l
 			return 1;
 		}
 	} else if (class1 == NULL && class2 != NULL) {
-		const1 = registerClassLoadingConstraint (vmThread, loader1, name1, length, copyUTFs);
+		const1 = registerClassLoadingConstraint (vmThread, loader1, name1, length, copyName1);
 		if (const1 == NULL) return 1;
 		if (const1->clazz != NULL) {
 			if (const1->clazz != class2) {
@@ -151,7 +150,7 @@ j9bcv_checkClassLoadingConstraintForName (J9VMThread* vmThread, J9ClassLoader* l
 			const1->clazz = class2;
 		}
 	} else if (class2 == NULL && class1 != NULL) {
-		const2 = registerClassLoadingConstraint (vmThread, loader2, name2, length, copyUTFs);
+		const2 = registerClassLoadingConstraint (vmThread, loader2, name2, length, copyName2);
 		if (const2->clazz != NULL) {
 			if (const2->clazz != class1) {
 				return 1;
@@ -164,11 +163,11 @@ j9bcv_checkClassLoadingConstraintForName (J9VMThread* vmThread, J9ClassLoader* l
 		J9ClassLoadingConstraint *tempNext;
 		J9ClassLoadingConstraint *tempPrevious;
 
-		const1 = registerClassLoadingConstraint (vmThread, loader1, name1, length, copyUTFs);
+		const1 = registerClassLoadingConstraint (vmThread, loader1, name1, length, copyName1);
 		if (const1 == NULL) {
 			return 1;
 		}
-		const2 = registerClassLoadingConstraint (vmThread, loader2, name2, length, copyUTFs);
+		const2 = registerClassLoadingConstraint (vmThread, loader2, name2, length, copyName2);
 		if (const2 == NULL) {
 			return 1;
 		}
@@ -203,7 +202,7 @@ j9bcv_checkClassLoadingConstraintForName (J9VMThread* vmThread, J9ClassLoader* l
 /* NOTE: the current thread must own the class table mutex */
 
 static J9ClassLoadingConstraint*
-registerClassLoadingConstraint (J9VMThread* vmThread, J9ClassLoader* loader, U_8* name, UDATA length, UDATA copyName)
+registerClassLoadingConstraint (J9VMThread* vmThread, J9ClassLoader* loader, U_8* name, UDATA length, BOOLEAN copyName)
 {
 	PORT_ACCESS_FROM_VMC (vmThread);
 	J9JavaVM* vm = vmThread->javaVM;

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -375,7 +375,16 @@ accessCheckFieldSignature(J9VMThread *currentThread, J9Class* lookupClass, UDATA
 				U_32 sigLength = J9UTF8_LENGTH(lookupSig) - sigOffset - 1;
 				
 				omrthread_monitor_enter(vm->classTableMutex);
-				if(verifyData->checkClassLoadingConstraintForNameFunction(currentThread, targetClassloader, ramClass->classLoader, &lookupSigData[sigOffset], &lookupSigData[sigOffset], sigLength, TRUE) != 0) {
+				if (0 != verifyData->checkClassLoadingConstraintForNameFunction(
+						currentThread,
+						targetClassloader,
+						ramClass->classLoader,
+						&lookupSigData[sigOffset],
+						&lookupSigData[sigOffset],
+						sigLength,
+						TRUE,
+						TRUE)
+				) {
 					result = FALSE;
 				}
 				omrthread_monitor_exit(vm->classTableMutex);
@@ -445,7 +454,16 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 
 				/* Check if we really need to check this classloader constraint */
 				if (argumentRamClass->classLoader != targetClassloader) {
-					if(verifyData->checkClassLoadingConstraintForNameFunction(currentThread, targetClassloader, argumentRamClass->classLoader, &J9UTF8_DATA(targetSig)[index], &lookupSigData[index], endIndex - index, TRUE) != 0) {
+					if(0 != verifyData->checkClassLoadingConstraintForNameFunction(
+						currentThread,
+						targetClassloader,
+						argumentRamClass->classLoader,
+						&J9UTF8_DATA(targetSig)[index],
+						&lookupSigData[index],
+						endIndex - index,
+						TRUE,
+						TRUE)
+					) {
 						result = FALSE;
 						goto releaseMutexAndReturn;
 					}
@@ -477,7 +495,16 @@ accessCheckMethodSignature(J9VMThread *currentThread, J9Method *method, j9object
 					endIndex++;
 				}
 
-				if(verifyData->checkClassLoadingConstraintForNameFunction(currentThread, targetClassloader, returnRamClass->classLoader, &J9UTF8_DATA(targetSig)[index], &lookupSigData[index], endIndex - index, TRUE) != 0) {
+				if(0 != verifyData->checkClassLoadingConstraintForNameFunction(
+						currentThread,
+						targetClassloader,
+						returnRamClass->classLoader,
+						&J9UTF8_DATA(targetSig)[index],
+						&lookupSigData[index],
+						endIndex - index,
+						TRUE,
+						TRUE)
+				) {
 					result = FALSE;
 					goto releaseMutexAndReturn;
 				}

--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -1323,6 +1323,7 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(
 																	J9UTF8_DATA(signature) + sigOffset,
 																	J9UTF8_DATA(signature) + sigOffset,
 																	J9UTF8_LENGTH(signature) - sigOffset - 1, /* -1 to remove the trailing ;*/
+																	true,
 																	true);
 									omrthread_monitor_exit(vm->classTableMutex);
 									if (0 != clConstraintResult) {

--- a/runtime/jcl/common/java_lang_invoke_VarHandle.c
+++ b/runtime/jcl/common/java_lang_invoke_VarHandle.c
@@ -64,6 +64,7 @@ accessCheckFieldType(J9VMThread *currentThread, J9Class* lookupClass, J9Class* t
 						&lookupSigData[1],
 						&lookupSigData[1],
 						J9UTF8_LENGTH(lookupSig) - 2, 
+						TRUE,
 						TRUE) != 0) {
 					result = FALSE;
 				}

--- a/runtime/oti/bcverify_api.h
+++ b/runtime/oti/bcverify_api.h
@@ -160,10 +160,11 @@ bcvIsInitOrClinit (J9CfrConstantPoolInfo * info);
 * @param loader2
 * @param sig1
 * @param sig2
+* @param copySig1
 * @return UDATA
 */
 UDATA
-j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread* vmThread, J9ClassLoader* loader1, J9ClassLoader* loader2, J9UTF8* sig1, J9UTF8* sig2);
+j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread *vmThread, J9ClassLoader *loader1, J9ClassLoader *loader2, J9UTF8 *sig1, J9UTF8 *sig2, BOOLEAN copySig1);
 
 /**
 * @brief
@@ -173,10 +174,12 @@ j9bcv_checkClassLoadingConstraintsForSignature (J9VMThread* vmThread, J9ClassLoa
 * @param name1
 * @param name2
 * @param length
+* @param copyName1
+* @param copyName2
 * @return UDATA
  */
 UDATA
-j9bcv_checkClassLoadingConstraintForName (J9VMThread* vmThread, J9ClassLoader* loader1, J9ClassLoader* loader2, U_8* name1, U_8* name2, UDATA length, UDATA copyUTFs);
+j9bcv_checkClassLoadingConstraintForName (J9VMThread *vmThread, J9ClassLoader *loader1, J9ClassLoader *loader2, U_8 *name1, U_8 *name2, UDATA length, BOOLEAN copyName1, BOOLEAN copyName2);
 
 /**
 * @brief

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2007,7 +2007,7 @@ typedef struct J9TranslationBufferSet {
 
 typedef struct J9BytecodeVerificationData {
 	IDATA  ( *verifyBytecodesFunction)(struct J9PortLibrary *portLib, struct J9Class *ramClass, struct J9ROMClass *romClass, struct J9BytecodeVerificationData *verifyData) ;
-	UDATA  ( *checkClassLoadingConstraintForNameFunction)(struct J9VMThread* vmThread, struct J9ClassLoader* loader1, struct J9ClassLoader* loader2, U_8* name1, U_8* name2, UDATA length, UDATA copyUTFs) ;
+	UDATA  ( *checkClassLoadingConstraintForNameFunction)(struct J9VMThread *vmThread, struct J9ClassLoader *loader1, struct J9ClassLoader *loader2, U_8 *name1, U_8 *name2, UDATA length, BOOLEAN copyName1, BOOLEAN copyName2) ;
 	struct J9UTF8** classNameList;
 	struct J9UTF8** classNameListEnd;
 	U_8* classNameSegment;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -634,7 +634,7 @@ add_existing:
 									vTableMethodLoader = methodClass->classLoader;
 								}
 								if (interfaceLoader != vTableMethodLoader) {
-									if (0 != j9bcv_checkClassLoadingConstraintsForSignature(vmStruct, vTableMethodLoader, interfaceLoader, vTableMethodSigUTF, interfaceMethodSigUTF)) {
+									if (0 != j9bcv_checkClassLoadingConstraintsForSignature(vmStruct, vTableMethodLoader, interfaceLoader, vTableMethodSigUTF, interfaceMethodSigUTF, FALSE)) {
 										J9UTF8 *vTableMethodClassNameUTF = J9ROMCLASS_CLASSNAME(romClass);
 										if (NULL != methodClass) {
 											vTableMethodClassNameUTF = J9ROMCLASS_CLASSNAME(methodClass->romClass);
@@ -1282,7 +1282,7 @@ processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTa
 							J9ClassLoader *superclassVTableMethodLoader = superclassVTableMethodClass->classLoader;
 							if (superclassVTableMethodLoader != classLoader) {
 								J9UTF8 *superclassVTableMethodSigUTF = J9ROMMETHOD_SIGNATURE(superclassVTableROMMethod);
-								if (0 != j9bcv_checkClassLoadingConstraintsForSignature(vmThread, classLoader, superclassVTableMethodLoader, sigUTF, superclassVTableMethodSigUTF)) {
+								if (0 != j9bcv_checkClassLoadingConstraintsForSignature(vmThread, classLoader, superclassVTableMethodLoader, sigUTF, superclassVTableMethodSigUTF, FALSE)) {
 									J9UTF8 *superclassVTableMethodClassNameUTF = J9ROMCLASS_CLASSNAME(superclassVTableMethodClass->romClass);
 									J9UTF8 *newClassNameUTF = J9ROMCLASS_CLASSNAME(romClass);
 									J9UTF8 *superclassVTableMethodNameUTF = J9ROMMETHOD_NAME(superclassVTableROMMethod);

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -242,7 +242,14 @@ processMethod(J9VMThread * currentThread, UDATA lookupOptions, J9Method * method
 					lookupSig = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
 				}
 				
-				if (j9bcv_checkClassLoadingConstraintsForSignature(currentThread, cl1, cl2, lookupSig, methodSig) != 0) {
+				if (0 != j9bcv_checkClassLoadingConstraintsForSignature(
+						currentThread,
+						cl1,
+						cl2,
+						lookupSig,
+						methodSig,
+						J9_ARE_ALL_BITS_SET(lookupOptions, J9_LOOK_DIRECT_NAS))
+				) {
 					*exception = J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR; /* was VerifyError; but Sun throws Linkage */
 					*exceptionClass = methodClass;
 					*errorType = J9_VISIBILITY_NON_MODULE_ACCESS_ERROR;

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -810,7 +810,7 @@ illegalAccess:
 				}
 				if (cl1 != cl2) {
 					J9UTF8 *fieldSignature = J9ROMFIELDSHAPE_SIGNATURE(field);
-					if (j9bcv_checkClassLoadingConstraintsForSignature(vmStruct, cl1, cl2, signature, fieldSignature) != 0) {
+					if (0 != j9bcv_checkClassLoadingConstraintsForSignature(vmStruct, cl1, cl2, signature, fieldSignature, FALSE)) {
 						if (throwException) {
 							setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGVERIFYERROR, NULL);
 						}
@@ -1060,7 +1060,7 @@ illegalAccess:
 				}
 				if (cl1 != cl2) {
 					J9UTF8 *fieldSignature = J9ROMFIELDSHAPE_SIGNATURE(field);
-					if (j9bcv_checkClassLoadingConstraintsForSignature(vmStruct, cl1, cl2, signature, fieldSignature) != 0) {
+					if (0 != j9bcv_checkClassLoadingConstraintsForSignature(vmStruct, cl1, cl2, signature, fieldSignature, FALSE)) {
 						if (throwException) {
 							setCurrentException(vmStruct, J9VMCONSTANTPOOL_JAVALANGVERIFYERROR, NULL);
 						}


### PR DESCRIPTION
For the case mentioned in https://github.com/eclipse-openj9/openj9/issues/20189#issuecomment-2491620527 `sig1` in `j9bcv_checkClassLoadingConstraintsForSignature` should be copied but `sig2` does not need to be copied. I added an additional boolean for each signature and it is only set to false if the signature is found in a class memory segment.

Related to: https://github.com/eclipse-openj9/openj9/issues/20189