### PR TITLE
JDK 24 remove java.security.AccessController.doPrivileged part 1

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/Msg.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/Msg.java
@@ -24,7 +24,9 @@ package com.ibm.oti.util;
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.AccessController;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.*;
 import com.ibm.oti.vm.*;
 
@@ -61,9 +63,18 @@ public class Msg {
 	static private Hashtable messages;
 
 	static {
+		String resourceName = "com/ibm/oti/util/ExternalMessages"; //$NON-NLS-1$
 		// Attempt to load the messages.
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		try {
+			messages = MsgHelp.loadMessages(resourceName);
+		} catch (java.io.IOException e) {
+			// ignore: continue without messages
+		}
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		messages = (Hashtable) AccessController.doPrivileged(
-				PriviAction.loadMessages("com/ibm/oti/util/ExternalMessages")); //$NON-NLS-1$
+				PriviAction.loadMessages(resourceName));
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/PriviAction.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/PriviAction.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION < 24]*/
 package com.ibm.oti.util;
 
 /*

--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/RuntimePermissions.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/RuntimePermissions.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar18-SE]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION < 24]*/
 package com.ibm.oti.util;
 
 /*

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/BootstrapClassLoader.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/BootstrapClassLoader.java
@@ -24,8 +24,6 @@ package com.ibm.oti.vm;
 
 import java.util.*;
 
-import com.ibm.oti.util.PriviAction;
-
 import java.io.FilePermission;
 import java.lang.reflect.Method;
 import java.security.AccessController;

--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -35,7 +35,6 @@ import java.lang.StringConcatHelper;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Executable;
 import java.lang.reflect.Method;
-import java.security.AccessControlContext;
 import java.util.Map;
 
 import com.ibm.oti.reflect.AnnotationParser;
@@ -173,7 +172,7 @@ final class Access implements JavaLangAccess {
 /*[IF JAVA_SPEC_VERSION < 24]*/
 	/*[PR CMVC 199693] Prevent trusted method chain attack. */
 	@SuppressWarnings("removal")
