### PR TITLE
Verify off heap entry during update and free offheap array

### DIFF
--- a/runtime/gc_check/CheckEngine.cpp
+++ b/runtime/gc_check/CheckEngine.cpp
@@ -468,8 +468,12 @@ GC_CheckEngine::checkJ9Object(J9JavaVM *javaVM, J9Object* objectPtr, J9MM_Iterat
 	if (extensions->isVirtualLargeObjectHeapEnabled && extensions->objectModel.isIndexable(objectPtr)) {
 		/* Check that the indexable object has the correct data address pointer */
 		void *dataAddr = extensions->indexableObjectModel.getDataAddrForIndexableObject((J9IndexableObject *)objectPtr);
-		bool isValidDataAddr = extensions->largeObjectVirtualMemory->getSparseDataPool()->isValidDataPtr(dataAddr);
-		if (!isValidDataAddr && !extensions->indexableObjectModel.isValidDataAddr((J9IndexableObject *)objectPtr, dataAddr, isValidDataAddr)) {
+		bool isDataNonAdjacent = false;
+		bool isValidDataAddr = extensions->indexableObjectModel.isValidDataAddrForAdjacentData((J9IndexableObject *)objectPtr, dataAddr, &isDataNonAdjacent);
+		if (isDataNonAdjacent) {
+			isValidDataAddr = extensions->largeObjectVirtualMemory->getSparseDataPool()->isValidDataPtr(dataAddr, objectPtr, extensions->indexableObjectModel.getDataSizeInBytes((J9IndexableObject *)objectPtr));
+		}
+		if (!isValidDataAddr) {
 			return J9MODRON_GCCHK_RC_INVALID_INDEXABLE_DATA_ADDRESS;
 		}
 	}

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -947,17 +947,17 @@ public:
 	 * Checks that the dataAddr field of the indexable object is correct.
 	 * this method is supposed to be called only if offheap is enabled.
 	 *
-	 * @param arrayPtr      Pointer to the indexable object
-	 * @param isValidDataAddrForOffHeapObject	Boolean to determine whether the given indexable object is off heap
-	 * @return if the dataAddr field of the indexable object is correct
+	 * @param arrayPtr[in]              Pointer to the indexable object
+	 * @param isDataNonAdjacent[out]    set true if the given indexable object is off heap
+	 * @return if the dataAddr field of the indexable object is correct(not heap object case), return false if indexable object is off heap
 	 */
 	MMINLINE bool
-	isValidDataAddr(J9IndexableObject *arrayPtr, bool isValidDataAddrForOffHeapObject)
+	isValidDataAddrForAdjacentData(J9IndexableObject *arrayPtr, bool *isDataNonAdjacent)
 	{
 		bool isValidDataAddress = true;
 		if (_isIndexableDataAddrPresent) {
 			void *dataAddr = getDataAddrForIndexableObject(arrayPtr);
-			isValidDataAddress = isValidDataAddr(arrayPtr, dataAddr, isValidDataAddrForOffHeapObject);
+			isValidDataAddress = isValidDataAddrForAdjacentData(arrayPtr, dataAddr, isDataNonAdjacent);
 		}
 		return isValidDataAddress;
 	}
@@ -966,12 +966,12 @@ public:
 	 * Checks that the dataAddr field of the indexable object is correct.
 	 * this method is supposed to be called only if offheap is enabled
 	 *
-	 * @param arrayPtr      Pointer to the indexable object
-	 * @param isValidDataAddrForOffHeapObject	Boolean to determine whether the given indexable object is off heap
-	 * @return if the dataAddr field of the indexable object is correct
+	 * @param arrayPtr                 Pointer to the indexable object
+	 * @param isDataNonAdjacent[out]   set true if the given indexable object is off heap
+	 * @return if the dataAddr field of the indexable object is correct(not heap object case),  return false if indexable object is off heap
 	 */
 	MMINLINE bool
-	isValidDataAddr(J9IndexableObject *arrayPtr, void *dataAddr, bool isValidDataAddrForOffHeapObject)
+	isValidDataAddrForAdjacentData(J9IndexableObject *arrayPtr, void *dataAddr, bool *isDataNonAdjacent)
 	{
 		bool isValidDataAddress = false;
 		uintptr_t dataSizeInBytes = getDataSizeInBytes(arrayPtr);
@@ -981,7 +981,7 @@ public:
 		} else if (dataSizeInBytes < _omrVM->_arrayletLeafSize) {
 			isValidDataAddress = (dataAddr == (void *)((uintptr_t)arrayPtr + contiguousIndexableHeaderSize()));
 		} else {
-			isValidDataAddress = isValidDataAddrForOffHeapObject;
+			*isDataNonAdjacent = true;
 		}
 
 		return isValidDataAddress;

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -4096,7 +4096,7 @@ private:
 				Assert_MM_mustBeClass(_extensions->objectModel.getPreservedClass(&forwardedHeader));
 				env->_copyForwardStats._offHeapRegionsCleared += 1;
 				void *dataAddr = _extensions->indexableObjectModel.getDataAddrForContiguous((J9IndexableObject *)objectPtr);
-				_extensions->largeObjectVirtualMemory->freeSparseRegionAndUnmapFromHeapObject(_env, dataAddr);
+				_extensions->largeObjectVirtualMemory->freeSparseRegionAndUnmapFromHeapObject(_env, dataAddr, objectPtr, _extensions->indexableObjectModel.getDataSizeInBytes((J9IndexableObject *)objectPtr));
 				*sparseHeapAllocation = false;
 			} else {
 				void *dataAddr = _extensions->indexableObjectModel.getDataAddrForContiguous((J9IndexableObject *)fwdOjectPtr);
@@ -4104,8 +4104,7 @@ private:
 					/* There might be the case that GC finds a floating arraylet, which was a result of an allocation
 					 * failure (reason why this GC cycle is happening).
 					 */
-					_extensions->largeObjectVirtualMemory->updateSparseDataEntryAfterObjectHasMoved(dataAddr, fwdOjectPtr);
-				}
+					_extensions->largeObjectVirtualMemory->updateSparseDataEntryAfterObjectHasMoved(dataAddr, objectPtr,  _extensions->indexableObjectModel.getDataSizeInBytes((J9IndexableObject *)fwdOjectPtr), fwdOjectPtr);				}
 			}
 		}
 	}

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1378,7 +1378,8 @@ private:
 			env->_markVLHGCStats._offHeapRegionsCleared += 1;
 			void *dataAddr = _extensions->indexableObjectModel.getDataAddrForContiguous((J9IndexableObject *)objectPtr);
 			if (NULL != dataAddr) {
-				_extensions->largeObjectVirtualMemory->freeSparseRegionAndUnmapFromHeapObject(_env, dataAddr);
+				_extensions->largeObjectVirtualMemory->freeSparseRegionAndUnmapFromHeapObject(_env, dataAddr, objectPtr, _extensions->indexableObjectModel.getDataSizeInBytes((J9IndexableObject *)objectPtr));
+
 				*sparseHeapAllocation = false;
 			}
 		}

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1697,7 +1697,7 @@ public:
 				/* There might be the case that GC finds a floating arraylet, which was a result of an allocation
 				 * failure (reason why this GC cycle is happening).
 				 */
-				_extensions->largeObjectVirtualMemory->updateSparseDataEntryAfterObjectHasMoved(dataAddr, fwdOjectPtr);
+				_extensions->largeObjectVirtualMemory->updateSparseDataEntryAfterObjectHasMoved(dataAddr, objectPtr, _extensions->indexableObjectModel.getDataSizeInBytes((J9IndexableObject *)fwdOjectPtr), fwdOjectPtr);
 			}
 		}
 	}


### PR DESCRIPTION
Verify the consistency (dataAddr, size and related proxy array object) of off heap Entry before freeing the off heap array or updating related proxy object.

depends on: https://github.com/eclipse-omr/omr/pull/7614

Signed-off-by: lhu <linhu@ca.ibm.com>