### PR TITLE
Make disable CAS and CAE options consistant

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -101,6 +101,18 @@ J9::ARM64::CodeGenerator::initialize()
       }
    if (comp->fej9()->hasFixedFrameC_CallingConvention())
       cg->setHasFixedFrameC_CallingConvention();
+
+   static bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
+   if (!disableCASInlining)
+      {
+      cg->setSupportsInlineUnsafeCompareAndSet();
+      }
+
+   static bool disableCAEInlining = feGetEnv("TR_DisableCAEInlining") != NULL;
+   if (!disableCAEInlining)
+      {
+      cg->setSupportsInlineUnsafeCompareAndExchange();
+      }
    }
 
 TR::Linkage *

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -6883,7 +6883,8 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             break;
          }
 
-      static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;
+      bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
+      bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
       switch (methodSymbol->getRecognizedMethod())
          {
          case TR::java_lang_Thread_onSpinWait:
@@ -6977,8 +6978,11 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
             if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
                {
-               resultReg = VMinlineCompareAndSwap(node, cg, false);
-               return true;
+               if (!disableCASInlining)
+                  {
+                  resultReg = VMinlineCompareAndSwap(node, cg, false);
+                  return true;
+                  }
                }
             break;
             }
@@ -6991,8 +6995,11 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
             if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
                {
-               resultReg = VMinlineCompareAndSwap(node, cg, true);
-               return true;
+               if (!disableCASInlining)
+                  {
+                  resultReg = VMinlineCompareAndSwap(node, cg, true);
+                  return true;
+                  }
                }
             break;
             }
@@ -7004,8 +7011,11 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
             if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
                {
-               resultReg = VMinlineCompareAndSwapObject(node, cg);
-               return true;
+               if (!disableCASInlining)
+                  {
+                  resultReg = VMinlineCompareAndSwapObject(node, cg);
+                  return true;
+                  }
                }
             break;
             }
