### PR TITLE
Properly initialize the extensionClassLoader from the VM snapshot

### DIFF
--- a/runtime/vm/FastJNI_com_ibm_oti_vm_VM.cpp
+++ b/runtime/vm/FastJNI_com_ibm_oti_vm_VM.cpp
@@ -140,10 +140,17 @@ internalError:
 			}
 			allClassesEndDo(&classWalkState);
 		} else {
-			J9ClassLoader *classLoaderStruct = internalAllocateClassLoader(vm, classLoaderObject);
-			if (J9_CLASSLOADER_TYPE_PLATFORM == loaderType) {
-				/* extensionClassLoader holds the platform class loader in Java 11+ */
-				vm->extensionClassLoader = classLoaderStruct;
+#if defined(J9VM_OPT_SNAPSHOTS)
+			if (IS_RESTORE_RUN(vm) && (J9_CLASSLOADER_TYPE_PLATFORM == loaderType)) {
+				vm->internalVMFunctions->initializeSnapshotClassLoaderObject(vm, vm->extensionClassLoader, classLoaderObject);
+			} else
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+			{
+				J9ClassLoader *classLoaderStruct = internalAllocateClassLoader(vm, classLoaderObject);
+				if (J9_CLASSLOADER_TYPE_PLATFORM == loaderType) {
+					/* extensionClassLoader holds the platform class loader in Java 11+ */
+					vm->extensionClassLoader = classLoaderStruct;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
This patch properly initializes the `extensionClassLoader` on restore runs through the paths in `BytecodeInterpreter.hpp` and `FastJNI_com_ibm_oti_vm_VM.cpp` rather than, incorrectly, allocating a new class loader.

Fixes: eclipse-openj9/openj9#20861
Signed-off-by: Nathan Henderson <nathan.henderson@ibm.com>