### PR TITLE
Use dependency table as arbitrary class fallback

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -389,6 +389,9 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    // fails serialization by setting _aotCacheStore to false if we are not ignoring the client's SCC, and otherwise
    // fails the compilation entirely.
    void addThunkRecord(const AOTCacheThunkRecord *record);
+#else
+   bool isDeserializedAOTMethod() const { return false; }
+   bool ignoringLocalSCC() const { return false; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }

--- a/runtime/compiler/env/DependencyTable.hpp
+++ b/runtime/compiler/env/DependencyTable.hpp
@@ -39,7 +39,8 @@ public:
    void classLoadEvent(TR_OpaqueClassBlock *ramClass, bool isClassLoad, bool isClassInitialization) {}
    void invalidateUnloadedClass(TR_OpaqueClassBlock *ramClass) {}
    void invalidateRedefinedClass(TR_PersistentCHTable *table, TR_J9VMBase *fej9, TR_OpaqueClassBlock *oldClass, TR_OpaqueClassBlock *freshClass) {}
-   TR_OpaqueClassBlock *findClassCandidate(uintptr_t offset) { return NULL; }
+   J9Class *findCandidateWithChainAndLoader(TR::Compilation *comp, uintptr_t classChainOffset, void *classLoaderChain) { return NULL; }
+   J9Class *findCandidateWithChainAndLoader(TR::Compilation *comp, uintptr_t *classChain, void *classLoaderChain) { return NULL; }
    void methodWillBeCompiled(J9Method *method) {}
    void printStats() {}
    };
@@ -118,9 +119,11 @@ public:
    // RAM method of ramClass.
    void invalidateRedefinedClass(TR_PersistentCHTable *table, TR_J9VMBase *fej9, TR_OpaqueClassBlock *oldClass, TR_OpaqueClassBlock *freshClass);
 
-   // Given a ROM class offset, return an initialized class with a valid class
-   // chain starting with that offset.
-   TR_OpaqueClassBlock *findClassCandidate(uintptr_t offset);
+   // Given a class chain and class loader chain, return an initialized class
+   // with a valid class chain starting with that offset and with a class loader
+   // with that loader chain
+   J9Class *findCandidateWithChainAndLoader(TR::Compilation *comp, uintptr_t classChainOffset, void *classLoaderChain);
+   J9Class *findCandidateWithChainAndLoader(TR::Compilation *comp, uintptr_t *classChain, void *classLoaderChain);
 
    static uintptr_t decodeDependencyOffset(uintptr_t offset)
       {
@@ -169,6 +172,7 @@ private:
    OffsetEntry *getOffsetEntry(uintptr_t offset, bool create);
 
    J9Class *findCandidateForDependency(const PersistentUnorderedSet<J9Class *> &loadedClasses, bool needsInitialization);
+   J9Class *findChainLoaderCandidate(TR::Compilation *comp, uintptr_t *classChain, void *classLoaderChain);
 
    // Stop tracking the given method. This will invalidate the MethodEntryRef
    // for the method.

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -40,6 +40,7 @@
 #include "control/Options_inlines.hpp"
 #include "env/CHTable.hpp"
 #include "env/ClassLoaderTable.hpp"
+#include "env/DependencyTable.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/jittypes.h"
 #include "env/VMAccessCriticalSection.hpp"
@@ -3362,6 +3363,12 @@ TR_RelocationRecordProfiledInlinedMethod::preparePrivateData(TR_RelocationRuntim
                                                                                       reloRuntime->comp());
             }
 #endif /* defined(J9VM_OPT_JITSERVER) */
+         }
+      if (!inlinedCodeClass)
+         {
+         if (auto dependencyTable = reloRuntime->comp()->getPersistentInfo()->getAOTDependencyTable())
+            inlinedCodeClass = (TR_OpaqueClassBlock *)dependencyTable->findCandidateWithChainAndLoader(reloRuntime->comp(), classChainForInlinedMethod(reloTarget),
+                                                                                                       classChainIdentifyingLoader);
          }
       }
 


### PR DESCRIPTION
For classes acquired via profiling, the dependency table can be used to obtain candidates for relocation.