### PR TITLE
Fix spelling of contiguous/discontiguous

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -6510,7 +6510,7 @@ TR::Register *J9::Power::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeG
                TR_ASSERT_FATAL_WITH_NODE(node,
                   (fej9->getOffsetOfDiscontiguousDataAddrField() - fej9->getOffsetOfContiguousDataAddrField()) == 8,
                   "Offset of dataAddr field in discontiguous array is expected to be 8 bytes more than contiguous array. "
-                  "But was %d bytes for discontigous and %d bytes for contiguous array.\n",
+                  "But was %d bytes for discontiguous and %d bytes for contiguous array.\n",
                   fej9->getOffsetOfDiscontiguousDataAddrField(), fej9->getOffsetOfContiguousDataAddrField());
 
                iCursor = generateTrg1Src1Instruction(cg, TR::InstOpCode::cntlzd, node, offsetReg, enumReg, iCursor);

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -1156,7 +1156,7 @@ public:
 	/**
 	 * Returns the address of first data slot in the array.
 	 *
-	 * @param arrayPtr Pointer to the contigous indexable object whose dataPointer we are trying to access
+	 * @param arrayPtr Pointer to the contiguous indexable object whose dataPointer we are trying to access
 	 * @return Address of first data slot in the array
 	 */
 	MMINLINE void *

--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -156,10 +156,10 @@ typedef struct J9IndexableObject* mm_j9array_t;
  * 	else if off-heap enabled (J9IndexableObjectLayout_DataAddr_NoArraylet)
  * 		contiguous-via-dataAddr
  * 	else balancedGC with off-heap disabled or Metronome GC (J9IndexableObjectLayout_NoDataAddr_Arraylet or J9IndexableObjectLayout_DataAddr_Arraylet)
- * 		if contigious
+ * 		if contiguous
  * 			contiguous
  * 		else
- * 			discontigous
+ * 			discontiguous
  */
 #define J9JAVAARRAY_EA(vmThread, array, index, elemType) \
 	((J9IndexableObjectLayout_NoDataAddr_NoArraylet == (vmThread)->indexableObjectLayout) \

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/HeapArrayTests1.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/HeapArrayTests1.java
@@ -44,7 +44,7 @@ import java.lang.invoke.MethodHandle;
 
 /**
  * Test cases for JEP 454: Foreign Linker API for argument/return struct in the
- * case of contiguous/discontigous heap array in downcall.
+ * case of contiguous/discontiguous heap array in downcall.
  *
  * Note:
  * The test suite is mainly intended for the following Clinker API:

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/HeapArrayTests2.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/HeapArrayTests2.java
@@ -44,7 +44,7 @@ import java.lang.invoke.MethodHandle;
 
 /**
  * Test cases for JEP 454: Foreign Linker API for argument/return struct in the
- * case of contiguous/discontigous heap array in downcall.
+ * case of contiguous/discontiguous heap array in downcall.
  *
  * Note:
  * The test suite is mainly intended for the following Clinker API:


### PR DESCRIPTION
New misspellings were introduced in #20888.