### PR TITLE
Reduce the amount of fanin info collected by IProfiler

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -191,6 +191,7 @@ int32_t J9::Options::_maxIprofilingCount = TR_DEFAULT_INITIAL_COUNT; // 3000
 int32_t J9::Options::_maxIprofilingCountInStartupMode = TR_QUICKSTART_INITIAL_COUNT; // 1000
 int32_t J9::Options::_iprofilerFailRateThreshold = 70; // percent 1-100
 int32_t J9::Options::_iprofilerFailHistorySize = 10; // percent 1-100
+int32_t J9::Options::_iprofilerFaninMethodMinSize = 50; // bytecodes
 
 int32_t J9::Options::_compYieldStatsThreshold = 1000; // usec
 int32_t J9::Options::_compYieldStatsHeartbeatPeriod = 0; // ms
@@ -1045,6 +1046,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_iprofilerFailHistorySize, 0, "F%d", NOT_IN_SUBSET},
    {"iprofilerFailRateThreshold=", "I<nnn>\tReactivate Iprofiler if fail rate exceeds this threshold. 1-100",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_iprofilerFailRateThreshold, 0, "F%d", NOT_IN_SUBSET},
+   {"iprofilerFaninMethodMinSize=", "I<nnn>\tMinimum size of methods considered by the fanin mechanism",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_iprofilerFaninMethodMinSize, 50, "F%d", NOT_IN_SUBSET},
    {"iprofilerIntToTotalSampleRatio=", "O<nnn>\tRatio of Interpreter samples to Total samples",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_iprofilerIntToTotalSampleRatio, 0, "F%d", NOT_IN_SUBSET},
    {"iprofilerMaxCount=", "O<nnn>\tmax invocation count for IProfiler to be active",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -292,6 +292,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
                                                     // during STARTUP phase (and only during classLoadPhase)
    static int32_t _iprofilerFailRateThreshold; // will reactivate Iprofiler if failure rate exceeds this threshold
    static int32_t _iprofilerFailHistorySize;
+   static int32_t _iprofilerFaninMethodMinSize; // minimum method size (in bytecodes) so that the method is
+                                                // considered by the fanin mechanism in the inliner
    static int32_t _iProfilerMemoryConsumptionLimit;
    static int32_t _iProfilerBcHashTableSize;
    static int32_t _iProfilerMethodHashTableSize;

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -87,7 +87,6 @@ namespace TR { class SimpleRegex; }
 #define OWNING_METHOD_MAY_NOT_BE_THE_CALLER (1)
 
 #define MIN_NUM_CALLERS 20
-#define MIN_FAN_IN_SIZE 50
 #define SIZE_MULTIPLIER 4
 #define FANIN_OTHER_BUCKET_THRESHOLD 0.5
 #define DEFAULT_CONST_CLASS_WEIGHT 10
@@ -2932,11 +2931,8 @@ TR_J9InlinerPolicy::adjustFanInSizeInWeighCallSite(int32_t& weight,
       if (comp()->getMethodHotness() > warm)
          return;
 
-      static const char *qq = feGetEnv("TR_Min_FanIn_Size");
-      static const uint32_t min_size = ( qq ) ? atoi(qq) : MIN_FAN_IN_SIZE;
-
       uint32_t thresholdSize = (!comp()->getOption(TR_InlinerFanInUseCalculatedSize)) ? getJ9InitialBytecodeSize(callee, 0, comp()) : size;
-      if (thresholdSize <= min_size)  // if we are less than min_fan_in size, we don't want to apply fan-in heuristic
+      if (thresholdSize <= TR::Options::_iprofilerFaninMethodMinSize)  // if we are less than min_fan_in size, we don't want to apply fan-in heuristic
          {
          return;
          }
@@ -3047,15 +3043,12 @@ TR_J9InlinerPolicy::adjustFanInSizeInExceedsSizeThreshold(int bytecodeSize,
    static const char *q = feGetEnv("TR_SizeMultiplier");
    static const uint32_t multiplier = ( q ) ? atoi (q) : SIZE_MULTIPLIER;
 
-   static const char *qq = feGetEnv("TR_Min_FanIn_Size");
-   static const uint32_t min_size = ( qq ) ? atoi(qq) : MIN_FAN_IN_SIZE;
-
    static const char *qqq = feGetEnv("TR_OtherBucketThreshold");
    static const float otherBucketThreshold = (qqq) ? (float) (atoi (qqq) /100.0) : FANIN_OTHER_BUCKET_THRESHOLD;
 
 
    uint32_t thresholdSize = (!comp()->getOption(TR_InlinerFanInUseCalculatedSize)) ? getJ9InitialBytecodeSize(callee, 0, comp()) : calculatedSize;
-   if (thresholdSize <= min_size)  // if we are less than min_fan_in size, we don't want to apply fan-in heuristic
+   if (thresholdSize <= TR::Options::_iprofilerFaninMethodMinSize)  // if we are less than min_fan_in size, we don't want to apply fan-in heuristic
       {
       return false;
       }
@@ -4982,11 +4975,9 @@ TR_MultipleCallTargetInliner::exceedsSizeThreshold(TR_CallSite *callSite, int by
  */
        }
 
-   static const char *qq;
-   static uint32_t min_size = ( qq = feGetEnv("TR_Min_FanIn_Size")) ? atoi(qq) : MIN_FAN_IN_SIZE;
    static const char *q;
    static uint32_t multiplier = ( q = feGetEnv("TR_SizeMultiplier")) ? atoi (q) : SIZE_MULTIPLIER;
-   uint32_t calculatedSize = bytecodeSize; //(bytecodeSize - MIN_FAN_IN_SIZE);
+   uint32_t calculatedSize = bytecodeSize;
 
    if (!comp()->getOption(TR_DisableInlinerFanIn))  // TODO: make the default for everybody
       {

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -1179,6 +1179,12 @@ TR_IProfiler::findOrCreateMethodEntry(J9Method *callerMethod, J9Method *calleeMe
 
    if (!_methodHashTable)
       return NULL;
+
+   // There is no point to add small methods to the table because
+   // the inliner does not consider them in its heristics.
+   if (addIt && TR::Compiler->mtd.bytecodeSize((TR_OpaqueMethodBlock*)calleeMethod) <= TR::Options::_iprofilerFaninMethodMinSize)
+      return NULL;
+
    // Search the hashtable
    int32_t bucket = methodHash((uintptr_t)calleeMethod);
    entry = searchForMethodSample((TR_OpaqueMethodBlock*)calleeMethod, bucket);


### PR DESCRIPTION
The only consumer of the fanin info is the inliner. However, the inliner will ignore the fanin data for any method (callee) that is less than 50 bytecodes. Thus, it makes sense to avoid storing fanin info for such small methods. 
With this change the number of entries stored by the fanin mechanism is reduced by about 72%. This is expected to reduce footprint somewhat and to reduce the overhead of the methodinfo hashtable which stores fanin info.
The threshold that decides what is consiredered a small method from the fanin mechanism point of view can be changed with `-Xjit:iprofilerFaninMethodMinSize=` option (default is 50 bytecodes)