### PR TITLE
Reduce the number of VM_isStable messages

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1275,7 +1275,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          {
          auto recv = client->getRecvData<J9Class *, int>();
          J9Class *fieldClass = std::get<0>(recv);
-         int cpIndex = std::get<1>(recv);
+         int32_t cpIndex = std::get<1>(recv);
 
          bool isStable = fe->isStable(fieldClass, cpIndex);
          client->write(response, isStable);

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -1280,6 +1280,18 @@ JITServerHelpers::getROMClassData(const ClientSessionData::ClassInfo &classInfo,
       }
    }
 
+ClientSessionData::ClassInfo &
+JITServerHelpers::getJ9ClassInfo(TR::CompilationInfoPerThread *threadCompInfo, J9Class *clazz)
+   {
+   // This function assumes that you are inside of _romMapMonitor
+   // Do not use it otherwise
+   auto &classMap = threadCompInfo->getClientData()->getROMClassMap();
+   auto it = classMap.find(clazz);
+   TR_ASSERT_FATAL(it != classMap.end(),"compThreadID %d, ClientData %p, clazz %p: ClassInfo is not in the class map %p!!\n",
+      threadCompInfo->getCompThreadId(), threadCompInfo->getClientData(), clazz, &classMap);
+   return it->second;
+   }
+
 J9ROMMethod *
 JITServerHelpers::romMethodOfRamMethod(J9Method* method)
    {

--- a/runtime/compiler/control/JITServerHelpers.hpp
+++ b/runtime/compiler/control/JITServerHelpers.hpp
@@ -116,6 +116,7 @@ public:
    static bool getAndCacheRAMClassInfo(J9Class *clazz, ClientSessionData *clientSessionData,
                                        JITServer::ServerStream *stream, ClassInfoDataType dataType1, void *data1,
                                        ClassInfoDataType dataType2, void *data2);
+   static ClientSessionData::ClassInfo &getJ9ClassInfo(TR::CompilationInfoPerThread *threadCompInfo, J9Class *clazz);
    static J9ROMMethod *romMethodOfRamMethod(J9Method* method);
 
    static void insertIntoOOSequenceEntryList(ClientSessionData *clientData, TR_MethodToBeCompiled *entry);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1250,9 +1250,8 @@ TR_J9VMBase::getObjectClassInfoFromObjectReferenceLocation(TR::Compilation *comp
    if (knot)
       {
       TR::VMAccessCriticalSection getObjectReferenceLocation(comp);
-      uintptr_t objectReference = getStaticReferenceFieldAtAddress
-         (objectReferenceLocation);
-      ci.clazz   = getObjectClass(objectReference);
+      uintptr_t objectReference = getStaticReferenceFieldAtAddress(objectReferenceLocation);
+      ci.clazz = getObjectClass(objectReference);
       ci.isString = isString(ci.clazz);
       ci.jlClass = getClassClassPointer(ci.clazz);
       ci.isFixedJavaLangClass = (ci.jlClass == ci.clazz);
@@ -3936,7 +3935,7 @@ TR_J9VMBase::canDereferenceAtCompileTimeWithFieldSymbol(TR::Symbol * fieldSymbol
    {
    TR::Compilation *comp = TR::comp();
 
-   if (isStable(cpIndex, owningMethod, comp))
+   if (owningMethod->isStable(cpIndex, comp))
       return true;
 
    switch (fieldSymbol->getRecognizedField())
@@ -4013,37 +4012,7 @@ TR_J9VMBase::canDereferenceAtCompileTime(TR::SymbolReference *fieldRef, TR::Comp
    }
 
 bool
-TR_J9VMBase::isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp)
-   {
-   // NOTE: the field must be resolved!
-
-   if (comp->getOption(TR_DisableStableAnnotations))
-      return false;
-
-   if (cpIndex < 0)
-      return false;
-
-   J9Class *fieldClass = (J9Class*)owningMethod->classOfMethod();
-   if (!fieldClass)
-      return false;
-
-   bool isFieldStable = isStable(fieldClass, cpIndex);
-
-   if (isFieldStable && comp->getOption(TR_TraceOptDetails))
-      {
-      int classLen;
-      const char * className= owningMethod->classNameOfFieldOrStatic(cpIndex, classLen);
-      int fieldLen;
-      const char * fieldName = owningMethod->fieldNameChars(cpIndex, fieldLen);
-      traceMsg(comp, "   Found stable field: %.*s.%.*s\n", classLen, className, fieldLen, fieldName);
-      }
-
-   // Not checking for JCL classes since @Stable annotation only visible inside JCL
-   return isFieldStable;
-   }
-
-bool
-TR_J9VMBase::isStable(J9Class *fieldClass, int cpIndex)
+TR_J9VMBase::isStable(J9Class *fieldClass, int32_t cpIndex)
    {
    TR_ASSERT_FATAL(fieldClass, "fieldClass must not be NULL");
    return jitIsFieldStable(vmThread(), fieldClass, cpIndex);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1081,8 +1081,7 @@ public:
     *    the method accessing the field
     *
     */
-   virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp);
-   virtual bool isStable(J9Class *fieldClass, int cpIndex);
+   virtual bool isStable(J9Class *fieldClass, int32_t cpIndex);
 
    /*
     * \brief
@@ -1671,8 +1670,8 @@ public:
    virtual bool               supportsJitMethodEntryAlignment()               { return false; }
    virtual bool               isBenefitInliningCheckIfFinalizeObject()        { return true; }
    virtual bool               needsContiguousCodeAndDataCacheAllocation()     { return true; }
-   virtual bool               needRelocatableTarget()                          { return true; }
-   virtual bool               isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp) { return false; }
+   virtual bool               needRelocatableTarget()                         { return true; }
+   virtual bool               isStable(J9Class *fieldClass, int32_t cpIndex)  { return false; }
 
    virtual bool               isResolvedDirectDispatchGuaranteed(TR::Compilation *comp);
    virtual bool               isResolvedVirtualDispatchGuaranteed(TR::Compilation *comp);

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -172,7 +172,7 @@ public:
    virtual uintptr_t getClassFlagsValue(TR_OpaqueClassBlock * clazz) override;
    virtual TR_OpaqueMethodBlock *getMethodFromName(const char *className, const char *methodName, const char *signature) override;
    virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, const char *methodName, const char *signature, TR_OpaqueClassBlock *callingClass) override;
-   virtual bool isStable(J9Class *fieldClass, int cpIndex) override;
+   virtual bool isStable(J9Class *fieldClass, int32_t cpIndex) override;
    virtual bool isForceInline(TR_ResolvedMethod *method) override;
    virtual bool isIntrinsicCandidate(TR_ResolvedMethod *method) override;
    virtual bool isDontInline(TR_ResolvedMethod *method) override;
@@ -333,7 +333,7 @@ public:
    virtual bool       isResolvedVirtualDispatchGuaranteed(TR::Compilation *comp) override;
 
    virtual bool shouldDelayAotLoad() override                                  { return true; }
-   virtual bool isStable(int cpIndex, TR_ResolvedMethod *owningMethod, TR::Compilation *comp) override { return false; }
+   virtual bool isStable(J9Class *fieldClass, int32_t cpIndex) override { return false; }
    virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) override;
    virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -6449,6 +6449,33 @@ TR_ResolvedJ9Method::getClassFromCP(TR_J9VMBase *fej9, J9ConstantPool *cp, TR::C
    return result;
    }
 
+bool
+TR_ResolvedJ9Method::isStable(int32_t cpIndex, TR::Compilation *comp)
+   {
+   if (comp->getOption(TR_DisableStableAnnotations))
+      return false;
+
+   if (cpIndex < 0)
+      return false;
+
+   J9Class *fieldClass = (J9Class*)classOfMethod();
+   if (!fieldClass)
+      return false;
+
+   bool isFieldStable = fej9()->isStable(fieldClass, cpIndex);
+
+   if (isFieldStable && comp->getOption(TR_TraceOptDetails))
+      {
+      int classLen;
+      const char * className= classNameOfFieldOrStatic(cpIndex, classLen);
+      int fieldLen;
+      const char * fieldName = fieldNameChars(cpIndex, fieldLen);
+      traceMsg(comp, "   Found stable field: %.*s.%.*s\n", classLen, className, fieldLen, fieldName);
+      }
+
+   return isFieldStable;
+   }
+
 TR_OpaqueClassBlock *
 TR_ResolvedJ9Method::getClassFromConstantPool(TR::Compilation * comp, uint32_t cpIndex, bool)
    {

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -412,6 +412,7 @@ public:
    virtual void *                  callSiteTableEntryAddress(int32_t callSiteIndex);
    virtual bool                    isUnresolvedMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  methodTypeTableEntryAddress(int32_t cpIndex);
+   virtual bool                    isStable(int32_t cpIndex, TR::Compilation *comp) override;
 #if defined(J9VM_OPT_METHOD_HANDLE)
    virtual bool                    isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  varHandleMethodTypeTableEntryAddress(int32_t cpIndex);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 77; // ID: J440z7/ZN5+KF233VhGB
+   static const uint16_t MINOR_NUMBER = 78; // ID: DGwBSxx9FLiSwWTdQCIn
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -424,6 +424,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _fieldOrStaticDeclaringClassCache(decltype(_fieldOrStaticDeclaringClassCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _fieldOrStaticDefiningClassCache(decltype(_fieldOrStaticDefiningClassCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _J9MethodNameCache(decltype(_J9MethodNameCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
+   _isStableCache(decltype(_isStableCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _referencingClassLoaders(decltype(_referencingClassLoaders)::allocator_type(persistentMemory->_persistentAllocator.get()))
    {
    }

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -225,6 +225,7 @@ public:
       // a different API to populate it. In the future we may want to unify these two caches
       PersistentUnorderedMap<int32_t, TR_OpaqueClassBlock *> _fieldOrStaticDefiningClassCache;
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
+      PersistentUnorderedMap<int32_t, bool> _isStableCache; // Store the presence of the Stable annotation for the field indicated by a cpIndex
       PersistentUnorderedSet<J9ClassLoader *> _referencingClassLoaders;
       }; // struct ClassInfo
 


### PR DESCRIPTION
The frontend query `isStable(J9Class *fieldClass, int32_t cpIndex)` determines if the field at given J9Class and cpIndex has the @stable annotation.
Before this commit, the JITServer implementation had to send a VM_isStable message to the client for every such query. This commit implements caching of the isStable values at JITServer. Caching is done with a hashtable per J9Class, where the key is the cpIndex we are interested in.
To further reduce the number of the hashtables that serve as a cache, the `isStable()` will answer `false` for any non-bootstrap class. The reason is that at the moment only bootstrap classs have the @stable annotation. This behavior can be disabled by defining the following environment variable:
`TR_DontIgnoreStableAnnotationForUserClasses`.
Another optimization regards the implementation of `isArrayWithStableElements(cpIndex, owningMethod, comp)`. In here, we first check to see if we are dealing with an array (which is simpler) and only then call the isStable() query.

Depends on https://github.com/eclipse-omr/omr/pull/7642