-	public Thread newThreadWithAcc(Runnable runnable, AccessControlContext acc) {
+	public Thread newThreadWithAcc(Runnable runnable, java.security.AccessControlContext acc) {
 		return new Thread(runnable, acc);
 	}
 /*[ENDIF] JAVA_SPEC_VERSION < 24 */

--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -25,16 +25,18 @@ package java.lang;
 import com.ibm.oti.vm.J9UnmodifiableClass;
 import java.lang.ref.SoftReference;
 import java.lang.reflect.*;
+/*[IF JAVA_SPEC_VERSION < 24]*/
+import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 import java.util.WeakHashMap;
-import java.security.AccessControlContext;
-import java.security.CodeSource;
-import java.security.ProtectionDomain;
 import java.io.FileDescriptor;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -271,8 +273,11 @@ final class J9VMInternals {
 	private static native Throwable newInstance(Class exceptionClass, Class constructorClass);
 
 	private static Throwable cloneThrowable(final Throwable throwable, final HashMap hashMapThrowable) {
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 		return (Throwable)AccessController.doPrivileged(new PrivilegedAction() {
+			@Override
 			public Object run() {
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 				Throwable clone;
 				try {
 					Class cls = throwable.getClass();
@@ -305,8 +310,10 @@ final class J9VMInternals {
 					clone = new Throwable(Msg.getString("K05c3", e, throwable.toString())); //$NON-NLS-1$
 				}
 				return clone;
+		/*[IF JAVA_SPEC_VERSION < 24]*/
 			}
 		});
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 	}
 
 	/**
@@ -612,9 +619,11 @@ final class J9VMInternals {
 			ClassLoader classLoader = clazz.getClassLoader();
 			if (classLoader != null) {
 				classLoaderStr = classLoader.toString();
+				/*[IF JAVA_SPEC_VERSION < 24]*/
 				classPath = AccessController.doPrivileged(new PrivilegedAction<String>() {
 					@Override
 					public String run() {
+				/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 						String path = null;
 						try {
 							ProtectionDomain pd = clazz.getProtectionDomain();
@@ -629,9 +638,13 @@ final class J9VMInternals {
 							}
 						} catch (Exception e) {
 						}
+				/*[IF JAVA_SPEC_VERSION >= 24]*/
+						classPath = path;
+				/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 						return path;
 					}
 				});
+				/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 			}
 		}
 		if (classPath != null) {

--- a/jcl/src/java.base/share/classes/java/lang/RuntimePermission.java
+++ b/jcl/src/java.base/share/classes/java/lang/RuntimePermission.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION < 24]*/
 package java.lang;
 
 /*

--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -22,8 +22,10 @@
  */
 package java.lang.ref;
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 import jdk.internal.access.JavaLangRefAccess;
@@ -65,11 +67,16 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	 */
 	static class ClearBeforeEnqueue {
 		@SuppressWarnings("boxing")
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		static final boolean ENABLED = !Boolean.getBoolean("jdk.lang.ref.disableClearBeforeEnqueue"); //$NON-NLS-1$
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		static final boolean ENABLED = AccessController.doPrivileged(new PrivilegedAction<Boolean>() {
-			@Override public Boolean run() {
+			@Override
+			public Boolean run() {
 				return !Boolean.getBoolean("jdk.lang.ref.disableClearBeforeEnqueue"); //$NON-NLS-1$
 			}
 		});
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 
 	/*[IF Sidecar18-SE-OpenJ9 | (JAVA_SPEC_VERSION >= 9)]*/

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/Attachment.java
@@ -33,8 +33,10 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.InetAddress;
 import java.net.Socket;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.Objects;
 import java.util.Properties;
 import java.util.ServiceLoader;
@@ -75,7 +77,9 @@ final class Attachment extends Thread implements Response {
 		static Method startRemoteManagementAgentMethod = null;
 		static final Throwable managementAgentMethodThrowable;
 		static {
+			/*[IF JAVA_SPEC_VERSION < 24]*/
 			managementAgentMethodThrowable = AccessController.doPrivileged((PrivilegedAction<Throwable>) () -> {
+			/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 				String agentClassName =
 						/*[IF JAVA_SPEC_VERSION >= 9]*/
 						"jdk.internal.agent.Agent"; //$NON-NLS-1$
@@ -117,8 +121,12 @@ final class Attachment extends Thread implements Response {
 					IPC.logMessage("Error loading " + agentClassName, e); //$NON-NLS-1$
 					mamtTemp = e;
 				}
+			/*[IF JAVA_SPEC_VERSION >= 24]*/
+				managementAgentMethodThrowable = mamtTemp;
+			/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 				return mamtTemp;
 			});
+			/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 		}
 	}
 

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticProperties.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticProperties.java
@@ -25,8 +25,10 @@ package openj9.internal.tools.attach.target;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.Comparator;
 import java.util.Properties;
 
@@ -60,10 +62,14 @@ public class DiagnosticProperties {
 	public static boolean isDebug;
 
 	static {
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		isDebug = Boolean.getBoolean(DEBUG_PROPERTY);
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
 			isDebug = Boolean.getBoolean(DEBUG_PROPERTY);
 			return null;
 		});
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 
 	/**

--- a/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
@@ -52,9 +52,11 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * supplying the value &quot;os.arch&quot; for the key.
 	 *
 	 * @return the identifier for the operating system architecture.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getArch();
@@ -76,9 +78,11 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * &quot;os.name&quot; for the key.
 	 *
 	 * @return the name of the operating system.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getName();
@@ -90,9 +94,11 @@ public interface OperatingSystemMXBean extends PlatformManagedObject {
 	 * &quot;os.version&quot; for the key.
 	 *
 	 * @return the version of the operating system.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getVersion();

--- a/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
@@ -121,6 +121,7 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	 * @throws IllegalArgumentException if there is no <code>Logger</code>
 	 * with the name <code>loggerName</code>. Also may be thrown if
 	 * <code>loggerName</code> is not a known log level name.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager active and
 	 * the caller does not have
 	/*[IF JAVA_SPEC_VERSION >= 17]
@@ -129,6 +130,7 @@ public interface PlatformLoggingMXBean extends PlatformManagedObject{
 	 * {@link java.util.logging.LoggingPermission}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17
 	 * of &quot;control&quot;.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public void setLoggerLevel(String loggerName, String levelName);
 

--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -22,8 +22,10 @@
  */
 package java.lang.management;
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.AccessController;
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.List;
 import java.util.Map;
 
@@ -84,9 +86,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * @return the system classpath with each entry separated by the path
 	 *         separator character corresponding to the underlying operating
 	 *         system.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getClassPath();
@@ -112,9 +116,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * @return the Java library path with each entry separated by the path
 	 *         separator character corresponding to the underlying operating
 	 *         system.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getLibraryPath();
@@ -146,11 +152,16 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 */
 	@SuppressWarnings("boxing")
 	default long getPid() {
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		return ProcessHandle.current().pid();
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		return AccessController.doPrivileged(new PrivilegedAction<Long>() {
+			@Override
 			public Long run() {
 				return ProcessHandle.current().pid();
 			}
 		});
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 10 */
 
@@ -161,9 +172,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * supplying the value &quot;java.vm.specification.name&quot; for the key.
 	 *
 	 * @return the name of the Java virtual machine specification.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getSpecName();
@@ -175,9 +188,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * &quot;java.vm.specification.vendor&quot; for the key.
 	 *
 	 * @return the name of the Java virtual machine specification vendor.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getSpecVendor();
@@ -189,9 +204,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * &quot;java.vm.specification.version&quot; for the key.
 	 *
 	 * @return the Java virtual machine specification version.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getSpecVersion();
@@ -208,9 +225,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * the virtual machine.
 	 *
 	 * @return a map containing the names and values of every system property.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public Map<String, String> getSystemProperties();
 
@@ -228,9 +247,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * &quot;java.vm.name&quot; for the key.
 	 *
 	 * @return the name of the Java virtual machine implementation.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getVmName();
@@ -242,9 +263,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * &quot;java.vm.vendor&quot; for the key.
 	 *
 	 * @return the name of the Java virtual machine implementation vendor.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getVmVendor();
@@ -256,9 +279,11 @@ public interface RuntimeMXBean extends PlatformManagedObject {
 	 * &quot;java.vm.version&quot; for the key.
 	 *
 	 * @return the version of the Java virtual machine implementation.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if there is a security manager in operation and the caller
 	 *             does not have permission to check system properties.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @see System#getProperty(java.lang.String)
 	 */
 	public String getVmVersion();

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9AttachProvider.java
@@ -24,10 +24,12 @@ package com.ibm.tools.attach.attacher;
 
 import java.io.File;
 import java.io.IOException;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.ArrayList;
 import java.util.List;
 
@@ -101,6 +103,9 @@ public class OpenJ9AttachProvider extends AttachProvider {
 
 	@Override
 	public List<VirtualMachineDescriptor> listVirtualMachines() {
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		return listVirtualMachinesImp();
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		List<VirtualMachineDescriptor> ret = null;
 		PrivilegedExceptionAction<List<VirtualMachineDescriptor>> action = () -> listVirtualMachinesImp();
 		try {
@@ -116,6 +121,7 @@ public class OpenJ9AttachProvider extends AttachProvider {
 			}
 		}
 		return ret;
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 
 	private List<VirtualMachineDescriptor> listVirtualMachinesImp() {
@@ -228,7 +234,6 @@ public class OpenJ9AttachProvider extends AttachProvider {
 
 	/*[IF JAVA_SPEC_VERSION < 24]*/
 	private static void checkAttachSecurity() {
-		@SuppressWarnings("removal")
 		final SecurityManager securityManager = System.getSecurityManager();
 		if (securityManager != null) {
 			securityManager.checkPermission(Permissions.ATTACH_VM);

--- a/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
+++ b/jcl/src/jdk.attach/share/classes/com/ibm/tools/attach/attacher/OpenJ9VirtualMachine.java
@@ -33,10 +33,12 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketTimeoutException;
 import java.nio.charset.StandardCharsets;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
@@ -96,12 +98,17 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 	private Socket targetSocket;
 
 	static {
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		MAXIMUM_ATTACH_TIMEOUT = Integer.getInteger("com.ibm.tools.attach.timeout", DEFAULT_ATTACH_TIMEOUT).intValue(); //$NON-NLS-1$
+		COMMAND_TIMEOUT = Integer.getInteger("com.ibm.tools.attach.command_timeout", DEFAULT_COMMAND_TIMEOUT).intValue(); //$NON-NLS-1$
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		PrivilegedAction<Object> action = () -> {
 			MAXIMUM_ATTACH_TIMEOUT = Integer.getInteger("com.ibm.tools.attach.timeout", DEFAULT_ATTACH_TIMEOUT).intValue(); //$NON-NLS-1$
 			COMMAND_TIMEOUT = Integer.getInteger("com.ibm.tools.attach.command_timeout", DEFAULT_COMMAND_TIMEOUT).intValue(); //$NON-NLS-1$
 			return null;
 		};
 		AccessController.doPrivileged(action);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 
 	/**
@@ -129,6 +136,9 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 	 *             if the descriptor is null the target does not respond.
 	 */
 	void attachTarget() throws IOException, AttachNotSupportedException {
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		attachTargetImpl();
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		PrivilegedExceptionAction<Object> action = () -> {attachTargetImpl(); return null;};
 		try {
 			AccessController.doPrivileged(action);
@@ -146,6 +156,7 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 				throw new RuntimeException(cause);
 			}
 		}
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 
 	private void attachTargetImpl() throws AttachNotSupportedException, IOException {
@@ -624,10 +635,12 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 	 * @return byte stream containing the UTF-8 text of the formatted output
 	 */
 	public InputStream heapHisto(Object... opts) {
-		InputStream ret = null;
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		return heapHistoImpl(opts);
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		PrivilegedExceptionAction<InputStream> action = () -> heapHistoImpl(opts);
 		try {
-			ret = AccessController.doPrivileged(action);
+			return AccessController.doPrivileged(action);
 		} catch (PrivilegedActionException e) {
 			Throwable cause = e.getCause();
 			if (cause instanceof RuntimeException) {
@@ -638,7 +651,7 @@ public final class OpenJ9VirtualMachine extends VirtualMachine implements Respon
 				throw new RuntimeException(cause);
 			}
 		}
-		return ret;
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	}
 
 	private InputStream heapHistoImpl(Object... opts) {

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/MemoryMXBean.java
@@ -67,10 +67,12 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
 	 * @throws IllegalArgumentException
 	 *             if input value <code>size</code> is either less than
 	 *             getMinHeapSize() or greater than getMaxHeapSizeLimit().
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if a {@link SecurityManager} is being used and the caller
 	 *             does not have the <code>ManagementPermission</code> value
 	 *             of "control".
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public void setMaxHeapSize( long size );
 
@@ -140,10 +142,12 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
 	 * @return whether the requested operation has been completed.
 	 * @throws IllegalArgumentException
 	 *             if input value <code>value</code> is less than 0.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if a {@link SecurityManager} is being used and the caller
 	 *             does not have the <code>ManagementPermission</code> value
 	 *             of "control".
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public boolean setSharedClassCacheSoftmxBytes(long value);
 
@@ -156,10 +160,12 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
 	 * @return whether the requested operation has been completed.
 	 * @throws IllegalArgumentException
 	 *             if input value <code>value</code> is less than 0.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if a {@link SecurityManager} is being used and the caller
 	 *             does not have the <code>ManagementPermission</code> value
 	 *             of "control".
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public boolean setSharedClassCacheMinAotBytes(long value);
 
@@ -172,10 +178,12 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
 	 * @return whether the requested operation has been completed.
 	 * @throws IllegalArgumentException
 	 *             if input value <code>value</code> is less than 0.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if a {@link SecurityManager} is being used and the caller
 	 *             does not have the <code>ManagementPermission</code> value
 	 *             of "control".
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public boolean setSharedClassCacheMaxAotBytes(long value);
 
@@ -188,10 +196,12 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
 	 * @return whether the requested operation has been completed.
 	 * @throws IllegalArgumentException
 	 *             if input value <code>value</code> is less than 0.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if a {@link SecurityManager} is being used and the caller
 	 *             does not have the <code>ManagementPermission</code> value
 	 *             of "control".
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public boolean setSharedClassCacheMinJitDataBytes(long value);
 
@@ -204,10 +214,12 @@ public interface MemoryMXBean extends java.lang.management.MemoryMXBean {
 	 * @return whether the requested operation has been completed.
 	 * @throws IllegalArgumentException
 	 *             if input value <code>value</code> is less than 0.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException
 	 *             if a {@link SecurityManager} is being used and the caller
 	 *             does not have the <code>ManagementPermission</code> value
 	 *             of "control".
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public boolean setSharedClassCacheMaxJitDataBytes(long value);
 

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ThreadMXBean.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/ThreadMXBean.java
@@ -39,11 +39,17 @@ public interface ThreadMXBean extends com.sun.management.ThreadMXBean
 	 * 			given set of IDs is no longer alive or does not exist, a -1 is set in the corresponding
 	 * 			element of the returned array.
 	 * @throws IllegalArgumentException is thrown if any of the thread identifiers passed is invalid (&lt;=0).
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException is thrown if the caller does not have sufficient permissions
 	 * (ManagementPermission("monitor"))
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24
 	 */
 	public long[] getNativeThreadIds(long[] threadIDs)
-			throws IllegalArgumentException, SecurityException;
+			throws IllegalArgumentException
+			/*[IF JAVA_SPEC_VERSION < 24]*/
+			, SecurityException
+			/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+			;
 
 	/**
 	 * Find the native (operating system assigned) thread identifiers corresponding
@@ -53,11 +59,17 @@ public interface ThreadMXBean extends com.sun.management.ThreadMXBean
 	 * @return Operating system assigned native thread identifier. If the thread corresponding to the
 	 * 			ID is no longer alive or does not exist, -1 is returned.
 	 * @throws IllegalArgumentException is thrown if the thread identifier passed is invalid (&lt;=0).
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException is thrown if the caller does not have sufficient permissions
 	 * (ManagementPermission("monitor"))
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24
 	 */
 	public long getNativeThreadId(long threadId)
-			throws IllegalArgumentException, SecurityException;
+			throws IllegalArgumentException
+			/*[IF JAVA_SPEC_VERSION < 24]*/
+			, SecurityException
+			/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
+			;
 
 	/**
 	 * API method that fetches an array of ExtendedThreadInfo objects corresponding to
@@ -75,13 +87,20 @@ public interface ThreadMXBean extends com.sun.management.ThreadMXBean
 	 *					currently locked ownable synchronizers is to be included in
 	 *					the returned array
 	 * @return  Array of ExtendedThreadInfo objects.
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException is thrown if the caller does not have sufficient permissions
 	 * (ManagementPermission("monitor"))
+	/*[ENDIF] JAVA_SPEC_VERSION >= 24
 	 * @throws UnsupportedOperationException is thrown if the JVM does not support monitoring
 	 * object monitor usage or ownable synchronizer usage, even as it has been specified.
 	 * @throws InternalError is thrown in case an error occurs while fetching thread information,
 	 * typically, an internal error resulting from an inconsistency in the class library.
 	 */
 	public ExtendedThreadInfo[] dumpAllExtendedThreads(boolean lockedMonitors, boolean lockedSynchronizers)
-			throws SecurityException, UnsupportedOperationException, InternalError;
+		throws
+			InternalError,
+			/*[IF JAVA_SPEC_VERSION < 24]*/
+			SecurityException,
+			/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+			UnsupportedOperationException;
 }

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
@@ -22,7 +22,9 @@
  */
 package com.ibm.lang.management.internal;
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.Objects;
 
 import javax.management.MBeanNotificationInfo;
@@ -112,6 +114,11 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 		super();
 		// only launch the notification thread if the environment could change
 		if (isDLPAREnabled()) {
+			/*[IF JAVA_SPEC_VERSION >= 24]*/
+			Thread thread = VM.getVMLangAccess().createThread(new OperatingSystemNotificationThread(this),
+					"OperatingSystemMXBean notification dispatcher", true, false, true, ClassLoader.getSystemClassLoader()); //$NON-NLS-1$
+			thread.setPriority(Thread.NORM_PRIORITY + 1);
+			/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 			PrivilegedAction<Thread> createThread = () -> {
 				Thread thread = VM.getVMLangAccess().createThread(new OperatingSystemNotificationThread(this),
 					"OperatingSystemMXBean notification dispatcher", true, false, true, ClassLoader.getSystemClassLoader()); //$NON-NLS-1$
@@ -123,6 +130,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 			@SuppressWarnings("removal")
 			/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 			Thread thread = java.security.AccessController.doPrivileged(createThread);
+			/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 			thread.start();
 		}
 	}

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedThreadInfoImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedThreadInfoImpl.java
@@ -23,9 +23,6 @@
 package com.ibm.lang.management.internal;
 
 import java.lang.management.ThreadInfo;
-import java.lang.reflect.Field;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 
 import com.ibm.lang.management.ExtendedThreadInfo;
 

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/OperatingSystemNotificationThread.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/OperatingSystemNotificationThread.java
@@ -22,7 +22,9 @@
  */
 package com.ibm.lang.management.internal;
 
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import javax.management.Notification;
 
 import com.ibm.lang.management.AvailableProcessorsNotificationInfo;
@@ -49,13 +51,16 @@ final class OperatingSystemNotificationThread implements Runnable {
 	 * then enter the native that services an internal notification queue.
 	 */
 	@Override
-	/*[IF JAVA_SPEC_VERSION >= 17]*/
+	/*[IF (17 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24)]*/
 	@SuppressWarnings("removal")
-	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+	/*[ENDIF] (17 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24) */
 	public void run() {
 		Thread myShutdownNotifier = new OperatingSystemNotificationThreadShutdown(Thread.currentThread());
 
 		try {
+			/*[IF JAVA_SPEC_VERSION >= 24]*/
+			Runtime.getRuntime().addShutdownHook(myShutdownNotifier);
+			/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 			java.security.AccessController.doPrivileged(new PrivilegedAction<Void>() {
 				@Override
 				public Void run() {
@@ -63,6 +68,7 @@ final class OperatingSystemNotificationThread implements Runnable {
 					return null;
 				}
 			});
+			/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 		} catch (IllegalStateException e) {
 			/* if by chance we are already shutting down when we try to
 			 * register the shutdown hook, allow this thread to terminate

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/OpenJ9DiagnosticsMXBean.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/OpenJ9DiagnosticsMXBean.java
@@ -61,7 +61,9 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	 * handled.
 	 *
 	 * @throws ConfigurationUnavailableException if the configuration cannot be changed because a dump is already in progress
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to change the dump settings
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public void resetDumpOptions() throws ConfigurationUnavailableException;
 
@@ -72,7 +74,9 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	 * the documentation for the OpenJ9 JVM.
 	 *
 	 * @return the dump configuration as an array of Strings
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to read the dump settings
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public String[] queryDumpOptions();
 
@@ -85,7 +89,9 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	 *
 	 * @return the dump configuration as a String, with multiple options separated by
 	 * a vertical bar
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to read the dump settings
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public String getDumpOptions();
 
@@ -99,7 +105,9 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	 * @param dumpOptions the options string to be set
 	 * @throws InvalidOptionException if the specified dumpOptions cannot be set or is incorrect
 	 * @throws ConfigurationUnavailableException if the configuration cannot be changed because a dump is already in progress
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to change the dump settings
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws NullPointerException if dumpOptions is null
 	 */
 	public void setDumpOptions(String dumpOptions) throws InvalidOptionException, ConfigurationUnavailableException;
@@ -115,7 +123,9 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	 * @param dumpAgent the dump agent to be triggered
 	 * @throws IllegalArgumentException if the specified dump agent is invalid or unsupported by this method
 	 * @throws RuntimeException if the vm does not contain RAS dump support
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to trigger this dump
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws NullPointerException if dumpAgent is null
 	 */
 	public void triggerDump(String dumpAgent) throws IllegalArgumentException;
@@ -141,15 +151,19 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	 *  the command line.</li>
 	 * </ul>
 	 *
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * If a security manager exists a permission check for com.ibm.jvm.DumpPermission will be
 	 * made, if this fails a SecurityException will be thrown.
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 *
 	 * @return the file name that the dump was actually written to
 	 * @param dumpAgent the dump agent to be triggered
 	 * @param fileNamePattern the filename to write to, which may be null, empty or include replacement tokens
 	 * @throws InvalidOptionException if the fileNamePattern was invalid
 	 * @throws IllegalArgumentException if the specified dump agent is invalid or unsupported by this method
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to trigger this dump
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws NullPointerException if dumpAgent is null
 	 */
 	public String triggerDumpToFile(String dumpAgent, String fileNamePattern) throws IllegalArgumentException, InvalidOptionException;
@@ -160,7 +174,9 @@ public interface OpenJ9DiagnosticsMXBean extends PlatformManagedObject {
 	 * @return the file name of the dump that was created
 	 * @throws InvalidOptionException if the dump operation fails
 	 * @throws RuntimeException if the JVM does not contain RAS dump support
+	/*[IF JAVA_SPEC_VERSION < 24]
 	 * @throws SecurityException if there is a security manager and it doesn't allow the checks required to trigger this dump
+	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 */
 	public String triggerClassicHeapDump() throws InvalidOptionException;
 }

--- a/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/openj9/lang/management/internal/OpenJ9DiagnosticsMXBeanImpl.java
@@ -27,7 +27,9 @@ import javax.management.ObjectName;
 /*[IF JAVA_SPEC_VERSION >= 9]*/
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 import java.security.PrivilegedAction;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 import java.util.Optional;
 /*[ELSE] JAVA_SPEC_VERSION >= 9 */
 import com.ibm.jvm.Dump;
@@ -81,6 +83,13 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 			return null;
 		}
 
+		/*[IF JAVA_SPEC_VERSION >= 24]*/
+		try {
+			return new OpenJ9DiagnosticsMXBeanImpl(openj9_jvm.get());
+		} catch (Exception e) {
+			throw handleError(e);
+		}
+		/*[ELSE] JAVA_SPEC_VERSION >= 24 */
 		PrivilegedAction<OpenJ9DiagnosticsMXBean> action = new PrivilegedAction<OpenJ9DiagnosticsMXBean>() {
 			@Override
 			public OpenJ9DiagnosticsMXBean run() {
@@ -93,6 +102,7 @@ public final class OpenJ9DiagnosticsMXBeanImpl implements OpenJ9DiagnosticsMXBea
 		};
 
 		return java.security.AccessController.doPrivileged(action);
+		/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 		/*[ELSE] JAVA_SPEC_VERSION > 8
 		return new OpenJ9DiagnosticsMXBeanImpl();
 		/*[ENDIF] JAVA_SPEC_VERSION > 8 */


### PR DESCRIPTION
This pull requests is the first of two prs to remove the use of java.security.AccessController.doPrivileged in JDK 24. It also removes a few cases of System.getSystemProperty and SecurityException mentions that were previously missed.

21 and 24 sanity https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/26116/
24 extended https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/47217/

Related: https://github.com/eclipse-openj9/openj9/issues/20563