### PR TITLE
Mark loop end label as end-of-internal-control-flow label

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9656,7 +9656,7 @@ J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, TR::DataType dt
    TR::LabelSymbol *residueLoopLabel = generateLabelSymbol(cg);
 
    residueBeginLoopLabel->setStartInternalControlFlow();
-   residueBeginLoopLabel->setEndInternalControlFlow();
+   residueEndLoopLabel->setEndInternalControlFlow();
 
    generateLabelInstruction(TR::InstOpCode::label, node, residueBeginLoopLabel, cg);
    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, length, cg);


### PR DESCRIPTION
The label that marked the beginning of a loop that handles residual bytes for the inline implementation of ArraysSupport.vectorizedHashCode was incorrectly marked as both the Start and End of internal control flow.  The end loop label should have been marked as the End of internal control flow.

Fixes #20786