### PR TITLE
Add override to virtual methods of TR_J9SharedCache and TR_J9VMBase

### DIFF
--- a/runtime/compiler/env/J9SharedCache.hpp
+++ b/runtime/compiler/env/J9SharedCache.hpp
@@ -101,7 +101,7 @@ public:
    virtual uint16_t getAllEnabledHints(J9Method *method);
    virtual void addHint(J9Method *, TR_SharedCacheHint);
    virtual void addHint(TR_ResolvedMethod *, TR_SharedCacheHint);
-   virtual bool isMostlyFull();
+   virtual bool isMostlyFull() override;
 
    static void validateAOTHeader(J9JITConfig *jitConfig, J9VMThread *vmThread, TR::CompilationInfo *compInfo);
 
@@ -144,7 +144,7 @@ public:
     * \param[in] offset The offset to convert.
     * \return A pointer. Raises a fatal assertion before returning NULL if the offset is invalid.
     */
-   virtual void *pointerFromOffsetInSharedCache(uintptr_t offset);
+   virtual void *pointerFromOffsetInSharedCache(uintptr_t offset) override;
 
    /**
     * \brief Converts a pointer into the metadata section of the SCC into an offset, calculated
@@ -153,7 +153,7 @@ public:
     * \param[in] ptr The pointer to convert.
     * \return An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
     */
-   virtual uintptr_t offsetInSharedCacheFromPointer(void *ptr);
+   virtual uintptr_t offsetInSharedCacheFromPointer(void *ptr) override;
 
    /**
     * \brief Converts an offset into the ROMClass section into a J9ROMClass *.
@@ -161,7 +161,7 @@ public:
     * \param[in] offset The offset to convert.
     * \return A J9ROMClass *. Raises a fatal assertion before returning NULL if the offset is invalid.
     */
-   virtual J9ROMClass *romClassFromOffsetInSharedCache(uintptr_t offset);
+   virtual J9ROMClass *romClassFromOffsetInSharedCache(uintptr_t offset) override;
 
    /**
     * \brief Converts a J9ROMClass * pointer into the SCC into an offset.
@@ -169,7 +169,7 @@ public:
     * \param[in] romClass The J9ROMClass * to convert
     * \return An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
     */
-   virtual uintptr_t offsetInSharedCacheFromROMClass(J9ROMClass *romClass);
+   virtual uintptr_t offsetInSharedCacheFromROMClass(J9ROMClass *romClass) override;
 
    /**
     * \brief Converts an offset into the ROMClass section into a J9ROMMethod *.
@@ -177,7 +177,7 @@ public:
     * \param[in] offset The offset to convert
     * \return A J9ROMMethod *. Raises a fatal assertion before returning NULL if the offset is invalid.
     */
-   virtual J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset);
+   virtual J9ROMMethod *romMethodFromOffsetInSharedCache(uintptr_t offset) override;
 
    /**
     * \brief Converts a J9ROMMethod * pointer into the SCC into an offset.
@@ -185,7 +185,7 @@ public:
     * \param[in] romMethod The J9ROMMethod * to convert
     * \return An offset. Raises a fatal assertion before returning INVALID_ROM_METHOD_OFFSET if the pointer is invalid.
     */
-   virtual uintptr_t offsetInSharedCacheFromROMMethod(J9ROMMethod *romMethod);
+   virtual uintptr_t offsetInSharedCacheFromROMMethod(J9ROMMethod *romMethod) override;
 
    /**
     * \brief Converts an offset into the ROMClass section into a pointer.
@@ -193,7 +193,7 @@ public:
     * \param[in] offset The offset to convert
     * \return A pointer. Raises a fatal assertion before returning NULL if the offset is invalid.
     */
-   virtual void *ptrToROMClassesSectionFromOffsetInSharedCache(uintptr_t offset);
+   virtual void *ptrToROMClassesSectionFromOffsetInSharedCache(uintptr_t offset) override;
 
    /**
     * \brief Converts a pointer into the ROM Classes section of the SCC into an offset.
@@ -201,21 +201,21 @@ public:
     * \param[in] ptr The pointer to convert
     * \return  An offset. Raises a fatal assertion before returning 0 if the pointer is invalid.
     */
