### PR TITLE
Move JFR loadedClassCount to J9JavaVM

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3632,9 +3632,6 @@ typedef struct J9ClassLoader {
 	omrthread_rwmutex_t cpEntriesMutex;
 	UDATA initClassPathEntryCount;
 	UDATA asyncGetCallTraceUsed;
-#if defined(J9VM_OPT_JFR)
-	UDATA loadedClassCount;
-#endif /* defined(J9VM_OPT_JFR) */
 } J9ClassLoader;
 
 #define J9CLASSLOADER_SHARED_CLASSES_ENABLED  8
@@ -6307,6 +6304,9 @@ typedef struct J9JavaVM {
 	VMSnapshotImplPortLibrary *vmSnapshotImplPortLibrary;
 	const char *vmSnapshotFilePath;
 #endif /* defined(J9VM_OPT_SNAPSHOTS) */
+#if defined(J9VM_OPT_JFR)
+	UDATA loadedClassCount;
+#endif /* defined(J9VM_OPT_JFR) */
 } J9JavaVM;
 
 #define J9JFR_SAMPLER_STATE_UNINITIALIZED 0

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -170,10 +170,6 @@ allocateClassLoader(J9JavaVM *javaVM)
 		classLoader->packageHashTable = hashPackageTableNew(javaVM, INITIAL_PACKAGE_HASHTABLE_SIZE);
 #endif /* JAVA_SPEC_VERSION > 8 */
 
-#if defined(J9VM_OPT_JFR)
-		classLoader->loadedClassCount = 0;
-#endif /* defined(J9VM_OPT_JFR) */
-
 		/* Allocate classLocationHashTable only for bootloader which is the first classloader to be allocated.
 		 * The classLoader being allocated must be the bootloader if javaVM->systemClassLoader is NULL.
 		 */

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2169,7 +2169,7 @@ internalCreateRAMClassDone(J9VMThread *vmThread, J9ClassLoader *classLoader, J9C
 		}
 
 #if defined(J9VM_OPT_JFR)
-		hostClassLoader->loadedClassCount += 1;
+		javaVM->loadedClassCount += 1;
 #endif /* defined(J9VM_OPT_JFR) */
 
 		/* Create all the method IDs if class load is hooked */

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -1020,7 +1020,6 @@ void
 jfrClassLoadingStatistics(J9VMThread *currentThread)
 {
 	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9JFRClassLoadingStatistics *jfrEvent = (J9JFRClassLoadingStatistics *)reserveBuffer(currentThread, sizeof(J9JFRClassLoadingStatistics));
 
 	if (NULL != jfrEvent) {
@@ -1030,20 +1029,7 @@ jfrClassLoadingStatistics(J9VMThread *currentThread)
 		UDATA unloadedAnonClassCount = 0;
 		vm->memoryManagerFunctions->j9gc_get_cumulative_class_unloading_stats(currentThread, &unloadedAnonClassCount, &unloadedClassCount, NULL);
 		jfrEvent->unloadedClassCount = (I_64)(unloadedClassCount + unloadedAnonClassCount);
-
-		internalReleaseVMAccess(currentThread);
-
-		J9ClassLoaderWalkState walkState = {0};
-		J9ClassLoader *classLoader = vmFuncs->allClassLoadersStartDo(&walkState, vm, 0);
-
-		while (NULL != classLoader) {
-			jfrEvent->loadedClassCount += classLoader->loadedClassCount;
-
-			classLoader= vmFuncs->allClassLoadersNextDo(&walkState);
-		}
-		vmFuncs->allClassLoadersEndDo(&walkState);
-
-		internalAcquireVMAccess(currentThread);
+		jfrEvent->loadedClassCount = vm->loadedClassCount;
 	}
 }
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1179,6 +1179,9 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	vm->internalVMLabels = (J9InternalVMLabels*)-1001;
 	vm->cInterpreter = J9_BUILDER_SYMBOL(cInterpreter);
 	vm->threadDllHandle = createParams->threadDllHandle;
+#if defined(J9VM_OPT_JFR)
+	vm->loadedClassCount = 0;
+#endif /* defined(J9VM_OPT_JFR) */
 
 #if JAVA_SPEC_VERSION >= 19
 	/* tid 1 will be use by main thread, first usable tid starts at 2 */


### PR DESCRIPTION
JFR loadedClassCount was originally kept tracked in classloader. When the classloader gets unloaded, we will lose the count.

Related: https://github.com/eclipse-openj9/openj9/pull/20679