### PR TITLE
Effectively revert PR #20975

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -1180,11 +1180,6 @@ TR_IProfiler::findOrCreateMethodEntry(J9Method *callerMethod, J9Method *calleeMe
    if (!_methodHashTable)
       return NULL;
 
-   // There is no point to add small methods to the table because
-   // the inliner does not consider them in its heristics.
-   if (addIt && TR::Compiler->mtd.bytecodeSize((TR_OpaqueMethodBlock*)calleeMethod) <= TR::Options::_iprofilerFaninMethodMinSize)
-      return NULL;
-
    // Search the hashtable
    int32_t bucket = methodHash((uintptr_t)calleeMethod);
    entry = searchForMethodSample((TR_OpaqueMethodBlock*)calleeMethod, bucket);


### PR DESCRIPTION
PR #20975 is known to cause some throughput regressions. These regressions are caused by limiting the IProfiler to collect fanin info only for methods larger than 50 bytecodes. It turns out that the code in `isLargeCompiledMethod()` does not refer to the size of the callee in the variable called `bytecodeSize`. `bytecodeSize` is actually some computed value which can be much bigger than the size of the callee.

This commit eliminates the code that restricts the fanin info to the methods larger than 50 bytecodes, but leaves all the other changes of PR #20975 intact.