### PR TITLE
Ensure relocating fresh AOT is interruptible

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10450,7 +10450,7 @@ TR::CompilationInfo::compilationEnd(J9VMThread * vmThread, TR::IlGeneratorMethod
                      }
                   try
                      {
-                     TR::CompilationInfoPerThreadBase::InterruptibleOperation(*entry->_compInfoPT);
+                     TR::CompilationInfoPerThreadBase::InterruptibleOperation relocatingAOTBody(*entry->_compInfoPT);
                      // need to get a non-shared cache VM to relocate
                      TR_J9VMBase *fe = TR_J9VMBase::get(jitConfig, vmThread);
                      TR_ResolvedMethod *compilee = fe->createResolvedMethod(comp->trMemory(), (TR_OpaqueMethodBlock *)method);


### PR DESCRIPTION
The existing code does not bind the InterruptibleOperation object to a name, so it is destroyed immediately after it is created.