### PR TITLE
JDK24 adds JavaLangAccess.virtualThreadDelayedTaskSchedulers()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -87,6 +87,7 @@ import sun.nio.ch.Interruptible;
 import sun.reflect.annotation.AnnotationType;
 /*[IF JAVA_SPEC_VERSION >= 24]*/
 import java.util.concurrent.Executor;
+import java.util.concurrent.ScheduledExecutorService;
 import jdk.internal.loader.NativeLibraries;
 /*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
@@ -863,6 +864,13 @@ final class Access implements JavaLangAccess {
 	@Override
 	public Executor virtualThreadDefaultScheduler() {
 		return VirtualThread.defaultScheduler();
+	}
+
+	/*[IF !INLINE-TYPES]*/
+	@Override
+	/*[ENDIF] !INLINE-TYPES */
+	public Stream<ScheduledExecutorService> virtualThreadDelayedTaskSchedulers() {
+		return VirtualThread.delayedTaskSchedulers();
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 

--- a/jcl/src/java.base/share/classes/openj9/internal/criu/security/CRIUConfigurator.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/security/CRIUConfigurator.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import java.util.TreeMap;
 
 import openj9.internal.criu.CRIUSECProvider;
-import sun.security.action.GetPropertyAction;
 import sun.security.jca.ProviderList;
 import sun.security.jca.Providers;
 
@@ -48,7 +47,12 @@ public final class CRIUConfigurator {
 	private static final HashMap<String, String> oldProviders = new HashMap<>();
 	/** Tracing for CRIUSEC. */
 	private static final boolean debug = Boolean.parseBoolean(
-			GetPropertyAction.privilegedGetProperty("enable.j9internal.checkpoint.security.api.debug", "false"));
+			/*[IF JAVA_SPEC_VERSION < 24]*/
+			sun.security.action.GetPropertyAction.privilegedGetProperty
+			/*[ELSE] JAVA_SPEC_VERSION < 24
+			System.getProperty
+			/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+					("enable.j9internal.checkpoint.security.api.debug", "false"));
 	private static final Map<String, Set<String>> cachedAlgorithms = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 	private static boolean isCacheEligible;
 


### PR DESCRIPTION
JDK24 adds `JavaLangAccess.virtualThreadDelayedTaskSchedulers()` and removes `GetPropertyAction`.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/902

Signed-off-by: Jason Feng <fengj@ca.ibm.com>