### PR TITLE
Remove dead versions in test playlists

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1129,7 +1129,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>11</version>
 			<version>17</version>
-			<version>18</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -1332,7 +1331,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>11</version>
 			<version>17</version>
-			<version>18</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -1568,7 +1566,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>11</version>
 			<version>17</version>
-			<version>18</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -1600,7 +1597,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>11</version>
 			<version>17</version>
-			<version>18</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -1760,7 +1756,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<versions>
 			<version>11</version>
 			<version>17</version>
-			<version>18</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/Jsr292/playlist.xml
+++ b/test/functional/Jsr292/playlist.xml
@@ -1,24 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright IBM Corp. and others 2016
+Copyright IBM Corp. and others 2016
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<include>variables.mk</include>
@@ -44,7 +44,7 @@
 		<versions>
 			<version>8</version>
 		</versions>
-		<!-- 
+		<!--
 			TODO: Further investigation is needed for running against non-openj9 sdk
 		-->
 		<impls>
@@ -131,7 +131,7 @@
 		<versions>
 			<version>11+</version>
 		</versions>
-		<!-- 
+		<!--
 			TODO: Further investigation is needed for running against non-openj9 sdk
 		-->
 		<impls>
@@ -163,7 +163,6 @@
 		<versions>
 			<version>11</version>
 			<version>17</version>
-			<version>18</version>
 		</versions>
 		<!--
 			TODO: Further investigation is needed for running against non-openj9 sdk
@@ -284,7 +283,6 @@
 		<versions>
 			<version>11</version>
 			<version>17</version>
-			<version>18</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -391,7 +389,7 @@
 		<versions>
 			<version>9+</version>
 		</versions>
-		<!-- 
+		<!--
 			TODO: Further investigation is needed for running against non-openj9 sdk
 		-->
 		<impls>
@@ -478,10 +476,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>9</version>
-			<version>10</version>
 			<version>11</version>
-			<version>13</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -510,10 +505,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>9</version>
-			<version>10</version>
 			<version>11</version>
-			<version>13</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -244,7 +244,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>ibm</impl>
 		</impls>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 		<features>
@@ -277,7 +276,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>ibm</impl>
 		</impls>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 		<features>
@@ -310,7 +308,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>ibm</impl>
 		</impls>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 		<features>
@@ -342,7 +339,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>ibm</impl>
 		</impls>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 		<features>
@@ -529,7 +525,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<type>native</type>
 		</types>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 		<impls>
@@ -600,7 +595,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<type>native</type>
 		</types>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 	</test>

--- a/test/functional/OpenJ9_Jsr_292_API/playlist.xml
+++ b/test/functional/OpenJ9_Jsr_292_API/playlist.xml
@@ -1,24 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright IBM Corp. and others 2017
+Copyright IBM Corp. and others 2017
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TKG/playlist.xsd">
 	<!--
@@ -47,7 +47,6 @@
 		</groups>
 		<versions>
 			<version>11</version>
-			<version>13</version>
 		</versions>
 	</test>
 	<test>
@@ -73,7 +72,6 @@
 		</groups>
 		<versions>
 			<version>11</version>
-			<version>13</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/playlist.xml
@@ -74,7 +74,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</groups>
 		<versions>
 			<version>8</version>
-			<version>9</version>
 		</versions>
 	</test>
 	<test>

--- a/test/functional/cmdLineTests/gptest/playlist.xml
+++ b/test/functional/cmdLineTests/gptest/playlist.xml
@@ -1,24 +1,24 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <!--
-  Copyright IBM Corp. and others 2016
+Copyright IBM Corp. and others 2016
 
-  This program and the accompanying materials are made available under
-  the terms of the Eclipse Public License 2.0 which accompanies this
-  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
-  or the Apache License, Version 2.0 which accompanies this distribution and
-  is available at https://www.apache.org/licenses/LICENSE-2.0.
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
 
-  This Source Code may also be made available under the following
-  Secondary Licenses when the conditions for such availability set
-  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
-  General Public License, version 2 with the GNU Classpath
-  Exception [1] and GNU General Public License, version 2 with the
-  OpenJDK Assembly Exception [2].
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
 
-  [1] https://www.gnu.org/software/classpath/license.html
-  [2] https://openjdk.org/legal/assembly-exception.html
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
 
-  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
 	<include>../variables.mk</include>
@@ -39,7 +39,7 @@
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config  $(Q)$(TEST_RESROOT)$(D)gptests.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
-	${TEST_STATUS}	</command>
+	${TEST_STATUS}</command>
 		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -75,7 +75,7 @@
 	-DJVM_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) \
 	-jar $(CMDLINETESTER_JAR) \
 	-config  $(Q)$(TEST_RESROOT)$(D)gptests.xml$(Q) -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) -xlist $(Q)$(TEST_RESROOT)$(D)cmdlineopttest_exclude.xml$(Q) -nonZeroExitWhenError; \
-	${TEST_STATUS}	</command>
+	${TEST_STATUS}</command>
 		<platformRequirements>^os.win</platformRequirements>
 		<levels>
 			<level>sanity</level>
@@ -87,7 +87,6 @@
 			<type>native</type>
 		</types>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 		<impls>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/playlist.xml
@@ -112,7 +112,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<type>native</type>
 		</types>
 		<versions>
-			<version>9</version>
 			<version>11+</version>
 		</versions>
 		<impls>


### PR DESCRIPTION
Versions 9, 10, 13 and 18 are no longer supported.