### PR TITLE
x86: Fix reg marked as live in vectorizedHashCode

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9686,7 +9686,6 @@ J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, TR::DataType dt
    cg->stopUsingRegister(index);
    cg->stopUsingRegister(tmp);
 
-   node->setRegister(result);
    cg->decReferenceCount(node->getChild(0));
    cg->decReferenceCount(node->getChild(1));
    cg->decReferenceCount(node->getChild(2));


### PR DESCRIPTION
The result register from inline vectorizedHashCode implementation is marked as live at the end of the method. The call node->setRegister(result) should not happen twice.

Issue: eclipse-openj9/openj9#20824