### PR TITLE
Disable cmdLineTester_libpathTestRtfChild for headless riscv64_linux built at Adoptium

### DIFF
--- a/test/functional/cmdLineTests/libpathTest/playlist.xml
+++ b/test/functional/cmdLineTests/libpathTest/playlist.xml
@@ -65,6 +65,10 @@
 				<comment>https://github.com/adoptium/aqa-tests/issues/2877</comment>
 				<platform>(?:aarch64_alpine-linux|x86-64_alpine-linux)</platform>
 			</disable>
+                        <disable>
+                                <comment>https://github.com/adoptium/aqa-tests/issues/5879</comment>
+                                <platform>riscv64_linux</platform>
+                        </disable>
 		</disables>
 		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJAVA_EXE=$(JAVA_COMMAND) -DEXTRA_OPTIONS=$(Q)$(JVM_OPTIONS)$(Q) -DJAVATEST_ROOT=$(JAVATEST_ROOT) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) \
 	-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)libpathTest.jar$(Q) \


### PR DESCRIPTION
Adoptium builds riscv64_linux "headless", test cmdLineTester_libpathTestRtfChild needs excluding for headless builds
Ref: https://github.com/adoptium/aqa-tests/issues/5879
