### PR TITLE
Flag Call to isClassLibraryMethod in isChangeCurrentThread as vettedForAOT

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4026,7 +4026,7 @@ TR_J9VMBase::isChangesCurrentThread(TR_ResolvedMethod *method)
 #if JAVA_SPEC_VERSION >= 21
    TR_OpaqueMethodBlock* m = method->getPersistentIdentifier();
    // @ChangesCurrentThread should be ignored if used outside the class library
-   if (isClassLibraryMethod(m))
+   if (isClassLibraryMethod(m, true))
       return jitIsMethodTaggedWithChangesCurrentThread(vmThread(), (J9Method*)m);
 #endif /* JAVA_SPEC_VERSION >= 21 */
 


### PR DESCRIPTION
The call to isClassLibraryMethod in isChangeCurrentThread should be safe during AOT(https://github.com/eclipse-openj9/openj9/issues/19965), setting the parameter to true prevents the assertion failure in isClassLibraryMethod.

Fixes https://github.com/eclipse-openj9/openj9/issues/19965