### PR TITLE
Optimize array access macros to reduce using is-contiguous check

### DIFF
--- a/runtime/gc_glue_java/EnvironmentDelegate.hpp
+++ b/runtime/gc_glue_java/EnvironmentDelegate.hpp
@@ -207,7 +207,7 @@ public:
 #if defined(J9VM_ENV_DATA64)
 		if (objectModel->isIndexable(objectPtr)) {
 			GC_ArrayObjectModel *indexableObjectModel = &_extensions->indexableObjectModel;
-			if (_vmThread->isVirtualLargeObjectHeapEnabled && indexableObjectModel->isInlineContiguousArraylet((J9IndexableObject *)objectPtr)) {
+			if (indexableObjectModel->isVirtualLargeObjectHeapEnabled() && indexableObjectModel->isInlineContiguousArraylet((J9IndexableObject *)objectPtr)) {
 				_gcEnv._shouldFixupDataAddrForContiguous = indexableObjectModel->shouldFixupDataAddrForContiguous((J9IndexableObject *)objectPtr);
 			} else {
 				_gcEnv._shouldFixupDataAddrForContiguous = false;

--- a/runtime/gc_include/ObjectAllocationAPI.hpp
+++ b/runtime/gc_include/ObjectAllocationAPI.hpp
@@ -321,7 +321,7 @@ public:
 		: _gcAllocationType(currentThread->javaVM->gcAllocationType)
 		, _contiguousIndexableHeaderSize(currentThread->contiguousIndexableHeaderSize)
 #if defined(J9VM_ENV_DATA64)
-		, _isIndexableDataAddrPresent(currentThread->isIndexableDataAddrPresent)
+		, _isIndexableDataAddrPresent(currentThread->javaVM->isIndexableDataAddrPresent)
 #endif /* defined(J9VM_ENV_DATA64) */
 #if defined(J9VM_GC_BATCH_CLEAR_TLH)
 		, _initializeSlotsOnTLHAllocate(currentThread->javaVM->initializeSlotsOnTLHAllocate)

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -2972,7 +2972,7 @@ gcInitializeDefaults(J9JavaVM* vm)
 #if defined(J9VM_ENV_DATA64)
 	vm->isIndexableDualHeaderShapeEnabled = TRUE;
 	vm->isIndexableDataAddrPresent = FALSE;
-	vm->isVirtualLargeObjectHeapEnabled = FALSE;
+	vm->indexableObjectLayout = J9IndexableObjectLayout_NoDataAddr_NoArraylet;
 #endif /* defined(J9VM_ENV_DATA64) */
 
 	/* enable estimateFragmentation for all GCs as default for java, but not the estimated result would not affect concurrentgc kickoff by default */

--- a/runtime/gc_realtime/ConfigurationRealtime.cpp
+++ b/runtime/gc_realtime/ConfigurationRealtime.cpp
@@ -108,7 +108,9 @@ MM_Heap *
 MM_ConfigurationRealtime::createHeapWithManager(MM_EnvironmentBase *env, uintptr_t heapBytesRequested, MM_HeapRegionManager *regionManager)
 {
 	MM_GCExtensionsBase *extensions = env->getExtensions();
-
+	J9JavaVM *vm = (J9JavaVM *)extensions->getOmrVM()->_language_vm;
+	/* Let VM know that Metronome GC has discontiguous indexable object (arraylet layout) */
+	vm->indexableObjectLayout = J9IndexableObjectLayout_NoDataAddr_Arraylet;
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -136,6 +136,11 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 
 #if defined(J9VM_ENV_DATA64)
 	extensions->indexableObjectModel.setIsDataAddressPresent(true);
+	J9JavaVM *vm = (J9JavaVM *)extensions->getOmrVM()->_language_vm;
+	/* Let VM know that indexable objects in Balanced always have dataAddr, and
+	   let's assume initially it has arraylets, which can be later overridden if Offheap is Enabled.
+	 */
+	vm->indexableObjectLayout = J9IndexableObjectLayout_DataAddr_Arraylet;
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	if (extensions->isVirtualLargeObjectHeapRequested) {
 		/* Create off-heap */
@@ -144,9 +149,9 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 			extensions->largeObjectVirtualMemory = largeObjectVirtualMemory;
 			extensions->indexableObjectModel.setEnableVirtualLargeObjectHeap(true);
 			extensions->isVirtualLargeObjectHeapEnabled = true;
-			/* reset vm->isVirtualLargeObjectHeapEnabled and vm->unsafeIndexableHeaderSize for off-heap case */
-			J9JavaVM *vm = (J9JavaVM *)extensions->getOmrVM()->_language_vm;
-			vm->isVirtualLargeObjectHeapEnabled = TRUE;
+			/* Overriding the original assumption that Balanced has arraylets. */
+			vm->indexableObjectLayout = J9IndexableObjectLayout_DataAddr_NoArraylet;
+			/* reset vm->unsafeIndexableHeaderSize for off-heap case */
 			vm->unsafeIndexableHeaderSize = 0;
 		} else {
 #if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -254,7 +254,7 @@ MM_VLHGCAccessBarrier::indexableDataDisplacement(J9VMThread *vmThread, J9Indexab
 	IDATA displacement = 0;
 
 #if defined(J9VM_ENV_DATA64)
-	Assert_MM_true(vmThread->isVirtualLargeObjectHeapEnabled);
+	Assert_MM_true(_extensions->isVirtualLargeObjectHeapEnabled);
 	/* Adjacency check against dst object since src object may be overwritten during sliding compaction. */
 	if (_extensions->indexableObjectModel.isDataAdjacentToHeader(dst))
 #endif /* defined(J9VM_ENV_DATA64) */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -140,6 +140,13 @@
 #define J9ArrayShape32Bit 0x2
 #define J9ArrayShape64Bit 0x3
 
+/* J9IndexableObjectLayout_xxx are used in indexableObjectLayout field in J9VMThread and J9JavaVM */
+#define J9IndexableObjectLayout_NoDataAddr_NoArraylet 0x0 /* StandardGC case */
+#define J9IndexableObjectLayout_NoDataAddr_Arraylet 0x1 /* Metronome GC case */
+#define J9IndexableObjectLayout_DataAddr_NoArraylet 0x2 /* Balanced GC Offheap enabled case */
+#define J9IndexableObjectLayout_DataAddr_Arraylet 0x3 /* Balanced GC Offheap disabled case */
+#define J9IndexableObjectLayout_DataAddrMask 0x2
+#define J9IndexableObjectLayout_ArrayletMask 0x1
 /* @ddr_namespace: map_to_type=J9ClassInitFlags */
 
 /* Constants from J9ClassInitFlags */
@@ -5540,8 +5547,7 @@ typedef struct J9VMThread {
 	UDATA contiguousIndexableHeaderSize;
 	UDATA discontiguousIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
-	UDATA isIndexableDataAddrPresent;
-	U_32 isVirtualLargeObjectHeapEnabled;
+	U_32 indexableObjectLayout;
 #endif /* defined(J9VM_ENV_DATA64) */
 	void* gpInfo;
 	void* jitVMwithThreadInfo;
@@ -5660,6 +5666,10 @@ typedef struct J9VMThread {
 #endif /* defined(J9VM_OPT_JFR) */
 } J9VMThread;
 
+#if defined(J9VM_ENV_DATA64)
+#define J9VMTHREAD_IS_ARRAYLET_ENABLED(vmThread) (J9IndexableObjectLayout_ArrayletMask & (vmThread)->indexableObjectLayout)
+#define J9VMTHREAD_IS_INDEXBLE_DATAADDR_PRESENT(vmThread) (J9IndexableObjectLayout_DataAddrMask & (vmThread)->indexableObjectLayout)
+#endif
 #define J9VMTHREAD_ALIGNMENT  0x100
 #define J9VMTHREAD_RESERVED_C_STACK_FRACTION  8
 #define J9VMTHREAD_STATE_RUNNING  1
@@ -6106,7 +6116,7 @@ typedef struct J9JavaVM {
 	UDATA discontiguousIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
 	UDATA isIndexableDataAddrPresent;
-	U_32 isVirtualLargeObjectHeapEnabled;
+	U_32 indexableObjectLayout;
 	U_32 isIndexableDualHeaderShapeEnabled;
 #endif /* defined(J9VM_ENV_DATA64) */
 	struct J9VMThread* exclusiveVMAccessQueueHead;
@@ -6347,6 +6357,10 @@ typedef struct J9JavaVM {
 #define J9JAVAVM_OBJECT_HEADER_SIZE(vm) (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm) ? sizeof(J9ObjectCompressed) : sizeof(J9ObjectFull))
 #define J9JAVAVM_CONTIGUOUS_INDEXABLE_HEADER_SIZE(vm) ((vm)->contiguousIndexableHeaderSize)
 #define J9JAVAVM_DISCONTIGUOUS_INDEXABLE_HEADER_SIZE(vm) ((vm)->discontiguousIndexableHeaderSize)
+#if defined(J9VM_ENV_DATA64)
+#define J9JAVAVM_IS_ARRAYLET_ENABLED(vm) (J9IndexableObjectLayout_ArrayletMask & (vm)->indexableObjectLayout)
+#define J9JAVAVM_IS_INDEXBLE_DATAADDR_PRESENT(vm) (J9IndexableObjectLayout_DataAddrMask & (vm)->indexableObjectLayout)eObjectLayout)
+#endif
 
 #if JAVA_SPEC_VERSION >= 16
 /* The mask for the signature type identifier */

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -196,8 +196,7 @@ allocateVMThread(J9JavaVM *vm, omrthread_t osThread, UDATA privateFlags, void *m
 	newThread->discontiguousIndexableHeaderSize = vm->discontiguousIndexableHeaderSize;
 	newThread->unsafeIndexableHeaderSize = vm->unsafeIndexableHeaderSize;
 #if defined(J9VM_ENV_DATA64)
-	newThread->isIndexableDataAddrPresent = vm->isIndexableDataAddrPresent;
-	newThread->isVirtualLargeObjectHeapEnabled = vm->isVirtualLargeObjectHeapEnabled;
+	newThread->indexableObjectLayout = vm->indexableObjectLayout;
 #endif /* defined(J9VM_ENV_DATA64) */
 
 	newThread->privateFlags = privateFlags;


### PR DESCRIPTION
Optimize array access macros to use is-contiguous check only in presence
of arraylets

Along with new offheap feature support, Macro Array Element Access
J9JAVAARRAY_EA/J9JAVAARRAY_EA_VM need 1 or 2 more runtime flags check to
handle new cases/new structures. extra runtime condition checks in the
Macro, which is called in hotspot, could cause certain performance
regression in some platforms. especially for standard GC cases, off-heap
would not contribute any benefit at all.

Optimize Macro J9JAVAARRAY_EA/J9JAVAARRAY_EA_VM to avoid runtime check
IsContiguousArray for stamdard GC and balanced GC with off-heap eanable
cases, because there is no discontigouos array for these cases(except o
size array).
1, replace isVirtualLargeObjectHeapEnabled and
isIndexableDataAddrPresent flag with indexableObjectLayout in JavaVM and
J9VmThread.
2, indexableObjectLayout have only 4 states
J9IndexableObjectLayout_NoDataAddr_NoArraylet 0x0 /* StandardGC case */
J9IndexableObjectLayout_NoDataAddr_Arraylet 0x1 /* Metronome GC case */
J9IndexableObjectLayout_DataAddr_NoArraylet 0x2 /* Balanced GC Offheap
enabled case */
J9IndexableObjectLayout_DataAddr_Arraylet 0x3 /* Balanced GC Offheap
disabled case */
3, in Macro J9JAVAARRAY_EA/J9JAVAARRAY_EA_VM, check StandardGC case and
Balanced GC Offheap enabled case first in order to reduce runtime
 condition check for standard GC(Balanced GC Offheap enabled case too),
 then avoid performance regression(reduce flag numbers in J9VmThread
 also could help reduce the regression for some platforms).
4, flag isVirtualLargeObjectHeapEnabled and isIndexableDataAddrPresent
has been removed from J9VmThread
flag isVirtualLargeObjectHeapEnabled has been removed from JavaVM (we
still keep flag isIndexableDataAddrPresent in JavaVM for minimizing the
changes).

Signed-off-by: lhu <linhu@ca.ibm.com>