### PR TITLE
Recognize StringLatin1.inflate([BI[BII)V

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -6960,7 +6960,7 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             resultReg = inlineFPTrg1Src3(node, TR::InstOpCode::fmadds, cg);
             return true;
 
-         case TR::java_lang_StringLatin1_inflate:
+         case TR::java_lang_StringLatin1_inflate_BICII:
             if (cg->getSupportsInlineStringLatin1Inflate())
                {
                resultReg = inlineStringLatin1Inflate(node, cg);

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -189,7 +189,6 @@
    java_lang_String_decompressedArrayCopy_BICII,
    java_lang_String_decompressedArrayCopy_CIBII,
    java_lang_String_decompressedArrayCopy_CICII,
-   java_lang_StringLatin1_inflate,
    java_lang_String_concat,
    java_lang_String_length,
    java_lang_String_lengthInternal,
@@ -232,6 +231,8 @@
 
    java_lang_StringLatin1_indexOf,
    java_lang_StringLatin1_indexOfChar,
+   java_lang_StringLatin1_inflate_BICII,
+   java_lang_StringLatin1_inflate_BIBII,
 
    java_lang_StringUTF16_charAt,
    java_lang_StringUTF16_checkIndex,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3234,7 +3234,8 @@ void TR_ResolvedJ9Method::construct()
       {
       { x(TR::java_lang_StringLatin1_indexOf,                                 "indexOf",       "([BI[BII)I")},
       { x(TR::java_lang_StringLatin1_indexOfChar,                             "indexOfChar",   "([BIII)I")},
-      { x(TR::java_lang_StringLatin1_inflate,                                 "inflate",       "([BI[CII)V")},
+      { x(TR::java_lang_StringLatin1_inflate_BICII,                           "inflate",       "([BI[CII)V")},
+      { x(TR::java_lang_StringLatin1_inflate_BIBII,                           "inflate",       "([BI[BII)V")},
       { TR::unknownMethod }
       };
 
@@ -5121,7 +5122,8 @@ TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
             case TR::java_lang_System_nanoTime:
             case TR::java_lang_String_hashCodeImplCompressed:
             case TR::java_lang_String_hashCodeImplDecompressed:
-            case TR::java_lang_StringLatin1_inflate:
+            case TR::java_lang_StringLatin1_inflate_BICII:
+            case TR::java_lang_StringLatin1_inflate_BIBII:
             case TR::java_lang_StringCoding_hasNegatives:
             case TR::java_lang_StringCoding_countPositives:
             case TR::sun_nio_ch_NativeThread_current:

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5603,8 +5603,13 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
             }
          break;
          }
-      case TR::java_lang_StringLatin1_inflate:
+      case TR::java_lang_StringLatin1_inflate_BICII:
          if (comp->cg()->getSupportsInlineStringLatin1Inflate())
+            {
+            return true;
+            }
+      case TR::java_lang_StringLatin1_inflate_BIBII:
+         if (comp->cg()->getSupportsArrayTranslateTROTNoBreak() && !comp->target().cpu.isPower())
             {
             return true;
             }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -122,6 +122,25 @@ class RecognizedCallTransformer : public OMR::RecognizedCallTransformer
     */
    void process_java_lang_StringCoding_encodeASCII(TR::TreeTop* treetop, TR::Node* node);
    /** \brief
+    *     Transforms java/lang/StringLatin1.inflate([BI[BII)V using arraytranslate
+    *
+    *  \param treetop
+    *     The treetop which anchors the call node.
+    *
+    *  \param node
+    *     The call node representing a call to java/lang/StringLatin1.inflate([BI[BII)V which has the following shape:
+    *
+    *     \code
+    *     acall <java/lang/StringLatin1.inflate([BI[BII)V>
+    *       <src byte array>
+    *       <src offset>
+    *       <dst byte array>
+    *       <dst offset>
+    *       <length>
+    *     \endcode
+    */
+   void process_java_lang_StringLatin1_inflate_BIBII(TR::TreeTop* treetop, TR::Node* node);
+   /** \brief
     *     Transforms java/lang/StringUTF16.toBytes([CII)[B into a fast allocate and arraycopy sequence with equivalent
     *     semantics.
     *

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12230,7 +12230,7 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
             }
          break;
 
-      case TR::java_lang_StringLatin1_inflate:
+      case TR::java_lang_StringLatin1_inflate_BICII:
          if (cg->getSupportsInlineStringLatin1Inflate())
             {
             bool result = inlineIntrinsicInflate(node, cg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12127,7 +12127,7 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
             }
 
          break;
-      case TR::java_lang_StringLatin1_inflate:
+      case TR::java_lang_StringLatin1_inflate_BICII:
          if (cg->getSupportsInlineStringLatin1Inflate())
             {
             return TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4069,7 +4069,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
          break;
          }
 
-      case TR::java_lang_StringLatin1_inflate:
+      case TR::java_lang_StringLatin1_inflate_BICII:
          if (cg->getSupportsInlineStringLatin1Inflate())
             {
             resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);


### PR DESCRIPTION
This commit recognizes StringLatin1.inflate([BI[BII)V and changes it to an arraytranslate node with boundary checks.