### PR TITLE
Track JIT body invalidation reasons as bit flags

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2595,7 +2595,9 @@ void jitClassesRedefined(J9VMThread * currentThread, UDATA classCount, J9JITRede
                if (bodyInfo)
                   {
                   reportHookDetail(currentThread, "jitClassesRedefined", "    Invalidate method body stale=%p startPC=%p", staleMethod, startPC);
-                  TR::Recompilation::invalidateMethodBody(startPC, fe);
+                  TR::Recompilation::invalidateMethodBody(
+                     startPC, fe, TR_JitBodyInvalidations::HCR);
+
                   bodyInfo->setDisableSampling(true);
                   TR_PersistentMethodInfo *pmi = bodyInfo->getMethodInfo();
                   if (pmi)

--- a/runtime/compiler/control/J9CompilationStrategy.cpp
+++ b/runtime/compiler/control/J9CompilationStrategy.cpp
@@ -180,7 +180,7 @@ TR_OptimizationPlan *J9::CompilationStrategy::processEvent(TR_MethodEvent *event
          hotnessLevel = bodyInfo->getHotness();
          plan = TR_OptimizationPlan::alloc(hotnessLevel);
          *newPlanCreated = true;
-         bodyInfo->getMethodInfo()->incrementNumberOfInvalidations();
+         bodyInfo->getMethodInfo()->addInvalidationReasons(bodyInfo->invalidationReasons());
 
          // the following is just for compatibility with older implementation
          //bodyInfo->getMethodInfo()->setNextCompileLevel(hotnessLevel, false); // no profiling

--- a/runtime/compiler/control/J9CompilationStrategy.hpp
+++ b/runtime/compiler/control/J9CompilationStrategy.hpp
@@ -33,6 +33,7 @@
 #endif
 
 #include "control/OMRCompilationStrategy.hpp"
+#include "control/RecompilationInfo.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "runtime/CodeCacheManager.hpp"
 

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -588,7 +588,7 @@ TR_PersistentMethodInfo::TR_PersistentMethodInfo(TR::Compilation *comp) :
    _bestProfileInfo(0),
    _optimizationPlan(0),
    _catchBlockCounter(0),
-   _numberOfInvalidations(0),
+   _numberOfPreexistenceInvalidations(0),
    _numberOfInlinedMethodRedefinition(0),
    _numPrexAssumptions(0)
    {
@@ -619,7 +619,7 @@ TR_PersistentMethodInfo::TR_PersistentMethodInfo(TR_OpaqueMethodBlock *methodInf
    _bestProfileInfo(0),
    _optimizationPlan(0),
    _catchBlockCounter(0),
-   _numberOfInvalidations(0),
+   _numberOfPreexistenceInvalidations(0),
    _numberOfInlinedMethodRedefinition(0),
    _numPrexAssumptions(0)
    {
@@ -654,7 +654,6 @@ TR_PersistentJittedBodyInfo::TR_PersistentJittedBodyInfo(
    _flags(0),
    _sampleIntervalCount(0),
    _startCount(0),
-   _isInvalidated(false),
    _aggressiveRecompilationChances((uint8_t)TR::Options::_aggressiveRecompilationChances),
    _startPCAfterPreviousCompile(0),
    _longRunningInterpreted(false),

--- a/runtime/compiler/control/J9Recompilation.hpp
+++ b/runtime/compiler/control/J9Recompilation.hpp
@@ -118,7 +118,7 @@ public:
 
    static bool isAlreadyBeingCompiled(TR_OpaqueMethodBlock *methodInfo, void *startPC, TR_FrontEnd *fe);
    static void methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *fe);
-   static void invalidateMethodBody(void *startPC, TR_FrontEnd *fe);
+   static void invalidateMethodBody(void *startPC, TR_FrontEnd *fe, TR_JitBodyInvalidations::Reason reason);
 
    // Called at runtime to sample a method
    //

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -437,9 +437,8 @@ J9::OptionsPostRestore::invalidateCompiledMethod(J9Method *method, TR_J9VMBase *
          }
 
       TR_PersistentMethodInfo *pmi = bodyInfo->getMethodInfo();
-      pmi->setIsExcludedPostRestore();
-
-      TR::Recompilation::invalidateMethodBody(startPC, fej9);
+      TR::Recompilation::invalidateMethodBody(
+         startPC, fej9, TR_JitBodyInvalidations::PostRestoreExclude);
 
       // TODO: add method to a list to check the stack of java threads to print out message
       }

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -305,7 +305,7 @@ j9jit_testarossa_err(
          // Obsolete method bodies are invalid.
          //
          TR::Recompilation::fixUpMethodCode(oldStartPC);
-         jbi->setIsInvalidated();
+         jbi->setIsInvalidated(TR_JitBodyInvalidations::HCR);
          }
 
       if (jbi->getIsInvalidated())

--- a/runtime/compiler/runtime/JitRuntime.cpp
+++ b/runtime/compiler/runtime/JitRuntime.cpp
@@ -237,14 +237,14 @@ J9::Recompilation::sampleMethod(
       }
    }
 
-void J9::Recompilation::invalidateMethodBody(void *startPC, TR_FrontEnd *fe)
+void J9::Recompilation::invalidateMethodBody(
+   void *startPC, TR_FrontEnd *fe, TR_JitBodyInvalidations::Reason reason)
    {
-   // Pre-existence assumptions for this method have been violated. Make the
-   // method no-longer runnable and schedule it for sync recompilation
-   //
+   // Make the method no longer runnable and schedule it for sync recompilation
+   // or switch to interpreter
    J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
    TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(startPC);
-   bodyInfo->setIsInvalidated(); // bodyInfo must exist
+   bodyInfo->setIsInvalidated(reason); // bodyInfo must exist
 
    // If the compilation has been attempted before then we are fine (in case of success,
    // each caller is being re-directed to the new method -- in case if failure, all callers

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -129,7 +129,8 @@ TR_PreXRecompile::compensate(TR_FrontEnd *fe, bool, void *)
    TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
 
 #if (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))
-   TR::Recompilation::invalidateMethodBody(_startPC, fe);
+   TR::Recompilation::invalidateMethodBody(
+      _startPC, fe, TR_JitBodyInvalidations::Preexistence);
    // Generate a trace point
    fej9->reportPrexInvalidation(_startPC);
 #else


### PR DESCRIPTION
...and specify the reason whenever we invalidate a JIT body.

Post-restore exclusion was already specially distinguished by a flag in `TR_PersistentMethodInfo`.

Preexistence invalidation should also have been similarly distinguished, but the logic to avoid making new preexistence assumptions has been treating all invalidations as potentially preexistence-related.

This change is in preparation to add a new invalidation reason: the unloading of an inlined method. It will be important to know when a method has had a JIT body invalidated due to unloading so that when recompiling, inlining can be restricted to avoid repeated invalidation.