### PR TITLE
Remove some permission checks for jdk24+

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -563,6 +563,9 @@ private static Class<?> forNameHelper(
 	String className, boolean initializeBoolean, ClassLoader classLoader,
 	Class<?> caller, boolean isAdapter) throws ClassNotFoundException
 {
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	return forNameImpl(className, initializeBoolean, classLoader);
+/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	@SuppressWarnings("removal")
 	SecurityManager sm = null;
 	if (J9VMInternals.initialized) {
@@ -590,6 +593,7 @@ private static Class<?> forNameHelper(
 		J9VMInternals.initialize(c);
 	}
 	return c;
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
@@ -678,14 +682,15 @@ private static Class<?> forName(Module module, String name, Class<?> caller)
 @CallerSensitive
 private static Class<?> forNameHelper(Module module, String name, Class<?> caller, boolean isAdapter)
 {
-	@SuppressWarnings("removal")
-	SecurityManager sm = null;
-	ClassLoader classLoader;
-	Class<?> c;
-
 	if ((null == module) || (null == name)) {
 		throw new NullPointerException();
 	}
+	ClassLoader classLoader;
+	Class<?> c;
+/*[IF JAVA_SPEC_VERSION < 24]*/
+	@SuppressWarnings("removal")
+	SecurityManager sm = null;
+
 	if (J9VMInternals.initialized) {
 		sm = System.getSecurityManager();
 	}
@@ -702,7 +707,9 @@ private static Class<?> forNameHelper(Module module, String name, Class<?> calle
 				return module.getClassLoader();
 			}
 		});
-	} else {
+	} else
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+	{
 		classLoader = module.getClassLoader();
 	}
 
@@ -799,9 +806,10 @@ public Class<?>[] getClasses() {
 @CallerSensitive
 public ClassLoader getClassLoader() {
 	if (null != classLoader) {
-		if (classLoader == ClassLoader.bootstrapClassLoader)	{
+		if (classLoader == ClassLoader.bootstrapClassLoader) {
 			return null;
 		}
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (null != security) {
@@ -810,6 +818,7 @@ public ClassLoader getClassLoader() {
 				security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
 		}
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	}
 	return classLoader;
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
@@ -321,13 +321,13 @@ final class MethodTypeHelper {
 	static MethodType fromMethodDescriptorStringInternal(String methodDescriptor, ClassLoader loader) {
 		ClassLoader classLoader = loader;
 		if (classLoader == null) {
-			/*[IF JAVA_SPEC_VERSION >= 14]*/
+			/*[IF (14 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24)]*/
 			@SuppressWarnings("removal")
 			SecurityManager security = System.getSecurityManager();
 			if (security != null) {
 				security.checkPermission(sun.security.util.SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
-			/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
+			/*[ENDIF] (14 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24) */
 			classLoader = ClassLoader.getSystemClassLoader();
 		}
 


### PR DESCRIPTION
`SecurityConstants.GET_CLASSLOADER_PERMISSION` removed upstream in
* [8344299: SM cleanup in javax.naming modules](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/20bddbc359ac802ce8353891245b6c8d537ad647)

Acceptance build is failing: https://openj9-jenkins.osuosl.org/job/Pipeline-OpenJDK-Acceptance/868.