### PR TITLE
Clean Up VM Accesses in Vector Expansion API for the JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -445,7 +445,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             {
             vmInfo._arrayTypeClasses[i] = fe->getClassFromNewArrayTypeNonNull(i + 4);
             }
-         vmInfo._byteArrayClass = fe->getByteArrayClass();
+         vmInfo._byteArrayClassOffset = fe->getByteArrayClass();
          vmInfo._isIndexableDataAddrPresent = TR::Compiler->om.isIndexableDataAddrPresent();
          vmInfo._contiguousIndexableHeaderSize = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
          vmInfo._discontiguousIndexableHeaderSize = TR::Compiler->om.discontiguousArrayHeaderSizeInBytes();
@@ -562,6 +562,14 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          vmInfo._shortReflectClassPtr = javaVM->shortReflectClass;
          vmInfo._intReflectClassPtr = javaVM->intReflectClass;
          vmInfo._longReflectClassPtr = javaVM->longReflectClass;
+         vmInfo._booleanArrayClass = javaVM->booleanArrayClass;
+         vmInfo._charArrayClass = javaVM->charArrayClass;
+         vmInfo._floatArrayClass = javaVM->floatArrayClass;
+         vmInfo._doubleArrayClass = javaVM->doubleArrayClass;
+         vmInfo._byteArrayClass = javaVM->byteArrayClass;
+         vmInfo._shortArrayClass = javaVM->shortArrayClass;
+         vmInfo._intArrayClass = javaVM->intArrayClass;
+         vmInfo._longArrayClass = javaVM->longArrayClass;
 
          client->write(response, vmInfo, listOfCacheDescriptors, comp->getPersistentInfo()->getJITServerAOTCacheName());
          }

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1411,6 +1411,43 @@ TR_J9VMBase::getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz)
    }
 
 TR_OpaqueClassBlock *
+TR_J9VMBase::getArrayClassFromDataType(TR::DataType type, bool booleanClass)
+   {
+   J9Class *j9class;
+   J9JavaVM *vm = getJ9JITConfig()->javaVM;
+
+   switch (type)
+      {
+      case TR::Float:
+         j9class = vm->floatArrayClass;
+         break;
+      case TR::Double:
+         j9class = vm->doubleArrayClass;
+         break;
+      case TR::Int8:
+         j9class = vm->byteArrayClass;
+         break;
+      case TR::Int16:
+         j9class = vm->shortArrayClass;
+         break;
+      case TR::Int32:
+         j9class = vm->intArrayClass;
+         break;
+      case TR::Int64:
+         j9class = vm->longArrayClass;
+         break;
+      default:
+         TR_ASSERT_FATAL(false, "Incorrect array element type");
+         return NULL;
+      }
+
+   if (booleanClass)
+      j9class = vm->booleanArrayClass;
+
+   return convertClassPtrToClassOffset(j9class);
+   }
+
+TR_OpaqueClassBlock *
 TR_J9VMBase::getClassFromJavaLangClass(uintptr_t objectPointer)
    {
    return (TR_OpaqueClassBlock*)J9VM_J9CLASS_FROM_HEAPCLASS(_vmThread, objectPointer);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -686,6 +686,7 @@ public:
    virtual TR_OpaqueClassBlock *getClassFromJavaLangClass(uintptr_t objectPointer);
    virtual TR_arrayTypeCode    getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz);
    virtual TR::DataType        getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz);
+   virtual TR_OpaqueClassBlock *getArrayClassFromDataType(TR::DataType type, bool booleanClass);
    virtual TR_OpaqueClassBlock * getSystemClassFromClassName(const char * name, int32_t length, bool callSiteVettedForAOT=false) { return 0; }
    virtual TR_OpaqueClassBlock * getByteArrayClass();
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -253,7 +253,7 @@ TR_J9ServerVM::getByteArrayClass()
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    auto *vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(stream);
-   return vmInfo->_byteArrayClass;
+   return vmInfo->_byteArrayClassOffset;
    }
 
 bool
@@ -2689,6 +2689,42 @@ TR_J9ServerVM::getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz)
       return TR::NoType;
    }
 
+TR_OpaqueClassBlock *
+TR_J9ServerVM::getArrayClassFromDataType(TR::DataType type, bool booleanClass)
+   {
+   J9Class *j9class;
+   auto vmInfo = _compInfoPT->getClientData()->getOrCacheVMInfo(_compInfoPT->getStream());
+
+   switch (type)
+      {
+      case TR::Float:
+         j9class = (J9Class *) vmInfo->_floatArrayClass;
+         break;
+      case TR::Double:
+         j9class = (J9Class *) vmInfo->_doubleArrayClass;
+         break;
+      case TR::Int8:
+         j9class = (J9Class *) vmInfo->_byteArrayClass;
+         break;
+      case TR::Int16:
+         j9class = (J9Class *) vmInfo->_shortArrayClass;
+         break;
+      case TR::Int32:
+         j9class = (J9Class *) vmInfo->_intArrayClass;
+         break;
+      case TR::Int64:
+         j9class = (J9Class *) vmInfo->_longArrayClass;
+         break;
+      default:
+         TR_ASSERT_FATAL(false, "Incorrect array element type");
+         return NULL;
+      }
+
+   if (booleanClass)
+      j9class = (J9Class *) vmInfo->_booleanArrayClass;
+
+   return convertClassPtrToClassOffset(j9class);
+   }
 
 bool
 TR_J9SharedCacheServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -270,6 +270,7 @@ public:
 
    virtual TR_arrayTypeCode       getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz) override;
    virtual TR::DataType           getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz) override;
