### PR TITLE
Replace nullptr with NULL in java_lang_invoke_MethodHandleNatives.cpp

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -297,9 +297,9 @@ struct LocalJ9UTF8Buffer {
 	 * Constructs an empty LocalJ9UTF8Buffer.
 	 */
 	LocalJ9UTF8Buffer()
-		: utf8(nullptr)
+		: utf8(NULL)
 		, capacity(0)
-		, cursor(nullptr)
+		, cursor(NULL)
 	{
 	}
 


### PR DESCRIPTION
`nullptr` isn't supported on the z/OS XLC v2r1 compiler used for IBM Java 8 builds on s390x.

`java_lang_invoke_MethodHandleNatives.cpp` is only compiled in builds with OpenJDK MethodHandles enabled. Once OpenJDK MHs are enabled by default, the `nullptr`s here would cause build errors on the platform mentioned above. Probably best just to remove the `nullptr` uses now to conform with the supported C++ features list.

Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>
