### PR TITLE
Enable new Class.isAssignableFrom evaluator on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4309,3 +4309,10 @@ J9::Z::CodeGenerator::supportsTrapsInTMRegion()
    {
    return self()->comp()->target().isZOS();
    }
+
+bool
+J9::Z::CodeGenerator::supportsInliningOfIsAssignableFrom()
+   {
+   static const bool disableInliningOfIsAssignableFrom = feGetEnv("TR_disableInlineIsAssignableFrom") != NULL;
+   return !disableInliningOfIsAssignableFrom;
+   }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -113,6 +113,7 @@ public:
    bool constLoadNeedsLiteralFromPool(TR::Node *node);
 
    bool supportsTrapsInTMRegion();
+   bool supportsInliningOfIsAssignableFrom();
 
    using J9::CodeGenerator::addAllocatedRegister;
    void addAllocatedRegister(TR_PseudoRegister * temp);


### PR DESCRIPTION
enables new version of the evaluator for Class.isAssignableFrom which uses a C Helper call for interfaces and abstract classes as opposed to a JNI call. The enabled change also does a class depth test at compile time (when possible) to further improve performance of Class.isAssignableFrom