### PR TITLE
Downgrade isIndexableDataAddrPresent  to BOOLEAN

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5514,7 +5514,7 @@ typedef struct J9VMThread {
 	UDATA contiguousIndexableHeaderSize;
 	UDATA discontiguousIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
-	UDATA isIndexableDataAddrPresent;
+	BOOLEAN isIndexableDataAddrPresent;
 	BOOLEAN isVirtualLargeObjectHeapEnabled;
 #endif /* defined(J9VM_ENV_DATA64) */
 	void* gpInfo;
@@ -6074,7 +6074,7 @@ typedef struct J9JavaVM {
 	UDATA contiguousIndexableHeaderSize;
 	UDATA discontiguousIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
-	UDATA isIndexableDataAddrPresent;
+	BOOLEAN isIndexableDataAddrPresent;
 	BOOLEAN isVirtualLargeObjectHeapEnabled;
 	BOOLEAN isIndexableDualHeaderShapeEnabled;
 #endif /* defined(J9VM_ENV_DATA64) */


### PR DESCRIPTION
Effectively this was already a boolean, just taking more space than necessary. Thus compiler will be able to better pack 2 consecutive booleans (isIndexableDataAddrPresent and
isVirtualLargeObjectHeapEnabled)