### PR TITLE
Add support for JFR type IDs

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -350,8 +350,20 @@ Java_jdk_jfr_internal_JVM_getTypeId(JNIEnv *env, jobject obj, jclass clazz)
 Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_Class_2(JNIEnv *env, jobject obj, jclass clazz)
 #endif /* JAVA_SPEC_VERSION == 11 */
 {
-	// TODO: implementation
-	return 0;
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+
+	j9object_t classObject = J9_JNI_UNWRAP_REFERENCE(clazz);
+	J9Class *ramClass = J9VMJAVALANGCLASS_VMREF(currentThread, classObject);
+
+	jlong result = vmFuncs->getTypeId(currentThread, ramClass);
+
+	vmFuncs->internalExitVMToJNI(currentThread);
+
+	return result;
 }
 
 jobject JNICALL

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -183,6 +183,7 @@ typedef struct J9ClassLoaderWalkState {
 #define J9UTF8_DATA_EQUALS(data1, length1, data2, length2) ((((length1) == (length2)) && (memcmp((data1), (data2), (length1)) == 0)))
 #define J9UTF8_EQUALS(utf1, utf2) (((utf1) == (utf2)) || (J9UTF8_DATA_EQUALS(J9UTF8_DATA(utf1), J9UTF8_LENGTH(utf1), J9UTF8_DATA(utf2), J9UTF8_LENGTH(utf2))))
 #define J9UTF8_LITERAL_EQUALS(data1, length1, cString) (J9UTF8_DATA_EQUALS((data1), (length1), (cString), sizeof(cString) - 1))
+#define J9UTF8_LITERAL_EQUALS_UTF8(utf8, cString) (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA((utf8)), J9UTF8_LENGTH((utf8)), cString))
 
 /*
  * Equivalent to ((int)strlen(string_literal)) when given a literal string.

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3640,6 +3640,9 @@ typedef struct J9ClassLoader {
 	omrthread_rwmutex_t cpEntriesMutex;
 	UDATA initClassPathEntryCount;
 	UDATA asyncGetCallTraceUsed;
+#if defined(J9VM_OPT_JFR)
+	J9HashTable *typeIDs;
+#endif /* defined(J9VM_OPT_JFR) */
 } J9ClassLoader;
 
 #define J9CLASSLOADER_SHARED_CLASSES_ENABLED  8
