### PR TITLE
[JDK24] Find and consume --illegal-native-access=<VALUE>

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -683,6 +683,7 @@ enum INIT_STAGE {
 #define VMOPT_PATCH_MODULE "--patch-module"
 #define VMOPT_ILLEGAL_ACCESS "--illegal-access="
 #define VMOPT_ENABLE_NATIVE_ACCESS "--enable-native-access"
+#define VMOPT_ILLEGAL_NATIVE_ACCESS "--illegal-native-access="
 
 /* JEP 421: Deprecate Finalization for Removal */
 #define VMOPT_DISABLE_FINALIZATION "--finalization="
@@ -722,6 +723,7 @@ enum INIT_STAGE {
 #if JAVA_SPEC_VERSION >= 23
 #define SYSPROP_SUN_MISC_UNSAFE_MEMORY_ACCESS "sun.misc.unsafe.memory.access"
 #endif /* JAVA_SPEC_VERSION >= 23 */
+#define SYSPROP_JDK_MODULE_ILLEGALNATIVEACCESS "jdk.module.illegal.native.access"
 #define JAVA_BASE_MODULE "java.base"
 
 #define SYSPROP_COM_SUN_MANAGEMENT "-Dcom.sun.management."

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -530,6 +530,17 @@ addModularitySystemProperties(J9JavaVM * vm)
 	}
 #endif /* JAVA_SPEC_VERSION >= 17 */
 
+#if JAVA_SPEC_VERSION >= 24
+	/* Find and consume the last --illegal-native-access option. */
+	rc = addPropertyForOptionWithEqualsArg(
+			vm, VMOPT_ILLEGAL_NATIVE_ACCESS,
+			LITERAL_STRLEN(VMOPT_ILLEGAL_NATIVE_ACCESS),
+			SYSPROP_JDK_MODULE_ILLEGALNATIVEACCESS);
+	if (J9SYSPROP_ERROR_NONE != rc) {
+		goto _end;
+	}
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
 	/* Find last --illegal-access */
 	rc = addPropertyForOptionWithEqualsArg(vm, VMOPT_ILLEGAL_ACCESS, LITERAL_STRLEN(VMOPT_ILLEGAL_ACCESS), SYSPROP_JDK_MODULE_ILLEGALACCESS);
 


### PR DESCRIPTION
After reading the last `--illegal-native-access=<VALUE>` option,
the system property `jdk.module.illegal.native.access` is assigned
the specified `<VALUE>`.

Related: #19680
Related: #20354