### PR TITLE
Use correct arrayBaseNode in BoolArrayStoreTransformer for OffHeap

### DIFF
--- a/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
+++ b/runtime/compiler/optimizer/BoolArrayStoreTransformer.cpp
@@ -728,6 +728,10 @@ void TR_BoolArrayStoreTransformer::transformUnknownTypeArrayStore()
       TR::Node *bstoreiNode = *it;
       dumpOptDetails(comp(), "%s transform value child of bstorei node of unknown type n%dn\n", OPT_DETAILS, bstoreiNode->getGlobalIndex());
       TR::Node *arrayBaseNode = bstoreiNode->getFirstChild()->getFirstChild();
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+      if (arrayBaseNode->isDataAddrPointer())
+         arrayBaseNode = arrayBaseNode->getFirstChild();
+#endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
       TR::Node *vft = TR::Node::createWithSymRef(TR::aloadi, 1, 1, arrayBaseNode, comp()->getSymRefTab()->findOrCreateVftSymbolRef());
       TR::Node *aconstNode = TR::Node::aconst(bstoreiNode, j9class);
       aconstNode->setIsClassPointerConstant(true);


### PR DESCRIPTION
When BoolArrayStoreTransformer insert runtime checks for unknown array type stores generated by `bastore` bytecode, it uses the target array address (without offset) as the base array to load the `vft-symbol` and check the class type. With OffHeap that node would be the `dataAddrPtr` instead of array base.

This PR checks if its the `dataAddrPtr` and uses the correct array base node for the generated check. 

```
BEFORE
n88n      bstorei  <array-shadow>[#244  Shadow] 
n87n        aladd (internalPtr )                                                              
n85n          aloadi  <contiguousArrayDataAddrField>[#347  final Shadow +8] 
n69n            aload  UnsafeArrayGetTest.largeByteArray [B[#404  final Static] (obj1) 
n86n          i2l (X>=0 )                                                                     
n70n            iload  <auto slot 1>[#403  Auto] 
n471n       i2b                                                                               
n470n         iand                                                                           
n78n            isub                                                                      
n71n              iconst 127 (X!=0 X>=0 )                                                
n75n              ==>icalli
n468n           iadd                                                                    
n466n             ishl                                                                 
n464n               acmpeq                                                            
n462n                 aloadi  <vft-symbol>[#315  Shadow] 
n85n                    ==>aloadi
n463n                 aconst 0xb6d00 Abstract ([Z.class) (classPointerConstant X!=0 X>=0 X<=0 )
n465n               iconst 1 (X!=0 X>=0 )                                                     
n467n             iconst -1 (X!=0 X<=0 )                                                     


AFTER
n88n      bstorei  <array-shadow>[#244  Shadow] 
n87n        aladd (internalPtr )                                                              
n85n          aloadi  <contiguousArrayDataAddrField>[#347  final Shadow +8] 
n69n            aload  UnsafeArrayGetTest.largeByteArray [B[#404  final Static] (obj1) 
n86n          i2l (X>=0 )                                                                     
n70n            iload  <auto slot 1>[#403  Auto] 
n471n       i2b                                                                               
n470n         iand                                                                           
n78n            isub                                                                      
n71n              iconst 127 (X!=0 X>=0 )                                                
n75n              ==>icalli
n468n           iadd                                                                    
n466n             ishl                                                                 
n464n               acmpeq                                                            
n462n                 aloadi  <vft-symbol>[#315  Shadow] 
n69n                    ==>aload
n463n                 aconst 0xb6d00 Abstract ([Z.class) (classPointerConstant X!=0 X>=0 X<=0 )
n465n               iconst 1 (X!=0 X>=0 )                                                     
n467n             iconst -1 (X!=0 X<=0 )                                                     
```