+   virtual TR_OpaqueClassBlock *getArrayClassFromDataType(TR::DataType type, bool booleanClass) override;
 
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -863,7 +863,7 @@ TR_VectorAPIExpansion::getOpaqueClassBlockFromClassNode(TR::Compilation *comp, T
          {
          auto stream = comp->getStream();
          stream->write(JITServer::MessageType::KnownObjectTable_getOpaqueClass,
-                        symRef->getKnownObjectIndex());
+                        knownObjectIndex);
 
          clazz = (TR_OpaqueClassBlock *)std::get<0>(stream->read<uintptr_t>());
          }
@@ -898,40 +898,7 @@ TR_VectorAPIExpansion::getDataTypeFromClassNode(TR::Compilation *comp, TR::Node 
 TR_OpaqueClassBlock *
 TR_VectorAPIExpansion::getArrayClassFromDataType(TR::Compilation *comp, TR::DataType type, bool booleanClass)
    {
-   TR_J9VMBase *fej9 = comp->fej9();
-   J9JavaVM *vm = fej9->getJ9JITConfig()->javaVM;
-   J9Class *j9class;
-
-
-   switch (type)
-      {
-      case TR::Float:
-         j9class = vm->floatArrayClass;
-         break;
-      case TR::Double:
-         j9class = vm->doubleArrayClass;
-         break;
-      case TR::Int8:
-         j9class = vm->byteArrayClass;
-         break;
-      case TR::Int16:
-         j9class = vm->shortArrayClass;
-         break;
-      case TR::Int32:
-         j9class = vm->intArrayClass;
-         break;
-      case TR::Int64:
-         j9class = vm->longArrayClass;
-         break;
-      default:
-         TR_ASSERT_FATAL(false, "Incorrect array element type");
-         return NULL;
-      }
-
-   if (booleanClass)
-      j9class = vm->booleanArrayClass;
-
-   return fej9->convertClassPtrToClassOffset(j9class);
+   return comp->fej9()->getArrayClassFromDataType(type, booleanClass);
    }
 
 
@@ -1519,7 +1486,6 @@ TR_VectorAPIExpansion::boxChild(TR::TreeTop *treeTop, TR::Node *node, uint32_t i
    newObject->setSymbolReference(comp()->getSymRefTab()->findOrCreateNewObjectSymbolRef(comp()->getMethodSymbol()));
 
    TR_J9VMBase *fej9 = comp()->fej9();
-   TR::VMAccessCriticalSection getClassFromSignature(fej9);
    TR::SymbolReference *j9class = comp()->getSymRefTab()->findOrCreateClassSymbol(comp()->getMethodSymbol(), -1, vecClass);
 
    TR_ASSERT_FATAL(j9class, "J9Class symbol reference should not be null");

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -277,7 +277,7 @@ public:
       bool _elgibleForPersistIprofileInfo;
       bool _reportByteCodeInfoAtCatchBlock;
       TR_OpaqueClassBlock *_arrayTypeClasses[8];
-      TR_OpaqueClassBlock *_byteArrayClass;
+      TR_OpaqueClassBlock *_byteArrayClassOffset;
       bool _isIndexableDataAddrPresent;
       uintptr_t _contiguousIndexableHeaderSize;
       uintptr_t _discontiguousIndexableHeaderSize;
@@ -335,7 +335,7 @@ public:
       bool _isPortableRestoreMode;
       bool _isSnapshotModeEnabled;
       bool _isNonPortableRestoreMode;
-      // The reflect class pointers for the server to identify the classes
+      // The reflect and array class pointers for the server to identify the classes
       void *_voidReflectClassPtr;
       void *_booleanReflectClassPtr;
       void *_charReflectClassPtr;
@@ -345,6 +345,14 @@ public:
       void *_shortReflectClassPtr;
       void *_intReflectClassPtr;
       void *_longReflectClassPtr;
+      void *_booleanArrayClass;
+      void *_charArrayClass;
+      void *_floatArrayClass;
+      void *_doubleArrayClass;
+      void *_byteArrayClass;
+      void *_shortArrayClass;
+      void *_intArrayClass;
+      void *_longArrayClass;
       }; // struct VMInfo
 
    /**


### PR DESCRIPTION
Move the relevant VM Accesses in the Vector API to the frontend and remove unnecessary ones to ensure compatability with the JITServer.

Addresses https://github.com/eclipse-openj9/openj9/issues/20798