### PR TITLE
Improve definition of j9str_printf()

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -420,7 +420,7 @@ ROMClassBuilder::handleAnonClassName(J9CfrClassFile *classfile, ROMClassCreation
 	 * 0x<romAddress> will be appended to anon/hidden class name.
 	 * Initialize the 0x<romAddress> part to 0x00000000 or 0x0000000000000000 (depending on the platforms).
 	 */
-	j9str_printf(PORTLIB, buf, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, 0);
+	j9str_printf(buf, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, 0);
 	memcpy(constantPool[newUtfCPEntry].bytes + newHostPackageLength + originalStringLength + 1, buf, ROM_ADDRESS_LENGTH + 1);
 
 	/* Mark if the class is a Lambda class. */
@@ -900,7 +900,7 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 			 * write the name into a buffer first because j9str_printf automatically adds a NULL terminator
 			 * at the end, and J9UTF8 are not NULL terminated
 			 */
-			j9str_printf(PORTLIB, message, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, (UDATA)romClassBuffer);
+			j9str_printf(message, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, (UDATA)romClassBuffer);
 			nameString = (char*) message;
 		}
 		memcpy((char*) (classNameBytes + classNameRealLenghth), nameString, ROM_ADDRESS_LENGTH);

--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -507,10 +507,10 @@ public:
 		 */
 		nlsMessage = OMRPORT_FROM_J9PORT(PORTLIB)->nls_lookup_message(OMRPORT_FROM_J9PORT(PORTLIB), J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, module_name, message_num, NULL);
 		if(NULL != nlsMessage) {
-			UDATA messageLength = j9str_printf(PORTLIB, NULL, 0, nlsMessage, memberNameLength, memberName, classNameLength, className);
+			UDATA messageLength = j9str_printf(NULL, 0, nlsMessage, memberNameLength, memberName, classNameLength, className);
 			U_8* message = (U_8*)j9mem_allocate_memory(messageLength, OMRMEM_CATEGORY_VM);
 			if(NULL != message) {
-				j9str_printf(PORTLIB, (char*)message, messageLength, nlsMessage, memberNameLength, memberName, classNameLength, className);
+				j9str_printf((char *)message, messageLength, nlsMessage, memberNameLength, memberName, classNameLength, className);
 				recordCFRError(message);
 			}
 		}

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -1014,13 +1014,13 @@ createErrorMessage(J9VMThread *vmStruct, J9ROMClass *anonROMClass, J9ROMClass *h
 			}
 		}
 
