### PR TITLE
Fix dangling-doc-comments warnings

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
@@ -511,7 +511,7 @@ public class PointerGenerator {
 	}
 
 	private void writeGeneratedWarning(PrintWriter writer) {
-		writer.println("/**");
+		writer.println("/*");
 		writer.println(" * WARNING!!! GENERATED FILE");
 		writer.println(" *");
 		writer.println(" * This class is generated.");

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/Format2Tprof.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/Format2Tprof.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
  * Copyright IBM Corp. and others 2000
  *
@@ -22,12 +22,12 @@
  */
 package com.ibm.jvm.format;
 
-/**
- * Trace Tool routine for generating profile format output.
- */
 import java.io.*;
 import java.util.*;
 
+/**
+ * Trace Tool routine for generating profile format output.
+ */
 public class Format2Tprof {
 	final String Trc_JIT_Component_Name = "j9jit";
 	final int    Trc_JIT_Sampling_Id = 13;

--- a/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceSection.java
+++ b/jcl/src/openj9.traceformat/share/classes/com/ibm/jvm/format/TraceSection.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
  * Copyright IBM Corp. and others 2000
  *
@@ -71,28 +71,7 @@ public class TraceSection {
 		Util.Debug.println("TraceSection: type:                " + type); //  0=internal 1=external
 		Util.Debug.println("TraceSection: generations:         " + generations);
 		Util.Debug.println("TraceSection: pointerSize:         " + pointerSize);
-
 	}
-
-	/** summarizes the trace section
-	 *
-	 * @return  null
-	 */
-	//final protected void summary(BufferedWriter out) throws IOException
-	//{
-	//        int            off   = offset;
-	//        String         temp  = Util.constructString(data, off);
-	//
-	//        out.write("Internal Trace Data :");
-	//        out.newLine();
-	//        while ( !temp.equals("") ) {
-	//            out.write((Util.SUM_TAB+temp));
-	//            out.newLine();
-	//            off += (temp.length() + 1);
-	//            temp = Util.constructString(data, off);
-	//        }
-	//        out.newLine();
-	//}
 
 	/** returns the type of trace ( INTERNAL or EXTERNAL )
 	 *


### PR DESCRIPTION
Don't generate or use javadoc style comments in inappropriate places.

For example, 101 such warnings are reported in https://openj9-jenkins.osuosl.org/job/Build_JDKnext_x86-64_linux_OpenJDK/824. There are more, but only the first 100 warnings are printed for each module.