### PR TITLE
Bypass Code Requiring VM Read at JITServer

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -2130,6 +2130,11 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 #if defined(J9VM_OPT_METHOD_HANDLE)
          case TR::java_lang_invoke_PrimitiveHandle_initializeClassIfRequired:
             {
+            // The macro J9VMJAVALANGINVOKEPRIMITIVEHANDLE used later
+            // will access vm information which is not available on the JITServer,
+            // bypass in this case to prevent an invalid class pointer being retrieved
+            if (comp()->isOutOfProcessCompilation())
+               break;
             TR::Node* mh = node->getArgument(0);
             bool mhConstraintGlobal;
             TR::VPConstraint* mhConstraint = getConstraint(mh, mhConstraintGlobal);


### PR DESCRIPTION
Bypass the code that requires a VM read in constraintRecognizedMethod under JITServer mode, to prevent an invalid class pointer being sent to the client and crashing the client.

This block of code should only be reached in jdk11, fixing a crash caused by https://github.com/eclipse-omr/omr/pull/7565.