### PR TITLE
Change return type of getStringUTF8Length

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -630,15 +630,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->stackWalkerMaySkipFrames(method, clazz));
          }
          break;
-      case MessageType::VM_getStringUTF8Length:
-         {
-         uintptr_t string = std::get<0>(client->getRecvData<uintptr_t>());
-            {
-            TR::VMAccessCriticalSection getStringUTF8Length(fe);
-            client->write(response, fe->getStringUTF8Length(string));
-            }
-         }
-         break;
       case MessageType::VM_classInitIsFinished:
          {
          TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
@@ -2351,7 +2342,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             "next",             "Ljava/lang/invoke/MethodHandle;"),
             "type",             "Ljava/lang/invoke/MethodType;"),
             "methodDescriptor", "Ljava/lang/String;");
-         size_t methodDescriptorLength = fe->getStringUTF8Length(methodDescriptorRef);
+         intptr_t methodDescriptorLength = fe->getStringUTF8Length(methodDescriptorRef);
          char *methodDescriptor = (char*)alloca(methodDescriptorLength+1);
          fe->getStringUTF8(methodDescriptorRef, methodDescriptor, methodDescriptorLength+1);
          client->write(response, std::string(methodDescriptor, methodDescriptorLength));
@@ -2504,7 +2495,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          int32_t numArgsPassToFinallyTarget = (int32_t)fe->getArrayLengthInElements(arguments);
 
          uintptr_t methodDescriptorRef = fe->getReferenceField(finallyType, "methodDescriptor", "Ljava/lang/String;");
-         int methodDescriptorLength = fe->getStringUTF8Length(methodDescriptorRef);
+         intptr_t methodDescriptorLength = fe->getStringUTF8Length(methodDescriptorRef);
          char *methodDescriptor = (char*)alloca(methodDescriptorLength+1);
          fe->getStringUTF8(methodDescriptorRef, methodDescriptor, methodDescriptorLength+1);
          client->write(response, numArgsPassToFinallyTarget, std::string(methodDescriptor, methodDescriptorLength));

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1117,7 +1117,7 @@ public:
     */
    virtual bool isChangesCurrentThread(TR_ResolvedMethod *method);
 
-   /*
+   /**
     * \brief
     *    tell whether it's possible to dereference a field given the field symbol at compile time
     *
@@ -1138,8 +1138,29 @@ public:
    virtual bool      isJavaLangObject(TR_OpaqueClassBlock *clazz);
    virtual int32_t   getStringLength(uintptr_t objectPointer);
    virtual uint16_t  getStringCharacter(uintptr_t objectPointer, int32_t index);
-   virtual intptr_t getStringUTF8Length(uintptr_t objectPointer);
-   virtual char     *getStringUTF8      (uintptr_t objectPointer, char *buffer, intptr_t bufferSize);
+
+   /**
+    * \brief Returns the number of UTF-8 encoded bytes needed to represent a Java String object.
+    *        The number of bytes needed to UTF-8 encode the String is representable as
+    *        a \c uint64_t, in general, but this method returns a length of type \c int32_t.
+    *        If the length might exceed the range of \c int32_t, use
+    *        \ref getStringUTF8UnabbreviatedLength instead.
+    *
+    * \param[in] objectPointer A pointer to a Java String object
+    *
+    * \return The number of UTF-8 encoded bytes needed to represent the String
+    */
+   virtual int32_t getStringUTF8Length(uintptr_t objectPointer);
+
+   /**
+    * \brief Returns the number of UTF-8 encoded bytes needed to represent a Java String object.
+    *
+    * \param[in] objectPointer A pointer to a Java String object
+    *
+    * \return The number of UTF-8 encoded bytes needed to represent the String
+    */
+   virtual uint64_t  getStringUTF8UnabbreviatedLength(uintptr_t objectPointer);
+   virtual char     *getStringUTF8(uintptr_t objectPointer, char *buffer, uintptr_t bufferSize);
 
    virtual uint32_t getVarHandleHandleTableOffset(TR::Compilation *);
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1073,12 +1073,16 @@ TR_J9ServerVM::getHostClass(TR_OpaqueClassBlock *clazz)
    return hostClass;
    }
 
-intptr_t
+int32_t
 TR_J9ServerVM::getStringUTF8Length(uintptr_t objectPointer)
    {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getStringUTF8Length, objectPointer);
-   return std::get<0>(stream->read<intptr_t>());
+   TR_ASSERT_FATAL(false, "getStringUTF8Length(uintptr_t) should not be called by JITServer");
+   }
+
+uint64_t
+TR_J9ServerVM::getStringUTF8UnabbreviatedLength(uintptr_t objectPointer)
+   {
+   TR_ASSERT_FATAL(false, "getStringUTF8UnabbreviatedLength(uintptr_t) should not be called by JITServer");
    }
 
 bool

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -121,7 +121,8 @@ public:
    virtual bool hasFinalFieldsInClass(TR_OpaqueClassBlock *clazz) override;
    virtual const char *sampleSignature(TR_OpaqueMethodBlock * aMethod, char *buf, int32_t bufLen, TR_Memory *memory) override;
    virtual TR_OpaqueClassBlock * getHostClass(TR_OpaqueClassBlock *clazzOffset) override;
