### PR TITLE
Compare nodes in addition to symRef in SequentialStoreSimplification

### DIFF
--- a/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
+++ b/runtime/compiler/optimizer/SequentialStoreSimplifier.cpp
@@ -1655,8 +1655,9 @@ bool TR_arraycopySequentialStores::insertConsistentTree()
       dumpOptDetails(comp(), " insertTree: multiplier must be 1 in aiadd tree\n");
       return false;
       }
-   TR::SymbolReference* activeBaseRef = _activeAddrTree->getBaseVarNode()->isNull() ? NULL : _activeAddrTree->getBaseVarNode()->getChild()->skipConversions()->getSymbolReference();
-   if (activeBaseRef == NULL)
+
+   TR::Node* activeBaseNode = _activeAddrTree->getBaseVarNode()->isNull() ? NULL : _activeAddrTree->getBaseVarNode()->getChild()->skipConversions();
+   if (activeBaseNode == NULL)
       {
       dumpOptDetails(comp(), " insertTree: no base variable in aiadd tree\n");
       return false;
@@ -1670,8 +1671,9 @@ bool TR_arraycopySequentialStores::insertConsistentTree()
       }
 
    // make sure the index variable and base variable is consistent with the first tree
+   TR::Node* baseNode = _addrTree[0]->getBaseVarNode()->isNull() ? NULL : _addrTree[0]->getBaseVarNode()->getChild()->skipConversions();
    TR::SymbolReference* baseRef = _addrTree[0]->getBaseVarNode()->isNull() ? NULL : _addrTree[0]->getBaseVarNode()->getChild()->skipConversions()->getSymbolReference();
-   if (baseRef != activeBaseRef)
+   if (baseNode != activeBaseNode)
       {
       dumpOptDetails(comp(), " insertTree: base variable is different than previous tree\n");
       return false;


### PR DESCRIPTION
SequentialStoreSimplification compares baseVar (first child to `aladd`) symRef to confirm stores being to the same array for simplification. For object fields the symRef matches even if arrays are different.

To fix the issue a node check is added to make sure that its storing to the same array even if symRefs match.


```
n64n      bstorei  <array-shadow>[#222  Shadow] [flags 0x80000601 0x0 ]                       [0x7284a30603c0] bci=[-1,46,2542] rc=0 vc=730 vn=- li=- udi=- nc=2
n63n        aladd (X>=0 internalPtr )                                                         [0x7284a3060370] bci=[-1,46,2542] rc=1 vc=730 vn=- li=- udi=- nc=2 flg=0x8100
n8n           aloadi  TestSeqStore.a [B[#419  Shadow +8] [flags 0x607 0x0 ]                     [0x736004404ac0] bci=[-1,1,5] rc=6 vc=2185 vn=- li=- udi=- nc=1
n7n             aload  <parm 0 LTestSeqStore;>[#417  Parm] [flags 0x40000107 0x0 ] (X>=0 )      [0x736004404a70] bci=[-1,0,5] rc=2 vc=2185 vn=- li=- udi=13 nc=0 flg=0x100
n62n          lconst 9 (highWordZero X!=0 X>=0 )                                              [0x7284a3060320] bci=[-1,46,2542] rc=1 vc=730 vn=- li=- udi=- nc=0 flg=0x4104
n56n        bconst  93 (X!=0 X>=0 )                                                           [0x7284a3060140] bci=[-1,46,2542] rc=1 vc=730 vn=- li=- udi=- nc=0 flg=0x104
n76n      bstorei  <array-shadow>[#222  Shadow] [flags 0x80000601 0x0 ]                       [0x7284a3060780] bci=[-1,51,2543] rc=0 vc=730 vn=- li=- udi=- nc=2
n75n        aladd (X>=0 internalPtr )                                                         [0x7284a3060730] bci=[-1,51,2543] rc=1 vc=730 vn=- li=- udi=- nc=2 flg=0x8100
n19n          aloadi  TestSeqStore.a [B[#419  Shadow +8] [flags 0x607 0x0 ]                     [0x736004404e30] bci=[-1,10,5] rc=4 vc=2185 vn=- li=- udi=- nc=1
n18n            aload  <parm 1 LTestSeqStore;>[#418  Parm] [flags 0x40000107 0x0 ] (X>=0 )      [0x736004404de0] bci=[-1,9,5] rc=1 vc=2185 vn=- li=- udi=14 nc=0 flg=0x100
n74n          lconst 10 (highWordZero X!=0 X>=0 )                                             [0x7284a30606e0] bci=[-1,51,2543] rc=2 vc=730 vn=- li=- udi=- nc=0 flg=0x4104
n68n        bconst  13 (X!=0 X>=0 )                                                           [0x7284a3060500] bci=[-1,51,2543] rc=1 vc=730 vn=- li=- udi=- nc=0 flg=0x104
```