### PR TITLE
Add missing exit tracepoint in performVerification

### DIFF
--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -271,6 +271,7 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 		}
 	}
 done:
+	Trc_VM_performVerification_Exit(currentThread);
 	return;
 }
 


### PR DESCRIPTION
Discovered because it messes up indentation when iprinting tracepoints. Tracepoint already exists but never called at the end of performVerification.