### PR TITLE
TransformIndirectLoadChain at JITServer

### DIFF
--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -231,7 +231,7 @@ J9::KnownObjectTable::getPointerLocation(Index index)
 
 #if defined(J9VM_OPT_JITSERVER)
 void
-J9::KnownObjectTable::updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocationClient)
+J9::KnownObjectTable::updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocationClient, bool isArrayWithConstantElements)
    {
    TR_ASSERT_FATAL(self()->comp()->isOutOfProcessCompilation(), "updateKnownObjectTableAtServer should only be called at the server");
    if (index == TR::KnownObjectTable::UNKNOWN)
@@ -257,6 +257,9 @@ J9::KnownObjectTable::updateKnownObjectTableAtServer(Index index, uintptr_t *obj
       {
       TR_ASSERT_FATAL(false, "index %d from the client is greater than the KOT nextIndex %d at the server", index, nextIndex);
       }
+
+   if (isArrayWithConstantElements)
+      addArrayWithConstantElements(index);
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/env/J9KnownObjectTable.hpp
+++ b/runtime/compiler/env/J9KnownObjectTable.hpp
@@ -107,7 +107,7 @@ public:
    uintptr_t getPointer(Index index);
 
 #if defined(J9VM_OPT_JITSERVER)
-   void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocationClient);
+   void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocationClient, bool isArrayWithConstantElements = false);
    void getKnownObjectTableDumpInfo(std::vector<TR_KnownObjectTableDumpInfo> &knotDumpInfoList);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -210,7 +210,8 @@ public:
    virtual intptr_t getVFTEntry(TR_OpaqueClassBlock *clazz, int32_t offset) override;
    virtual bool isClassArray(TR_OpaqueClassBlock *klass) override;
    virtual uintptr_t getFieldOffset(TR::Compilation * comp, TR::SymbolReference* classRef, TR::SymbolReference* fieldRef) override { return 0; } // safe answer
-   virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) override { return false; } // safe answer, might change in the future
+// The base version should be safe, no need to override.
+//   virtual bool canDereferenceAtCompileTime(TR::SymbolReference *fieldRef,  TR::Compilation *comp) override; // safe answer, might change in the future
    virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class* castClass) override;
    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 75; // ID: kzkyjklaOnYjEzzJyIl7
+   static const uint16_t MINOR_NUMBER = 76; // ID: BpR0Syhau116Bh0vAoVr
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -263,6 +263,8 @@ const char *messageNames[] =
    "KnownObjectTable_getKnownObjectTableDumpInfo",
    "KnownObjectTable_getOpaqueClass",
    "KnownObjectTable_getVectorBitSize",
+   "KnownObjectTable_addFieldAddressFromBaseIndex",
+   "KnownObjectTable_getFieldAddressData",
    "AOTCache_getROMClassBatch",
    "AOTCacheMap_request",
    "AOTCacheMap_reply"

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -290,6 +290,9 @@ enum MessageType : uint16_t
    KnownObjectTable_getOpaqueClass,
    // for getting a vectorBitSize from KnownObjectTable
    KnownObjectTable_getVectorBitSize,
+   // used with J9TransformUtil
+   KnownObjectTable_addFieldAddressFromBaseIndex,
+   KnownObjectTable_getFieldAddressData,
 
    AOTCache_getROMClassBatch,
 

--- a/runtime/compiler/optimizer/J9TransformUtil.hpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.hpp
@@ -220,9 +220,18 @@ public:
       TR_ResolvedMethod *owningMethod,
       int32_t cpIndex);
 
+   union value{
+      int32_t i;
+      int64_t l;
+      float f;
+      double d;
+      void *p;
+      TR::KnownObjectTable::Index idx;
+   };
+
    static bool transformIndirectLoadChain(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, TR::KnownObjectTable::Index baseKnownObject, TR::Node **removedNode);
    static bool transformIndirectLoadChainAt(TR::Compilation *, TR::Node *node, TR::Node *baseExpression, uintptr_t *baseReferenceLocation, TR::Node **removedNode);
-   static bool transformIndirectLoadChainImpl( TR::Compilation *, TR::Node *node, TR::Node *baseExpression, void *baseAddress, int32_t baseStableArrayRank, TR::Node **removedNode);
+   static bool transformIndirectLoadChainImpl( TR::Compilation *, TR::Node *node, TR::Node *baseExpression, TR::KnownObjectTable::Index baseKnownObject, void *baseAddress, int32_t baseStableArrayRank, TR::Node **removedNode);
 
    static bool fieldShouldBeCompressed(TR::Node *node, TR::Compilation *comp);
 


### PR DESCRIPTION
Implement TransformIndirectLoadChain partially for the JITServer so it can employ the Vector API during optimization.