### PR TITLE
Modify compile-time static field ref resolution

### DIFF
--- a/runtime/jit_vm/ctsupport.cpp
+++ b/runtime/jit_vm/ctsupport.cpp
@@ -79,9 +79,6 @@ jitGetClassInClassloaderFromUTF8(J9VMThread *vmStruct, J9ClassLoader *classLoade
 }
 
 /**
- * This function returns the class associated to a static field ref at a particular cpIndex in a constant pool.
- * The class entry will be resolved with resolveStaticFieldRef if it is not already resolved.
- *
  * @param vmStruct, the current J9VMThread
  * @param constantPool, the constant pool that the cpIndex is referring to
  * @param fieldIndex, the index of an entry in a constant pool, pointing at a static field ref.
@@ -98,11 +95,6 @@ jitGetClassOfFieldFromCP(J9VMThread *vmStruct, J9ConstantPool *constantPool, UDA
 
 	/* romConstantPool is a J9ROMConstantPoolItem */
 	ramRefWrapper = ((J9RAMStaticFieldRef*) constantPool) + fieldIndex;
-
-	if (!J9RAMSTATICFIELDREF_IS_RESOLVED(ramRefWrapper)) {
-	   vmStruct->javaVM->internalVMFunctions->resolveStaticFieldRef(vmStruct, NULL, constantPool, fieldIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, NULL);
-	}
-
 	if (J9RAMSTATICFIELDREF_IS_RESOLVED(ramRefWrapper)) {
 		J9Class *classWrapper = J9RAMSTATICFIELDREF_CLASS(ramRefWrapper);
 		UDATA initStatus = classWrapper->initializeStatus;


### PR DESCRIPTION
The existing code was introduced to improve the relocation success rate for AOT compilations that track dependencies, by attempting to resolve static field refs in jitGetClassOfFieldFromCP if they were not already resolved. This has introduced a regression in comp CPU for AOT stores, so the attempted field resolution has now been moved to the relevant record validation function to avoid this defect.