### PR TITLE
Improve VectorAPI tracing

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -225,6 +225,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
       Invalid
       };
 
+   static const char *vapiObjTypeNames[];
 
   /** \brief
    *  Used to specify Vector API opcode category


### PR DESCRIPTION
- print intrinsic info as soon as it's parsed
- print astore info during IL transformation phase