### PR TITLE
Improve VectorAPI Expansion IL transformation phase

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -379,6 +379,7 @@ TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node, bool verify
       _nodeTable[nodeIndex]._objectType = getReturnType(methodSymbol);
 
       // Find return object type
+      // For intrinsics below, the class child indicates the object type of the result
       if (_aliasTable[methodRefNum]._objectType == Unknown &&
           isVectorAPICall)
          {
@@ -388,7 +389,7 @@ TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node, bool verify
             _aliasTable[methodRefNum]._objectType = getObjectTypeFromClassNode(comp(), node->getFirstChild());
             _nodeTable[nodeIndex]._objectType = getObjectTypeFromClassNode(comp(), node->getFirstChild());
             }
-         if (methodSymbol->getRecognizedMethod() == TR::jdk_internal_vm_vector_VectorSupport_binaryOp) // can be used for Mask objects too
+         if (methodSymbol->getRecognizedMethod() == TR::jdk_internal_vm_vector_VectorSupport_binaryOp)
             {
             _aliasTable[methodRefNum]._objectType = getObjectTypeFromClassNode(comp(), node->getSecondChild());
             _nodeTable[nodeIndex]._objectType = getObjectTypeFromClassNode(comp(), node->getSecondChild());
@@ -533,11 +534,13 @@ TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node, bool verify
 
          if (supportedOnPlatform(comp(), bitsLength) != TR::NoVectorLength)
             {
-            canVectorize = methodTable[handlerIndex]._methodHandler(this, NULL, node, methodElementType, vectorLength, methodNumLanes,
+            canVectorize = methodTable[handlerIndex]._methodHandler(this, NULL, node, methodElementType, vectorLength,
+                                                                    _nodeTable[nodeIndex]._objectType, methodNumLanes,
                                                                     checkVectorization);
             }
 
-         bool canScalarize = methodTable[handlerIndex]._methodHandler(this, NULL, node, methodElementType, vectorLength, methodNumLanes,
+         bool canScalarize = methodTable[handlerIndex]._methodHandler(this, NULL, node, methodElementType, vectorLength,
+                                                                      _nodeTable[nodeIndex]._objectType, methodNumLanes,
                                                                       checkScalarization);
 
          if (boxingAllowed())
@@ -1664,15 +1667,15 @@ TR_VectorAPIExpansion::transformIL(bool checkBoxing)
       bool scalarized;
       bool vectorizedNode;
 
-      TR::DataType elementTypeTmp;
-      int32_t bitsLengthTmp;
-      vapiObjType objectTypeTmp;
+      TR::DataType elementType;
+      int32_t bitsLength;
+      vapiObjType objectType;
 
-      vectorizedNode = isVectorizedOrScalarizedNode(node, elementTypeTmp, bitsLengthTmp, objectTypeTmp, scalarized);
+      bool vectorizedOrScalarizedNode = isVectorizedOrScalarizedNode(node, elementType, bitsLength, objectType, scalarized);
 
       // Handle non-vectorized nodes by boxing their children
       if (boxingAllowed() &&
-          !vectorizedNode &&
+          !vectorizedOrScalarizedNode &&
           (opCodeValue == TR::astore ||
            opCodeValue == TR::astorei ||
            opCode.isFunctionCall() ||
@@ -1720,7 +1723,7 @@ TR_VectorAPIExpansion::transformIL(bool checkBoxing)
       if (_aliasTable[classId]._classId == -1)  // class was invalidated
          continue;
 
-      TR_ASSERT_FATAL(!boxingAllowed() || vectorizedNode,
+      TR_ASSERT_FATAL(!boxingAllowed() || vectorizedOrScalarizedNode,
                       "Node %p should be either a candidate for vectorization or already vectorized", node);
 
       handlerMode checkMode = checkVectorization;
@@ -1754,17 +1757,13 @@ TR_VectorAPIExpansion::transformIL(bool checkBoxing)
          traceMsg(comp(), "%s node %p of class #%d\n", checkBoxing ? "Checking for boxing" : "Transforming",
                           node, classId);
 
-      int32_t numLanes;
+
+      TR::VectorLength vectorLength = OMR::DataType::bitsToVectorLength(bitsLength);
+      int32_t elementSize = OMR::DataType::getSize(elementType);
+      int32_t numLanes = bitsLength/8/elementSize;
 
       if (opCodeValue == TR::astore)
          {
-         TR::DataType elementType = _aliasTable[tempClassId]._elementType;
-         int32_t bitsLength = _aliasTable[tempClassId]._vecLen;
-         vapiObjType objectType = _aliasTable[tempClassId]._objectType;
-         TR::VectorLength vectorLength = OMR::DataType::bitsToVectorLength(bitsLength);
-         int32_t elementSize = OMR::DataType::getSize(elementType);
-         numLanes = bitsLength/8/elementSize;
-
          if (_trace)
             {
             traceMsg(comp(), "%s astore %p (temp class #%d) elementType=%d vectorLength=%d objectType=%s\n",
@@ -1774,12 +1773,12 @@ TR_VectorAPIExpansion::transformIL(bool checkBoxing)
 
          if (boxingAllowed())
             {
-            TR::DataType elementTypeTmp;
-            int32_t bitsLengthTmp;
-            vapiObjType objectTypeTmp;
-            bool scalarizedTmp;
-            bool rhsVectorizedOrScalarized = isVectorizedOrScalarizedNode(node->getFirstChild(), elementTypeTmp, bitsLengthTmp,
-                                                                          objectTypeTmp, scalarizedTmp);
+            TR::DataType rhsElementType;
+            int32_t rhsBitsLength;
+            vapiObjType rhsObjectType;
+            bool rhsScalarized;
+            bool rhsVectorizedOrScalarized = isVectorizedOrScalarizedNode(node->getFirstChild(), rhsElementType, rhsBitsLength,
+                                                                          rhsObjectType, rhsScalarized);
 
             TR_ASSERT_FATAL(rhsVectorizedOrScalarized, "RHS of vectorized astore should be vectorized too");
             }
@@ -1796,15 +1795,8 @@ TR_VectorAPIExpansion::transformIL(bool checkBoxing)
 
          TR::RecognizedMethod index = methodSymbol->getRecognizedMethod();
          int32_t handlerIndex = index - _firstMethod;
-         TR::DataType elementType;
 
-         getElementTypeAndNumLanes(node, elementType, numLanes);
-
-         int32_t elementSize = OMR::DataType::getSize(elementType);
-         int32_t bitsLength = numLanes*elementSize*8;
-         TR::VectorLength vectorLength = OMR::DataType::bitsToVectorLength(bitsLength);
-
-         TR_ASSERT_FATAL(methodTable[handlerIndex]._methodHandler(this, treeTop, node, elementType, vectorLength, numLanes, checkMode),
+         TR_ASSERT_FATAL(methodTable[handlerIndex]._methodHandler(this, treeTop, node, elementType, vectorLength, objectType, numLanes, checkMode),
                          "Analysis should've proved that method %p is supported for %s", node,
                          (checkMode == checkScalarization) ? "scalarization" : "vectorization");
 
@@ -1832,13 +1824,13 @@ TR_VectorAPIExpansion::transformIL(bool checkBoxing)
                   TR::Node *operand = node->getChild(i);
                   bool vectorizedOrScalarized = false;
 
-                  TR::DataType elementTypeTmp;
-                  int32_t bitsLengthTmp;
-                  vapiObjType objectTypeTmp;
-                  bool scalarizedTmp;
+                  TR::DataType operandElementType;
+                  int32_t operandBitsLength;
+                  vapiObjType operandObjectType;
+                  bool operandScalarized;
 
-                  vectorizedOrScalarized = isVectorizedOrScalarizedNode(operand, elementTypeTmp, bitsLengthTmp,
-                                                                        objectTypeTmp, scalarizedTmp);
+                  vectorizedOrScalarized = isVectorizedOrScalarizedNode(operand, operandElementType, operandBitsLength,
+                                                                        operandObjectType, operandScalarized);
 
                   if (!vectorizedOrScalarized)
                      {
@@ -1873,7 +1865,7 @@ TR_VectorAPIExpansion::transformIL(bool checkBoxing)
 
          if (!checkBoxing)
             {
-            methodTable[handlerIndex]._methodHandler(this, treeTop, node, elementType, vectorLength, numLanes, doMode);
+            methodTable[handlerIndex]._methodHandler(this, treeTop, node, elementType, vectorLength, objectType, numLanes, doMode);
             }
          }
 
@@ -2144,9 +2136,10 @@ void TR_VectorAPIExpansion::astoreHandler(TR_VectorAPIExpansion *opt, TR::TreeTo
    }
 
 
-TR::Node *TR_VectorAPIExpansion::unsupportedHandler(TR_VectorAPIExpansion *, TR::TreeTop *treeTop,
+TR::Node *TR_VectorAPIExpansion::unsupportedHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop,
                                                     TR::Node *node, TR::DataType elementType,
-                                                    TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode)
+                                                    TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes,
+                                                    handlerMode mode)
    {
    return NULL;
    }
@@ -2154,19 +2147,18 @@ TR::Node *TR_VectorAPIExpansion::unsupportedHandler(TR_VectorAPIExpansion *, TR:
 
 TR::Node *TR_VectorAPIExpansion::loadIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop,
                                                       TR::Node *node, TR::DataType elementType,
-                                                      TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode)
+                                                      TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes,
+                                                      handlerMode mode)
    {
    TR::Compilation *comp = opt->comp();
 
-   vapiObjType objType = getObjectTypeFromClassNode(comp, node->getFirstChild());
-
    if (mode == checkScalarization)
       {
-      return (objType == Vector) ? node : NULL;
+      return (objectType == Vector) ? node : NULL;
       }
    else if (mode == checkVectorization)
       {
-      if (objType == Vector)
+      if (objectType == Vector)
          {
          if (opt->_trace)
             traceMsg(comp, "Vector load with numLanes %d in node %p\n", numLanes, node);
@@ -2179,7 +2171,7 @@ TR::Node *TR_VectorAPIExpansion::loadIntrinsicHandler(TR_VectorAPIExpansion *opt
 
          return node;
          }
-      else if (objType == Mask)
+      else if (objectType == Mask)
          {
          if (opt->_trace)
             traceMsg(comp, "Mask load with numLanes %d in node %p\n", numLanes, node);
@@ -2231,13 +2223,13 @@ TR::Node *TR_VectorAPIExpansion::loadIntrinsicHandler(TR_VectorAPIExpansion *opt
    TR::Node *base = node->getChild(3);
    TR::Node *offset = node->getChild(4);
 
-   return transformLoadFromArray(opt, treeTop, node, elementType, vectorLength, numLanes, mode, base, offset, objType);
+   return transformLoadFromArray(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, base, offset);
    }
 
 TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                        TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                        handlerMode mode,
-                                                        TR::Node *base, TR::Node *offset, vapiObjType objType)
+                                                        TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                        int32_t numLanes, handlerMode mode,
+                                                        TR::Node *base, TR::Node *offset)
 
    {
    TR::Compilation *comp = opt->comp();
@@ -2247,7 +2239,7 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
 
    anchorOldChildren(opt, treeTop, node);
 
-   if (objType != Mask)
+   if (objectType != Mask)
       node->setAndIncChild(0, aladdNode);
 
    node->setNumChildren(1);
@@ -2288,7 +2280,7 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
       TR::DataType vectorType = TR::DataType::createVectorType(elementType, vectorLength);
       TR::ILOpCodes op;
 
-      if (objType == Vector)
+      if (objectType == Vector)
          {
          TR::DataType symRefType = vectorType;
          TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateArrayShadowSymbolRef(symRefType, NULL);
@@ -2296,7 +2288,7 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
          TR::Node::recreate(node, op);
          node->setSymbolReference(symRef);
          }
-      else if (objType == Mask)
+      else if (objectType == Mask)
          {
          TR::ILOpCodes loadOpCode;
          TR::DataType symRefType;
@@ -2363,20 +2355,18 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
 
 
 TR::Node *TR_VectorAPIExpansion::storeIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                       TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                       handlerMode mode)
+                                                       TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                       int32_t numLanes, handlerMode mode)
    {
    TR::Compilation *comp = opt->comp();
 
-   vapiObjType objType = getObjectTypeFromClassNode(comp, node->getFirstChild());
-
    if (mode == checkScalarization)
       {
-      return (objType == Vector) ? node : NULL;
+      return (objectType == Vector) ? node : NULL;
       }
    else if (mode == checkVectorization)
       {
-      if (objType == Vector)
+      if (objectType == Vector)
          {
          TR::DataType vectorType = TR::DataType::createVectorType(elementType, vectorLength);
          TR::ILOpCodes vectorOpCode = TR::ILOpCode::createVectorOpCode(TR::vstorei, vectorType);
@@ -2386,7 +2376,7 @@ TR::Node *TR_VectorAPIExpansion::storeIntrinsicHandler(TR_VectorAPIExpansion *op
 
          return node;
          }
-      else if (objType == Mask)
+      else if (objectType == Mask)
          {
          if (opt->_trace)
             traceMsg(comp, "Mask store with numLanes %d in node %p\n", numLanes, node);
@@ -2445,14 +2435,14 @@ TR::Node *TR_VectorAPIExpansion::storeIntrinsicHandler(TR_VectorAPIExpansion *op
    TR::Node *valueToWrite = node->getChild(6);
 #endif
 
-   return transformStoreToArray(opt, treeTop, node, elementType, vectorLength, numLanes, mode, valueToWrite, base, offset, objType);
+   return transformStoreToArray(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, valueToWrite, base, offset);
    }
 
 
 TR::Node *TR_VectorAPIExpansion::transformStoreToArray(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                       TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                       handlerMode mode,
-                                                       TR::Node *valueToWrite, TR::Node *base, TR::Node *offset, vapiObjType objType)
+                                                       TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                       int32_t numLanes, handlerMode mode,
+                                                       TR::Node *valueToWrite, TR::Node *base, TR::Node *offset)
 
    {
    TR::Compilation *comp = opt->comp();
@@ -2507,21 +2497,21 @@ TR::Node *TR_VectorAPIExpansion::transformStoreToArray(TR_VectorAPIExpansion *op
    else if (mode == doVectorization)
       {
       TR::DataType opCodeType = TR::DataType::createVectorType(elementType, vectorLength);
-      if (objType == Mask)
+      if (objectType == Mask)
           opCodeType = TR::DataType::createMaskType(elementType, vectorLength);
 
       if (valueToWrite->getOpCodeValue() == TR::aload) vectorizeLoadOrStore(opt, valueToWrite, opCodeType);
 
       TR::ILOpCodes op;
 
-      if (objType == Vector)
+      if (objectType == Vector)
          {
          TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateArrayShadowSymbolRef(opCodeType, NULL);
          op = TR::ILOpCode::createVectorOpCode(TR::vstorei, opCodeType);
          TR::Node::recreate(node, op);
          node->setSymbolReference(symRef);
          }
-      else if (objType == Mask)
+      else if (objectType == Mask)
          {
          TR::ILOpCodes storeOpCode;
 
@@ -2582,46 +2572,46 @@ TR::Node *TR_VectorAPIExpansion::transformStoreToArray(TR_VectorAPIExpansion *op
 
 
 TR::Node *TR_VectorAPIExpansion::unaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                       TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                       handlerMode mode)
+                                                       TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                       int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 1, Other);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 1, Other);
    }
 
 TR::Node *TR_VectorAPIExpansion::binaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                        TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                        handlerMode mode)
+                                                        TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                        int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 2, Other);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 2, Other);
    }
 
 TR::Node *TR_VectorAPIExpansion::maskReductionCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                                  TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                                  handlerMode mode)
+                                                                      TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                                      int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 1, MaskReduction);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 1, MaskReduction);
    }
 
 
 TR::Node *TR_VectorAPIExpansion::reductionCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                                  TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                                  handlerMode mode)
+                                                                  TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                                  int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 1, Reduction);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 1, Reduction);
    }
 
 TR::Node *TR_VectorAPIExpansion::ternaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                         TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                         handlerMode mode)
+                                                         TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                         int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 3, Other);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 3, Other);
    }
 
 TR::Node *TR_VectorAPIExpansion::testIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                         TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                         handlerMode mode)
