### PR TITLE
Change DLT opt level based on option

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -938,7 +938,6 @@ static void emptyJitGCMapCheck(J9VMThread * currentThread, J9StackWalkState * wa
 
 static void jitGCMapCheck(J9VMThread* vmThread, IDATA handlerKey, void* userData)
    {
-
    J9StackWalkState walkState;
    walkState.flags = J9_STACKWALK_ITERATE_O_SLOTS | J9_STACKWALK_ITERATE_HIDDEN_JIT_FRAMES | J9_STACKWALK_CHECK_I_SLOTS_FOR_OBJECTS;
    walkState.objectSlotWalkFunction = emptyJitGCMapCheck;
@@ -1067,33 +1066,42 @@ void DLTLogic(J9VMThread* vmThread, TR::CompilationInfo *compInfo)
       TR_J9VMBase * vm = TR_J9VMBase::get(jitConfig, vmThread);
 
       static char *enableDebugDLT = feGetEnv("TR_DebugDLT");
-      bool dltMostOnce = false;
       int32_t enableDLTidx = -1;
       int32_t disableDLTidx = -1;
-      int32_t dltOptLevel = -1;
 
-      if (enableDebugDLT!=NULL)
+      TR::Options *options = TR::Options::getCmdLineOptions();
+      TR::OptionSet *optionSet = NULL;
+      bool dltMostOnce = options->getOption(TR_DLTMostOnce);
+      if (options->anOptionSetContainsADltOptLevel())
          {
-         TR::OptionSet *optionSet = findOptionSet(walkState.method, false);
-         TR::Options *options = optionSet ? optionSet->getOptions() : NULL;
+         optionSet = findOptionSet(walkState.method, false/*AOT*/);
+         if (optionSet)
+            options = optionSet->getOptions();
+         }
+      int32_t dltOptLevel = options->getDLTOptLevel();
 
-         enableDLTidx = options ? options->getEnableDLTBytecodeIndex() : -1;
-         disableDLTidx = options ? options->getDisableDLTBytecodeIndex() : -1;
-
-         if (enableDLTidx != -1)
+      if (enableDebugDLT != NULL)
+         {
+         if (!optionSet)
+            optionSet = findOptionSet(walkState.method, false);
+         // If option set exist, extract DLT related options from it
+         if (optionSet)
             {
-            J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState.method);
-            bcIndex = enableDLTidx;
-            if (enableDLTidx >= (J9_BYTECODE_END_FROM_ROM_METHOD(romMethod)) - (J9_BYTECODE_START_FROM_ROM_METHOD(romMethod)))
+            TR::Options *options = optionSet->getOptions();
+            enableDLTidx = options->getEnableDLTBytecodeIndex();
+            disableDLTidx = options->getDisableDLTBytecodeIndex();
+            if (enableDLTidx != -1)
+               {
+               J9ROMMethod * romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState.method);
+               bcIndex = enableDLTidx;
+               if (enableDLTidx >= (J9_BYTECODE_END_FROM_ROM_METHOD(romMethod)) - (J9_BYTECODE_START_FROM_ROM_METHOD(romMethod)))
+                  return;
+               dltBlock->bcIndex[idx] = enableDLTidx;
+               }
+            if (disableDLTidx != -1 && disableDLTidx == bcIndex)
                return;
-            dltBlock->bcIndex[idx] = enableDLTidx;
+            dltMostOnce = options->getOption(TR_DLTMostOnce);
             }
-         if (disableDLTidx != -1 && disableDLTidx == bcIndex) return;
-
-         dltMostOnce = options ? options->getOption(TR_DLTMostOnce) :
-            TR::Options::getCmdLineOptions()->getOption(TR_DLTMostOnce);
-         dltOptLevel = options ? options->getDLTOptLevel() :
-            TR::Options::getCmdLineOptions()->getDLTOptLevel();
          }
 
       // This setup is for matching dltEntry to the right transfer point. It can be an issue only


### PR DESCRIPTION
Before this change one could force the optimization level of a particular DLT compilation through a command line option (dltOptLevel=...) only if the TR_DebugDLT env var was defined. This was done to avoid the overhead of searching the option subsets for a given method.
This commit allows one to specify the optimization level of DLT compilations without the need of an env var. Examples:
  -Xjit:dltOptLevel=hot
  -Xjit:{myMethod}(dltOptLevel=cold)
The overhead for searching option sets has been eliminated if no option subset uses the dltOptlevel= option

Depends on eclipse/omr#7596