@@ -7014,7 +7024,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             {
             if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
                {
-               if (!disableCAEIntrinsic)
+               if (!disableCAEInlining)
                   {
                   resultReg = VMinlineCompareAndSwap(node, cg, false, true);
                   return true;
@@ -7027,7 +7037,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             {
             if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
                {
-               if (!disableCAEIntrinsic)
+               if (!disableCAEInlining)
                   {
                   resultReg = VMinlineCompareAndSwap(node, cg, true, true);
                   return true;
@@ -7049,7 +7059,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             {
             if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
                {
-               if (!disableCAEIntrinsic)
+               if (!disableCAEInlining)
                   {
                   resultReg = VMinlineCompareAndSwapObject(node, cg, true);
                   return true;

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -542,6 +542,26 @@ public:
    */
    void setSupportsInlineMath_MaxMin_FD() { _j9Flags.set(SupportsInlineMath_MaxMin_FD); }
 
+   /** \brief
+   *    Determines whether the code generator supports inlining of jdk/internal/misc/Unsafe.CompareAndSet[Object|Reference|Int|Long]
+   */
+   bool getSupportsInlineUnsafeCompareAndSet() { return _j9Flags.testAny(SupportsInlineUnsafeCompareAndSet); }
+
+   /** \brief
+   *    The code generator supports inlining of jdk/internal/misc/Unsafe.CompareAndSet[Object|Reference|Int|Long]
+   */
+   void setSupportsInlineUnsafeCompareAndSet() { _j9Flags.set(SupportsInlineUnsafeCompareAndSet); }
+
+   /** \brief
+   *    Determines whether the code generator supports inlining of jdk/internal/misc/Unsafe.CompareAndExchange[Object|Reference|Int|Long]
+   */
+   bool getSupportsInlineUnsafeCompareAndExchange() { return _j9Flags.testAny(SupportsInlineUnsafeCompareAndExchange); }
+
+   /** \brief
+   *    The code generator supports inlining of jdk/internal/misc/Unsafe.CompareAndExchange[Object|Reference|Int|Long]
+   */
+   void setSupportsInlineUnsafeCompareAndExchange() { _j9Flags.set(SupportsInlineUnsafeCompareAndExchange); }
+
    /**
     * \brief
     *    The number of nodes between a monext and the next monent before
@@ -710,6 +730,8 @@ private:
       SupportsInlineStringCodingHasNegatives              = 0x00004000,
       SupportsInlineStringCodingCountPositives            = 0x00008000,
       SupportsInlineMath_MaxMin_FD                        = 0x00010000,
+      SupportsInlineUnsafeCompareAndSet                   = 0x00020000,
+      SupportsInlineUnsafeCompareAndExchange              = 0x00040000,
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -108,6 +108,18 @@ J9::Power::CodeGenerator::initialize()
       !disableStringInflateIntrinsic)
       cg->setSupportsInlineStringLatin1Inflate();
 
+   static bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
+   if (!disableCASInlining)
+      {
+      cg->setSupportsInlineUnsafeCompareAndSet();
+      }
+
+   static bool disableCAEInlining = feGetEnv("TR_DisableCAEInlining") != NULL;
+   if (!disableCAEInlining)
+      {
+      cg->setSupportsInlineUnsafeCompareAndExchange();
+      }
+
    if (!comp->getOption(TR_DisableReadMonitors))
       cg->setSupportsReadOnlyLocks();
 

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11900,7 +11900,8 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
       }
    else if (methodSymbol)
       {
-      static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;
+      bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
+      bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
       switch (methodSymbol->getRecognizedMethod())
          {
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer:
@@ -12189,8 +12190,11 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
         if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = VMinlineCompareAndSetOrExchange(node, cg, 4, false);
-            return true;
+            if (!disableCASInlining)
+               {
+               resultReg = VMinlineCompareAndSetOrExchange(node, cg, 4, false);
+               return true;
+               }
             }
          break;
 
@@ -12203,13 +12207,19 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
          if (comp->target().is64Bit() && (node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = VMinlineCompareAndSetOrExchange(node, cg, 8, false);
-            return true;
+            if (!disableCASInlining)
+               {
+               resultReg = VMinlineCompareAndSetOrExchange(node, cg, 8, false);
+               return true;
+               }
             }
          else if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = inlineAtomicOperation(node, cg, methodSymbol);
-            return true;
+            if (!disableCASInlining)
+               {
+               resultReg = inlineAtomicOperation(node, cg, methodSymbol);
+               return true;
+               }
             }
          break;
 
@@ -12220,15 +12230,18 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
 
          if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = VMinlineCompareAndSetOrExchangeReference(node, cg, false);
-            return true;
+            if (!disableCASInlining)
+               {
+               resultReg = VMinlineCompareAndSetOrExchangeReference(node, cg, false);
+               return true;
+               }
             }
          break;
 
       case TR::jdk_internal_misc_Unsafe_compareAndExchangeInt:
         if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            if (!disableCAEIntrinsic)
+            if (!disableCAEInlining)
                {
                resultReg = VMinlineCompareAndSetOrExchange(node, cg, 4, true);
                return true;
@@ -12239,7 +12252,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
       case TR::jdk_internal_misc_Unsafe_compareAndExchangeLong:
         if (comp->target().is64Bit() && (node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            if (!disableCAEIntrinsic)
+            if (!disableCAEInlining)
                {
                resultReg = VMinlineCompareAndSetOrExchange(node, cg, 8, true);
                return true;
@@ -12259,7 +12272,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
       case TR::jdk_internal_misc_Unsafe_compareAndExchangeReference:
          if ((node->isUnsafeGetPutCASCallOnNonArray() || !TR::Compiler->om.canGenerateArraylets()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            if (!disableCAEIntrinsic)
+            if (!disableCAEInlining)
                {
                resultReg = VMinlineCompareAndSetOrExchangeReference(node, cg, true);
                return true;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -10067,11 +10067,6 @@ inlineCompareAndSwapNative(
    if (TR::Compiler->om.canGenerateArraylets() && !node->isUnsafeGetPutCASCallOnNonArray())
       return false;
 
-   static char *disableCASInlining = feGetEnv("TR_DisableCASInlining");
-
-   if (disableCASInlining /* || comp->useCompressedPointers() */)
-      return false;
-
    // size = 4 --> CMPXCHG4
    // size = 8 --> if 64-bit -> CMPXCHG8
    //              else if proc supports CMPXCHG8B -> CMPXCHG8B
@@ -10373,7 +10368,8 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
    bool callWasInlined = false;
    TR::Compilation *comp = cg->comp();
 
-   static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;
+   bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
+   bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
 
    if (methodSymbol)
       {
@@ -10456,20 +10452,20 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
             return false; // Call the native version of NativeThread.current()
          case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
             {
-            if (node->isSafeForCGToFastPathUnsafeCall())
+            if (!disableCASInlining && node->isSafeForCGToFastPathUnsafeCall())
                return inlineCompareAndSwapNative(node, 4, false, false, cg);
             }
             break;
          case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z:
             {
-            if (node->isSafeForCGToFastPathUnsafeCall())
+            if (!disableCASInlining && node->isSafeForCGToFastPathUnsafeCall())
                return inlineCompareAndSwapNative(node, 8, false, false, cg);
             }
             break;
          case TR::sun_misc_Unsafe_compareAndSwapObject_jlObjectJjlObjectjlObject_Z:
             {
             static bool useOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
-            if (node->isSafeForCGToFastPathUnsafeCall())
+            if (!disableCASInlining && node->isSafeForCGToFastPathUnsafeCall())
                {
                if (useOldCompareAndSwapObject)
                   return inlineCompareAndSwapNative(node, TR::Compiler->om.sizeofReferenceField(), true, false, cg);
@@ -10483,13 +10479,13 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
             break;
          case TR::jdk_internal_misc_Unsafe_compareAndExchangeInt:
             {
-            if (!disableCAEIntrinsic && node->isSafeForCGToFastPathUnsafeCall())
+            if (!disableCAEInlining && node->isSafeForCGToFastPathUnsafeCall())
                return inlineCompareAndSwapNative(node, 4, false, true, cg);
             }
             break;
          case TR::jdk_internal_misc_Unsafe_compareAndExchangeLong:
             {
-            if (!disableCAEIntrinsic && node->isSafeForCGToFastPathUnsafeCall())
+            if (!disableCAEInlining && node->isSafeForCGToFastPathUnsafeCall())
                return inlineCompareAndSwapNative(node, 8, false, true, cg);
             }
             break;
@@ -10497,7 +10493,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(
          case TR::jdk_internal_misc_Unsafe_compareAndExchangeReference:
             {
             static bool useOldCompareAndSwapObject = (bool)feGetEnv("TR_UseOldCompareAndSwapObject");
-            if (!disableCAEIntrinsic && node->isSafeForCGToFastPathUnsafeCall())
+            if (!disableCAEInlining && node->isSafeForCGToFastPathUnsafeCall())
                {
                if (useOldCompareAndSwapObject)
                   return inlineCompareAndSwapNative(node, TR::Compiler->om.sizeofReferenceField(), true, true, cg);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -162,6 +162,18 @@ J9::Z::CodeGenerator::initialize()
       cg->setSupportsInlineVectorizedMismatch();
       }
 
+   static bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
+   if (!disableCASInlining)
+      {
+      cg->setSupportsInlineUnsafeCompareAndSet();
+      }
+
+   static bool disableCAEInlining = feGetEnv("TR_DisableCAEInlining") != NULL;
+   if (!disableCAEInlining)
+      {
+      cg->setSupportsInlineUnsafeCompareAndExchange();
+      }
+
    // Let's turn this on.  There is more work needed in the opt
    // to catch the case where the BNDSCHK is inserted after
    //
@@ -3834,8 +3846,11 @@ J9::Z::CodeGenerator::inlineDirectCall(
       }
 
    static const char * enableTRTRE = feGetEnv("TR_enableTRTRE");
-   static bool disableCAEIntrinsic = feGetEnv("TR_DisableCAEIntrinsic") != NULL;
    static const bool enableOSW = feGetEnv("TR_noPauseOnSpinWait") == NULL;
+
+   bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
+   bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
+
    switch (methodSymbol->getRecognizedMethod())
       {
       case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
@@ -3847,8 +3862,11 @@ J9::Z::CodeGenerator::inlineDirectCall(
 
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CS, IS_NOT_OBJ);
-            return true;
+            if (!disableCASInlining)
+               {
+               resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CS, IS_NOT_OBJ);
+               return true;
+               }
             }
          break;
 
@@ -3860,8 +3878,11 @@ J9::Z::CodeGenerator::inlineDirectCall(
          // Too risky to do Long-31bit version now.
          if (comp->target().is64Bit() && (!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CSG, IS_NOT_OBJ);
-            return true;
+            if (!disableCASInlining)
+               {
+               resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CSG, IS_NOT_OBJ);
+               return true;
+               }
             }
          break;
 
@@ -3872,15 +3893,18 @@ J9::Z::CodeGenerator::inlineDirectCall(
 
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, (comp->useCompressedPointers() ? TR::InstOpCode::CS : TR::InstOpCode::getCmpAndSwapOpCode()), IS_OBJ);
-            return true;
+            if (!disableCASInlining)
+               {
+               resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, (comp->useCompressedPointers() ? TR::InstOpCode::CS : TR::InstOpCode::getCmpAndSwapOpCode()), IS_OBJ);
+               return true;
+               }
             }
          break;
 
       case TR::jdk_internal_misc_Unsafe_compareAndExchangeInt:
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            if (!disableCAEIntrinsic)
+            if (!disableCAEInlining)
                {
                resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CS, IS_NOT_OBJ, true);
                return true;
@@ -3892,7 +3916,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
          // Too risky to do Long-31bit version now.
          if (comp->target().is64Bit() && (!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            if (!disableCAEIntrinsic)
+            if (!disableCAEInlining)
                {
                resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, TR::InstOpCode::CSG, IS_NOT_OBJ, true);
                return true;
@@ -3912,7 +3936,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
       case TR::jdk_internal_misc_Unsafe_compareAndExchangeReference:
          if ((!TR::Compiler->om.canGenerateArraylets() || node->isUnsafeGetPutCASCallOnNonArray()) && node->isSafeForCGToFastPathUnsafeCall())
             {
-            if (!disableCAEIntrinsic)
+            if (!disableCAEInlining)
                {
                resultReg = TR::TreeEvaluator::VMinlineCompareAndSwap(node, cg, (comp->useCompressedPointers() ? TR::InstOpCode::CS : TR::InstOpCode::getCmpAndSwapOpCode()), IS_OBJ, true);
                return true;


### PR DESCRIPTION
Changes TR_DisableCASInlining envvar to disable inlining Unsafe compareAndSwap on all platforms. This used to only work on X and would also disable inlining compareAndExchange at the same time. Now it only disables inlining compareAndSwap.

Renames TR_DisableCAEIntrinsic envvar to TR_DisableCAEIntrinsic and it disables inlining Unsafe compareAndExchange on all platforms.

Envvars are now checked in fewer locations and set an option bit instead. The following methods were added to support this: getSupportsInlineUnsafeCompareAndSet
setSupportsInlineUnsafeCompareAndSet
getSupportsInlineUnsafeCompareAndExchange
setSupportsInlineUnsafeCompareAndExchange

These methods are used to indicate support for inlining CAS/CAE and also to query for suppport.