### PR TITLE
Remove unused checkInlinedClassValidity method

### DIFF
--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -3289,13 +3289,6 @@ TR_RelocationRecordProfiledInlinedMethod::methodIndex(TR_RelocationTarget *reloT
    return reloTarget->loadRelocationRecordValue((uintptr_t *) &((TR_RelocationRecordProfiledInlinedMethodBinaryTemplate *)_record)->_methodIndex);
    }
 
-
-bool
-TR_RelocationRecordProfiledInlinedMethod::checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedClass)
-   {
-   return true;
-   }
-
 TR_OpaqueMethodBlock *
 TR_RelocationRecordProfiledInlinedMethod::getInlinedMethod(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, TR_OpaqueClassBlock *inlinedCodeClass)
    {
@@ -3370,7 +3363,7 @@ TR_RelocationRecordProfiledInlinedMethod::preparePrivateData(TR_RelocationRuntim
          }
       }
 
-   if (inlinedCodeClass && checkInlinedClassValidity(reloRuntime, inlinedCodeClass))
+   if (inlinedCodeClass)
       {
       RELO_LOG(reloRuntime->reloLogger(), 6,"\tpreparePrivateData: inlined class valid\n");
       reloPrivateData->_inlinedCodeClass = inlinedCodeClass;
@@ -3446,13 +3439,6 @@ TR_RelocationRecordProfiledClassGuard::name()
    return "TR_ProfiledClassGuard";
    }
 
-bool
-TR_RelocationRecordProfiledClassGuard::checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass)
-   {
-   return true;
-   return !reloRuntime->fej9()->classHasBeenExtended(inlinedCodeClass) && !reloRuntime->options()->getOption(TR_DisableProfiledInlining);
-   }
-
 void
 TR_RelocationRecordProfiledClassGuard::setupInlinedMethodData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget)
    {
@@ -3478,13 +3464,6 @@ const char *
 TR_RelocationRecordProfiledMethodGuard::name()
    {
    return "TR_ProfiledMethodGuard";
-   }
-
-bool
-TR_RelocationRecordProfiledMethodGuard::checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass)
-   {
-   return true;
-   return !reloRuntime->options()->getOption(TR_DisableProfiledMethodInlining);
    }
 
 void

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -984,7 +984,6 @@ class TR_RelocationRecordProfiledInlinedMethod : public TR_RelocationRecordInlin
    private:
 
       virtual void setupInlinedMethodData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
-      virtual bool checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass);
       virtual void activateGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation) {}
       virtual void invalidateGuard(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget, uint8_t *reloLocation) {}
       virtual void updateFailedStats(TR_AOTStats *aotStats);
@@ -1009,7 +1008,6 @@ class TR_RelocationRecordProfiledClassGuard : public TR_RelocationRecordProfiled
       virtual const char *name();
 
    private:
-      virtual bool checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass);
       virtual void setupInlinedMethodData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual void updateFailedStats(TR_AOTStats *aotStats);
       virtual void updateSucceededStats(TR_AOTStats *aotStats);
@@ -1023,7 +1021,6 @@ class TR_RelocationRecordProfiledMethodGuard : public TR_RelocationRecordProfile
       virtual const char *name();
 
    private:
-      virtual bool checkInlinedClassValidity(TR_RelocationRuntime *reloRuntime, TR_OpaqueClassBlock *inlinedCodeClass);
       virtual void setupInlinedMethodData(TR_RelocationRuntime *reloRuntime, TR_RelocationTarget *reloTarget);
       virtual void updateFailedStats(TR_AOTStats *aotStats);
       virtual void updateSucceededStats(TR_AOTStats *aotStats);


### PR DESCRIPTION
This method and its overrides have returned true unconditionally since at least the initial commit.