### PR TITLE
Add new jdk.internal.value.ValueClass native methods

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -481,10 +481,13 @@ endif()
 
 if(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	jvm_add_exports(jvm
-		JVM_IsValhallaEnabled
+		JVM_IsFlatArray
 		JVM_IsImplicitlyConstructibleClass
 		JVM_IsNullRestrictedArray
+		JVM_IsValhallaEnabled
+		JVM_NewNullableAtomicArray
 		JVM_NewNullRestrictedArray
+		JVM_NewNullRestrictedAtomicArray
 		JVM_VirtualThreadHideFrames
 	)
 endif()

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -331,7 +331,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<export name="AsyncGetCallTrace"/>
 
 		<!-- Additions for Valhalla -->
-		<export name="JVM_IsValhallaEnabled">
+		<export name="JVM_IsFlatArray">
 			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
 		</export>
 		<export name="JVM_IsImplicitlyConstructibleClass">
@@ -340,7 +340,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<export name="JVM_IsNullRestrictedArray">
 			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
 		</export>
+		<export name="JVM_IsValhallaEnabled">
+			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
+		</export>
+		<export name="JVM_NewNullableAtomicArray">
+			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
+		</export>
 		<export name="JVM_NewNullRestrictedArray">
+			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
+		</export>
+		<export name="JVM_NewNullRestrictedAtomicArray">
 			<include-if condition="spec.flags.opt_valhallaValueTypes"/>
 		</export>
 		<export name="JVM_VirtualThreadHideFrames">

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -421,13 +421,19 @@ _IF([JAVA_SPEC_VERSION >= 21],
 _IF([JAVA_SPEC_VERSION >= 21],
 	[_X(JVM_VirtualThreadUnmount, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
-	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
+	[_X(JVM_IsFlatArray, JNICALL, false, jboolean, JNIEnv *env, jclass cls)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsImplicitlyConstructibleClass, JNICALL, false, jboolean, JNIEnv *env, jclass cls)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsNullRestrictedArray, JNICALL, false, jboolean, JNIEnv *env, jobject obj)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
+	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
+_IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
+	[_X(JVM_NewNullableAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length)])
+_IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_NewNullRestrictedArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length)])
+_IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
+	[_X(JVM_NewNullRestrictedAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
 _IF([JAVA_SPEC_VERSION == 22],


### PR DESCRIPTION
This change adds:
- JVM_IsFlatArray
- JVM_NewNullableAtomicArray
- JVM_NewNullRestrictedAtomicArray

Fixes: https://github.com/eclipse-openj9/openj9/issues/20973