### PR TITLE
Add functions to GC Table to return min and max young gen size

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -118,6 +118,8 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_get_softmx,
 	j9gc_get_initial_heap_size,
 	j9gc_get_maximum_heap_size,
+	j9gc_get_minimum_young_generation_size,
+	j9gc_get_maximum_young_generation_size,
 	j9gc_objaccess_checkClassLive,
 #if defined(J9VM_GC_OBJECT_ACCESS_BARRIER)
 	j9gc_objaccess_indexableReadI8,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -138,6 +138,8 @@ extern J9_CFUNC jint  JNICALL queryGCStatus(JavaVM *vm, jint *nHeaps, GCStatus *
 extern J9_CFUNC int j9gc_finalizer_startup(J9JavaVM * vm);
 extern J9_CFUNC UDATA j9gc_wait_for_reference_processing(J9JavaVM *vm);
 extern J9_CFUNC UDATA j9gc_get_maximum_heap_size(J9JavaVM *javaVM);
+extern J9_CFUNC UDATA j9gc_get_minimum_young_generation_size(J9JavaVM *javaVM);
+extern J9_CFUNC UDATA j9gc_get_maximum_young_generation_size(J9JavaVM *javaVM);
 extern J9_CFUNC I_32 j9gc_get_jit_string_dedup_policy(J9JavaVM *javaVM);
 extern J9_CFUNC void* j9gc_objaccess_staticReadAddress(J9VMThread *vmThread, J9Class *clazz, void **srcSlot, UDATA isVolatile);
 extern J9_CFUNC IDATA j9gc_objaccess_indexableReadI32(J9VMThread *vmThread, J9IndexableObject *srcObject, I_32 index, UDATA isVolatile);

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -840,6 +840,92 @@ j9gc_get_maximum_heap_size(J9JavaVM *javaVM)
 }
 
 /**
+ * API to return the minimum young generation memory size
+ * for all GC policies that apply:
+ * - Nursery minimum size for Gencon
+ * - Eden minimum size for Balanced
+ * - 0 for all other policies
+ */
+UDATA
+j9gc_get_minimum_young_generation_size(J9JavaVM *javaVM)
+{
+	MM_GCExtensions *ext = MM_GCExtensions::getExtensions(javaVM);
+	OMR_VM *omrVM = javaVM->omrVM;
+	UDATA result = 0;
+
+	switch (omrVM->gcPolicy) {
+	case OMR_GC_POLICY_OPTTHRUPUT:
+		break;
+
+	case OMR_GC_POLICY_OPTAVGPAUSE:
+		break;
+
+	case OMR_GC_POLICY_GENCON:
+		result = ext->minNewSpaceSize;
+		break;
+
+	case OMR_GC_POLICY_METRONOME:
+		break;
+
+	case OMR_GC_POLICY_BALANCED:
+		result = ext->tarokIdealEdenMinimumBytes;
+		break;
+
+	case OMR_GC_POLICY_NOGC:
+		break;
+
+	default:
+		/* Undefined or unknown GC policy */
+		Assert_MM_unreachable();
+		break;
+	}
+	return result;
+}
+
+/**
+ * API to return the maximum young generation memory size
+ * for all GC policies that apply:
+ * - Nursery maximum size for Gencon
+ * - Eden maximum size for Balanced
+ * - 0 for all other policies
+ */
+UDATA
+j9gc_get_maximum_young_generation_size(J9JavaVM *javaVM)
+{
+	MM_GCExtensions *ext = MM_GCExtensions::getExtensions(javaVM);
+	OMR_VM *omrVM = javaVM->omrVM;
+	UDATA result = 0;
+
+	switch (omrVM->gcPolicy) {
+	case OMR_GC_POLICY_OPTTHRUPUT:
+		break;
+
+	case OMR_GC_POLICY_OPTAVGPAUSE:
+		break;
+
+	case OMR_GC_POLICY_GENCON:
+		result = ext->maxNewSpaceSize;
+		break;
+
+	case OMR_GC_POLICY_METRONOME:
+		break;
+
+	case OMR_GC_POLICY_BALANCED:
+		result = ext->tarokIdealEdenMaximumBytes;
+		break;
+
+	case OMR_GC_POLICY_NOGC:
+		break;
+
+	default:
+		/* Undefined or unknown GC policy */
+		Assert_MM_unreachable();
+		break;
+	}
+	return result;
+}
+
+/**
  * API to return a string representing the current GC mode.
  * Examples of the string returned are "optthruput", and "gencon".
  */

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -85,6 +85,8 @@ UDATA j9gc_set_softmx(J9JavaVM *javaVM, UDATA newsoftMx);
 UDATA j9gc_get_softmx(J9JavaVM *javaVM);
 UDATA j9gc_get_initial_heap_size(J9JavaVM *javaVM);
 UDATA j9gc_get_maximum_heap_size(J9JavaVM *javaVM);
+UDATA j9gc_get_minimum_young_generation_size(J9JavaVM *javaVM);
+UDATA j9gc_get_maximum_young_generation_size(J9JavaVM *javaVM);
 const char *j9gc_get_gcmodestring(J9JavaVM *javaVM);
 UDATA j9gc_get_object_size_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 UDATA j9gc_get_object_total_footprint_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4707,6 +4707,8 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA  ( *j9gc_get_softmx)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_get_initial_heap_size)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_get_maximum_heap_size)(struct J9JavaVM *javaVM) ;
+	UDATA  ( *j9gc_get_minimum_young_generation_size)(struct J9JavaVM *javaVM) ;
+	UDATA  ( *j9gc_get_maximum_young_generation_size)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_objaccess_checkClassLive)(struct J9JavaVM *javaVM, J9Class *classPtr) ;
 #if defined(J9VM_GC_OBJECT_ACCESS_BARRIER)
 	IDATA  ( *j9gc_objaccess_indexableReadI8)(struct J9VMThread *vmThread, J9IndexableObject *srcObject, I_32 index, UDATA isVolatile) ;


### PR DESCRIPTION
JFR stats needs API to get YoungGenerationConfiguration->minSize and YoungGenerationConfiguration->maxSize.
For OpenJ9 Gencon use Nursery minimum/maximum sizes. For OpenJ9 Balanced use Eden Ideal minimum/maximum sizes.