+                                                      TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                      int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 1, Test);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 1, Test);
    }
 
 TR::Node *TR_VectorAPIExpansion::transformRORtoROL(TR_VectorAPIExpansion *opt, TR::Node *shiftAmount,
@@ -2663,8 +2653,8 @@ TR::Node *TR_VectorAPIExpansion::transformRORtoROL(TR_VectorAPIExpansion *opt, T
 
 
 TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                      TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                      handlerMode mode,
+                                                      TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                      int32_t numLanes, handlerMode mode,
                                                       int32_t numChildren, vapiOpCodeType opCodeType)
    {
    TR::Compilation *comp = opt->comp();
@@ -2717,7 +2707,7 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
       // and all operations should be done in Int in the case of scalarization
       if (elementType == TR::Int8 || elementType == TR::Int16)
            opType = TR::Int32;
-      scalarOpCode = ILOpcodeFromVectorAPIOpcode(comp, vectorAPIOpcode, opType, TR::NoVectorLength, opCodeType, withMask);
+      scalarOpCode = ILOpcodeFromVectorAPIOpcode(comp, vectorAPIOpcode, opType, TR::NoVectorLength, objectType, opCodeType, withMask);
 
       if (mode == checkScalarization)
          {
@@ -2786,7 +2776,7 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
 
       if (mode == checkVectorization)
          {
-         vectorOpCode = ILOpcodeFromVectorAPIOpcode(comp, vectorAPIOpcode, opType, vectorLength, opCodeType, withMask,
+         vectorOpCode = ILOpcodeFromVectorAPIOpcode(comp, vectorAPIOpcode, opType, vectorLength, objectType, opCodeType, withMask,
                                                     resultElementType, resultVectorLength);
 
          if (vectorOpCode == TR::BadILOp || !comp->cg()->getSupportsOpCodeForAutoSIMD(vectorOpCode))
@@ -2828,7 +2818,7 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
          }
       else
          {
-         vectorOpCode = ILOpcodeFromVectorAPIOpcode(comp, vectorAPIOpcode, opType, vectorLength, opCodeType, withMask,
+         vectorOpCode = ILOpcodeFromVectorAPIOpcode(comp, vectorAPIOpcode, opType, vectorLength, objectType, opCodeType, withMask,
                                                     resultElementType, resultVectorLength);
 
          TR_ASSERT_FATAL(vectorOpCode != TR::BadILOp, "Vector opcode should exist for node %p\n", node);
@@ -2849,22 +2839,22 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
    }
 
 TR::Node *TR_VectorAPIExpansion::blendIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                       TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                       handlerMode mode)
+                                                       TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                       int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 3, Blend);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 3, Blend);
    }
 
 TR::Node *TR_VectorAPIExpansion::broadcastIntIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                       TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                       handlerMode mode)
