### PR TITLE
Change -Xtune:throughput to disable AOT

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -505,7 +505,7 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
 #if defined(J9VM_OPT_SHARED_CLASSES)
          // ENABLE_AOT must be set AND the shared class must be properly initialized
          UDATA aotFlags = J9SHR_RUNTIMEFLAG_CACHE_INITIALIZATION_COMPLETE;
-         if (vm->sharedClassConfig && ((vm->sharedClassConfig->runtimeFlags & aotFlags) == aotFlags))
+         if (vm->sharedClassConfig && ((vm->sharedClassConfig->runtimeFlags & aotFlags) == aotFlags) && TR::Options::getAggressivityLevel() != OMR::Options::AGGRESSIVE_THROUGHPUT)
             {
             TR::Options::setSharedClassCache(true); // Set to true as long as cache is present and initialized
 


### PR DESCRIPTION
This change improves throughput, footprint and CompCPU while possibly affecting rampup. However, since the goal is to have to best throughput possible in the long run, this change is justified.