### PR TITLE
CRIU DeadlockTest adds thread synchronization to prevent premature exit

### DIFF
--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -291,7 +291,7 @@
   </test>
 
   <test id="Create and Restore Criu Checkpoint Image once - NotCheckpointSafeDeadlock">
-    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:+ThrowOnDelayedCheckpointOperation -Xtrace:print=j9vm.731 --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  $STD_CMD_OPTS$" $MAINCLASS_DEADLOCK_TEST$ NotCheckpointSafeDeadlock 1 false false</command>
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:+ThrowOnDelayedCheckpointOperation -Xtrace:print={j9jcl.533,j9vm.684-696,j9vm.699,j9vm.717-743} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED  $STD_CMD_OPTS$" $MAINCLASS_DEADLOCK_TEST$ NotCheckpointSafeDeadlock 1 false false</command>
     <output type="success" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="failure" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore</output>
     <output type="success" caseSensitive="yes" regex="no">TEST PASSED</output>


### PR DESCRIPTION
CRIU `DeadlockTest` adds thread synchronization to prevent premature exit

Ensure a test thread with `@NotCheckpointSafe` is running while another thread attempts to checkpoint in the single thread mode;
Also add a few log messages and trace points.

Related to
* https://github.com/eclipse-openj9/openj9/issues/20832

Signed-off-by: Jason Feng <fengj@ca.ibm.com>