+                                                              TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                              int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 2, BroadcastInt);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 2, BroadcastInt);
    }
 
 TR::Node *TR_VectorAPIExpansion::fromBitsCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                                 TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                                 handlerMode mode)
+                                                                 TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                                 int32_t numLanes, handlerMode mode)
    {
    TR::Compilation *comp = opt->comp();
 
@@ -2888,6 +2878,9 @@ TR::Node *TR_VectorAPIExpansion::fromBitsCoercedIntrinsicHandler(TR_VectorAPIExp
 
    if (mode == checkVectorization)
       {
+      if (objectType == Mask)
+         return NULL; // TODO: support Mask
+
       TR::ILOpCodes splatsOpCode = TR::ILOpCode::createVectorOpCode(mask ? TR::mLongBitsToMask : TR::vsplats,
                                                                     TR::DataType::createVectorType(elementType, vectorLength));
 
@@ -2973,41 +2966,43 @@ TR::Node *TR_VectorAPIExpansion::fromBitsCoercedIntrinsicHandler(TR_VectorAPIExp
    }
 
 TR::Node *TR_VectorAPIExpansion::compareIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                         TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                         handlerMode mode)
+                                                         TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                         int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 2, Compare);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 2, Compare);
    }
 
 TR::Node *TR_VectorAPIExpansion::compressExpandOpIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                         TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                         handlerMode mode)
