### PR TITLE
Account for Truncated Signatures in a JITServerHelpers Assertion

### DIFF
--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -329,7 +329,15 @@ packCallback(const J9ROMClass *romClass, const J9SRP *origSrp, const char *slotN
    if (dst == ctx._cursor)
       ctx._cursor += copyUTF8((J9UTF8 *)dst, str, it->second.second/*truncate*/ ? ctx._generatedPrefixLength : 0);
    else
-      TR_ASSERT((dst < ctx._cursor) && (memcmp(dst, str, J9UTF8_TOTAL_SIZE(str)) == 0), "Must be already copied");
+      TR_ASSERT(
+         (dst < ctx._cursor) && (
+            (it->second.second && (memcmp(utf8Data((J9UTF8 *) dst),
+                                          utf8Data((J9UTF8 *) str),
+                                          ctx._generatedPrefixLength) == 0)) ||
+            (!it->second.second && (memcmp(dst, str, J9UTF8_TOTAL_SIZE(str)) == 0))
+         ),
+         "Must be already copied"
+      );
    }
 
 static void


### PR DESCRIPTION
Add additional checks so that the assertion "(memcmp(dst, str, J9UTF8_TOTAL_SIZE(str)) == 0)" in packCallBack() also accounts for the dst signature being truncated for generated classes. Prevents the non-fatal assertion from failing.

Fixes https://github.com/eclipse-openj9/openj9/issues/20046