### PR TITLE
Include temporarily disabled Valhalla code

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -583,9 +583,7 @@ final class Access implements JavaLangAccess {
 		return StringConcatHelper.mix(lengthCoder, value);
 	}
 
-	/*[IF !INLINE-TYPES]*/
 	@Override
-	/*[ENDIF] !INLINE-TYPES */
 	public PrintStream initialSystemErr() {
 		return System.initialErr;
 	}
@@ -868,9 +866,7 @@ final class Access implements JavaLangAccess {
 		return VirtualThread.defaultScheduler();
 	}
 
-	/*[IF !INLINE-TYPES]*/
 	@Override
-	/*[ENDIF] !INLINE-TYPES */
 	public Stream<ScheduledExecutorService> virtualThreadDelayedTaskSchedulers() {
 		return VirtualThread.delayedTaskSchedulers();
 	}


### PR DESCRIPTION
The changes reflect part of the fix for issue https://github.com/eclipse-openj9/openj9/issues/19144.

Removed `!INLINE-TYPES ` for changes now supported by Valhalla project.
There is still some code not supported by Valhalla.

Signed-off-by: Nick Kamal <[nick.kamal@ibm.com](mailto:nick.kamal@ibm.com)>