+                                                                  TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                                  int32_t numLanes, handlerMode mode)
    {
-   TR::Compilation *comp = opt->comp();
-   vapiObjType objType;
-
-   if (node->getFirstChild()->getOpCode().isLoadConst() &&
-       node->getFirstChild()->get32bitIntegralValue() == VECTOR_OP_MASK_COMPRESS)
-       objType = Mask;
-   else
-       objType = Vector;
-
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, objType == Vector ? 2 : 1, Compress);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, objectType == Vector ? 2 : 1, Compress);
    }
 
 TR::Node *TR_VectorAPIExpansion::convertIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node,
-                                                         TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes,
-                                                         handlerMode mode)
+                                                         TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType,
+                                                         int32_t numLanes, handlerMode mode)
    {
-   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, numLanes, mode, 1, Convert);
+   return naryIntrinsicHandler(opt, treeTop, node, elementType, vectorLength, objectType, numLanes, mode, 1, Convert);
    }
 
 TR::ILOpCodes TR_VectorAPIExpansion::ILOpcodeFromVectorAPIOpcode(TR::Compilation *comp, int32_t vectorAPIOpCode, TR::DataType elementType,
-                                                                 TR::VectorLength vectorLength, vapiOpCodeType opCodeType,
+                                                                 TR::VectorLength vectorLength, vapiObjType objectType,
+                                                                 vapiOpCodeType opCodeType,
                                                                  bool withMask,
                                                                  TR::DataType resultElementType,
                                                                  TR::VectorLength resultVectorLength)
    {
+   // Skip some unsupported operations on Mask for now (e.g. binary operation on Mask). TODO: implement
+   if (objectType == Mask &&
+       vectorAPIOpCode != VECTOR_OP_MASK_COMPRESS &&
+       opCodeType != Test &&
+       opCodeType != MaskReduction &&
+       opCodeType != Compare)  // for Compare, objectType is Mask (the result) but the operands are always vectors
+      {
+      return TR::BadILOp;
+      }
+
    // TODO: support more scalarization
 
    bool scalar = (vectorLength == TR::NoVectorLength);

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -250,7 +250,8 @@ class TR_VectorAPIExpansion : public TR::Optimization
    */
    struct methodTableEntry
       {
-      TR::Node * (* _methodHandler)(TR_VectorAPIExpansion *, TR::TreeTop *, TR::Node *, TR::DataType, TR::VectorLength, int32_t, handlerMode);
+      TR::Node * (* _methodHandler)(TR_VectorAPIExpansion *, TR::TreeTop *, TR::Node *, TR::DataType, TR::VectorLength,
+                                    vapiObjType, int32_t, handlerMode);
       vapiObjType  _returnType;
       int32_t      _elementTypeIndex;
       int32_t      _numLanesIndex;
@@ -306,7 +307,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
       int32_t              _classId;
       bool                 _cantVectorize;
       bool                 _cantScalarize;
-      vapiObjType          _objectType;
+      vapiObjType          _objectType;   // resulting object type
 
       TR_BitVector        *_tempAliases;
       int32_t              _tempClassId;
@@ -328,7 +329,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
 
       vec_sz_t             _vecLen;
       TR::DataType         _elementType;
-      vapiObjType          _objectType;
+      vapiObjType          _objectType;  // resulting object type
       bool                 _canVectorize;
       bool                 _canScalarize;
 
@@ -783,6 +784,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *  \param vectorLength
    *     return scalar opcode if vectorLength == 0 and vector opcode otherwise
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *  \param opCodeType
    *     opcode type
    *
@@ -799,7 +803,8 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *     scalar TR::IL opcode if scalar is true, otherwise vector opcode
    */
    static TR::ILOpCodes ILOpcodeFromVectorAPIOpcode(TR::Compilation *comp, int32_t vectorOpCode, TR::DataType elementType,
-                                                    TR::VectorLength vectorLength, vapiOpCodeType opCodeType, bool withMask,
+                                                    TR::VectorLength vectorLength, vapiObjType objectType,
+                                                    vapiOpCodeType opCodeType, bool withMask,
                                                     TR::DataType resultElementType = TR::NoType,
                                                     TR::VectorLength resultVectorLength = TR::NoVectorLength);
 
@@ -946,7 +951,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      NULL
    */
-   static TR::Node *unsupportedHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *unsupportedHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.load() intrinsic.
@@ -968,6 +973,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *       Number of elements
    *
@@ -978,7 +986,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *loadIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *loadIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
 
   /** \brief
@@ -1001,6 +1009,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1011,7 +1022,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *storeIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *storeIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.unaryOp() intrinsic.
@@ -1033,6 +1044,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1043,7 +1057,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *unaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *unaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.binaryOp() intrinsic.
@@ -1065,6 +1079,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1075,7 +1092,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *binaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *binaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.maskReductionCoerced() intrinsic.
@@ -1097,6 +1114,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1107,7 +1127,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *maskReductionCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *maskReductionCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.reductionCoerced() intrinsic.
@@ -1129,6 +1149,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1139,7 +1162,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *reductionCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *reductionCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.ternaryOp() intrinsic.
@@ -1161,6 +1184,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1171,7 +1197,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *ternaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *ternaryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
 
   /** \brief
@@ -1194,6 +1220,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *  \param objectType
+   *     Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1204,7 +1233,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *      Transformed node
    *
    */
-   static TR::Node *testIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *testIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
 
   /** \brief
@@ -1251,6 +1280,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1266,7 +1298,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      Transformed node
    */
-   static TR::Node *naryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode, int32_t numChidren, vapiOpCodeType opCodeType);
+   static TR::Node *naryIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode, int32_t numChidren, vapiOpCodeType opCodeType);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.blend() intrinsic.
@@ -1288,6 +1320,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1297,7 +1332,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      Transformed node
    */
