### PR TITLE
Deduplicate definition of J9::Recompilation::invalidateMethodBody()

### DIFF
--- a/runtime/compiler/aarch64/runtime/Recomp.cpp
+++ b/runtime/compiler/aarch64/runtime/Recomp.cpp
@@ -273,24 +273,6 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    omrthread_jit_write_protect_enable();
    }
 
-void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
-   {
-   // Pre-existence assumptions for this method have been violated. Make the
-   // method no-longer runnable and schedule it for sync recompilation
-   //
-   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
-   TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
-   bodyInfo->setIsInvalidated(); // bodyInfo must exist
-
-   // If the compilation has been attempted before then we are fine (in case of success,
-   // each caller is being re-directed to the new method -- in case if failure, all callers
-   // are being sent to the interpreter)
-   //
-   if (linkageInfo->recompilationAttempted())
-      return;
-   fixUpMethodCode(startPC);
-   }
-
 // in Trampoline.cpp
 extern bool arm64CodePatching(void *method, void *callSite, void *currentPC, void *currentTramp, void *newPC, void *extra);
 

--- a/runtime/compiler/arm/runtime/Recomp.cpp
+++ b/runtime/compiler/arm/runtime/Recomp.cpp
@@ -333,25 +333,6 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    linkageInfo->setHasFailedRecompilation();
    }
 
-void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
-   {
-   // Pre-existence assumptions for this method have been violated. Make the
-   // method no-longer runnable and schedule it for sync recompilation
-   //
-   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
-   //linkageInfo->setInvalidated();
-   TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
-   bodyInfo->setIsInvalidated(); // bodyInfo must exist
-
-   // If the compilation has been attempted before then we are fine (in case of success,
-   // each caller is being re-directed to the new method -- in case if failure, all callers
-   // are being sent to the interpreter)
-   //
-   if (linkageInfo->recompilationAttempted())
-      return;
-   fixUpMethodCode(startPC);
-   }
-
 extern bool armCodePatching(void *method, void *callSite, void *currentPC, void *currentTramp, void *newPC, void *extra);
 extern "C" {
 void armIndirectCallPatching_unwrapper(void **argsPtr, void **resPtr)

--- a/runtime/compiler/p/runtime/Recomp.cpp
+++ b/runtime/compiler/p/runtime/Recomp.cpp
@@ -266,26 +266,6 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    linkageInfo->setHasFailedRecompilation();
    }
 
-void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
-   {
-   // Pre-existence assumptions for this method have been violated. Make the
-   // method no-longer runnable and schedule it for sync recompilation
-   //
-   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
-   //linkageInfo->setInvalidated();
-   TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
-   bodyInfo->setIsInvalidated(); // bodyInfo must exist
-
-   // If the compilation has been attempted before then we are fine (in case of success,
-   // each caller is being re-directed to the new method -- in case if failure, all callers
-   // are being sent to the interpreter)
-   //
-   if (linkageInfo->recompilationAttempted())
-      return;
-   fixUpMethodCode(startPC);
-   }
-
-
 extern bool ppcCodePatching(void *method, void *callSite, void *currentPC, void *currentTramp, void *newPC, void *extra);
 extern "C" {
 void ppcIndirectCallPatching_unwrapper(void **argsPtr, void **resPtr)

--- a/runtime/compiler/x/runtime/Recomp.cpp
+++ b/runtime/compiler/x/runtime/Recomp.cpp
@@ -349,25 +349,6 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    linkageInfo->setHasFailedRecompilation();
    }
 
-void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
-   {
-   // Preexistence assumptions for this method have been violated.  Make the
-   // method no-longer runnable and schedule it for a sync recompilation
-   //
-   J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
-   //linkageInfo->setInvalidated();
-   TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
-   bodyInfo->setIsInvalidated(); // bodyInfo must exist
-
-   // If the compilation has been attempted before then we are fine (in case of success,
-   // each caller is being re-directed to the new method -- in case if failure, all callers
-   // are being sent to the interpreter)
-   //
-   if (linkageInfo->recompilationAttempted())
-      return;
-   fixUpMethodCode(startPC); // schedule a sync compilation
-   }
-
 #if defined(TR_HOST_X86)
 void fixupMethodInfoAddressInCodeCache(void *startPC, void *bodyInfo)
    {

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -399,30 +399,3 @@ J9::Recompilation::methodCannotBeRecompiled(void * oldStartPC, TR_FrontEnd * fe)
       }
    linkageInfo->setHasFailedRecompilation();
    }
-
-void
-J9::Recompilation::invalidateMethodBody(void * startPC, TR_FrontEnd * fe)
-   {
-   if (debug("traceRecompilation"))
-      {
-      ;//diagnostic("RC>>Invalidating %p\n", startPC);
-      }
-
-   // Pre-existence assumptions for this method have been violated. Make the
-   // method no-longer runnable and schedule it for sync recompilation
-   //
-   J9::PrivateLinkage::LinkageInfo * linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
-   //linkageInfo->setInvalidated();
-   TR_PersistentJittedBodyInfo* bodyInfo = getJittedBodyInfoFromPC(startPC);
-   bodyInfo->setIsInvalidated(); // bodyInfo must exist
-
-   // If the compilation has been attempted before then we are fine (in case of success,
-   // each caller is being re-directed to the new method -- in case if failure, all callers
-   // are being sent to the interpreter)
-   //
-   if (linkageInfo->recompilationAttempted())
-      {
-      return;
-      }
-   fixUpMethodCode(startPC);
-   }


### PR DESCRIPTION
This code was copied with minor cosmetic differences into five places.