-		bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
+		bufLen = j9str_printf(NULL, 0, errorMsg,
 						hostClassNameLength, hostClassNameData,
 						anonClassNameLength, anonClassNameData);
 		if (bufLen > 0) {
 			buf = j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 			if (NULL != buf) {
-				j9str_printf(PORTLIB, buf, bufLen, errorMsg,
+				j9str_printf(buf, bufLen, errorMsg,
 						hostClassNameLength, hostClassNameData,
 						anonClassNameLength, anonClassNameData);
 			}

--- a/runtime/bcutil/jimageintf.c
+++ b/runtime/bcutil/jimageintf.c
@@ -339,7 +339,7 @@ jimageFindResource(J9JImageIntf *jimageIntf, UDATA handle, const char *moduleNam
 		IDATA resourceNameLen = 1 + strlen(moduleName) + 1 + strlen(name) + 1; /* +1 for preceding '/' and, +1 for '/' between module and resource name, and +1 for \0 character */
 		char *resourceName = j9mem_allocate_memory(resourceNameLen, J9MEM_CATEGORY_CLASSES);
 		if ((NULL != j9jimageLocation) && (NULL != resourceName)) {
-			j9str_printf(PORTLIB, resourceName, resourceNameLen, "/%s/%s", moduleName, name);
+			j9str_printf(resourceName, resourceNameLen, "/%s/%s", moduleName, name);
 			rc = j9bcutil_lookupJImageResource(PORTLIB, jimage, j9jimageLocation, resourceName);
 			j9mem_free_memory(resourceName);
 			if (J9JIMAGE_NO_ERROR == rc) {

--- a/runtime/bcutil/jimagereader.c
+++ b/runtime/bcutil/jimagereader.c
@@ -167,7 +167,7 @@ j9bcutil_loadJImage(J9PortLibrary *portlib, const char *fileName, J9JImage **pji
 	memset(jimage, 0, sizeof(J9JImage));
 	jimage->fd = jimagefd;
 	jimage->fileName = (char *)(jimage + 1);
-	j9str_printf(PORTLIB, jimage->fileName, fileNameLen + 1, "%s", fileName);
+	j9str_printf(jimage->fileName, fileNameLen + 1, "%s", fileName);
 	jimage->fileLength = fileSize;
 	j9jimageHeader = jimage->j9jimageHeader = (J9JImageHeader *)((U_8 *)jimage + sizeof(J9JImage) + (fileNameLen + 1));
 
@@ -703,20 +703,20 @@ j9bcutil_getJImageResourceName(J9PortLibrary *portlib, J9JImage *jimage, const c
 	cursor = fullName;
 	spaceLeft = fullNameLen;
 	if (NULL != module) {
-		count = j9str_printf(PORTLIB, cursor, spaceLeft, "/%s/", module);
+		count = j9str_printf(cursor, spaceLeft, "/%s/", module);
 		cursor += count;
 		spaceLeft -= count;
 	}
 	if (NULL != parent) {
-		count = j9str_printf(PORTLIB, cursor, spaceLeft, "%s/", parent);
+		count = j9str_printf(cursor, spaceLeft, "%s/", parent);
 		cursor += count;
 		spaceLeft -= count;
 	}
-	count = j9str_printf(PORTLIB, cursor, spaceLeft, "%s", base);
+	count = j9str_printf(cursor, spaceLeft, "%s", base);
 	cursor += count;
 	spaceLeft -= count;
 	if (NULL != extension) {
-		count = j9str_printf(PORTLIB, cursor, spaceLeft, ".%s", extension);
+		count = j9str_printf(cursor, spaceLeft, ".%s", extension);
 	}
 
 	*resourceName = fullName;
@@ -761,7 +761,7 @@ j9bcutil_findModuleForPackage(J9PortLibrary *portlib, J9JImage *jimage, const ch
 		goto _end;
 	}
 
-	j9str_printf(PORTLIB, packageName, packageNameLen, "%s", packagePrefix);
+	j9str_printf(packageName, packageNameLen, "%s", packagePrefix);
 
 	for (i = 0; i <= strlen(package); i++) { /* include '\0' character as well */
 		/* convert any '/' to '.' */

--- a/runtime/bcutil/test/dyntest/testHelpers.c
+++ b/runtime/bcutil/test/dyntest/testHelpers.c
@@ -375,7 +375,7 @@ deleteControlDirectory(struct J9PortLibrary *portLibrary, char* baseDir) {
 		UDATA handle, rc;
 		char mybaseFilePath[J9SH_MAXPATH];
 
-		j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s/*", baseDir);
+		j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s/*", baseDir);
 		rc = handle = j9file_findfirst(mybaseFilePath, resultBuffer);
 		while (-1 != rc) {
 			j9file_unlink(resultBuffer);

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -850,14 +850,14 @@ j9bcv_createVerifyErrorString(J9PortLibrary * portLib, J9BytecodeVerificationDat
 		J9UTF8 * romMethodSignatureString = J9ROMMETHOD_SIGNATURE(error->romMethod);
 
 		if (NULL == error->errorSignatureString) {
-			errStrLength = j9str_printf(PORTLIB, (char*) verifyError, stringLength, formatString, errorString,
+			errStrLength = j9str_printf((char *)verifyError, stringLength, formatString, errorString,
 					(U_32) J9UTF8_LENGTH(romClassName), J9UTF8_DATA(romClassName),
 					(U_32) J9UTF8_LENGTH(romMethodName), J9UTF8_DATA(romMethodName),
 					(U_32) J9UTF8_LENGTH(romMethodSignatureString), J9UTF8_DATA(romMethodSignatureString),
 					error->errorPC);
 		} else {
 			/* Jazz 82615: Print the corresponding NLS message to buffer for type mismatch error */
-			errStrLength = j9str_printf(PORTLIB, (char*) verifyError, stringLength, formatString, errorString,
+			errStrLength = j9str_printf((char *)verifyError, stringLength, formatString, errorString,
 					(U_32) J9UTF8_LENGTH(romClassName), J9UTF8_DATA(romClassName),
 					(U_32) J9UTF8_LENGTH(romMethodName), J9UTF8_DATA(romMethodName),
 					(U_32) J9UTF8_LENGTH(romMethodSignatureString), J9UTF8_DATA(romMethodSignatureString),
@@ -870,7 +870,7 @@ j9bcv_createVerifyErrorString(J9PortLibrary * portLib, J9BytecodeVerificationDat
 
 		/* Jazz 82615: Print the error message framework to the existing error buffer */
 		if (detailedErrMsgLength > 0) {
-			j9str_printf(PORTLIB, (char*)&verifyError[errStrLength], stringLength - errStrLength, "%.*s", detailedErrMsgLength, detailedErrMsg);
+			j9str_printf((char *)&verifyError[errStrLength], stringLength - errStrLength, "%.*s", detailedErrMsgLength, detailedErrMsg);
 		}
 	}
 

--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -2833,9 +2833,9 @@ processJImageResource(const char *jimageFileName, J9JImage *jimage, J9JImageLoca
 
 		/* skip leading '/' if present */
 		if ('/' == resourceName[0]) {
-			j9str_printf(PORTLIB, tempPath, EsMaxPath, "%s", resourceName + 1);
+			j9str_printf(tempPath, EsMaxPath, "%s", resourceName + 1);
 		} else {
-			j9str_printf(PORTLIB, tempPath, EsMaxPath, "%s", resourceName);
+			j9str_printf(tempPath, EsMaxPath, "%s", resourceName);
 		}
 		current = strchr(tempPath, jimageFileSeparator);
 		while (NULL != current) {
@@ -3220,7 +3220,7 @@ static I_32 processROMClass(J9ROMClass* romClass, char* requestedFile, U_32 flag
 					length = (((length & 0xFF00) >> 8) | (length & 0x00FF) << 8);
 				}
 
-				j9str_printf(PORTLIB, tempPath, EsMaxPath, "%.*s", length, romClassName);
+				j9str_printf(tempPath, EsMaxPath, "%.*s", length, romClassName);
 				current = strchr(tempPath, DIR_SEPARATOR);
 				while (NULL != current) {
 					*current = '\0';

--- a/runtime/cfdumper/romdump.c
+++ b/runtime/cfdumper/romdump.c
@@ -184,9 +184,9 @@ escapeUTF8(J9PortLibrary *portLib, J9UTF8 *utf8, char *str, size_t strSize)
 				break;
 			}
 
-			escapedLength = j9str_printf(PORTLIB, str, strSize, "\\u%04x", (UDATA)c);
+			escapedLength = j9str_printf(str, strSize, "\\u%04x", (UDATA)c);
 		} else {
-			escapedLength = j9str_printf(PORTLIB, str, strSize, "%c", (char)c);
+			escapedLength = j9str_printf(str, strSize, "%c", (char)c);
 		}
 
 		strSize -= (size_t)escapedLength;
@@ -456,35 +456,35 @@ getRegionValueString(J9PortLibrary *portLib, J9ROMClass *romClass, J9ROMClassReg
 
 	switch (region->type) {
 		case J9ROM_U8:
-			j9str_printf(PORTLIB, str, strSize, "%12u", *(U_8 *)fieldPtr);
+			j9str_printf(str, strSize, "%12u", *(U_8 *)fieldPtr);
 			return;
 		case J9ROM_U16:
-			j9str_printf(PORTLIB, str, strSize, "%12u", *(U_16 *)fieldPtr);
+			j9str_printf(str, strSize, "%12u", *(U_16 *)fieldPtr);
 			return;
 		case J9ROM_U32:
-			j9str_printf(PORTLIB, str, strSize, "%12u", *(U_32 *)fieldPtr);
+			j9str_printf(str, strSize, "%12u", *(U_32 *)fieldPtr);
 			return;
 		case J9ROM_U64:
-			j9str_printf(PORTLIB, str, strSize, "%12llu", *(U_64 *)fieldPtr);
+			j9str_printf(str, strSize, "%12llu", *(U_64 *)fieldPtr);
 			return;
 		case J9ROM_UTF8:
-			j9str_printf(PORTLIB, str, strSize, "(UTF-8)");
+			j9str_printf(str, strSize, "(UTF-8)");
 			return;
 		case J9ROM_SRP:
-			j9str_printf(PORTLIB, str, strSize, "0x%08x", *(J9SRP *)fieldPtr);
+			j9str_printf(str, strSize, "0x%08x", *(J9SRP *)fieldPtr);
 			return;
 		case J9ROM_WSRP:
-			j9str_printf(PORTLIB, str, strSize, "0x%08x", *(J9WSRP *)fieldPtr);
+			j9str_printf(str, strSize, "0x%08x", *(J9WSRP *)fieldPtr);
 			return;
 		case J9ROM_SECTION_END:
-			j9str_printf(PORTLIB, str, strSize, "(SECTION)");
+			j9str_printf(str, strSize, "(SECTION)");
 			return;
 		case J9ROM_INTERMEDIATECLASSDATA:
-			j9str_printf(PORTLIB, str, strSize, "");
+			j9str_printf(str, strSize, "");
 			return;
 	}
 
-	j9str_printf(PORTLIB, str, strSize, "<error>");
+	j9str_printf(str, strSize, "<error>");
 }
 
 static void
@@ -522,7 +522,7 @@ getRegionDetailString(J9PortLibrary *portLib, J9ROMClassGatherLayoutInfoState *s
 				}
 
 				if (rangeValid) {
-					UDATA length = j9str_printf(PORTLIB, str, strSize, " -> ");
+					UDATA length = j9str_printf(str, strSize, " -> ");
 
 					escapeUTF8(PORTLIB, utf8, str + length, strSize - length);
 					printedUTF8 = TRUE;
@@ -534,16 +534,16 @@ getRegionDetailString(J9PortLibrary *portLib, J9ROMClassGatherLayoutInfoState *s
 			U_8 *addr = SRP_PTR_GET((J9SRP*)fieldPtr, U_8*);
 
 			if (NULL != addr) {
-				j9str_printf(PORTLIB, str, strSize, " -> 0x%p%s", (UDATA)addr - (UDATA)romClass,
+				j9str_printf(str, strSize, " -> 0x%p%s", (UDATA)addr - (UDATA)romClass,
 					((UDATA)addr - (UDATA)romClass) > romClass->romSize ? " (external)" : "");
 			}
 		}
 	} else if (J9ROM_INTERMEDIATECLASSDATA == region->type) {
-		j9str_printf(PORTLIB, str, strSize, " %5d bytes  !j9x 0x%p,0x%p", region->length, base + region->offset, region->length);
+		j9str_printf(str, strSize, " %5d bytes  !j9x 0x%p,0x%p", region->length, base + region->offset, region->length);
 	}
 
 	if (J9ROM_SECTION_END == region->type) {
-		j9str_printf(PORTLIB, str, strSize, " %5d bytes", region->length);
+		j9str_printf(str, strSize, " %5d bytes", region->length);
 	}
 }
 
@@ -611,7 +611,7 @@ j9bcutil_linearDumpROMClass(J9PortLibrary *portLib, J9ROMClass *romClass, void *
 				lastOffset = region->offset;
 			}
 			if (nesting < nestingThreshold) {
-				j9str_printf(PORTLIB, buf, sizeof(buf), "Section Start: %s (%d bytes)", region->name, region->length);
+				j9str_printf(buf, sizeof(buf), "Section Start: %s (%d bytes)", region->name, region->length);
 				j9tty_printf(PORTLIB, "=== %-59s ===\n", buf);
 			}
 			nesting++;
@@ -623,7 +623,7 @@ j9bcutil_linearDumpROMClass(J9PortLibrary *portLib, J9ROMClass *romClass, void *
 						reportSuspectedPadding(portLib, romClass, &state, lastOffset, region->offset, base);
 					}
 				}
-				j9str_printf(PORTLIB, buf, sizeof(buf), "Section End: %s", region->name);
+				j9str_printf(buf, sizeof(buf), "Section End: %s", region->name);
 				j9tty_printf(PORTLIB, "=== %-59s ===\n", buf);
 			} else if (nesting == nestingThreshold) {
 				printRegionLine(portLib, &state, romClass, region, base - region->length);
@@ -811,12 +811,12 @@ j9bcutil_queryROMClass(J9PortLibrary *portLib, J9ROMClass *romClass, void *baseA
 				char buf[256];
 
 				if (J9ROM_SECTION_START == region->type) {
-					j9str_printf(PORTLIB, buf, sizeof(buf), "Section Start: %s (%d bytes)", region->name, region->length);
+					j9str_printf(buf, sizeof(buf), "Section Start: %s (%d bytes)", region->name, region->length);
 					j9tty_printf(PORTLIB, "=== %-59s ===\n", buf);
 					nesting++;
 				} else if (J9ROM_SECTION_END == region->type) {
 					nesting--;
-					j9str_printf(PORTLIB, buf, sizeof(buf), "Section End: %s", region->name);
+					j9str_printf(buf, sizeof(buf), "Section End: %s", region->name);
 					j9tty_printf(PORTLIB, "=== %-59s ===\n", buf);
 					if (0 == nesting) {
 						queryMatched = TRUE;
@@ -911,16 +911,16 @@ getRegionValueStringXML(J9PortLibrary *portLib, J9ROMClass *romClass, J9ROMClass
 
 	switch (region->type) {
 		case J9ROM_U8:
-			j9str_printf(PORTLIB, str, strSize, "%u", *(U_8 *)fieldPtr);
+			j9str_printf(str, strSize, "%u", *(U_8 *)fieldPtr);
 			return;
 		case J9ROM_U16:
-			j9str_printf(PORTLIB, str, strSize, "%u", *(U_16 *)fieldPtr);
+			j9str_printf(str, strSize, "%u", *(U_16 *)fieldPtr);
 			return;
 		case J9ROM_U32:
-			j9str_printf(PORTLIB, str, strSize, "%u", *(U_32 *)fieldPtr);
+			j9str_printf(str, strSize, "%u", *(U_32 *)fieldPtr);
 			return;
 		case J9ROM_U64:
-			j9str_printf(PORTLIB, str, strSize, "%llu", *(U_64 *)fieldPtr);
+			j9str_printf(str, strSize, "%llu", *(U_64 *)fieldPtr);
 			return;
 		case J9ROM_UTF8: {
 			J9UTF8 *utf8 = fieldPtr;
@@ -928,14 +928,14 @@ getRegionValueStringXML(J9PortLibrary *portLib, J9ROMClass *romClass, J9ROMClass
 			return;
 		}
 		case J9ROM_SRP:
-			j9str_printf(PORTLIB, str, strSize, "0x%08x", *(J9SRP *)fieldPtr);
+			j9str_printf(str, strSize, "0x%08x", *(J9SRP *)fieldPtr);
 			return;
 		case J9ROM_WSRP:
-			j9str_printf(PORTLIB, str, strSize, "0x%08x", *(J9WSRP *)fieldPtr);
+			j9str_printf(str, strSize, "0x%08x", *(J9WSRP *)fieldPtr);
 			return;
 	}
 
-	j9str_printf(PORTLIB, str, strSize, "error>");
+	j9str_printf(str, strSize, "error>");
 }
 
 void

--- a/runtime/codert_vm/jswalk.c
+++ b/runtime/codert_vm/jswalk.c
@@ -636,7 +636,7 @@ static void walkJITFrameSlots(J9StackWalkState * walkState, U_8 * jitDescription
 		{
 #ifdef J9VM_INTERP_STACKWALK_TRACING
 			PORT_ACCESS_FROM_WALKSTATE(walkState);
-			j9str_printf(PORTLIB, indexedTag, 64, "O-Slot: %s%d", slotDescription, slotsRemaining - 1);
+			j9str_printf(indexedTag, 64, "O-Slot: %s%d", slotDescription, slotsRemaining - 1);
 			WALK_NAMED_O_SLOT((j9object_t*) scanCursor, indexedTag);
 #else
 			WALK_O_SLOT((j9object_t*) scanCursor);
@@ -650,7 +650,7 @@ static void walkJITFrameSlots(J9StackWalkState * walkState, U_8 * jitDescription
 		{
 #ifdef J9VM_INTERP_STACKWALK_TRACING
 			PORT_ACCESS_FROM_WALKSTATE(walkState);
-			j9str_printf(PORTLIB, indexedTag, 64, "I-Slot: %s%d", slotDescription, slotsRemaining - 1);
+			j9str_printf(indexedTag, 64, "I-Slot: %s%d", slotDescription, slotsRemaining - 1);
 			WALK_NAMED_I_SLOT(scanCursor, indexedTag);
 #else
 			WALK_I_SLOT(scanCursor);

--- a/runtime/exelib/common/libhlp.c
+++ b/runtime/exelib/common/libhlp.c
@@ -513,7 +513,7 @@ char * vmDetailString( J9PortLibrary *portLib, char *detailString, UDATA detailS
 	osversion = j9sysinfo_get_OS_version();
 	osarch = j9sysinfo_get_CPU_architecture();
 
-	j9str_printf (PORTLIB, detailString, detailStringLength, "%s (%s %s %s)", EsBuildVersionString, ostype ? ostype : "unknown", osversion ? osversion : "unknown", osarch ? osarch : "unknown");
+	j9str_printf(detailString, detailStringLength, "%s (%s %s %s)", EsBuildVersionString, ostype ? ostype : "unknown", osversion ? osversion : "unknown", osarch ? osarch : "unknown");
 	return detailString;
 }
 

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -361,7 +361,7 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 
 			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
 			if (NULL != buffer) {
-				j9str_printf(PORTLIB, buffer, formatLength, format, size, qualifier);
+				j9str_printf(buffer, formatLength, format, size, qualifier);
 			}
 			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 			break;
@@ -383,7 +383,7 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 
 			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
 			if (NULL != buffer) {
-				j9str_printf(PORTLIB, buffer, formatLength, format, size, qualifier);
+				j9str_printf(buffer, formatLength, format, size, qualifier);
 			}
 			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 			break;
@@ -409,7 +409,7 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 
 			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
 			if (NULL != buffer) {
-				j9str_printf(PORTLIB, buffer, formatLength, format, heapSize, heapSizeQualifier, pageSize, pageSizeQualifier);
+				j9str_printf(buffer, formatLength, format, heapSize, heapSizeQualifier, pageSize, pageSizeQualifier);
 			}
 			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 			extensions->largePageFailedToSatisfy = true;
@@ -435,11 +435,11 @@ j9gc_initialize_heap(J9JavaVM *vm, IDATA *memoryParameterTable, UDATA heapBytesR
 			UDATA newSpaceSize = extensions->newSpaceSize;
 			const char* newQualifier = NULL;
 			qualifiedSize(&newSpaceSize, &newQualifier);
-			UDATA formatLength = j9str_printf(PORTLIB, NULL, 0, format, splitFailure, newSpaceSize, newQualifier, oldSpaceSize, oldQualifier);
+			UDATA formatLength = j9str_printf(NULL, 0, format, splitFailure, newSpaceSize, newQualifier, oldSpaceSize, oldQualifier);
 
 			char *buffer = (char *)j9mem_allocate_memory(formatLength, OMRMEM_CATEGORY_MM);
 			if (NULL != buffer) {
-				j9str_printf(PORTLIB, buffer, formatLength, format, splitFailure, newSpaceSize, newQualifier, oldSpaceSize, oldQualifier);
+				j9str_printf(buffer, formatLength, format, splitFailure, newSpaceSize, newQualifier, oldSpaceSize, oldQualifier);
 			}
 			vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, buffer, TRUE);
 		}

--- a/runtime/gc_verbose_java/VerboseJava.cpp
+++ b/runtime/gc_verbose_java/VerboseJava.cpp
@@ -209,7 +209,7 @@ gcDumpQualifiedSize(J9PortLibrary* portLib, UDATA byteSize, const char* optionNa
 		NULL);
 
 	/* Format output String */
-	paramSize = j9str_printf(PORTLIB, buffer, 16, "%zu%s", size, qualifier);
+	paramSize = j9str_printf(buffer, 16, "%zu%s", size, qualifier);
 	paramSize = 15 - paramSize;
 	paramSize += strlen(optionDescription);
 	paramSize -= strlen(optionName);
@@ -294,7 +294,7 @@ gcDumpMemorySizes(J9JavaVM *javaVM)
 			NULL);
 
 		if (J9PORT_VMEM_PAGE_FLAG_NOT_USED != extensions->requestedPageFlags) {
-			j9str_printf(PORTLIB, postOption, 16, ",%s", getPageTypeString(extensions->requestedPageFlags));
+			j9str_printf(postOption, 16, ",%s", getPageTypeString(extensions->requestedPageFlags));
 		}
 
 		j9tty_printf(PORTLIB, "  %s%zu%s%s\t %s\n", optionName, size, qualifier, postOption, optionDescription);

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -4056,7 +4056,7 @@ JVM_LoadLibrary(const char *libName, jboolean throwOnFailure)
 							doOpenLibrary = FALSE;
 							Trc_SC_allocate_memory_failed(libPathLength);
 						} else {
-							j9str_printf(PORTLIB,
+							j9str_printf(
 									libNameNotDecorated,
 									libPathLength,
 									"%.*s%.*s",

--- a/runtime/jcl/common/bootstrp.c
+++ b/runtime/jcl/common/bootstrp.c
@@ -43,10 +43,9 @@ char* catPaths(J9PortLibrary* portLib, char* path1, char* path2) {
 	newPathLength = strlen(path1) + strlen(path2) + 2;
 	newPath = j9mem_allocate_memory(newPathLength, J9MEM_CATEGORY_VM_JCL);
 	if (newPath) {
-		j9str_printf(PORTLIB, newPath, (U_32)newPathLength, "%s%c%s", path1, (char) j9sysinfo_get_classpathSeparator(), path2);
+		j9str_printf(newPath, (U_32)newPathLength, "%s%c%s", path1, (char) j9sysinfo_get_classpathSeparator(), path2);
 	}
 	return newPath;
 }
 
 #endif /* J9VM_OPT_DYNAMIC_LOAD_SUPPORT */
-

--- a/runtime/jcl/common/bpinit.c
+++ b/runtime/jcl/common/bpinit.c
@@ -89,10 +89,10 @@ char* getDefaultBootstrapClassPath(J9JavaVM * vm, char* javaHome)
 			lastEntry = *entry;
 
 			if ('!' == lastEntry[0]) {
-				j9str_printf(PORTLIB, subPath, (U_32)pathLength, "%s", lastEntry + 1);
+				j9str_printf(subPath, (U_32)pathLength, "%s", lastEntry + 1);
 				j9mem_free_memory(*entry);
 			} else {
-				j9str_printf(PORTLIB, subPath, (U_32)pathLength,
+				j9str_printf(subPath, (U_32)pathLength,
 								"%s" DIR_SEPARATOR_STR "lib" DIR_SEPARATOR_STR "%s",
 								/* classes.zip */ javaHome, *entry);
 				/* if this entry was allocated then free it as we will not use it

--- a/runtime/jcl/common/extendedosmbean.c
+++ b/runtime/jcl/common/extendedosmbean.c
@@ -138,12 +138,12 @@ handle_error(JNIEnv *env, IDATA error, jint type)
 					J9NLS_PORT_SYSINFO_USAGE_RETRIEVAL_ERROR_MSG,
 					NULL);
 	/* Add in the specific error and the type. */
-	j9str_printf(PORTLIB,
-		exceptionMessage,
-		sizeof(exceptionMessage),
-		(char *)formatString,
-		error,
-		objType[type].name);
+	j9str_printf(
+			exceptionMessage,
+			sizeof(exceptionMessage),
+			(char *)formatString,
+			error,
+			objType[type].name);
 
 	if (PROCESSOR_USAGE_ERROR == type) {
 		exceptionClass = (*env)->FindClass(env, "com/ibm/lang/management/ProcessorUsageRetrievalException");

--- a/runtime/jcl/common/java_dyn_methodhandle.c
+++ b/runtime/jcl/common/java_dyn_methodhandle.c
@@ -112,7 +112,7 @@ lookupInterfaceMethod(J9VMThread *currentThread, J9Class *lookupClass, J9UTF8 *n
 						+ 4 /* period, parentheses, and terminating null */;
 					char *msg = j9mem_allocate_memory(nameAndSigLength, OMRMEM_CATEGORY_VM);
 					if (NULL != msg) {
-						j9str_printf(PORTLIB, msg, nameAndSigLength, "%.*s.%.*s(%.*s)",
+						j9str_printf(msg, nameAndSigLength, "%.*s.%.*s(%.*s)",
 								J9UTF8_LENGTH(className), J9UTF8_DATA(className),
 								J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName),
 								J9UTF8_LENGTH(sig), J9UTF8_DATA(sig));

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -141,7 +141,7 @@ jint computeFullVersionString(J9JavaVM* vm)
 	#define VENDOR_INFO ""
 #endif /* VENDOR_SHORT_NAME && VENDOR_SHA */
 
-	if (BUFFER_SIZE <= j9str_printf(PORTLIB, vminfo, BUFFER_SIZE + 1,
+	if (BUFFER_SIZE <= j9str_printf(vminfo, BUFFER_SIZE + 1,
 			"JRE %s %s %s-%s %s" JIT_INFO J9VM_VERSION_STRING OMR_INFO VENDOR_INFO OPENJDK_INFO,
 			j2se_version_info,
 			(NULL != osname ? osname : " "),
@@ -810,13 +810,13 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 				/* this is implicitly an unused property */
 				vmFuncs->setSystemProperty(vm, systemProperty, moduleName);
 			} else {
-				UDATA indexLen = j9str_printf(PORTLIB, NULL, 0, "%zu", vm->addModulesCount); /* get the length of the number string */
+				UDATA indexLen = j9str_printf(NULL, 0, "%zu", vm->addModulesCount); /* get the length of the number string */
 				char *propNameBuffer = j9mem_allocate_memory(sizeof(ADDMODS_PROPERTY_BASE) + indexLen, OMRMEM_CATEGORY_VM);
 				if (NULL == propNameBuffer) {
 					Trc_JCL_initializeRequiredClasses_addAgentModuleOutOfMemory(vmThread);
 					return 1;
 				}
-				j9str_printf(PORTLIB, propNameBuffer, sizeof(ADDMODS_PROPERTY_BASE) + indexLen, ADDMODS_PROPERTY_BASE "%zu", vm->addModulesCount);
+				j9str_printf(propNameBuffer, sizeof(ADDMODS_PROPERTY_BASE) + indexLen, ADDMODS_PROPERTY_BASE "%zu", vm->addModulesCount);
 				Trc_JCL_initializeRequiredClasses_addAgentModuleSetProperty(vmThread, propNameBuffer, moduleName);
 				vmFuncs->addSystemProperty(vm, propNameBuffer, moduleName, J9SYSPROP_FLAG_NAME_ALLOCATED);
 			}
@@ -849,13 +849,13 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 				/* this is implicitly an unused property */
 				vmFuncs->setSystemProperty(vm, systemProperty, moduleName);
 			} else {
-				UDATA indexLen = j9str_printf(PORTLIB, NULL, 0, "%zu", vm->addModulesCount); /* get the length of the number string */
+				UDATA indexLen = j9str_printf(NULL, 0, "%zu", vm->addModulesCount); /* get the length of the number string */
 				char *propNameBuffer = j9mem_allocate_memory(sizeof(ADDMODS_PROPERTY_BASE) + indexLen, OMRMEM_CATEGORY_VM);
 				if (NULL == propNameBuffer) {
 					Trc_JCL_initializeRequiredClasses_addAgentModuleOutOfMemory(vmThread);
 					return 1;
 				}
-				j9str_printf(PORTLIB, propNameBuffer, sizeof(ADDMODS_PROPERTY_BASE) + indexLen, ADDMODS_PROPERTY_BASE "%zu", vm->addModulesCount);
+				j9str_printf(propNameBuffer, sizeof(ADDMODS_PROPERTY_BASE) + indexLen, ADDMODS_PROPERTY_BASE "%zu", vm->addModulesCount);
 				Trc_JCL_initializeRequiredClasses_addAgentModuleSetProperty(vmThread, propNameBuffer, moduleName);
 				vmFuncs->addSystemProperty(vm, propNameBuffer, moduleName, J9SYSPROP_FLAG_NAME_ALLOCATED);
 			}

--- a/runtime/jcl/common/jcltrace.c
+++ b/runtime/jcl/common/jcltrace.c
@@ -240,7 +240,7 @@ processAndCheckNameString(JNIEnv *env, jobject name, const char **applicationNam
 		PORT_ACCESS_FROM_ENV(env);
 
 		memset(messageBuffer, 0, sizeof(messageBuffer));
-		j9str_printf(PORTLIB, messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Application name is too long. Maximum length %d characters, supplied string was %d characters.\n", MAX_APPLICATION_NAME_CHARS, strlen(*applicationName));
+		j9str_printf(messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Application name is too long. Maximum length %d characters, supplied string was %d characters.\n", MAX_APPLICATION_NAME_CHARS, strlen(*applicationName));
 		throwIllegalArgumentException(env, messageBuffer);
 		return 2;
 	}
@@ -515,7 +515,7 @@ extractAndProcessFormatStrings(JNIEnv *env, jarray templates, char ***const form
 			char messageBuffer[ERROR_MESSAGE_BUFFER_LENGTH + 1];
 
 			memset(messageBuffer, 0, sizeof(messageBuffer));
-			j9str_printf(PORTLIB, messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Error: template %d does not have a valid trace prefix. Trace templates should start with one of Trace.EVENT, Trace.EXIT, Trace.ENTRY, Trace.EXCEPTION or Trace.EXCEPTION_EXIT", i);
+			j9str_printf(messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Error: template %d does not have a valid trace prefix. Trace templates should start with one of Trace.EVENT, Trace.EXIT, Trace.ENTRY, Trace.EXCEPTION or Trace.EXCEPTION_EXIT", i);
 			throwIllegalArgumentException(env, messageBuffer);
 		}
 
@@ -721,7 +721,7 @@ Java_com_ibm_jvm_Trace_registerApplicationImpl(JNIEnv *env, jobject this, jobjec
 		char messageBuffer[ERROR_MESSAGE_BUFFER_LENGTH + 1];
 
 		memset(messageBuffer, 0, sizeof(messageBuffer));
-		j9str_printf(PORTLIB, messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Failed to register application with trace engine: %d", err);
+		j9str_printf(messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Failed to register application with trace engine: %d", err);
 		throwRuntimeException(env, messageBuffer);
 		toReturn = JNI_ERR;
 		goto error;
@@ -840,7 +840,7 @@ trace(JNIEnv *const env, const jint handle, const jint traceId, const UDATA meth
 		PORT_ACCESS_FROM_ENV(env);
 
 		memset(messageBuffer, 0, sizeof(messageBuffer));
-		j9str_printf(PORTLIB, messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Specified tracepoint: %d outside of valid range 0<=x<%d\n", traceId, modInfo->count);
+		j9str_printf(messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Specified tracepoint: %d outside of valid range 0<=x<%d\n", traceId, modInfo->count);
 		throwIllegalArgumentException(env, messageBuffer);
 		return;
 	}
@@ -854,7 +854,7 @@ trace(JNIEnv *const env, const jint handle, const jint traceId, const UDATA meth
 		PORT_ACCESS_FROM_ENV(env);
 
 		memset(messageBuffer, 0, sizeof(messageBuffer));
-		j9str_printf(PORTLIB, messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Wrong number of arguments passed to tracepoint %s.%d expected %d received %d.", modInfo->name, traceId, numberOfArgumentsExpected, numberOfArgumentsSupplied);
+		j9str_printf(messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Wrong number of arguments passed to tracepoint %s.%d expected %d received %d.", modInfo->name, traceId, numberOfArgumentsExpected, numberOfArgumentsSupplied);
 		throwIllegalArgumentException(env, messageBuffer);
 		return;
 	}
@@ -867,7 +867,7 @@ trace(JNIEnv *const env, const jint handle, const jint traceId, const UDATA meth
 		PORT_ACCESS_FROM_ENV(env);
 
 		memset(messageBuffer, 0, sizeof(messageBuffer));
-		j9str_printf(PORTLIB, messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Invalid arguments passed to tracepoint %s.%d. Tracepoint expects: ", modInfo->name, traceId);
+		j9str_printf(messageBuffer, ERROR_MESSAGE_BUFFER_LENGTH, "Invalid arguments passed to tracepoint %s.%d. Tracepoint expects: ", modInfo->name, traceId);
 
 		p = messageBuffer + strlen(messageBuffer);
 		formatCallPattern(p, end, callPatternsArray[traceId]);

--- a/runtime/jcl/common/jclvm.c
+++ b/runtime/jcl/common/jclvm.c
@@ -260,7 +260,7 @@ printHeapStatistics(JNIEnv *env,J9HeapStatisticsTableEntry **statsArray,
 
 	PORT_ACCESS_FROM_ENV(env);
 
-	result = j9str_printf(PORTLIB, bufferCursor, bufferSize,
+	result = j9str_printf(bufferCursor, bufferSize,
 			"%5s %14s %14s    %s\n-------------------------------------------------\n",
 			"num", "object count", "total size", "class name"
 	);
@@ -268,7 +268,7 @@ printHeapStatistics(JNIEnv *env,J9HeapStatisticsTableEntry **statsArray,
 	bufferSize -= result;
 	for (classCursor = 0; (result > 0) && (classCursor < numClasses); ++classCursor) {
 		J9Class *currentClass = statsArray[classCursor]->clazz;
-		result = j9str_printf(PORTLIB, bufferCursor, bufferSize,
+		result = j9str_printf(bufferCursor, bufferSize,
 				"%5d %14zu %14zu    ",
 				classCursor + 1, statsArray[classCursor]->objectCount,
 				statsArray[classCursor]->aggregateSize
@@ -284,20 +284,20 @@ printHeapStatistics(JNIEnv *env,J9HeapStatisticsTableEntry **statsArray,
 			UDATA isPrimitive = J9ROMCLASS_IS_PRIMITIVE_TYPE(leafROMClass);
 			UDATA i = 0;
 			for (i = 0; i < arity; ++i) {
-				result = j9str_printf(PORTLIB, bufferCursor, bufferSize, "[");
+				result = j9str_printf(bufferCursor, bufferSize, "[");
 				bufferCursor += result;
 				bufferSize -= result;
 			}
 			if (isPrimitive) {
-				result = j9str_printf(PORTLIB, bufferCursor, bufferSize, "%c\n",
+				result = j9str_printf(bufferCursor, bufferSize, "%c\n",
 						J9UTF8_DATA(J9ROMCLASS_CLASSNAME(leafComponentType->arrayClass->romClass))[1]);
 			} else {
-				result = j9str_printf(PORTLIB, bufferCursor, bufferSize, "L%.*s;\n",
+				result = j9str_printf(bufferCursor, bufferSize, "L%.*s;\n",
 						J9UTF8_LENGTH(leafName), J9UTF8_DATA(leafName));
 			}
 		} else {
 			J9UTF8 *className = J9ROMCLASS_CLASSNAME(currentClass->romClass);
-			result = j9str_printf(PORTLIB, bufferCursor, bufferSize, "%.*s\n",
+			result = j9str_printf(bufferCursor, bufferSize, "%.*s\n",
 					J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 		}
 		bufferCursor += result;
@@ -305,7 +305,7 @@ printHeapStatistics(JNIEnv *env,J9HeapStatisticsTableEntry **statsArray,
 		cumulativeCount += statsArray[classCursor]->objectCount;
 		cumulativeSize += statsArray[classCursor]->aggregateSize;
 	}
-	result = j9str_printf(PORTLIB, bufferCursor, bufferSize,
+	result = j9str_printf(bufferCursor, bufferSize,
 			"%5s %14zd %14zd\n",
 			"Total", cumulativeCount, cumulativeSize
 	);

--- a/runtime/jcl/common/mgmthypervisor.c
+++ b/runtime/jcl/common/mgmthypervisor.c
@@ -126,13 +126,13 @@ handle_error(JNIEnv *env, IDATA error, jint type)
 					J9NLS_JCL_HYPERVISOR_USAGE_RETRIEVAL_ERROR_MSG,
 					NULL);
 	/* Add in the specific error and the type. Append the port library specific error. */
-	j9str_printf(PORTLIB,
-		exceptionMessage,
-		sizeof(exceptionMessage),
-		(char *)formatString,
-		error,
-		objType[type].name,
-		j9error_last_error_message());
+	j9str_printf(
+			exceptionMessage,
+			sizeof(exceptionMessage),
+			(char *)formatString,
+			error,
+			objType[type].name,
+			j9error_last_error_message());
 
 	exceptionClass = (*env)->FindClass(env, "com/ibm/virtualization/management/GuestOSInfoRetrievalException");
 	if (NULL != exceptionClass) {

--- a/runtime/jcl/common/mgmtruntime.c
+++ b/runtime/jcl/common/mgmtruntime.c
@@ -36,7 +36,7 @@ Java_com_ibm_java_lang_management_internal_RuntimeMXBeanImpl_getNameImpl(JNIEnv 
 
 	pid = j9sysinfo_get_pid();
 	omrsysinfo_get_hostname( hostname, 256 );
-	j9str_printf( PORTLIB, result, 256, "%zu@%s", pid, hostname );
+	j9str_printf(result, sizeof(result), "%zu@%s", pid, hostname);
 
 	return (*env)->NewStringUTF( env, result );
 }

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -82,7 +82,7 @@ Java_java_lang_System_initJCLPlatformEncoding(JNIEnv *env, jclass clazz)
 	encoding = getPlatformFileEncoding(env, property, sizeof(property), 1); /* platform encoding */
 #endif /* defined(OSX) */
 	/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
-	written = j9str_printf(PORTLIB, dllPath, sizeof(dllPath), "%s/../java", vm->j2seRootDirectory);
+	written = j9str_printf(dllPath, sizeof(dllPath), "%s/../java", vm->j2seRootDirectory);
 	/* Assert the number of characters written (not including the null) fit within the dllPath buffer */
 	Assert_JCL_true(written < (sizeof(dllPath) - 1));
 	if (0 == j9sl_open_shared_library(dllPath, &handle, J9PORT_SLOPEN_DECORATE)) {
@@ -531,7 +531,7 @@ jobject getPropertyList(JNIEnv *env)
 		if ((~(UDATA)0) == javaVM->directByteBufferMemoryMax) {
 			strcpy(maxDirectMemBuff, "-1");
 		} else {
-			j9str_printf(PORTLIB, maxDirectMemBuff, sizeof(maxDirectMemBuff), "%zu", javaVM->directByteBufferMemoryMax);
+			j9str_printf(maxDirectMemBuff, sizeof(maxDirectMemBuff), "%zu", javaVM->directByteBufferMemoryMax);
 		}
 		strings[propIndex] = maxDirectMemBuff;
 		propIndex += 1;

--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -521,7 +521,7 @@ loadClasslibPropertiesFile(J9JavaVM *vm, UDATA *cursor)
 
 #define RELATIVE_PROPSPATH DIR_SEPARATOR_STR "lib" DIR_SEPARATOR_STR "classlib.properties"
 
-	j9str_printf(PORTLIB, propsPath, sizeof(propsPath), "%s" RELATIVE_PROPSPATH, vm->javaHome);
+	j9str_printf(propsPath, sizeof(propsPath), "%s" RELATIVE_PROPSPATH, vm->javaHome);
 
 #undef RELATIVE_PROPSPATH
 

--- a/runtime/jextractnatives/jextractnatives.c
+++ b/runtime/jextractnatives/jextractnatives.c
@@ -131,7 +131,7 @@ validateDump(JNIEnv *env, jboolean disableBuildIdCheck)
 		}
 
 		if (eyecatcher == (jlong)-1) {
-			j9str_printf(PORTLIB,
+			j9str_printf(
 					errBuf, sizeof(errBuf),
 					"JVM anchor block (J9VMRAS) not found in dump. Dump may be truncated, corrupted or contains a partially initialized JVM.");
 			(*env)->ThrowNew(env, errorClazz, errBuf);
@@ -140,10 +140,10 @@ validateDump(JNIEnv *env, jboolean disableBuildIdCheck)
 
 #if !defined(J9VM_ENV_DATA64)
 		if ((U_64)eyecatcher > (U_64)0xFFFFFFFF) {
-			j9str_printf(PORTLIB,
-				errBuf, sizeof(errBuf),
-				"J9RAS is out of range for a 32-bit pointer (0x%16.16llx). This version of jextract is incompatible with this dump.",
-				eyecatcher);
+			j9str_printf(
+					errBuf, sizeof(errBuf),
+					"J9RAS is out of range for a 32-bit pointer (0x%16.16llx). This version of jextract is incompatible with this dump.",
+					eyecatcher);
 			(*env)->ThrowNew(env, errorClazz, errBuf);
 			return JNI_FALSE;
 		}
@@ -155,20 +155,20 @@ validateDump(JNIEnv *env, jboolean disableBuildIdCheck)
 		if (ras != NULL) {
 			if (ras->bitpattern1 == 0xaa55aa55 && ras->bitpattern2 == 0xaa55aa55) {
 				if (ras->version != J9RASVersion) {
-					j9str_printf(PORTLIB,
-						errBuf, sizeof(errBuf),
-						"J9RAS.version is incorrect (found %u, expecting %u). This version of jextract is incompatible with this dump.",
-						ras->version,
-						J9RASVersion);
+					j9str_printf(
+							errBuf, sizeof(errBuf),
+							"J9RAS.version is incorrect (found %u, expecting %u). This version of jextract is incompatible with this dump.",
+							ras->version,
+							J9RASVersion);
 					(*env)->ThrowNew(env, errorClazz, errBuf);
 					return JNI_FALSE;
 				}
 				if (ras->length != sizeof(J9RAS)) {
-					j9str_printf(PORTLIB,
-						errBuf, sizeof(errBuf),
-						"J9RAS.length is incorrect (found %u, expecting %u). This version of jextract is incompatible with this dump.",
-						ras->length,
-						sizeof(J9RAS));
+					j9str_printf(
+							errBuf, sizeof(errBuf),
+							"J9RAS.length is incorrect (found %u, expecting %u). This version of jextract is incompatible with this dump.",
+							ras->length,
+							sizeof(J9RAS));
 					(*env)->ThrowNew(env, errorClazz, errBuf);
 					return JNI_FALSE;
 				}
@@ -180,13 +180,13 @@ validateDump(JNIEnv *env, jboolean disableBuildIdCheck)
 							ras->buildID,
 							(U_64)J9UniqueBuildID);
 					} else {
-						j9str_printf(PORTLIB,
-							errBuf, sizeof(errBuf),
-							"J9RAS.buildID is incorrect (found %llx, expecting %llx)."
-							" This version of jextract is incompatible with this dump"
-							" (use '-r' option to relax this check).",
-							ras->buildID,
-							(U_64)J9UniqueBuildID);
+						j9str_printf(
+								errBuf, sizeof(errBuf),
+								"J9RAS.buildID is incorrect (found %llx, expecting %llx)."
+								" This version of jextract is incompatible with this dump"
+								" (use '-r' option to relax this check).",
+								ras->buildID,
+								(U_64)J9UniqueBuildID);
 						(*env)->ThrowNew(env, errorClazz, errBuf);
 						return JNI_FALSE;
 					}
@@ -201,10 +201,10 @@ validateDump(JNIEnv *env, jboolean disableBuildIdCheck)
 			/* On 64-bit platforms, the code that tries to allocate the scratch space J9DBGEXT_SCRATCH_SIZE
 			 * scratch space will have issued it's own informative error already.
 			 */
-			j9str_printf(PORTLIB,
-				errBuf, sizeof(errBuf),
-				"Cannot allocate %zu bytes of memory for initial RAS eyecatcher, cannot continue processing this dump.",
-				sizeof(J9RAS));
+			j9str_printf(
+					errBuf, sizeof(errBuf),
+					"Cannot allocate %zu bytes of memory for initial RAS eyecatcher, cannot continue processing this dump.",
+					sizeof(J9RAS));
 			(*env)->ThrowNew(env, errorClazz, errBuf);
 			return JNI_FALSE;
 		}

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -1783,7 +1783,7 @@ methodEnterHook(J9HookInterface** hook, UDATA eventNum, void* eventData, void* u
 
 		argBuffer[0] = '\0';
 		if (!(romMethod->modifiers & J9AccStatic)) {
-			written = j9str_printf(PORTLIB, current, remainingSize, "receiver ");
+			written = j9str_printf(current, remainingSize, "receiver ");
 			current += written;
 			remainingSize -= written;
 			jniDecodeValue(vmThread, 'L', argPtr, &current, &remainingSize);
@@ -1791,7 +1791,7 @@ methodEnterHook(J9HookInterface** hook, UDATA eventNum, void* eventData, void* u
 		}
 		while ((sigChar = jniNextSigChar(&sigData)) != ')') {
 			if (argPtr != arg0EA) {
-				written = j9str_printf(PORTLIB, current, remainingSize, ", ");
+				written = j9str_printf(current, remainingSize, ", ");
 				current += written;
 				remainingSize -= written;
 			}
@@ -1891,38 +1891,38 @@ jniDecodeValue(J9VMThread * vmThread, UDATA sigChar, void * valuePtr, char ** ou
 
 	switch (sigChar) {
 		case 'B':
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jbyte)%d", *((I_32 *) valuePtr));
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jbyte)%d", *((I_32 *) valuePtr));
 			break;
 		case 'C':
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jchar)%d", *((I_32 *) valuePtr));
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jchar)%d", *((I_32 *) valuePtr));
 			break;
 		case 'D':
 			memcpy(&doubleValue, valuePtr, 8);
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jdouble)%lf", doubleValue);
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jdouble)%lf", doubleValue);
 			argSize = 2;
 			break;
 		case 'F':
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jfloat)%lf", *((float *) valuePtr));
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jfloat)%lf", *((float *) valuePtr));
 			break;
 		case 'I':
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jint)%d", *((I_32 *) valuePtr));
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jint)%d", *((I_32 *) valuePtr));
 			break;
 		case 'J':
 			memcpy(&longValue, valuePtr, 8);
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jlong)%lld", longValue);
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jlong)%lld", longValue);
 			argSize = 2;
 			break;
 		case 'S':
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jshort)%d", *((I_32 *) valuePtr));
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jshort)%d", *((I_32 *) valuePtr));
 			break;
 		case 'Z':
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jboolean)%s", *((I_32 *) valuePtr) ? "true" : "false");
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jboolean)%s", *((I_32 *) valuePtr) ? "true" : "false");
 			break;
 		case 'L':
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "(jobject)0x%p", *((UDATA *) valuePtr));
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "(jobject)0x%p", *((UDATA *) valuePtr));
 			break;
 		default:
-			written = j9str_printf(PORTLIB, *outputBuffer, *outputBufferLength, "void");
+			written = j9str_printf(*outputBuffer, *outputBufferLength, "void");
 			argSize = 0;
 			break;
 	}

--- a/runtime/jvmti/jvmtiStartup.c
+++ b/runtime/jvmti/jvmtiStartup.c
@@ -784,12 +784,11 @@ loadAgentLibraryOnAttach(struct J9JavaVM * vm, const char * library, const char 
 		/* Try invoking Agent_OnAttach_L function, if agent was linked statically.  */
 		if (J9NATIVELIB_LINK_MODE_STATIC == agentLibrary->nativeLib.linkMode) {
 			loadFunctionNameLength = j9str_printf(
-											PORTLIB,
-											loadFunctionName,
-											(J9JVMTI_BUFFER_LENGTH + 1),
-											"%s_%s",
-											J9JVMTI_AGENT_ONATTACH,
-											agentLibrary->nativeLib.name);
+					loadFunctionName,
+					(J9JVMTI_BUFFER_LENGTH + 1),
+					"%s_%s",
+					J9JVMTI_AGENT_ONATTACH,
+					agentLibrary->nativeLib.name);
 			if (loadFunctionNameLength >= J9JVMTI_BUFFER_LENGTH) {
 				rc = JNI_ERR;
 				goto exit;
@@ -816,12 +815,11 @@ loadAgentLibraryOnAttach(struct J9JavaVM * vm, const char * library, const char 
 			goto exit;
 		}
 		loadFunctionNameLength = j9str_printf(
-			PORTLIB,
-			loadFunctionName,
-			(J9JVMTI_BUFFER_LENGTH + 1),
-			"%s_%s",
-			J9JVMTI_AGENT_ONATTACH,
-			agentLibrary->nativeLib.name);
+				loadFunctionName,
+				(J9JVMTI_BUFFER_LENGTH + 1),
+				"%s_%s",
+				J9JVMTI_AGENT_ONATTACH,
+				agentLibrary->nativeLib.name);
 		if (loadFunctionNameLength >= J9JVMTI_BUFFER_LENGTH) {
 			rc = JNI_ERR;
 			goto exit;
@@ -902,12 +900,11 @@ loadAgentLibrary(J9JavaVM * vm, J9JVMTIAgentLibrary * agentLibrary)
 	 * If this is not found, fall back on the regular, dynamic linking way.
 	 */
 	nameBufferLengh = j9str_printf(
-							PORTLIB,
-							nameBuffer,
-							(J9JVMTI_BUFFER_LENGTH + 1),
-							"%s_%s",
-							J9JVMTI_AGENT_ONLOAD,
-							agentLibrary->nativeLib.name);
+			nameBuffer,
+			(J9JVMTI_BUFFER_LENGTH + 1),
+			"%s_%s",
+			J9JVMTI_AGENT_ONLOAD,
+			agentLibrary->nativeLib.name);
 	if (nameBufferLengh >= J9JVMTI_BUFFER_LENGTH) {
 		result = JNI_ERR;
 		goto exit;
@@ -976,12 +973,12 @@ shutDownAgentLibraries(J9JavaVM * vm, UDATA closeLibrary)
 				 * Agent_OnUnload, or else invoke Agent_OnUnload_L.
 				 */
 				if (J9NATIVELIB_LINK_MODE_STATIC == agentLibrary->nativeLib.linkMode) {
-					j9str_printf(PORTLIB,
-								 nameBuffer,
-								 sizeof(nameBuffer),
-								 "%s_%s",
-								 J9JVMTI_AGENT_ONUNLOAD,
-								 agentLibrary->nativeLib.name);
+					j9str_printf(
+							nameBuffer,
+							sizeof(nameBuffer),
+							"%s_%s",
+							J9JVMTI_AGENT_ONUNLOAD,
+							agentLibrary->nativeLib.name);
 				} else /* J9NATIVELIB_LINK_MODE_DYNAMIC == linkMode */ {
 					strcpy(nameBuffer, J9JVMTI_AGENT_ONUNLOAD);
 				}
@@ -1480,8 +1477,8 @@ isAgentLibraryLoaded(J9JavaVM *vm, const char *library, BOOLEAN decorate)
 				libNameSo = (char *)j9mem_allocate_memory(sizeLibNameSo, J9MEM_CATEGORY_JVMTI);
 				libNameAr = (char *)j9mem_allocate_memory(sizeLibNameAr, J9MEM_CATEGORY_JVMTI);
 				if ((NULL != libNameSo) && (NULL != libNameAr)) {
-					j9str_printf(PORTLIB, libNameSo, sizeLibNameSo, "lib%s.so", library);
-					j9str_printf(PORTLIB, libNameAr, sizeLibNameAr, "lib%s.a", library);
+					j9str_printf(libNameSo, sizeLibNameSo, "lib%s.so", library);
+					j9str_printf(libNameAr, sizeLibNameAr, "lib%s.a", library);
 					Trc_JVMTI_isAgentLibraryLoaded_libNames(libNameSo, libNameAr);
 				} else {
 					Trc_JVMTI_isAgentLibraryLoaded_OOM("libNameSo or libNameAr");
@@ -1547,13 +1544,13 @@ findAgentLibrary(J9JavaVM * vm, const char *libraryAndOptions, UDATA libraryLeng
 	J9JVMTIAgentLibrary * agentLibrary;
 	J9NativeLibrary * nativeLibrary = NULL;
 	UDATA nativeLibraryNameLength;
-    pool_state state;
+	pool_state state;
 
-    Trc_JVMTI_findAgentLibrary_Entry(libraryAndOptions);
+	Trc_JVMTI_findAgentLibrary_Entry(libraryAndOptions);
 	agentLibrary = pool_startDo(jvmtiData->agentLibraries, &state);
 	while (agentLibrary) {
-        nativeLibrary = &(agentLibrary->nativeLib);
- 		nativeLibraryNameLength = strlen(nativeLibrary->name);
+		nativeLibrary = &(agentLibrary->nativeLib);
+		nativeLibraryNameLength = strlen(nativeLibrary->name);
 		if (nativeLibraryNameLength == libraryLength) {
 			if (!strncmp(libraryAndOptions, nativeLibrary->name, libraryLength)) {
 				Trc_JVMTI_findAgentLibrary_successExit(nativeLibrary->name);

--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -620,7 +620,7 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9gp_handler_function() privatePortLibrary->gp_handler_function(privatePortLibrary)
 #define j9str_startup() OMRPORT_FROM_J9PORT(privatePortLibrary)->str_startup(OMRPORT_FROM_J9PORT(privatePortLibrary))
 #define j9str_shutdown() OMRPORT_FROM_J9PORT(privatePortLibrary)->str_shutdown(OMRPORT_FROM_J9PORT(privatePortLibrary))
-#define j9str_printf(param1,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_printf(OMRPORT_FROM_J9PORT(param1), ## __VA_ARGS__)
+#define j9str_printf(param1,param2,param3,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_printf(OMRPORT_FROM_J9PORT(privatePortLibrary), param1, param2, param3, ## __VA_ARGS__)
 #define j9str_vprintf(param1,param2,param3,param4) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_vprintf(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4)
 #define j9str_create_tokens(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_create_tokens(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
 #define j9str_set_token(param1,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_set_token(OMRPORT_FROM_J9PORT(param1), ## __VA_ARGS__)

--- a/runtime/rasdump/TextFileStream.cpp
+++ b/runtime/rasdump/TextFileStream.cpp
@@ -176,7 +176,7 @@ TextFileStream::writeInteger(UDATA data, const char *format)
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 	UDATA length;
 	
-	length = j9str_printf(PORTLIB, buffer, sizeof(buffer), format, data);
+	length = j9str_printf(buffer, sizeof(buffer), format, data);
 
 	writeCharacters(buffer, length);
 }
@@ -189,7 +189,7 @@ TextFileStream::writeInteger64(U_64 data, const char *format)
 	PORT_ACCESS_FROM_PORT(_PortLibrary);
 	UDATA length;
 	
-	length = j9str_printf(PORTLIB, buffer, sizeof(buffer), format, data);
+	length = j9str_printf(buffer, sizeof(buffer), format, data);
 
 	writeCharacters(buffer, length);
 }

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -2060,13 +2060,13 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 	
 	/* copy in the events */
 	separator = "";
-	len = j9str_printf(PORTLIB, temp_buf, sizeof(temp_buf), "%s", ":events=");
+	len = j9str_printf(temp_buf, sizeof(temp_buf), "%s", ":events=");
 	for (i = 0; i < J9RAS_DUMP_KNOWN_EVENTS; i++)
 	{
 		if ( agent->eventMask & rasDumpEvents[i].bits )
 		{
 			/* Switch between multi-line and single-line styles */
-			len += j9str_printf(PORTLIB, &temp_buf[len], sizeof(temp_buf) - len, "%s%s", separator, rasDumpEvents[i].name);
+			len += j9str_printf(&temp_buf[len], sizeof(temp_buf) - len, "%s%s", separator, rasDumpEvents[i].name);
 			separator = "+";
 		}
 	}
@@ -2083,7 +2083,7 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 	len = 0;
 	if (agent->detailFilter != NULL) {
 		/* Limit filter to 1000 characters so we don't overflow temp_buf and lose the "," */
-		len = j9str_printf(PORTLIB, temp_buf, sizeof(temp_buf), "filter=%.1000s,", agent->detailFilter);
+		len = j9str_printf(temp_buf, sizeof(temp_buf), "filter=%.1000s,", agent->detailFilter);
 	}
 	if (len > 0) {
 		/*increment buf here if it needs to be used further*/
@@ -2097,7 +2097,7 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 	/* copy in the subfilters */
 	len = 0;
 	if (agent->subFilter != NULL) {                
-		len = j9str_printf(PORTLIB, temp_buf, sizeof(temp_buf), "msg_filter=%.1000s,", agent->subFilter);
+		len = j9str_printf(temp_buf, sizeof(temp_buf), "msg_filter=%.1000s,", agent->subFilter);
 	}
 	if (len > 0) {
 		rc = writeIntoBuffer(buffer, buffer_size, &next_char, temp_buf);
@@ -2108,7 +2108,7 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 
 	/* copy in the label, range and priority */
 	len = 0;
-	len += j9str_printf(PORTLIB, temp_buf, sizeof(temp_buf),
+	len += j9str_printf(temp_buf, sizeof(temp_buf),
 			"%s%s,"
 			"range=%d..%d,"
 			"priority=%d,",
@@ -2127,13 +2127,13 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 
 	/* copy in the requests */
 	separator = "";
-	len = j9str_printf(PORTLIB, temp_buf, sizeof(temp_buf), "%s", "request=");
+	len = j9str_printf(temp_buf, sizeof(temp_buf), "%s", "request=");
 	for (i = 0; i < J9RAS_DUMP_KNOWN_REQUESTS; i++)
 	{
 		if ( agent->requestMask & rasDumpRequests[i].bits )
 		{
 			/* Switch between multi-line and single-line styles */
-			len += j9str_printf(PORTLIB, &temp_buf[len], sizeof(temp_buf) - len, "%s%s", separator, rasDumpRequests[i].name);
+			len += j9str_printf(&temp_buf[len], sizeof(temp_buf) - len, "%s%s", separator, rasDumpRequests[i].name);
 			separator = "+";
 		}
 	}
@@ -2141,10 +2141,10 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 	/* copy in the options */
 	if ( agent->dumpOptions != NULL ){
 		 /* Switch between multi-line and single-line styles */
-		len += j9str_printf(PORTLIB, &temp_buf[len], sizeof(temp_buf) - len, ",%s=%s", "opts", agent->dumpOptions);
+		len += j9str_printf(&temp_buf[len], sizeof(temp_buf) - len, ",%s=%s", "opts", agent->dumpOptions);
 	}
 
-	len += j9str_printf(PORTLIB, &temp_buf[len], sizeof(temp_buf) - len, "\n");
+	len += j9str_printf(&temp_buf[len], sizeof(temp_buf) - len, "\n");
 	if (len > 0) {
 		rc = writeIntoBuffer(buffer, buffer_size, &next_char, temp_buf);
 		if (rc == FALSE) {

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -1443,9 +1443,9 @@ initDumpDirectory(J9JavaVM *vm)
 			printDumpUsage(vm);
 			return OMR_ERROR_INTERNAL;
 		} else {
-			dumpDirectoryPrefix = (char *)j9mem_allocate_memory(strlen(optionString)+1, OMRMEM_CATEGORY_VM);
-			if( dumpDirectoryPrefix != NULL ) {
-				j9str_printf(PORTLIB, dumpDirectoryPrefix, strlen(optionString)+1, "%s", optionString);
+			dumpDirectoryPrefix = (char *)j9mem_allocate_memory(strlen(optionString) + 1, OMRMEM_CATEGORY_VM);
+			if (NULL != dumpDirectoryPrefix) {
+				j9str_printf(dumpDirectoryPrefix, strlen(optionString) + 1, "%s", optionString);
 			} else {
 				retVal = OMR_ERROR_INTERNAL;
 			}

--- a/runtime/rasdump/heapdump.cpp
+++ b/runtime/rasdump/heapdump.cpp
@@ -559,16 +559,16 @@ public :
 	{
 		PORT_ACCESS_FROM_PORT(_PortLibrary);
 		char buffer[1 + (sizeof(UDATA) * 8)];
-		
+
 		switch (radix) {
 		case 16:
-			j9str_printf(PORTLIB, buffer, sizeof(buffer), "%.*zX", sizeof(UDATA) * 2, data);
+			j9str_printf(buffer, sizeof(buffer), "%.*zX", sizeof(UDATA) * 2, data);
 			break;
 		default:
-			j9str_printf(PORTLIB, buffer, sizeof(buffer), "%zu", data);
+			j9str_printf(buffer, sizeof(buffer), "%zu", data);
 			break;
 		}
-		
+
 		append(buffer, strlen(buffer));
 
 		return *this;

--- a/runtime/rasdump/heapdump_classic.c
+++ b/runtime/rasdump/heapdump_classic.c
@@ -179,11 +179,11 @@ hdClassicMultiSpaceIteratorCallback(J9JavaVM *vm, J9MM_IterateSpaceDescriptor *s
 	char *cursor = ctx->label;
 	char *end = cursor + strlen(ctx->label);
 	PORT_ACCESS_FROM_JAVAVM(ctx->vm);
-	
+
 	memset(&(ctx->filename), 0, sizeof(ctx->filename));
 
-	j9str_printf(PORTLIB, insert, sizeof(insert), "%s%.*zX", spaceDescriptor->name, sizeof(UDATA) * 2, spaceDescriptor->id);
-	
+	j9str_printf(insert, sizeof(insert), "%s%.*zX", spaceDescriptor->name, sizeof(UDATA) * 2, spaceDescriptor->id);
+
 	/* Generate the filename to be written to by substituting "%id" for insert */
 	while (cursor < end) {
 		if (cursor == strstr(cursor, "%id")) {

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -416,7 +416,7 @@ matchesExceptionFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDAT
 					if (stackOffsetFilter) {
 						end += J9UTF8_LENGTH(throwMethodName) + 1;
 						buf[end] = '#';
-						j9str_printf(PORTLIB, buf + end + 1, buflen - end, "%d", throwSite.desiredOffset);
+						j9str_printf(buf + end + 1, buflen - end, "%d", throwSite.desiredOffset);
 					}
 					buf[buflen] = '\0';
 				}
@@ -1233,7 +1233,7 @@ rasDumpHookVmShutdown(J9HookInterface** hookInterface, UDATA eventNum, void* eve
 	char details[32];
 	PORT_ACCESS_FROM_VMC(vmThread);
 
-	length = j9str_printf(PORTLIB, details, sizeof(details), "#%0*zx", sizeof(UDATA) * 2, data->exitCode);
+	length = j9str_printf(details, sizeof(details), "#%0*zx", sizeof(UDATA) * 2, data->exitCode);
 
 	dumpData.detailLength = length;
 	dumpData.detailData = details;
@@ -1438,17 +1438,17 @@ rasDumpHookAllocationThreshold(J9HookInterface** hookInterface, UDATA eventNum, 
 
 		/* For arrays we print the name of the leaf class then add enough '[]' to describe the arity */
 
-		length = j9str_printf(PORTLIB, details, sizeof(details), "%zu bytes, type %.*s", data->size, J9UTF8_LENGTH(leafClassName), J9UTF8_DATA(leafClassName));
+		length = j9str_printf(details, sizeof(details), "%zu bytes, type %.*s", data->size, J9UTF8_LENGTH(leafClassName), J9UTF8_DATA(leafClassName));
 
 		for (i=0;i<arrayClass->arity;i++) {
-			length += j9str_printf(PORTLIB, details + length, sizeof(details) - length, "[]");
+			length += j9str_printf(details + length, sizeof(details) - length, "[]");
 		}
 	} else {
 		J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 
 		/* For regular objects, we just print the name from the ROMclass */
 
-		length = j9str_printf(PORTLIB, details, sizeof(details), "%zu bytes, type %.*s", data->size, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
+		length = j9str_printf(details, sizeof(details), "%zu bytes, type %.*s", data->size, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 	}
 
 	/* Change any /s to .s so class names are in customer-friendly format */
@@ -1486,7 +1486,7 @@ rasDumpHookSlowExclusive(J9HookInterface** hookInterface, UDATA eventNum, void* 
 	char details[32];
 	PORT_ACCESS_FROM_VMC(vmThread);
 
-	length = j9str_printf(PORTLIB, details, sizeof(details), "%zums", data->timeTaken);
+	length = j9str_printf(details, sizeof(details), "%zums", data->timeTaken);
 
 	dumpData.detailLength = length;
 	dumpData.detailData = details;

--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -420,7 +420,7 @@ traceMethodArgDouble(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 	/* read a potentially misaligned double value */
 	memcpy(&data, arg0EA, sizeof(data));
 
-	j9str_printf(PORTLIB, cursor, length, "(double)%f", data);
+	j9str_printf(cursor, length, "(double)%f", data);
 }
 
 /*
@@ -432,7 +432,7 @@ traceMethodArgFloat(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 	jfloat data = *(jfloat*)arg0EA;
 	PORT_ACCESS_FROM_VMC(thr);
 
-	j9str_printf(PORTLIB, cursor, length, "(float)%f", data);
+	j9str_printf(cursor, length, "(float)%f", data);
 }
 
 /*
@@ -444,7 +444,7 @@ traceMethodArgInt(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length, ch
 	jint data = *(jint*)arg0EA;
 	PORT_ACCESS_FROM_VMC(thr);
 
-	j9str_printf(PORTLIB, cursor, length, "(%s)%d", type, data);
+	j9str_printf(cursor, length, "(%s)%d", type, data);
 }
 
 /*
@@ -459,7 +459,7 @@ traceMethodArgLong(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 	/* read a potentially misaligned long value */
 	memcpy(&data, arg0EA, sizeof(data));
 
-	j9str_printf(PORTLIB, cursor, length, "(long)%lld", data);
+	j9str_printf(cursor, length, "(long)%lld", data);
 }
 
 /*
@@ -472,7 +472,7 @@ traceMethodArgObject(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 	PORT_ACCESS_FROM_VMC(thr);
 
 	if (object == NULL) {
-		j9str_printf(PORTLIB, cursor, length, "null");
+		j9str_printf(cursor, length, "null");
 	} else {
 		J9Class *clazz = J9OBJECT_CLAZZ(thr, object);
 		J9JavaVM *vm = thr->javaVM;
@@ -496,11 +496,11 @@ traceMethodArgObject(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 					&utf8Length);
 
 			if (NULL == utf8String) {
-				j9str_printf(PORTLIB, cursor, length, "(String)<Memory allocation error>");
+				j9str_printf(cursor, length, "(String)<Memory allocation error>");
 			} else if (utf8Length > maxStringLength) {
-				j9str_printf(PORTLIB, cursor, length, "(String)\"%.*s\"...", (U_32)maxStringLength, utf8String);
+				j9str_printf(cursor, length, "(String)\"%.*s\"...", (U_32)maxStringLength, utf8String);
 			} else {
-				j9str_printf(PORTLIB, cursor, length, "(String)\"%.*s\"", (U_32)utf8Length, utf8String);
+				j9str_printf(cursor, length, "(String)\"%.*s\"", (U_32)utf8Length, utf8String);
 			}
 
 			if (utf8Buffer != utf8String) {
@@ -511,7 +511,7 @@ traceMethodArgObject(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 
 			J9ROMClass *romClass = clazz->romClass;
 			J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
-			j9str_printf(PORTLIB, cursor, length, "%.*s@%p", (U_32)J9UTF8_LENGTH(className), J9UTF8_DATA(className), object);
+			j9str_printf(cursor, length, "%.*s@%p", (U_32)J9UTF8_LENGTH(className), J9UTF8_DATA(className), object);
 		}
 	}
 }
@@ -662,6 +662,5 @@ traceMethodArgBoolean(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length
 	jint data = *(jint*)arg0EA;
 	PORT_ACCESS_FROM_VMC(thr);
 
-	j9str_printf(PORTLIB, cursor, length, data ? "true" : "false");
+	j9str_printf(cursor, length, data ? "true" : "false");
 }
-

--- a/runtime/rastrace/method_trigger.c
+++ b/runtime/rastrace/method_trigger.c
@@ -1065,27 +1065,27 @@ uncompressedStackFrameFormatter(J9VMThread *vmThread, J9Method * method, J9UTF8 
 	char *cursor = buf;
 	char *end = buf + sizeof(buf);
 
-	cursor += j9str_printf(PORTLIB, cursor, end - cursor, "%.*s.%.*s", J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName));
+	cursor += j9str_printf(cursor, end - cursor, "%.*s.%.*s", J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName));
 
 	slashesToDots(buf,cursor);
 
 	if (NATIVE_METHOD == frameType) {
 		/*increment cursor here by the return value of j9str_printf if it needs to be used further*/
-		j9str_printf(PORTLIB, cursor, end - cursor, " (Native Method)");
+		j9str_printf(cursor, end - cursor, " (Native Method)");
 	} else {
 		if (sourceFile) {
-			cursor += j9str_printf(PORTLIB, cursor, end - cursor, " (%.*s", J9UTF8_LENGTH(sourceFile), J9UTF8_DATA(sourceFile));
+			cursor += j9str_printf(cursor, end - cursor, " (%.*s", J9UTF8_LENGTH(sourceFile), J9UTF8_DATA(sourceFile));
 			if (lineNumber != -1) {
-				cursor += j9str_printf(PORTLIB, cursor, end - cursor, ":%zu", lineNumber);
+				cursor += j9str_printf(cursor, end - cursor, ":%zu", lineNumber);
 			}
-			cursor += j9str_printf(PORTLIB, cursor, end - cursor, ")");
+			cursor += j9str_printf(cursor, end - cursor, ")");
 		} else {
-			cursor += j9str_printf(PORTLIB, cursor, end - cursor, " (Bytecode PC: %zu)", offsetPC);
+			cursor += j9str_printf(cursor, end - cursor, " (Bytecode PC: %zu)", offsetPC);
 		}
 
 		if (COMPILED_METHOD == frameType) {
 			/*increment cursor here by the return value of j9str_printf if it needs to be used further*/
-			j9str_printf(PORTLIB, cursor, end - cursor, " (Compiled Code)", offsetPC);
+			j9str_printf(cursor, end - cursor, " (Compiled Code)", offsetPC);
 		}
 	}
 

--- a/runtime/rastrace/trccomponent.c
+++ b/runtime/rastrace/trccomponent.c
@@ -70,7 +70,7 @@ initializeComponentData(UtComponentData **componentDataPtr, UtModuleInfo *module
 	 */
 	if (moduleInfo->traceVersionInfo->traceVersion >= 7 && moduleInfo->containerModule != NULL) {
 		char qualifiedName[MAX_QUALIFIED_NAME_LENGTH];
-		j9str_printf(PORTLIB, qualifiedName, MAX_QUALIFIED_NAME_LENGTH, "%s(%s)", moduleInfo->name, moduleInfo->containerModule->name);
+		j9str_printf(qualifiedName, MAX_QUALIFIED_NAME_LENGTH, "%s(%s)", moduleInfo->name, moduleInfo->containerModule->name);
 		componentData->qualifiedComponentName = (char *)j9mem_allocate_memory(strlen(qualifiedName) + 1, OMRMEM_CATEGORY_TRACE);
 		if (componentData->qualifiedComponentName == NULL) {
 			UT_DBGOUT(1, ("<UT> Unable to allocate componentData's name field for %s\n", componentName));

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -325,7 +325,7 @@ J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 		 *  are processed so it's Ok to use stack space.
 		 */
 		opts[0] = UT_FORMAT_KEYWORD;
-		j9str_printf(PORTLIB, tempPath, sizeof(tempPath), "%s" DIR_SEPARATOR_STR "lib;.", javahome);
+		j9str_printf(tempPath, sizeof(tempPath), "%s" DIR_SEPARATOR_STR "lib;.", javahome);
 
 		opts[1] = tempPath;
 		opts[2] = NULL;

--- a/runtime/rastrace/trcformatter.c
+++ b/runtime/rastrace/trcformatter.c
@@ -395,34 +395,34 @@ readConsumeAndSPrintfParameter(J9PortLibrary *portLib, char *rawParameterData, u
 		/* handling a generic 64 bit integer */
 		u64data = getU_64FromBuffer((UtTraceRecord *)rawParameterData, *offsetInParameterData, isBigEndian);
 		if (nWidthAndPrecisions == 2) {
-			temp = j9str_printf(PORTLIB, NULL, 0, format, precisionOrWidth1, precisionOrWidth2, u64data);
+			temp = j9str_printf(NULL, 0, format, precisionOrWidth1, precisionOrWidth2, u64data);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, precisionOrWidth1, precisionOrWidth2, u64data);
 		} else if (nWidthAndPrecisions == 1) {
-			temp = j9str_printf(PORTLIB, NULL, 0, format, precisionOrWidth1, u64data);
+			temp = j9str_printf(NULL, 0, format, precisionOrWidth1, u64data);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, precisionOrWidth1, u64data);
 		} else {
-			temp = j9str_printf(PORTLIB, NULL, 0, format, u64data);
+			temp = j9str_printf(NULL, 0, format, u64data);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, u64data);
 		}
 		*offsetInParameterData += 8;
@@ -430,48 +430,48 @@ readConsumeAndSPrintfParameter(J9PortLibrary *portLib, char *rawParameterData, u
 		/* handling a generic 32 bit integer */
 		u32data = getU_32FromBuffer((UtTraceRecord *)rawParameterData, *offsetInParameterData, isBigEndian);
 		if (nWidthAndPrecisions == 2) {
-			temp = j9str_printf(PORTLIB, NULL, 0, format, precisionOrWidth1, precisionOrWidth2, u32data);
+			temp = j9str_printf(NULL, 0, format, precisionOrWidth1, precisionOrWidth2, u32data);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, precisionOrWidth1, precisionOrWidth2, u32data);
 		} else if (nWidthAndPrecisions == 1) {
-			temp = j9str_printf(PORTLIB, NULL, 0, format, precisionOrWidth1, u32data);
+			temp = j9str_printf(NULL, 0, format, precisionOrWidth1, u32data);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, precisionOrWidth1, u32data);
 		} else {
-			temp = j9str_printf(PORTLIB, NULL, 0, format, u32data);
+			temp = j9str_printf(NULL, 0, format, u32data);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, u32data);
 		}
 		*offsetInParameterData += 4;
 	} else if (dataType == UT_TRACE_FORMATTER_8BIT_DATA) {
 		/* handling a char */
 		u8data = getUnsignedByteFromBuffer((UtTraceRecord *)rawParameterData, *offsetInParameterData);
-		temp = j9str_printf(PORTLIB, NULL, 0, format, u8data);
+		temp = j9str_printf(NULL, 0, format, u8data);
 		if (temp > destBufferLength) {
 			/* can't write data to dest buffer - it's too full, be cautious and just return */
 			UT_DBGOUT_CHECKED(1,
 					("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 			return 0;
 		}
-		temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+		temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 				format, u8data);
 		*offsetInParameterData += 1;
 	} else if (dataType == UT_TRACE_FORMATTER_STRING_DATA) {
@@ -482,26 +482,26 @@ readConsumeAndSPrintfParameter(J9PortLibrary *portLib, char *rawParameterData, u
 			i16data = (int16_t)getU_16FromBuffer((UtTraceRecord *)rawParameterData, *offsetInParameterData, isBigEndian);
 			*offsetInParameterData += 2;
 			strValue = rawParameterData + (*offsetInParameterData);
-			temp = j9str_printf(PORTLIB, NULL, 0, format, i16data, strValue);
+			temp = j9str_printf(NULL, 0, format, i16data, strValue);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, i16data, strValue);
 		} else {
 			/* it's just a plain string */
 			strValue = rawParameterData + (*offsetInParameterData);
-			temp = j9str_printf(PORTLIB, NULL, 0, format, strValue);
+			temp = j9str_printf(NULL, 0, format, strValue);
 			if (temp > destBufferLength) {
 				/* can't write data to dest buffer - it's too full, be cautious and just return */
 				UT_DBGOUT_CHECKED(1,
 						("<UT> readConsumeAndSPrintfParameter destination buffer exhausted: %d [%s]\n", dataType, format));
 				return 0;
 			}
-			temp = j9str_printf(PORTLIB, destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
+			temp = j9str_printf(destBuffer + (*offsetInDestBuffer), destBufferLength - (*offsetInDestBuffer),
 					format, strValue);
 			/* for the null in the parm data */
 			*offsetInParameterData += 1;
@@ -806,7 +806,7 @@ parseTracePoint(J9PortLibrary *portLib, UtTraceRecord *record, uint32_t offset, 
 
 	nanos = (uint32_t)((millis * ONEMILLION) + (splitTimeRem * ONEMILLION / iter->timeConversion));
 
-	offsetOfParameters = (uint32_t) j9str_printf(PORTLIB, NULL, 0, "%02u:%02u:%02u:%09u GMT %.*s.%u - ", hours, minutes,
+	offsetOfParameters = (uint32_t) j9str_printf(NULL, 0, "%02u:%02u:%02u:%09u GMT %.*s.%u - ", hours, minutes,
 			seconds, nanos, modNameLength, modName, traceId);
 
 	if (offsetOfParameters > bufferLength) {
@@ -815,7 +815,7 @@ parseTracePoint(J9PortLibrary *portLib, UtTraceRecord *record, uint32_t offset, 
 		return NULL;
 	}
 
-	offsetOfParameters = (uint32_t) j9str_printf(PORTLIB, buffer, bufferLength, "%02u:%02u:%02u:%09u GMT %.*s.%u - ", hours,
+	offsetOfParameters = (uint32_t) j9str_printf(buffer, bufferLength, "%02u:%02u:%02u:%09u GMT %.*s.%u - ", hours,
 			minutes, seconds, nanos, modNameLength, modName, traceId);
 
 	rawParameterData = tempPtr + offset + TRACEPOINT_RAW_DATA_MODULE_NAME_DATA_OFFSET + modNameLength;

--- a/runtime/rastrace/trclog.c
+++ b/runtime/rastrace/trclog.c
@@ -1331,7 +1331,7 @@ tracePrint(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, va_list 
 		strcpy(qualifiedModuleName, "dg");
 		moduleName = "dg";
 	} else 	if ( modInfo->traceVersionInfo->traceVersion >= 7 && modInfo->containerModule != NULL ) {
-		j9str_printf(PORTLIB, qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
+		j9str_printf(qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
 		moduleName = modInfo->name;
 	} else {
 		strncpy(qualifiedModuleName, modInfo->name, MAX_QUALIFIED_NAME_LENGTH);
@@ -1449,7 +1449,7 @@ traceAssertion(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, va_l
 	if (modInfo == NULL){
 		strcpy(qualifiedModuleName, "dg");
 	} else 	if ( modInfo->traceVersionInfo->traceVersion >= 7 && modInfo->containerModule != NULL ) {
-		j9str_printf(PORTLIB, qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
+		j9str_printf(qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
 	} else {
 		strncpy(qualifiedModuleName, modInfo->name, MAX_QUALIFIED_NAME_LENGTH);
 	}
@@ -2552,7 +2552,7 @@ raiseAssertion(UtThreadData **thread, UtModuleInfo *modInfo, uint32_t traceId)
 
 		/* Set and fire the trigger to fire the dump assertion event. */
 		memset(triggerClause, 0, sizeof(triggerClause));
-		j9str_printf(PORTLIB, triggerClause, sizeof(triggerClause), "tpnid{%s.%d,assert}", (NULL != modInfo)?modInfo->name:"dg", (traceId >> 8) & UT_TRC_ID_MASK);
+		j9str_printf(triggerClause, sizeof(triggerClause), "tpnid{%s.%d,assert}", (NULL != modInfo)?modInfo->name:"dg", (traceId >> 8) & UT_TRC_ID_MASK);
 		setTriggerActions(thread, triggerClause, TRUE);
 		fireTriggerHit(thread, (NULL != modInfo)?modInfo->name:"dg", (traceId >> 8) & UT_TRC_ID_MASK, AFTER_TRACEPOINT);
 		j9exit_shutdown_and_exit(-1);
@@ -2590,7 +2590,7 @@ void omrTraceMem(void *env, UtModuleInfo *modInfo, uint32_t traceId, uintptr_t l
 	if (modInfo == NULL) {
 		strcpy(qualifiedModuleName, "dg");
 	} else 	if ( modInfo->traceVersionInfo->traceVersion >= 7 && modInfo->containerModule != NULL ) {
-		j9str_printf(PORTLIB, qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
+		j9str_printf(qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
 	} else {
 		strncpy(qualifiedModuleName, modInfo->name, MAX_QUALIFIED_NAME_LENGTH);
 	}
@@ -2622,7 +2622,7 @@ void omrTraceState(void *env, UtModuleInfo *modInfo, uint32_t traceId, const cha
 	if (modInfo == NULL) {
 		strcpy(qualifiedModuleName, "dg");
 	} else 	if ( modInfo->traceVersionInfo->traceVersion >= 7 && modInfo->containerModule != NULL ) {
-		j9str_printf(PORTLIB, qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
+		j9str_printf(qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
 	} else {
 		strncpy(qualifiedModuleName, modInfo->name, MAX_QUALIFIED_NAME_LENGTH);
 	}
@@ -2664,7 +2664,7 @@ callSubscriber(UtThreadData **thr, UtSubscription *subscription, UtModuleInfo *m
 		strcpy(qualifiedModuleName, "dg");
 		moduleName = "dg";
 	} else if ( modInfo->traceVersionInfo->traceVersion >= 7 && modInfo->containerModule != NULL ) {
-		j9str_printf(PORTLIB, qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
+		j9str_printf(qualifiedModuleName, MAX_QUALIFIED_NAME_LENGTH,"%s(%s)", modInfo->name, modInfo->containerModule->name);
 		moduleName = modInfo->name;
 	} else {
 		strncpy(qualifiedModuleName, modInfo->name, MAX_QUALIFIED_NAME_LENGTH);
@@ -2680,7 +2680,7 @@ callSubscriber(UtThreadData **thr, UtSubscription *subscription, UtModuleInfo *m
 	}
 
 	/* Calculate the size of buffer we need to hold the tracepoint header plus formatted tracepoint data */
-	headerSize = j9str_printf(PORTLIB, NULL, 0, "%02d:%02d:%02d.%03d 0x%x %s.%3d", hours, mins, secs, msecs, (*thr)->id, qualifiedModuleName, id);
+	headerSize = j9str_printf(NULL, 0, "%02d:%02d:%02d.%03d 0x%x %s.%3d", hours, mins, secs, msecs, (*thr)->id, qualifiedModuleName, id);
 	COPY_VA_LIST(argsCopy, args);
 	dataSize = j9str_vprintf(NULL, 0, format, argsCopy); 
 
@@ -2694,7 +2694,7 @@ callSubscriber(UtThreadData **thr, UtSubscription *subscription, UtModuleInfo *m
 
 	/* Format the tracepoint header information, followed by the tracepoint data, into the buffer */
 	cursor = buffer;
-	j9str_printf(PORTLIB, cursor, headerSize, "%02d:%02d:%02d.%03d 0x%x %s.%3d", hours, mins, secs, msecs, (*thr)->id, qualifiedModuleName, id);
+	j9str_printf(cursor, headerSize, "%02d:%02d:%02d.%03d 0x%x %s.%3d", hours, mins, secs, msecs, (*thr)->id, qualifiedModuleName, id);
 	cursor += headerSize - 1;
 	COPY_VA_LIST(argsCopy, args);
 	j9str_vprintf(cursor, dataSize, format, argsCopy); 

--- a/runtime/rastrace/trcmisc.c
+++ b/runtime/rastrace/trcmisc.c
@@ -194,7 +194,7 @@ listCounters(void)
 					if (f < 0) {
 						j9tty_err_printf(PORTLIB, "%s.%d %ld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 					} else {
-						j9str_printf(PORTLIB, tempBuf, TEMPBUFLEN, "%s.%d %lld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
+						j9str_printf(tempBuf, TEMPBUFLEN, "%s.%d %lld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 						/* convert to ebcdic if on zos */
 						j9file_write_text(f, tempBuf, strlen(tempBuf));
 					}
@@ -213,7 +213,7 @@ listCounters(void)
 					if (f < 0) {
 						j9tty_err_printf(PORTLIB, "%s.%d %ld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 					} else {
-						j9str_printf(PORTLIB, tempBuf, TEMPBUFLEN, "%s.%d %lld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
+						j9str_printf(tempBuf, TEMPBUFLEN, "%s.%d %lld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 						/* convert to ebcdic if on zos */
 						j9file_write_text(f, tempBuf, strlen(tempBuf));
 					}

--- a/runtime/shared_common/CacheLifecycleManager.cpp
+++ b/runtime/shared_common/CacheLifecycleManager.cpp
@@ -293,7 +293,7 @@ printSharedCache(void* element, void* param)
 		char addrmodeStr[10];
 		getStringForShcAddrmode(PORTLIB, currentItem->versionData.addrmode, addrmodeStr);
 		char levelStr[20];
-		j9str_printf(PORTLIB, levelStr, sizeof(levelStr), "%s %s", jclLevelStr, addrmodeStr);
+		j9str_printf(levelStr, sizeof(levelStr), "%s %s", jclLevelStr, addrmodeStr);
 		j9tty_printf(PORTLIB, "%-15s", levelStr);
 		if (J9PORT_SHR_CACHE_TYPE_PERSISTENT == currentItem->versionData.cacheType) {
 			j9tty_printf(PORTLIB, "%-16s", "persistent");

--- a/runtime/shared_common/CacheMap.cpp
+++ b/runtime/shared_common/CacheMap.cpp
@@ -2801,7 +2801,7 @@ SH_CacheMap::addROMClassResourceToCache(J9VMThread* currentThread, const void* r
 		/* TODO: In offline mode, should be fatal */
 		if (NULL != p_subcstr) {
 			const char* tmpstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG),J9NLS_SHRC_CM_CANNOT_ALLOC_DATA_SIZE,"no space in cache for %d bytes");
-			j9str_printf(PORTLIB, (char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpstr, dataLength);
+			j9str_printf((char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpstr, dataLength);
 		}
 		return (void*)J9SHR_RESOURCE_STORE_ERROR;
 	}
@@ -2833,7 +2833,7 @@ SH_CacheMap::addROMClassResourceToCache(J9VMThread* currentThread, const void* r
 	if (itemInCache == NULL) {
 		if (NULL != p_subcstr) {
 			const char* tmpstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG),J9NLS_SHRC_CM_CANNOT_ALLOC_DATA_SIZE, "no space in cache for %d bytes");
-			j9str_printf(PORTLIB, (char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpstr, dataLength);
+			j9str_printf((char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpstr, dataLength);
 		}
 		Trc_SHR_CM_addROMClassResourceToCache_Exit_Null(currentThread);
 		return (void*)J9SHR_RESOURCE_STORE_FULL;
@@ -2990,7 +2990,7 @@ SH_CacheMap::updateROMClassResource(J9VMThread* currentThread, const void* addre
 			if ((UDATA)updateAtOffset+data->length > dataLength) {
 				if (NULL != p_subcstr) {
 					const char* tmpcstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG), J9NLS_SHRC_CM_DATA_SIZE_LARGER, "data %d larger than available %d");
-					j9str_printf(PORTLIB, (char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpcstr, updateAtOffset+(data->length), dataLength);
+					j9str_printf((char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpcstr, updateAtOffset+(data->length), dataLength);
 				}
 				Trc_SHR_CM_updateROMClassResource_Exit4(currentThread, updateAtOffset, data->length, dataLength);
 				result = J9SHR_RESOURCE_STORE_ERROR;
@@ -3596,7 +3596,7 @@ SH_CacheMap::findAttachedData(J9VMThread* currentThread, const void* addressInCa
 				result = (U_8 *)J9SHR_RESOURCE_STORE_ERROR;
 				if (NULL != p_subcstr) {
 					const char *tmpcstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG), J9NLS_SHRC_CM_DATA_SIZE_LARGER, "data %d larger than available %d");
-					j9str_printf(PORTLIB, (char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpcstr, dataLength, data->length);
+					j9str_printf((char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpcstr, dataLength, data->length);
 				}
 				goto _exitWithError;
 			}
@@ -3606,7 +3606,7 @@ SH_CacheMap::findAttachedData(J9VMThread* currentThread, const void* addressInCa
 				result = (const U_8 *)J9SHR_RESOURCE_BUFFER_ALLOC_FAILED;
 				if (NULL != p_subcstr) {
 					const char *tmpcstr = j9nls_lookup_message((J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG), J9NLS_SHRC_CM_MEMORY_ALLOC_FAILED, "memory allocation of %d bytes failed");
-					j9str_printf(PORTLIB, (char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpcstr, dataLength);
+					j9str_printf((char *)*p_subcstr, VERBOSE_BUFFER_SIZE, tmpcstr, dataLength);
 				}
 				goto _exit;
 			}
@@ -6139,7 +6139,7 @@ formatAttachedDataString(J9VMThread* currentThread, U_8 *attachedData, UDATA att
 
 	*stringCursor = '\0'; /* handle the zero-length case */
 	while ((bytesRemaining > 0) && ((stringCursor+BYTE_STRING_LENGTH) < stringBufferEnd)){
-		stringCursor += j9str_printf(PORTLIB, stringCursor, bufferLength, "0x%#02x ", *dataCursor); /* increment does not include the trailing '\0' */
+		stringCursor += j9str_printf(stringCursor, bufferLength, "0x%#02x ", *dataCursor); /* increment does not include the trailing '\0' */
 		++dataCursor;
 		--bytesRemaining;
 	}

--- a/runtime/shared_common/OSCache.cpp
+++ b/runtime/shared_common/OSCache.cpp
@@ -68,7 +68,7 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 
 	memset(versionStr, 0, J9SH_VERSION_STRING_LEN+1);
 	if (generation <= J9SH_GENERATION_07) {
-		J9SH_GET_VERSION_G07ANDLOWER_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
+		J9SH_GET_VERSION_G07ANDLOWER_STRING(versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
 	} else {
 		U_64 curVMVersion = 0;
 		U_64 oldVMVersion = 0;
@@ -88,14 +88,14 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 
 		if ( curVMVersion >= oldVMVersion) {
 			if (generation <= J9SH_GENERATION_29) {
-				J9SH_GET_VERSION_G07TO29_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
+				J9SH_GET_VERSION_G07TO29_STRING(versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
 			} else if (versionData->modlevel < 10) {
-				J9SH_GET_VERSION_STRING_JAVA9ANDLOWER(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->feature, versionData->addrmode);
+				J9SH_GET_VERSION_STRING_JAVA9ANDLOWER(versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->feature, versionData->addrmode);
 			} else {
-				J9SH_GET_VERSION_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->feature, versionData->addrmode);
+				J9SH_GET_VERSION_STRING(versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->feature, versionData->addrmode);
 			}
 		} else {
-			J9SH_GET_VERSION_G07ANDLOWER_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
+			J9SH_GET_VERSION_G07ANDLOWER_STRING(versionStr, J9SH_VERSION(versionData->esVersionMajor, versionData->esVersionMinor), versionData->modlevel, versionData->addrmode);
 		}
 	}
 
@@ -106,28 +106,28 @@ SH_OSCache::getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* bu
 		versionStr[versionStrLen] = J9SH_SNAPSHOT_PREFIX_CHAR;
 	}
 	if (generation <= J9SH_GENERATION_37) {
-		j9str_printf(PORTLIB, genString, 4, "G%02d", generation);
+		j9str_printf(genString, 4, "G%02d", generation);
 	} else {
 		Trc_SHR_Assert_True(
 							((0 <= layer) && (layer <= J9SH_LAYER_NUM_MAX_VALUE))
 							|| (J9SH_LAYER_NUM_UNSET == layer)
 							);
-		j9str_printf(PORTLIB, genString, 7, "G%02dL%02d", generation, layer);
+		j9str_printf(genString, 7, "G%02dL%02d", generation, layer);
 	}
 
 #if defined(WIN32)
-	j9str_printf(PORTLIB, buffer, bufferSize, "%s%c%s%c%s", versionStr, J9SH_PREFIX_SEPARATOR_CHAR, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
+	j9str_printf(buffer, bufferSize, "%s%c%s%c%s", versionStr, J9SH_PREFIX_SEPARATOR_CHAR, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
 #else
 	/* In either case we avoid attaching the "_memory_" or "_semaphore_" substring. */
 	if ((J9PORT_SHR_CACHE_TYPE_PERSISTENT == versionData->cacheType)
 		|| (J9PORT_SHR_CACHE_TYPE_SNAPSHOT == versionData->cacheType)
 		|| (J9PORT_SHR_CACHE_TYPE_CROSSGUEST == versionData->cacheType)
 	) {
-		j9str_printf(PORTLIB, buffer, bufferSize, "%s%c%s%c%s", versionStr, J9SH_PREFIX_SEPARATOR_CHAR, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
+		j9str_printf(buffer, bufferSize, "%s%c%s%c%s", versionStr, J9SH_PREFIX_SEPARATOR_CHAR, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
 	} else {
 		const char* identifier = isMemoryType ? J9SH_MEMORY_ID : J9SH_SEMAPHORE_ID;
 
-		j9str_printf(PORTLIB, buffer, bufferSize, "%s%s%s%c%s", versionStr, identifier, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
+		j9str_printf(buffer, bufferSize, "%s%s%s%c%s", versionStr, identifier, cacheName, J9SH_PREFIX_SEPARATOR_CHAR, genString);
 	}
 #endif
 	Trc_SHR_OSC_getCacheVersionAndGen_Exit(buffer);
@@ -288,7 +288,7 @@ SH_OSCache::getCachePathName(J9PortLibrary* portLibrary, const char* cacheDirNam
 
 	Trc_SHR_OSC_getCachePathName_Entry(cacheNameWithVGen);
 
-	j9str_printf(PORTLIB, buffer, bufferSize, "%s%s", cacheDirName, cacheNameWithVGen);
+	j9str_printf(buffer, bufferSize, "%s%s", cacheDirName, cacheNameWithVGen);
 
 	Trc_SHR_OSC_getCachePathName_Exit();
 	return 0;
@@ -311,7 +311,7 @@ SH_OSCache::statCache(J9PortLibrary* portLibrary, const char* cacheDirName, cons
 
 	Trc_SHR_OSC_statCache_Entry(cacheNameWithVGen);
 
-	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", cacheDirName, cacheNameWithVGen);
+	j9str_printf(fullPath, J9SH_MAXPATH, "%s%s", cacheDirName, cacheNameWithVGen);
 	if (j9file_attr(fullPath) == EsIsFile) {
 		Trc_SHR_OSC_statCache_cacheFound();
 		return 1;
@@ -1399,10 +1399,10 @@ SH_OSCache::generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDi
 #endif
 	I_64 fileSize = j9file_length(cacheFilePathName);
 	if (NULL != buf) {
-		UDATA bufLenRequired = j9str_printf(PORTLIB, NULL, 0, format, cacheFilePathName, fileSize, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
+		UDATA bufLenRequired = j9str_printf(NULL, 0, format, cacheFilePathName, fileSize, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
 		Trc_SHR_Assert_True(bufLenRequired <= bufLen);
 	}
-	return j9str_printf(PORTLIB, buf, bufLen, format, cacheFilePathName, fileSize, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
+	return j9str_printf(buf, bufLen, format, cacheFilePathName, fileSize, createtime, metadataBytes, classesBytes, lineNumTabBytes, varTabBytes);
 }
 
 /**
@@ -1421,7 +1421,7 @@ SH_OSCache::getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* uniqueID,
 	char versionStr[J9SH_VERSION_STRING_LEN +3];
 	J9PortShcVersion versionData;
 	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
-	J9SH_GET_VERSION_STRING(PORTLIB, versionStr, J9SH_VERSION(versionData.esVersionMajor, versionData.esVersionMinor), versionData.modlevel, versionData.feature, versionData.addrmode);
+	J9SH_GET_VERSION_STRING(versionStr, J9SH_VERSION(versionData.esVersionMajor, versionData.esVersionMinor), versionData.modlevel, versionData.feature, versionData.addrmode);
 	const char* cacheNameWithVGenStart = strstr(uniqueID, versionStr);
 	char* cacheNameWithVGenEnd = strnrchrHelper(cacheNameWithVGenStart, '-', idLen - (cacheNameWithVGenStart - uniqueID));
 	if (NULL == cacheNameWithVGenStart || NULL == cacheNameWithVGenEnd) {

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -64,23 +64,23 @@
 #define OSCACHE_CURRENT_CACHE_GEN 45
 #define OSCACHE_CURRENT_LAYER_LAYER 0
 
-#define J9SH_VERSION(versionMajor, versionMinor) (versionMajor*100 + versionMinor)
+#define J9SH_VERSION(versionMajor, versionMinor) (((versionMajor) * 100) + versionMinor)
 
-#define J9SH_GET_VERSION_STRING(portLib, versionStr, version, modlevel, feature, addrmode)\
-											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN, J9SH_VERSION_STRING_SPEC,\
-											 version, modlevel, feature, addrmode)
+#define J9SH_GET_VERSION_STRING(versionStr, version, modlevel, feature, addrmode) \
+		j9str_printf(versionStr, J9SH_VERSION_STRING_LEN, J9SH_VERSION_STRING_SPEC, \
+				version, modlevel, feature, addrmode)
 
-#define J9SH_GET_VERSION_STRING_JAVA9ANDLOWER(portLib, versionStr, version, modlevel, feature, addrmode)\
-											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_SPEC,\
-											 version, modlevel, feature, addrmode)
+#define J9SH_GET_VERSION_STRING_JAVA9ANDLOWER(versionStr, version, modlevel, feature, addrmode) \
+		j9str_printf(versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_SPEC, \
+				version, modlevel, feature, addrmode)
 
-#define J9SH_GET_VERSION_G07TO29_STRING(portLib, versionStr, version, modlevel, addrmode)\
-											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29 - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_G07TO29_SPEC,\
-											 version, modlevel, addrmode)
+#define J9SH_GET_VERSION_G07TO29_STRING(versionStr, version, modlevel, addrmode) \
+		j9str_printf(versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29 - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_G07TO29_SPEC, \
+				version, modlevel, addrmode)
 
-#define J9SH_GET_VERSION_G07ANDLOWER_STRING(portLib, versionStr, version, modlevel, addrmode)\
-											 j9str_printf(portLib, versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29 - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_G07ANDLOWER_SPEC,\
-											 version, modlevel, addrmode)
+#define J9SH_GET_VERSION_G07ANDLOWER_STRING(versionStr, version, modlevel, addrmode) \
+		j9str_printf(versionStr, J9SH_VERSION_STRING_LEN - J9SH_VERSTRLEN_INCREASED_SINCEG29 - J9SH_VERSTRLEN_INCREASED_SINCEJAVA10, J9SH_VERSION_STRING_G07ANDLOWER_SPEC, \
+				version, modlevel, addrmode)
 
 #define OSC_TRACE(var) if (_verboseFlags) j9nls_printf(PORTLIB, J9NLS_INFO, var)
 #define OSC_TRACE1(var, p1) if (_verboseFlags) j9nls_printf(PORTLIB, J9NLS_INFO, var, p1)

--- a/runtime/shared_common/OSCachesysv.cpp
+++ b/runtime/shared_common/OSCachesysv.cpp
@@ -2635,7 +2635,7 @@ SH_OSCachesysv::getControlFilePerm(char *cacheDirName, char *filename, bool *isN
 	I_32 rc;
 	PORT_ACCESS_FROM_PORT(_portLibrary);
 
-	j9str_printf(_portLibrary, baseFile, J9SH_MAXPATH, "%s%s", cacheDirName, filename);
+	j9str_printf(baseFile, J9SH_MAXPATH, "%s%s", cacheDirName, filename);
 	rc = j9file_stat(baseFile, 0, &statbuf);
 	if (0 == rc) {
 		UDATA euid = j9sysinfo_get_euid();

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -5286,9 +5286,9 @@ generateStartupHintsKey(J9JavaVM* vm)
 		) {
 			if (firstOption) {
 				firstOption = false;
-				j9str_printf(PORTLIB, key, keyLength, "%s%s", key, option);
+				j9str_printf(key, keyLength, "%s%s", key, option);
 			} else {
-				j9str_printf(PORTLIB, key, keyLength, "%s%s%s", key, " ", option);
+				j9str_printf(key, keyLength, "%s%s%s", key, " ", option);
 			}
 		}
 	}

--- a/runtime/tests/algorithm/srphashtabletest.c
+++ b/runtime/tests/algorithm/srphashtabletest.c
@@ -443,10 +443,10 @@ runTests(J9PortLibrary *portLib, char * id, J9SRPHashTable **srptable, UDATA *da
 
 	/* remove all elements verifying the integrity */
 	if (removeOffset == REVERSE) {
-		j9str_printf(PORTLIB, buf, sizeof(buf), "%s reverse remove", id);
+		j9str_printf(buf, sizeof(buf), "%s reverse remove", id);
 		operation = buf;
 	} else if (removeOffset > 0) {
-		j9str_printf(PORTLIB, buf, sizeof(buf), "%s offset %d remove", id, removeOffset);
+		j9str_printf(buf, sizeof(buf), "%s offset %d remove", id, removeOffset);
 		operation = buf;
 	}
 	for (i = 0; i < dataLength; i++) {
@@ -995,7 +995,7 @@ verifySRPHashtable(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 		UDATA offset = i;
 		char name[32];
 
-		j9str_printf(PORTLIB, name, sizeof(name), "randomData%d", i);
+		j9str_printf(name, sizeof(name), "randomData%d", i);
 		if (RandomValues[i] == 0) {
 			continue;
 		}

--- a/runtime/tests/port/j9fileTest.c
+++ b/runtime/tests/port/j9fileTest.c
@@ -4156,13 +4156,13 @@ j9file_test_long_file_name(struct J9PortLibrary *portLibrary)
 	basePaths[1] = cwd; /* to test an absolute path */
 
 	for ( i = 0; i < 2; i ++) {
-		j9str_printf(portLibrary, filePathName, FILENAME_LENGTH, "%s", basePaths[i]);
+		j9str_printf(filePathName, FILENAME_LENGTH, "%s", basePaths[i]);
 
 		/* build up a file name that is longer than 256 characters,
 		 * comprised of directories, each of which are less than 256 characters in length*/
 		while (strlen(filePathName) < MIN_LENGTH ) {
 
-			j9str_printf(portLibrary, filePathName + strlen(filePathName), FILENAME_LENGTH - strlen(filePathName), "%s", longDirName);
+			j9str_printf(filePathName + strlen(filePathName), FILENAME_LENGTH - strlen(filePathName), "%s", longDirName);
 
 			mkdirRc = j9file_mkdir(filePathName);
 
@@ -4173,10 +4173,10 @@ j9file_test_long_file_name(struct J9PortLibrary *portLibrary)
 		}
 
 		/* now append filePathName with the actual filename */
-		j9str_printf(portLibrary, filePathName + strlen(filePathName), FILENAME_LENGTH - strlen(filePathName), "\\%s", testName);
-		
+		j9str_printf(filePathName + strlen(filePathName), FILENAME_LENGTH - strlen(filePathName), "\\%s", testName);
+
 		j9tty_printf(portLibrary, "\ttesting filename: %s\n", filePathName);
-		
+
 		/* can we open and write to the file? */
 		fd = FILE_OPEN_FUNCTION(portLibrary, filePathName, EsOpenCreate | EsOpenWrite, 0666);
 		if (-1 == fd) {

--- a/runtime/tests/port/j9memTest.c
+++ b/runtime/tests/port/j9memTest.c
@@ -294,42 +294,42 @@ j9mem_test2(struct J9PortLibrary *portLibrary)
 
 	/* allocate some memory of various sizes */
 	byteAmount = 0;
-	(void)j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
+	(void)j9str_printf(allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
 	memPtr = j9mem_allocate_memory(byteAmount, OMRMEM_CATEGORY_PORT_LIBRARY);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = 1;
-	(void)j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
+	(void)j9str_printf(allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
 	memPtr = j9mem_allocate_memory(byteAmount, OMRMEM_CATEGORY_PORT_LIBRARY);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/8;
-	(void)j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
+	(void)j9str_printf(allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
 	memPtr = j9mem_allocate_memory(byteAmount, OMRMEM_CATEGORY_PORT_LIBRARY);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/4;
-	(void)j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
+	(void)j9str_printf(allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
 	memPtr = j9mem_allocate_memory(byteAmount, OMRMEM_CATEGORY_PORT_LIBRARY);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/2;
-	(void)j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
+	(void)j9str_printf(allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
 	memPtr = j9mem_allocate_memory(byteAmount, OMRMEM_CATEGORY_PORT_LIBRARY);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE;
-	(void)j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
+	(void)j9str_printf(allocName, allocNameSize, "j9mem_allocate_memory(%d)", byteAmount);
 	memPtr = j9mem_allocate_memory(byteAmount, OMRMEM_CATEGORY_PORT_LIBRARY);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
@@ -381,42 +381,42 @@ j9mem_test4(struct J9PortLibrary *portLibrary)
 	/* Now re-allocate memory of various sizes */
 	/* TODO is memPtr supposed to be re-used? */
 	byteAmount = 0;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
 	memPtr = j9mem_reallocate_memory(saveMemPtr, byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = 1;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
 	memPtr = j9mem_reallocate_memory(saveMemPtr, byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/8;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
 	memPtr = j9mem_reallocate_memory(saveMemPtr, byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/4;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
 	memPtr = j9mem_reallocate_memory(saveMemPtr, byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/2;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
 	memPtr = j9mem_reallocate_memory(saveMemPtr, byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_reallocate_memory(%d)", byteAmount);
 	memPtr = j9mem_reallocate_memory(saveMemPtr, byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_free_memory(memPtr);
@@ -519,42 +519,42 @@ j9mem_test6(struct J9PortLibrary *portLibrary)
 
 	/* allocate some memory of various sizes */
 	byteAmount = 0;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
 	memPtr = j9mem_allocate_portLibrary(byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_deallocate_portLibrary(memPtr);
 	memPtr = NULL;
 
 	byteAmount = 1;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
 	memPtr = j9mem_allocate_portLibrary(byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_deallocate_portLibrary(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/8;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
 	memPtr = j9mem_allocate_portLibrary(byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_deallocate_portLibrary(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/4;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
 	memPtr = j9mem_allocate_portLibrary(byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_deallocate_portLibrary(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE/2;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
 	memPtr = j9mem_allocate_portLibrary(byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_deallocate_portLibrary(memPtr);
 	memPtr = NULL;
 
 	byteAmount = MAX_ALLOC_SIZE;
-	rc = j9str_printf(PORTLIB, allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
+	rc = j9str_printf(allocName, allocNameSize, "j9mem_allocate_portLibrary(%d)", byteAmount);
 	memPtr = j9mem_allocate_portLibrary(byteAmount);
 	verifyMemory(portLibrary, testName, memPtr, byteAmount, allocName);
 	j9mem_deallocate_portLibrary(memPtr);
@@ -642,7 +642,7 @@ j9mem_test7_allocate32(struct J9PortLibrary *portLibrary, int randomSeed)
 		UDATA byteAmount = allocBlockSizes[allocBlockCursor];
 		void **returnPtrLocation = &allocBlockReturnPtrs[allocBlockCursor]; 
 		
-		j9str_printf(PORTLIB, allocName, allocNameSize, "\nj9mem_allocate_memory32(%d)", byteAmount);
+		j9str_printf(allocName, allocNameSize, "\nj9mem_allocate_memory32(%d)", byteAmount);
 		pointer = j9mem_allocate_memory32(byteAmount, OMRMEM_CATEGORY_PORT_LIBRARY);
 		verifyMemory(portLibrary, testName, pointer, byteAmount, allocName);
 		
@@ -662,7 +662,7 @@ j9mem_test7_allocate32(struct J9PortLibrary *portLibrary, int randomSeed)
 	 * This should not incur any vmem allocation.  
 	 */
 	finalAllocSize = HEAP_SIZE_BYTES-60;
-	j9str_printf(PORTLIB, allocName, allocNameSize, "\nj9mem_allocate_memory32(%d)", finalAllocSize);
+	j9str_printf(allocName, allocNameSize, "\nj9mem_allocate_memory32(%d)", finalAllocSize);
 	pointer = j9mem_allocate_memory32(finalAllocSize, OMRMEM_CATEGORY_PORT_LIBRARY);
 	verifyMemory(portLibrary, testName, pointer, finalAllocSize, allocName);
 #endif
@@ -1561,4 +1561,3 @@ j9mem_runTests(struct J9PortLibrary *portLibrary, int randomSeed)
 	j9tty_printf(PORTLIB, "\nMemory test done%s\n\n", rc == TEST_PASS ? "." : ", failures detected.");
 	return TEST_PASS == rc ? 0 : -1;
 }
-

--- a/runtime/tests/port/j9shsemTest.c
+++ b/runtime/tests/port/j9shsemTest.c
@@ -45,8 +45,7 @@ getControlDirectoryName(struct J9PortLibrary *portLibrary, char* baseDir)
 #define J9SHTEST_BASEDIR "/tmp/j9shsem/"
 #endif
 
-	j9str_printf(PORTLIB, baseDir, J9SH_MAXPATH, "%s", J9SHTEST_BASEDIR);
-
+	j9str_printf(baseDir, J9SH_MAXPATH, "%s", J9SHTEST_BASEDIR);
 }
 
 static void
@@ -129,7 +128,7 @@ j9shsem_test2(J9PortLibrary *portLibrary)
 		goto cleanup;
 	}
 
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s", params.controlFileDir, params.semName);
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s", params.controlFileDir, params.semName);
 	fd = j9file_open(mybaseFilePath, EsOpenRead, 0);
 
 	if(-1 == fd) {
@@ -422,8 +421,8 @@ j9shsem_test5(J9PortLibrary *portLibrary)
 		goto cleanup;
 	}
 
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s", params.controlFileDir, params.semName);
-	j9str_printf(PORTLIB, myNewFilePath, J9SH_MAXPATH, "%s%s_new", params.controlFileDir, params.semName);
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s", params.controlFileDir, params.semName);
+	j9str_printf(myNewFilePath, J9SH_MAXPATH, "%s%s_new", params.controlFileDir, params.semName);
 
 	j9file_move(mybaseFilePath, myNewFilePath);
 
@@ -586,10 +585,10 @@ static void test7_cleanup(J9PortLibrary *portLibrary,
 	if (myhandleB != NULL) {
 		j9shsem_destroy(&myhandleB);
 	}
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s",
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s",
 			params->controlFileDir, params->semName);
 	j9file_unlink(mybaseFilePath);
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s_new",
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s_new",
 			params->controlFileDir, params->semName);
 	j9file_unlink(mybaseFilePath);
 }
@@ -611,7 +610,7 @@ static IDATA destroyAndReopenSemaphore(J9PortLibrary *portLibrary,
 		 * this code is for testing the test: to make the test fail, set deleteBasefile=1.
 		 * j9shsem_destroy deletes the file and j9file_open with a different name ensures that j9shsem_open doesn't reuse the same inode.
 		 */
-		j9str_printf(PORTLIB, dummyFilePath, J9SH_MAXPATH, "%s%s_new", params->controlFileDir, params->semName);
+		j9str_printf(dummyFilePath, J9SH_MAXPATH, "%s%s_new", params->controlFileDir, params->semName);
 		fd = j9file_open(dummyFilePath, EsOpenWrite | EsOpenCreate, 0);
 	}
 
@@ -767,4 +766,3 @@ j9shsem_runTests(struct J9PortLibrary *portLibrary, char* argv0, char* shsem_chi
 	deleteControlDirectory(portLibrary, baseDir);
 	return TEST_PASS == rc ? 0 : -1;
 }
-

--- a/runtime/tests/port/j9shsem_deprecatedTest.c
+++ b/runtime/tests/port/j9shsem_deprecatedTest.c
@@ -168,8 +168,8 @@ j9shsem_deprecated_test2(J9PortLibrary *portLibrary)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "cannot create initial semaphore");
 		goto cleanup;
 	}
-	
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTSEM_NAME);
+
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTSEM_NAME);
 	fd = j9file_open(mybaseFilePath, EsOpenRead, 0);
 
 	if(-1 == fd) {
@@ -476,8 +476,8 @@ j9shsem_deprecated_test5(J9PortLibrary *portLibrary)
 		goto cleanup;
 	}
 
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTSEM_NAME);
-	j9str_printf(PORTLIB, myNewFilePath, J9SH_MAXPATH, "%s%s_new", cacheDir, TESTSEM_NAME);
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTSEM_NAME);
+	j9str_printf(myNewFilePath, J9SH_MAXPATH, "%s%s_new", cacheDir, TESTSEM_NAME);
 
 	j9file_move(mybaseFilePath, myNewFilePath);
 
@@ -655,12 +655,11 @@ j9shsem_deprecated_test7(J9PortLibrary *portLibrary, char* argv0)
 	reportTestEntry(portLibrary, testName);	
 
 	if (j9shmem_getDir(NULL, J9SHMEM_GETDIR_APPEND_BASEDIR, basedir, 1024) >= 0) {
-		j9str_printf(PORTLIB, mybaseFilePath, 1024, "%s%s", basedir, TEST7_SEMAPHORE_NAME);
+		j9str_printf(mybaseFilePath, 1024, "%s%s", basedir, TEST7_SEMAPHORE_NAME);
 	} else {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Cannot get a directory");
 		goto cleanup;
 	}
-	
 
 	/* This first call to j9shxxx_open is simply to ensure that we don't use any old SysV objects.*/
 	rc = j9shsem_deprecated_open(basedir, 0, &sem0, TEST7_SEMAPHORE_NAME, TEST7_SEMAPHORE_SIZE, 0600, J9SHSEM_NO_FLAGS, NULL);
@@ -1179,8 +1178,7 @@ j9shsem_deprecated_runTests(struct J9PortLibrary *portLibrary, char* argv0, char
 #if !(defined(WIN32) || defined(WIN64))
 	rc |= j9shsem_deprecated_test8(portLibrary);
 #endif /* !(defined(WIN32) || defined(WIN64)) */
-	
+
 	j9tty_printf(PORTLIB, "\nDeprecated Shared Semaphore test done%s\n\n", rc == TEST_PASS ? "." : ", failures detected.");
 	return TEST_PASS == rc ? 0 : -1;
 }
-

--- a/runtime/tests/port/j9strTest.c
+++ b/runtime/tests/port/j9strTest.c
@@ -386,14 +386,14 @@ j9str_test1(struct J9PortLibrary *portLibrary)
 	/* Save the real function, put in a fake one, call it, restore old one */
 	realVprintf = OMRPORT_FROM_J9PORT(portLibrary)->str_vprintf;
 	OMRPORT_FROM_J9PORT(portLibrary)->str_vprintf = fake_j9str_vprintf;
-	j9strRC = j9str_printf(PORTLIB, NULL, 0, "Simple test");
+	j9strRC = j9str_printf(NULL, 0, "Simple test");
 	OMRPORT_FROM_J9PORT(portLibrary)->str_vprintf = realVprintf;
 
 	if (J9STR_PRIVATE_RETURN_VALUE != j9strRC) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9str_printf() does not call j9str_vprintf()\n");
 	}
 
-	j9strRC = j9str_printf(PORTLIB, NULL, 0, "Simple test");
+	j9strRC = j9str_printf(NULL, 0, "Simple test");
 	if ((strlen("Simple test")+1) != j9strRC) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9str_vprintf() not restored\n");
 	}

--- a/runtime/tests/port/j9vmemTest.c
+++ b/runtime/tests/port/j9vmemTest.c
@@ -362,7 +362,7 @@ j9vmem_test1(struct J9PortLibrary *portLibrary)
 		}
 		
 		/* can we read and write to the memory? */
-		(void) j9str_printf(PORTLIB, allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSizes[i]);
+		(void) j9str_printf(allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSizes[i]);
 		verifyMemory(portLibrary, testName, memPtr, pageSizes[i], allocName);
 		
 		/* free the memory (reuse the vmemID) */
@@ -848,7 +848,7 @@ j9vmem_decommit_memory_test(struct J9PortLibrary *portLibrary)
 		}
 		
 		/* can we read and write to the memory? */
-		(void) j9str_printf(PORTLIB, allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSizes[i]);
+		(void) j9str_printf(allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSizes[i]);
 		verifyMemory(portLibrary, testName, memPtr, pageSizes[i], allocName);
 		
 		/* decommit the memory */
@@ -1126,7 +1126,7 @@ j9vmem_testReserveMemoryEx_impl(struct J9PortLibrary *portLibrary, const char* t
 				}
 
 				/* can we read and write to the memory? */
-				j9str_printf(PORTLIB, allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSizes[i]);
+				j9str_printf(allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSizes[i]);
 				verifyMemory(portLibrary, testName, memPtr[j], pageSizes[i], allocName);
 
 				/* Have the memory categories been updated properly */
@@ -1317,7 +1317,7 @@ j9vmem_testReserveMemoryEx_zOSLargePageBelowBar(struct J9PortLibrary *portLibrar
 		}
 	
 		/* can we read and write to the memory? */
-		j9str_printf(PORTLIB, allocName, allocNameSize, "j9vmem_reserve_memory(%d)", params.byteAmount);
+		j9str_printf(allocName, allocNameSize, "j9vmem_reserve_memory(%d)", params.byteAmount);
 		verifyMemory(portLibrary, testName, memPtr, params.byteAmount, allocName);
 	
 		/* free the memory */
@@ -1421,7 +1421,7 @@ j9vmem_testReserveMemoryExStrictAddress_zOSLargePageBelowBar(struct J9PortLibrar
 		}
 
 		/* can we read and write to the memory? */
-		j9str_printf(PORTLIB, allocName, allocNameSize, "j9vmem_reserve_memory(%d)", params.byteAmount);
+		j9str_printf(allocName, allocNameSize, "j9vmem_reserve_memory(%d)", params.byteAmount);
 		verifyMemory(portLibrary, testName, memPtr, params.byteAmount, allocName);
 
 		/* free the memory */
@@ -1512,7 +1512,7 @@ j9vmem_testReserveMemoryEx_zOS_useExtendedPrivateAreaMemoryLargePage(struct J9Po
 		}
 
 		/* can we read and write to the memory? */
-		j9str_printf(PORTLIB, allocName, allocNameSize, "j9vmem_reserve_memory(%d)", params.byteAmount);
+		j9str_printf(allocName, allocNameSize, "j9vmem_reserve_memory(%d)", params.byteAmount);
 		verifyMemory(portLibrary, testName, memPtr, params.byteAmount, allocName);
 
 		/* free the memory */
@@ -1867,7 +1867,7 @@ j9vmem_test_numa(struct J9PortLibrary *portLibrary)
 				/* ideally we'd test that the memory actually has some NUMA characteristics, but that's difficult to prove */
 
 				/* can we read and write to the memory? */
-				j9str_printf(PORTLIB, allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSize);
+				j9str_printf(allocName, allocNameSize, "j9vmem_reserve_memory(%d)", pageSize);
 				verifyMemory(portLibrary, testName, memPtr, reserveSizeInBytes, allocName);
 				
 				/* free the memory (reuse the vmemID) */

--- a/runtime/tests/port/shmem.c
+++ b/runtime/tests/port/shmem.c
@@ -378,7 +378,7 @@ j9shmem_test4(J9PortLibrary *portLibrary, char* argv0)
 	}
 
 	regionChar = (char*) region;
-	j9str_printf(PORTLIB, regionChar, 30, TESTSTRING);
+	j9str_printf(regionChar, 30, TESTSTRING);
 	termstat = waitForTestProcess(portLibrary, pid);
 
 	if(termstat != 0) {
@@ -497,7 +497,7 @@ int j9shmem_test5(J9PortLibrary *portLibrary) {
 		goto exit;
 	}
 
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTMEM_NAME);
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTMEM_NAME);
 	rc = j9file_attr(mybaseFilePath);
 
 	if(rc != EsIsFile) {
@@ -634,7 +634,7 @@ j9shmem_test6(J9PortLibrary *portLibrary)
 	 * maybe we should have a private interface so that porttest can get the
 	 * basefile name
 	 */
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTMEM_NAME);
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TESTMEM_NAME);
 	rc = j9file_attr(mybaseFilePath);
 
 	if(rc != EsIsFile) {
@@ -1531,8 +1531,8 @@ j9shmem_test15(J9PortLibrary *portLibrary, char* argv0)
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Cannot create the directory");
 		goto cleanup;
 	}
-	
-	j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TEST15_MEM_NAME);
+
+	j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s%s", cacheDir, TEST15_MEM_NAME);
 
 	/*This first call to j9shxxx_open is simply to ensure that we don't use any old SysV objects. If j9shxxx_open returns 'OPENED' then we destroy the object.*/
 	rc = j9shmem_open(cacheDir, 0, &mem0, TEST15_MEM_NAME, TEST15_MEM_SIZE, 0600, OMRMEM_CATEGORY_PORT_LIBRARY, J9SHMEM_NO_FLAGS, NULL);
@@ -2165,4 +2165,3 @@ j9shmem_runTests(J9PortLibrary *portLibrary, char* argv0, const char* shmem_chil
 	j9tty_printf(PORTLIB, "\nShared Memory test done%s\n\n", rc == TEST_PASS ? "." : ", failures detected.");
 	return TEST_PASS == rc ? 0 : -1;
 }
-

--- a/runtime/tests/port/si.c
+++ b/runtime/tests/port/si.c
@@ -212,7 +212,7 @@ int j9sysinfo_test1 (J9PortLibrary* portLibrary) {
 		return reportTestExit(portLibrary, testName);
 	} else {
 		char msg[256]= "";
-		j9str_printf(PORTLIB, msg, sizeof(msg), "User name returned = \"%s\"\n", username);
+		j9str_printf(msg, sizeof(msg), "User name returned = \"%s\"\n", username);
 		outputComment(PORTLIB, msg);
 	}
 	
@@ -243,7 +243,7 @@ int j9sysinfo_test2 (J9PortLibrary* portLibrary) {
 		return reportTestExit(portLibrary, testName);
 	} else {
 		char msg[256]= "";
-		j9str_printf(PORTLIB, msg, sizeof(msg), "Group name returned = \"%s\"\n", groupname);
+		j9str_printf(msg, sizeof(msg), "Group name returned = \"%s\"\n", groupname);
 		outputComment(PORTLIB, msg);
 	}
 	
@@ -273,7 +273,7 @@ int j9sysinfo_get_OS_type_test (J9PortLibrary* portLibrary) {
 		return reportTestExit(portLibrary, testName);
 	} else {
 		char msg[256];
-		j9str_printf(PORTLIB, msg, sizeof(msg), "j9sysinfo_get_OS_type returned : \"%s\"\n", osName);
+		j9str_printf(msg, sizeof(msg), "j9sysinfo_get_OS_type returned : \"%s\"\n", osName);
 		outputComment(PORTLIB, msg);
 	}
 	
@@ -283,7 +283,7 @@ int j9sysinfo_get_OS_type_test (J9PortLibrary* portLibrary) {
 		return reportTestExit(portLibrary, testName);
 	} else {
 		char msg[256];
-		j9str_printf(PORTLIB, msg, sizeof(msg), "j9sysinfo_get_OS_version returned : \"%s\"\n", osVersion);
+		j9str_printf(msg, sizeof(msg), "j9sysinfo_get_OS_version returned : \"%s\"\n", osVersion);
 		outputComment(PORTLIB, msg);
 	}
 

--- a/runtime/tests/port/testHelpers.c
+++ b/runtime/tests/port/testHelpers.c
@@ -403,24 +403,24 @@ deleteControlDirectory(struct J9PortLibrary *portLibrary, char* baseDir) {
 		char mybaseFilePath[J9SH_MAXPATH];
 		char resultBuffer[J9SH_MAXPATH];
 		UDATA rc, handle;
-		
-        j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s", baseDir);
-        rc = handle = j9file_findfirst(mybaseFilePath, resultBuffer);
-        while (-1 != rc) {
-        	char nextEntry[J9SH_MAXPATH];
-        	/* skip current and parent dir */
-        	if (resultBuffer[0] == '.') {
-        		rc = j9file_findnext(handle, resultBuffer);
-        		continue;
-        	}
-        	j9str_printf(PORTLIB, nextEntry, J9SH_MAXPATH, "%s/%s", mybaseFilePath, resultBuffer);
-        	deleteControlDirectory(portLibrary, nextEntry);
-        	rc = j9file_findnext(handle, resultBuffer);
-        }
-        if (handle != -1) {
-        	j9file_findclose(handle);
-        }
-        j9file_unlinkdir(mybaseFilePath);
+
+		j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s", baseDir);
+		rc = handle = j9file_findfirst(mybaseFilePath, resultBuffer);
+		while (-1 != rc) {
+			char nextEntry[J9SH_MAXPATH];
+			/* skip current and parent dir */
+			if (resultBuffer[0] == '.') {
+				rc = j9file_findnext(handle, resultBuffer);
+				continue;
+			}
+			j9str_printf(nextEntry, J9SH_MAXPATH, "%s/%s", mybaseFilePath, resultBuffer);
+			deleteControlDirectory(portLibrary, nextEntry);
+			rc = j9file_findnext(handle, resultBuffer);
+		}
+		if (handle != -1) {
+			j9file_findclose(handle);
+		}
+		j9file_unlinkdir(mybaseFilePath);
 	}
 }
 
@@ -505,4 +505,3 @@ raiseSEGV(J9PortLibrary* portLibrary, void* arg)
 
 	return 8096;
 }
-

--- a/runtime/tests/shared/CacheDirPerm.cpp
+++ b/runtime/tests/shared/CacheDirPerm.cpp
@@ -104,14 +104,14 @@ CacheDirPerm::getTempCacheDir(J9JavaVM *vm, I_32 cacheType, bool useDefaultDir, 
 		goto _end;
 	}
 	if (useDefaultDir) {
-		j9str_printf(PORTLIB, cacheDir, sizeof(cacheDir), "%s", baseDir);
+		j9str_printf(cacheDir, sizeof(cacheDir), "%s", baseDir);
 	} else {
-		j9str_printf(PORTLIB, cacheDir, sizeof(cacheDir), "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
+		j9str_printf(cacheDir, sizeof(cacheDir), "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
 		if (J9PORT_SHR_CACHE_TYPE_NONPERSISTENT == cacheType) {
 			/* for non-persistent cache, actual cache dir is cacheDir/J9SH_BASEDIR. So parent dir is same as cacheDir. */
-			j9str_printf(PORTLIB, parentDir, sizeof(parentDir), "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
+			j9str_printf(parentDir, sizeof(parentDir), "%s%s/%s/", baseDir, TEST_PARENTDIR, TEST_TEMPDIR);
 		} else {
-			j9str_printf(PORTLIB, parentDir, sizeof(parentDir), "%s%s/", baseDir, TEST_PARENTDIR);
+			j9str_printf(parentDir, sizeof(parentDir), "%s%s/", baseDir, TEST_PARENTDIR);
 		}
 	}
 _end:
@@ -128,12 +128,12 @@ CacheDirPerm::createTempCacheDir(I_32 cacheType, bool useDefaultDir)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	if (useDefaultDir) {
-		j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
+		j9str_printf(actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 	} else {
 		if (J9PORT_SHR_CACHE_TYPE_NONPERSISTENT == cacheType) {
-			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s/%s", cacheDir, J9SH_BASEDIR);
+			j9str_printf(actualCacheDir, sizeof(actualCacheDir), "%s/%s", cacheDir, J9SH_BASEDIR);
 		} else {
-			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
+			j9str_printf(actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 		}
 	}
 
@@ -161,12 +161,12 @@ CacheDirPerm::getCacheDirPerm(I_32 cacheType, bool isDefaultDir)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	if (isDefaultDir) {
-		j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
+		j9str_printf(actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 	} else {
 		if (J9PORT_SHR_CACHE_TYPE_NONPERSISTENT == cacheType) {
-			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s/%s", cacheDir, J9SH_BASEDIR);
+			j9str_printf(actualCacheDir, sizeof(actualCacheDir), "%s/%s", cacheDir, J9SH_BASEDIR);
 		} else {
-			j9str_printf(PORTLIB, actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
+			j9str_printf(actualCacheDir, sizeof(actualCacheDir), "%s", cacheDir);
 		}
 	}
 
@@ -219,7 +219,7 @@ removeTempDir(J9JavaVM *vm, char *dir)
 		char resultBuffer[J9SH_MAXPATH];
 		UDATA rc, handle;
 
-		j9str_printf(PORTLIB, baseFilePath, sizeof(baseFilePath), "%s", dir);
+		j9str_printf(baseFilePath, sizeof(baseFilePath), "%s", dir);
 		rc = handle = j9file_findfirst(baseFilePath, resultBuffer);
 		while ((UDATA)-1 != rc) {
 			char nextEntry[J9SH_MAXPATH];
@@ -228,7 +228,7 @@ removeTempDir(J9JavaVM *vm, char *dir)
 				rc = j9file_findnext(handle, resultBuffer);
 				continue;
 			}
-			j9str_printf(PORTLIB, nextEntry, sizeof(nextEntry), "%s/%s", baseFilePath, resultBuffer);
+			j9str_printf(nextEntry, sizeof(nextEntry), "%s/%s", baseFilePath, resultBuffer);
 			removeTempDir(vm, nextEntry);
 			rc = j9file_findnext(handle, resultBuffer);
 		}

--- a/runtime/tests/shared/CacheFullTests.cpp
+++ b/runtime/tests/shared/CacheFullTests.cpp
@@ -209,7 +209,7 @@ IDATA test1(J9JavaVM* vm) {
 	/* Add a ROMClass with size more than available bytes */
 	romClassSize = CC_MIN_SPACE_BEFORE_CACHE_FULL + (2 * ONE_K_BYTES);
 	romClassSize = ROUND_UP_TO(sizeof(U_64), romClassSize);
-	j9str_printf(PORTLIB, romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
+	j9str_printf(romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
 	if (PASS == cacheHelper.addDummyROMClass(romClassName, romClassSize)) {
 		ERRPRINTF("Error: Successfully added dummy class twice the size of cache!");
 		rc = FAIL;
@@ -411,7 +411,7 @@ IDATA test2(J9JavaVM* vm) {
 	requiredFreeBytes = CC_MIN_SPACE_BEFORE_CACHE_FULL - ONE_K_BYTES;
 	romClassSize = (U_32)((ca->updateSRP - requiredFreeBytes) - ca->segmentSRP);
 	romClassSize = ROUND_UP_TO(sizeof(U_64), romClassSize);
-	j9str_printf(PORTLIB, romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
+	j9str_printf(romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
 	if (FAIL == cacheHelper.addDummyROMClass(romClassName, romClassSize)) {
 		ERRPRINTF("Error: Failed to add dummy class to the cache.");
 		rc = FAIL;
@@ -774,7 +774,7 @@ IDATA test3(J9JavaVM* vm) {
 	/* Add a ROMClass of size (1 page - 8 bytes). This will bring cache to the state shown in Fig 3-2 */
 	romClassSize = (U_32) (pageSizeToUse - (2*sizeof(U_32)));
 	romClassSize = ROUND_UP_TO(sizeof(U_64), romClassSize);
-	j9str_printf(PORTLIB, romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
+	j9str_printf(romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
 	if (FAIL == cacheHelper.addDummyROMClass(romClassName, romClassSize)) {
 		ERRPRINTF("Error: Failed to add dummy class to the cache.");
 		rc = FAIL;
@@ -1090,7 +1090,7 @@ IDATA test4(J9JavaVM* vm) {
 	/* Add a ROMClass to set segmentSRP and updateSRP to same value as shown in Fig 3-2 */
 	romClassSize = (U_32) pageSizeToUse;
 	romClassSize = ROUND_UP_TO(sizeof(U_64), romClassSize);
-	j9str_printf(PORTLIB, romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
+	j9str_printf(romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
 	if (FAIL == cacheHelper.addDummyROMClass(romClassName, romClassSize)) {
 		ERRPRINTF("Error: Failed to add dummy class to the cache.");
 		rc = FAIL;
@@ -2815,7 +2815,7 @@ IDATA test9(J9JavaVM* vm)
 	 * unstoredBytes in phase 3 can take effect. Otherwise, it has no effect as free available space can still be less than CC_MIN_SPACE_BEFORE_CACHE_FULL. */
 	romClassSize = (TEST9_SOFTMX_SIZE - usedBytes - CC_MIN_SPACE_BEFORE_CACHE_FULL + romClassSize2/2);
 	romClassSize = ROUND_UP_TO(sizeof(U_64), romClassSize);
-	j9str_printf(PORTLIB, romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
+	j9str_printf(romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass1", testName);
 	if (PASS == cacheHelper.addDummyROMClass(romClassName, romClassSize)) {
 		INFOPRINTF("Successfully added dummy class1 into the cache");
 	} else {
@@ -2882,7 +2882,7 @@ IDATA test9(J9JavaVM* vm)
 	 */
 
 	/* Try adding a ROMClass when the cache is soft full */
-	j9str_printf(PORTLIB, romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass2", testName);
+	j9str_printf(romClassName, ROMCLASS_NAME_LEN, "%s_DummyClass2", testName);
 	if (FAIL == cacheHelper.addDummyROMClass(romClassName, romClassSize2)) {
 		INFOPRINTF("Dummy class2 is not added into the cache as the cache is soft full");
 	} else {

--- a/runtime/tests/shared/CompiledMethodTest.cpp
+++ b/runtime/tests/shared/CompiledMethodTest.cpp
@@ -250,11 +250,11 @@ IDATA storeAndFindTest(J9JavaVM* vm)
 	/* Set the method name and signature */
 	methodNameAndSigMem = (BlockPtr)((UDATA)romMethod1 + sizeof(J9ROMMethod));
 	J9UTF8_SET_LENGTH(methodNameAndSigMem, (U_16)strlen(TEST_METHOD_NAME));
-	j9str_printf(PORTLIB, (BlockPtr) (J9UTF8_DATA(methodNameAndSigMem)), sizeof(TEST_METHOD_NAME), "%s", TEST_METHOD_NAME);
+	j9str_printf((BlockPtr) (J9UTF8_DATA(methodNameAndSigMem)), sizeof(TEST_METHOD_NAME), "%s", TEST_METHOD_NAME);
 	NNSRP_SET(romMethod1->nameAndSignature.name, (J9UTF8*)methodNameAndSigMem);
 
 	J9UTF8_SET_LENGTH((methodNameAndSigMem + METHOD_NAME_SIZE), (U_16)strlen(TEST_METHOD_SIG));
-	j9str_printf(PORTLIB, (BlockPtr) (J9UTF8_DATA(methodNameAndSigMem + METHOD_NAME_SIZE)), sizeof(TEST_METHOD_SIG), "%s",TEST_METHOD_SIG);
+	j9str_printf((BlockPtr) (J9UTF8_DATA(methodNameAndSigMem + METHOD_NAME_SIZE)), sizeof(TEST_METHOD_SIG), "%s",TEST_METHOD_SIG);
 	NNSRP_SET(romMethod1->nameAndSignature.signature, (J9UTF8*)(methodNameAndSigMem + METHOD_NAME_SIZE));
 
 	/* PHASE 1
@@ -534,4 +534,3 @@ cleanup:
 
 	return rc;
 }
-

--- a/runtime/tests/shared/CorruptCacheTest.cpp
+++ b/runtime/tests/shared/CorruptCacheTest.cpp
@@ -789,7 +789,7 @@ zeroOutCache(J9JavaVM *vm, I_32 cacheType)
 	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
 	versionData.cacheType = cacheType;
 	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true, 0);
-	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);
+	j9str_printf(fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);
 
 	fd = j9file_open(fullPath, EsOpenRead | EsOpenWrite, 0644);
 	if (-1 == fd) {
@@ -855,7 +855,7 @@ truncateCache(J9JavaVM *vm, I_32 cacheType)
 	setCurrentCacheVersion(vm, J2SE_VERSION(vm), &versionData);
 	versionData.cacheType = cacheType;
 	SH_OSCache::getCacheVersionAndGen(PORTLIB, vm, cacheName, J9SH_MAXPATH, BROKEN_TEST_CACHE, &versionData, OSCACHE_CURRENT_CACHE_GEN, true, 0);
-	j9str_printf(PORTLIB, fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);
+	j9str_printf(fullPath, J9SH_MAXPATH, "%s%s", baseDir, cacheName);
 
 	fd = j9file_open(fullPath, EsOpenRead | EsOpenWrite, 0644);
 	if (-1 == fd) {

--- a/runtime/tests/thread/thrstate/testsetup.c
+++ b/runtime/tests/thread/thrstate/testsetup.c
@@ -440,7 +440,7 @@ bufferTestDataDesc(JNIEnv *env, char *buf, UDATA buflen)
 	UDATA rc = 0;
 	PORT_ACCESS_FROM_ENV(env);
 
-	rc += j9str_printf(PORTLIB, buf, buflen,
+	rc += j9str_printf(buf, buflen,
 			"Test Data\n"
 			"\tself  vmthread: %p osthread: %p\n"
 			"\tother vmthread: %p osthread: %p\n"

--- a/runtime/tests/vm/testHelpers.c
+++ b/runtime/tests/vm/testHelpers.c
@@ -375,7 +375,7 @@ deleteControlDirectory(struct J9PortLibrary *portLibrary, char* baseDir)
 		UDATA handle, rc;
 		char mybaseFilePath[J9SH_MAXPATH];
 
-		j9str_printf(PORTLIB, mybaseFilePath, J9SH_MAXPATH, "%s/*", baseDir);
+		j9str_printf(mybaseFilePath, J9SH_MAXPATH, "%s/*", baseDir);
 		rc = handle = j9file_findfirst(mybaseFilePath, resultBuffer);
 		while (-1 != rc) {
 			j9file_unlink(resultBuffer);

--- a/runtime/util/jlm.c
+++ b/runtime/util/jlm.c
@@ -365,21 +365,18 @@ GetMonitorName(J9VMThread *vmThread, J9ThreadAbstractMonitor *monitor, char *nam
 			}
 		}
 
-
-		 j9str_printf(PORTLIB, nameBuf, OBJ_MON_NAME_BUF_SIZE,
+		j9str_printf(nameBuf, OBJ_MON_NAME_BUF_SIZE,
 				OBJ_MON_NAME_FORMAT,
 				monitor,
 				(length < OBJ_MON_NAME_CLASS_NAME_SIZE) ? length : OBJ_MON_NAME_CLASS_NAME_SIZE, 
 				name, 
 				object, objType);
 
-
-
 		if (free){
 			j9mem_free_memory(name);
 		}
 	} else {
-		j9str_printf(PORTLIB, nameBuf, OBJ_MON_NAME_BUF_SIZE, "[%p] %s", monitor, omrthread_monitor_get_name((omrthread_monitor_t) monitor));
+		j9str_printf(nameBuf, OBJ_MON_NAME_BUF_SIZE, "[%p] %s", monitor, omrthread_monitor_get_name((omrthread_monitor_t) monitor));
 	}
 }
 

--- a/runtime/util/resolvehelp.c
+++ b/runtime/util/resolvehelp.c
@@ -146,13 +146,13 @@ createErrorMessage(J9VMThread *vmStruct, J9Class *resolvedOrReceiverClass, J9Cla
 	if (NULL != errorMsg) {
 		J9UTF8 *resolvedOrReceiverName = J9ROMCLASS_CLASSNAME(resolvedOrReceiverClass->romClass);
 		J9UTF8 *currentName = J9ROMCLASS_CLASSNAME(currentClass->romClass);
-		UDATA bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
+		UDATA bufLen = j9str_printf(NULL, 0, errorMsg,
 				J9UTF8_LENGTH(resolvedOrReceiverName), J9UTF8_DATA(resolvedOrReceiverName),
 				J9UTF8_LENGTH(currentName), J9UTF8_DATA(currentName));
 		if (bufLen > 0) {
 			buf = j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 			if (NULL != buf) {
-				j9str_printf(PORTLIB, buf, bufLen, errorMsg,
+				j9str_printf(buf, bufLen, errorMsg,
 					J9UTF8_LENGTH(resolvedOrReceiverName), J9UTF8_DATA(resolvedOrReceiverName),
 					J9UTF8_LENGTH(currentName), J9UTF8_DATA(currentName));
 			}

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -674,7 +674,7 @@ addOptionsDefaultFile(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsL
 	UDATA resultLength  = 0;
 	PORT_ACCESS_FROM_PORT(portLib);
 
-	resultLength  = j9str_printf(PORTLIB, optionsArgumentBuffer, sizeof(optionsArgumentBuffer), VMOPT_XOPTIONSFILE_EQUALS "%s" DIR_SEPARATOR_STR OPTIONS_DEFAULT, optionsDirectory);
+	resultLength  = j9str_printf(optionsArgumentBuffer, sizeof(optionsArgumentBuffer), VMOPT_XOPTIONSFILE_EQUALS "%s" DIR_SEPARATOR_STR OPTIONS_DEFAULT, optionsDirectory);
 	if (resultLength > (sizeof(VMOPT_XOPTIONSFILE_EQUALS) + MAX_PATH)) {
 		return -1; /* overflow */
 	}
@@ -701,7 +701,7 @@ addXjcl(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA j2s
 	if (NULL == argString) {
 		return -1;
 	}
-	j9str_printf(PORTLIB, argString, argumentLength, VMOPT_XJCL_COLON "%s", dllName);
+	j9str_printf(argString, argumentLength, VMOPT_XJCL_COLON "%s", dllName);
 	optArg = newJavaVMArgInfo(vmArgumentsList, argString, ARG_MEMORY_ALLOCATION | CONSUMABLE_ARG);
 	if (NULL == optArg) {
 		j9mem_free_memory(argString);
@@ -726,7 +726,7 @@ addBootLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 		return -1;
 	}
 
-	j9str_printf(PORTLIB, optionsArgumentBuffer, argumentLength, "%s%s" J9JAVA_PATH_SEPARATOR "%s", propertyNameEquals, j9binPath, jrebinPath);
+	j9str_printf(optionsArgumentBuffer, argumentLength, "%s%s" J9JAVA_PATH_SEPARATOR "%s", propertyNameEquals, j9binPath, jrebinPath);
 
 	optArg = newJavaVMArgInfo(vmArgumentsList, optionsArgumentBuffer, ARG_MEMORY_ALLOCATION|CONSUMABLE_ARG);
 	if (NULL == optArg) {
@@ -984,7 +984,7 @@ addJavaHome(J9PortLibrary *portLib, J9JavaVMArgInfoList *vmArgumentsList, UDATA 
 		if (NULL == optionsArgumentBuffer) {
 			return -1;
 		}
-		j9str_printf(PORTLIB, optionsArgumentBuffer, argumentLength, JAVA_HOME_EQUALS "%s" J9JAVA_PATH_SEPARATOR "%s", altJavaHomeBuffer, jrelibPath);
+		j9str_printf(optionsArgumentBuffer, argumentLength, JAVA_HOME_EQUALS "%s" J9JAVA_PATH_SEPARATOR "%s", altJavaHomeBuffer, jrelibPath);
 	} else
 #endif /* WIN32 */
 	{
@@ -1073,7 +1073,7 @@ addUserDir(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *
 		return -1;
 	}
 
-	j9str_printf(PORTLIB, optionsArgumentBuffer, argumentLength, JAVA_USER_DIR_EQUALS "%s", cwd);
+	j9str_printf(optionsArgumentBuffer, argumentLength, JAVA_USER_DIR_EQUALS "%s", cwd);
 
 	optArg = newJavaVMArgInfo(vmArgumentsList, optionsArgumentBuffer, ARG_MEMORY_ALLOCATION|CONSUMABLE_ARG);
 	if (NULL == optArg) {

--- a/runtime/util_core/j9shchelp.c
+++ b/runtime/util_core/j9shchelp.c
@@ -316,7 +316,7 @@ getStringForShcModlevel(J9PortLibrary* portlib, uint32_t modlevel, char* buffer,
 		break;
 	default :
 		if (modlevel >= 10) {
-			j9str_printf(portlib, buffer, buffSize, "%s%u", "Java", modlevel);
+			j9str_printf(buffer, buffSize, "%s%u", "Java", modlevel);
 		} else {
 			/* J9SH_MODLEVEL_JAVA9 is 5. Does not have modlevel that is 7,8,9 */
 			strncpy(buffer, "Unknown", buffSize);

--- a/runtime/verbose/verbose.c
+++ b/runtime/verbose/verbose.c
@@ -323,7 +323,7 @@ dumpQualifiedSize(J9PortLibrary* portLib, UDATA byteSize, const char* optionName
 		message_num,
 		NULL);
 
-	paramSize = j9str_printf(PORTLIB, buffer, 16, "%zu%s", size, qualifier);
+	paramSize = j9str_printf(buffer, 16, "%zu%s", size, qualifier);
 	paramSize = 15 - paramSize;
 	paramSize += strlen(optionDescription);
 	paramSize -= strlen(optionName);
@@ -1792,4 +1792,3 @@ initVerboseVerificationBuffer(VerboseVerificationBuffer* buf, UDATA size, char* 
 	buf->cursor = 0;
 	buf->buffer = (U_8*)byteArray;
 }
-

--- a/runtime/verutil/cfrerr.c
+++ b/runtime/verutil/cfrerr.c
@@ -51,7 +51,7 @@ getJ9CfrErrorNormalMessage(J9PortLibrary* portLib, J9CfrError* error, const U_8*
 	allocSize = strlen(template) + strlen(errorDescription) + classNameLength + MAX_INT_SIZE;
 	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
 	if (NULL != errorString) {
-		j9str_printf(PORTLIB, errorString, allocSize, template, errorDescription, classNameLength, className, error->errorOffset);
+		j9str_printf(errorString, allocSize, template, errorDescription, classNameLength, className, error->errorOffset);
 	}
 
 	return errorString;
@@ -71,7 +71,7 @@ getJ9CfrErrorBsmMessage(J9PortLibrary* portLib, J9CfrError* error, const U_8* cl
 	allocSize = strlen(template) + classNameLength + (MAX_INT_SIZE * 4);
 	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
 	if (NULL != errorString) {
-		j9str_printf(PORTLIB, errorString, allocSize, template,
+		j9str_printf(errorString, allocSize, template,
 			error->errorBsmIndex, error->errorBsmArgsIndex, error->errorCPType, classNameLength, className, error->errorOffset);
 	}
 
@@ -87,7 +87,7 @@ getJ9CfrErrorMajorVersionMessage(J9PortLibrary* portLib, J9CfrError* error, cons
 	char *errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
 
 	if (NULL != errorString) {
-		j9str_printf(PORTLIB, errorString, allocSize, template,
+		j9str_printf(errorString, allocSize, template,
 			error->errorMajorVersion, error->errorMinorVersion, classNameLength, className, error->errorMaxMajorVersion, error->errorOffset);
 	}
 
@@ -103,7 +103,7 @@ getJ9CfrErrorMinorVersionMessage(J9PortLibrary* portLib, J9CfrError* error, cons
 	char *errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
 
 	if (NULL != errorString) {
-		j9str_printf(PORTLIB, errorString, allocSize, template,
+		j9str_printf(errorString, allocSize, template,
 			classNameLength, className, error->errorMinorVersion, error->errorMajorVersion, error->errorOffset);
 	}
 
@@ -119,7 +119,7 @@ getJ9CfrErrorPreviewVersionMessage(J9PortLibrary* portLib, J9CfrError* error, co
 	char *errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
 
 	if (NULL != errorString) {
-		j9str_printf(PORTLIB, errorString, allocSize, template,
+		j9str_printf(errorString, allocSize, template,
 			error->errorMajorVersion, error->errorMinorVersion, classNameLength, className, error->errorMaxMajorVersion, error->errorOffset);
 	}
 
@@ -135,7 +135,7 @@ getJ9CfrErrorPreviewVersionNotEnabledMessage(J9PortLibrary* portLib, J9CfrError*
 	char *errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
 
 	if (NULL != errorString) {
-		j9str_printf(PORTLIB, errorString, allocSize, template,
+		j9str_printf(errorString, allocSize, template,
 			error->errorMajorVersion, error->errorMinorVersion, classNameLength, className, error->errorOffset);
 	}
 
@@ -189,22 +189,22 @@ getJ9CfrErrorDetailMessageForMethod(J9PortLibrary* portLib, J9CfrError* error, c
 
 	errorString = j9mem_allocate_memory(allocSize, OMRMEM_CATEGORY_VM);
 	if (errorString != NULL) {
-		UDATA cursor = j9str_printf(PORTLIB,
-			errorString, 
-			allocSize,
-			template, 
-			errorDescription, 
-			classNameLength, 
-			className, 
-			methodNameLength,
-			methodName,
-			methodSignatureLength,
-			methodSignature,
-			error->errorPC);
+		UDATA cursor = j9str_printf(
+				errorString,
+				allocSize,
+				template,
+				errorDescription,
+				classNameLength,
+				className,
+				methodNameLength,
+				methodName,
+				methodSignatureLength,
+				methodSignature,
+				error->errorPC);
 
 		/* Jazz 82615: Print the detailed exception info to the error message buffer if not empty */
 		if ((NULL != detailedException) && (detailedExceptionLength > 0)) {
-			j9str_printf(PORTLIB, &errorString[cursor], allocSize - cursor, "%.*s", detailedExceptionLength, detailedException);
+			j9str_printf(&errorString[cursor], allocSize - cursor, "%.*s", detailedExceptionLength, detailedException);
 		}
 	}
 
@@ -279,4 +279,3 @@ buildMethodErrorWithExceptionDetails(J9CfrError * errorStruct, UDATA code, I_32 
 	errorStruct->errorFrameIndex = stackmapFrameIndex;
 	errorStruct->errorFrameBCI = stackmapFrameBCI;
 }
-

--- a/runtime/vm/BytecodeInterpreter.inc
+++ b/runtime/vm/BytecodeInterpreter.inc
@@ -59,7 +59,7 @@ getMethodName(J9PortLibrary *PORTLIB, J9Method *method, U_8 *pc, char *buffer)
 	char temp[1024];
 	buffer[0] = '\0';
 	if ((UDATA)pc <= J9SF_MAX_SPECIAL_FRAME_TYPE) {
-		j9str_printf(PORTLIB, temp, sizeof(temp), "SPECIAL %d", pc);
+		j9str_printf(temp, sizeof(temp), "SPECIAL %d", pc);
 		strcat(buffer, temp);
 #if defined(J9VM_OPT_METHOD_HANDLE)
 	} else if (((U_8*)-1 != pc) && (JBimpdep1 == *pc)) {
@@ -70,7 +70,7 @@ getMethodName(J9PortLibrary *PORTLIB, J9Method *method, U_8 *pc, char *buffer)
 	} else if (((U_8*)-1 != pc) && (((*pc >= JBretFromNative0) && (*pc <= JBreturnFromJ2I)) || (JBreturnFromJ2I == *pc))) {
 		strcat(buffer, "JITRETURN");
 	} else if (NULL == method->bytecodes) {
-		j9str_printf(PORTLIB, temp, sizeof(temp), "(no bytecodes) (%p)", method);
+		j9str_printf(temp, sizeof(temp), "(no bytecodes) (%p)", method);
 		strcat(buffer, temp);
 	} else {
 		J9UTF8 *className = J9ROMCLASS_CLASSNAME(J9_CLASS_FROM_METHOD(method)->romClass);
@@ -81,16 +81,16 @@ getMethodName(J9PortLibrary *PORTLIB, J9Method *method, U_8 *pc, char *buffer)
 			if ((UDATA)method->constantPool & J9_STARTPC_JNI_NATIVE) {
 				strcat(buffer, "JNI ");
 			} else {
-				strcat(buffer, "INL ");			
+				strcat(buffer, "INL ");
 			}
 		}
 		if (0 == ((UDATA)method->extra & 1)) {
 			strcat(buffer, "JITTED ");
 		}
-		j9str_printf(PORTLIB, temp, sizeof(temp), "%.*s.%.*s%.*s (%p)", J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSig), J9UTF8_DATA(methodSig), method);
+		j9str_printf(temp, sizeof(temp), "%.*s.%.*s%.*s (%p)", J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSig), J9UTF8_DATA(methodSig), method);
 		strcat(buffer, temp);
 		if ((U_8*)-1 != pc) {
-			j9str_printf(PORTLIB, temp, sizeof(temp), " @ %p (offset %d)", pc, pc - method->bytecodes);
+			j9str_printf(temp, sizeof(temp), " @ %p (offset %d)", pc, pc - method->bytecodes);
 			strcat(buffer, temp);
 		}
 	}

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -2095,10 +2095,10 @@ freeDir:
 	 * Pending exceptions will be set by the JVM hooks, these exception will take precedence.
 	 */
 	if ((NULL != currentExceptionClass) && (NULL == currentThread->currentException)) {
-		msgCharLength = j9str_printf(PORTLIB, NULL, 0, nlsMsgFormat, systemReturnCode);
+		msgCharLength = j9str_printf(NULL, 0, nlsMsgFormat, systemReturnCode);
 		exceptionMsg = (char*) j9mem_allocate_memory(msgCharLength, J9MEM_CATEGORY_VM);
 
-		j9str_printf(PORTLIB, exceptionMsg, msgCharLength, nlsMsgFormat, systemReturnCode);
+		j9str_printf(exceptionMsg, msgCharLength, nlsMsgFormat, systemReturnCode);
 
 		jmethodID init = NULL;
 		if (vm->checkpointState.criuJVMCheckpointExceptionClass == currentExceptionClass) {

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -133,7 +133,7 @@ classHashEqualFn(void *tableNode, void *queryNode, void *userData)
 	if (isTableNodeHiddenClass) {
 		/* Hidden class is keyed on its rom address, not on its name. */
 		PORT_ACCESS_FROM_JAVAVM(javaVM);
-		j9str_printf(PORTLIB, buf, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, (UDATA)((KeyHashTableClassEntry *)tableNode)->ramClass->romClass);
+		j9str_printf(buf, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, (UDATA)((KeyHashTableClassEntry *)tableNode)->ramClass->romClass);
 		tableNodeName = (const U_8 *)buf;
 		tableNodeLength = ROM_ADDRESS_LENGTH;
 	}
@@ -232,7 +232,7 @@ classHashFn(void *key, void *userData)
 	if (isTableNodeHiddenClass) {
 		/* for hidden class, do not key on its name, key on its rom address */
 		PORT_ACCESS_FROM_JAVAVM(javaVM);
-		j9str_printf(PORTLIB, buf, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, (UDATA)((KeyHashTableClassEntry *)key)->ramClass->romClass);
+		j9str_printf(buf, ROM_ADDRESS_LENGTH + 1, ROM_ADDRESS_FORMAT, (UDATA)((KeyHashTableClassEntry *)key)->ramClass->romClass);
 		name = (const U_8 *)buf;
 		length = ROM_ADDRESS_LENGTH;
 	}

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -340,7 +340,7 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 					/* Prevent call to JNI_OnUnload; can't invoke JNI_OnUnload based on VM oom. */
 					unloadPerformed = TRUE;
 				} else {
-					j9str_printf(PORTLIB, onUnloadRtnName, nameLength, "%s%s", J9STATIC_ONUNLOAD, nativeLibrary->logicalName);
+					j9str_printf(onUnloadRtnName, nameLength, "%s%s", J9STATIC_ONUNLOAD, nativeLibrary->logicalName);
 
 					/* Invoke the JNI_OnUnLoad_L routine, if present. */
 					rc = (*nativeLibrary->send_lifecycle_event)(vmThread, nativeLibrary, onUnloadRtnName, (UDATA) -1);
@@ -527,4 +527,3 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 
 	Trc_VM_freeClassLoader_Exit();
 }
-

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1478,7 +1478,7 @@ setCurrentExceptionForBadClass(J9VMThread *vmThread, J9UTF8 *badClassName, UDATA
 		U_16 badClassNameLength = J9UTF8_LENGTH(badClassName);
 		U_8 * badClassNameStr = J9UTF8_DATA(badClassName);
 
-		UDATA errorMsgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage, badClassNameLength, badClassNameStr);
+		UDATA errorMsgLen = j9str_printf(NULL, 0, nlsMessage, badClassNameLength, badClassNameStr);
 		errorMsg = (char*)j9mem_allocate_memory(errorMsgLen, OMRMEM_CATEGORY_VM);
 		if (NULL == errorMsg) {
 			J9MemoryManagerFunctions *gcFuncs = vmThread->javaVM->memoryManagerFunctions;
@@ -1486,7 +1486,7 @@ setCurrentExceptionForBadClass(J9VMThread *vmThread, J9UTF8 *badClassName, UDATA
 			setCurrentException(vmThread, exceptionIndex, (UDATA *)detailMessage);
 			return;
 		}
-		j9str_printf(PORTLIB, errorMsg, errorMsgLen, nlsMessage, badClassNameLength, badClassNameStr);
+		j9str_printf(errorMsg, errorMsgLen, nlsMessage, badClassNameLength, badClassNameStr);
 	}
 
 	setCurrentExceptionUTF(vmThread, exceptionIndex, errorMsg);

--- a/runtime/vm/dllsup.c
+++ b/runtime/vm/dllsup.c
@@ -82,8 +82,7 @@ loadJ9DLLWithPath(J9JavaVM *vm, J9VMDllLoadInfo *info, char *dllName)
 			superSeparatorIndex = strrchr(dllDirectory, DIR_SEPARATOR) - dllDirectory;
 			bufferSize = superSeparatorIndex + 1 + sizeof(DIR_SEPARATOR_STR) + strlen(dllName);  /* +1 for NUL */
 		} else {
-			bufferSize = j9str_printf(PORTLIB, NULL, 0, "%s%s%s",
-				dllDirectory, DIR_SEPARATOR_STR, dllName);
+			bufferSize = j9str_printf(NULL, 0, "%s%s%s", dllDirectory, DIR_SEPARATOR_STR, dllName);
 		}
 		localBuffer = j9mem_allocate_memory(bufferSize, OMRMEM_CATEGORY_VM);
 
@@ -98,9 +97,8 @@ loadJ9DLLWithPath(J9JavaVM *vm, J9VMDllLoadInfo *info, char *dllName)
 			localBuffer[superSeparatorIndex+1] = (char) 0;
 			strcat(localBuffer, dllName);
 		} else {
-			j9str_printf(PORTLIB, localBuffer, bufferSize, "%s%s%s",
-				dllDirectory, DIR_SEPARATOR_STR, dllName);
-		}	
+			j9str_printf(localBuffer, bufferSize, "%s%s%s", dllDirectory, DIR_SEPARATOR_STR, dllName);
+		}
 	} else {
 		localBuffer = dllName;
 	}
@@ -177,4 +175,3 @@ setErrorJ9dll(J9PortLibrary *portLib, J9VMDllLoadInfo *info, const char *error, 
 		info->loadFlags &= ~FREE_ERROR_STRING;
 	}
 }
-

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -859,7 +859,7 @@ setNegativeArraySizeException(J9VMThread *currentThread, I_32 size)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	char buffer[15];
-	j9str_printf(PORTLIB, buffer, sizeof(buffer), "%d", size);
+	j9str_printf(buffer, sizeof(buffer), "%d", size);
 	setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGNEGATIVEARRAYSIZEEXCEPTION, buffer);
 }
 
@@ -886,13 +886,13 @@ setClassLoadingConstraintError(J9VMThread * currentThread, J9ClassLoader * initi
 		J9UTF8 * existingClassNameUTF = J9ROMCLASS_CLASSNAME(existingClass->romClass);
 		U_16 existingClassNameLength = J9UTF8_LENGTH(existingClassNameUTF);
 		U_8 * existingClassName = J9UTF8_DATA(existingClassNameUTF);
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(NULL, 0, nlsMessage,
 			initiatingLoaderClassNameLength, initiatingLoaderClassName, initiatingLoaderHash,
 			existingClassNameLength, existingClassName,
 			definingLoaderClassNameLength, definingLoaderClassName, definingLoaderHash);
 		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
 		/* msg NULL check omitted since str_printf accepts NULL (as above) */
-		j9str_printf(PORTLIB, msg, msgLen, nlsMessage,
+		j9str_printf(msg, msgLen, nlsMessage,
 			initiatingLoaderClassNameLength, initiatingLoaderClassName, initiatingLoaderHash,
 			existingClassNameLength, existingClassName,
 			definingLoaderClassNameLength, definingLoaderClassName, definingLoaderHash);
@@ -940,27 +940,24 @@ setClassLoadingConstraintSignatureError(J9VMThread *currentThread, J9ClassLoader
 		U_16 exceptionClassNameLength = J9UTF8_LENGTH(exceptionClassNameUTF);
 		U_8 * exceptionClassName = J9UTF8_DATA(exceptionClassNameUTF);
 
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(NULL, 0, nlsMessage,
 				exceptionClassNameLength, exceptionClassName,
 				methodNameLength, methodName,
 				signatureLength, signature,
 				loader1ClassNameLength, loader1ClassName, loader1Hash,
 				class1ClassNameLength, class1ClassName,
 				loader2ClassNameLength, loader2ClassName, loader2Hash,
-				class2ClassNameLength, class2ClassName
-
-		);
+				class2ClassNameLength, class2ClassName);
 		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
 		/* msg NULL check omitted since str_printf accepts NULL (as above) */
-		j9str_printf(PORTLIB, msg, msgLen, nlsMessage,
+		j9str_printf(msg, msgLen, nlsMessage,
 				exceptionClassNameLength, exceptionClassName,
 				methodNameLength, methodName,
 				signatureLength, signature,
-				 loader1ClassNameLength, loader1ClassName, loader1Hash,
-				 class1ClassNameLength, class1ClassName,
-				 loader2ClassNameLength, loader2ClassName, loader2Hash,
-				 class2ClassNameLength, class2ClassName
-			);
+				loader1ClassNameLength, loader1ClassName, loader1Hash,
+				class1ClassNameLength, class1ClassName,
+				loader2ClassNameLength, loader2ClassName, loader2Hash,
+				class2ClassNameLength, class2ClassName);
 	}
 
 	setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, msg);
@@ -1007,7 +1004,7 @@ setClassLoadingConstraintOverrideError(J9VMThread *currentThread, J9UTF8 *newCla
 		U_16 newClassNameLength = J9UTF8_LENGTH(newClassNameUTF);
 		U_8 * newClassName = J9UTF8_DATA(newClassNameUTF);
 
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(NULL, 0, nlsMessage,
 				exceptionClassNameLength, exceptionClassName,
 				methodNameLength, methodName,
 				signatureLength, signature,
@@ -1015,21 +1012,18 @@ setClassLoadingConstraintOverrideError(J9VMThread *currentThread, J9UTF8 *newCla
 				class1ClassNameLength, class1ClassName,
 				loader2ClassNameLength, loader2ClassName, loader2Hash,
 				class2ClassNameLength, class2ClassName,
-				newClassNameLength, newClassName
-
-		);
+				newClassNameLength, newClassName);
 		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
 		/* msg NULL check omitted since str_printf accepts NULL (as above) */
-		j9str_printf(PORTLIB, msg, msgLen, nlsMessage,
+		j9str_printf(msg, msgLen, nlsMessage,
 				exceptionClassNameLength, exceptionClassName,
 				methodNameLength, methodName,
 				signatureLength, signature,
-				 loader1ClassNameLength, loader1ClassName, loader1Hash,
-				 class1ClassNameLength, class1ClassName,
-				 loader2ClassNameLength, loader2ClassName, loader2Hash,
-				 class2ClassNameLength, class2ClassName,
-				 newClassNameLength, newClassName
-			);
+				loader1ClassNameLength, loader1ClassName, loader1Hash,
+				class1ClassNameLength, class1ClassName,
+				loader2ClassNameLength, loader2ClassName, loader2Hash,
+				class2ClassNameLength, class2ClassName,
+				newClassNameLength, newClassName);
 	}
 
 	setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, msg);
@@ -1056,23 +1050,23 @@ nlsMessageForMethod(J9VMThread * currentThread, J9Method * method, U_32 module_n
 		U_8 * methodName = J9UTF8_DATA(methodNameUTF);
 		U_16 methodSignatureLength = J9UTF8_LENGTH(methodSignatureUTF);
 		U_8 * methodSignature = J9UTF8_DATA(methodSignatureUTF);
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
-					classNameLength, className,
-					methodNameLength, methodName,
-					methodSignatureLength, methodSignature);
+		UDATA msgLen = j9str_printf(NULL, 0, nlsMessage,
+				classNameLength, className,
+				methodNameLength, methodName,
+				methodSignatureLength, methodSignature);
 		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
 		/* msg NULL check omitted since str_printf accepts NULL (as above) */
-		j9str_printf(PORTLIB, msg, msgLen, nlsMessage,
-					classNameLength, className,
-					methodNameLength, methodName,
-					methodSignatureLength, methodSignature);
+		j9str_printf(msg, msgLen, nlsMessage,
+				classNameLength, className,
+				methodNameLength, methodName,
+				methodSignatureLength, methodSignature);
 	}
 
 	return msg;
 }
 
 
-void  
+void
 setNativeBindOutOfMemoryError(J9VMThread * currentThread, J9Method * method)
 {
 	char * msg = nlsMessageForMethod(currentThread, method, J9NLS_VM_BIND_OUT_OF_MEMORY);
@@ -1161,16 +1155,16 @@ setIncompatibleClassChangeErrorForDefaultConflict(J9VMThread * vmThread, J9Metho
 		U_8 * methodName = J9UTF8_DATA(methodNameUTF);
 		U_16 methodSignatureLength = J9UTF8_LENGTH(methodSignatureUTF);
 		U_8 * methodSignature = J9UTF8_DATA(methodSignatureUTF);
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
-					classNameLength, className,
-					methodNameLength, methodName,
-					methodSignatureLength, methodSignature);
+		UDATA msgLen = j9str_printf(NULL, 0, nlsMessage,
+				classNameLength, className,
+				methodNameLength, methodName,
+				methodSignatureLength, methodSignature);
 		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
 		/* msg NULL check omitted since str_printf accepts NULL (as above) */
-		j9str_printf(PORTLIB, msg, msgLen, nlsMessage,
-					classNameLength, className,
-					methodNameLength, methodName,
-					methodSignatureLength, methodSignature);
+		j9str_printf(msg, msgLen, nlsMessage,
+				classNameLength, className,
+				methodNameLength, methodName,
+				methodSignatureLength, methodSignature);
 	}
 
 	setCurrentExceptionUTF(vmThread, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, msg);
@@ -1198,13 +1192,13 @@ setIllegalAccessErrorNonPublicInvokeInterface(J9VMThread *vmThread, J9Method *me
 		U_8 * methodName = J9UTF8_DATA(methodNameUTF);
 		U_16 methodSignatureLength = J9UTF8_LENGTH(methodSigUTF);
 		U_8 * methodSignature = J9UTF8_DATA(methodSigUTF);
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(NULL, 0, nlsMessage,
 				classNameLength, className,
 				methodNameLength, methodName,
 				methodSignatureLength, methodSignature);
 		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
 		/* msg NULL check omitted since str_printf accepts NULL (as above) */
-		j9str_printf(PORTLIB, msg, msgLen,nlsMessage,
+		j9str_printf(msg, msgLen,nlsMessage,
 				classNameLength, className,
 				methodNameLength, methodName,
 				methodSignatureLength, methodSignature);
@@ -1271,13 +1265,13 @@ setIllegalAccessErrorFinalFieldSet(J9VMThread *currentThread, UDATA isStatic, J9
 		U_8 * fieldName = J9UTF8_DATA(fieldNameUTF);
 		U_16 methodNameLength = J9UTF8_LENGTH(methodNameUTF);
 		U_8 * methodName = J9UTF8_DATA(methodNameUTF);
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsMessage,
+		UDATA msgLen = j9str_printf(NULL, 0, nlsMessage,
 				classNameLength, className,
 				fieldNameLength, fieldName,
 				methodNameLength, methodName);
 		msg = j9mem_allocate_memory(msgLen, OMRMEM_CATEGORY_VM);
 		/* msg NULL check omitted since str_printf accepts NULL (as above) */
-		j9str_printf(PORTLIB, msg, msgLen,nlsMessage,
+		j9str_printf(msg, msgLen,nlsMessage,
 				classNameLength, className,
 				fieldNameLength, fieldName,
 				methodNameLength, methodName);

--- a/runtime/vm/extendedMessageNPE.cpp
+++ b/runtime/vm/extendedMessageNPE.cpp
@@ -248,7 +248,7 @@ convertMethodSignature(J9VMThread *vmThread, J9UTF8 *methodSig)
 
 		memset(result, 0, bufferSize);
 		/* first character is '(' */
-		j9str_printf(PORTLIB, cursor, availableSize, "(");
+		j9str_printf(cursor, availableSize, "(");
 		cursor += 1;
 		availableSize -= 1;
 		for (i = 1; (')' != string[i]); i++) {
@@ -303,23 +303,23 @@ convertMethodSignature(J9VMThread *vmThread, J9UTF8 *methodSig)
 					break;
 				}
 				UDATA elementLength = strlen(elementType);
-				j9str_printf(PORTLIB, cursor, availableSize, elementType);
+				j9str_printf(cursor, availableSize, elementType);
 				cursor += elementLength;
 				availableSize -= elementLength;
 			}
 			for(j = 0; j < arity; j++) {
-				j9str_printf(PORTLIB, cursor, availableSize, "[]");
+				j9str_printf(cursor, availableSize, "[]");
 				cursor += 2;
 				availableSize -= 2;
 			}
 
 			if (')' != string[i + 1]) {
-				j9str_printf(PORTLIB, cursor, availableSize, ", ");
+				j9str_printf(cursor, availableSize, ", ");
 				cursor += 2;
 				availableSize -= 2;
 			}
 		}
-		j9str_printf(PORTLIB, cursor, availableSize, ")");
+		j9str_printf(cursor, availableSize, ")");
 	} else {
 		bufferSize = 0;
 	}

--- a/runtime/vm/gphandle.c
+++ b/runtime/vm/gphandle.c
@@ -971,13 +971,13 @@ writeGPInfo(struct J9PortLibrary* portLibrary, void *writeGPInfoCrashData)
 
 		switch (infoKind) {
 		case J9PORT_SIG_VALUE_16:
-				n = j9str_printf(PORTLIB, cursor, length, "%s=%04X%c", name, *(U_16 *)value, c);
+				n = j9str_printf(cursor, length, "%s=%04X%c", name, *(U_16 *)value, c);
 			break;
 		case J9PORT_SIG_VALUE_32:
-				n = j9str_printf(PORTLIB, cursor, length, "%s=%08.8x%c", name, *(U_32 *)value, c);
+				n = j9str_printf(cursor, length, "%s=%08.8x%c", name, *(U_32 *)value, c);
 			break;
 		case J9PORT_SIG_VALUE_64:
-				n = j9str_printf(PORTLIB, cursor, length, "%s=%016.16llx%c", name, *(U_64 *)value, c);
+				n = j9str_printf(cursor, length, "%s=%016.16llx%c", name, *(U_64 *)value, c);
 			break;
 		case J9PORT_SIG_VALUE_128:
 			{
@@ -985,22 +985,22 @@ writeGPInfo(struct J9PortLibrary* portLibrary, void *writeGPInfoCrashData)
 				const U_64 h = v->high64;
 				const U_64 l = v->low64;
 
-				n = j9str_printf(PORTLIB, cursor, length, "%s=%016.16llx%016.16llx%c", name, h, l, c);
+				n = j9str_printf(cursor, length, "%s=%016.16llx%016.16llx%c", name, h, l, c);
 			}
 			break;
 		case J9PORT_SIG_VALUE_STRING:
-				n = j9str_printf(PORTLIB, cursor, length, "%s=%s%c", name, (char *)value, c);
+				n = j9str_printf(cursor, length, "%s=%s%c", name, (char *)value, c);
 			break;
 		case J9PORT_SIG_VALUE_ADDRESS:
-				n = j9str_printf(PORTLIB, cursor, length, "%s=%p%c", name, *(void**)value, c);
+				n = j9str_printf(cursor, length, "%s=%p%c", name, *(void**)value, c);
 			break;
 		case J9PORT_SIG_VALUE_FLOAT_64:
 			/* make sure when casting to a float that we get least significant 32-bits. */
-				n = j9str_printf(PORTLIB, cursor, length, "%s=%016.16llx (f: %f, d: %e)%c", name, *(U_64 *)value, (float)LOW_U32_FROM_DBL_PTR(value), *(double *)value, c);
+				n = j9str_printf(cursor, length, "%s=%016.16llx (f: %f, d: %e)%c", name, *(U_64 *)value, (float)LOW_U32_FROM_DBL_PTR(value), *(double *)value, c);
 			break;
 		case J9PORT_SIG_VALUE_UNDEFINED:
 		default:
-				n = j9str_printf(PORTLIB, cursor, length, "%s=<UNDEFINED>%c", name, c);
+				n = j9str_printf(cursor, length, "%s=<UNDEFINED>%c", name, c);
 			break;
 		}
 
@@ -1044,12 +1044,12 @@ writeJITInfo(J9VMThread* vmThread, char* s, UDATA length, void* gpInfo)
 			J9UTF8 *methSig = J9ROMMETHOD_SIGNATURE(romMethod);
 			J9UTF8 *className = J9ROMCLASS_CLASSNAME(clazz->romClass);
 
-			n = j9str_printf(PORTLIB, s, length, "\nMethod_being_compiled=%.*s.%.*s%.*s\n",
+			n = j9str_printf(s, length, "\nMethod_being_compiled=%.*s.%.*s%.*s\n",
 					(UDATA)J9UTF8_LENGTH(className), J9UTF8_DATA(className),
 					(UDATA)J9UTF8_LENGTH(methName), J9UTF8_DATA(methName),
 					(UDATA)J9UTF8_LENGTH(methSig), J9UTF8_DATA(methSig));
 		} else {
-			n = j9str_printf(PORTLIB, s, length, "\nMethod_being_compiled=<unknown>\n");
+			n = j9str_printf(s, length, "\nMethod_being_compiled=<unknown>\n");
 		}
 		numBytesWritten += n;
 		return numBytesWritten;
@@ -1076,7 +1076,7 @@ writeJITInfo(J9VMThread* vmThread, char* s, UDATA length, void* gpInfo)
 			J9UTF8 *methSig = J9ROMMETHOD_SIGNATURE(romMethod);
 			J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
 
-			n = j9str_printf(PORTLIB, s, length, "\nCompiled_method=%.*s.%.*s%.*s\n",
+			n = j9str_printf(s, length, "\nCompiled_method=%.*s.%.*s%.*s\n",
 					(UDATA)J9UTF8_LENGTH(className), J9UTF8_DATA(className),
 					(UDATA)J9UTF8_LENGTH(methName), J9UTF8_DATA(methName),
 					(UDATA)J9UTF8_LENGTH(methSig), J9UTF8_DATA(methSig));
@@ -1085,7 +1085,7 @@ writeJITInfo(J9VMThread* vmThread, char* s, UDATA length, void* gpInfo)
 			/* scan code segments to see if we're in a segment but somehow not in a method */
 			MEMORY_SEGMENT_LIST_DO(jitConfig->codeCacheList, seg);
 			if((pc >= (UDATA) seg->heapBase) && (pc < (UDATA) seg->heapTop)) {
-				n = j9str_printf(PORTLIB, s, length, "\nCompiled_method=unknown (In JIT code segment %p but no method found)\n", seg);
+				n = j9str_printf(s, length, "\nCompiled_method=unknown (In JIT code segment %p but no method found)\n", seg);
 				numBytesWritten += n;
 				return numBytesWritten;
 			}
@@ -1109,22 +1109,22 @@ writeVMInfo(J9JavaVM* vm, char* s, UDATA length)
 		UDATA n;
 
 		/* show number of options */
-		n = j9str_printf(PORTLIB, s, length, "\nJavaVMInitArgs.nOptions=%i:\n", numOptions);  
+		n = j9str_printf(s, length, "\nJavaVMInitArgs.nOptions=%i:\n", numOptions);
 		length -= n;
 		s += n;
 		numBytesWritten += n;
 
 		for (optionCount = 0; optionCount < numOptions; optionCount++) {
-			n = j9str_printf(PORTLIB, s, length, "    %s", j9vm_args->actualVMArgs->options[optionCount].optionString);
+			n = j9str_printf(s, length, "    %s", j9vm_args->actualVMArgs->options[optionCount].optionString);
 			length -= n;
 			s += n;
 			numBytesWritten += n;
 
 			/* append option with only non-zero extra info */
 			if (j9vm_args->actualVMArgs->options[optionCount].extraInfo != 0) {
-				n = j9str_printf(PORTLIB, s, length, " (extra info: %p)\n", j9vm_args->actualVMArgs->options[optionCount].extraInfo);
+				n = j9str_printf(s, length, " (extra info: %p)\n", j9vm_args->actualVMArgs->options[optionCount].extraInfo);
 			} else {
-				n = j9str_printf(PORTLIB, s, length, "\n");
+				n = j9str_printf(s, length, "\n");
 			}
 			numBytesWritten += n;
 
@@ -1370,7 +1370,7 @@ javaAndCStacksMustBeInSync(J9VMThread *vmThread, BOOLEAN fromJIT)
 
 	j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_TERMINATING_PROCESS_USING_CEEAB2, code, reason, cleanup);
 	CEE3AB2(&code, &reason, &cleanup); /* terminate the process, no chance for anyone to resume */
-	
+
 	/* can't get here */
 }
 #endif

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -2649,7 +2649,7 @@ defineClass(JNIEnv *env, const char *name, jobject loader, const jbyte *buf, jsi
 					msgChars = (char *)j9mem_allocate_memory(msgCharLength + 1, J9MEM_CATEGORY_JNI);
 
 					if (NULL != msgChars) {
-						j9str_printf(PORTLIB, msgChars, msgCharLength, nlsMsgFormat, classNameLength, className, JAVA_PACKAGE_NAME_LENGTH, javaPackageName);
+						j9str_printf(msgChars, msgCharLength, nlsMsgFormat, classNameLength, className, JAVA_PACKAGE_NAME_LENGTH, javaPackageName);
 					}
 				}
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1804,7 +1804,7 @@ initializeModulesPath(J9JavaVM *vm)
 	}
 	memset(vm->modulesPathEntry, 0, sizeof(J9ClassPathEntry));
 	modulesPath = (U_8 *)(vm->modulesPathEntry + 1);
-	j9str_printf(PORTLIB, (char*)modulesPath, (U_32)modulesPathLen + 1, "%s" DIR_SEPARATOR_STR "lib" DIR_SEPARATOR_STR "modules", javaHomeValue);
+	j9str_printf((char *)modulesPath, (U_32)modulesPathLen + 1, "%s" DIR_SEPARATOR_STR "lib" DIR_SEPARATOR_STR "modules", javaHomeValue);
 
 	vm->modulesPathEntry->path = modulesPath;
 	vm->modulesPathEntry->pathLength = (U_32)modulesPathLen;
@@ -1813,7 +1813,7 @@ initializeModulesPath(J9JavaVM *vm)
 		vm->modulesPathEntry->type = CPE_TYPE_UNKNOWN;
 		/* If <JAVA_HOME>/lib/modules is not usable, try to use <JAVA_HOME>/modules dir */
 		modulesPathLen = javaHomeValueLen + LITERAL_STRLEN(DIR_SEPARATOR_STR) + LITERAL_STRLEN("modules");
-		j9str_printf(PORTLIB, (char*)modulesPath, (U_32)modulesPathLen + 1, "%s" DIR_SEPARATOR_STR "modules", javaHomeValue);
+		j9str_printf((char *)modulesPath, (U_32)modulesPathLen + 1, "%s" DIR_SEPARATOR_STR "modules", javaHomeValue);
 		vm->modulesPathEntry->pathLength = (U_32)modulesPathLen;
 		rc = initializeModulesPathEntry(vm, vm->modulesPathEntry);
 		if (CPE_TYPE_UNUSABLE == rc) {
@@ -3613,7 +3613,7 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 					return JNI_ERR;
 				}
 			}
-			j9str_printf(PORTLIB, zlibDllDir, expectedZlibPathLength, "%s%s%s",
+			j9str_printf(zlibDllDir, expectedZlibPathLength, "%s%s%s",
 					vm->j9libvmDirectory, DIR_SEPARATOR_STR, J9_ZIP_DLL_NAME);
 			zlibFileHandle = j9sl_open_shared_library(zlibDllDir, &(entry->descriptor), openFlags);
 			if (0 != zlibFileHandle) {
@@ -3645,7 +3645,7 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 					return JNI_ERR;
 				}
 			}
-			j9str_printf(PORTLIB, dllCheckPathPtr, expectedPathLength, "%s%s%s",
+			j9str_printf(dllCheckPathPtr, expectedPathLength, "%s%s%s",
 					jitdirectoryValue, DIR_SEPARATOR_STR, entry->dllName);
 
 			jitFileHandle = j9sl_open_shared_library(dllCheckPathPtr, &(entry->descriptor), openFlags);

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -965,25 +965,25 @@ defaultMethodConflictExceptionMessage(J9VMThread *currentThread, J9Class *target
 	listString[listLength] = '\0'; /* Overallocated by 1 to enable null termination */
 
 	/* Write error message to buffer */
-	bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
-				nameLength,
-				name,
-				sigLength,
-				sig,
-				(UDATA)J9UTF8_LENGTH(targetClassNameUTF),
-				J9UTF8_DATA(targetClassNameUTF),
-				listString);
+	bufLen = j9str_printf(NULL, 0, errorMsg,
+			nameLength,
+			name,
+			sigLength,
+			sig,
+			(UDATA)J9UTF8_LENGTH(targetClassNameUTF),
+			J9UTF8_DATA(targetClassNameUTF),
+			listString);
 	if (bufLen > 0) {
 		buf = j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 		if (NULL != buf) {
-			bufLen = j9str_printf(PORTLIB, buf, bufLen, errorMsg,
-						nameLength,
-						name,
-						sigLength,
-						sig,
-						J9UTF8_LENGTH(targetClassNameUTF),
-						J9UTF8_DATA(targetClassNameUTF),
-						listString);
+			bufLen = j9str_printf(buf, bufLen, errorMsg,
+					nameLength,
+					name,
+					sigLength,
+					sig,
+					J9UTF8_LENGTH(targetClassNameUTF),
+					J9UTF8_DATA(targetClassNameUTF),
+					listString);
 		}
 	}
 	j9mem_free_memory(listString);
@@ -1016,7 +1016,7 @@ getModuleNameUTF(J9VMThread *currentThread, j9object_t moduleObject, char *buffe
 		/* ensure bufferLength is not less than 128 which is enough for unnamed module */
 		PORT_ACCESS_FROM_VMC(currentThread);
 		Assert_VM_true(bufferLength >= 128);
-		j9str_printf(PORTLIB, buffer, bufferLength, "%s0x%p", UNNAMED_MODULE, moduleObject);
+		j9str_printf(buffer, bufferLength, "%s0x%p", UNNAMED_MODULE, moduleObject);
 		nameBuffer = buffer;
 #undef UNNAMED_MODULE
 	} else {
@@ -1116,7 +1116,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 					NULL);
 		}
 
-		bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
+		bufLen = j9str_printf(NULL, 0, errorMsg,
 				J9UTF8_LENGTH(nestMemberNameUTF),
 				J9UTF8_DATA(nestMemberNameUTF),
 				J9UTF8_LENGTH(nestHostNameUTF),
@@ -1127,7 +1127,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 			if (NULL == buf) {
 				goto allocationFailure;
 			}
-			j9str_printf(PORTLIB, buf, bufLen, errorMsg,
+			j9str_printf(buf, bufLen, errorMsg,
 					J9UTF8_LENGTH(nestMemberNameUTF),
 					J9UTF8_DATA(nestMemberNameUTF),
 					J9UTF8_LENGTH(nestHostNameUTF),
@@ -1150,7 +1150,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 		if (J9_VISIBILITY_MODULE_READ_ACCESS_ERROR == errorType) {
 			/* module read access NOT allowed */
 			errorMsg = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_ILLEGAL_ACCESS_MODULE_READ, NULL);
-			bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
+			bufLen = j9str_printf(NULL, 0, errorMsg,
 					J9UTF8_LENGTH(senderClassNameUTF),
 					J9UTF8_DATA(senderClassNameUTF),
 					srcModuleMsg,
@@ -1160,7 +1160,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 			if (bufLen > 0) {
 				buf = j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 				if (NULL != buf) {
-					j9str_printf(PORTLIB, buf, bufLen, errorMsg,
+					j9str_printf(buf, bufLen, errorMsg,
 							J9UTF8_LENGTH(senderClassNameUTF),
 							J9UTF8_DATA(senderClassNameUTF),
 							srcModuleMsg,
@@ -1192,7 +1192,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 			}
 			*(packageNameMsg + packageNameLength) = '\0';
 			errorMsg = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE, J9NLS_VM_ILLEGAL_ACCESS_MODULE_EXPORT, NULL);
-			bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
+			bufLen = j9str_printf(NULL, 0, errorMsg,
 					J9UTF8_LENGTH(senderClassNameUTF),
 					J9UTF8_DATA(senderClassNameUTF),
 					srcModuleMsg,
@@ -1203,7 +1203,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 			if (bufLen > 0) {
 				buf = j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 				if (NULL != buf) {
-					j9str_printf(PORTLIB, buf, bufLen, errorMsg,
+					j9str_printf(buf, bufLen, errorMsg,
 							J9UTF8_LENGTH(senderClassNameUTF),
 							J9UTF8_DATA(senderClassNameUTF),
 							srcModuleMsg,
@@ -1256,7 +1256,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 		 * second is member access flag
 		 * third  is declaring class
 		 */
-		bufLen = j9str_printf(PORTLIB, NULL, 0, errorMsg,
+		bufLen = j9str_printf(NULL, 0, errorMsg,
 				J9UTF8_LENGTH(senderClassNameUTF),
 				J9UTF8_DATA(senderClassNameUTF),
 				modifierStr,
@@ -1266,7 +1266,7 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 			buf = j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 			if (buf) {
 				/* j9str_printf return value doesn't include the NULL terminator */
-				j9str_printf(PORTLIB, buf, bufLen, errorMsg,
+				j9str_printf(buf, bufLen, errorMsg,
 						J9UTF8_LENGTH(senderClassNameUTF),
 						J9UTF8_DATA(senderClassNameUTF),
 						modifierStr,

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -406,7 +406,7 @@ j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion) {
 
 	serviceLevel = j9mem_allocate_memory((UDATA)(size + 1), OMRMEM_CATEGORY_VM);
 	if (NULL != serviceLevel) {
-		j9str_printf(PORTLIB, serviceLevel, size + 1, formatString,
+		j9str_printf(serviceLevel, size + 1, formatString,
 				javaVersion, osname, osarch, ossize, openBracket, runtimeVersion, closeBracket);
 		serviceLevel[size] = '\0';
 

--- a/runtime/vm/swalk.c
+++ b/runtime/vm/swalk.c
@@ -667,10 +667,10 @@ static void walkDescribedPushes(J9StackWalkState * walkState, UDATA * highestSlo
 			char indexedTag[64];
 			PORT_ACCESS_FROM_WALKSTATE(walkState);
 			if (walkState->slotType == J9_STACKWALK_SLOT_TYPE_METHOD_LOCAL) {
-				j9str_printf(PORTLIB, indexedTag, 64, "%s-Slot: %s%d",
-						 (description & 1) ? "O" : "I", (walkState->slotIndex >= (IDATA)argCount) ? "t" : "a", walkState->slotIndex);
+				j9str_printf(indexedTag, 64, "%s-Slot: %s%d",
+						(description & 1) ? "O" : "I", (walkState->slotIndex >= (IDATA)argCount) ? "t" : "a", walkState->slotIndex);
 			} else {
-				j9str_printf(PORTLIB, indexedTag, 64, "%s-Slot: p%d", (description & 1) ? "O" : "I", walkState->slotIndex);
+				j9str_printf(indexedTag, 64, "%s-Slot: p%d", (description & 1) ? "O" : "I", walkState->slotIndex);
 			}
 
 			if (description & 1) {

--- a/runtime/vm/visible.c
+++ b/runtime/vm/visible.c
@@ -250,7 +250,7 @@ setNestmatesError(J9VMThread *vmThread, J9Class *nestMember, J9Class *nestHost, 
 	}
 
 	if (NULL != nlsTemplate) {
-		UDATA msgLen = j9str_printf(PORTLIB, NULL, 0, nlsTemplate,
+		UDATA msgLen = j9str_printf(NULL, 0, nlsTemplate,
 				J9UTF8_LENGTH(nestMemberName), J9UTF8_DATA(nestMemberName),
 				J9UTF8_LENGTH(nestHostName), J9UTF8_DATA(nestHostName),
 				J9UTF8_LENGTH(nestMemberName), J9UTF8_DATA(nestMemberName));
@@ -259,7 +259,7 @@ setNestmatesError(J9VMThread *vmThread, J9Class *nestMember, J9Class *nestHost, 
 
 		/* If msg is NULL we can still throw the exception without it. */
 		if (NULL != msg) {
-			j9str_printf(PORTLIB, msg, msgLen, nlsTemplate,
+			j9str_printf(msg, msgLen, nlsTemplate,
 					J9UTF8_LENGTH(nestMemberName), J9UTF8_DATA(nestMemberName),
 					J9UTF8_LENGTH(nestHostName), J9UTF8_DATA(nestHostName),
 					J9UTF8_LENGTH(nestMemberName), J9UTF8_DATA(nestMemberName));

--- a/runtime/vm/vmbootlib.c
+++ b/runtime/vm/vmbootlib.c
@@ -292,7 +292,7 @@ openNativeLibrary(J9JavaVM *vm, J9ClassLoader *classLoader, const char *libName,
 					}
 					fullPathBufferLength = expectedPathLength;
 				}
-				j9str_printf(PORTLIB, fullPathPtr, expectedPathLength, "%.*s%s%s", pathLength, libraryPath, dirSeparator, libName);
+				j9str_printf(fullPathPtr, expectedPathLength, "%.*s%s%s", pathLength, libraryPath, dirSeparator, libName);
 				result = openFunction(userData, classLoader, libName, fullPathPtr, libraryPtr, errorBuffer, bufferLength, flags | J9PORT_SLOPEN_DECORATE | J9PORT_SLOPEN_NO_LOOKUP_MSG_FOR_NOT_FOUND);
 				if(result == J9NATIVELIB_LOAD_ERR_NOT_FOUND) {
 					result = openFunction(userData, classLoader, libName, fullPathPtr, libraryPtr, errorBuffer, bufferLength, flags | J9PORT_SLOPEN_NO_LOOKUP_MSG_FOR_NOT_FOUND);
@@ -627,7 +627,7 @@ classLoaderRegisterLibrary(void *voidVMThread, J9ClassLoader *classLoader, const
 				/* Proceed to check for the JNI_OnLoad_L() routine.  If not found skip to linking 
 				 * dynamically.
 				 */
-				j9str_printf(PORTLIB, onloadRtnName, nameLength, "%s%s", J9STATIC_ONLOAD, logicalName);
+				j9str_printf(onloadRtnName, nameLength, "%s%s", J9STATIC_ONLOAD, logicalName);
 				RELEASE_CLASS_LOADER_BLOCKS_MUTEX(javaVM);
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 				exitVMToJNI(vmThread);
@@ -668,11 +668,11 @@ classLoaderRegisterLibrary(void *voidVMThread, J9ClassLoader *classLoader, const
 						j9sl_close_shared_library(newNativeLibrary->handle);
 						newNativeLibrary->handle = 0;
 						rc = J9NATIVELIB_LOAD_ERR_JNI_ONLOAD_FAILED;
-						j9str_printf(PORTLIB, 
-									 msgBuffer, 
-									 MAXIMUM_MESSAGE_LENGTH, 
-									 "0x%.8x not a valid JNI version for static linking (1.8 or later required)",
-									 jniVersion);
+						j9str_printf(
+								msgBuffer,
+								MAXIMUM_MESSAGE_LENGTH,
+								"0x%.8x not a valid JNI version for static linking (1.8 or later required)",
+								jniVersion);
 						reportError(errBuf, msgBuffer, bufLen);
 						goto leave_routine;
 					}
@@ -743,11 +743,11 @@ classLoaderRegisterLibrary(void *voidVMThread, J9ClassLoader *classLoader, const
 			if ((FALSE == jniVersionIsValid(jniVersion)) || (NULL != vmThread->currentException)) {
 				char msgBuffer[MAXIMUM_MESSAGE_LENGTH];
 
-				j9str_printf(PORTLIB, 
-							 msgBuffer, 
-							 MAXIMUM_MESSAGE_LENGTH, 
-							 "0x%.8x is not a valid JNI version", 
-							 jniVersion);
+				j9str_printf(
+						msgBuffer,
+						MAXIMUM_MESSAGE_LENGTH,
+						"0x%.8x is not a valid JNI version",
+						jniVersion);
 				if ((UDATA)-1 == jniVersion) {
 					strcpy(msgBuffer, "JNI_OnLoad returned JNI_ERR");
 				}

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -342,7 +342,7 @@ addPropertyForOptionWithModuleListArg(J9JavaVM *vm, const char *optionName, IDAT
 					listSize += strlen(prevList);
 					modulesList = j9mem_allocate_memory(listSize + 2, OMRMEM_CATEGORY_VM); /* +1 for ',' and +1 for '\0' */
 					if (NULL != modulesList) {
-						j9str_printf(PORTLIB, modulesList, listSize + 2, "%s,%s", prevList, optionArg);
+						j9str_printf(modulesList, listSize + 2, "%s,%s", prevList, optionArg);
 						j9mem_free_memory(prevList);
 					} else {
 						j9mem_free_memory(optionArg);
@@ -427,7 +427,7 @@ addPropertiesForOptionWithAssignArg(J9JavaVM *vm, const char *optionName, UDATA 
 					rc = J9SYSPROP_ERROR_OUT_OF_MEMORY;
 					goto _end;
 				}
-				j9str_printf(PORTLIB, propName, propNameLen, "%s%zu", basePropName, index);
+				j9str_printf(propName, propNameLen, "%s%zu", basePropName, index);
 				rc = addSystemProperty(vm, propName, optionArg, J9SYSPROP_FLAG_NAME_ALLOCATED | J9SYSPROP_FLAG_VALUE_ALLOCATED );
 				if (J9SYSPROP_ERROR_NONE != rc) {
 					goto _end;
@@ -441,7 +441,7 @@ addPropertiesForOptionWithAssignArg(J9JavaVM *vm, const char *optionName, UDATA 
 
 			argIndex = FIND_NEXT_ARG_IN_VMARGS_FORWARD(OPTIONAL_LIST_MATCH_USING_EQUALS, optionName, NULL, argIndex);
 			index += 1;
-			indexLen = j9str_printf(PORTLIB, NULL, 0, "%zu", index); /* get number of digits in 'index' */
+			indexLen = j9str_printf(NULL, 0, "%zu", index); /* get number of digits in 'index' */
 		} while (argIndex >= 0);
 		if (NULL != propertyCount) {
 			*propertyCount = index;

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -1545,11 +1545,11 @@ static UDATA printMethodInfo(J9VMThread *currentThread , J9StackWalkState *state
 	char *end = buf + sizeof(buf);
 	PORT_ACCESS_FROM_VMC(currentThread);
 
-	cursor += j9str_printf(PORTLIB, cursor, end - cursor, "\tat %.*s.%.*s%.*s", J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(sig), J9UTF8_DATA(sig));
+	cursor += j9str_printf(cursor, end - cursor, "\tat %.*s.%.*s%.*s", J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(sig), J9UTF8_DATA(sig));
 
 	if (romMethod->modifiers & J9AccNative) {
 	/*increment cursor here by the return of j9str_printf if it needs to be used further*/
-		j9str_printf(PORTLIB, cursor, end - cursor, " (Native Method)");
+		j9str_printf(cursor, end - cursor, " (Native Method)");
 	} else {
 		UDATA offsetPC = state->bytecodePCOffset;
 #ifdef J9VM_OPT_DEBUG_INFO_SERVER
@@ -1558,21 +1558,21 @@ static UDATA printMethodInfo(J9VMThread *currentThread , J9StackWalkState *state
 		if (sourceFile) {
 			IDATA lineNumber = getLineNumberForROMClass(vm, method, offsetPC);
 
-			cursor += j9str_printf(PORTLIB, cursor, end - cursor, " (%.*s", J9UTF8_LENGTH(sourceFile), J9UTF8_DATA(sourceFile));
+			cursor += j9str_printf(cursor, end - cursor, " (%.*s", J9UTF8_LENGTH(sourceFile), J9UTF8_DATA(sourceFile));
 			if (lineNumber != -1) {
-				cursor += j9str_printf(PORTLIB, cursor, end - cursor, ":%zu", lineNumber);
+				cursor += j9str_printf(cursor, end - cursor, ":%zu", lineNumber);
 			}
-			cursor += j9str_printf(PORTLIB, cursor, end - cursor, ")");
+			cursor += j9str_printf(cursor, end - cursor, ")");
 		} else
 #endif
 		{
-			cursor += j9str_printf(PORTLIB, cursor, end - cursor, " (Bytecode PC: %zu)", offsetPC);
+			cursor += j9str_printf(cursor, end - cursor, " (Bytecode PC: %zu)", offsetPC);
 		}
 
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 		if (state->jitInfo != NULL) {
 		/*increment cursor here by the return of j9str_printf if it needs to be used further*/
-			j9str_printf(PORTLIB, cursor, end - cursor, " (Compiled Code)");
+			j9str_printf(cursor, end - cursor, " (Compiled Code)");
 		}
 #endif
 	}
@@ -1627,8 +1627,8 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 			j9tty_err_printf(PORTLIB, "Error: Failed to open dump file %s.\nWill output to stderr instead:\n", fileName);
 		}
 	} else if (vm->sigquitToFileDir != NULL) {
-		j9str_printf(PORTLIB, fileName, EsMaxPath, "%s%s%s%d%s",
-							vm->sigquitToFileDir, DIR_SEPARATOR_STR, SIGQUIT_FILE_NAME, j9time_usec_clock(), SIGQUIT_FILE_EXT);
+		j9str_printf(fileName, EsMaxPath, "%s%s%s%d%s",
+				vm->sigquitToFileDir, DIR_SEPARATOR_STR, SIGQUIT_FILE_NAME, j9time_usec_clock(), SIGQUIT_FILE_EXT);
 		if ((tracefd = j9file_open(fileName, EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666))==-1) {
 			j9tty_err_printf(PORTLIB, "Error: Failed to open trace file %s.\nWill output to stderr instead:\n", fileName);
 		}
@@ -2051,12 +2051,12 @@ setFailedToForkThreadException(J9VMThread *currentThread, IDATA retVal, omrthrea
 			J9NLS_VM_THREAD_CREATE_FAILED_WITH_32BIT_ERRNO2, NULL);
 
 	if (errorMessage) {
-		bufLen = j9str_printf(PORTLIB, NULL, 0, errorMessage, retVal, os_errno, os_errno, (U_32)(UDATA)os_errno2);
+		bufLen = j9str_printf(NULL, 0, errorMessage, retVal, os_errno, os_errno, (U_32)(UDATA)os_errno2);
 		if (bufLen > 0) {
 			buf = (char*)j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 			if (buf) {
 				/* j9str_printf return value doesn't include the NUL terminator */
-				if ((bufLen - 1) == j9str_printf(PORTLIB, buf, bufLen, errorMessage, retVal, os_errno, os_errno, os_errno2, os_errno2)) {
+				if ((bufLen - 1) == j9str_printf(buf, bufLen, errorMessage, retVal, os_errno, os_errno, os_errno2, os_errno2)) {
 					setCurrentExceptionUTF(currentThread, J9_EX_OOM_THREAD | J9VMCONSTANTPOOL_JAVALANGOUTOFMEMORYERROR, buf);
 					rc = 0;
 				}
@@ -2090,12 +2090,12 @@ setFailedToForkThreadException(J9VMThread *currentThread, IDATA retVal, omrthrea
 		J9NLS_VM_THREAD_CREATE_FAILED_WITH_ERRNO, NULL);
 
 	if (errorMessage) {
-		bufLen = j9str_printf(PORTLIB, NULL, 0, errorMessage, retVal, os_errno);
+		bufLen = j9str_printf(NULL, 0, errorMessage, retVal, os_errno);
 		if (bufLen > 0) {
 			buf = (char*)j9mem_allocate_memory(bufLen, OMRMEM_CATEGORY_VM);
 			if (buf) {
 				/* j9str_printf return value doesn't include the NUL terminator */
-				if ((bufLen - 1) == j9str_printf(PORTLIB, buf, bufLen, errorMessage, retVal, os_errno)) {
+				if ((bufLen - 1) == j9str_printf(buf, bufLen, errorMessage, retVal, os_errno)) {
 					setCurrentExceptionUTF(currentThread, J9_EX_OOM_THREAD | J9VMCONSTANTPOOL_JAVALANGOUTOFMEMORYERROR, buf);
 					rc = 0;
 				}

--- a/runtime/zip/zipcache.c
+++ b/runtime/zip/zipcache.c
@@ -201,13 +201,13 @@ const char *zipCache_uniqueId(J9ZipCache * zipCache) {
 			break;
 		}
 	}
-	
-	sizeRequired = j9str_printf(PORTLIB, NULL, 0, "%s_%d_%lld_%d", fileName, zce->zipFileSize, zce->zipTimeStamp, ZIP_CACHE_VERSION);
+
+	sizeRequired = j9str_printf(NULL, 0, "%s_%d_%lld_%d", fileName, zce->zipFileSize, zce->zipTimeStamp, ZIP_CACHE_VERSION);
 	buf = j9mem_allocate_memory(sizeRequired, J9MEM_CATEGORY_VM_JCL);
 	if (!buf) {
 		return NULL;
 	}
-	j9str_printf(PORTLIB, buf, sizeRequired, "%s_%d_%lld_%d", fileName, zce->zipFileSize, zce->zipTimeStamp, ZIP_CACHE_VERSION);
+	j9str_printf(buf, sizeRequired, "%s_%d_%lld_%d", fileName, zce->zipFileSize, zce->zipTimeStamp, ZIP_CACHE_VERSION);
 	return (const char *)buf;
 }
 #endif

--- a/runtime/zip/zipsup.c
+++ b/runtime/zip/zipsup.c
@@ -140,7 +140,7 @@ I_32 initZipLibrary(J9PortLibrary* portLib, char* dir)
 				return ZIP_ERR_OUT_OF_MEMORY;
 			}
 		}
-		j9str_printf(portLib, correctPathPtr, expectedPathLength, "%s/%s", dir, J9_ZIP_DLL_NAME);
+		j9str_printf(correctPathPtr, expectedPathLength, "%s/%s", dir, J9_ZIP_DLL_NAME);
 		if(j9sl_open_shared_library(correctPathPtr, &zipDLLDescriptor, TRUE)) goto openFailed;
 	} else {
 		/* dir is NULL. It shouldn't happen, but in case, revert back to original dlopen that


### PR DESCRIPTION
There's no need to expect users to provide a pointer to the port library (the macro already assumes access via `PORTLIB`); this avoids possible problems being used with a different, incompatible argument.

At least three parameters must be supplied (so the function in `omrstr.c` receives at least four).