### PR TITLE
Do not build class verification exit tracepoint by default

### DIFF
--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -271,7 +271,10 @@ performVerification(J9VMThread *currentThread, J9Class *clazz)
 		}
 	}
 done:
+#if defined(J9VM_OPT_INCLUDE_CLASSVERIFY_EXIT_TRACEPOINT)
+	/* This tracepoint can introduce startup regressions even when disabled, so don't build into the VM by default */
 	Trc_VM_performVerification_Exit(currentThread);
+#endif
 	return;
 }
 


### PR DESCRIPTION
Adds a J9VM_OPT_INCLUDE_CLASSVERIFY_EXIT_TRACEPOINT macro (not defined by default) to guard the recently (re?)introduced VerifyExit tracepoint, which resulted in some start-up regressions in -Xint mode.