### PR TITLE
(0.49.0) Change J9::VMMethodEnv::startPC error return value

### DIFF
--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -67,7 +67,14 @@ uintptr_t
 J9::VMMethodEnv::startPC(TR_OpaqueMethodBlock *method)
    {
    J9Method *j9method = reinterpret_cast<J9Method *>(method);
-   return reinterpret_cast<uintptr_t>(TR::CompilationInfo::getJ9MethodStartPC(j9method));
+   uintptr_t returnStartPC = reinterpret_cast<uintptr_t>(TR::CompilationInfo::getJ9MethodStartPC(j9method));
+
+   if ((returnStartPC & J9_STARTPC_NOT_TRANSLATED) == J9_STARTPC_NOT_TRANSLATED)
+      {
+      returnStartPC = 0;
+      }
+
+   return returnStartPC;
    }
 
 

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -552,7 +552,8 @@ J9::CodeCache::addFreeBlock(void  *voidMetaData)
                {
                // There could be several bodyInfo pointing to the same methodInfo
                // Prevent deallocating twice by freeing only for the last body
-               if (TR::Compiler->mtd.startPC((TR_OpaqueMethodBlock*)metaData->ramMethod) == (uintptr_t)metaData->startPC)
+               uintptr_t ramMethodStartPC = TR::Compiler->mtd.startPC((TR_OpaqueMethodBlock*)metaData->ramMethod);
+               if ((ramMethodStartPC != 0) && (ramMethodStartPC == (uintptr_t)metaData->startPC))
                   {
                   // Clear profile info
                   pmi->setBestProfileInfo(NULL);


### PR DESCRIPTION
OMR version of startPC expects either a valid start PC or 0 to be returned from J9::VMMethodEnv::startPC since it isn't aware of the J9 specific non-startPC special values that are currently being returned.

This change checks if the J9_STARTPC_NOT_TRANSLATED bit flag is set on the startPC to be returned. This indicates that it isn't a real startPC and will return 0 instead.

Error checking has also been added to addFreeBlock to handle startPC returning 0.

Backport of https://github.com/eclipse-openj9/openj9/pull/20657