### PR TITLE
Prevent redundant call transformation

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -1768,6 +1768,10 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
          }
       case TR::java_lang_Class_getComponentType:
          {
+         // Constrain the call in the last run of vp to avoid adding the transformation twice if the call is inside a loop.
+         if (!lastTimeThrough())
+            return;
+
          TR::Node *classChild = node->getLastChild();
          bool classChildGlobal;
          TR::VPConstraint *classChildConstraint = getConstraint(classChild, classChildGlobal);


### PR DESCRIPTION
Redundant getComponentType() transformation was observed in value propagation optimization. Adding condition to perform this transformation only in last time through run.
@hzongaro 