### PR TITLE
Fix some include warnings in JITServer

### DIFF
--- a/runtime/compiler/env/J9KnownObjectTable.hpp
+++ b/runtime/compiler/env/J9KnownObjectTable.hpp
@@ -37,6 +37,7 @@ namespace J9 { typedef J9::KnownObjectTable KnownObjectTableConnector; }
 #include "infra/Array.hpp"
 #include "infra/BitVector.hpp"
 #if defined(J9VM_OPT_JITSERVER)
+#include <string>
 #include <tuple>
 #include <vector>
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -24,9 +24,10 @@
 #define COMMUNICATION_STREAM_H
 
 #include <unistd.h>
+#include "infra/Statistics.hpp"
 #include "net/LoadSSLLibs.hpp"
 #include "net/Message.hpp"
-#include "infra/Statistics.hpp"
+#include "net/StreamExceptions.hpp"
 #include "env/VerboseLog.hpp"
 #include "control/MethodToBeCompiled.hpp"
 

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.hpp
@@ -23,8 +23,9 @@
 #ifndef JITSERVER_AOT_DESERIALIZER_H
 #define JITSERVER_AOT_DESERIALIZER_H
 
-#include "env/TRMemory.hpp"
 #include "env/PersistentCollections.hpp"
+#include "env/SystemSegmentProvider.hpp"
+#include "env/TRMemory.hpp"
 #include "runtime/JITServerAOTSerializationRecords.hpp"
 
 class TR_PersistentClassLoaderTable;


### PR DESCRIPTION
These headers mention certain types but do not include the relevant headers for them. This does not yet cause a compilation error because all of their use sites are coincidentally only after those headers have been included.