### PR TITLE
Handle frame-skipping of jvmtiGetFrameLocation in frame callback

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -182,6 +182,7 @@ public class Continuation {
 	}
 
 	@Hidden
+	@JvmtiMountTransition
 	private static void enter(Continuation cont) {
 		try {
 			cont.runnable.run();
@@ -229,6 +230,7 @@ public class Continuation {
 	 * @return {@link true} or {@link false} based on success/failure
 	 */
 	@Hidden
+	@JvmtiMountTransition
 	public static boolean yield(ContinuationScope scope) {
 		/* TODO find matching scope to yield */
 		Thread carrierThread = JLA.currentCarrierThread();
@@ -238,6 +240,7 @@ public class Continuation {
 	}
 
 	@Hidden
+	@JvmtiMountTransition
 	private boolean yield0() {
 		int rcPinned = isPinnedImpl();
 		if (rcPinned != 0) {


### PR DESCRIPTION
Since frame callback is not called for skipped frame, frames with JvmtiMountTransition annotation will not be correctly handled.

Also added JvmtiMountTransition annotations to `Continuation.enter()`, `Continuation.yield()`, and `Continuation.yield0()`.

Fixes: https://github.com/eclipse-openj9/openj9/issues/20541