### PR TITLE
Add new test modes for J9vmTest

### DIFF
--- a/test/functional/VM_Test/playlist.xml
+++ b/test/functional/VM_Test/playlist.xml
@@ -29,6 +29,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode351</variation>
 			<variation>Mode501</variation>
 			<variation>Mode551</variation>
+			<variation>Mode501 -XXgc:disableVirtualLargeObjectHeap</variation>
+			<variation>Mode551 -XXgc:disableVirtualLargeObjectHeap</variation>
 			<variation>Mode610</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \


### PR DESCRIPTION
Off Heap Feature would be enabled by default in near future, after Off Heap is enabled by default, J9vmTest variation Mode501 and Mode551(-Xjit -Xgcpolicy:balanced -Xnocompressedrefs /-Xcompressedrefs) would not cover Arraylet(Discontiguous Array) case.

Add new variation
	<variation>Mode501 -XXgc:disableVirtualLargeObjectHeap</variation>
	<variation>Mode551 -XXgc:disableVirtualLargeObjectHeap</variation>
for detecting any regrassion in old Arraylet case.