### PR TITLE
Support Accelerating ArraysSupport.vectorizedMismatch for OffHeap

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -79,9 +79,6 @@ J9::ARM64::CodeGenerator::initialize()
 
    static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
    if (cg->getSupportsArrayCmpLen() &&
-#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-         !TR::Compiler->om.isOffHeapAllocationEnabled() &&
-#endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
          !disableInlineVectorizedMismatch)
       {
       cg->setSupportsInlineVectorizedMismatch();

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -79,9 +79,6 @@ J9::Power::CodeGenerator::initialize()
 
    static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
    if (cg->getSupportsArrayCmpLen() &&
-#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-         !TR::Compiler->om.isOffHeapAllocationEnabled() &&
-#endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
          !disableInlineVectorizedMismatch)
       {
       cg->setSupportsInlineVectorizedMismatch();

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -141,9 +141,6 @@ J9::X86::CodeGenerator::initialize()
 
    static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
    if (cg->getSupportsArrayCmpLen() &&
-#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-         !TR::Compiler->om.isOffHeapAllocationEnabled() &&
-#endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
          !disableInlineVectorizedMismatch)
       {
       cg->setSupportsInlineVectorizedMismatch();

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -155,9 +155,6 @@ J9::Z::CodeGenerator::initialize()
 
    static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
    if (cg->getSupportsArrayCmpLen() &&
-#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-         !TR::Compiler->om.isOffHeapAllocationEnabled() &&
-#endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
          !disableInlineVectorizedMismatch)
       {
       cg->setSupportsInlineVectorizedMismatch();


### PR DESCRIPTION
Support the acceleration of vectorizedMisMatch for OffHeap implementation by adding a block of code to calculate the address of the arrays, while accounting for null values.