### PR TITLE
Add 'lowCodeCacheFreeSpace' field to J9JITConfig

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -743,13 +743,15 @@ J9::CodeCacheManager::almostOutOfCodeCache()
 
    TR::CodeCacheConfig &config = self()->codeCacheConfig();
 
-   // If we can allocate another code cache we are fine
-   // Put common case first
+   // If we can allocate another code cache we are fine.
+   // Put common case first.
    if (self()->canAddNewCodeCache())
+      {
       return false;
+      }
    else
       {
-      // Check the space in the most current code cache
+      // Check the space in the most current code cache.
       bool foundSpace = false;
 
          {
@@ -767,6 +769,7 @@ J9::CodeCacheManager::almostOutOfCodeCache()
       if (!foundSpace)
          {
          _lowCodeCacheSpaceThresholdReached = true;   // Flag can be checked under debugger
+         _jitConfig->lowCodeCacheFreeSpace = 1;
          if (config.verbosePerformance())
             {
             TR_VerboseLog::writeLineLocked(TR_Vlog_CODECACHE,"Reached code cache space threshold. Disabling JIT profiling.");

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4364,6 +4364,7 @@ typedef struct J9JITConfig {
 	void *serverAOTMethodSet;
 	UDATA serverAOTQueryThread;
 #endif /* defined(J9VM_OPT_JITSERVER) */
+	I_32 lowCodeCacheFreeSpace; /* bool set to 1 when the JIT detects a very low amount of free code cache space; never reset */
 } J9JITConfig;
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)


### PR DESCRIPTION
This field is set to 1 by the JIT when it detects that that no additional code cache can be allocated and all of the allocated code caches are very low on free space. This information can be used by other VM components. For example, the GC can use it to trigger class unloading more aggressively, to make more room in the code caches.