-   virtual uintptr_t offsetInSharedCacheFromPtrToROMClassesSection(void *ptr);
+   virtual uintptr_t offsetInSharedCacheFromPtrToROMClassesSection(void *ptr) override;
 
 
-   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *comp);
-   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *comp);
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR::Compilation *comp) override;
+   virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *, TR_ResolvedMethod*, TR::Compilation *comp) override;
 
    static const uint32_t maxClassChainLength = 32;
 
-   virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr)
+   virtual bool canRememberClass(TR_OpaqueClassBlock *classPtr) override
       {
       return rememberClass((J9Class *)classPtr, NULL, false) != TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET;
       }
 
    virtual uintptr_t rememberClass(TR_OpaqueClassBlock *classPtr,
-                                    const AOTCacheClassChainRecord **classChainRecord = NULL)
+                                   const AOTCacheClassChainRecord **classChainRecord = NULL) override
       {
       return rememberClass((J9Class *)classPtr, classChainRecord, true);
       }
@@ -227,7 +227,7 @@ public:
    virtual const char *getDebugCounterName(UDATA offset);
 
    virtual bool classMatchesCachedVersion(J9Class *clazz, UDATA *chainData=NULL);
-   virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *classPtr, UDATA *chainData=NULL)
+   virtual bool classMatchesCachedVersion(TR_OpaqueClassBlock *classPtr, UDATA *chainData=NULL) override
       {
       return classMatchesCachedVersion((J9Class *) classPtr, chainData);
       }
@@ -239,9 +239,9 @@ public:
     * \param[in] chainData The pointer to convert, which should have come from pointerFromOffsetInSharedCache().
     * \return A pointer. Raises a fatal assertion before returning NULL if the pointer is invalid.
     */
-   virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData);
+   virtual void *lookupClassLoaderAssociatedWithClassChain(void *chainData) override;
    virtual TR_OpaqueClassBlock *lookupClassFromChainAndLoader(uintptr_t *chainData, void *classLoader,
-                                                              TR::Compilation *comp);
+                                                              TR::Compilation *comp) override;
 
    /**
     * \brief Checks whether the specified pointer points into the metadata section
@@ -255,7 +255,7 @@ public:
     *             the SCC.
     * \return True if the pointer points into the shared cache, false otherwise.
     */
-   virtual bool isPointerInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL);
+   virtual bool isPointerInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL) override;
 
    /**
     * \brief Checks whether the specified offset, calculated from the end of the SCC,
@@ -267,7 +267,7 @@ public:
     *             here. If offset is not within the shared cache this parameter is ignored.
     * \return True if the offset is within the shared cache, false otherwise.
     */
-   virtual bool isOffsetInSharedCache(uintptr_t encoded_offset, void *ptr = NULL);
+   virtual bool isOffsetInSharedCache(uintptr_t encoded_offset, void *ptr = NULL) override;
 
    /**
     * \brief Checks whether the J9ROMClass underlying the given class exists in the SCC
@@ -279,7 +279,7 @@ public:
     *             parameter is ignored.
     * \return True if romClass points into the SCC, false otherwise.
     */
-   virtual bool isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset = NULL);
+   virtual bool isClassInSharedCache(TR_OpaqueClassBlock *clazz, uintptr_t *cacheOffset = NULL) override;
    virtual bool isClassInSharedCache(J9Class *clazz, uintptr_t *cacheOffset = NULL)
       { return isClassInSharedCache(reinterpret_cast<TR_OpaqueClassBlock *>(clazz), cacheOffset); }
 
@@ -293,7 +293,7 @@ public:
     *             parameter is ignored.
     * \return True if romClass points into the SCC, false otherwise.
     */
