### PR TITLE
Add -XXgc:regionSizeWithOverride

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -230,6 +230,7 @@ public:
 	bool recycleRemainders; /**< true if need to recycle TLHRemainders at the end of PGC, for balanced GC only */
 
 	bool forceGPFOnHeapInitializationError; /**< if set causes GPF generation on heap initialization error */
+	bool isRegionSizeWithOverrideSpecified; /**< set true if -XXgc:regionSizeWithOverride is specified */
 
 	enum ContinuationListOption {
 		disable_continuation_list = 0,
@@ -440,6 +441,7 @@ public:
 		, freeSizeThresholdForSurvivor(DEFAULT_SURVIVOR_THRESHOLD)
 		, recycleRemainders(true)
 		, forceGPFOnHeapInitializationError(false)
+		, isRegionSizeWithOverrideSpecified(false)
 		, continuationListOption(enable_continuation_list)
 		, timingAddContinuationInList(onCreated)
 		, testContainerMemLimit(false)

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1573,6 +1573,16 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		if (try_scan(&scan_start, "regionSizeWithOverride=")) {
+			if(!scan_udata_memory_size_helper(vm, &scan_start, &extensions->regionSize, "regionSizeWithOverride=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+			extensions->isRegionSizeWithOverrideSpecified = true;
+			continue;
+		}
+
+
 		/* Couldn't find a match for arguments */
 		j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_GC_OPTION_UNKNOWN, error_scan);
 		returnValue = JNI_EINVAL;

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -421,7 +421,8 @@ MM_ConfigurationIncrementalGenerational::prepareParameters(OMR_VM *omrVM, UDATA 
 bool
 MM_ConfigurationIncrementalGenerational::verifyRegionSize(MM_EnvironmentBase *env, UDATA regionSize)
 {
-	return regionSize >= TAROK_MINIMUM_REGION_SIZE_BYTES;
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	return extensions->isRegionSizeWithOverrideSpecified || (regionSize >= TAROK_MINIMUM_REGION_SIZE_BYTES);
 }
 
 bool


### PR DESCRIPTION
The standard way to set region size is -Xgc:regionSize. However JVM performs check for minimum region size. We need an alternative option for debugging purpose to provide region size without limitations.