-   virtual intptr_t getStringUTF8Length(uintptr_t objectPointer) override;
+   virtual int32_t getStringUTF8Length(uintptr_t objectPointer) override;
+   virtual uint64_t getStringUTF8UnabbreviatedLength(uintptr_t objectPointer) override;
    virtual bool classInitIsFinished(TR_OpaqueClassBlock *) override;
    virtual int32_t getNewArrayTypeFromClass(TR_OpaqueClassBlock *clazz) override;
    virtual TR_OpaqueClassBlock *getClassFromNewArrayType(int32_t arrayType) override;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -8413,7 +8413,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
 
          uintptr_t methodHandle;
          uintptr_t methodDescriptorRef;
-         intptr_t methodDescriptorLength;
+         uintptr_t methodDescriptorLength;
 
 #if defined(J9VM_OPT_JITSERVER)
          if (comp()->isOutOfProcessCompilation())
@@ -9262,7 +9262,7 @@ TR_J9ByteCodeIlGenerator::runFEMacro(TR::SymbolReference *symRef)
             numArgsPassToFinallyTarget = (int32_t)fej9->getArrayLengthInElements(arguments);
 
             uintptr_t methodDescriptorRef = fej9->getReferenceField(finallyType, "methodDescriptor", "Ljava/lang/String;");
-            int methodDescriptorLength = fej9->getStringUTF8Length(methodDescriptorRef);
+            intptr_t methodDescriptorLength = fej9->getStringUTF8Length(methodDescriptorRef);
             methodDescriptor = (char*)alloca(methodDescriptorLength+1);
             fej9->getStringUTF8(methodDescriptorRef, methodDescriptor, methodDescriptorLength+1);
             }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 78; // ID: DGwBSxx9FLiSwWTdQCIn
+   static const uint16_t MINOR_NUMBER = 79; // ID: Su+UK1Q5oJlgUkWIBA6f
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -121,7 +121,6 @@ const char *messageNames[] =
    "VM_getObjectClassFromKnownObjectIndexJLClass",
    "VM_getObjectClassInfoFromObjectReferenceLocation",
    "VM_stackWalkerMaySkipFrames",
-   "VM_getStringUTF8Length",
    "VM_classInitIsFinished",
    "VM_getClassFromNewArrayType",
    "VM_getArrayClassFromComponentClass",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -130,7 +130,6 @@ enum MessageType : uint16_t
    VM_getObjectClassFromKnownObjectIndexJLClass,
    VM_getObjectClassInfoFromObjectReferenceLocation,
    VM_stackWalkerMaySkipFrames,
-   VM_getStringUTF8Length,
    VM_classInitIsFinished,
    VM_getClassFromNewArrayType,
    VM_getArrayClassFromComponentClass,


### PR DESCRIPTION
The return type of the JVM's `getStringUTF8Length` method has changed from `IDATA` to `UDATA`.  This change adjusts the JIT compiler's uses of that method.  In particular, the return type of `TR_FrontEnd::getStringUTF8Length` and its overriding methods change from `intptr_t` to `int32_t`.  Similarly, the `bufferSize` argument of `TR_FrontEnd::getStringUTF8` becomes `uintptr_t` where it was `int32_t`.

The motivation was that the length of a UTF-8 encoded String could be greater than 2<sup>32</sup> bytes, so the length could overflow `intptr_t` on a 32-bit platform.  All uses of `getStringUTF8Length` in the JIT involve signatures, descriptors, method names and class names, which will never be large enough to exceed the range of the `int32_t` type.  This was something that @jpmpapin was good enough to verify.  Just to be cautious, however, this change includes an assertion test that the computed length is in range for the `int32_t` type.

This change also introduces a method, `getStringUTF8UnabbreviatedLength`, that returns a length value of type `uint64_t` if the JIT compiler ever needs to determine the UTF-8 encoded length of an arbitrary String.  The method is currently unused.

In addition, String Builder Transformer uses the result of `getStringUTF8Length` to estimate the `StringBuilder` buffer size needed to accommodate appending a constant `String` to a `StringBuilder`.  That could overestimate the space required.  This has been changed to use `getStringLength` instead, to use the actual lengths of constant `String` objects.  A test has also been added to detect integer overflow of the capacity estimate, aborting the transformation, as `StringBuilder.<init>`
will throw a `NegativeArraySizeException` if the specified capacity is negative.

This pull request requires a coordinated merge with OMR pull request eclipse-omr/omr#7620