-   static TR::Node *blendIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *blendIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.broadcastInt() intrinsic.
@@ -1319,6 +1354,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1328,7 +1366,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      Transformed node
    */
-   static TR::Node *broadcastIntIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *broadcastIntIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.fromBitsCoerced() intrinsic.
@@ -1350,6 +1388,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1359,7 +1400,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      Transformed node
    */
-   static TR::Node *fromBitsCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *fromBitsCoercedIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
   /** \brief
    *    Scalarizes or vectorizes a node that is a call to \c VectorSupport.compare() intrinsic.
@@ -1381,6 +1422,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1390,7 +1434,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      Transformed node
    */
-   static TR::Node *compareIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *compareIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
 
   /** \brief
@@ -1413,6 +1457,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1422,7 +1469,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      Transformed node
    */
-   static TR::Node *compressExpandOpIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *compressExpandOpIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
 
   /** \brief
@@ -1445,6 +1492,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1454,7 +1504,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      Transformed node
    */
-   static TR::Node *convertIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode);
+   static TR::Node *convertIntrinsicHandler(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode);
 
 
   /** \brief
@@ -1475,6 +1525,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1487,14 +1540,11 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param arrayIndex
    *      array index node
    *
-   *   \param objType
-   *      Vector API object type (Vector, Mask, Shuffle, etc.)
-   *
    *   \return
    *      Transformed node
    *
    */
