### PR TITLE
Remove System.getSecurityManager calls from java.base and criu

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -64,9 +64,9 @@ import sun.reflect.generics.scope.ClassScope;
 import sun.reflect.annotation.AnnotationType;
 import java.util.Arrays;
 import com.ibm.oti.vm.VM;
-/*[IF JAVA_SPEC_VERSION >= 11]*/
+/*[IF (11 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24)]*/
 import static com.ibm.oti.util.Util.doesClassLoaderDescendFrom;
-/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
+/*[ENDIF] (11 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24) */
 
 /*[IF JAVA_SPEC_VERSION >= 9]
 import jdk.internal.misc.Unsafe;
@@ -5547,9 +5547,11 @@ private native Class<?>[] getNestMembersImpl();
 /**
  * Answers the host class of the receiver's nest.
  *
+/*[IF JAVA_SPEC_VERSION < 24]
  * @throws SecurityException if nestHost is not same as the current class, a security manager
  *	is present, the classloader of the caller is not the same or an ancestor of nestHost
  * 	class, and checkPackageAccess() denies access
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  * @return the host class of the receiver.
  */
 @CallerSensitive
@@ -5561,6 +5563,7 @@ public Class<?> getNestHost()
 	if (nestHost == null) {
 		nestHost = getNestHostImpl();
 	}
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	/* The specification requires that if:
 	 *    - the returned class is not the current class
 	 *    - a security manager is present
@@ -5582,6 +5585,7 @@ public Class<?> getNestHost()
 			}
 		}
 	}
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	return nestHost;
 }
 

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -324,14 +324,21 @@ public abstract class ClassLoader {
  * Constructs a new instance of this class with the system
  * class loader as its parent.
  *
+/*[IF JAVA_SPEC_VERSION < 24]
  * @exception	SecurityException
  *					if a security manager exists and it does not
  *					allow the creation of new ClassLoaders.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  */
 protected ClassLoader() {
+	/*[IF JAVA_SPEC_VERSION >= 24]*/
+	this(null, null, applicationClassLoader);
+	/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	this(checkSecurityPermission(), null, applicationClassLoader);
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 /**
  * This is a static helper method to perform security check earlier such that current ClassLoader object
  * can't be resurrected when there is a SecurityException thrown.
@@ -346,6 +353,7 @@ private static Void checkSecurityPermission() {
 	}
 	return null;
 }
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 /**
  * Constructs a new instance of this class with the given
@@ -354,12 +362,18 @@ private static Void checkSecurityPermission() {
  * @param		parentLoader ClassLoader
  *					the ClassLoader to use as the new class
  *					loaders parent.
+/*[IF JAVA_SPEC_VERSION < 24]
  * @exception	SecurityException
  *					if a security manager exists and it does not
  *					allow the creation of new ClassLoaders.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  */
 protected ClassLoader(ClassLoader parentLoader) {
+	/*[IF JAVA_SPEC_VERSION >= 24]*/
+	this(null, null, parentLoader);
+	/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	this(checkSecurityPermission(), null, parentLoader);
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 
 /*[IF JAVA_SPEC_VERSION >= 9]*/
@@ -374,13 +388,19 @@ protected ClassLoader(ClassLoader parentLoader) {
  *					loaders parent.
  * @exception	IllegalArgumentException
  *					if the name of this class loader is empty.
+/*[IF JAVA_SPEC_VERSION < 24]
  * @exception	SecurityException
  *					if a security manager exists and it does not
  *					allow the creation of new ClassLoaders.
+/*[ENDIF] JAVA_SPEC_VERSION < 24
  *@since 9
  */
 protected ClassLoader(String classLoaderName, ClassLoader parentLoader) {
+	/*[IF JAVA_SPEC_VERSION >= 24]*/
+	this(null, classLoaderName, parentLoader);
+	/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 	this(checkSecurityPermission(), classLoaderName, parentLoader);
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 

--- a/jcl/src/java.base/share/classes/java/lang/StackWalker.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackWalker.java
@@ -27,7 +27,9 @@ import java.lang.invoke.MethodType;
 /*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 import java.lang.module.ModuleDescriptor;
 import java.lang.module.ModuleDescriptor.Version;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.Permission;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
@@ -125,11 +127,13 @@ public final class StackWalker {
 		}
 
 		if ((flags & J9_RETAIN_CLASS_REFERENCE) != 0) {
+			/*[IF JAVA_SPEC_VERSION < 24]*/
 			@SuppressWarnings("removal")
 			SecurityManager securityMgr = System.getSecurityManager();
 			if (null != securityMgr) {
 				securityMgr.checkPermission(PermissionSingleton.perm);
 			}
+			/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 			/*[IF JAVA_SPEC_VERSION >= 19]*/
 			this.retainClassRef = true;
 		} else {
@@ -166,9 +170,11 @@ public final class StackWalker {
 	 * @param option
 	 *            select the type of information to include
 	 * @return StackWalker instance configured with the value of option
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if option is RETAIN_CLASS_REFERENCE and the security manager
 	 *             check fails
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public static StackWalker getInstance(Option option) {
 		Objects.requireNonNull(option);
@@ -181,9 +187,11 @@ public final class StackWalker {
 	 * @param options
 	 *            select the types of information to include
 	 * @return StackWalker instance configured with the given options
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if RETAIN_CLASS_REFERENCE is requested and not permitted by
 	 *             the security manager
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public static StackWalker getInstance(Set<Option> options) {
 		return getInstance(options, DEFAULT_BUFFER_SIZE);
@@ -198,9 +206,11 @@ public final class StackWalker {
 	 *            hint for the size of buffer to use. Must be 1 or greater
 	 * @return StackWalker instance with the given options specifying the stack
 	 *         frame information it can access
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if RETAIN_CLASS_REFERENCE is requested and not permitted by
 	 *             the security manager
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public static StackWalker getInstance(Set<Option> options, int estimatedDepth) {
 		Objects.requireNonNull(options);
@@ -585,8 +595,10 @@ public final class StackWalker {
 		/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 	}
 
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	static final class PermissionSingleton {
 		static final Permission perm =
 				new RuntimePermission("getStackWalkerWithClassReference"); //$NON-NLS-1$
 	}
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 }

--- a/jcl/src/java.base/share/classes/openj9/internal/criu/CRIUDumpPermission.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/CRIUDumpPermission.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF CRIU_SUPPORT]*/
+/*[INCLUDE-IF CRIU_SUPPORT & (JAVA_SPEC_VERSION < 24)]*/
 /*
  * Copyright IBM Corp. and others 2023
  *

--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -64,6 +64,9 @@ import jdk.internal.misc.SharedSecrets;
  * This API enables the use of CRIU capabilities provided by the OS as well as JVM support for facilitating a successful checkpoint
  * and restore in varying environments.
  */
+/*[IF 17 <= JAVA_SPEC_VERSION]*/
+@SuppressWarnings({ "deprecation", "removal" })
+/*[ENDIF] 17 <= JAVA_SPEC_VERSION */
 public final class InternalCRIUSupport {
 	private static final boolean criuSupportEnabled = isCRIUSupportEnabledImpl();
 	private static long checkpointRestoreNanoTimeDelta;
@@ -210,7 +213,9 @@ public final class InternalCRIUSupport {
 
 	@SuppressWarnings("restriction")
 	private static Unsafe unsafe;
+	/*[IF JAVA_SPEC_VERSION < 24]*/
 	private static final CRIUDumpPermission CRIU_DUMP_PERMISSION = new CRIUDumpPermission();
+	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	private static boolean nativeLoaded;
 	private static boolean initComplete;
 	private static String errorMsg;
@@ -307,16 +312,19 @@ public final class InternalCRIUSupport {
 	 * @param imageDir the directory that will hold the dump files as a
 	 *                 java.nio.file.Path
 	 * @throws NullPointerException     if imageDir is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException        if no permission to access imageDir or no
 	 *                                  CRIU_DUMP_PERMISSION
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws IllegalArgumentException if imageDir is not a valid directory
 	 */
 	public InternalCRIUSupport(Path imageDir) {
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkPermission(CRIU_DUMP_PERMISSION);
 		}
-
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 		setImageDir(imageDir);
 	}
 
@@ -431,7 +439,9 @@ public final class InternalCRIUSupport {
 	 * @param imageDir the directory as a java.nio.file.Path
 	 * @return this
 	 * @throws NullPointerException     if imageDir is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException        if no permission to access imageDir
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws IllegalArgumentException if imageDir is not a valid directory
 	 */
 	public InternalCRIUSupport setImageDir(Path imageDir) {
@@ -441,10 +451,12 @@ public final class InternalCRIUSupport {
 		}
 		String dir = imageDir.toAbsolutePath().toString();
 
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkWrite(dir);
 		}
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 		this.imageDir = dir;
 		return this;
@@ -592,7 +604,9 @@ public final class InternalCRIUSupport {
 	 * @param workDir the directory as a java.nio.file.Path
 	 * @return this
 	 * @throws NullPointerException     if workDir is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException        if no permission to access workDir
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws IllegalArgumentException if workDir is not a valid directory
 	 */
 	public InternalCRIUSupport setWorkDir(Path workDir) {
@@ -602,10 +616,12 @@ public final class InternalCRIUSupport {
 		}
 		String dir = workDir.toAbsolutePath().toString();
 
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		SecurityManager manager = System.getSecurityManager();
 		if (manager != null) {
 			manager.checkWrite(dir);
 		}
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 		this.workDir = dir;
 		return this;

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUDumpPermission.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUDumpPermission.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF CRIU_SUPPORT]*/
+/*[INCLUDE-IF CRIU_SUPPORT & (JAVA_SPEC_VERSION < 24)]*/
 /*
  * Copyright IBM Corp. and others 2021
  *

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -35,9 +35,6 @@ import openj9.internal.criu.InternalCRIUSupport;
  * This API enables the use of CRIU capabilities provided by the OS as well as JVM support for facilitating a successful checkpoint
  * and restore in varying environments.
  */
-/*[IF JAVA_SPEC_VERSION >= 17]*/
-@SuppressWarnings({ "deprecation", "removal" })
-/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 public final class CRIUSupport {
 
 	/**
@@ -86,8 +83,10 @@ public final class CRIUSupport {
 	 * @param imageDir the directory that will hold the dump files as a
 	 *                 java.nio.file.Path
 	 * @throws NullPointerException     if imageDir is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException        if no permission to access imageDir or no
 	 *                                  CRIU_DUMP_PERMISSION
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws IllegalArgumentException if imageDir is not a valid directory
 	 */
 	public CRIUSupport(Path imageDir) {
@@ -141,7 +140,9 @@ public final class CRIUSupport {
 	 * @param imageDir the directory as a java.nio.file.Path
 	 * @return this
 	 * @throws NullPointerException     if imageDir is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException        if no permission to access imageDir
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws IllegalArgumentException if imageDir is not a valid directory
 	 */
 	public CRIUSupport setImageDir(Path imageDir) {
@@ -283,7 +284,9 @@ public final class CRIUSupport {
 	 * @param workDir the directory as a java.nio.file.Path
 	 * @return this
 	 * @throws NullPointerException     if workDir is null
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException        if no permission to access workDir
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws IllegalArgumentException if workDir is not a valid directory
 	 */
 	public CRIUSupport setWorkDir(Path workDir) {


### PR DESCRIPTION
Remove calls to System.getSecurityManager for JDK 24 since this method is deprecated for removal and returns null. This change also removes javadoc references to SecurityException which no longer apply with the removal of System.getSecurityManager.

I have more pull requests removing SecurityException and System.getSecurityManager coming. I wanted to break this into smaller chunks for review since there are many uses in OpenJ9.

Related: https://github.com/eclipse-openj9/openj9/issues/20563