### PR TITLE
Remove System.security field and getSecurityManager calls for JDK 24

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -599,7 +599,7 @@ public static void setIn(InputStream newIn) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)	{
+	if (security != null) {
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
@@ -616,7 +616,7 @@ public static void setOut(java.io.PrintStream newOut) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)	{
+	if (security != null) {
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
@@ -633,7 +633,7 @@ public static void setErr(java.io.PrintStream newErr) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)	{
+	if (security != null) {
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
@@ -921,8 +921,9 @@ public static String getenv(String var) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)
+	if (security != null) {
 		security.checkPermission(new RuntimePermission("getenv." + var)); //$NON-NLS-1$
+	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return ProcessEnvironment.getenv(var);
 }
@@ -945,8 +946,9 @@ public static Properties getProperties() {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)
+	if (security != null) {
 		security.checkPropertiesAccess();
+	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return systemProperties;
 }
@@ -1011,8 +1013,9 @@ public static String getProperty(String prop, String defaultValue) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)
+	if (security != null) {
 		security.checkPropertyAccess(prop);
+	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	if (!propertiesInitialized
@@ -1054,9 +1057,9 @@ public static String setProperty(String prop, String value) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)
-		security.checkPermission(
-			new PropertyPermission(prop, "write")); //$NON-NLS-1$
+	if (security != null) {
+		security.checkPermission(new PropertyPermission(prop, "write")); //$NON-NLS-1$
+	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	return (String)systemProperties.setProperty(prop, value);
@@ -1281,8 +1284,9 @@ public static void setProperties(Properties p) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)
+	if (security != null) {
 		security.checkPropertiesAccess();
+	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	if (p == null) {
 		ensureProperties(false);
@@ -1547,8 +1551,9 @@ public static String clearProperty(String prop) {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)
+	if (security != null) {
 		security.checkPermission(new PropertyPermission(prop, "write")); //$NON-NLS-1$
+	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return (String)systemProperties.remove(prop);
 }
@@ -1562,8 +1567,9 @@ public static Map<String, String> getenv() {
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
-	if (security != null)
+	if (security != null) {
 		security.checkPermission(new RuntimePermission("getenv.*")); //$NON-NLS-1$
+	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return ProcessEnvironment.getenv();
 }
@@ -2003,7 +2009,7 @@ public abstract static class LoggerFinder {
 	private static void verifyPermissions() {
 		@SuppressWarnings("removal")
 		SecurityManager securityManager = System.getSecurityManager();
-		if (securityManager != null)	{
+		if (securityManager != null) {
 			securityManager.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionLoggerFinder);
 		}
 	}

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -124,10 +124,12 @@ public final class System {
 	 */
 	private static Properties systemProperties;
 
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	/**
 	 * The System default SecurityManager.
 	 */
 	private static SecurityManager security;
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	private static volatile Console console;
 	private static volatile boolean consoleInitialized;
@@ -1085,7 +1087,11 @@ private static native String getSysPropBeforePropertiesInitialized(int sysPropID
 @Deprecated(since="17", forRemoval=true)
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public static SecurityManager getSecurityManager() {
+	/*[IF JAVA_SPEC_VERSION >= 24]*/
+	return null;
+	/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	return security;
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
 /**

--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -596,12 +596,13 @@ static URL codeSource(Class<?> callerClass) {
  * @param		newIn 		the new value for in.
  */
 public static void setIn(InputStream newIn) {
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
-
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	setFieldImpl("in", newIn); //$NON-NLS-1$
 }
 
@@ -612,11 +613,13 @@ public static void setIn(InputStream newIn) {
  * @param		newOut 		the new value for out.
  */
 public static void setOut(java.io.PrintStream newOut) {
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	setFieldImpl("out", newOut); //$NON-NLS-1$
 }
 
@@ -627,12 +630,13 @@ public static void setOut(java.io.PrintStream newOut) {
  * @param		newErr  	the new value for err.
  */
 public static void setErr(java.io.PrintStream newErr) {
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)	{
 		security.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionSetIO);
 	}
-
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	setFieldImpl("err", newErr); //$NON-NLS-1$
 }
 
@@ -914,11 +918,12 @@ public static void gc() {
 @SuppressWarnings("dep-ann")
 public static String getenv(String var) {
 	if (var == null) throw new NullPointerException();
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new RuntimePermission("getenv." + var)); //$NON-NLS-1$
-
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return ProcessEnvironment.getenv(var);
 }
 
@@ -927,19 +932,22 @@ public static String getenv(String var) {
  * not a copy, so that changes made to the returned
  * Properties object will be reflected in subsequent
  * calls to {@code getProperty()} and {@code getProperties()}.
+/*[IF JAVA_SPEC_VERSION < 24]
  * <p>
  * Security managers should restrict access to this
  * API if possible.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  *
  * @return		the system properties
  */
 public static Properties getProperties() {
 	if (!propertiesInitialized) throw new Error("bootstrap error, system property access before init"); //$NON-NLS-1$
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPropertiesAccess();
-
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return systemProperties;
 }
 
@@ -1000,10 +1008,12 @@ public static String getProperty(String prop) {
 public static String getProperty(String prop, String defaultValue) {
 	if (prop.length() == 0) throw new IllegalArgumentException();
 
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPropertyAccess(prop);
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	if (!propertiesInitialized
 			&& !prop.equals("com.ibm.IgnoreMalformedInput") //$NON-NLS-1$
@@ -1041,11 +1051,13 @@ public static String setProperty(String prop, String value) {
 	/*[PR CMVC 80288] should check for empty key */
 	if (prop.length() == 0) throw new IllegalArgumentException();
 
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(
 			new PropertyPermission(prop, "write")); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 	return (String)systemProperties.setProperty(prop, value);
 }
@@ -1124,10 +1136,11 @@ public static int identityHashCode(Object anObject) {
  * @param pathName the path of the file to be loaded
  *
  * @throws UnsatisfiedLinkError if the library could not be loaded
- * @throws SecurityException if the library was not allowed to be loaded
  * @throws NullPointerException if pathName is null
 /*[IF JAVA_SPEC_VERSION >= 24]
  * @throws IllegalCallerException if the caller belongs to a module where native access is not enabled
+/*[ELSE] JAVA_SPEC_VERSION >= 24
+ * @throws SecurityException if the library was not allowed to be loaded
 /*[ENDIF] JAVA_SPEC_VERSION >= 24
  */
 @CallerSensitive
@@ -1138,14 +1151,14 @@ public static void load(String pathName) {
 	/*[IF JAVA_SPEC_VERSION >= 24]*/
 	Class<?> caller = Reflection.getCallerClass();
 	Reflection.ensureNativeAccess(caller, System.class, "load", false);
-	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
-
+	/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	@SuppressWarnings("removal")
 	SecurityManager smngr = System.getSecurityManager();
 	if (smngr != null) {
 		smngr.checkLink(pathName);
 	}
-/*[IF JAVA_SPEC_VERSION >= 15]*/
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+	/*[IF JAVA_SPEC_VERSION >= 15]*/
 	/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
 	ClassLoader.loadZOSLibrary(getCallerClass(), pathName);
 	/*[ELSE] PLATFORM-mz31 | PLATFORM-mz64 */
@@ -1156,9 +1169,9 @@ public static void load(String pathName) {
 	}
 	ClassLoader.loadLibrary(getCallerClass(), fileName);
 	/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 */
-/*[ELSE] JAVA_SPEC_VERSION >= 15 */
+	/*[ELSE] JAVA_SPEC_VERSION >= 15 */
 	ClassLoader.loadLibraryWithPath(pathName, ClassLoader.callerClassLoader(), null);
-/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 }
 
 /**
@@ -1167,10 +1180,11 @@ public static void load(String pathName) {
  * @param libName the name of the library to load
  *
  * @throws UnsatisfiedLinkError if the library could not be loaded
- * @throws SecurityException if the library was not allowed to be loaded
  * @throws NullPointerException if libName is null
 /*[IF JAVA_SPEC_VERSION >= 24]
  * @throws IllegalCallerException if the caller belongs to a module where native access is not enabled
+/*[ELSE] JAVA_SPEC_VERSION >= 24
+ * @throws SecurityException if the library was not allowed to be loaded
 /*[ENDIF] JAVA_SPEC_VERSION >= 24
  */
 @CallerSensitive
@@ -1193,12 +1207,13 @@ public static void loadLibrary(String libName) {
 			throw new UnsatisfiedLinkError(Msg.getString("K0B01", libName)); //$NON-NLS-1$
 		}
 	}
-
+/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager smngr = System.getSecurityManager();
 	if (smngr != null) {
 		smngr.checkLink(libName);
 	}
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 /*[IF JAVA_SPEC_VERSION >= 15]*/
 	Class<?> callerClass = getCallerClass();
 /*[ELSE]*/
@@ -1254,17 +1269,21 @@ public static void runFinalizersOnExit(boolean flag) {
  * Sets the system properties. Note that the object which is passed in
  * is not copied, so that subsequent changes made to it will be reflected
  * in calls to {@code getProperty()} and {@code getProperties()}.
+/*[IF JAVA_SPEC_VERSION < 24]
  * <p>
  * Security managers should restrict access to this
  * API if possible.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  *
  * @param		p			the properties to set
  */
 public static void setProperties(Properties p) {
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPropertiesAccess();
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	if (p == null) {
 		ensureProperties(false);
 	} else {
@@ -1525,10 +1544,12 @@ public static String clearProperty(String prop) {
 	if (!propertiesInitialized) throw new Error("bootstrap error, system property access before init: " + prop); //$NON-NLS-1$
 
 	if (prop.length() == 0) throw new IllegalArgumentException();
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new PropertyPermission(prop, "write")); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return (String)systemProperties.remove(prop);
 }
 
@@ -1538,11 +1559,12 @@ public static String clearProperty(String prop) {
  * @return	an unmodifiable Map containing all of the system environment variables.
  */
 public static Map<String, String> getenv() {
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	@SuppressWarnings("removal")
 	SecurityManager security = System.getSecurityManager();
 	if (security != null)
 		security.checkPermission(new RuntimePermission("getenv.*")); //$NON-NLS-1$
-
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return ProcessEnvironment.getenv();
 }
 
@@ -1903,10 +1925,14 @@ public abstract static class LoggerFinder {
 	/**
 	 * Checks needed runtime permissions
 	 *
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if RuntimePermission("loggerFinder") is not allowed
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	protected LoggerFinder() {
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		verifyPermissions();
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	}
 
 	/**
@@ -1917,10 +1943,14 @@ public abstract static class LoggerFinder {
 	 * @param callerModule The module for which the logger is being requested
 	 * @return an instance of Logger
 	 * @throws NullPointerException if loggerName or callerModule is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if RuntimePermission("loggerFinder") is not allowed
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public Logger getLocalizedLogger(String loggerName, ResourceBundle bundle, Module callerModule) {
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		verifyPermissions();
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 		Objects.requireNonNull(loggerName);
 		Objects.requireNonNull(callerModule);
 		Logger logger = this.getLogger(loggerName, callerModule);
@@ -1935,7 +1965,9 @@ public abstract static class LoggerFinder {
 	 * @param callerModule The module for which the logger is being requested
 	 * @return a Logger suitable for use within the given module
 	 * @throws NullPointerException if loggerName or callerModule is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if RuntimePermission("loggerFinder") is not allowed
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public abstract Logger getLogger(String loggerName, Module callerModule);
 
@@ -1943,10 +1975,14 @@ public abstract static class LoggerFinder {
 	 * Returns the LoggerFinder instance
 	 *
 	 * @return the LoggerFinder instance.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if RuntimePermission("loggerFinder") is not allowed
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public static LoggerFinder getLoggerFinder() {
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		verifyPermissions();
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 		LoggerFinder localFinder = loggerFinder;
 		if (localFinder == null) {
 			localFinder = AccessController.doPrivileged(
@@ -1963,6 +1999,7 @@ public abstract static class LoggerFinder {
 		return localFinder;
 	}
 
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	private static void verifyPermissions() {
 		@SuppressWarnings("removal")
 		SecurityManager securityManager = System.getSecurityManager();
@@ -1970,6 +2007,7 @@ public abstract static class LoggerFinder {
 			securityManager.checkPermission(com.ibm.oti.util.RuntimePermissions.permissionLoggerFinder);
 		}
 	}
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 }
 
 /**

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2920,8 +2920,7 @@ fieldIndexTableRemove(J9JavaVM* vm, J9Class *ramClass);
 
 
 /* ---------------- resolvesupport.c ---------------- */
-/*
- */
+#if JAVA_SPEC_VERSION < 24
 /**
  * Perform a package access check from the ProtectionDomain to the targetClass
  * No check is required if no SecurityManager is in place.  If a check is required and the
@@ -2949,6 +2948,7 @@ packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t
  */
 BOOLEAN
 requirePackageAccessCheck(J9JavaVM *vm, J9ClassLoader *srcClassLoader, J9Module *srcModule, J9Class *targetClass);
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 /**
  * @brief

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -502,7 +502,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<!-- Static method references needed to support VirtualThread/Continuation. -->
 	<staticmethodref class="jdk/internal/vm/Continuation" name="enter" signature="(Ljdk/internal/vm/Continuation;)V" versions="19-"/>
 	<!-- Security manager check -->
-	<staticfieldref class="java/lang/System" name="security" signature="Ljava/lang/SecurityManager;"/>
+	<staticfieldref class="java/lang/System" name="security" signature="Ljava/lang/SecurityManager;" versions="8-23"/>
 
 	<!-- VM constants in java -->
 	<staticfieldref class="com/ibm/oti/vm/VM" name="J9_GC_WRITE_BARRIER_TYPE" signature="I"/>

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -155,7 +155,9 @@ static void copyVTable(J9VMThread *vmStruct, J9Class *ramClass, J9Class *supercl
 static UDATA processVTableMethod(J9VMThread *vmThread, J9ClassLoader *classLoader, UDATA *vTableAddress, J9Class *superclass, J9ROMClass *romClass, J9ROMMethod *romMethod, UDATA localPackageID, UDATA vTableMethodCount, void *storeValue, J9OverrideErrorData *errorData);
 static VMINLINE UDATA growNewVTableSlot(UDATA *vTableAddress, UDATA vTableMethodCount, void *storeValue);
 static UDATA getVTableIndexForNameAndSigStartingAt(UDATA *vTable, J9UTF8 *name, J9UTF8 *signature, UDATA vTableIndex);
+#if JAVA_SPEC_VERSION < 24
 static UDATA checkPackageAccess(J9VMThread *vmThread, J9Class *foundClass, UDATA classPreloadFlags);
+#endif /* JAVA_SPEC_VERSION < 24 */
 static void setCurrentExceptionForBadClass(J9VMThread *vmThread, J9UTF8 *badClassName, UDATA exceptionIndex, U_32 nlsModuleName, U_32 nlsMessageID);
 static BOOLEAN verifyClassLoadingStack(J9VMThread *vmThread, J9ClassLoader *classLoader, J9ROMClass *romClass);
 static void popFromClassLoadingStack(J9VMThread *vmThread);
@@ -1441,22 +1443,22 @@ getVTableOffsetForMethod(J9Method * method, J9Class *clazz, J9VMThread *vmThread
 	return 0;
 }
 
+#if JAVA_SPEC_VERSION < 24
 static UDATA
 checkPackageAccess(J9VMThread *vmThread, J9Class *foundClass, UDATA classPreloadFlags)
 {
-	if ((classPreloadFlags & J9_FINDCLASS_FLAG_CHECK_PKG_ACCESS) == J9_FINDCLASS_FLAG_CHECK_PKG_ACCESS) {
-
-		if (!packageAccessIsLegal(vmThread, foundClass, PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0), TRUE))
-		{
-			if ((classPreloadFlags & J9_FINDCLASS_FLAG_THROW_ON_FAIL) != J9_FINDCLASS_FLAG_THROW_ON_FAIL) {
-				vmThread->currentException = NULL;
-				vmThread->privateFlags &= ~J9_PRIVATE_FLAGS_REPORT_EXCEPTION_THROW;
-			}
-			return 1;
+	if (J9_ARE_ANY_BITS_SET(classPreloadFlags, J9_FINDCLASS_FLAG_CHECK_PKG_ACCESS)
+		&& !packageAccessIsLegal(vmThread, foundClass, PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0), TRUE)
+	) {
+		if (J9_ARE_NO_BITS_SET(classPreloadFlags, J9_FINDCLASS_FLAG_THROW_ON_FAIL)) {
+			vmThread->currentException = NULL;
+			vmThread->privateFlags &= ~J9_PRIVATE_FLAGS_REPORT_EXCEPTION_THROW;
 		}
+		return 1;
 	}
 	return 0;
 }
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 /**
  * Sets the current exception using the detailed error message plus the specified class name.
@@ -1690,7 +1692,6 @@ static VMINLINE BOOLEAN
 loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9ROMClass *romClass, UDATA options, J9Class *elementClass,
 	BOOLEAN hotswapping, UDATA classPreloadFlags, J9Class **superclassOut, J9Module *module)
 {
-	J9JavaVM *vm = vmThread->javaVM;
 	BOOLEAN isExemptFromValidation = J9_ARE_ANY_BITS_SET(options, J9_FINDCLASS_FLAG_UNSAFE);
 	J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 	J9UTF8 *superclassName = NULL;
@@ -1724,12 +1725,14 @@ loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9
 				/* we will inherit exemption from superclass */
 				isExemptFromValidation = TRUE;
 			}
+#if JAVA_SPEC_VERSION < 24
 			if (!isExemptFromValidation
-				&& requirePackageAccessCheck(vm, classLoader, module, superclass)
-				&& (checkPackageAccess(vmThread, superclass, classPreloadFlags) != 0)
+				&& requirePackageAccessCheck(vmThread->javaVM, classLoader, module, superclass)
+				&& (0 != checkPackageAccess(vmThread, superclass, classPreloadFlags))
 			) {
 				return FALSE;
 			}
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 			/* ensure that the superclass isn't an interface or final */
 			if (J9_ARE_ANY_BITS_SET(superclass->romClass->modifiers, J9AccFinal)) {
@@ -1782,11 +1785,13 @@ loadSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J9
 					if (interfaceClass == NULL) {
 						return FALSE;
 					}
-					if (requirePackageAccessCheck(vm, classLoader, module, interfaceClass)
-						&& (checkPackageAccess(vmThread, interfaceClass, classPreloadFlags) != 0)
+#if JAVA_SPEC_VERSION < 24
+					if (requirePackageAccessCheck(vmThread->javaVM, classLoader, module, interfaceClass)
+						&& (0 != checkPackageAccess(vmThread, interfaceClass, classPreloadFlags))
 					) {
 						return FALSE;
 					}
+#endif /* JAVA_SPEC_VERSION < 24 */
 					/* ensure that the interface is in fact an interface */
 					if ((interfaceClass->romClass->modifiers & J9AccInterface) != J9AccInterface) {
 						Trc_VM_CreateRAMClassFromROMClass_interfaceIsNotAnInterface(vmThread, interfaceClass);

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -157,12 +157,10 @@ isMethodHandleINL(U_8 *methodName, U_16 methodNameLength)
 }
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
+#if JAVA_SPEC_VERSION < 24
 UDATA   
 packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t protectionDomain, UDATA canRunJavaCode)
 {
-#if JAVA_SPEC_VERSION >= 24
-	return TRUE;
-#else /* JAVA_SPEC_VERSION >= 24 */
 	UDATA legal = FALSE;
 	j9object_t security = J9VMJAVALANGSYSTEM_SECURITY(currentThread, J9VMCONSTANTPOOL_CLASSREF_AT(currentThread->javaVM, J9VMCONSTANTPOOL_JAVALANGSYSTEM)->value);
 	if (NULL == security) {
@@ -178,7 +176,6 @@ packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t
 		}
 	}
 	return legal;
-#endif /* JAVA_SPEC_VERSION >= 24 */
 }
 
 BOOLEAN
@@ -199,6 +196,7 @@ requirePackageAccessCheck(J9JavaVM *vm, J9ClassLoader *srcClassLoader, J9Module 
 	
 	return checkFlag;
 }
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 j9object_t   
 resolveStringRef(J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags)
@@ -361,6 +359,7 @@ tryAgain:
 		goto done;
 	}
 
+#if JAVA_SPEC_VERSION < 24
 	/* Perform a package access check from the current class to the resolved class.
 	 * No check is required if any of the following is true:
 	 * 		- the current class and resolved class are identical
@@ -386,6 +385,7 @@ tryAgain:
 			goto bail;
 		}
 	}
+#endif /* JAVA_SPEC_VERSION < 24 */
 
 	if (jitCompileTimeResolve) {
 		if (J9_ARE_NO_BITS_SET(resolvedClass->romClass->modifiers, J9AccInterface)) {

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -160,6 +160,9 @@ isMethodHandleINL(U_8 *methodName, U_16 methodNameLength)
 UDATA   
 packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t protectionDomain, UDATA canRunJavaCode)
 {
+#if JAVA_SPEC_VERSION >= 24
+	return TRUE;
+#else /* JAVA_SPEC_VERSION >= 24 */
 	UDATA legal = FALSE;
 	j9object_t security = J9VMJAVALANGSYSTEM_SECURITY(currentThread, J9VMCONSTANTPOOL_CLASSREF_AT(currentThread->javaVM, J9VMCONSTANTPOOL_JAVALANGSYSTEM)->value);
 	if (NULL == security) {
@@ -175,6 +178,7 @@ packageAccessIsLegal(J9VMThread *currentThread, J9Class *targetClass, j9object_t
 		}
 	}
 	return legal;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 }
 
 BOOLEAN

--- a/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
+++ b/test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java
@@ -719,17 +719,10 @@ public void test_getDeclaredFieldLjava_lang_String() {
 	}
 */
 
-	/**
-	 * Disable temporarily for Java 24+ until the
-	 * System.security field is removed.
-	 * https://github.com/eclipse-openj9/openj9/issues/20563
-	 */
-	if (VersionCheck.major() < 24) {
-		try {
-			java.lang.reflect.Field f = System.class.getDeclaredField("security");
-			Assert.fail("java.lang.System.security shoud NOT be accessible via reflection");
-		} catch (NoSuchFieldException e) {
-		}
+	try {
+		java.lang.reflect.Field f = System.class.getDeclaredField("security");
+		Assert.fail("java.lang.System.security shoud NOT be accessible via reflection");
+	} catch (NoSuchFieldException e) {
 	}
 
 	try {


### PR DESCRIPTION
This change removes the `System.security` private field from Java 24 which fixes the previously failing reflection check to `System.security` in `test/functional/Java8andUp/src_110_up/org/openj9/test/java/lang/Test_Class.java`.

For previous JDK versions `System.security` was included in [`jdk/internal/reflect/Reflection.fieldFilterMap`](https://github.com/ibmruntimes/openj9-openjdk-jdk23/blob/openj9/src/java.base/share/classes/jdk/internal/reflect/Reflection.java#L65) which would cause a `NoSuchFieldException ` to be thrown during an attempt to reflectively access `System.security`. In JDK 24 OpenJDK has removed the `security` field from the System class and from the fieldFilterMap as well. Since OpenJ9 does not need this field in JDK 24 I will remove it as well. The absence of this field will cause a `NoSuchFieldException` to be thrown if reflective access is attempted.

I have also removed all the calls to `System.getSecurityManager` from JDK 24+ in the System class since it just returns null. There are many other unnecessary calls to `System.getSecurityManager` throughout the code base. I will work on removing these for JDK 24 in a future pull request.

Related: https://github.com/eclipse-openj9/openj9/issues/20563