-   virtual bool isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset = NULL);
+   virtual bool isROMClassInSharedCache(J9ROMClass *romClass, uintptr_t *cacheOffset = NULL) override;
 
    /**
     * \brief Checks whether the specified offset is within the ROMClass section
@@ -305,7 +305,7 @@ public:
     *             here. If offset is not within the shared cache this parameter is ignored.
     * \return True if the offset is within the shared cache, false otherwise.
     */
-   virtual bool isROMClassOffsetInSharedCache(uintptr_t offset, J9ROMClass **romClassPtr = NULL);
+   virtual bool isROMClassOffsetInSharedCache(uintptr_t offset, J9ROMClass **romClassPtr = NULL) override;
 
    /**
     * \brief Checks whether the persisent representation of a J9Method exists in the SCC
@@ -317,7 +317,7 @@ public:
     *             be returned here. If it is not in the SCC, this parameter is ignored.
     * \return True if the J9Method's romMethod exists in the SCC, false otherwise.
     */
-   virtual bool isMethodInSharedCache(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass, uintptr_t *cacheOffset = NULL);
+   virtual bool isMethodInSharedCache(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *definingClass, uintptr_t *cacheOffset = NULL) override;
 
    /**
     * \brief Checks whether the specified J9ROMMethod exists in the SCC
@@ -329,7 +329,7 @@ public:
     *             parameter is ignored.
     * \return True if romMethod points into the SCC, false otherwise.
     */
-   virtual bool isROMMethodInSharedCache(J9ROMMethod *romMethod, uintptr_t *cacheOffset = NULL);
+   virtual bool isROMMethodInSharedCache(J9ROMMethod *romMethod, uintptr_t *cacheOffset = NULL) override;
 
    /**
     * \brief Checks whether the specified offset is within the ROMClass section
@@ -340,7 +340,7 @@ public:
     *             here. If offset is not within the shared cache this parameter is ignored.
     * \return True if the offset is within the shared cache, false otherwise.
     */
-   virtual bool isROMMethodOffsetInSharedCache(uintptr_t offset, J9ROMMethod **romMethodPtr = NULL);
+   virtual bool isROMMethodOffsetInSharedCache(uintptr_t offset, J9ROMMethod **romMethodPtr = NULL) override;
 
    /**
     * \brief Checks whether the specified pointer points into the ROMClass section
@@ -353,7 +353,7 @@ public:
     *             parameter is ignored.
     * \return True if the pointer points into the shared cache, false otherwise.
     */
-   virtual bool isPtrToROMClassesSectionInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL);
+   virtual bool isPtrToROMClassesSectionInSharedCache(void *ptr, uintptr_t *cacheOffset = NULL) override;
 
    /**
     * \brief Checks whether the specified offset is within the ROMClass section
@@ -365,12 +365,12 @@ public:
     *             here. If offset is not within the shared cache this parameter is ignored.
     * \return True if the offset is within the shared cache, false otherwise.
     */
-   virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL);
+   virtual bool isOffsetOfPtrToROMClassesSectionInSharedCache(uintptr_t offset, void **ptr = NULL) override;
 
    J9ROMClass *startingROMClassOfClassChain(UDATA *classChain);
    uintptr_t startingROMClassOffsetOfClassChain(void *chain);
 
