### PR TITLE
CRIU DeadlockTest adds thread synchronization to keep the lock

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -273,7 +273,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image once - CheckpointDeadlock">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  $STD_CMD_OPTS$" $MAINCLASS_DEADLOCK_TEST$ CheckpointDeadlock 1 false false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -Xtrace:print={j9jcl.533,j9vm.684-696,j9vm.699,j9vm.717-743} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  $STD_CMD_OPTS$" $MAINCLASS_DEADLOCK_TEST$ CheckpointDeadlock 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="failure" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore</output>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>


### PR DESCRIPTION
CRIU `DeadlockTest` adds thread synchronization to keep the lock

Ensure the test thread holds the lock while a checkpoint thread attempts to acquire this lock in the single thread mode;
Also add a few log messages and trace points.

Related to
* https://github.com/eclipse-openj9/openj9/issues/19618

Signed-off-by: Jason Feng <fengj@ca.ibm.com>