### PR TITLE
Address some compiler warnings in DDR

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
@@ -182,12 +182,10 @@ public class J9DDRClassLoader extends SecureClassLoader {
 		if (finalSeparator != -1) {
 			String packageName = name.substring(0, finalSeparator);
 
-			if (getPackage(packageName) != null) {
-				return;
+			if (getDefinedPackage(packageName) == null) {
+				// TODO think about the correct values here
+				definePackage(packageName, "J9DDR", "0.1", "IBM", "J9DDR", "0.1", "IBM", null);
 			}
-
-			// TODO think about the correct values here
-			definePackage(packageName, "J9DDR", "0.1", "IBM", "J9DDR", "0.1", "IBM", null);
 		}
 	}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -49,7 +49,7 @@ import javax.imageio.stream.ImageInputStream;
 import com.ibm.j9ddr.logging.LoggerNames;
 
 // TODO: Lazy initializing has been removed.  Need to decide if it stays out.
-public class StructureReader {
+public final class StructureReader {
 	public static final int VERSION = 1;
 	public static final int J9_STRUCTURES_EYECATCHER = 0xFACEDEB8; // eyecatcher / magic identifier for a J9 structure file
 	private Map<String, StructureDescriptor> structures = null;
@@ -63,8 +63,7 @@ public class StructureReader {
 	private static final Logger logger = Logger.getLogger(LoggerNames.LOGGER_STRUCTURE_READER);
 	private StructureHeader header;
 
-	@SuppressWarnings("rawtypes")
-	public static final Class<?>[] STRUCTURE_CONSTRUCTOR_SIGNATURE = new Class[] { Long.TYPE };
+	public static final Class<?>[] STRUCTURE_CONSTRUCTOR_SIGNATURE = new Class<?>[] { Long.TYPE };
 	public static final byte BIT_FIELD_FORMAT_LITTLE_ENDIAN = 1;
 	public static final byte BIT_FIELD_FORMAT_BIG_ENDIAN = 2;
 	public static final int BIT_FIELD_CELL_SIZE = 32;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/VMDataFactory.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/VMDataFactory.java
@@ -221,7 +221,7 @@ public abstract class VMDataFactory {
 			// Load an instantiate a VM specific J9RASPointer via a call to J9RASPointer.cast(long);
 			String basePackageName = structureReader.getPackageName(PackageNameType.POINTER_PACKAGE_DOT_NAME);
 			Class<?> rasClazz = ddrClassLoader.loadClass(basePackageName + ".J9RASPointer");
-			Method getStructureMethod = rasClazz.getDeclaredMethod("cast", new Class[] { Long.TYPE });
+			Method getStructureMethod = rasClazz.getDeclaredMethod("cast", Long.TYPE);
 			Object pointer = getStructureMethod.invoke(null, new Object[] { j9RASAddress });
 
 			// Set the J9RASPointer on DataType.

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindCode.java
@@ -19,7 +19,6 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-
 package com.ibm.j9ddr.corereaders.minidump.unwind;
 
 import com.ibm.j9ddr.CorruptDataException;
@@ -32,51 +31,50 @@ public class UnwindCode {
 	private UnwindModule module;
 	private UnwindInfo info;
 	private IAddressSpace process;
-	
+
 	// Offsets worked out from UNWIND_CODE in port\win64amd\j9signal.c
 	// Also available from MSDN.
 	private static final int OFFSET_CODEOFFSET = 0;
 	private static final int OFFSET_UNWINDOP = 1; // First four bits.
-	private static final int OFFSET_OPINFO = 1;   // Second four bits.
+	private static final int OFFSET_OPINFO = 1; // Second four bits.
 	private static final int OFFSET_SLOT1 = 2; // Next two slots, optional.
 	private static final int OFFSET_SLOT2 = 4;
-	
+
 	final static String[] REGISTERS = {"RAX", "RCX", "RDX", "RBX", "RSP", "RBP", "RSI", "RDI",
 		"R8", "R9", "R10", "R11", "R12", "R13", "R14", "R15"};
-	
+
 	public UnwindCode(IAddressSpace process, UnwindModule module, UnwindInfo info, long address) {
 		this.process = process;
 		this.module = module;
 		this.info = info;
 		this.address = address;
 	}
-	
+
 	private byte getOffset() throws MemoryFault {
-		byte offset = (byte)(process.getByteAt(OFFSET_CODEOFFSET + module.getLoadAddress() + address));
+		byte offset = process.getByteAt(OFFSET_CODEOFFSET + module.getLoadAddress() + address);
 		return offset;
 	}
-	
+
 	private byte getOpCode() throws MemoryFault {
-		byte code = (byte)(process.getByteAt(OFFSET_UNWINDOP + module.getLoadAddress() + address) & (byte)0x0F);
+		byte code = (byte) (process.getByteAt(OFFSET_UNWINDOP + module.getLoadAddress() + address) & 0x0F);
 		return code;
 	}
-	
+
 	private byte getOpInfo() throws MemoryFault {
-		byte info = (byte)(process.getByteAt(OFFSET_OPINFO + module.getLoadAddress() + address) & (byte)0xF0);
-		info = (byte)((info >> (byte)4) & 0x0F);
+		byte info = (byte) ((process.getByteAt(OFFSET_OPINFO + module.getLoadAddress() + address) >> 4) & 0x0F);
 		return info;
 	}
-	
+
 	private short getNode1() throws MemoryFault {
-		short node = (short)(process.getShortAt(OFFSET_SLOT1 + module.getLoadAddress() + address));
+		short node = process.getShortAt(OFFSET_SLOT1 + module.getLoadAddress() + address);
 		return node;
 	}
-	
+
 	private short getNode2() throws MemoryFault {
-		short node = (short)(process.getShortAt(OFFSET_SLOT2 + module.getLoadAddress() + address));
+		short node = process.getShortAt(OFFSET_SLOT2 + module.getLoadAddress() + address);
 		return node;
 	}
-	
+
 	/* Format the arguments for an operation. n1 and n2 are the next two
 	 * slots in case this operation requires them.
 	 * Full explanations of each op are on the msdn page for UNWIND_CODE here:
@@ -90,27 +88,27 @@ public class UnwindCode {
 		byte opInfo = getOpInfo();
 		switch (opCode) {
 		case (byte)0: //UWOP_PUSH_NONVOL
-			return String.format("Op: PUSH_NONVOL, Info: 0x%x, register = %s", opInfo, REGISTERS[opInfo]); 
+			return String.format("Op: PUSH_NONVOL, Info: 0x%x, register = %s", opInfo, REGISTERS[opInfo]);
 		case (byte)1: //UWOP_ALLOC_LARGE
 			if( opInfo == 0 ) {
-				return String.format("Op: ALLOC_LARGE, Info: 0x%x, size = 0x%x", opInfo, (getNode1()*8));
+				return String.format("Op: ALLOC_LARGE, Info: 0x%x, size = 0x%x", opInfo, getNode1() * 8);
 			} else {
 				return String.format("Op: ALLOC_LARGE - Untested");
 			}
 		case (byte)2: //UWOP_ALLOC_SMALL
-			return String.format("Op: ALLOC_SMALL, Info: 0x%x, size = 0x%x", opInfo, (opInfo*8) + 8); 
+			return String.format("Op: ALLOC_SMALL, Info: 0x%x, size = 0x%x", opInfo, (opInfo * 8) + 8);
 		case (byte)3: //UWOP_SET_FPREG
 			return String.format("Op: SET_FPREG,Info: 0x%x, Set %s to  RSP + FrameOffset", opInfo, "FrameRegister"); // opInfo is reserved and should not be used for this operation.
 		case (byte)4: //UWOP_SAVE_NONVOL
-			return String.format("Op: SAVE_NONVOL, Info: 0x%x, register = %s, offset=0x%x", opInfo, REGISTERS[opInfo], (getNode1()*8)); 
+			return String.format("Op: SAVE_NONVOL, Info: 0x%x, register = %s, offset=0x%x", opInfo, REGISTERS[opInfo], getNode1() * 8);
 		case (byte)5: //UWOP_SAVE_NONVOL_FAR
-			return String.format("Op: SAVE_NONVOL_FAR, Info: 0x%x, register = %s, offset=0x%x", opInfo, REGISTERS[opInfo], ((int)(getNode1())) << 16 + (int)getNode2()); 
+			return String.format("Op: SAVE_NONVOL_FAR, Info: 0x%x, register = %s, offset=0x%x", opInfo, REGISTERS[opInfo], ((int)(getNode1()) << 16) + (int)getNode2());
 		case (byte)8: //UWOP_SAVE_XMM128
-			return String.format("Op: SAVE_XMM128, Info: 0x%x, register = %s, offset=0x%x", opInfo, REGISTERS[opInfo], (getNode1()*16));
+			return String.format("Op: SAVE_XMM128, Info: 0x%x, register = %s, offset=0x%x", opInfo, REGISTERS[opInfo], getNode1() * 16);
 		case (byte)9: //UWOP_SAVE_XMM128_FAR
-			return String.format("Op: SAVE_XMM128_FAR, Info:  register = %s, offset=0x%x", REGISTERS[opInfo], ((int)(getNode1())) << 16 + (int)getNode2());
-		case (byte)10://UWOP_PUSH_MACHFRAME 
-			if( opInfo == 0 ) {
+			return String.format("Op: SAVE_XMM128_FAR, Info:  register = %s, offset=0x%x", REGISTERS[opInfo], ((int)(getNode1()) << 16) + (int)getNode2());
+		case (byte) 10://UWOP_PUSH_MACHFRAME
+			if (opInfo == 0) {
 				return "Op: UWOP_PUSH_MACHFRAME with no error code - Untested";
 			} else {
 				return "Op: UWOP_PUSH_MACHFRAME with error code - Untested";
@@ -120,7 +118,7 @@ public class UnwindCode {
 			throw new CorruptDataException("Invalid stack unwind opcode " + opCode);
 		}
 	}
-	
+
 	/* Returns the number of unwind code slots this op
 	 * occupies. Used to work out where the next opcode is.
 	 */
@@ -128,28 +126,28 @@ public class UnwindCode {
 		byte opCode = getOpCode();
 		byte opInfo = getOpInfo();
 		switch (opCode) {
-		case (byte)0: //UWOP_PUSH_NONVOL
-			return 1; 
-		case (byte)1: //UWOP_ALLOC_LARGE
-			if( opInfo == 0 ) {
+		case (byte) 0: //UWOP_PUSH_NONVOL
+			return 1;
+		case (byte) 1: //UWOP_ALLOC_LARGE
+			if (opInfo == 0) {
 				return 2;
 			} else {
 				return 3;
 			}
-		case (byte)2: //UWOP_ALLOC_SMALL
+		case (byte) 2: //UWOP_ALLOC_SMALL
 			return 1;
-		case (byte)3: //UWOP_SET_FPREG
+		case (byte) 3: //UWOP_SET_FPREG
 			return 1;
-		case (byte)4: //UWOP_SAVE_NONVOL
-			return 2; 
-		case (byte)5: //UWOP_SAVE_NONVOL_FAR
-			return 3; 
-		case (byte)8: //UWOP_SAVE_XMM128
-			return 2; 
-		case (byte)9: //UWOP_SAVE_XMM128_FAR
-			return 3;  
-		case (byte)10://UWOP_PUSH_MACHFRAME 
-			return 1; 
+		case (byte) 4: //UWOP_SAVE_NONVOL
+			return 2;
+		case (byte) 5: //UWOP_SAVE_NONVOL_FAR
+			return 3;
+		case (byte) 8: //UWOP_SAVE_XMM128
+			return 2;
+		case (byte) 9: //UWOP_SAVE_XMM128_FAR
+			return 3;
+		case (byte) 10://UWOP_PUSH_MACHFRAME
+			return 1;
 		default:
 			throw new CorruptDataException("Invalid stack unwind opcode " + opCode);
 		}
@@ -158,7 +156,7 @@ public class UnwindCode {
 	/*
 	 * To adjust the stack pointer we don't need to run the operation just
 	 * work out by how much that operation adjusts the stack pointer.
-	 * 
+	 *
 	 */
 	/* TODO There's only about 8 operations but I've only some in real stacks so
 	 * far and others only by dumping all the unwind info for all modules in
@@ -173,16 +171,16 @@ public class UnwindCode {
 		byte opInfo = getOpInfo();
 		switch (opCode) {
 		case (byte)0: //UWOP_PUSH_NONVOL
-			return currentSP + 8; // Decrements SP by 8, so return +8 
+			return currentSP + 8; // Decrements SP by 8, so return +8
 		case (byte)1: //UWOP_ALLOC_LARGE
 			if( opInfo == 0 ) {
-				return currentSP + (getNode1()*8); // Node1 contains alloc size / 8
+				return currentSP + (getNode1() * 8); // Node1 contains alloc size / 8
 			} else {
 				//System.err.println("Found untested opcode UWOP_ALLOC_LARGE with opInfo != 0");
 				throw new CorruptDataException("Untested stack unwind opcode " + opCode);
 			}
 		case (byte)2: //UWOP_ALLOC_SMALL
-			return currentSP + ((opInfo*8) + 8); // Allocates (opInfo*8) + 8 bytes of stack space.
+			return currentSP + ((opInfo * 8) + 8); // Allocates (opInfo * 8) + 8 bytes of stack space.
 		case (byte)3: //UWOP_SET_FPREG
 			//System.err.println("Found untested opcode UWOP_SET_FPREG");
 			throw new CorruptDataException("Untested stack unwind opcode " + opCode);
@@ -201,7 +199,7 @@ public class UnwindCode {
 			throw new CorruptDataException("Invalid stack unwind opcode " + opCode);
 		}
 	}
-	
+
 	public String toString() {
 		try {
 			return String.format("Offset 0x%02x : ", getOffset()) + formatOp();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
@@ -19,10 +19,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-
 package com.ibm.j9ddr.corereaders.minidump.unwind;
-
-import java.io.IOException;
 
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.corereaders.memory.IAddressSpace;
@@ -34,60 +31,57 @@ public class UnwindInfo {
 	private long address;
 	private UnwindModule module;
 	private IAddressSpace process;
-	
+
 	// Offsets worked out from UNWIND_INFO in port\win64amd\j9signal.c
 	// Also available from MSDN.
 	// First and second fields and fifth and sixth fields are bit fields.
 	private static final int OFFSET_VERSION = 0; // 3 bits
-	private static final int OFFSET_FLAGS = 0;   // 4 bits
+	private static final int OFFSET_FLAGS = 0; // 4 bits
 	private static final int OFFSET_SIZEOFPROLOG = 1;
 	private static final int OFFSET_COUNTOFCODES = 2;
 	private static final int OFFSET_FRAMEREGISTER = 3; // 4 bits
-	private static final int OFFSET_FRAMEOFFSET = 3;   // 4 bits
+	private static final int OFFSET_FRAMEOFFSET = 3; // 4 bits
 	private static final int OFFSET_UNWINDCODE = 4;
-	
+
 	/**
 	 * Constructor for UnwindInfo, takes the address in
 	 * the module where the unwind information can be found.
 	 * @param address
 	 * @throws CorruptDataException 
-	 * @throws IOException 
 	 */
 	public UnwindInfo(IAddressSpace process, UnwindModule module, long address) throws CorruptDataException {
 		this.address = address;
 		this.module = module;
 		this.process = process;
 		byte version = getVersion();
-		if( version != 1 ) {
-			throw new CorruptDataException(String.format("Incorrect version number %d in UNWIND_INFO at 0x&08x", version, address));
+		if (version != 1) {
+			throw new CorruptDataException(String.format("Incorrect version number %d in UNWIND_INFO at 0x%08x", version, address));
 		}
 	}
-	
+
 	/* The version is actually only the first 3 bits and should always
 	 * be 1;
 	 */
 	private byte getVersion() throws MemoryFault {
-		byte version = (byte)(process.getByteAt(OFFSET_VERSION + module.getLoadAddress() + address) & (byte)0x7);
+		byte version = (byte) (process.getByteAt(OFFSET_VERSION + module.getLoadAddress() + address) & 0x7);
 		return version;
 	}
 
 	private byte getFlags() throws MemoryFault {
-		byte flags = (byte)(process.getByteAt(OFFSET_FLAGS + module.getLoadAddress() + address) & (byte)0xf8);
-		flags = (byte)(flags >> 3);
+		byte flags = (byte) ((process.getByteAt(OFFSET_FLAGS + module.getLoadAddress() + address) >> 3) & 0x1f);
 		return flags;
 	}
 
 	private byte getPrologSize() throws MemoryFault {
-		byte prologSize = (byte)process.getByteAt(OFFSET_SIZEOFPROLOG + module.getLoadAddress() + address);
+		byte prologSize = process.getByteAt(OFFSET_SIZEOFPROLOG + module.getLoadAddress() + address);
 		return prologSize;
 	}
 
-	
 	private byte getCountOfCodes() throws MemoryFault {
-		byte codeCount = (byte)process.getByteAt(OFFSET_COUNTOFCODES + module.getLoadAddress() + address);
-		return codeCount ;
+		byte codeCount = process.getByteAt(OFFSET_COUNTOFCODES + module.getLoadAddress() + address);
+		return codeCount;
 	}
-	
+
 	public String toString() {
 		String str = "";
 		try {
@@ -95,17 +89,17 @@ public class UnwindInfo {
 			byte flags = getFlags();
 			byte prologSize = getPrologSize();
 			byte countOfCodes = getCountOfCodes();
-			str += String.format("Version: 0x%x, flags 0x%x, SizeOfProlog 0x%02x, CountOfCodes %d", version, flags, prologSize, countOfCodes );
+			str += String.format("Version: 0x%x, flags 0x%x, SizeOfProlog 0x%02x, CountOfCodes %d", version, flags, prologSize, countOfCodes);
 			long unwindCodeAddr = OFFSET_UNWINDCODE + address;
-			for ( byte codeIndex = 0; codeIndex < countOfCodes; ) { 
+			for (byte codeIndex = 0; codeIndex < countOfCodes;) {
 				UnwindCode c = new UnwindCode(process, module, this, unwindCodeAddr);
 				str += "\n\t";
 				str += c.toString();
 				codeIndex += c.getNodeCount();
-				unwindCodeAddr += 2*c.getNodeCount();// An unwind code is 2 bytes.
+				unwindCodeAddr += 2 * c.getNodeCount();// An unwind code is 2 bytes.
 			}
 			return str;
-		} catch (MemoryFault mf ) {
+		} catch (MemoryFault mf) {
 			return "Error getting UnwindInfo " + mf.toString();
 		} catch (CorruptDataException e) {
 			return "Error getting UnwindInfo " + e.toString();
@@ -117,10 +111,9 @@ public class UnwindInfo {
 	 * http://msdn.microsoft.com/en-us/library/8ydc79k6%28v=vs.110%29.aspx
 	 */
 	public long apply(long stackPointer) throws CorruptDataException {
-
 		// Need to account for no codes and chained data.
 		byte version = getVersion();
-		if( version != 1 ) {
+		if (version != 1) {
 			// The version number should always be 1, if it goes up we won't know what to
 			// do with the data anyway.
 			throw new CorruptDataException("Invalid version " + version + " in UNWIND_INFO expected 1");
@@ -128,25 +121,25 @@ public class UnwindInfo {
 		byte flags = getFlags();
 		byte prologSize = getPrologSize();
 		byte countOfCodes = getCountOfCodes();
-		
-		if( countOfCodes == 0 ) {
+
+		if (countOfCodes == 0) {
 			// Just return stackPointer.
 			// System.err.println("No unwind codes, returning rsp");
 		} else {
 			// Hopefully we are just interested in the effect on the stack pointer.
 			long unwindCodeAddr = OFFSET_UNWINDCODE + address;
 
-			for ( byte codeIndex = 0; codeIndex < countOfCodes; ) { 
+			for (byte codeIndex = 0; codeIndex < countOfCodes;) {
 				//System.err.println(String.format("Stack pointer is: 0x%08x", stackPointer));
 				UnwindCode c = new UnwindCode(process, module, this, unwindCodeAddr);
 
 				//System.err.println("Applying: " + c.formatOp());
 				stackPointer = c.getNewSP(stackPointer);
 				codeIndex += c.getNodeCount();
-				unwindCodeAddr += 2*c.getNodeCount();// An unwind code is 2 bytes.
+				unwindCodeAddr += 2 * c.getNodeCount(); // An unwind code is 2 bytes.
 			}
 		}
-		if( (flags & FLAGS_CHAINED) == FLAGS_CHAINED) {
+		if ((flags & FLAGS_CHAINED) == FLAGS_CHAINED) {
 			UnwindInfo chainedInfo = getChainedUnwindInfo();
 			//System.err.println("Applying chained info: " + chainedInfo);
 			stackPointer = chainedInfo.apply(stackPointer);
@@ -158,11 +151,9 @@ public class UnwindInfo {
 		// This is a runtime function entry that comes after the unwind codes, address + OFFSET_UNWINDCODE
 		// Unwind codes are two bytes, (getCountOfCodes() * 2)
 		// The address of the next unwind info is the third int field in that structure, (2*4)  
-		long chainedAddress = process.getIntAt(module.getLoadAddress() + address + OFFSET_UNWINDCODE + (getCountOfCodes() * 2) + (2*4));
+		long chainedAddress = process.getIntAt(module.getLoadAddress() + address + OFFSET_UNWINDCODE + (getCountOfCodes() * 2) + (2 * 4));
 		UnwindInfo chainedEntry = new UnwindInfo(process, module, chainedAddress);
 		return chainedEntry;
 	}
 
-
-	
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/TDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/TDumpReader.java
@@ -78,24 +78,22 @@ import com.ibm.j9ddr.corereaders.tdump.zebedee.util.FileFormatException;
 
 /**
  * zOS dump reader implemented as a thin wrapper around Zebedee.
- * 
+ *
  * @author andhall
- * 
  */
 public class TDumpReader implements ICoreFileReader
 {
 	private static final Logger logger = Logger.getLogger(J9DDR_CORE_READERS_LOGGER_NAME);
-	
+
 	private final static int DR1 = 0xC4D9F140; // 31-bit OS
 	private final static int DR2 = 0xC4D9F240; // 64-bit OS
 
 	public boolean validDump(byte[] data, long filesize)
 	{
-
-	int signature = (0xFF000000 & data[0] << 24)
+		int signature = (0xFF000000 & data[0] << 24)
 		| (0x00FF0000 & data[1] << 16) | (0x0000FF00 & data[2] << 8)
 		| (0xFF & data[3]);
-	
+
 		return (signature == DR1 || signature == DR2);
 	}
 
@@ -103,7 +101,7 @@ public class TDumpReader implements ICoreFileReader
 	{
 		return new DumpAdapter(new com.ibm.j9ddr.corereaders.tdump.zebedee.dumpreader.Dump(path));
 	}
-	
+
 	public ICore processDump(ImageInputStream in) throws InvalidDumpFormatException, IOException
 	{
 		return new DumpAdapter(new com.ibm.j9ddr.corereaders.tdump.zebedee.dumpreader.Dump(in));
@@ -133,13 +131,13 @@ public class TDumpReader implements ICoreFileReader
 			throw new IOException(ex.getMessage());
 		}
 	}
-	
+
 	public DumpTestResult testDump(ImageInputStream in) throws IOException
-	{	
+	{
 		try {
 			in.seek(0);
 			int header = in.readInt();
-			if((header == DR1) || (header == DR2)) {
+			if ((header == DR1) || (header == DR2)) {
 				return DumpTestResult.RECOGNISED_FORMAT;
 			} else {
 				return DumpTestResult.UNRECOGNISED_FORMAT;
@@ -151,40 +149,36 @@ public class TDumpReader implements ICoreFileReader
 			ioe.initCause(ex);
 			throw ioe;
 		} finally {
-			in.seek(0);		//reset the header
+			in.seek(0); //reset the header
 		}
 	}
 
 	private static class DumpAdapter implements ICore
 	{
-	
+
 		private final Dump _dump;
-	
+
 		private List<IAddressSpace> addressSpaces = null;
-		
-		public DumpAdapter(Dump dump)
-		{
+
+		public DumpAdapter(Dump dump) {
 			_dump = dump;
 		}
 
 		public void close() throws IOException {
 			_dump.close();
 		}
-		
+
 		/*
 		 * (non-Javadoc)
 		 * 
 		 * @see com.ibm.dtfj.j9ddr.corereaders.ICoreReader#getAddressSpaces()
 		 */
-		public List<IAddressSpace> getAddressSpaces()
-		{
+		public List<IAddressSpace> getAddressSpaces() {
 			if (null == addressSpaces) {
-			
 				AddressSpace[] zebAddressSpaces = _dump.getAddressSpaces();
-				
-				addressSpaces = new ArrayList<IAddressSpace>(
-						zebAddressSpaces.length);
-				
+
+				addressSpaces = new ArrayList<>(zebAddressSpaces.length);
+
 				for (AddressSpace thisAs : zebAddressSpaces) {
 					/* Ignore A/S 0 */
 					if (thisAs.getAsid() != 0) {
@@ -192,25 +186,21 @@ public class TDumpReader implements ICoreFileReader
 					}
 				}
 			}
-	
+
 			return addressSpaces;
 		}
-	
+
 		/*
 		 * (non-Javadoc)
 		 * 
 		 * @see com.ibm.dtfj.j9ddr.corereaders.ICoreReader#getDumpFormat()
 		 */
-		public String getDumpFormat()
-		{
+		public String getDumpFormat() {
 			return "tdump";
 		}
-	
-	
-	
+
 		@Override
-		public boolean equals(Object obj)
-		{
+		public boolean equals(Object obj) {
 			if (this == obj) {
 				return true;
 			}
@@ -230,34 +220,31 @@ public class TDumpReader implements ICoreFileReader
 			}
 			return true;
 		}
-	
+
 		@Override
-		public int hashCode()
-		{
+		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
 			result = prime * result + ((_dump == null) ? 0 : _dump.hashCode());
 			return result;
 		}
-		
-		public Properties getProperties()
-		{
+
+		public Properties getProperties() {
 			Properties properties = new Properties();
-			
+
 			properties.setProperty(ICore.CORE_CREATE_TIME_PROPERTY, Long.toString(_dump.getCreationDate().getTime()));
 			properties.setProperty(ICore.PROCESSOR_TYPE_PROPERTY,"s390");
 			properties.setProperty(ICore.PROCESSOR_SUBTYPE_PROPERTY,"");
-			properties.setProperty(ICore.SYSTEM_TYPE_PROPERTY,"z/OS");
-			
+			properties.setProperty(ICore.SYSTEM_TYPE_PROPERTY, "z/OS");
+
 			return properties;
 		}
-		
-		public Platform getPlatform()
-		{
+
+		public Platform getPlatform() {
 			return Platform.ZOS;
 		}
 	}
-	
+
 	/**
 	 * Adapter for Zebedee address spaces to make them implement the
 	 * IAddressSpace interface
@@ -265,8 +252,7 @@ public class TDumpReader implements ICoreFileReader
 	 * @author andhall
 	 * 
 	 */
-	private static class AddressSpaceAdapter extends SearchableMemory implements IAddressSpace
-	{
+	private static class AddressSpaceAdapter extends SearchableMemory implements IAddressSpace {
 
 		private final AddressSpace addressSpace;
 		private final ICore reader;
@@ -276,8 +262,7 @@ public class TDumpReader implements ICoreFileReader
 		 */
 		private Set<IProcess> processes;
 
-		private AddressSpaceAdapter(AddressSpace as, ICore reader)
-		{
+		private AddressSpaceAdapter(AddressSpace as, ICore reader) {
 			this.addressSpace = as;
 			this.reader = reader;
 		}
@@ -285,9 +270,8 @@ public class TDumpReader implements ICoreFileReader
 		public ICore getCore() {
 			return reader;
 		}
-		
-		public Collection<IProcess> getProcesses()
-		{
+
+		public Collection<IProcess> getProcesses() {
 			initializeProcesses();
 
 			if (processes != null) {
@@ -297,8 +281,7 @@ public class TDumpReader implements ICoreFileReader
 			}
 		}
 
-		private void initializeProcesses()
-		{
+		private void initializeProcesses() {
 			if (processes != null) {
 				return;
 			}
@@ -306,14 +289,14 @@ public class TDumpReader implements ICoreFileReader
 			Tcb tc[] = Tcb.getTcbs(addressSpace);
 			if (tc != null) {
 				processes = new HashSet<IProcess>();
-				
+
 				Set<Edb> knownEdbs = new HashSet<Edb>();
-				
+
 				for (int i = 0; i < tc.length; ++i) {
 					try {
 						Caa ca = new Caa(tc[i]);
 						Edb edb = ca.getEdb();
-						if (! knownEdbs.contains(edb)) {
+						if (!knownEdbs.contains(edb)) {
 							knownEdbs.add(edb);
 							// Some EDBs don't have any modules, so ignore them
 							if (edb.getFirstDll() != null) {
@@ -327,14 +310,12 @@ public class TDumpReader implements ICoreFileReader
 			}
 		}
 
-		public int getAddressSpaceId()
-		{
+		public int getAddressSpaceId() {
 			return addressSpace.getAsid();
 		}
-		
+
 		@Override
-		public int hashCode()
-		{
+		public int hashCode() {
 			final int prime = 31;
 			int result = 1;
 			result = prime * result
@@ -347,8 +328,7 @@ public class TDumpReader implements ICoreFileReader
 		}
 
 		@Override
-		public boolean equals(Object obj)
-		{
+		public boolean equals(Object obj) {
 			if (this == obj) {
 				return true;
 			}
@@ -415,7 +395,7 @@ public class TDumpReader implements ICoreFileReader
 			} catch (IOException e) {
 				throw new MemoryFault(address, e);
 			}
-			
+
 			return length;
 		}
 
@@ -440,12 +420,12 @@ public class TDumpReader implements ICoreFileReader
 		public Collection<? extends IMemoryRange> getMemoryRanges()
 		{
 			AddressRange[] zebedeeRanges = addressSpace.getAddressRanges();
-			List<IMemoryRange> memoryRanges = new ArrayList<IMemoryRange>(zebedeeRanges.length);
-			
+			List<IMemoryRange> memoryRanges = new ArrayList<>(zebedeeRanges.length);
+
 			for (AddressRange thisRange : zebedeeRanges) {
 				memoryRanges.add(new AddressRangeAdapter(addressSpace, thisRange));
 			}
-			
+
 			return memoryRanges;
 		}
 
@@ -473,7 +453,7 @@ public class TDumpReader implements ICoreFileReader
 		{
 			return false;
 		}
-		
+
 		public Properties getProperties(long address)
 		{
 			return new Properties();
@@ -500,7 +480,6 @@ public class TDumpReader implements ICoreFileReader
 	 * Edb.
 	 * 
 	 * @author andhall
-	 * 
 	 */
 	private static class EdbAdapter implements IProcess
 	{
@@ -609,14 +588,14 @@ public class TDumpReader implements ICoreFileReader
 		public IModule getExecutable() throws CorruptDataException
 		{
 			loadModules();
-			
+
 			return executable;
 		}
 
 		public List<IModule> getModules() throws CorruptDataException
 		{
 			loadModules();
-			
+
 			return Collections.unmodifiableList(modules);
 		}
 		
@@ -625,20 +604,18 @@ public class TDumpReader implements ICoreFileReader
 			if (modulesLoaded) {
 				return;
 			}
-			
+
 			AddressRange rr[] = as.addressSpace.getAddressRanges();
 			Map<Long, String> stackSyms = getStackSymbols();
 			try {
 				// Do the lookup once per symbol
-				Map<Long, Dll> closestDlls = new HashMap<Long, Dll>();
-				for (Iterator<Long> i = stackSyms.keySet().iterator(); i.hasNext();) {
-					Long addr = (Long)i.next();
-					long address = addr.longValue();
-					Dll closest = closestDll(edb, address);
+				Map<Long, Dll> closestDlls = new HashMap<>();
+				for (Long addr : stackSyms.keySet()) {
+					Dll closest = closestDll(edb, addr.longValue());
 					closestDlls.put(addr, closest);
 				}
 				boolean firstPass = true;
-				
+
 				for (Dll dll = edb.getFirstDll(); dll != null; dll = dll.getNext()) {
 					final DllFunction f[] = dll.getFunctions();
 					final DllVariable g[] = dll.getVariables();
@@ -658,7 +635,7 @@ public class TDumpReader implements ICoreFileReader
 						symbols.add(new Symbol(f[i].name, f[i].address));
 						findRange(f[i].address, usedTextRangeLimits, rr);
 					}
-					
+
 					// Add variables
 					for (int i = 0; i < g.length; ++i) {
 						symbols.add(new Symbol(g[i].getName(), g[i].getAddress()));
@@ -668,14 +645,14 @@ public class TDumpReader implements ICoreFileReader
 					for (Iterator<Long> i = stackSyms.keySet().iterator(); i.hasNext();) {
 						Long addr = i.next();
 						long address = addr.longValue();
-						Dll closest = (Dll)closestDlls.get(addr);
+						Dll closest = (Dll) closestDlls.get(addr);
 						// Fix when Zebedee does equals() for Dll
 						//if (dll.equals(closest)) {
 						if (closest != null && dll.getName().equals(closest.getName())) {
 							// Check if the stack symbol is within the address range of functions for this DLL
 							int r = findRange(address, rr);
 							if (r >= 0 && (address > usedTextRangeLimits[r][0]) && (address < usedTextRangeLimits[r][1])) {
-								String name = (String)stackSyms.get(addr);
+								String name = (String) stackSyms.get(addr);
 								symbols.add(new Symbol(name, address));
 								i.remove();
 							}
@@ -683,25 +660,25 @@ public class TDumpReader implements ICoreFileReader
 					}
 
 					// Construct the memory sections for this DLL
-					List<IMemoryRange> sections = new ArrayList<IMemoryRange>();
+					List<IMemoryRange> sections = new ArrayList<>();
 					for (int i = 0; i < rr.length; ++i) {
 						if (usedTextRangeLimits[i][1] != 0) {
-							long base = roundToPage(usedTextRangeLimits[i][0],Direction.DOWN);
-							long size = roundToPage(usedTextRangeLimits[i][1],Direction.UP) - base;
+							long base = roundToPage(usedTextRangeLimits[i][0], Direction.DOWN);
+							long size = roundToPage(usedTextRangeLimits[i][1], Direction.UP) - base;
 							sections.add(new MemoryRange(this.as, base, size, ".text"));
 						}
 						if (usedDataRangeLimits[i][1] != 0) {
-							long base = roundToPage(usedDataRangeLimits[i][0],Direction.DOWN);
-							long size = roundToPage(usedDataRangeLimits[i][1],Direction.UP) - base;
+							long base = roundToPage(usedDataRangeLimits[i][0], Direction.DOWN);
+							long size = roundToPage(usedDataRangeLimits[i][1], Direction.UP) - base;
 							sections.add(new MemoryRange(this.as, base, size, ".data"));
-						} 
+						}
 					}
-					
+
 					long loadAddress;
 					try {
 						// Not yet implemented by Zebedee, which throws an Error() 
 						loadAddress = dll.getLoadAddress();
-					} catch (Error e) {	
+					} catch (Error e) {
 						// since the load address for z/OS modules is not available, find the first procedure symbol
 						loadAddress = Long.MAX_VALUE;
 						for (int i = 0; i < f.length; ++i) {
@@ -710,29 +687,29 @@ public class TDumpReader implements ICoreFileReader
 						if (loadAddress == Long.MAX_VALUE) {
 							loadAddress = 0;
 						} else {
-							loadAddress = roundToPage(loadAddress,Direction.DOWN);
+							loadAddress = roundToPage(loadAddress, Direction.DOWN);
 						}
 					}
-					
+
 					Properties props = new Properties();
 					props.setProperty("Load address", format(loadAddress));
-					props.setProperty("Writable Static Area address",format(dll.getWsa()));
-					
+					props.setProperty("Writable Static Area address", format(dll.getWsa()));
+
 					IModule module = new Module(this, dllname, symbols, sections, loadAddress, props);
-				
+
 					if (firstPass) {
 						executable = module;
 						firstPass = false;
-					} else  {
+					} else {
 						modules.add(module);
 					}
 				}
-				
+
 				if (stackSyms.size() > 0) {
 					// Unrecognised symbols, so put them into a dummy DLL where they can be found for printing stack frames
 					final String dllname = "ExtraSymbolsModule";
 					long loadAddress = Long.MAX_VALUE;
-					List<ISymbol> symbols = new ArrayList<ISymbol>();
+					List<ISymbol> symbols = new ArrayList<>();
 					// Array of lowest and highest symbol addresses found in each contiguous memory range
 					long usedTextRangeLimits[][] = new long[rr.length][2];
 					// initialize start address to high
@@ -753,7 +730,7 @@ public class TDumpReader implements ICoreFileReader
 					if (loadAddress == Long.MAX_VALUE) {
 						loadAddress = 0;
 					} else {
-						loadAddress = roundToPage(loadAddress,Direction.DOWN);
+						loadAddress = roundToPage(loadAddress, Direction.DOWN);
 					}
 
 					Properties props = new Properties();
@@ -762,30 +739,29 @@ public class TDumpReader implements ICoreFileReader
 
 					for (int i = 0; i < rr.length; ++i) {
 						if (usedTextRangeLimits[i][1] != 0) {
-							long base = roundToPage(usedTextRangeLimits[i][0],Direction.DOWN);
-							long size = roundToPage(usedTextRangeLimits[i][1],Direction.UP) - base;
+							long base = roundToPage(usedTextRangeLimits[i][0], Direction.DOWN);
+							long size = roundToPage(usedTextRangeLimits[i][1], Direction.UP) - base;
 							sections.add(new MemoryRange(this.as, base, size, ".text"));
 						}
 					}
-					
+
 					IModule mod = new Module(this, dllname, symbols, sections, loadAddress, props);
 					modules.add(mod);
 				}
 			} catch (IOException e) {
 				logger.log(Level.FINE, "Problem for Zebedee finding module information", e);
 			}
-			
+
 			modulesLoaded = true;
 		}
-		
-		private Map<Long, String> getStackSymbols() throws CorruptDataException
-		{
-			Map<Long, String> result = new HashMap<Long, String>();
-			
+
+		private Map<Long, String> getStackSymbols() throws CorruptDataException {
+			Map<Long, String> result = new HashMap<>();
+
 			for (TCBAdapter thread : getThreads()) {
 				result.putAll(thread.getStackSymbols());
 			}
-			
+
 			return result;
 		}
 
@@ -800,13 +776,13 @@ public class TDumpReader implements ICoreFileReader
 		 */
 		private void findRange(long address, long[][] usedRangeLimits, AddressRange rr[]) {
 			int r = findRange(address, rr);
-			
+
 			if (r >= 0) {
 				usedRangeLimits[r][0] = Math.min(usedRangeLimits[r][0], address);
 				usedRangeLimits[r][1] = Math.max(usedRangeLimits[r][1], address);
 			}
 		}
-		
+
 		/**
 		 * Sees which AddressRange the routine it is in. 
 		 * @param routine
@@ -818,12 +794,12 @@ public class TDumpReader implements ICoreFileReader
 			for (int i = 0; i < rr.length; ++i) {
 				if (rr[i].getStartAddress() <= routine && routine <= rr[i].getEndAddress()) {
 					/* Found */
-					logger.fine("Found address "+format(routine)+" at "+format(rr[i].getStartAddress())+":"+format(rr[i].getEndAddress()));
+					logger.fine("Found address " + format(routine) + " at " + format(rr[i].getStartAddress()) + ":" + format(rr[i].getEndAddress()));
 					return i;
 				}
 			}
 			// Not found on the address range
-			logger.fine("Didn't find address "+format(routine));
+			logger.fine("Didn't find address " + format(routine));
 			return -2;
 		}
 
@@ -870,7 +846,7 @@ public class TDumpReader implements ICoreFileReader
 							closestDll = dll;
 							closestDist = dist;
 						}
-					}	
+					}
 				} catch (IOException e) {
 					logger.log(Level.FINE, "Skipping DDL due to IOException ", e);
 				}
@@ -882,7 +858,7 @@ public class TDumpReader implements ICoreFileReader
 		{
 			return edb.address();
 		}
-		
+
 		public boolean isExecutable(long address)
 		{
 			return as.isExecutable(address);
@@ -897,29 +873,29 @@ public class TDumpReader implements ICoreFileReader
 		{
 			return as.isShared(address);
 		}
-		
+
 		public Properties getProperties(long address) {
 			return as.getProperties(address);
 		}
-		
+
 		public String getProcedureNameForAddress(long address) throws CorruptDataException, DataUnavailableException {
 			return getProcedureNameForAddress(address, false);
 		}
-		
+
 		public String getProcedureNameForAddress(long address, boolean dtfjFormat) throws CorruptDataException, DataUnavailableException
 		{
 			//Weirdness in z/OS DLL regions (some overlapping) breaks the SymbolUtil.getProcedureNameForAddress() code.
 			//Instead, iterate over all symbols and find the closest.
-			
+
 			ISymbol closestSymbol = null;
 			IModule closestModule = null;
 			long diff = Long.MAX_VALUE;
-			
+
 			for (IModule thisModule : getModules()) {
 				for (ISymbol thisSymbol : thisModule.getSymbols()) {
 					if (Addresses.lessThan(thisSymbol.getAddress(), address)) {
 						long thisDiff = address - thisSymbol.getAddress();
-						
+
 						if (thisDiff < diff) {
 							diff = thisDiff;
 							closestSymbol = thisSymbol;
@@ -928,7 +904,7 @@ public class TDumpReader implements ICoreFileReader
 					}
 				}
 			}
-			
+
 			if (closestSymbol != null) {
 				return closestModule.getName() + "::" + closestSymbol.getName() + "+0x" + Long.toHexString(diff);
 			} else {
@@ -938,8 +914,8 @@ public class TDumpReader implements ICoreFileReader
 
 		public List<TCBAdapter> getThreads() throws CorruptDataException
 		{
-			if( threads == null ) {
-				List<TCBAdapter> threadsList = new LinkedList<TCBAdapter>();
+			if (threads == null) {
+				List<TCBAdapter> threadsList = new LinkedList<>();
 				Tcb tcbs[] = Tcb.getTcbs(as.addressSpace);
 
 				for (Tcb tcb : tcbs) {
@@ -947,7 +923,7 @@ public class TDumpReader implements ICoreFileReader
 						continue;
 					}
 
-					Caa caa = null;
+					Caa caa;
 					try {
 						caa = new Caa(tcb);
 					} catch (CaaNotFound e) {
@@ -962,7 +938,7 @@ public class TDumpReader implements ICoreFileReader
 				}
 				threads = Collections.unmodifiableList(threadsList);
 			}
-			
+
 			return threads;
 		}
 
@@ -1020,10 +996,10 @@ public class TDumpReader implements ICoreFileReader
 			try {
 				return caa.getTcb().tcbcmp() != 0L;
 			} catch (IOException e) {
-				throw new DataUnavailableException("Couldn't determine TCB CMP status",e);
+				throw new DataUnavailableException("Couldn't determine TCB CMP status", e);
 			}
 		}
-		
+
 	}
 
 	/**
@@ -1032,22 +1008,21 @@ public class TDumpReader implements ICoreFileReader
 	 * @author andhall
 	 * 
 	 */
-	private static class AddressRangeAdapter extends ProtectedMemoryRange
-	{
+	private static class AddressRangeAdapter extends ProtectedMemoryRange {
 
 		private final AddressSpace addressSpace;
 		private final String name;
 
 		public AddressRangeAdapter(AddressSpace space, AddressRange range, String name)
 		{
-			super(range.getStartAddress(),range.getLength());
+			super(range.getStartAddress(), range.getLength());
 			this.addressSpace = space;
 			this.name = name;
 		}
-		
+
 		public AddressRangeAdapter(AddressSpace space, AddressRange range)
 		{
-			this(space,range,null);
+			this(space, range, null);
 		}
 
 		public int getAddressSpaceId()
@@ -1058,7 +1033,7 @@ public class TDumpReader implements ICoreFileReader
 		@Override
 		public String toString()
 		{
-			return String.format("TDumpReader address range from 0x%X to 0x%X in address space %x",getBaseAddress(),getTopAddress(),getAddressSpaceId());
+			return String.format("TDumpReader address range from 0x%X to 0x%X in address space %x", getBaseAddress(), getTopAddress(), getAddressSpaceId());
 		}
 
 		public String getName()
@@ -1106,9 +1081,9 @@ public class TDumpReader implements ICoreFileReader
 			}
 			return true;
 		}
-		
+
 	}
-	
+
 	private static class TCBAdapter implements IOSThread
 	{
 		private static final int NUMBER_OF_GP_REGISTERS = 16;
@@ -1116,15 +1091,14 @@ public class TDumpReader implements ICoreFileReader
 		private final Caa caa;
 		private final Properties props = new Properties();
 		private final EdbAdapter edb;
-		private List<DSAAdapter> stackFrames = new LinkedList<DSAAdapter>();
+		private List<DSAAdapter> stackFrames = new LinkedList<>();
 		private boolean stacksWalked = false;
-		
-		public TCBAdapter(Tcb tcb, Caa caa, EdbAdapter edb)
-		{
+
+		public TCBAdapter(Tcb tcb, Caa caa, EdbAdapter edb) {
 			this.tcb = tcb;
 			this.caa = caa;
 			this.edb = edb;
-			
+
 			props.setProperty("TCB", format(tcb.address()));
 			props.setProperty("CAA", format(caa.address()));
 			props.setProperty("EDB", format(caa.getEdb().address()));
@@ -1133,26 +1107,26 @@ public class TDumpReader implements ICoreFileReader
 			} catch (IOException e) {
 				props.setProperty("PTHREADID", "unknown");
 			}
-			
+
 			try {
 				props.setProperty("Stack direction", caa.ceecaa_stackdirection() == 0 ? "up" : "down");
 				props.setProperty("CAA CEL level", format(caa.ceecaalevel()));
 			} catch (IOException e) {
 				//TODO handle
 			}
-			
+
 			// Get the Task Completion Code
 			try {
-				int code = tcb.space().readInt(tcb.address()+0x10);
+				int code = tcb.space().readInt(tcb.address() + 0x10);
 				props.setProperty("Task Completion Code", format(code));
 			} catch (IOException e) {
 				//TODO handle
 			}
-			
+
 			try {
 				long psw = tcb.getRegisters().getPSW();
 				String pswn = null;
-				switch ((int)(psw >> 31) & 3) {
+				switch ((int) (psw >> 31) & 3) {
 				case 0x0:
 					pswn = "PSW:24";
 					break;
@@ -1163,25 +1137,25 @@ public class TDumpReader implements ICoreFileReader
 					pswn = "PSW:64";
 					break;
 				}
-				
+
 				props.setProperty(pswn, format(psw));
 			} catch (IOException e) {
 				//TODO handle
 			}
-			
+
 			/*
 			 * see if this is a failing thread - in the zebedee code if the task completion code is non-zero then
 			 * the code also sets a failingregisters RegisterSet on the CAA. This is the same set as is returned 
 			 * for registers, so all we need to do is set a property if the failingregister set is not null.
 			 */
-			if(null != caa.getFailingRegisters()) {
+			if (null != caa.getFailingRegisters()) {
 				props.setProperty("FailingRegisters", "true");
 			}
-			
+
 			// Set up IFA/zAAP/zIIP enabled properties for this thread, if the information is available
 			try {
 				props.setProperty("IFA Enabled", tcb.isIFAEnabled() ? "yes" : "no");
-				props.setProperty("WEBFLAG2", String.format("0x%02x",tcb.getIFAFlags())); // the actual bit-field
+				props.setProperty("WEBFLAG2", String.format("0x%02x", tcb.getIFAFlags())); // the actual bit-field
 			} catch (IOException e) {
 				// Unable to get IFA information, leave properties unset
 			}
@@ -1191,30 +1165,30 @@ public class TDumpReader implements ICoreFileReader
 		{
 			//Populate stackFrames
 			this.getStackFrames();
-			
-			Map<Long,String> symbols = new HashMap<Long,String>();
-			
+
+			Map<Long, String> symbols = new HashMap<>();
+
 			for (DSAAdapter frame : getStackFrames()) {
 				Symbol sym = frame.getSymbol();
 				symbols.put(sym.getAddress(), sym.getName());
 			}
-			
+
 			return symbols;
 		}
 
 		public Collection<? extends IMemoryRange> getMemoryRanges()
 		{
 			List<? extends IOSStackFrame> frames = getStackFrames();
-			Set<IMemoryRange> ranges = new HashSet<IMemoryRange>();
-			
+			Set<IMemoryRange> ranges = new HashSet<>();
+
 			for (IOSStackFrame frame : frames) {
 				IMemoryRange range = edb.getAddressSpace().getRangeForAddress(frame.getBasePointer());
-				
+
 				if (range != null) {
-					ranges.add(new MemoryRange(edb.getAddressSpace(),range,"Stack"));
+					ranges.add(new MemoryRange(edb.getAddressSpace(), range, "Stack"));
 				}
 			}
-			
+
 			return ranges;
 		}
 
@@ -1227,7 +1201,7 @@ public class TDumpReader implements ICoreFileReader
 		{
 			RegisterSet rs = new RegisterSet();
 			DsaStackFrame dsa = caa.getCurrentFrame();
-			
+
 			// Get registers from the current (top) stack frame if available, else from the TCB
 			if (dsa != null && dsa.getRegisterSet() != null) {
 				rs = dsa.getRegisterSet();
@@ -1244,18 +1218,17 @@ public class TDumpReader implements ICoreFileReader
 			}
 			List<IRegister> regs = new ArrayList<IRegister>(NUMBER_OF_GP_REGISTERS + 1);
 			long psw = rs.getPSW();
-			
+
 			regs.add(new Register("PSW", psw));
 			// There isn't an easy way to get the total number of registers, so hard code it
 			for (int i = 0; i < NUMBER_OF_GP_REGISTERS; ++i) {
-				regs.add(new Register("R"+i, rs.getRegister(i)));
+				regs.add(new Register("R" + i, rs.getRegister(i)));
 			}
-			
+
 			return regs;
 		}
 
-		public List<DSAAdapter> getStackFrames()
-		{
+		public List<DSAAdapter> getStackFrames() {
 			if (!stacksWalked) {
 				DsaStackFrame dsa = null;
 				try {
@@ -1263,12 +1236,12 @@ public class TDumpReader implements ICoreFileReader
 				} catch (Exception e) {
 					//TODO handle
 				}
-				
+
 				if (dsa == null) {
 					// No stack frames available, leave an indication of the problem
 					//TODO handle this case
 					// Don't add corruptData to the stackFrames as getStackFrames throws DataUnavailable for us if the list is empty
-				} else { 
+				} else {
 					try {
 						for (; dsa != null; dsa = dsa.getParentFrame()) {
 							stackFrames.add(new DSAAdapter(dsa, edb));
@@ -1277,7 +1250,7 @@ public class TDumpReader implements ICoreFileReader
 						//TODO handle
 					}
 				}
-				
+
 				stacksWalked = true;
 			}
 
@@ -1310,12 +1283,12 @@ public class TDumpReader implements ICoreFileReader
 					return 0;
 				}
 			}
-				
+
 			return dsa.getInstructionPointer();
 		}
 
 		public long getBasePointer() {
-			DSAAdapter dsa = null;
+			DSAAdapter dsa;
 			if (stacksWalked) {
 				if (stackFrames.isEmpty()) {
 					logger.log(Level.FINE, "No stack frames for DSA");
@@ -1331,7 +1304,7 @@ public class TDumpReader implements ICoreFileReader
 					return 0;
 				}
 			}
-				
+
 			return dsa.getBasePointer();
 		}
 
@@ -1344,7 +1317,7 @@ public class TDumpReader implements ICoreFileReader
 			 * fastlink - GPR13 => the callers stack frame in the Language Environment stack. Each such stack frame begins with a 36-word save area.
 			 * xplink - GPR4 => the callers stack frame in the downward- growing stack. This is biased and actually points to 2048 bytes before the real start of the stack frame 
 			 */
-			DSAAdapter dsa = null;
+			DSAAdapter dsa;
 			if (stacksWalked) {
 				if (stackFrames.isEmpty()) {
 					logger.log(Level.FINE, "No stack frames for DSA");
@@ -1360,7 +1333,7 @@ public class TDumpReader implements ICoreFileReader
 					return 0;
 				}
 			}
-				
+
 			return dsa.getStackPointer();
 		}
 
@@ -1370,7 +1343,7 @@ public class TDumpReader implements ICoreFileReader
 	{
 		private final DsaStackFrame dsa;
 		private final EdbAdapter edb;
-		
+
 		public DSAAdapter(DsaStackFrame dsa, EdbAdapter edb)
 		{
 			this.dsa = dsa;
@@ -1402,6 +1375,6 @@ public class TDumpReader implements ICoreFileReader
 	}
 
 	private static String format(long l) {
-		return "0x"+Long.toHexString(l);
+		return "0x" + Long.toHexString(l);
 	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/OptInfo.java
@@ -61,9 +61,8 @@ import com.ibm.j9ddr.vm29.types.UDATA;
 
 /**
  * Analogue to util/optinfo.c
- * 
+ *
  * @author andhall
- * 
  */
 public class OptInfo {
 	private static IOptInfoImpl impl;
@@ -72,7 +71,7 @@ public class OptInfo {
 
 		@Override
 		protected Iterable<? extends IOptInfoImpl> allAlgorithms() {
-			List<IOptInfoImpl> list = new LinkedList<IOptInfoImpl>();
+			List<IOptInfoImpl> list = new LinkedList<>();
 
 			list.add(new OptInfo_29_V0());
 
@@ -107,13 +106,13 @@ public class OptInfo {
 			 * AOTd and the bytecodes have been stripped. So we can allow a
 			 * relativePC that is >= bytecodeSize in that case
 			 */
-			if ((relativePC.lt(bytecodeSize)) || (bytecodeSize.eq(0))) {
+			if (relativePC.lt(bytecodeSize) || bytecodeSize.eq(0)) {
 				J9MethodDebugInfoPointer methodInfo = getMethodDebugInfoForROMClass(method);
 
 				if (methodInfo.notNull()) {
 					Iterator<LineNumber> lineNumberIterator = LineNumberIterator.lineNumberIteratorFor(methodInfo);
 					LineNumber lineNumber;
-					
+
 					while (lineNumberIterator.hasNext()) {
 						lineNumber = lineNumberIterator.next();
 						if (relativePC.lt(lineNumber.getLocation())) {
@@ -138,9 +137,9 @@ public class OptInfo {
 	public static J9MethodDebugInfoPointer getMethodDebugInfoForROMClass(J9MethodPointer method) throws CorruptDataException {
 		return ROMHelp.getMethodDebugInfoFromROMMethod(ROMHelp.getOriginalROMMethod(method));
 	}
-	
+
 	private static SelfRelativePointer getSRPPtr(U32Pointer ptr, UDATA flags, long option) {
-		if ((!(flags.anyBitsIn(option))) || (ptr.isNull())) {
+		if ((!flags.anyBitsIn(option)) || ptr.isNull()) {
 			return SelfRelativePointer.NULL;
 		}
 
@@ -152,25 +151,26 @@ public class OptInfo {
 	}
 
 	/**
-	 * This method should be used when VM_LOCAL_VARIABLE_TABLE_VERSION >= 1
+	 * This method should be used when VM_LOCAL_VARIABLE_TABLE_VERSION >= 1.
 	 */
-	public static U8Pointer	getV1VariableTableForMethodDebugInfo(J9MethodDebugInfoPointer methodInfo) throws CorruptDataException {
+	public static U8Pointer getV1VariableTableForMethodDebugInfo(J9MethodDebugInfoPointer methodInfo) throws CorruptDataException {
 		LocalVariableTableIterator.checkVariableTableVersion();
 		return U8Pointer.cast(OptInfo._getVariableTableForMethodDebugInfo(methodInfo));
 	}
+
 	private static VoidPointer _getVariableTableForMethodDebugInfo(J9MethodDebugInfoPointer methodInfo) throws CorruptDataException {
 		if (!methodInfo.varInfoCount().eq(0)) {
 			/* check for low tag */
 			U32 taggedSizeOrSRP = U32Pointer.cast(methodInfo).at(0);
-			if ( taggedSizeOrSRP.allBitsIn(1) ) {
-				/* 
-				 * low tag indicates that debug information is in line 
+			if (taggedSizeOrSRP.allBitsIn(1)) {
+				/*
+				 * low tag indicates that debug information is in line
 				 * skip over J9MethodDebugInfo header and the J9LineNumber table
 				 */
 				U32 lineNumberTableSize = J9MethodDebugInfoHelper.getLineNumberCompressedSize(methodInfo);
 				return VoidPointer.cast(((U8Pointer.cast(methodInfo).addOffset(J9MethodDebugInfo.SIZEOF).addOffset(lineNumberTableSize))));
 			} else {
-				/* 
+				/*
 				 * debug information is out of line, this slot is an SRP to the
 				 * J9VariableInfo table
 				 */
@@ -196,7 +196,7 @@ public class OptInfo {
 		VoidPointer structure = getStructure(romClass, J9_ROMCLASS_OPTINFO_CLASS_ANNOTATION_INFO);
 		return U32Pointer.cast(structure);
 	}
-	
+
 	public static U32Pointer getClassTypeAnnotationsDataForROMClass(J9ROMClassPointer romClass) throws CorruptDataException {
 		VoidPointer structure = getStructure(romClass, J9_ROMCLASS_OPTINFO_TYPE_ANNOTATION_INFO);
 		return U32Pointer.cast(structure);
@@ -208,7 +208,7 @@ public class OptInfo {
 
 	public static J9EnclosingObjectPointer getEnclosingMethodForROMClass(J9ROMClassPointer romClass) throws CorruptDataException {
 		VoidPointer structure = getStructure(romClass, J9_ROMCLASS_OPTINFO_ENCLOSING_METHOD);
-		if (!structure.isNull()) {
+		if (structure.notNull()) {
 			return J9EnclosingObjectPointer.cast(structure);
 		} else {
 			return J9EnclosingObjectPointer.NULL;
@@ -217,23 +217,23 @@ public class OptInfo {
 
 	private static String getOption(J9ROMClassPointer romClass, long option) throws CorruptDataException {
 		VoidPointer structure = getStructure(romClass, option);
-		if (structure != VoidPointer.NULL) {
+		if (structure.notNull()) {
 			return J9UTF8Helper.stringValue(J9UTF8Pointer.cast(structure));
-		} 
+		}
 		return null;
 	}
 
 	private static VoidPointer getStructure(J9ROMClassPointer romClass, long option) throws CorruptDataException {
 		SelfRelativePointer ptr = getSRPPtr(J9ROMClassHelper.optionalInfo(romClass), romClass.optionalFlags(), option);
-		if (!ptr.isNull()) {
+		if (ptr.notNull()) {
 			return VoidPointer.cast(ptr.get());
-		} 
+		}
 		return VoidPointer.NULL;
 	}
 
 	public static J9SourceDebugExtensionPointer getSourceDebugExtensionForROMClass(J9ROMClassPointer romClass) throws CorruptDataException {
 		SelfRelativePointer srpPtr = getSRPPtr(J9ROMClassHelper.optionalInfo(romClass), romClass.optionalFlags(), J9_ROMCLASS_OPTINFO_SOURCE_DEBUG_EXTENSION);
-		if (!srpPtr.isNull()) {
+		if (srpPtr.notNull()) {
 			return J9SourceDebugExtensionPointer.cast(srpPtr.get());
 		}
 		return J9SourceDebugExtensionPointer.NULL;


### PR DESCRIPTION
* remove redundant casts
* remove redundant initialization
* remove redundant type arguments
* suppress unavoidable rawtype warnings
* use getDefinedPackage() instead of deprecated getPackage()

Make some general improvements:
* make inner classes static where possible
* prefer notNull() over !isNull()

Fix error in format specifier (% instead of &).