### PR TITLE
Set SupportsReferenceArrayCopy for x86 with OffHeap

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -73,11 +73,11 @@ J9::X86::CodeGenerator::initialize()
 
    cg->setAheadOfTimeCompile(new (cg->trHeapMemory()) TR::AheadOfTimeCompile(cg));
 
-   if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
-      {
+   if (!TR::Compiler->om.canGenerateArraylets())
       cg->setSupportsReferenceArrayCopy();
+
+   if (!TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       cg->setSupportsInlineStringLatin1Inflate();
-      }
 
    if (comp->requiresSpineChecks())
       {


### PR DESCRIPTION
With OffHeap arraycopy optimizations are possible given that large heaps are allocated "off-heap" contiguously.
This PR sets the flag to enable that for reference arraycopy. The flag is already set for primitive and for other platforms.