### PR TITLE
Do not interrupt heap iteration if dataAddr is bad in DDR GC Check

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
@@ -228,11 +228,11 @@ class CheckEngine
 			CheckError error = new CheckError(object, _cycle, _currentCheck, elementName, result, _cycle.nextErrorCount());
 			_reporter.report(error);
 			/* There are some error cases would not prevent further iteration */
-			if (!(J9MODRON_GCCHK_RC_CLASS_IS_UNLOADED == result)) {
+			if ((J9MODRON_GCCHK_RC_CLASS_IS_UNLOADED == result) || (J9MODRON_GCCHK_RC_INVALID_INDEXABLE_DATA_ADDRESS == result)) {
+				return J9MODRON_SLOT_ITERATOR_OK;
+			} else {
 				_reporter.reportHeapWalkError(error, _lastHeapObject1, _lastHeapObject2, _lastHeapObject3);
 				return J9MODRON_SLOT_ITERATOR_UNRECOVERABLE_ERROR;
-			} else {
-				return J9MODRON_SLOT_ITERATOR_OK;
 			}
 		}
 


### PR DESCRIPTION
If dataAddr field is discovered bad and error code is returned this fact should not prevent continue to iterate through the region.