### PR TITLE
Update ClassLoader.findNative to support JEP 472

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -592,7 +592,7 @@ final class Access implements JavaLangAccess {
 /*[ENDIF] JAVA_SPEC_VERSION >= 23 */
 
 	public long findNative(ClassLoader loader, String entryName) {
-		return ClassLoader.findNative(loader, entryName);
+		return ClassLoader.findNative0(loader, entryName);
 	}
 
 	@Override

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -72,6 +72,10 @@ import jdk.internal.loader.NativeLibrary;
 import jdk.internal.reflect.CallerSensitiveAdapter;
 /*[ENDIF] JAVA_SPEC_VERSION >= 18 */
 
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+import jdk.internal.reflect.Reflection;
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+
 /*[IF CRIU_SUPPORT]*/
 import openj9.internal.criu.NotCheckpointSafe;
 /*[ENDIF] CRIU_SUPPORT*/
@@ -2101,13 +2105,27 @@ static void loadLibrary(Class<?> caller, String libName) {
 	}
 }
 
-static long findNative(ClassLoader loader, String entryName) {
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+static long findNative1(ClassLoader loader, String entryName, Class<?> cls, String javaName) {
+	long address = findNative0(loader, entryName);
+
+	if ((loader != null) && (address != 0)) {
+		Reflection.ensureNativeAccess(cls, cls, javaName, true);
+	}
+
+	return address;
+}
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+
+static long findNative0(ClassLoader loader, String entryName) {
 	NativeLibraries nativelib;
+
 	if ((loader == null) || (loader == bootstrapClassLoader)) {
 		nativelib = BootLoader.getNativeLibraries();
 	} else {
 		nativelib = loader.nativelibs;
 	}
+
 	return nativelib.find(entryName);
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 15 */

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -474,7 +474,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<virtualmethodref class="java/lang/ClassLoader" name="loadClass" signature="(Ljava/lang/String;)Ljava/lang/Class;"/>
 	<specialmethodref class="java/lang/Thread" name="uncaughtException" signature="(Ljava/lang/Throwable;)V"/>
 	<specialmethodref class="java/lang/Thread" name="&lt;init>" signature="(Ljava/lang/String;Ljava/lang/Object;IZ)V"/>
-	<staticmethodref class="java/lang/ClassLoader" name="findNative" signature="(Ljava/lang/ClassLoader;Ljava/lang/String;)J" versions="17-"/>
+	<staticmethodref class="java/lang/ClassLoader" name="findNative0" signature="(Ljava/lang/ClassLoader;Ljava/lang/String;)J" versions="17-23"/>
+	<staticmethodref class="java/lang/ClassLoader" name="findNative1" signature="(Ljava/lang/ClassLoader;Ljava/lang/String;Ljava/lang/Class;Ljava/lang/String;)J" versions="24-"/>
 
 	<fieldref class="java/lang/J9VMInternals$ClassInitializationLock" name="theClass" signature="Ljava/lang/Class;"/>
 


### PR DESCRIPTION
A new version of `ClassLoader.findNative` has been introduced, which
accepts the Java method name and the Java class where the native
method is declared as input parameters. It performs native access
checks to comply with JEP 472 (Prepare to Restrict the Use of JNI).

Related: #19680
Related: #20354