### PR TITLE
Remove support for the obsolute uma and cm spec suffixes

### DIFF
--- a/buildenv/jenkins/README.md
+++ b/buildenv/jenkins/README.md
@@ -84,7 +84,6 @@ This folder contains Jenkins pipeline scripts that are used in the OpenJ9 Jenkin
     - ALL
         - Launches a subset of 'all' platforms
         - ppc64le_linux, s390x_linux, x86-64_linux, aarch64_linux, ppc64_aix, x86-64_windows, x86-32_windows, x86-64_mac, aarch64_mac
-- Many specs support a suffix of `_cm` or `_uma` (omit the leading underscore for shortnames) to override the default build system.
 - OpenJ9 committers can request builds by commenting in a pull request
     - Format: `Jenkins <build type> <level>.<group>[+<test_flag>] <platform>[,<platform>,...,<platform>] jdk<version>[,jdk<version>,...,jdk<version>]`
     - `<build type>` is compile | test

--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -800,7 +800,7 @@ def move_spec_suffix_to_id(spec, id) {
     def spec_id = [:]
     spec_id['spec'] = spec
     spec_id['id'] = id
-    for (suffix in ['aot', 'cm', 'jit', 'ojdk292', 'uma', 'valhalla', 'vt_standard']) {
+    for (suffix in ['aot', 'jit', 'ojdk292', 'valhalla', 'vt_standard']) {
         if (spec.contains("_${suffix}")) {
             spec_id['spec'] = spec - "_${suffix}"
             spec_id['id'] = "${suffix}_" + id

--- a/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
+++ b/buildenv/jenkins/jobs/infrastructure/wrapper_variables.yml
@@ -36,7 +36,7 @@ Nightly:
             Java12: true
             Javanext: false
         string_parameters:
-            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,ppc64le_linux_xl,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
+            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux,ppc64le_linux,ppc64le_linux_xl,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
             TEST_TARGETS: "sanity.functional,extended.functional,sanity.system,extended.system"
             RESTART_TIMEOUT: "12"
             TIMEOUT_TIME: "14"
@@ -71,7 +71,7 @@ OMR_Acceptance:
             Java12: false
             PROMOTE_OMR: true
         string_parameters:
-            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,ppc64le_linux_xl,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
+            PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux,ppc64le_linux,ppc64le_linux_xl,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
             TEST_TARGETS: "sanity.functional"
             RESTART_TIMEOUT: ""
         choice_parameters:
@@ -160,7 +160,7 @@ PullRequest-OpenJDK:
 general:
     parameter_descriptions:
         TEST_TARGETS: "Use `none` for no testing.\nsanity.functional,extended.functional,sanity.system,extended.system"
-        PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux_cm,ppc64le_linux,ppc64le_linux_xl,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
+        PLATFORMS: "ppc64_aix,x86-64_linux,x86-64_linux_xl,x86-64_linux,ppc64le_linux,ppc64le_linux_xl,s390x_linux,s390x_linux_xl,x86-64_windows,x86-32_windows,x86-64_mac"
         RESTART_TIMEOUT: "Time allowed to restart a job"
         TIMEOUT_TIME: "Overall build timeout"
     repository_url: "https://github.com/eclipse-openj9/openj9.git"


### PR DESCRIPTION
Not sure if it ever worked, but it certainly won't now after https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/928 and backports.