### PR TITLE
JDK24 removes SecurityConstants.GET_CLASSLOADER_PERMISSION

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -563,6 +563,9 @@ private static Class<?> forNameHelper(
 	String className, boolean initializeBoolean, ClassLoader classLoader,
 	Class<?> caller, boolean isAdapter) throws ClassNotFoundException
 {
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+	return forNameImpl(className, initializeBoolean, classLoader);
+/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	@SuppressWarnings("removal")
 	SecurityManager sm = null;
 	if (J9VMInternals.initialized) {
@@ -590,6 +593,7 @@ private static Class<?> forNameHelper(
 		J9VMInternals.initialize(c);
 	}
 	return c;
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
@@ -678,14 +682,15 @@ private static Class<?> forName(Module module, String name, Class<?> caller)
 @CallerSensitive
 private static Class<?> forNameHelper(Module module, String name, Class<?> caller, boolean isAdapter)
 {
-	@SuppressWarnings("removal")
-	SecurityManager sm = null;
 	ClassLoader classLoader;
 	Class<?> c;
 
 	if ((null == module) || (null == name)) {
 		throw new NullPointerException();
 	}
+/*[IF JAVA_SPEC_VERSION < 24]*/
+	@SuppressWarnings("removal")
+	SecurityManager sm = null;
 	if (J9VMInternals.initialized) {
 		sm = System.getSecurityManager();
 	}
@@ -702,7 +707,9 @@ private static Class<?> forNameHelper(Module module, String name, Class<?> calle
 				return module.getClassLoader();
 			}
 		});
-	} else {
+	} else
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+	{
 		classLoader = module.getClassLoader();
 	}
 
@@ -799,9 +806,10 @@ public Class<?>[] getClasses() {
 @CallerSensitive
 public ClassLoader getClassLoader() {
 	if (null != classLoader) {
-		if (classLoader == ClassLoader.bootstrapClassLoader)	{
+		if (classLoader == ClassLoader.bootstrapClassLoader) {
 			return null;
 		}
+/*[IF JAVA_SPEC_VERSION < 24]*/
 		@SuppressWarnings("removal")
 		SecurityManager security = System.getSecurityManager();
 		if (null != security) {
@@ -810,6 +818,7 @@ public ClassLoader getClassLoader() {
 				security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
 		}
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	}
 	return classLoader;
 }

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -830,12 +830,15 @@ protected final Class<?> findSystemClass (String className) throws ClassNotFound
  *
  * @return 		java.lang.ClassLoader
  *					the class or null.
+/*[IF JAVA_SPEC_VERSION < 24]
  * @exception	SecurityException
  *					if a security manager exists and it does not
  *					allow the parent loader to be retrieved.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  */
 @CallerSensitive
 public final ClassLoader getParent() {
+/*[IF JAVA_SPEC_VERSION < 24]*/
 	if (parent == null) {
 		return null;
 	}
@@ -848,6 +851,7 @@ public final ClassLoader getParent() {
 			security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}
 	}
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return parent;
 }
 
@@ -1062,19 +1066,23 @@ static ClassLoader getClassLoader(Class<?> clz) {
  * allow access a SecurityException will be thrown.
  *
  * @return the platformClassLoader
+/*[IF JAVA_SPEC_VERSION < 24]
  * @throws SecurityException if access to the platform classloader is denied
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  */
 @CallerSensitive
 public static ClassLoader getPlatformClassLoader() {
+	ClassLoader platformClassLoader = ClassLoaders.platformClassLoader();
+/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	ClassLoader platformClassLoader = ClassLoaders.platformClassLoader();
 	if (security != null) {
 		ClassLoader callersClassLoader = callerClassLoader();
 		if (needsClassLoaderPermissionCheck(callersClassLoader, platformClassLoader)) {
 			security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}
 	}
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return platformClassLoader;
 }
 
@@ -1108,9 +1116,11 @@ public String getName() {
  * same <code>ClassLoader</code> as that used to launch an application.
  *
  * @return java.lang.ClassLoader the system classLoader.
+/*[IF JAVA_SPEC_VERSION < 24]
  * @exception SecurityException
  *                if a security manager exists and it does not permit the
  *                caller to access the system class loader.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  */
 @CallerSensitive
 public static ClassLoader getSystemClassLoader () {
@@ -1147,6 +1157,7 @@ public static ClassLoader getSystemClassLoader () {
 	}
 
 	ClassLoader sysLoader = applicationClassLoader;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null) {
@@ -1155,7 +1166,7 @@ public static ClassLoader getSystemClassLoader () {
 			security.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
 		}
 	}
-
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return sysLoader;
 }
 
@@ -2578,7 +2589,7 @@ public final boolean isRegisteredAsParallelCapable() {
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
-/*[IF JAVA_SPEC_VERSION >= 19]*/
+/*[IF (19 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24)]*/
 static void checkClassLoaderPermission(ClassLoader classLoader, Class<?> caller) {
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
@@ -2590,7 +2601,7 @@ static void checkClassLoaderPermission(ClassLoader classLoader, Class<?> caller)
 		}
 	}
 }
-/*[ENDIF] JAVA_SPEC_VERSION >= 19 */
+/*[ENDIF] (19 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24) */
 
 /*[IF JAVA_SPEC_VERSION >= 24]*/
 static NativeLibraries nativeLibrariesFor(ClassLoader loader) {

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodTypeHelper.java
@@ -321,13 +321,13 @@ final class MethodTypeHelper {
 	static MethodType fromMethodDescriptorStringInternal(String methodDescriptor, ClassLoader loader) {
 		ClassLoader classLoader = loader;
 		if (classLoader == null) {
-			/*[IF JAVA_SPEC_VERSION >= 14]*/
+			/*[IF (14 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24)]*/
 			@SuppressWarnings("removal")
 			SecurityManager security = System.getSecurityManager();
 			if (security != null) {
 				security.checkPermission(sun.security.util.SecurityConstants.GET_CLASSLOADER_PERMISSION);
 			}
-			/*[ENDIF] JAVA_SPEC_VERSION >= 14 */
+			/*[ENDIF] (14 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24) */
 			classLoader = ClassLoader.getSystemClassLoader();
 		}
 


### PR DESCRIPTION
`JDK24` removes `SecurityConstants.GET_CLASSLOADER_PERMISSION`

This resolves JDK next abuild compilation failures:
```
00:01:59  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Class.java:465: error: cannot find symbol
00:01:59  				sm.checkPermission(SecurityConstants.GET_CLASSLOADER_PERMISSION);
00:01:59  				                                    ^
00:01:59    symbol:   variable GET_CLASSLOADER_PERMISSION
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>