### PR TITLE
Force outlining for array EA API

### DIFF
--- a/runtime/oti/j9accessbarrier.h
+++ b/runtime/oti/j9accessbarrier.h
@@ -161,14 +161,11 @@ typedef struct J9IndexableObject* mm_j9array_t;
  * 		else
  * 			discontiguous
  */
-#define J9JAVAARRAY_EA(vmThread, array, index, elemType) \
-	((J9IndexableObjectLayout_NoDataAddr_NoArraylet == (vmThread)->indexableObjectLayout) \
-		? J9JAVAARRAYCONTIGUOUS_BASE_EA(vmThread, array, index, elemType) \
-		: ((J9IndexableObjectLayout_DataAddr_NoArraylet == (vmThread)->indexableObjectLayout) \
-			? J9JAVAARRAYCONTIGUOUS_WITH_DATAADDRESS_VIRTUALLARGEOBJECTHEAPENABLED_EA(vmThread, array, index, elemType) \
-			: (J9ISCONTIGUOUSARRAY(vmThread, array) \
-				? J9JAVAARRAYCONTIGUOUS_EA(vmThread, array, index, elemType) \
-				: J9JAVAARRAYDISCONTIGUOUS_EA(vmThread, array, index, elemType))))
+
+
+
+/* Effective Address calculation for callers using vmThread are passed to C implementation, which may force outlining for some platforms. */
+#define J9JAVAARRAY_EA(vmThread, array, index, elemType) j9javaArray_##elemType##_EA(vmThread, (J9IndexableObject *)(array), index)
 
 #define J9JAVAARRAY_EA_VM(javaVM, array, index, elemType) \
 	((J9IndexableObjectLayout_NoDataAddr_NoArraylet == (javaVM)->indexableObjectLayout) \


### PR DESCRIPTION
Macros for Array Effective Address calculations are inherently inlined
and seem to create much pressure either on register or code cash in
Bytecode interpreter.

They are rewritten in C and forced to be outlined specifically for GNU
compilers on X and Z, where we saw regression when Offheap was
introduced (what made the macros more complex, creating even more
pressure).

For other platforms where we did not see regression, we continue to
inline (ATM unknown if outlining would have negative or possitive
effect). Hence we still keep it in a header (*.h) file.