### PR TITLE
Initialize dataAddr field only for non-zero length array

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6612,7 +6612,6 @@ TR_J9VM::getObjectAlignmentInBytes()
    return (I_32)result;
    }
 
-
 TR_ResolvedMethod *
 TR_J9VM::getObjectNewInstanceImplMethod(TR_Memory * trMemory)
    {


### PR DESCRIPTION
Update array inline allocation sequence to initialize dataAddr field only for non-zero length arrays. Field should be left blank for zero length arrays. Additionally this also clears padding field after the size field.