### PR TITLE
GlobalCollectorDelegate::tearDown() shouldn't use local _extensions

### DIFF
--- a/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
+++ b/runtime/gc_glue_java/GlobalCollectorDelegate.cpp
@@ -121,9 +121,10 @@ MM_GlobalCollectorDelegate::initialize(MM_EnvironmentBase *env, MM_GlobalCollect
 void
 MM_GlobalCollectorDelegate::tearDown(MM_EnvironmentBase *env)
 {
-	if (_extensions->isStandardGC() && (NULL != _extensions->accessBarrier)) {
-		_extensions->accessBarrier->kill(env);
-		_extensions->accessBarrier = NULL;
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
+	if (extensions->isStandardGC() && (NULL != extensions->accessBarrier)) {
+		extensions->accessBarrier->kill(env);
+		extensions->accessBarrier = NULL;
 	}
 }
 


### PR DESCRIPTION
Local class _extensions field might be not initialized if we call tearDown() before initialize()