### PR TITLE
JProfiling fix to avoid too many internal pointers

### DIFF
--- a/runtime/compiler/optimizer/JProfilingValue.cpp
+++ b/runtime/compiler/optimizer/JProfilingValue.cpp
@@ -317,11 +317,23 @@ void
 TR_JProfilingValue::lowerCalls()
    {
    TR::TreeTop *cursor = comp()->getStartTree();
+   bool stopProfiling = false;
    TR_BitVector *backwardAnalyzedAddressNodesToCheck = new (comp()->trStackMemory()) TR_BitVector();
    while (cursor)
       {
       TR::Node * node = cursor->getNode();
       TR::TreeTop *nextTreeTop = cursor->getNextTreeTop();
+      int32_t ipMax = comp()->maxInternalPointers()/2;
+      static const char * ipl = feGetEnv("TR_ProfilingIPLimit");
+      if (ipl)
+         {
+         static const int32_t ipLimit = atoi(ipl);
+         ipMax = ipLimit;
+         }
+
+      if (!stopProfiling && (comp()->getSymRefTab()->getNumInternalPointers() >= ipMax))
+         stopProfiling = true;
+
       if (node->isProfilingCode() &&
          node->getOpCodeValue() == TR::treetop &&
          node->getFirstChild()->getOpCode().isCall() &&
@@ -354,15 +366,20 @@ TR_JProfilingValue::lowerCalls()
             }
 
          backwardAnalyzedAddressNodesToCheck->empty();
-         TR::Node *child = node->getFirstChild();
-         dumpOptDetails(comp(), "%s Replacing profiling placeholder n%dn with value profiling trees\n",
-            optDetailString(), child->getGlobalIndex());
-         // Extract the arguments and add the profiling trees
-         TR::Node *value = child->getFirstChild();
-         TR_AbstractHashTableProfilerInfo *table = (TR_AbstractHashTableProfilerInfo*) child->getSecondChild()->getAddress();
-         bool needNullTest =  comp()->getSymRefTab()->isNonHelper(child->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueWithNullCHKSymbol);
-         addProfilingTrees(comp(), cursor, value, table, needNullTest, true, trace());
-         // Remove the original trees and continue from the tree after the profiling
+
+         if (!stopProfiling)
+            {
+            TR::Node *child = node->getFirstChild();
+            dumpOptDetails(comp(), "%s Replacing profiling placeholder n%dn with value profiling trees\n",
+               optDetailString(), child->getGlobalIndex());
+            // Extract the arguments and add the profiling trees
+            TR::Node *value = child->getFirstChild();
+            TR_AbstractHashTableProfilerInfo *table = (TR_AbstractHashTableProfilerInfo*) child->getSecondChild()->getAddress();
+            bool needNullTest =  comp()->getSymRefTab()->isNonHelper(child->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueWithNullCHKSymbol);
+            addProfilingTrees(comp(), cursor, value, table, needNullTest, true, trace());
+            // Remove the original trees and continue from the tree after the profiling
+            }
+
          TR::TransformUtil::removeTree(comp(), cursor);
          if (trace())
             comp()->dumpMethodTrees("After Adding Profiling Trees");


### PR DESCRIPTION
Jprofiling adds control flow to the IL as part of the lowering of the calls to profile values. This control flow splits blocks, and in the process creates temps for values commoned across the split point. If there are enough internal pointers commoned in the method, the lower may end up creating more than the max number of internal pointers allowed, thus causing the compile to fail. This commit keeps track of how many internal pointers are created and avoids lowering any more calls once we have reached a certain threshold. Also added an env var to control this threshold for experimenting in the future.