### PR TITLE
(0.49) JFR threadpark event fix.

### DIFF
--- a/runtime/vm/JFRChunkWriter.hpp
+++ b/runtime/vm/JFRChunkWriter.hpp
@@ -157,6 +157,7 @@ private:
 	static constexpr int THREAD_END_EVENT_SIZE = (4 * sizeof(U_64)) + sizeof(U_32);
 	static constexpr int THREAD_SLEEP_EVENT_SIZE = (7 * sizeof(U_64)) + sizeof(U_32);
 	static constexpr int MONITOR_WAIT_EVENT_SIZE = (9 * sizeof(U_64)) + sizeof(U_32);
+	static constexpr int THREAD_PARK_EVENT_SIZE = (9 * sizeof(U_64)) + sizeof(U_32);
 	static constexpr int JVM_INFORMATION_EVENT_SIZE = 3000;
 	static constexpr int PHYSICAL_MEMORY_EVENT_SIZE = (4 * sizeof(U_64)) + sizeof(U_32);
 	static constexpr int VIRTUALIZATION_INFORMATION_EVENT_SIZE = 50;
@@ -761,6 +762,8 @@ done:
 		requiredBufferSize += (_constantPoolTypes.getThreadSleepCount() * THREAD_SLEEP_EVENT_SIZE);
 
 		requiredBufferSize += (_constantPoolTypes.getMonitorWaitCount() * MONITOR_WAIT_EVENT_SIZE);
+
+		requiredBufferSize += (_constantPoolTypes.getThreadParkCount() * THREAD_PARK_EVENT_SIZE);
 
 		requiredBufferSize += JVM_INFORMATION_EVENT_SIZE;
 

--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -1125,6 +1125,8 @@ VM_JFRConstantPoolTypes::addThreadParkEntry(J9JFRThreadParked* threadParkData)
 	entry->timeOut = threadParkData->timeOut;
 	entry->untilTime = threadParkData->untilTime;
 
+	_threadParkCount += 1;
+
 done:
 	return;
 }


### PR DESCRIPTION
Fixes for buffer size allocation into 0.49 release.