### PR TITLE
Close and Reopen JIT log files across a checkpoint/restore

### DIFF
--- a/runtime/compiler/runtime/CRRuntime.hpp
+++ b/runtime/compiler/runtime/CRRuntime.hpp
@@ -348,6 +348,16 @@ class CRRuntime
    void resetStartTime();
 
    /**
+    * @brief Closes various log files
+    */
+   void closeLogFiles();
+
+   /**
+    * @brief Reopens log files closed at checkpoint
+    */
+   void reopenLogFiles();
+
+   /**
     * @brief Helper method to push a J9Method onto the front of list that is
     *        used to memoize a future compilation of said J9Method. This method
     *        should only be called with the Comp Monitor in hand.


### PR DESCRIPTION
A common best practice in CRIU mode, at least in OpenJ9, is to close all open files before a checkpoint, and reopen them on restore. The JIT would keep log files such as the vlog and rtLog open across a checkpoint/restore boundary. This PR closes these files on checkpoint and reopens them on restore.