### PR TITLE
Update sample code for enum type fields in BytecodeGenerator.java

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/BytecodeGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/BytecodeGenerator.java
@@ -1089,9 +1089,9 @@ final class PointerHelper extends HelperBase {
 
 	/* Sample generated code:
 	 *
-	 * @com.ibm.j9ddr.GeneratedFieldAccessor(offsetFieldName="_physicalProcessorOffset_", declaredType="J9ProcessorArchitecture")
-	 * public long physicalProcessor() throws CorruptDataException {
-	 *     return getIntAtOffset(J9ProcessorDesc._physicalProcessorOffset_);
+	 * @com.ibm.j9ddr.GeneratedFieldAccessor(offsetFieldName="__allocationContextTypeOffset_", declaredType="const MM_AllocationContextTarok$AllocationContextType")
+	 * public long _allocationContextType() throws CorruptDataException {
+	 *     return getIntAtOffset(J9ProcessorDesc.__allocationContextTypeOffset_);
 	 * }
 	 *
 	 * If the size of the field type is not 4, getByteAtOffset, getShortAtOffset


### PR DESCRIPTION
Remove the reference to `J9ProcessorArchitecture` that will go away with the solution to #20668.