### PR TITLE
Prevent doube stop of JFR recording

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -484,7 +484,9 @@ public class DiagnosticUtils {
 						Timer timer = new Timer();
 						TimerTask jfrDumpTask = new TimerTask() {
 							public void run() {
-								VM.stopJFR();
+								if (VM.isJFRRecordingStarted()) {
+									VM.stopJFR();
+								}
 							}
 						};
 						timer.schedule(jfrDumpTask, duration);

--- a/test/functional/cmdLineTests/jfr/jfr.xml
+++ b/test/functional/cmdLineTests/jfr/jfr.xml
@@ -24,7 +24,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
-<suite id="JFR Tests" timeout="1800">
+<suite id="JFR Tests" timeout="2400">
 	<envvar name="OPENJ9_METADATA_BLOB_FILE_PATH" value="$METADATA_BLOB_PATH$" />
 	<test id="triggerExecutionSample">
 		<command>$EXE$ -XX:StartFlightRecording --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.TriggerExecutionSample</command>
@@ -42,6 +42,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	<test id="VM API Test - approx 2mins">
 		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest</command>
+		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
+		<output type="failure" caseSensitive="yes" regex="no">Failed</output>
+	</test>
+	<test id="VM API Test aggressive start and stop - approx 2mins">
+		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest 1</command>
+		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
+		<output type="failure" caseSensitive="yes" regex="no">Failed</output>
+	</test>
+	<test id="VM API Test2 - approx 2mins">
+		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest2</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
 		<output type="failure" caseSensitive="yes" regex="no">Failed</output>
 	</test>

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/VMAPITest2.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/VMAPITest2.java
@@ -23,51 +23,55 @@ package org.openj9.test;
 
 import com.ibm.oti.vm.VM;
 
-public class VMAPITest {
+public class VMAPITest2 {
 	public static void main(String[] args) throws Throwable {
 		final WorkLoad workLoad = new WorkLoad(200, 20000, 200);
-		int sleepDuration = 1000;
-
-		if (args.length > 1) {
-			sleepDuration = Integer.parseInt(args[0]);
-		}
-
-		if (VM.isJFRRecordingStarted()) {
-			System.out.println("Failed should not be recording.");
-			return;
-		}
 
 		Thread app = new Thread(() -> {
 			workLoad.runWork();
 		});
 		app.start();
 
-		for (int i = 0; i < 15; i++) {
-			Thread.sleep(100);
-
-			if (VM.startJFR() != 0) {
-				System.out.println("Failed to start.");
-				return;
-			}
-
-			if (!VM.isJFRRecordingStarted()) {
-				System.out.println("Failed to record.");
-				return;
-			}
-
-			if (!VM.setJFRRecordingFileName("sample" + i + ".jfr")) {
-				System.out.println("Failed to set name.");
-				return;
-			}
-
-			Thread.sleep(sleepDuration);
-			VM.jfrDump();
-			VM.stopJFR();
-
-			if (VM.isJFRRecordingStarted()) {
-				System.out.println("Failed to stop recording.");
-				return;
-			}
+		try {
+			Thread.sleep(3000);
+		} catch(Throwable t) {
+			t.printStackTrace();
 		}
+
+		if (VM.isJFRRecordingStarted()) {
+			System.out.println("Failed should not be recording 1.");
+			System.exit(0);
+		}
+
+		/* attempt a stop recording before it has started */
+		VM.stopJFR();
+
+		if (VM.isJFRRecordingStarted()) {
+			System.out.println("Failed should not be recording 2.");
+			System.exit(0);
+		}
+
+		VM.startJFR();
+		if (!VM.isJFRRecordingStarted()) {
+			System.out.println("Failed should be recording 3.");
+			System.exit(0);
+		}
+
+
+		/* attempt another start recording after one has already started */
+		VM.startJFR();
+		if (!VM.isJFRRecordingStarted()) {
+			System.out.println("Failed should be recording 4.");
+			System.exit(0);
+		}
+
+		VM.stopJFR();
+		if (VM.isJFRRecordingStarted()) {
+			System.out.println("Failed should not be recording 5.");
+			System.exit(0);
+		}
+
+		/* attempt a stop recording before it has started */
+		VM.stopJFR();
 	}
 }


### PR DESCRIPTION
There is an issue where jfr recording can be stopped twice. When this occurs buffers that are already free'd are freed a second time.