### PR TITLE
Bypass Code Blocks Requiring VM Access for the JIT Server

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -2078,6 +2078,13 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
          {
          case TR::java_lang_invoke_MethodHandle_asType:
             {
+#if defined(J9VM_OPT_JITSERVER)
+            // The J9VMJAVALANG macros used later
+            // will access vm information which is not available on the JITServer,
+            // bypass in this case to prevent an invalid class pointer being retrieved
+            if (comp()->isOutOfProcessCompilation())
+               break;
+#endif // J9VM_OPT_JITSERVER
             TR::Node* mh = node->getArgument(0);
             TR::Node* mt = node->getArgument(1);
             bool mhConstraintGlobal, mtConstraintGlobal;
@@ -2129,11 +2136,13 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
 #if defined(J9VM_OPT_METHOD_HANDLE)
          case TR::java_lang_invoke_PrimitiveHandle_initializeClassIfRequired:
             {
+#if defined(J9VM_OPT_JITSERVER)
             // The macro J9VMJAVALANGINVOKEPRIMITIVEHANDLE used later
             // will access vm information which is not available on the JITServer,
             // bypass in this case to prevent an invalid class pointer being retrieved
             if (comp()->isOutOfProcessCompilation())
                break;
+#endif // J9VM_OPT_JITSERVER
             TR::Node* mh = node->getArgument(0);
             bool mhConstraintGlobal;
             TR::VPConstraint* mhConstraint = getConstraint(mh, mhConstraintGlobal);


### PR DESCRIPTION
Bypass the code that requires a VM read in constraintRecognizedMethod() under JITServer mode, to prevent an invalid class pointer being sent to the client and crashing the client.