### PR TITLE
XMLParser: support attributes with empty values

### DIFF
--- a/test/functional/J9 Exclude File Support/src/com/oti/j9/exclude/XMLParser.java
+++ b/test/functional/J9 Exclude File Support/src/com/oti/j9/exclude/XMLParser.java
@@ -255,10 +255,10 @@ public class XMLParser {
 
 		XMLStringBuffer buffer = new XMLStringBuffer();
 
-		do {
+		while (_fScan != '"') {
 			buffer.append(_fScan);
 			scan_char();
-		} while ( _fScan != '"' );
+		}
 
 		// Advance past the final quote
 		scan_char();
@@ -396,6 +396,9 @@ public class XMLParser {
 		Hashtable attributes = _scan_attributes();
 
 		// Notify the content handler
+		if (VERBOSE) {
+			System.out.format("%nAbout to start <%s> at level %d%n", elementName, _fLevel + 1);
+		}
 		_fDocumentHandler.xmlStartElement(elementName, attributes);
 		_fLevel++;
 


### PR DESCRIPTION
In https://github.com/eclipse-openj9/openj9/pull/20625, I requested the space be removed from test xml files in places like this:
```
	<echo value=" "/>
```
However, the XML parser didn't support empty attribute values:
```
	<echo value=""/>
```
This fixes that.