### PR TITLE
Fix DDR build error for Java 8

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/J9DDRClassLoader.java
@@ -175,6 +175,7 @@ public class J9DDRClassLoader extends SecureClassLoader {
 		return baos.toByteArray();
 	}
 
+	@SuppressWarnings("deprecation")
 	private void definePackage(String name) {
 		// Split off the class name
 		int finalSeparator = name.lastIndexOf('.');
@@ -182,7 +183,8 @@ public class J9DDRClassLoader extends SecureClassLoader {
 		if (finalSeparator != -1) {
 			String packageName = name.substring(0, finalSeparator);
 
-			if (getDefinedPackage(packageName) == null) {
+			// getDefinedPackage() is only available in Java 9+
+			if (getPackage(packageName) == null) {
 				// TODO think about the correct values here
 				definePackage(packageName, "J9DDR", "0.1", "IBM", "J9DDR", "0.1", "IBM", null);
 			}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/plugins/DDRInteractiveClassLoader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/plugins/DDRInteractiveClassLoader.java
@@ -124,6 +124,7 @@ public class DDRInteractiveClassLoader extends ClassLoader {
 		}
 	}
 
+	@SuppressWarnings("deprecation")
 	private void definePackage(String name) {
 		// split off the class name
 		int finalSeparator = name.lastIndexOf('/');
@@ -131,7 +132,8 @@ public class DDRInteractiveClassLoader extends ClassLoader {
 		if (finalSeparator != -1) {
 			String packageName = name.substring(0, finalSeparator);
 
-			if (getDefinedPackage(packageName) == null) {
+			// getDefinedPackage() is only available in Java 9+
+			if (getPackage(packageName) == null) {
 				definePackage(packageName, "J9DDR", "0.1", "IBM", "J9DDR", "0.1", "IBM", null);
 			}
 		}


### PR DESCRIPTION
`ClassLoader.getDefinedPackage()` is only available in Java 9+.