### PR TITLE
Z accelerate on spin wait inlining

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4043,6 +4043,14 @@ J9::Z::CodeGenerator::inlineDirectCall(
             return resultReg != NULL;
             }
          break;
+      case TR::java_lang_Thread_onSpinWait:
+         static char *disableOSW = feGetEnv("TR_noPauseOnSpinWait");
+         if (!disableOSW)
+            {
+            resultReg = TR::TreeEvaluator::inlineOnSpinWait(node, cg);
+            return true;
+            }
+         break;
 
       default:
          break;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -14667,19 +14667,16 @@ J9::Z::TreeEvaluator::inlineIntegerStringSize(TR::Node* node, TR::CodeGenerator*
    }
 
 TR::Register*
-J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg) {
-   // Thread.onSpinWait() on z is a simple "nop" instruction.
-   //cg->generateNop(node);
-   TR::LabelSymbol *FOO = generateLabelSymbol(cg);
+J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg)
+   {
    TR::Instruction* cursor = new (cg->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cg);
-   cursor = generateS390LabelInstruction(cg, TR::InstOpCode::label, node, FOO);
-   if (cg->getDebug())
-      cg->getDebug()->addInstructionComment(cursor, "To replace onSpinWait");
+
    TR::Compilation *comp = cg->comp();
    static const bool printIt = feGetEnv("TR_showPauseOnSpinWait") != NULL;
    if (printIt && comp->getOption(TR_TraceCG))
       {
-      traceMsg(comp, "insert PAUSE for onSpinWait : node=%p, %s\n", node, comp->signature());
+      traceMsg(comp, "Insert NOP for onSpinWait : node=%p, %s\n", node, comp->signature());
       }
+
    return NULL;
-}
+   }

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -14669,7 +14669,9 @@ J9::Z::TreeEvaluator::inlineIntegerStringSize(TR::Node* node, TR::CodeGenerator*
 TR::Register*
 J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg) {
    // Thread.onSpinWait() on z is a simple "nop" instruction.
-   cg->generateNop(node);
+   //cg->generateNop(node);
+   TR::Instruction* cursor = new (cg->trHeapMemory()) TR::(TR::InstOpCode::NOP, 2, node, cg);
+   cg->getDebug()->addInstructionComment(cursor, "To replace onSpinWait");
    TR::Compilation *comp = cg->comp();
    static const bool printIt = feGetEnv("TR_showPauseOnSpinWait") != NULL;
    if (printIt && comp->getOption(TR_TraceCG))

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -14665,3 +14665,15 @@ J9::Z::TreeEvaluator::inlineIntegerStringSize(TR::Node* node, TR::CodeGenerator*
 
    return node->setRegister(lengthReg);
    }
+
+TR::Register*
+J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg) {
+   // Thread.onSpinWait() on z is a simple "nop" instruction.
+   cg->generateNop(node);
+   static const bool printIt = feGetEnv("TR_showPauseOnSpinWait") != NULL;
+   if (printIt && comp->getOption(TR_TraceCG))
+      {
+      traceMsg(comp, "insert PAUSE for onSpinWait : node=%p, %s\n", node, comp->signature());
+      }
+   return NULL;
+}

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -14670,7 +14670,7 @@ TR::Register*
 J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg) {
    // Thread.onSpinWait() on z is a simple "nop" instruction.
    //cg->generateNop(node);
-   TR::Instruction* cursor = new (cg->trHeapMemory()) TR::(TR::InstOpCode::NOP, 2, node, cg);
+   TR::Instruction* cursor = new (cg->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cg);
    cg->getDebug()->addInstructionComment(cursor, "To replace onSpinWait");
    TR::Compilation *comp = cg->comp();
    static const bool printIt = feGetEnv("TR_showPauseOnSpinWait") != NULL;

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -14670,7 +14670,9 @@ TR::Register*
 J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg) {
    // Thread.onSpinWait() on z is a simple "nop" instruction.
    //cg->generateNop(node);
+   TR::LabelSymbol *FOO = generateLabelSymbol(cg);
    TR::Instruction* cursor = new (cg->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cg);
+   cursor = generateS390LabelInstruction(cg, TR::InstOpCode::label, node, FOO);
    if (cg->getDebug())
       cg->getDebug()->addInstructionComment(cursor, "To replace onSpinWait");
    TR::Compilation *comp = cg->comp();

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -14670,6 +14670,7 @@ TR::Register*
 J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg) {
    // Thread.onSpinWait() on z is a simple "nop" instruction.
    cg->generateNop(node);
+   TR::Compilation *comp = cg->comp();
    static const bool printIt = feGetEnv("TR_showPauseOnSpinWait") != NULL;
    if (printIt && comp->getOption(TR_TraceCG))
       {

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -14671,7 +14671,8 @@ J9::Z::TreeEvaluator::inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg) {
    // Thread.onSpinWait() on z is a simple "nop" instruction.
    //cg->generateNop(node);
    TR::Instruction* cursor = new (cg->trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, node, cg);
-   cg->getDebug()->addInstructionComment(cursor, "To replace onSpinWait");
+   if (cg->getDebug())
+      cg->getDebug()->addInstructionComment(cursor, "To replace onSpinWait");
    TR::Compilation *comp = cg->comp();
    static const bool printIt = feGetEnv("TR_showPauseOnSpinWait") != NULL;
    if (printIt && comp->getOption(TR_TraceCG))

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -141,6 +141,20 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register* inlineUTF16BEEncode    (TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineCRC32CUpdateBytes(TR::Node *node, TR::CodeGenerator *cg, bool isDirectBuffer);
 
+      /**
+    * \brief
+    *
+    * Accelerate inlining onSpinWait() method.
+    *
+    * \details
+    *
+    * \param node the method call node.
+    * \param cg the code generator.
+    *
+    * \return NULL.
+    */
+   static TR::Register *inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg);
+
    static TR::Register *zdloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *zdloadiEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *zdstoreEvaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.hpp
@@ -141,18 +141,15 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register* inlineUTF16BEEncode    (TR::Node *node, TR::CodeGenerator *cg);
    static TR::Register *inlineCRC32CUpdateBytes(TR::Node *node, TR::CodeGenerator *cg, bool isDirectBuffer);
 
-      /**
-    * \brief
-    *
-    * Accelerate inlining onSpinWait() method.
-    *
-    * \details
-    *
-    * \param node the method call node.
-    * \param cg the code generator.
-    *
-    * \return NULL.
-    */
+   /**
+   * \brief
+   * Accelerate inlining onSpinWait() method.
+   *
+   * \param node the method call node.
+   * \param cg the code generator.
+   *
+   * \return NULL
+   */
    static TR::Register *inlineOnSpinWait(TR::Node *node, TR::CodeGenerator *cg);
 
    static TR::Register *zdloadEvaluator(TR::Node *node, TR::CodeGenerator *cg);


### PR DESCRIPTION
Accelerate inlining Thread.onSpinWait() on z.
Thread.onSpinWait() is a simple nop instruction on z. Enabled by default. Disable by setting the TR_noPauseOnSpinWait environment variable.