### PR TITLE
Add OMR UnsafeSubexpressionRemover.cpp to UMA makefile

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -241,6 +241,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/TranslateTable.cpp \
     omr/compiler/optimizer/TrivialDeadBlockRemover.cpp \
     omr/compiler/optimizer/UnionBitVectorAnalysis.cpp \
+    omr/compiler/optimizer/UnsafeSubexpressionRemover.cpp \
     omr/compiler/optimizer/UseDefInfo.cpp \
     omr/compiler/optimizer/ValueNumberInfo.cpp \
     omr/compiler/optimizer/ValuePropagationCommon.cpp \


### PR DESCRIPTION
The new OMR compiler source file `UnsafeSubexpressionRemoval.cpp` needs to be included in OpenJ9's UMA makefile in order to build OpenJ9 successfully in that build environment.

This change depends on OMR pull request eclipse-omr/omr#7573