### PR TITLE
Valhalla bringup for Java 25 updates

### DIFF
--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -965,7 +965,7 @@ extern "C" {
 
 /* Class version minimum for value type support. */
 
-#define VALUE_TYPES_MAJOR_VERSION 68
+#define VALUE_TYPES_MAJOR_VERSION 69
 #define PREVIEW_MINOR_VERSION 65535
 #define J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(classfileOrRomClass) (((classfileOrRomClass)->majorVersion >= VALUE_TYPES_MAJOR_VERSION) && (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion))
 

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -64,7 +64,7 @@
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
 			<compilerarg line='--add-exports java.base/jdk.internal.value=ALL-UNNAMED' />
 			<compilerarg line='--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED' />
-			<compilerarg line='--enable-preview -source 24'/>
+			<compilerarg line='--enable-preview -source 25'/>
 			<!-- uncomment when running with lw5 -->
 			<!--<compilerarg line='-XDenableNullRestrictedTypes' />-->
 			<classpath>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -25,12 +25,12 @@ import org.objectweb.asm.*;
 
 public class ValhallaUtils {
 	/**
-	 * Currently value type is built on JDK24, so use java file major version 68 for now.
-	 * If moved this needs to be incremented to the next class file version. The check in j9bcutil_readClassFileBytes()
-	 * against BCT_JavaMajorVersionShifted needs to be updated as well.
+	 * Currently value type is built on JDK25, so use java file major version 69 for now.
+	 * If moved this needs to be incremented to the next class file version.
+	 * VALUE_TYPES_MAJOR_VERSION in oti/j9consts.h needs to be updated as well.
 	 * Minor version is in 16 most significant bits for asm.
 	 */
-	static final int VALUE_TYPE_CLASS_FILE_VERSION = (65535 << 16) | 68;
+	static final int VALUE_TYPE_CLASS_FILE_VERSION = (65535 << 16) | 69;
 
 	/* workaround till the new ASM is released */
 	static final int ACC_IDENTITY = 0x20;


### PR DESCRIPTION
Valhalla bringup for Java 25 updates

Updated `-source` to `25`;
Updated `VALUE_TYPE_CLASS_FILE_VERSION` to `69`;
Updated `VALUE_TYPES_MAJOR_VERSION` to `69`.

This change is required for Valhalla extension Java 25 update
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/17

Signed-off-by: Jason Feng <fengj@ca.ibm.com>