### PR TITLE
Fix 32bit platform compiling error

### DIFF
--- a/runtime/gc_realtime/ConfigurationRealtime.cpp
+++ b/runtime/gc_realtime/ConfigurationRealtime.cpp
@@ -108,9 +108,11 @@ MM_Heap *
 MM_ConfigurationRealtime::createHeapWithManager(MM_EnvironmentBase *env, uintptr_t heapBytesRequested, MM_HeapRegionManager *regionManager)
 {
 	MM_GCExtensionsBase *extensions = env->getExtensions();
+#if defined(J9VM_ENV_DATA64)
 	J9JavaVM *vm = (J9JavaVM *)extensions->getOmrVM()->_language_vm;
 	/* Let VM know that Metronome GC has discontiguous indexable object (arraylet layout) */
 	vm->indexableObjectLayout = J9IndexableObjectLayout_NoDataAddr_Arraylet;
+#endif /* defined(J9VM_ENV_DATA64) */
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 


### PR DESCRIPTION
new flag indexableObjectLayout in J9JavaVM is only for 64bit platforms need to preprocessing check "#if defined(J9VM_ENV_DATA64)" for setting the flag in ConfigurationRealtime.