-   static TR::Node *transformLoadFromArray(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode, TR::Node *array, TR::Node *arrayIndex, vapiObjType objType);
+   static TR::Node *transformLoadFromArray(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode, TR::Node *array, TR::Node *arrayIndex);
 
   /** \brief
    *    Helper method to transform a store to array node
@@ -1514,6 +1564,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param vectorLength
    *      Vector length
    *
+   *   \param objectType
+   *      Vector API object type (Vector, Mask, Shuffle, etc.)
+   *
    *   \param numLanes
    *      Number of elements
    *
@@ -1529,14 +1582,11 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \param arrayIndex
    *      array index node
    *
-   *   \param objType
-   *      Vector API object type (Vector, Mask, Shuffle, etc.)
-   *
    *   \return
    *      Transformed node
    *
    */
-   static TR::Node *transformStoreToArray(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, int32_t numLanes, handlerMode mode, TR::Node *valueToWrite, TR::Node *array, TR::Node *arrayIndex, vapiObjType objType);
+   static TR::Node *transformStoreToArray(TR_VectorAPIExpansion *opt, TR::TreeTop *treeTop, TR::Node *node, TR::DataType elementType, TR::VectorLength vectorLength, vapiObjType objectType, int32_t numLanes, handlerMode mode, TR::Node *valueToWrite, TR::Node *array, TR::Node *arrayIndex);
 
 
   /** \brief


### PR DESCRIPTION
- only use elementType, vectorBitLength, and objectType info calculated during analysis phase (e.g. don't analyze nodes again)
- use objectType info when selecting opcode to distinguish between Vector and Mask operations. For example, some binary operations can be for vectors and for masks and require different opcodes