### PR TITLE
Change JFR default package name to empty string to avoid failure on JMC

### DIFF
--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -43,7 +43,7 @@ J9_DECLARE_CONSTANT_UTF8(nullString, "(nullString)");
 J9_DECLARE_CONSTANT_UTF8(unknownClass, "(defaultPackage)/(unknownClass)");
 J9_DECLARE_CONSTANT_UTF8(nativeMethod, "(nativeMethod)");
 J9_DECLARE_CONSTANT_UTF8(nativeMethodSignature, "()");
-J9_DECLARE_CONSTANT_UTF8(defaultPackage, "(defaultPackage)");
+J9_DECLARE_CONSTANT_UTF8(defaultPackage, "");
 J9_DECLARE_CONSTANT_UTF8(bootLoaderName, "boostrapClassLoader");
 J9_DECLARE_CONSTANT_UTF8(unknownThread, "unknown thread");
 


### PR DESCRIPTION
JMC wants to get class name from fully qualified class name. And the fully qualified class name of a class that isn't in a package doesn't contain the default package name, resulting a StringIndexOutOfBoundsException.