### PR TITLE
Fix potential issue in initializing unsafeIndexableHeaderSize

### DIFF
--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3325,11 +3325,8 @@ initializeIndexableObjectHeaderSizes(J9JavaVM* vm)
 #else /* defined(J9VM_ENV_DATA64) */
 	setIndexableObjectHeaderSizeWithoutDataAddress(vm);
 #endif /* defined(J9VM_ENV_DATA64) */
-	if (MM_GCExtensions::getExtensions(vm)->isVirtualLargeObjectHeapEnabled) {
-		vm->unsafeIndexableHeaderSize = 0;
-	} else {
-		vm->unsafeIndexableHeaderSize = vm->contiguousIndexableHeaderSize;
-	}
+	/* set default unsafeIndexableHeaderSize */
+	vm->unsafeIndexableHeaderSize = vm->contiguousIndexableHeaderSize;
 }
 
 #if defined(J9VM_ENV_DATA64)
@@ -3356,7 +3353,6 @@ setIndexableObjectHeaderSizeWithoutDataAddress(J9JavaVM* vm)
 		vm->contiguousIndexableHeaderSize = sizeof(J9IndexableObjectContiguousFull);
 		vm->discontiguousIndexableHeaderSize = sizeof(J9IndexableObjectDiscontiguousFull);
 	}
-	vm->unsafeIndexableHeaderSize = vm->contiguousIndexableHeaderSize;
 }
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER)


### PR DESCRIPTION
default setting unsafeIndexableHeaderSize is only covered IndexableObjectWithoutDataAddress case, so for Balanced GC Off heap disabled case, there is potentially missing to set unsafeIndexableHeaderSize, change to set default
unsafeIndexableHeaderSize for both w/wo DataAddress cases.