### PR TITLE
Recognize Thread.onSpinWait() on Power

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -11902,8 +11902,27 @@ J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
       {
       bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
       bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
+      static bool disableOSW = feGetEnv("TR_noPauseOnSpinWait") != NULL;
       switch (methodSymbol->getRecognizedMethod())
          {
+      case TR::java_lang_Thread_onSpinWait:
+         {
+         if (!disableOSW)
+            {
+            if (comp->getOption(TR_TraceCG))
+               {
+               traceMsg(comp, "Inlining Thread.onSpinWait call node %p as yield instruction.\n", node);
+               }
+
+            /*
+             * onSpinWait() method calls VM_AtomicSupport::yieldCPU() which is a yield instruction encoded as "or r27, r27, r27".
+             * Check omr/include_core/AtomicSupport.hpp for the JNI implementation.
+             */
+            generateInstruction(cg, TR::InstOpCode::yield, node);
+            return true;
+            }
+         break;
+         }
       case TR::java_util_concurrent_ConcurrentLinkedQueue_tmOffer:
          {
          if (cg->getSupportsInlineConcurrentLinkedQueue())


### PR DESCRIPTION
`Thread.onSpinWait()` is a `yield` instruction on Power. The method is recognized and inlined into JIT code.

Original behavior can be restored by setting the `TR_noPauseOnSpinWait` environment variable.

Edit:
Depends on https://github.com/eclipse-omr/omr/pull/7604
The OMR PR needs to be merged first since it implements the properties of the `yield` instruction.