### PR TITLE
Describe maxstringlength in -Xtrace:help output

### DIFF
--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -933,6 +933,11 @@ static void displayTraceHelp(J9JavaVM *vm)
 	j9tty_err_printf(PORTLIB, "     resumecount=nn                      Trigger count for \"trace resume\"\n");
 	j9tty_err_printf(PORTLIB, "     output=filespec[,nnm[,generations]] Sends maximal and minimal trace to a file\n");
 	j9tty_err_printf(PORTLIB, "     exception.output=filespec[,nnnm]    Sends exception trace to a file\n");
+	j9tty_err_printf(PORTLIB, "     maxstringlength=nn                  Limit length of string values to capture\n");
+	j9tty_err_printf(PORTLIB, "                                         "
+			"Maximum " J9_STR(RAS_MAX_STRING_LENGTH_LIMIT)
+			", use 0 to disable."
+			" Default: " J9_STR(RAS_MAX_STRING_LENGTH_DEFAULT) "\n");
 	j9tty_err_printf(PORTLIB, "     stackdepth=nn                       Set number of frames output by jstacktrace trigger action\n");
 	j9tty_err_printf(PORTLIB, "     sleeptime=nnt                       Time delay for sleep trigger action\n");
 	j9tty_err_printf(PORTLIB, "                                         Recognised suffixes: ms (milliseconds), s (seconds). Default: ms\n");


### PR DESCRIPTION
See https://github.com/eclipse-openj9/openj9/pull/20662#issuecomment-2533049801.