### PR TITLE
Consider the compileMethod() API in replenishInvocationCount() Assertion

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11955,7 +11955,9 @@ TR::CompilationInfo::replenishInvocationCount(J9Method *method, TR::Compilation 
       }
    else
       {
-      TR_ASSERT(false, "Unexpected value for method->extra = %p (method=%p)\n", TR::CompilationInfo::getJ9MethodExtra(method), method);
+      TR_ASSERT(comp->getOptimizationPlan()->isExplicitCompilation(),
+         "Unexpected value for method->extra = %p (method=%p)\n",
+         TR::CompilationInfo::getJ9MethodExtra(method), method);
       }
    }
 


### PR DESCRIPTION
Add a flag in the optimization plan for compilations triggered by the compileMethod API, which can have the invocation count be any positive integer; replenishInvocationCount will not raise the assertion failure for unexpected count value.

Based on https://github.com/eclipse-openj9/openj9/issues/15472

Depends on https://github.com/eclipse-omr/omr/pull/7598