@@ -5305,6 +5308,8 @@ typedef struct J9InternalVMFunctions {
 	void (*jfrExecutionSample)(struct J9VMThread *currentThread, struct J9VMThread *sampleThread);
 	jboolean (*setJFRRecordingFileName)(struct J9JavaVM *vm, char *fileName);
 	void (*tearDownJFR)(struct J9JavaVM *vm);
+	jlong (*getTypeIdUTF8)(struct J9VMThread *currentThread, const struct J9UTF8 *className);
+	jlong (*getTypeId)(struct J9VMThread *currentThread, struct J9Class *clazz);
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	void (*initializeSnapshotClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);
@@ -5760,6 +5765,8 @@ typedef struct JFRState {
 	int64_t prevProcTimestamp;
 	int64_t prevContextSwitchTimestamp;
 	uint64_t prevContextSwitches;
+	omrthread_monitor_t typeIDMonitor;
+	jlong typeIDcount;
 } JFRState;
 
 typedef struct J9ReflectFunctionTable {

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5519,6 +5519,44 @@ setJFRRecordingFileName(J9JavaVM *vm, char *fileName);
 void
 tearDownJFR(J9JavaVM *vm);
 
+/**
+ * Get the type ID for the JFR event type. This operation is
+ * thread safe as it internally acquires a mutex. Only
+ * subclasses of jdk.jfr.event.Event can be called with this
+ * function, this is enforced at the JCL level.
+ *
+ * @param currentThread[in] the current J9VMThread
+ * @param clazz JFR event class
+ */
+jlong
+getTypeId(J9VMThread *currentThread, J9Class *clazz);
+
+/**
+ * Get the type ID for the JFR event type. This operation is
+ * thread safe as it internally acquires a mutex.
+ *
+ * @param currentThread[in] the current J9VMThread
+ * @param className name of JFR event class
+ */
+jlong
+getTypeIdUTF8(J9VMThread *currentThread, const J9UTF8 *className);
+
+/**
+ * Initialize JFR ID structures
+ *
+ * @param vm[in] the J9JavaVM
+ */
+UDATA
+initializeJFRIDs(J9JavaVM *vm);
+
+/**
+ * Shutdown JFR ID structures
+ *
+ * @param vm[in] the J9JavaVM
+ */
+void
+shutdownJFRIDs(J9JavaVM *vm);
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 #ifdef __cplusplus

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -471,6 +471,8 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jfrExecutionSample,
 	setJFRRecordingFileName,
 	tearDownJFR,
+	getTypeIdUTF8,
+	getTypeId,
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	initializeSnapshotClassLoaderObject,

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1012,3 +1012,8 @@ TraceEntry=Trc_VM_snapshot_subAllocateSnapshotMemory_Entry NoEnv Overhead=1 Leve
 TraceExit=Trc_VM_snapshot_subAllocateSnapshotMemory_Exit NoEnv Overhead=1 Level=3 Template="subAllocateMemory() Memory allocated = %p."
 TraceEvent=Trc_VM_snapshot_loadWarmClassFromSnapshot_ClassLoadHookFailed Overhead=1 Level=3 Template="loadWarmClassFromSnapshot() Warm class load hook failed class=%p, %s"
 TraceEvent=Trc_VM_snapshot_loadWarmClassFromSnapshot_ClassInfo Overhead=1 Level=3 Template="loadWarmClassFromSnapshot() LoadClass clazz=%p, %s"
+
+TraceEntry=Trc_VM_getTypeIdUTF8_Entry Overhead=1 Level=5 Template="getTypeIdUTF8 className %.*s"
+TraceExit=Trc_VM_getTypeIdUTF8_Exit Overhead=1 Level=5 Template="getTypeIdUTF8 className %.*s clazz=%p result=%lli"
+TraceEntry=Trc_VM_getTypeId_Entry Overhead=1 Level=5 Template="getTypeId clazz=%p"
+TraceExit=Trc_VM_getTypeId_Exit Overhead=1 Level=5 Template="getTypeId clazz=%p result=%lli"

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -49,7 +49,7 @@
 
 static void trcModulesFreeJ9ModuleEntry(J9JavaVM *javaVM, J9Module *j9module);
 
-void 
+void
 freeClassLoaderEntries(J9VMThread * vmThread, J9ClassPathEntry **entries, UDATA count, UDATA initCount)
 {
 	/* free memory allocated to class path entries */
@@ -203,7 +203,7 @@ recycleVMThread(J9VMThread * vmThread)
 }
 
 
-void 
+void
 deallocateVMThread(J9VMThread * vmThread, UDATA decrementZombieCount, UDATA sendThreadDestroyEvent)
 {
 	J9JavaVM * vm = vmThread->javaVM;
@@ -242,7 +242,7 @@ deallocateVMThread(J9VMThread * vmThread, UDATA decrementZombieCount, UDATA send
 		print_verbose_stackUsage(vmThread, FALSE);
 	}
 #endif
-	
+
 	/* vm->memoryManagerFunctions will be NULL if we failed to load the gc dll */
 	if (NULL != vm->memoryManagerFunctions) {
 		/* Make sure the memory manager does anything needed before shutting down */
@@ -286,7 +286,7 @@ deallocateVMThread(J9VMThread * vmThread, UDATA decrementZombieCount, UDATA send
 			currentStack = previous;
 		} while (currentStack);
 	}
-	
+
 	if (vmThread->privateFlags & J9_PRIVATE_FLAGS_DAEMON_THREAD) {
 		--(vm->daemonThreadCount);
 	}
@@ -412,7 +412,7 @@ freeJ9Module(J9JavaVM *javaVM, J9Module *j9module) {
 	Trc_MODULE_freeJ9Module_exit(j9module);
 }
 
-#if (defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)) 
+#if (defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING))
 /**
  * Perform classloader-specific cleanup.  The current thread has exclusive access.
  * J9HOOK_VM_CLASS_LOADER_UNLOAD is triggered.
@@ -422,7 +422,7 @@ freeJ9Module(J9JavaVM *javaVM, J9Module *j9module) {
  * @param classLoader the classloader to cleanup
  */
 void
-cleanUpClassLoader(J9VMThread *vmThread, J9ClassLoader* classLoader) 
+cleanUpClassLoader(J9VMThread *vmThread, J9ClassLoader* classLoader)
 {
 	J9JavaVM *javaVM = vmThread->javaVM;
 	Trc_VM_cleanUpClassLoaders_Entry(vmThread, classLoader);
@@ -438,6 +438,13 @@ cleanUpClassLoader(J9VMThread *vmThread, J9ClassLoader* classLoader)
 	if (NULL != classLoader->classHashTable) {
 		hashClassTableFree(classLoader);
 	}
+
+#if defined(J9VM_OPT_JFR)
+	if (NULL != classLoader->typeIDs) {
+		hashTableFree(classLoader->typeIDs);
+		classLoader->typeIDs = NULL;
+	}
+#endif /* defined(J9VM_OPT_JFR) */
 
 	/* Free the rom class orphans class table */
 	if (NULL != classLoader->romClassOrphansHashTable) {

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -647,6 +647,12 @@ freeJavaVM(J9JavaVM * vm)
 	j9sig_set_async_signal_handler(sigxfszHandler, NULL, 0);
 #endif /* !defined(WIN32) */
 
+#if defined(J9VM_OPT_JFR)
+	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_JFR_ENABLED)) {
+		shutdownJFRIDs(vm);
+	}
+#endif /* defined(J9VM_OPT_JFR) */
+
 #if JAVA_SPEC_VERSION >= 16
 	if (NULL != vm->cifNativeCalloutDataCache) {
 		pool_state poolState;
@@ -2286,6 +2292,14 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 			if (0 != initializeHiddenInstanceFieldsList(vm)) {
 				goto _error;
 			}
+
+#if defined(J9VM_OPT_JFR)
+			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_JFR_ENABLED)) {
+				if (0 != initializeJFRIDs(vm)) {
+					goto _error;
+				}
+			}
+#endif /* defined(J9VM_OPT_JFR) */
 
 			if (FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XALLOWCONTENDEDCLASSLOAD, NULL) >= 0) {
 				contendedLoadTableFree(vm);


### PR DESCRIPTION
A unique type ID is assigned to each JFR event type. In a subsequent PR these type IDs will be used to generate the metadata blob file.