-   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL);
+   virtual uintptr_t getClassChainOffsetIdentifyingLoader(TR_OpaqueClassBlock *clazz, uintptr_t **classChain = NULL) override;
 
 #if defined(J9VM_OPT_JITSERVER)
    /**

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -296,7 +296,7 @@ public:
 
    virtual bool callTargetsNeedRelocations() { return false; }
 
-   virtual TR::DataType dataTypeForLoadOrStore(TR::DataType dt) { return (dt == TR::Int8 || dt == TR::Int16) ? TR::Int32 : dt; }
+   virtual TR::DataType dataTypeForLoadOrStore(TR::DataType dt) override { return (dt == TR::Int8 || dt == TR::Int16) ? TR::Int32 : dt; }
 
    static bool createGlobalFrontEnd(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo);
    static TR_J9VMBase * get(J9JITConfig *, J9VMThread *, VM_TYPE vmType=DEFAULT_VM);
@@ -335,11 +335,11 @@ public:
 
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) = 0;
 
-   virtual bool supportsEmbeddedHeapBounds()  { return true; }
+   virtual bool supportsEmbeddedHeapBounds()       { return true; }
    virtual bool supportsFastNanoTime();
-   virtual bool supportsGuardMerging()        { return true; }
-   virtual bool canDevirtualizeDispatch()     { return true; }
-   virtual bool doStringPeepholing()          { return true; }
+   virtual bool supportsGuardMerging()             { return true; }
+   virtual bool canDevirtualizeDispatch() override { return true; }
+   virtual bool doStringPeepholing()               { return true; }
    virtual bool isPortableSCCEnabled();
 
    /**
@@ -469,26 +469,26 @@ public:
    virtual TR::KnownObjectTable::Index getLayoutVarHandle(TR::Compilation *comp, TR::KnownObjectTable::Index layoutIndex);
 
    virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t);
-   virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
+   virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0) override;
    virtual TR_ResolvedMethod * createResolvedMethodWithVTableSlot(TR_Memory *, uint32_t vTableSlot, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod = 0, TR_OpaqueClassBlock * classForNewInstance = 0);
    virtual TR_ResolvedMethod * createResolvedMethodWithSignature(TR_Memory *, TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *, char *signature, int32_t signatureLength, TR_ResolvedMethod *, uint32_t = 0);
    virtual void * getStaticFieldAddress(TR_OpaqueClassBlock *, unsigned char *, uint32_t, unsigned char *, uint32_t);
    virtual int32_t getInterpreterVTableSlot(TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *);
    virtual int32_t getVTableSlot(TR_OpaqueMethodBlock *, TR_OpaqueClassBlock *);
-   virtual uint32_t           offsetOfIsOverriddenBit();
+   virtual uint32_t           offsetOfIsOverriddenBit() override;
    virtual uint32_t           offsetOfMethodIsBreakpointedBit();
 
-   virtual TR_Debug *     createDebug( TR::Compilation * comp = NULL);
+   virtual TR_Debug *     createDebug( TR::Compilation * comp = NULL) override;
 
    virtual void               acquireCompilationLock();
    virtual void               releaseCompilationLock();
 
-   virtual void               acquireLogMonitor();
-   virtual void               releaseLogMonitor();
+   virtual void               acquireLogMonitor() override;
+   virtual void               releaseLogMonitor() override;
 
    virtual bool               isAsyncCompilation();
    virtual uintptr_t         getProcessID();
-   virtual char *             getFormattedName(char *, int32_t, char *, char *, bool);
+   virtual char *             getFormattedName(char *, int32_t, char *, char *, bool) override;
 
    virtual void               invalidateCompilationRequestsForUnloadedMethods(TR_OpaqueClassBlock *, bool);
 
@@ -502,7 +502,7 @@ public:
    virtual bool               hasFixedFrameC_CallingConvention();
    virtual bool               pushesOutgoingArgsAtCallSite( TR::Compilation *comp);
 
-   virtual TR::PersistentInfo * getPersistentInfo()  { return ((TR_PersistentMemory *)_jitConfig->scratchSegment)->getPersistentInfo(); }
+   virtual TR::PersistentInfo *getPersistentInfo() override { return ((TR_PersistentMemory *)_jitConfig->scratchSegment)->getPersistentInfo(); }
    void                       unknownByteCode( TR::Compilation *, uint8_t opcode);
    void                       unsupportedByteCode( TR::Compilation *, uint8_t opcode);
 
@@ -513,7 +513,7 @@ public:
 
    virtual bool               vmRequiresSelector(uint32_t mask);
 
-   virtual int32_t            getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *method, int32_t bcIndex);
+   virtual int32_t            getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *method, int32_t bcIndex) override;
    virtual bool               isJavaOffloadEnabled();
    virtual uint32_t           getMethodSize(TR_OpaqueMethodBlock *method);
    virtual void *             getMethods(TR_OpaqueClassBlock *classPointer);
@@ -525,7 +525,7 @@ public:
    virtual uint8_t *          allocateCodeMemory( TR::Compilation *, uint32_t warmCodeSize, uint32_t coldCodeSize, uint8_t **coldCode, bool isMethodHeaderNeeded=true);
 
    virtual void               releaseCodeMemory(void *startPC, uint8_t bytesToSaveAtStart);
-   virtual uint8_t *          allocateRelocationData( TR::Compilation *, uint32_t numBytes);
+   virtual uint8_t *          allocateRelocationData( TR::Compilation *, uint32_t numBytes) override;
 
    virtual bool               supportsCodeCacheSnippets();
 #if defined(TR_TARGET_X86)
@@ -570,17 +570,17 @@ public:
    uintptr_t                 getDLTBufferOffsetInBlock();
    virtual int32_t *          getCurrentLocalsMapForDLT( TR::Compilation *);
    virtual bool               compiledAsDLTBefore(TR_ResolvedMethod *);
-   virtual uintptr_t         getObjectHeaderSizeInBytes();
+   virtual uintptr_t         getObjectHeaderSizeInBytes() override;
    uintptr_t                 getOffsetOfSuperclassesInClassObject();
    uintptr_t                 getOffsetOfBackfillOffsetField();
 
    static TR_OpaqueClassBlock *staticGetBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t &numDims);
    virtual TR_OpaqueClassBlock *getBaseComponentClass(TR_OpaqueClassBlock *clazz, int32_t &numDims) { return NULL; }
 
-   bool vftFieldRequiresMask(){ return ~TR::Compiler->om.maskOfObjectVftField() != 0; }
+   bool vftFieldRequiresMask() { return ~TR::Compiler->om.maskOfObjectVftField() != 0; }
 
-   virtual uintptr_t         getOffsetOfDiscontiguousArraySizeField();
-   virtual uintptr_t         getOffsetOfContiguousArraySizeField();
+   virtual uintptr_t         getOffsetOfDiscontiguousArraySizeField() override;
+   virtual uintptr_t         getOffsetOfContiguousArraySizeField() override;
    virtual uintptr_t         getJ9ObjectContiguousLength();
    virtual uintptr_t         getJ9ObjectDiscontiguousLength();
    virtual uintptr_t         getOffsetOfArrayClassRomPtrField();
@@ -618,7 +618,7 @@ public:
    virtual bool               generateCompressedPointers();
    virtual bool               generateCompressedLockWord();
 
-   virtual void                 printVerboseLogHeader(TR::Options *);
+   virtual void                 printVerboseLogHeader(TR::Options *) override;
    virtual void                 printPID();
 
    virtual void                 emitNewPseudoRandomNumberVerbosePrefix();
@@ -693,7 +693,7 @@ public:
    virtual uintptr_t         getOffsetOfClassDepthAndFlags();
    virtual uintptr_t         getOffsetOfClassFlags();
    virtual uintptr_t         getOffsetOfArrayComponentTypeField();
-   virtual uintptr_t         getOffsetOfIndexableSizeField();
+   virtual uintptr_t         getOffsetOfIndexableSizeField() override;
    virtual uintptr_t         constReleaseVMAccessOutOfLineMask();
    virtual uintptr_t         constReleaseVMAccessMask();
    virtual uintptr_t         constAcquireVMAccessOutOfLineMask();
@@ -753,8 +753,8 @@ public:
    virtual uintptr_t         thisThreadGetGSOperandAddressOffset();
    virtual uintptr_t         thisThreadGetGSHandlerAddressOffset();
 
-   virtual int32_t            getArraySpineShift(int32_t);
-   virtual int32_t            getArrayletMask(int32_t);
+   virtual int32_t            getArraySpineShift(int32_t) override;
+   virtual int32_t            getArrayletMask(int32_t) override;
    virtual int32_t            getArrayletLeafIndex(int64_t, int32_t);
    virtual int32_t            getLeafElementIndex(int64_t , int32_t);
    virtual bool               CEEHDLREnabled();
@@ -787,7 +787,7 @@ public:
    virtual bool               scanReferenceSlotsInClassForOffset( TR::Compilation * comp, TR_OpaqueClassBlock * classPointer, int32_t offset);
    virtual int32_t            findFirstHotFieldTenuredClassOffset( TR::Compilation *comp, TR_OpaqueClassBlock *opclazz);
 
-   virtual bool               isInlineableNativeMethod( TR::Compilation *, TR::ResolvedMethodSymbol * methodSymbol);
+   virtual bool               isInlineableNativeMethod(TR::Compilation *, TR::ResolvedMethodSymbol * methodSymbol) override;
    //receiverClass is for specifying a more specific receiver type. otherwise it is determined from the call.
    virtual bool               maybeHighlyPolymorphic(TR::Compilation *, TR_ResolvedMethod *caller, int32_t cpIndex, TR::Method *callee, TR_OpaqueClassBlock *receiverClass = NULL);
    virtual bool isQueuedForVeryHotOrScorching(TR_ResolvedMethod *calleeMethod, TR::Compilation *comp);
@@ -1124,8 +1124,8 @@ public:
    virtual bool      isJavaLangObject(TR_OpaqueClassBlock *clazz);
    virtual int32_t   getStringLength(uintptr_t objectPointer);
    virtual uint16_t  getStringCharacter(uintptr_t objectPointer, int32_t index);
-   virtual intptr_t getStringUTF8Length(uintptr_t objectPointer);
-   virtual char     *getStringUTF8      (uintptr_t objectPointer, char *buffer, intptr_t bufferSize);
+   virtual intptr_t getStringUTF8Length(uintptr_t objectPointer) override;
+   virtual char     *getStringUTF8      (uintptr_t objectPointer, char *buffer, intptr_t bufferSize) override;
 
    virtual uint32_t getVarHandleHandleTableOffset(TR::Compilation *);
 
@@ -1172,7 +1172,7 @@ public:
    virtual void setHasFailedCodeCacheAllocation(); // MCT
    void *getCCPreLoadedCodeAddress(TR::CodeCache *codeCache, TR_CCPreLoadedCode h, TR::CodeGenerator *cg);
 
-   virtual void reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding);
+   virtual void reserveTrampolineIfNecessary( TR::Compilation *, TR::SymbolReference *symRef, bool inBinaryEncoding) override;
    virtual TR::CodeCache* getResolvedTrampoline( TR::Compilation *, TR::CodeCache* curCache, J9Method * method, bool inBinaryEncoding) = 0;
 
    // Interpreter profiling support
@@ -1229,7 +1229,7 @@ public:
    virtual intptr_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset);
 
    TR::TreeTop * lowerAsyncCheck(TR::Compilation *, TR::Node * root,  TR::TreeTop * treeTop);
-   virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
+   virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
    virtual bool isMethodTracingEnabled(J9Method *j9method)
       {
       return isMethodTracingEnabled((TR_OpaqueMethodBlock *)j9method);
@@ -1441,8 +1441,8 @@ public:
 
    virtual bool classInitIsFinished(TR_OpaqueClassBlock *clazz) { return (((J9Class*)clazz)->initializeStatus & J9ClassInitStatusMask) == J9ClassInitSucceeded; }
 
-   virtual TR_OpaqueClassBlock * getClassFromNewArrayType(int32_t arrayType);
-   virtual TR_OpaqueClassBlock * getClassFromNewArrayTypeNonNull(int32_t arrayType);
+   virtual TR_OpaqueClassBlock *getClassFromNewArrayType(int32_t arrayType) override;
+   virtual TR_OpaqueClassBlock *getClassFromNewArrayTypeNonNull(int32_t arrayType);
 
    virtual TR_OpaqueClassBlock *getClassFromCP(J9ConstantPool *cp);
    virtual J9ROMMethod *getROMMethodFromRAMMethod(J9Method *ramMethod);


### PR DESCRIPTION
These overrides are helpful when changing the interfaces of classes, so that warnings (at least in clang) are generated if the methods of the base classes aren't changed to compensate.