### PR TITLE
Eliminate 'override' qualifier from funtion prototype

### DIFF
--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -412,7 +412,7 @@ public:
    virtual void *                  callSiteTableEntryAddress(int32_t callSiteIndex);
    virtual bool                    isUnresolvedMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  methodTypeTableEntryAddress(int32_t cpIndex);
-   virtual bool                    isStable(int32_t cpIndex, TR::Compilation *comp) override;
+   virtual bool                    isStable(int32_t cpIndex, TR::Compilation *comp);
 #if defined(J9VM_OPT_METHOD_HANDLE)
    virtual bool                    isUnresolvedVarHandleMethodTypeTableEntry(int32_t cpIndex);
    virtual void *                  varHandleMethodTypeTableEntryAddress(int32_t cpIndex);


### PR DESCRIPTION
On some platforms the C++ compiler is not C++-11 compliant and generates a compilation error when a method is declared as `override`