### PR TITLE
Add verbose logging to dependency table

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -31,6 +31,7 @@
 #include "il/Node_inlines.hpp"
 #include "il/SymbolReference.hpp"
 #include "il/StaticSymbol.hpp"
+#include "env/VerboseLog.hpp"
 #include "env/VMJ9.h"
 #include "codegen/AheadOfTimeCompile.hpp"
 #include "runtime/RelocationRuntime.hpp"
@@ -2633,6 +2634,8 @@ void J9::AheadOfTimeCompile::processRelocations()
             // flag must still be set to distinguish methods with zero
             // dependencies from methods with untracked dependencies.
             comp->getAotMethodHeaderEntry()->flags |= TR_AOTMethodHeader_TracksDependencies;
+            if (comp->getOptions()->getVerboseOption(TR_VerboseDependencyTracking))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "Method %p compiled with 0 tracked dependencies", method);
             }
          else
             {
@@ -2640,7 +2643,13 @@ void J9::AheadOfTimeCompile::processRelocations()
             auto vmThread = fej9->getCurrentVMThread();
             auto dependencyChain = sharedCache->storeAOTMethodDependencies(vmThread, method, definingClass, dependencies.data(), dependencies.size());
             if (dependencyChain)
+               {
                comp->getAotMethodHeaderEntry()->flags |= TR_AOTMethodHeader_TracksDependencies;
+               if (comp->getOptions()->getVerboseOption(TR_VerboseDependencyTracking))
+                  {
+                  TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "Method %p compiled with %lu tracked dependencies", method, totalDependencies);
+                  }
+               }
             }
          }
 #endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3579,6 +3579,12 @@ void TR::CompilationInfo::stopCompilationThreads()
          deserializer->printStats(stderr);
       }
 #endif /* defined(J9VM_OPT_JITSERVER) */
+   static char *printDependencyTableStats = feGetEnv("TR_PrintDependencyTableStats");
+   if (printDependencyTableStats)
+      {
+      if (auto dependencyTable = getPersistentInfo()->getAOTDependencyTable())
+         dependencyTable->printStats();
+      }
 
 #ifdef STATS
    if (compBudgetSupport() || dynamicThreadPriority())

--- a/runtime/compiler/env/DependencyTable.hpp
+++ b/runtime/compiler/env/DependencyTable.hpp
@@ -41,6 +41,7 @@ public:
    void invalidateRedefinedClass(TR_PersistentCHTable *table, TR_J9VMBase *fej9, TR_OpaqueClassBlock *oldClass, TR_OpaqueClassBlock *freshClass) {}
    TR_OpaqueClassBlock *findClassCandidate(uintptr_t offset) { return NULL; }
    void methodWillBeCompiled(J9Method *method) {}
+   void printStats() {}
    };
 
 #else
@@ -135,6 +136,7 @@ public:
       return needsInitialization ? offset : (offset & ~1);
       }
 
+   void printStats();
 private:
    bool isActive() const { return _isActive; }
    void setInactive() { _isActive = false; }
@@ -170,8 +172,8 @@ private:
 
    // Stop tracking the given method. This will invalidate the MethodEntryRef
    // for the method.
-   void stopTracking(MethodEntryRef entry);
-   void stopTracking(J9Method *method);
+   void stopTracking(MethodEntryRef entry, bool isEarlyStop);
+   void stopTracking(J9Method *method, bool isEarlyStop);
 
    // Queue and clear the _pendingLoads, and remove those methods from tracking.
    // Must be called at the end of any dependency table operation that could


### PR DESCRIPTION
The verbose options dependencyTracking and dependencyTrackingDetails turn on various verbose log messages related to class and method tracking in the dependency table, and method dependency gathering at compile time.

Depends on https://github.com/eclipse-omr/omr/pull/7571