### PR TITLE
Stop setting known object index in findOrCreateStaticSymbol()

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1940,29 +1940,7 @@ J9::SymbolReferenceTable::findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * ow
    if (sharesSymbol)
       symRef->setReallySharesSymbol();
 
-   TR::KnownObjectTable::Index knownObjectIndex = TR::KnownObjectTable::UNKNOWN;
-   if (resolved && isFinal && type == TR::Address)
-      {
-      TR_OpaqueClassBlock *declaringClass =
-         owningMethod->getDeclaringClassFromFieldOrStatic(comp(), cpIndex);
-
-      TR::Symbol::RecognizedField recField = sym->getRecognizedField();
-      TR_YesNoMaybe canFold =
-         TR::TransformUtil::canFoldStaticFinalField(
-            comp(), declaringClass, recField, owningMethod, cpIndex);
-
-      if (canFold == TR_yes)
-         {
-         TR::AnyConst value = TR::AnyConst::makeAddress(0);
-         bool gotValue = TR::TransformUtil::staticFinalFieldValue(
-            comp(), owningMethod, cpIndex, dataAddress, TR::Address, recField, &value);
-
-         if (gotValue && value.isKnownObject())
-            knownObjectIndex = value.getKnownObjectIndex();
-         }
-      }
-
-   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex, knownObjectIndex);
+   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), cpIndex, unresolvedIndex, TR::KnownObjectTable::UNKNOWN);
 
    checkUserField(symRef);
 


### PR DESCRIPTION
`SymbolReferenceTable::findOrCreateStaticSymbol()` is used only when generating IL for `putstatic` and `getstatic`.

For `putstatic`, if it attempts to store to a static final field, it's very likely that the store is illegal, in which case it will be treated as unresolved. But even if the store is legal, the known object index is useless.

For `getstatic`, the IL generator will use `foldReliableStaticFinalField()` from `TransformUtil` to get the same effect anyway, so setting the known object index here is redundant.