### PR TITLE
Command line option to control CS relative headroom

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1002,6 +1002,29 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->concurrentScavengeExhaustiveTermination = false;
 			continue;
 		}
+
+		if (try_scan(&scan_start, "concurrentScavengeAllocAverageBoost=")) {
+			UDATA value = 0;
+			if (!scan_udata_helper(vm, &scan_start, &value, "concurrentScavengeAllocAverageBoost=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+
+			extensions->concurrentScavengerAllocAverageBoost = value / 100.0f;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "concurrentScavengeAllocDeviationBoost=")) {
+			UDATA value = 0;
+			if (!scan_udata_helper(vm, &scan_start, &value, "concurrentScavengeAllocDeviationBoost=")) {
+				returnValue = JNI_EINVAL;
+				break;
+			}
+
+			extensions->concurrentScavengerAllocDeviationBoost = value / 100.0f;
+			continue;
+		}
+
 #endif /* defined(OMR_GC_CONCURRENT_SCAVENGER) */
 
 #endif /* defined(J9VM_GC_MODRON_SCAVENGER) */

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -305,16 +305,6 @@ j9gc_initialize_parse_gc_colon(J9JavaVM *javaVM, char **scan_start)
 		goto _exit;
 	}
 
-	if(try_scan(scan_start, "concurrentScavengeAllocDeviationBoost=")) {
-		UDATA value;
-		if(!scan_udata_helper(javaVM, scan_start, &value, "concurrentScavengeAllocDeviationBoost=")) {
-			goto _error;
-		}
-
-		extensions->concurrentScavengerAllocDeviationBoost = value / (float)10.0;
-		goto _exit;
-	}
-
 	if(try_scan(scan_start, "concurrentScavengeBackground=")) {
 		if(!scan_udata_helper(javaVM, scan_start, &extensions->concurrentScavengerBackgroundThreads, "concurrentScavengeBackground=")) {
 			goto _error;


### PR DESCRIPTION
Introduce -XXgc:concurrentScavengeAllocAverageBoost= option to control
headroom for CS. Similar to existing -Xgc:concurrentScavengeSlack=.

The former is a relative boost factor (to the existing allocation rate),
and the latter is an absoulte number in bytes.

Either one can be used to help with noisy applications with spikes in
allocations.

Also moving concurrentScavengeAllocDeviationBoost from -Xgc to -XXgc,
since both boost options are unlikely to be used with customers.

The values specified are integers that are 100x larger then the desired
values.

For example, 130 actually represents 1.30x boost factor.