### PR TITLE
Add SVM validations for JITServer ResolvedHandle/DynamicMethod APIs

### DIFF
--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 76; // ID: BpR0Syhau116Bh0vAoVr
+   static const uint16_t MINOR_NUMBER = 77; // ID: J440z7/ZN5+KF233VhGB
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 


### PR DESCRIPTION
The JITServer version of getResolvedDynamicMethod and getResolvedHandleMethod were missing SVM validations, which caused errors when enabling AOT support for Method Handles with JITServer.