### PR TITLE
Improve definition of j9tty_err_printf()

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1770,7 +1770,7 @@ static void initThreadAfterCreation(J9VMThread *vmThread)
 
          if ((tracefp = j9file_open(fileName, EsOpenWrite | EsOpenAppend | EsOpenCreate, 0644)) == -1)
             {
-            j9tty_err_printf(PORTLIB, "Error: Failed to open jit trace file %s.\n", fileName);
+            j9tty_err_printf("Error: Failed to open jit trace file %s.\n", fileName);
             }
 
          VMTHREAD_TRACINGBUFFER_FH(vmThread) = tracefp;

--- a/runtime/compiler/env/jitsupport.cpp
+++ b/runtime/compiler/env/jitsupport.cpp
@@ -300,7 +300,7 @@ I_32 j9jit_vfprintf(TR::FILE *pFile, const char *format, va_list args)
    if (!pFile || pFile == TR::IO::Stdout)
       j9tty_printf(privatePortLibrary, "%s", buf);
    else if (pFile == TR::IO::Stderr)
-      j9tty_err_printf(privatePortLibrary, "%s", buf);
+      j9tty_err_printf("%s", buf);
    else
       {
       char *bufPtr = buf;

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -150,7 +150,7 @@ jint computeFullVersionString(J9JavaVM* vm)
 			EsBuildVersionString,
 			jitEnabled,
 			aotEnabled)) {
-		j9tty_err_printf(PORTLIB, "\n%s - %d: %s: Error: Java VM info string exceeds buffer size\n", __FILE__, __LINE__, __FUNCTION__);
+		j9tty_err_printf("\n%s - %d: %s: Error: Java VM info string exceeds buffer size\n", __FILE__, __LINE__, __FUNCTION__);
 		return JNI_ERR;
 	}
 

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -129,7 +129,7 @@ J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 			}
 
 			if ((*hook)->J9HookRegisterWithCallSite(hook, J9HOOK_VM_NATIVE_METHOD_RETURN, methodExitHook, OMR_GET_CALLSITE(), NULL)) {
-				j9tty_err_printf(PORTLIB, "<JNI check utility: unable to hook event>\n");
+				j9tty_err_printf("<JNI check utility: unable to hook event>\n");
 				return J9VMDLLMAIN_FAILED;
 			}
 

--- a/runtime/jvmti/jvmtiStartup.c
+++ b/runtime/jvmti/jvmtiStartup.c
@@ -402,7 +402,7 @@ IDATA J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 			J9JVMTIData *jvmtiData = J9JVMTI_DATA_FROM_VM(vm);
 			if (hookGlobalEvents(jvmtiData)) {
 				PORT_ACCESS_FROM_JAVAVM(vm);
-				j9tty_err_printf(PORTLIB, "Need NLS message here\n");
+				j9tty_err_printf("Need NLS message here\n");
 				goto _error;
 			}
 

--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -569,7 +569,7 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9tty_printf(param1,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_printf(OMRPORT_FROM_J9PORT(param1), ## __VA_ARGS__)
 #define j9tty_vprintf(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_vprintf(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #define j9tty_get_chars(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_get_chars(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
-#define j9tty_err_printf(param1,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_err_printf(OMRPORT_FROM_J9PORT(param1), ## __VA_ARGS__)
+#define j9tty_err_printf(param1,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_err_printf(OMRPORT_FROM_J9PORT(privatePortLibrary), param1, ## __VA_ARGS__)
 #define j9tty_err_vprintf(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_err_vprintf(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #define j9tty_available() OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_available(OMRPORT_FROM_J9PORT(privatePortLibrary))
 #define j9tty_daemonize() OMRPORT_FROM_J9PORT(privatePortLibrary)->tty_daemonize(OMRPORT_FROM_J9PORT(privatePortLibrary))

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-
 /*
  * Note: remove this when portlib supports launching of executables
  */
@@ -625,7 +624,7 @@ doConsoleDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 	J9JavaVM *vm = context->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	j9tty_err_printf(PORTLIB, "-------- Console dump --------\n");
+	j9tty_err_printf("-------- Console dump --------\n");
 
 	/* Fatal dumps to stderr default to the old-style gpThreadDump */
 	if ( (context->eventFlags & J9RAS_DUMP_ON_GP_FAULT) && *label == '-' && FIND_DUMP_QUEUE(vm, queue) ) {
@@ -647,7 +646,7 @@ doConsoleDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 		vm->internalVMFunctions->printThreadInfo(vm, self, *label == '-' ? NULL : label, TRUE);
 	}
 
-	j9tty_err_printf(PORTLIB, "\n^^^^^^^^ Console dump ^^^^^^^^\n");
+	j9tty_err_printf("\n^^^^^^^^ Console dump ^^^^^^^^\n");
 
 	return OMR_ERROR_NONE;
 }
@@ -1836,18 +1835,18 @@ printDumpSpec(struct J9JavaVM *vm, IDATA kind, IDATA verboseLevel)
 
 			if ( verboseLevel > 1 ) {
 
-				j9tty_err_printf(PORTLIB,
+				j9tty_err_printf(
 					"\n%s:\n\n"
 					"  -Xdump:%s[:defaults][:<option>=<value>, ...]\n",
 					spec->summary,
 					spec->name
 				);
 
-				j9tty_err_printf(PORTLIB, "\nDump options:\n\n");
+				j9tty_err_printf("\nDump options:\n\n");
 
-				j9tty_err_printf(PORTLIB, "  events=<name>        Trigger dump on named events\n"
+				j9tty_err_printf("  events=<name>        Trigger dump on named events\n"
 					"       [+<name>...]      (see -Xdump:events)\n\n");
-				j9tty_err_printf(PORTLIB, "  filter=[*]<name>[*]  Filter on class (for load)\n"
+				j9tty_err_printf("  filter=[*]<name>[*]  Filter on class (for load)\n"
 					"         [*]<name>[*]  Filter on exception (for throw,systhrow,uncaught)\n"
 					"         [*]<name>#<class>.<method>[*]  with throwing class and method\n"
 					"         [*]<name>#<class>.<method>#<offset>  with throwing class stack offset\n"
@@ -1856,36 +1855,34 @@ printDumpSpec(struct J9JavaVM *vm, IDATA kind, IDATA verboseLevel)
 					"         #<n>[..<m>]            Filter on exit codes (for vmstop)\n"
 					"         #<msecs>ms             Filter on time (for slow)\n"
 					"         #<i>[k|m][..<j>[k|m]]  Filter on object size (for allocation)\n\n");
-				j9tty_err_printf(PORTLIB, "  msg_filter=[*]<string>[*] Filter based on the exception message string\n");
-				j9tty_err_printf(PORTLIB, "  %s<label>         %s\n",
+				j9tty_err_printf("  msg_filter=[*]<string>[*] Filter based on the exception message string\n");
+				j9tty_err_printf("  %s<label>         %s\n",
 					spec->labelTag, spec->labelDescription);
-				j9tty_err_printf(PORTLIB, "  range=<n>..<m>       Limit dumps\n");
-				j9tty_err_printf(PORTLIB, "  priority=<n>         Highest first\n");
-				j9tty_err_printf(PORTLIB, "  request=<name>       Request additional VM actions\n"
+				j9tty_err_printf("  range=<n>..<m>       Limit dumps\n");
+				j9tty_err_printf("  priority=<n>         Highest first\n");
+				j9tty_err_printf("  request=<name>       Request additional VM actions\n"
 					"        [+<name>...]     (see -Xdump:request)\n");
 
 				if (strcmp(spec->name, "heap") == 0) {
-					j9tty_err_printf(PORTLIB, "\n  opts=PHD|CLASSIC\n");
+					j9tty_err_printf("\n  opts=PHD|CLASSIC\n");
 				} else if (strcmp(spec->name, "tool") == 0) {
-					j9tty_err_printf(PORTLIB, "\n  opts=WAIT<msec>|ASYNC\n");
+					j9tty_err_printf("\n  opts=WAIT<msec>|ASYNC\n");
 #ifdef J9ZOS390
 				} else if (strcmp(spec->name, "system") == 0) {
-					j9tty_err_printf(PORTLIB, "\n  opts=IEATDUMP|CEEDUMP\n");
+					j9tty_err_printf("\n  opts=IEATDUMP|CEEDUMP\n");
 #endif
 				} else {
-					j9tty_err_printf(PORTLIB, "\n  opts=<NONE>\n");
+					j9tty_err_printf("\n  opts=<NONE>\n");
 				}
 			}
 
-			j9tty_err_printf(PORTLIB,
-				"\nDefault -Xdump:%s settings:\n\n",
-				spec->name);
+			j9tty_err_printf("\nDefault -Xdump:%s settings:\n\n", spec->name);
 
 			/* Use compact form */
-			j9tty_err_printf(PORTLIB, "  events=");
+			j9tty_err_printf("  events=");
 			printDumpEvents(vm, tmpSettings.eventMask, 0);
 
-			j9tty_err_printf(PORTLIB,
+			j9tty_err_printf(
 				"\n"
 				"  filter=%s\n"
 				"  %s%s\n"
@@ -1898,14 +1895,14 @@ printDumpSpec(struct J9JavaVM *vm, IDATA kind, IDATA verboseLevel)
 			);
 
 			/* Use compact form */
-			j9tty_err_printf(PORTLIB, "  request=");
+			j9tty_err_printf("  request=");
 			printDumpRequests(vm, tmpSettings.requestMask, 0);
 
-			j9tty_err_printf(PORTLIB, "\n  opts=%s\n\n",
+			j9tty_err_printf("\n  opts=%s\n\n",
 				tmpSettings.dumpOptions ? tmpSettings.dumpOptions : "");
 
 		} else {
-			j9tty_err_printf(PORTLIB, "  -Xdump:%s%*c%s\n", spec->name, 17-strlen(spec->name), ' ', spec->summary);
+			j9tty_err_printf("  -Xdump:%s%*c%s\n", spec->name, 17-strlen(spec->name), ' ', spec->summary);
 		}
 
 		return OMR_ERROR_NONE;
@@ -1940,15 +1937,15 @@ printDumpEvents(struct J9JavaVM *vm, UDATA bits, IDATA verbose)
 
 	/* Header */
 	if (verbose) {
-		j9tty_err_printf(PORTLIB, "  Name%*cEvent hook\n  ", maxNameLength - 2, ' ');
+		j9tty_err_printf("  Name%*cEvent hook\n  ", maxNameLength - 2, ' ');
 		for (i = 0; i < maxNameLength; i++) {
-			j9tty_err_printf(PORTLIB, "-");
+			j9tty_err_printf("-");
 		}
-		j9tty_err_printf(PORTLIB, "  ");
+		j9tty_err_printf("  ");
 		for (i = 0; i < maxDetailLength; i++) {
-			j9tty_err_printf(PORTLIB, "-");
+			j9tty_err_printf("-");
 		}
-		j9tty_err_printf(PORTLIB, "\n");
+		j9tty_err_printf("\n");
 	}
 
 	/* Events */
@@ -1956,9 +1953,9 @@ printDumpEvents(struct J9JavaVM *vm, UDATA bits, IDATA verbose)
 		if (bits & rasDumpEvents[i].bits) {
 			/* Switch between multi-line and single-line styles */
 			if (verbose) {
-				j9tty_err_printf(PORTLIB, "  %s%*c%s\n", rasDumpEvents[i].name, maxNameLength - strlen(rasDumpEvents[i].name) + 2, ' ', rasDumpEvents[i].detail);
+				j9tty_err_printf("  %s%*c%s\n", rasDumpEvents[i].name, maxNameLength - strlen(rasDumpEvents[i].name) + 2, ' ', rasDumpEvents[i].detail);
 			} else {
-				j9tty_err_printf(PORTLIB, "%s%s", separator, rasDumpEvents[i].name);
+				j9tty_err_printf("%s%s", separator, rasDumpEvents[i].name);
 			}
 
 			separator = "+";
@@ -1967,7 +1964,7 @@ printDumpEvents(struct J9JavaVM *vm, UDATA bits, IDATA verbose)
 
 	/* Footer */
 	if (verbose) {
-		j9tty_err_printf(PORTLIB, "\n");
+		j9tty_err_printf("\n");
 	}
 
 	return OMR_ERROR_NONE;
@@ -1981,7 +1978,9 @@ printDumpRequests(struct J9JavaVM *vm, UDATA bits, IDATA verbose)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	/* Header */
-	if (verbose) {j9tty_err_printf( PORTLIB, "  Name      VM action\n  --------  -----------------------\n" );}
+	if (verbose) {
+		j9tty_err_printf("  Name      VM action\n  --------  -----------------------\n" );
+	}
 
 	for (i = 0; i < J9RAS_DUMP_KNOWN_REQUESTS; i++)
 	{
@@ -1989,9 +1988,9 @@ printDumpRequests(struct J9JavaVM *vm, UDATA bits, IDATA verbose)
 		{
 			/* Switch between multi-line and single-line styles */
 			if (verbose) {
-				j9tty_err_printf( PORTLIB, "  %s%*c%s\n", rasDumpRequests[i].name, 10-strlen(rasDumpRequests[i].name), ' ', rasDumpRequests[i].detail );
+				j9tty_err_printf("  %s%*c%s\n", rasDumpRequests[i].name, 10-strlen(rasDumpRequests[i].name), ' ', rasDumpRequests[i].detail );
 			} else {
-				j9tty_err_printf( PORTLIB, "%s%s", separator, rasDumpRequests[i].name );
+				j9tty_err_printf("%s%s", separator, rasDumpRequests[i].name );
 			}
 
 			separator = "+";
@@ -1999,7 +1998,9 @@ printDumpRequests(struct J9JavaVM *vm, UDATA bits, IDATA verbose)
 	}
 
 	/* Footer */
-	if (verbose) {j9tty_err_printf( PORTLIB, "\n" );}
+	if (verbose) {
+		j9tty_err_printf("\n" );
+	}
 
 	return OMR_ERROR_NONE;
 }
@@ -2162,49 +2163,49 @@ printDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	j9tty_err_printf(PORTLIB, "-Xdump:");
+	j9tty_err_printf("-Xdump:");
 
 	if (agent->dumpFn == doSystemDump) {
-		j9tty_err_printf(PORTLIB, "system:\n");
+		j9tty_err_printf("system:\n");
 	} else if (agent->dumpFn == doHeapDump) {
-		j9tty_err_printf(PORTLIB, "heap:\n");
+		j9tty_err_printf("heap:\n");
 	} else if (agent->dumpFn == doJavaDump) {
-		j9tty_err_printf(PORTLIB, "java:\n");
+		j9tty_err_printf("java:\n");
 	} else if (agent->dumpFn == doToolDump) {
-		j9tty_err_printf(PORTLIB, "tool:\n");
+		j9tty_err_printf("tool:\n");
 	} else if (agent->dumpFn == doJitDump) {
-		j9tty_err_printf(PORTLIB, "jit:\n");
+		j9tty_err_printf("jit:\n");
 	} else if (agent->dumpFn == doConsoleDump) {
-		j9tty_err_printf(PORTLIB, "console:\n");
+		j9tty_err_printf("console:\n");
 	} else if (agent->dumpFn == doSilentDump) {
-		j9tty_err_printf(PORTLIB, "silent:\n");
+		j9tty_err_printf("silent:\n");
 #if defined(J9ZOS390)
 	} else if (agent->dumpFn == doCEEDump) {
-		j9tty_err_printf(PORTLIB, "ceedump:\n");
+		j9tty_err_printf("ceedump:\n");
 #endif
 	} else if(agent->dumpFn == doSnapDump) {
-		j9tty_err_printf(PORTLIB, "snap:\n");
+		j9tty_err_printf("snap:\n");
 	} else if (agent->dumpFn == doStackDump) {
-		j9tty_err_printf(PORTLIB, "stack:\n");
+		j9tty_err_printf("stack:\n");
 	} else if (agent->dumpFn == doJavaVMExit) {
-		j9tty_err_printf(PORTLIB, "exit:\n");
+		j9tty_err_printf("exit:\n");
 	} else {
-		j9tty_err_printf(PORTLIB, "dumpFn=%p\n", agent->dumpFn);
+		j9tty_err_printf("dumpFn=%p\n", agent->dumpFn);
 	}
 
-	j9tty_err_printf(PORTLIB, "    events=");
+	j9tty_err_printf("    events=");
 	printDumpEvents(vm, agent->eventMask, 0);
-	j9tty_err_printf(PORTLIB, ",");
+	j9tty_err_printf(",");
 
 	if (agent->detailFilter != NULL) {
-		j9tty_err_printf(PORTLIB, "\n    filter=%s,",	agent->detailFilter);
+		j9tty_err_printf("\n    filter=%s,",	agent->detailFilter);
 	}
 	
 	if (agent->subFilter != NULL) {
-		j9tty_err_printf(PORTLIB, "\n    msg_filter=%s,", agent->subFilter);
+		j9tty_err_printf("\n    msg_filter=%s,", agent->subFilter);
 	}
 
-	j9tty_err_printf(PORTLIB,
+	j9tty_err_printf(
 		"\n"
 		"    %s%s,\n"
 		"    range=%d..%d,\n"
@@ -2215,15 +2216,15 @@ printDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent)
 		agent->priority
 	);
 
-	j9tty_err_printf(PORTLIB, "    request=");
+	j9tty_err_printf("    request=");
 	printDumpRequests(vm, agent->requestMask, 0);
 
 	if (agent->dumpOptions != NULL) {
-		j9tty_err_printf(PORTLIB, ",");
-		j9tty_err_printf(PORTLIB, "\n    opts=%s",
+		j9tty_err_printf(",");
+		j9tty_err_printf("\n    opts=%s",
 			agent->dumpOptions ? agent->dumpOptions : "");
 	}
-	j9tty_err_printf(PORTLIB, "\n");
+	j9tty_err_printf("\n");
 
 	return OMR_ERROR_NONE;
 }
@@ -2961,14 +2962,14 @@ reportDumpRequest(struct J9PortLibrary* portLibrary, J9RASdumpContext * context,
 static char *
 scanSubFilter(J9JavaVM *vm, const J9RASdumpSettings *settings, const char **cursor, UDATA *actionPtr)
 {
-        UDATA eventMask = settings->eventMask;
-        char *subFilter = NULL;
+	UDATA eventMask = settings->eventMask;
+	char *subFilter = NULL;
 
-        subFilter = scanString(vm, cursor);
+	subFilter = scanString(vm, cursor);
 
-        if (0 == (eventMask & J9RAS_DUMP_EXCEPTION_EVENT_GROUP)) {
-            *actionPtr = BOGUS_DUMP_OPTION;
-        }
+	if (0 == (eventMask & J9RAS_DUMP_EXCEPTION_EVENT_GROUP)) {
+		*actionPtr = BOGUS_DUMP_OPTION;
+	}
 
-        return subFilter;
+	return subFilter;
 }

--- a/runtime/rasdump/dmpmap.c
+++ b/runtime/rasdump/dmpmap.c
@@ -379,8 +379,7 @@ mapDumpActions(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum, char 
 				length = eventStringLength + countChars;
 				eventString = j9mem_allocate_memory(length, OMRMEM_CATEGORY_VM);
 				if (NULL == eventString) {
-					j9tty_err_printf(PORTLIB, 
-						"Could not allocate memory to handle JAVA_DUMP_OPTS dump count option, option ignored.\n");
+					j9tty_err_printf("Could not allocate memory to handle JAVA_DUMP_OPTS dump count option, option ignored.\n");
 					countChars = 0;
 				} else {
 					/* eventString ends with "..0"; the '0' is replaced by countChars */
@@ -401,8 +400,7 @@ mapDumpActions(J9JavaVM *vm, J9RASdumpOption agentOpts[], IDATA *agentNum, char 
 					agentOpts[*agentNum].flags = J9RAS_DUMP_OPT_ARGS_ALLOC;
 					agentOpts[*agentNum].args = j9mem_allocate_memory(strlen(eventString) + 1, OMRMEM_CATEGORY_VM);
 					if(NULL == agentOpts[*agentNum].args) {
-						j9tty_err_printf(PORTLIB, 
-							"Could not allocate memory to handle JAVA_DUMP_OPTS dump count option, option ignored (extra copy failed).\n");
+						j9tty_err_printf("Could not allocate memory to handle JAVA_DUMP_OPTS dump count option, option ignored (extra copy failed).\n");
 						countChars = 0;
 						agentOpts[*agentNum].args = dgConditions[condition].eventString;
 						agentOpts[*agentNum].flags = J9RAS_DUMP_OPT_ARGS_STATIC;

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -144,7 +144,7 @@ loadOMRSIG(J9JavaVM *vm)
 	omrsigLoadInfo.loadFlags |= XRUN_LIBRARY;
 	strcpy((char *) &omrsigLoadInfo.dllName, "omrsig");
 	if (vm->internalVMFunctions->loadJ9DLL(vm, &omrsigLoadInfo) != TRUE) {
-		j9tty_err_printf(PORTLIB, "Can't open OMRSIG library\n");
+		j9tty_err_printf("Can't open OMRSIG library\n");
 		return FALSE;
 	}
 	omrsigHandle = omrsigLoadInfo.descriptor;
@@ -367,15 +367,15 @@ showDumpAgents(J9JavaVM *vm)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9RASdumpAgent *agent = NULL;
 
-	j9tty_err_printf(PORTLIB, "\nRegistered dump agents\n----------------------\n");
+	j9tty_err_printf("\nRegistered dump agents\n----------------------\n");
 
 	while (seekDumpAgent(vm, &agent, NULL) == OMR_ERROR_NONE)
 	{
 		printDumpAgent(vm, agent);
-		j9tty_err_printf(PORTLIB, "----------------------\n");
+		j9tty_err_printf("----------------------\n");
 	}
 
-	j9tty_err_printf(PORTLIB, "\n");
+	j9tty_err_printf("\n");
 
 	return OMR_ERROR_NONE;
 }
@@ -469,7 +469,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 	/* -Xdump:events */
 	if ( FIND_AND_CONSUME_ARG(j9vm_args, EXACT_MATCH, VMOPT_XDUMP ":events", NULL) >= 0 )
 	{
-		j9tty_err_printf(PORTLIB, "\nTrigger events:\n\n");
+		j9tty_err_printf("\nTrigger events:\n\n");
 		printDumpEvents( vm, J9RAS_DUMP_ON_ANY, 1 );
 		return J9VMDLLMAIN_SILENT_EXIT_VM;
 	}
@@ -477,7 +477,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 	/* -Xdump:request */
 	if ( FIND_AND_CONSUME_ARG(j9vm_args, EXACT_MATCH, VMOPT_XDUMP ":request", NULL) >= 0 )
 	{
-		j9tty_err_printf(PORTLIB, "\nAdditional VM requests:\n\n");
+		j9tty_err_printf("\nAdditional VM requests:\n\n");
 		printDumpRequests( vm, (UDATA)-1, 1 );
 		return J9VMDLLMAIN_SILENT_EXIT_VM;
 	}
@@ -485,7 +485,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 	/* -Xdump:tokens */
 	if ( FIND_AND_CONSUME_ARG(j9vm_args, EXACT_MATCH, VMOPT_XDUMP ":tokens", NULL) >= 0 )
 	{
-		j9tty_err_printf(PORTLIB, "\nLabel tokens:\n\n");
+		j9tty_err_printf("\nLabel tokens:\n\n");
 		printLabelSpec( vm );
 		return J9VMDLLMAIN_SILENT_EXIT_VM;
 	}
@@ -573,7 +573,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 
 	agentOpts = j9mem_allocate_memory(sizeof(J9RASdumpOption)*MAX_DUMP_OPTS, OMRMEM_CATEGORY_VM);
 	if( NULL == agentOpts ) {
-		j9tty_err_printf(PORTLIB, "Storage for dump options not available, unable to process dump options\n");
+		j9tty_err_printf("Storage for dump options not available, unable to process dump options\n");
 		return J9VMDLLMAIN_FAILED;
 	}
 	memset(agentOpts,0,sizeof(J9RASdumpOption)*MAX_DUMP_OPTS);
@@ -665,7 +665,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 							isMappedToolDump = TRUE;
 						} else {
 							char *mappingMapName = MAPPING_MAPNAME(j9vm_args, xdumpIndex);
-							j9tty_err_printf(PORTLIB, "Unable to map %s to J9 %s - Could not allocate the requested size of memory %zu for optionString\n", mappingMapName, mappingJ9Name, optionStringMemAlloc);
+							j9tty_err_printf("Unable to map %s to J9 %s - Could not allocate the requested size of memory %zu for optionString\n", mappingMapName, mappingJ9Name, optionStringMemAlloc);
 							return J9VMDLLMAIN_FAILED;
 						}
 					}
@@ -740,7 +740,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 		if (agentOpts[i].kind == J9RAS_DUMP_OPT_DISABLED) continue;
 		if (agentOpts[i].pass != J9RAS_DUMP_OPTS_PASS_ONE) continue;
 
-		/*j9tty_err_printf(PORTLIB, "configureDumpAgents() loading agent for %d %s\n",agentOpts[i].kind, agentOpts[i].args); */
+		/* j9tty_err_printf("configureDumpAgents() loading agent for %d %s\n",agentOpts[i].kind, agentOpts[i].args); */
 		if ( (strncmp(agentOpts[i].args, "none", strlen("none")) == 0)) {
 			if (deleteMatchingAgents(vm, agentOpts[i].kind, agentOpts[i].args) == OMR_ERROR_INTERNAL) {
 				printDumpSpec(vm, agentOpts[i].kind, 2);
@@ -766,7 +766,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 		if (agentOpts[i].kind == J9RAS_DUMP_OPT_DISABLED) continue;
 		if (agentOpts[i].pass == J9RAS_DUMP_OPTS_PASS_ONE) continue;
 
-		/*j9tty_err_printf(PORTLIB, "configureDumpAgents() loading agent for %d %s\n",agentOpts[i].kind, agentOpts[i].args); */
+		/* j9tty_err_printf("configureDumpAgents() loading agent for %d %s\n",agentOpts[i].kind, agentOpts[i].args); */
 		if ( (strncmp(agentOpts[i].args, "none", strlen("none")) == 0)) {
 			if (deleteMatchingAgents(vm, agentOpts[i].kind, agentOpts[i].args) == OMR_ERROR_INTERNAL) {
 				printDumpSpec(vm, agentOpts[i].kind, 2);
@@ -786,7 +786,7 @@ configureDumpAgents(J9JavaVM *vm, J9VMInitArgs *j9vm_args, BOOLEAN isBootup)
 		if (agentOpts[i].kind == J9RAS_DUMP_OPT_DISABLED) continue;
 		if (agentOpts[i].pass != J9RAS_DUMP_OPTS_PASS_ONE) continue;
 
-		/*j9tty_err_printf(PORTLIB, "configureDumpAgents() loading agent for %d %s\n",agentOpts[i].kind, agentOpts[i].args); */
+		/* j9tty_err_printf("configureDumpAgents() loading agent for %d %s\n",agentOpts[i].kind, agentOpts[i].args); */
 		if ( (strncmp(agentOpts[i].args, "none", strlen("none")) == 0)) {
 			if (deleteMatchingAgents(vm, agentOpts[i].kind, agentOpts[i].args) == OMR_ERROR_INTERNAL) {
 				printDumpSpec(vm, agentOpts[i].kind, 2);
@@ -852,35 +852,35 @@ printDumpUsage(J9JavaVM *vm)
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	j9tty_err_printf(PORTLIB, "\nUsage:\n\n");
+	j9tty_err_printf("\nUsage:\n\n");
 
-	j9tty_err_printf(PORTLIB, "  -Xdump:help             Print general dump help\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:none             Ignore all previous/default dump options\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:events           List available trigger events\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:request          List additional VM requests\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:tokens           List recognized label tokens\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:dynamic          Enable support for pluggable agents\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:what             Show registered agents on startup\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:nofailover       Disable dump failover to temporary directory\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:directory=<path> Set the default directory path for dump files to be written to\n");
+	j9tty_err_printf("  -Xdump:help             Print general dump help\n");
+	j9tty_err_printf("  -Xdump:none             Ignore all previous/default dump options\n");
+	j9tty_err_printf("  -Xdump:events           List available trigger events\n");
+	j9tty_err_printf("  -Xdump:request          List additional VM requests\n");
+	j9tty_err_printf("  -Xdump:tokens           List recognized label tokens\n");
+	j9tty_err_printf("  -Xdump:dynamic          Enable support for pluggable agents\n");
+	j9tty_err_printf("  -Xdump:what             Show registered agents on startup\n");
+	j9tty_err_printf("  -Xdump:nofailover       Disable dump failover to temporary directory\n");
+	j9tty_err_printf("  -Xdump:directory=<path> Set the default directory path for dump files to be written to\n");
 #if defined(OMR_CONFIGURABLE_SUSPEND_SIGNAL)
-	j9tty_err_printf(PORTLIB, "  -Xdump:suspendwith=<num> Use SIGRTMIN+<num> to suspend threads\n");
+	j9tty_err_printf("  -Xdump:suspendwith=<num> Use SIGRTMIN+<num> to suspend threads\n");
 #endif
-	j9tty_err_printf(PORTLIB, "\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:<type>:help      Print detailed dump help\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:<type>:none      Ignore previous dump options of this type\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:<type>:defaults  Print/update default settings for this type\n");
-	j9tty_err_printf(PORTLIB, "  -Xdump:<type>           Request this type of dump (using defaults)\n");
+	j9tty_err_printf("\n");
+	j9tty_err_printf("  -Xdump:<type>:help      Print detailed dump help\n");
+	j9tty_err_printf("  -Xdump:<type>:none      Ignore previous dump options of this type\n");
+	j9tty_err_printf("  -Xdump:<type>:defaults  Print/update default settings for this type\n");
+	j9tty_err_printf("  -Xdump:<type>           Request this type of dump (using defaults)\n");
 
-	j9tty_err_printf(PORTLIB, "\nDump types:\n\n");
+	j9tty_err_printf("\nDump types:\n\n");
 
 	/* Print dump specifications until all done */
 	while (printDumpSpec(vm, kind++, 0) == OMR_ERROR_NONE) {}
 
-	j9tty_err_printf(PORTLIB, "\nExample:\n\n");
+	j9tty_err_printf("\nExample:\n\n");
 
-	j9tty_err_printf(PORTLIB, "  java -Xdump:heap:none -Xdump:heap:events=fullgc class [args...]\n\n");
-	j9tty_err_printf(PORTLIB, "Turns off default heapdumps, then requests a heapdump on every full GC.\n\n");
+	j9tty_err_printf("  java -Xdump:heap:none -Xdump:heap:events=fullgc class [args...]\n\n");
+	j9tty_err_printf("Turns off default heapdumps, then requests a heapdump on every full GC.\n\n");
 
 	return OMR_ERROR_NONE;
 }
@@ -1582,22 +1582,22 @@ J9VMDllMain(J9JavaVM *vm, IDATA stage, void *reserved)
 				/* JVMRI init may happen in either dump or trace */
 				((RasGlobalStorage *)vm->j9rasGlobalStorage)->jvmriInterface = j9mem_allocate_memory(sizeof(DgRasInterface), OMRMEM_CATEGORY_VM);
 				if (((RasGlobalStorage *)vm->j9rasGlobalStorage)->jvmriInterface == NULL) {
-					j9tty_err_printf(PORTLIB, "Storage for jvmri interface not available, trace not enabled\n");
+					j9tty_err_printf("Storage for jvmri interface not available, trace not enabled\n");
 					return J9VMDLLMAIN_FAILED;
 				}
 
 				if ((vm->internalVMFunctions->fillInDgRasInterface( ((RasGlobalStorage *)vm->j9rasGlobalStorage)->jvmriInterface )) != JNI_OK){
-					j9tty_err_printf(PORTLIB, "Error initializing jvmri interface not available, trace not enabled\n");
+					j9tty_err_printf("Error initializing jvmri interface not available, trace not enabled\n");
 					return J9VMDLLMAIN_FAILED;
 				}
 
 				if ((vm->internalVMFunctions->initJVMRI(vm)) != JNI_OK){
-					j9tty_err_printf(PORTLIB, "Error initializing jvmri interface, trace not enabled\n");
+					j9tty_err_printf("Error initializing jvmri interface, trace not enabled\n");
 					return J9VMDLLMAIN_FAILED;
 				}
 
 				if ((*hook)->J9HookRegisterWithCallSite(hook, J9HOOK_VM_INITIALIZED, hookVmInitialized, OMR_GET_CALLSITE(), NULL)) {
-					j9tty_err_printf(PORTLIB, "Trace engine failed to hook VM events, trace not enabled\n");
+					j9tty_err_printf("Trace engine failed to hook VM events, trace not enabled\n");
 					return J9VMDLLMAIN_FAILED;
 				}
 			}

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -541,7 +541,7 @@ printLabelSpec(struct J9JavaVM *vm)
 			"  %%last  last dump\n"
 			"  %%event dump event\n"
 			"\n";
-	j9tty_err_printf(PORTLIB, labelSpec);
+	j9tty_err_printf(labelSpec);
 	return OMR_ERROR_NONE;
 }
 

--- a/runtime/rastrace/trcengine.c
+++ b/runtime/rastrace/trcengine.c
@@ -910,44 +910,44 @@ static void displayTraceHelp(J9JavaVM *vm)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	j9tty_err_printf(PORTLIB, "\nUsage:\n\n");
-	j9tty_err_printf(PORTLIB, "  java -Xtrace[:option,...]\n\n");
-	j9tty_err_printf(PORTLIB, "  Valid options are:\n\n");
-	j9tty_err_printf(PORTLIB, "     help                                Print general trace help\n");
-	j9tty_err_printf(PORTLIB, "     what                                Print current trace configuration\n");
-	j9tty_err_printf(PORTLIB, "     none[=tp_spec[,...]]                Ignore all previous/default trace options\n");
-	j9tty_err_printf(PORTLIB, "     properties[=filespec]               Use file for trace options\n");
-	j9tty_err_printf(PORTLIB, "     buffers=nnk|nnm|dynamic|nodynamic[,...] Buffer size and nature\n\n");
-	j9tty_err_printf(PORTLIB, "     minimal=[!]tp_spec[,...]            Minimal trace data (time and id)\n");
-	j9tty_err_printf(PORTLIB, "     maximal=[!]tp_spec[,...]            Time,id and parameters traced\n");
-	j9tty_err_printf(PORTLIB, "     count=[!]tp_spec[,...]              Count tracepoints\n");
-	j9tty_err_printf(PORTLIB, "     print=[!]tp_spec[,...]              Direct unindented trace data to stderr\n");
-	j9tty_err_printf(PORTLIB, "     iprint=[!]tp_spec[,...]             Indented version of print option\n");
-	j9tty_err_printf(PORTLIB, "     external=[!]tp_spec[,...]           Direct trace data to a JVMRI listener\n");
-	j9tty_err_printf(PORTLIB, "     exception=[!]tp_spec[,...]          Use reserved in-core buffer\n");
-	j9tty_err_printf(PORTLIB, "     methods=method_spec[,..]            Trace specified class(es) and methods\n\n");
-	j9tty_err_printf(PORTLIB, "     trigger=[!]clause[,clause]...       Enables triggering events (including dumps) on tracepoints\n");
-	j9tty_err_printf(PORTLIB, "     suspend                             Global trace suspend used with trigger\n");
-	j9tty_err_printf(PORTLIB, "     resume                              Global trace resume used with trigger\n");
-	j9tty_err_printf(PORTLIB, "     suspendcount=nn                     Trigger count for \"trace suspend\"\n");
-	j9tty_err_printf(PORTLIB, "     resumecount=nn                      Trigger count for \"trace resume\"\n");
-	j9tty_err_printf(PORTLIB, "     output=filespec[,nnm[,generations]] Sends maximal and minimal trace to a file\n");
-	j9tty_err_printf(PORTLIB, "     exception.output=filespec[,nnnm]    Sends exception trace to a file\n");
-	j9tty_err_printf(PORTLIB, "     maxstringlength=nn                  Limit length of string values to capture\n");
-	j9tty_err_printf(PORTLIB, "                                         "
+	j9tty_err_printf("\nUsage:\n\n");
+	j9tty_err_printf("  java -Xtrace[:option,...]\n\n");
+	j9tty_err_printf("  Valid options are:\n\n");
+	j9tty_err_printf("     help                                Print general trace help\n");
+	j9tty_err_printf("     what                                Print current trace configuration\n");
+	j9tty_err_printf("     none[=tp_spec[,...]]                Ignore all previous/default trace options\n");
+	j9tty_err_printf("     properties[=filespec]               Use file for trace options\n");
+	j9tty_err_printf("     buffers=nnk|nnm|dynamic|nodynamic[,...] Buffer size and nature\n\n");
+	j9tty_err_printf("     minimal=[!]tp_spec[,...]            Minimal trace data (time and id)\n");
+	j9tty_err_printf("     maximal=[!]tp_spec[,...]            Time,id and parameters traced\n");
+	j9tty_err_printf("     count=[!]tp_spec[,...]              Count tracepoints\n");
+	j9tty_err_printf("     print=[!]tp_spec[,...]              Direct unindented trace data to stderr\n");
+	j9tty_err_printf("     iprint=[!]tp_spec[,...]             Indented version of print option\n");
+	j9tty_err_printf("     external=[!]tp_spec[,...]           Direct trace data to a JVMRI listener\n");
+	j9tty_err_printf("     exception=[!]tp_spec[,...]          Use reserved in-core buffer\n");
+	j9tty_err_printf("     methods=method_spec[,..]            Trace specified class(es) and methods\n\n");
+	j9tty_err_printf("     trigger=[!]clause[,clause]...       Enables triggering events (including dumps) on tracepoints\n");
+	j9tty_err_printf("     suspend                             Global trace suspend used with trigger\n");
+	j9tty_err_printf("     resume                              Global trace resume used with trigger\n");
+	j9tty_err_printf("     suspendcount=nn                     Trigger count for \"trace suspend\"\n");
+	j9tty_err_printf("     resumecount=nn                      Trigger count for \"trace resume\"\n");
+	j9tty_err_printf("     output=filespec[,nnm[,generations]] Sends maximal and minimal trace to a file\n");
+	j9tty_err_printf("     exception.output=filespec[,nnnm]    Sends exception trace to a file\n");
+	j9tty_err_printf("     maxstringlength=nn                  Limit length of string values to capture\n");
+	j9tty_err_printf("                                         "
 			"Maximum " J9_STR(RAS_MAX_STRING_LENGTH_LIMIT)
 			", use 0 to disable."
 			" Default: " J9_STR(RAS_MAX_STRING_LENGTH_DEFAULT) "\n");
-	j9tty_err_printf(PORTLIB, "     stackdepth=nn                       Set number of frames output by jstacktrace trigger action\n");
-	j9tty_err_printf(PORTLIB, "     sleeptime=nnt                       Time delay for sleep trigger action\n");
-	j9tty_err_printf(PORTLIB, "                                         Recognised suffixes: ms (milliseconds), s (seconds). Default: ms\n");
-	j9tty_err_printf(PORTLIB, "\n     where tp_spec is, for example, j9vm.111 or {j9vm.111-114,j9trc.5}\n");
-	j9tty_err_printf(PORTLIB, "\n     IMPORTANT: Where an option value contains one or more commas, it must\n");
-	j9tty_err_printf(PORTLIB, "     be enclosed in curly braces, for example:\n\n");
-	j9tty_err_printf(PORTLIB, "         -Xtrace:maximal={j9vm,mt},methods={*.*,!java/lang/*},output=trace\n");
-	j9tty_err_printf(PORTLIB, "\n     You may need to enclose options in quotation marks to prevent the shell\n");
-	j9tty_err_printf(PORTLIB, "     intercepting and fragmenting comma-separated command lines, for example:\n\n");
-	j9tty_err_printf(PORTLIB, "         \"-Xtrace:methods={java/lang/*,java/util/*},print=mt\"\n\n");
+	j9tty_err_printf("     stackdepth=nn                       Set number of frames output by jstacktrace trigger action\n");
+	j9tty_err_printf("     sleeptime=nnt                       Time delay for sleep trigger action\n");
+	j9tty_err_printf("                                         Recognised suffixes: ms (milliseconds), s (seconds). Default: ms\n");
+	j9tty_err_printf("\n     where tp_spec is, for example, j9vm.111 or {j9vm.111-114,j9trc.5}\n");
+	j9tty_err_printf("\n     IMPORTANT: Where an option value contains one or more commas, it must\n");
+	j9tty_err_printf("     be enclosed in curly braces, for example:\n\n");
+	j9tty_err_printf("         -Xtrace:maximal={j9vm,mt},methods={*.*,!java/lang/*},output=trace\n");
+	j9tty_err_printf("\n     You may need to enclose options in quotation marks to prevent the shell\n");
+	j9tty_err_printf("     intercepting and fragmenting comma-separated command lines, for example:\n\n");
+	j9tty_err_printf("         \"-Xtrace:methods={java/lang/*,java/util/*},print=mt\"\n\n");
 }
 
 static void
@@ -1224,8 +1224,8 @@ printTraceWhat(J9PortLibrary* portLibrary)
 	void* cursor_ptr = NULL;
 	void** cursor = &cursor_ptr;
 	const char* option = walkTraceConfig(cursor);
-	j9tty_err_printf(PORTLIB, "Trace engine configuration\n");
-	j9tty_err_printf(PORTLIB, "--------------------------\n");
+	j9tty_err_printf("Trace engine configuration\n");
+	j9tty_err_printf("--------------------------\n");
 	if( NULL != option) {
 		while ( NULL != *cursor ) {
 			option = walkTraceConfig(cursor);
@@ -1236,13 +1236,13 @@ printTraceWhat(J9PortLibrary* portLibrary)
 			cursor = &cursor_ptr;
 			option = walkTraceConfig(cursor);
 		}
-		j9tty_err_printf(PORTLIB, "-Xtrace:%s\n", option);
+		j9tty_err_printf("-Xtrace:%s\n", option);
 		while ( NULL != *cursor ) {
 			option = walkTraceConfig(cursor);
-			j9tty_err_printf(PORTLIB, "-Xtrace:%s\n", option);
+			j9tty_err_printf("-Xtrace:%s\n", option);
 		}
 	}
-	j9tty_err_printf(PORTLIB, "--------------------------\n");
+	j9tty_err_printf("--------------------------\n");
 }
 
 /**************************************************************************

--- a/runtime/rastrace/trclog.c
+++ b/runtime/rastrace/trclog.c
@@ -1407,7 +1407,7 @@ tracePrint(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, va_list 
 		/*
 		 *  Indented print
 		 */
-		j9tty_err_printf(PORTLIB, "%02d:%02d:%02d.%03d%c" UT_POINTER_SPEC
+		j9tty_err_printf("%02d:%02d:%02d.%03d%c" UT_POINTER_SPEC
 				"%16s.%-6d %c %s %c ", hh, mm, ss, millis, threadSwitch, (*thr)->id, qualifiedModuleName,
 				id, excpt, indent, entryexit);
 		j9tty_err_vprintf(format + 2, var);
@@ -1419,13 +1419,13 @@ tracePrint(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, va_list 
 		excpt = format[0];
 		format[1] == ' ' ? (entryexit = '-') : (entryexit = format[1]);
 
-		j9tty_err_printf(PORTLIB, "%02d:%02d:%02d.%03d%c" UT_POINTER_SPEC
-				   "%16s.%-6d %c %c ", hh, mm, ss, millis, threadSwitch, (*thr)->id, qualifiedModuleName,
-				   id, excpt, entryexit);
+		j9tty_err_printf("%02d:%02d:%02d.%03d%c" UT_POINTER_SPEC
+				"%16s.%-6d %c %c ", hh, mm, ss, millis, threadSwitch, (*thr)->id, qualifiedModuleName,
+				id, excpt, entryexit);
 		j9tty_err_vprintf(format + 2, var);
 
 	}
-	j9tty_err_printf(PORTLIB, "\n");
+	j9tty_err_printf("\n");
 	freeTraceLock(thr);
 }
 
@@ -1472,12 +1472,11 @@ traceAssertion(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, va_l
 	/*
 	 *  Non-indented print
 	 */
-	j9tty_err_printf(PORTLIB, "%02d:%02d:%02d.%03d " UT_POINTER_SPEC
-			   "%8s.%-6d *   ", hh, mm, ss, millis, (*thr)->id, qualifiedModuleName,
-			   id);
+	j9tty_err_printf(
+			"%02d:%02d:%02d.%03d " UT_POINTER_SPEC "%8s.%-6d *   ",
+			hh, mm, ss, millis, (*thr)->id, qualifiedModuleName, id);
 	j9tty_err_vprintf(format + 2, var);
-
-	j9tty_err_printf(PORTLIB, "\n");
+	j9tty_err_printf("\n");
 
 	freeTraceLock(thr);
 }
@@ -2595,8 +2594,8 @@ void omrTraceMem(void *env, UtModuleInfo *modInfo, uint32_t traceId, uintptr_t l
 		strncpy(qualifiedModuleName, modInfo->name, MAX_QUALIFIED_NAME_LENGTH);
 	}
 
-	j9tty_err_printf(PORTLIB, "* ** ASSERTION FAILED ** Obsolete trace function TraceMem called for trace point %s.%-6d", qualifiedModuleName, id);
-	j9tty_err_printf(PORTLIB, "\n");
+	j9tty_err_printf("* ** ASSERTION FAILED ** Obsolete trace function TraceMem called for trace point %s.%-6d", qualifiedModuleName, id);
+	j9tty_err_printf("\n");
 
 	raiseAssertion(thr, modInfo, traceId);
 }
@@ -2627,8 +2626,8 @@ void omrTraceState(void *env, UtModuleInfo *modInfo, uint32_t traceId, const cha
 		strncpy(qualifiedModuleName, modInfo->name, MAX_QUALIFIED_NAME_LENGTH);
 	}
 
-	j9tty_err_printf(PORTLIB, "* ** ASSERTION FAILED ** Obsolete trace function TraceState called for trace point %s.%-6d", qualifiedModuleName, id);
-	j9tty_err_printf(PORTLIB, "\n");
+	j9tty_err_printf("* ** ASSERTION FAILED ** Obsolete trace function TraceState called for trace point %s.%-6d", qualifiedModuleName, id);
+	j9tty_err_printf("\n");
 
 	raiseAssertion(thr, modInfo, traceId);
 }

--- a/runtime/rastrace/trcmain.c
+++ b/runtime/rastrace/trcmain.c
@@ -678,13 +678,13 @@ threadStop(UtThreadData **thr)
 
 		/* Cannot use UT_DEBUG macro as utGlobal has been set to NULL */
 		if (global->traceDebug >= 2) {
-			j9tty_err_printf(PORTLIB, "<UT> ThreadStop entered for final thread " UT_POINTER_SPEC ", freeing buffers\n", thr);
+			j9tty_err_printf("<UT> ThreadStop entered for final thread " UT_POINTER_SPEC ", freeing buffers\n", thr);
 		}
 
 		while (current != NULL) {
 			UtTraceBuffer *gNext = NULL;
 			if (global->traceDebug >= 2) {
-				j9tty_err_printf(PORTLIB, "<UT>   ThreadStop freeing buffer " UT_POINTER_SPEC "\n", current);
+				j9tty_err_printf("<UT>   ThreadStop freeing buffer " UT_POINTER_SPEC "\n", current);
 			}
 			next = current->next;
 
@@ -693,7 +693,7 @@ threadStop(UtThreadData **thr)
 				gNext = global->traceGlobal;
 				if (gNext == NULL) {
 					if (global->traceDebug >= 1) {
-						j9tty_err_printf(PORTLIB, "<UT> NULL global buffer list! " UT_POINTER_SPEC " not found in global list\n", current);
+						j9tty_err_printf("<UT> NULL global buffer list! " UT_POINTER_SPEC " not found in global list\n", current);
 					}
 				} else if (gNext == current) {
 					global->traceGlobal = gNext->globalNext;
@@ -703,7 +703,7 @@ threadStop(UtThreadData **thr)
 						gNext->globalNext = current->globalNext;
 					} else {
 						if (global->traceDebug >= 1) {
-							j9tty_err_printf(PORTLIB, "<UT> trace buffer " UT_POINTER_SPEC " not found in global list\n", current);
+							j9tty_err_printf("<UT> trace buffer " UT_POINTER_SPEC " not found in global list\n", current);
 						}
 					}
 				}
@@ -720,8 +720,8 @@ threadStop(UtThreadData **thr)
 		/* output anything left on global if running with debug */
 		if (global->traceDebug >= 1) {
 			for (current = global->traceGlobal; current != NULL; current = current->globalNext) {
-				j9tty_err_printf(PORTLIB, "<UT> trace buffer " UT_POINTER_SPEC " not freed!\n", current);
-				j9tty_err_printf(PORTLIB, "<UT> owner: " UT_POINTER_SPEC " - %s\n", current->thr, current->record.threadName);
+				j9tty_err_printf("<UT> trace buffer " UT_POINTER_SPEC " not freed!\n", current);
+				j9tty_err_printf("<UT> owner: " UT_POINTER_SPEC " - %s\n", current->thr, current->record.threadName);
 			}
 		}
 

--- a/runtime/rastrace/trcmisc.c
+++ b/runtime/rastrace/trcmisc.c
@@ -192,7 +192,7 @@ listCounters(void)
 			for (i = 0; i < compData->tracepointCount; i++) {
 				if ( compData->tracepointcounters[i] > 0 ) {
 					if (f < 0) {
-						j9tty_err_printf(PORTLIB, "%s.%d %ld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
+						j9tty_err_printf("%s.%d %ld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 					} else {
 						j9str_printf(tempBuf, TEMPBUFLEN, "%s.%d %lld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 						/* convert to ebcdic if on zos */
@@ -211,7 +211,7 @@ listCounters(void)
 			for (i = 0; i < compData->tracepointCount; i++) {
 				if ( compData->tracepointcounters[i] > 0 ) {
 					if (f < 0) {
-						j9tty_err_printf(PORTLIB, "%s.%d %ld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
+						j9tty_err_printf("%s.%d %ld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 					} else {
 						j9str_printf(tempBuf, TEMPBUFLEN, "%s.%d %lld \n", compData->qualifiedComponentName, i, compData->tracepointcounters[i]);
 						/* convert to ebcdic if on zos */

--- a/runtime/tests/algorithm/argscantest.c
+++ b/runtime/tests/algorithm/argscantest.c
@@ -57,13 +57,13 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "2147483647";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != (UDATA)I_32_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zd\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zd\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -72,13 +72,13 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "4294967295 ";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != U_32_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start) - 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -87,13 +87,13 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "0";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -102,13 +102,13 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "0000";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -117,10 +117,10 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -130,13 +130,13 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "18446744073709551615";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != U_64_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -145,13 +145,13 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "18446744073709551615 ";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != U_64_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start) - 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -160,10 +160,10 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "18446744073709551616";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -171,10 +171,10 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "111111111111111111111";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -183,10 +183,10 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "4294967296";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -194,10 +194,10 @@ verify_scan_udata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "11111111111";
 	rc = scan_udata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -219,13 +219,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "2147483647";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != I_32_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zd\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zd\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -234,13 +234,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "2147483647 ";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != I_32_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zd\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zd\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start) - 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -249,13 +249,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "0";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -264,13 +264,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "0000";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -279,10 +279,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -291,10 +291,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "-";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -303,10 +303,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "+";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -315,10 +315,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "--0";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -327,10 +327,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "++0";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 1) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -339,13 +339,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "-0";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -354,13 +354,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "+0";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zu\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zu\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -369,13 +369,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "-2147483647";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != -I_32_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zd\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zd\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -384,13 +384,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "-2147483648";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != I_32_MIN) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zd\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zd\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -400,13 +400,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "9223372036854775807";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != I_64_MAX) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zd\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zd\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -415,13 +415,13 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "-9223372036854775808";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 0) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected error parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} else if (result != I_64_MIN) {
-		j9tty_err_printf(PORTLIB, "Unexpected result parsing \"%s\": %zd\n", start, result);
+		j9tty_err_printf("Unexpected result parsing \"%s\": %zd\n", start, result);
 		(*failCount)++;
 	} else if (cursor != start + strlen(start)) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -430,10 +430,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "9223372036854775808";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -442,10 +442,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "-9223372036854775809";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -454,10 +454,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "2147483648";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -466,10 +466,10 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	start = cursor = "-2147483649";
 	rc = scan_idata(&cursor, &result);
 	if (rc != 2) {
-		j9tty_err_printf(PORTLIB, "Unexpected rc parsing \"%s\": %d\n", start, rc);
+		j9tty_err_printf("Unexpected rc parsing \"%s\": %d\n", start, rc);
 		(*failCount)++;
 	} if (cursor != start) {
-		j9tty_err_printf(PORTLIB, "Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
+		j9tty_err_printf("Unexpected length parsing \"%s\": %zu\n", start, cursor - start);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -477,6 +477,3 @@ verify_scan_idata(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 #endif
 
 }
-
-
-

--- a/runtime/tests/algorithm/sendslottest.c
+++ b/runtime/tests/algorithm/sendslottest.c
@@ -60,9 +60,7 @@ verifySendSlots(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	return rc;
 }
 
-
-
-static I_32 
+static I_32
 testSignature(J9PortLibrary *portLib, const char* sig, UDATA expectedSlots, UDATA *passCount, UDATA *failCount)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
@@ -71,7 +69,7 @@ testSignature(J9PortLibrary *portLib, const char* sig, UDATA expectedSlots, UDAT
 	result = getSendSlotsFromSignature((const U_8*)sig);
 
 	if (result != expectedSlots) {
-		j9tty_err_printf(PORTLIB, "Incorrect result for \"%s\". Expected %u, got %u\n", sig, expectedSlots, result);
+		j9tty_err_printf("Incorrect result for \"%s\". Expected %u, got %u\n", sig, expectedSlots, result);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -79,6 +77,3 @@ testSignature(J9PortLibrary *portLib, const char* sig, UDATA expectedSlots, UDAT
 
 	return 0;
 }
-
-
-

--- a/runtime/tests/algorithm/wildcardtest.c
+++ b/runtime/tests/algorithm/wildcardtest.c
@@ -66,7 +66,7 @@ verifyWildcards(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 
 	/* test NULL and 0 length */
 	if (parseWildcard(NULL, 0, &needleString, &needleLength, &matchFlags)) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing NULL pattern\n");
+		j9tty_err_printf("Unexpected error parsing NULL pattern\n");
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -75,7 +75,7 @@ verifyWildcards(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	/* test expected error cases */
 	pattern = "X*X";
 	if (!parseWildcard(pattern, strlen(pattern), &needleString, &needleLength, &matchFlags)) {
-		j9tty_err_printf(PORTLIB, "Unexpected success parsing \"%s\"\n", pattern);
+		j9tty_err_printf("Unexpected success parsing \"%s\"\n", pattern);
 		(*failCount)++;
 	} else {
 		(*passCount)++;
@@ -86,9 +86,7 @@ verifyWildcards(J9PortLibrary *portLib, UDATA *passCount, UDATA *failCount)
 	return rc;
 }
 
-
-
-static I_32 
+static I_32
 verifyWildcard(J9PortLibrary *portLib, const char* pattern, const char* expectedMatch, const char* expectedMismatch, UDATA *passCount, UDATA *failCount) 
 {
 	const char* needleString;
@@ -97,13 +95,13 @@ verifyWildcard(J9PortLibrary *portLib, const char* pattern, const char* expected
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	if (parseWildcard(pattern, strlen(pattern), &needleString, &needleLength, &matchFlags)) {
-		j9tty_err_printf(PORTLIB, "Unexpected error parsing \"%s\"\n", pattern);
+		j9tty_err_printf("Unexpected error parsing \"%s\"\n", pattern);
 		return -1;
 	}
 
 	if (expectedMatch) {
 		if (!wildcardMatch(matchFlags, needleString, needleLength, expectedMatch, strlen(expectedMatch))) {
-			j9tty_err_printf(PORTLIB, "Failed to match \"%s\" with \"%s\"\n", expectedMatch, pattern);
+			j9tty_err_printf("Failed to match \"%s\" with \"%s\"\n", expectedMatch, pattern);
 			(*failCount)++;
 			return 0;
 		}
@@ -111,7 +109,7 @@ verifyWildcard(J9PortLibrary *portLib, const char* pattern, const char* expected
 
 	if (expectedMismatch) {
 		if (wildcardMatch(matchFlags, needleString, needleLength, expectedMismatch, strlen(expectedMismatch))) {
-			j9tty_err_printf(PORTLIB, "Unexpectedly matched \"%s\" with \"%s\"\n", expectedMismatch, pattern);
+			j9tty_err_printf("Unexpectedly matched \"%s\" with \"%s\"\n", expectedMismatch, pattern);
 			(*failCount)++;
 			return 0;
 		}
@@ -120,6 +118,3 @@ verifyWildcard(J9PortLibrary *portLib, const char* pattern, const char* expected
 	(*passCount)++;
 	return 0;
 }
-
-
-

--- a/runtime/tests/cutest/parser.c
+++ b/runtime/tests/cutest/parser.c
@@ -40,7 +40,7 @@ cutest_parseCmdLine( J9PortLibrary *portLibrary, UDATA lastLegalArg , char **arg
 		/* new style -Xcheck:memory options */
 		if (0 == strcmp("-verbose", argv[i])) {
 			verbose = 1;
-			j9tty_err_printf(PORTLIB, "cutest: verbose output enabled.\n");
+			j9tty_err_printf("cutest: verbose output enabled.\n");
 			return i;
 		}
 	}

--- a/runtime/tests/jni/memoryCheckTest.c
+++ b/runtime/tests/jni/memoryCheckTest.c
@@ -29,28 +29,23 @@
 
 /**
  * The block that isn't being freed should be detected.
- *
-*/
-void JNICALL 
+ */
+void JNICALL
 Java_j9vm_test_memchk_NoFree_test(JNIEnv * env, jclass clazz)
 {
-	char * charArray;
 	PORT_ACCESS_FROM_ENV(env);
-
-	charArray = j9mem_allocate_memory(11, OMRMEM_CATEGORY_VM);
-    strcpy(charArray, "nofree");
+	char *charArray = j9mem_allocate_memory(11, OMRMEM_CATEGORY_VM);
+	strcpy(charArray, "nofree");
 }
 
-void JNICALL 
+void JNICALL
 Java_j9vm_test_memchk_BlockOverrun_test(JNIEnv * env, jclass clazz)
 {
-	char * charArray;
 	PORT_ACCESS_FROM_ENV(env);
-
-	/* TODO - for mprotect, install a handler here that checks that we failed because we tried to write to a locked page */ 
-	charArray = j9mem_allocate_memory(OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, OMRMEM_CATEGORY_VM);
-	j9tty_err_printf(((J9VMThread *) (env))->javaVM->portLibrary, "j9mem_allocate_memory(%i) returned %p\n", OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, charArray);
-    strcpy(charArray, "overrun");
+	/* TODO - for mprotect, install a handler here that checks that we failed because we tried to write to a locked page */
+	char *charArray = j9mem_allocate_memory(OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, OMRMEM_CATEGORY_VM);
+	j9tty_err_printf("j9mem_allocate_memory(%i) returned %p\n", OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, charArray);
+	strcpy(charArray, "overrun");
 	charArray[16] = 'b';
 	charArray[17] = 'e';
 	charArray[18] = 'r';
@@ -62,15 +57,13 @@ Java_j9vm_test_memchk_BlockOverrun_test(JNIEnv * env, jclass clazz)
 	charArray[24] = 'r';
 }
 
-void JNICALL 
+void JNICALL
 Java_j9vm_test_memchk_BlockUnderrun_test(JNIEnv * env, jclass clazz)
 {
-	char * charArray;
 	PORT_ACCESS_FROM_ENV(env);
-
-	charArray = j9mem_allocate_memory(OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, OMRMEM_CATEGORY_VM);
-	j9tty_err_printf(((J9VMThread *) (env))->javaVM->portLibrary, "j9mem_allocate_memory(%i) returned %p\n", OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, charArray);
-    strcpy(charArray, "underrun");
+	char *charArray = j9mem_allocate_memory(OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, OMRMEM_CATEGORY_VM);
+	j9tty_err_printf("j9mem_allocate_memory(%i) returned %p\n", OVERRUN_UNDERRUN_TEST_BLOCK_SIZE_BYTES, charArray);
+	strcpy(charArray, "underrun");
 	charArray[-9] = 'b';
 	charArray[-8] = 'e';
 	charArray[-7] = 'r';
@@ -82,13 +75,11 @@ Java_j9vm_test_memchk_BlockUnderrun_test(JNIEnv * env, jclass clazz)
 	charArray[-1] = 'r';
 }
 
-void JNICALL 
+void JNICALL
 Java_j9vm_test_memchk_Generic_test(JNIEnv * env, jclass clazz)
 {
-	char * charArray;
 	PORT_ACCESS_FROM_ENV(env);
-
-	charArray = j9mem_allocate_memory(16, OMRMEM_CATEGORY_VM);
-    strcpy(charArray, "generic");
+	char *charArray = j9mem_allocate_memory(16, OMRMEM_CATEGORY_VM);
+	strcpy(charArray, "generic");
 	j9mem_free_memory(charArray);
 }

--- a/runtime/tests/port/j9ttyTest.c
+++ b/runtime/tests/port/j9ttyTest.c
@@ -415,7 +415,7 @@ j9tty_test4(struct J9PortLibrary *portLibrary)
 	OMRPORT_FROM_J9PORT(portLibrary)->tty_err_vprintf = fake_j9tty_vprintf;
 	
 	/* Verify tty_startup was correctly overridden, the parameters passed should not matter */
-	j9tty_err_printf(PORTLIB, "You should not see this\n");
+	j9tty_err_printf("You should not see this\n");
 	rc = j9tty_startup();
 
 	/* Restore the function pointers */
@@ -461,7 +461,7 @@ j9tty_test5(struct J9PortLibrary *portLibrary)
 	OMRPORT_FROM_J9PORT(portLibrary)->file_vprintf = fake_j9file_vprintf;
 	
 	/* Verify tty_startup was correctly overridden, the parameters passed should not matter */
-	j9tty_err_printf(PORTLIB, "You should not see this\n");
+	j9tty_err_printf("You should not see this\n");
 	rc = j9tty_startup();
 
 	/* Restore the function pointers */

--- a/runtime/tests/thread/cuharness/parser.c
+++ b/runtime/tests/thread/cuharness/parser.c
@@ -40,7 +40,7 @@ cutest_parseCmdLine( J9PortLibrary *portLibrary, UDATA lastLegalArg , char **arg
 		/* new style -Xcheck:memory options */
 		if (0 == strcmp("-verbose", argv[i])) {
 			verbose = 1;
-			j9tty_err_printf(PORTLIB, "cutest: verbose output enabled.\n");
+			j9tty_err_printf("cutest: verbose output enabled.\n");
 			return i;
 		}
 	}

--- a/runtime/tests/thread/thrstate/runtest.c
+++ b/runtime/tests/thread/thrstate/runtest.c
@@ -507,7 +507,7 @@ createVMArgs(J9PortLibrary *portLib, int argc, char **argv, UDATA handle, jint v
 
 	options = j9mem_allocate_memory(argc * sizeof(*options), OMRMEM_CATEGORY_THREADS);
 	if (options == NULL) {
-		j9tty_err_printf (PORTLIB, "Failed to allocate memory for options\n");
+		j9tty_err_printf("Failed to allocate memory for options\n");
 		return 1;
 	}
 

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -59,8 +59,8 @@ printExceptionInThread(J9VMThread* vmThread)
 
 	name = getOMRVMThreadName(vmThread->omrVMThread);
 
-	j9tty_err_printf(PORTLIB, format, name);
-	j9tty_err_printf(PORTLIB, " ");
+	j9tty_err_printf(format, name);
+	j9tty_err_printf(" ");
 
 	releaseOMRVMThreadName(vmThread->omrVMThread);
 }
@@ -87,7 +87,7 @@ printExceptionMessage(J9VMThread* vmThread, j9object_t exception) {
 		}
 	}
 
-	j9tty_err_printf(PORTLIB, "%.*s%s%.*s\n",
+	j9tty_err_printf("%.*s%s%.*s\n",
 		(UDATA)J9UTF8_LENGTH(exceptionClassName),
 		J9UTF8_DATA(exceptionClassName),
 		separator,
@@ -113,7 +113,7 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, UDATA bytecodeO
 			J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG,
 			J9NLS_VM_STACK_TRACE_UNKNOWN,
 			NULL);
-		j9tty_err_printf(PORTLIB, (char*)format);
+		j9tty_err_printf(format);
 	} else {
 		J9UTF8* className = J9ROMCLASS_CLASSNAME(romClass);
 		J9UTF8* methodName = J9ROMMETHOD_NAME(romMethod);
@@ -182,7 +182,7 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, UDATA bytecodeO
 					J9NLS_VM_STACK_TRACE_WITH_MODULE_VERSION,
 					"\tat %.*s.%.*s (%s@%s/%.*s)\n");
 			}
-			j9tty_err_printf(PORTLIB, (char*)format,
+			j9tty_err_printf(format,
 				(UDATA)J9UTF8_LENGTH(className), J9UTF8_DATA(className),
 				(UDATA)J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName),
 				moduleNameUTF, moduleVersionUTF,
@@ -200,7 +200,7 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, UDATA bytecodeO
 					J9NLS_VM_STACK_TRACE,
 					"\tat %.*s.%.*s (%.*s)\n");
 			}
-			j9tty_err_printf(PORTLIB, (char*)format,
+			j9tty_err_printf(format,
 				(UDATA)J9UTF8_LENGTH(className), J9UTF8_DATA(className),
 				(UDATA)J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName),
 				sourceFileNameLen, sourceFileName,

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -571,7 +571,7 @@ internalSetCurrentExceptionWithCause(J9VMThread *currentThread, UDATA exceptionN
 		if (J9_ARE_NO_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_CLASS_OBJECT_ASSIGNED)) {
 			/* This is JVM startup stage, exit with message now. */
 			PORT_ACCESS_FROM_JAVAVM(vm);
-			j9tty_err_printf(PORTLIB, "%s\n", utfMessage);
+			j9tty_err_printf("%s\n", utfMessage);
 			goto done;
 		}
 	}

--- a/runtime/vm/gphandle.c
+++ b/runtime/vm/gphandle.c
@@ -910,10 +910,10 @@ generateSystemDump(struct J9PortLibrary* portLibrary, void* gpInfo)
 			j9tty_printf(PORTLIB, "\nGenerated system dump: %s\n", dumpName);
 		} else {
 			/* failed, error message in dumpName */
-			j9tty_err_printf(PORTLIB, "\nError: %s\n", dumpName);
+			j9tty_err_printf("\nError: %s\n", dumpName);
 		}
 	} else {
-		j9tty_err_printf(PORTLIB, "\nSystem dump not written since \""J9DO_NOT_WRITE_DUMP"\" was defined in the environment\n");
+		j9tty_err_printf("\nSystem dump not written since \""J9DO_NOT_WRITE_DUMP"\" was defined in the environment\n");
 	}
 }
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2021,16 +2021,16 @@ j9print_internal_version(J9PortLibrary *portLib)
 
 #if defined(OPENJ9_BUILD)
 #if defined(J9JDK_EXT_VERSION) && defined(J9JDK_EXT_NAME)
-	j9tty_err_printf(PORTLIB, "Eclipse OpenJ9 %s %s-bit Server VM (%s) from %s-%s JRE with %s %s, built on %s %s by %s with %s\n",
-		J9PRODUCT_NAME, J9TARGET_CPU_BITS, J9VERSION_STRING, J9TARGET_OS, J9TARGET_CPU_OSARCH,
-		J9JDK_EXT_NAME, J9JDK_EXT_VERSION,__DATE__, __TIME__, J9USERNAME, J9COMPILER_VERSION_STRING);
+	j9tty_err_printf("Eclipse OpenJ9 %s %s-bit Server VM (%s) from %s-%s JRE with %s %s, built on %s %s by %s with %s\n",
+			J9PRODUCT_NAME, J9TARGET_CPU_BITS, J9VERSION_STRING, J9TARGET_OS, J9TARGET_CPU_OSARCH,
+			J9JDK_EXT_NAME, J9JDK_EXT_VERSION,__DATE__, __TIME__, J9USERNAME, J9COMPILER_VERSION_STRING);
 #else
-        j9tty_err_printf(PORTLIB, "Eclipse OpenJ9 %s %s-bit Server VM (%s) from %s-%s JRE, built on %s %s by %s with %s\n",
-                J9PRODUCT_NAME, J9TARGET_CPU_BITS, J9VERSION_STRING, J9TARGET_OS, J9TARGET_CPU_OSARCH,
-                __DATE__, __TIME__, J9USERNAME, J9COMPILER_VERSION_STRING);
+	j9tty_err_printf("Eclipse OpenJ9 %s %s-bit Server VM (%s) from %s-%s JRE, built on %s %s by %s with %s\n",
+			J9PRODUCT_NAME, J9TARGET_CPU_BITS, J9VERSION_STRING, J9TARGET_OS, J9TARGET_CPU_OSARCH,
+			__DATE__, __TIME__, J9USERNAME, J9COMPILER_VERSION_STRING);
 #endif /* J9JDK_EXT_VERSION && J9JDK_EXT_NAME */
 #else /* OPENJ9_BUILD */
-	j9tty_err_printf(PORTLIB, "internal version not supported\n");
+	j9tty_err_printf("internal version not supported\n");
 #endif /* OPENJ9_BUILD */
 }
 

--- a/runtime/vm/jvmrisup.c
+++ b/runtime/vm/jvmrisup.c
@@ -799,7 +799,7 @@ rasThreadProtectedStartFuncWrapper(J9PortLibrary* portLib, void *arg_struct )
 	result = (*vm)->AttachCurrentThread(vm, (void **)&env, NULL); 
 	if (result != JNI_OK) {
 		PORT_ACCESS_FROM_JAVAVM((J9JavaVM*)vm);
-		j9tty_err_printf(PORTLIB, "J9RI0018: jvmri->CreateThread cannot attach new thread\n");
+		j9tty_err_printf("J9RI0018: jvmri->CreateThread cannot attach new thread\n");
 
 		arg_s->started = JVMRI_THREAD_ERROR;
 		omrthread_monitor_notify(arg_s->monitor);

--- a/runtime/vm/logsupport.c
+++ b/runtime/vm/logsupport.c
@@ -329,19 +329,20 @@ _couldnotparse:
 
 	return rc;
 }
+
 static void
-printXlogUsage(struct J9PortLibrary* PORTLIB)
+printXlogUsage(struct J9PortLibrary *PORTLIB)
 {
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP01, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP02, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP03, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP04, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP05, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP06, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP07, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP08, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP09, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP10, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP11, NULL));
-	j9tty_err_printf(PORTLIB, j9nls_lookup_message(J9NLS_INFO|J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP12, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP01, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP02, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP03, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP04, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP05, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP06, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP07, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP08, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP09, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP10, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP11, NULL));
+	j9tty_err_printf(j9nls_lookup_message(J9NLS_INFO | J9NLS_DO_NOT_PRINT_MESSAGE_TAG, J9NLS_VM_XLOG_HELP12, NULL));
 }

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -1596,7 +1596,7 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 
 	if ( !vm->mainThread ) {
 		/* No main thread, so not much we can do here */
-		j9tty_err_printf(PORTLIB, "Thread info not available\n");
+		j9tty_err_printf("Thread info not available\n");
 		return;
 	}
 
@@ -1624,13 +1624,13 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 	if (toFile != NULL) {
 		strcpy(fileName, toFile);
 		if ((tracefd = j9file_open(fileName, EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666))==-1) {
-			j9tty_err_printf(PORTLIB, "Error: Failed to open dump file %s.\nWill output to stderr instead:\n", fileName);
+			j9tty_err_printf("Error: Failed to open dump file %s.\nWill output to stderr instead:\n", fileName);
 		}
 	} else if (vm->sigquitToFileDir != NULL) {
 		j9str_printf(fileName, EsMaxPath, "%s%s%s%d%s",
 				vm->sigquitToFileDir, DIR_SEPARATOR_STR, SIGQUIT_FILE_NAME, j9time_usec_clock(), SIGQUIT_FILE_EXT);
 		if ((tracefd = j9file_open(fileName, EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666))==-1) {
-			j9tty_err_printf(PORTLIB, "Error: Failed to open trace file %s.\nWill output to stderr instead:\n", fileName);
+			j9tty_err_printf("Error: Failed to open trace file %s.\nWill output to stderr instead:\n", fileName);
 		}
 	}
 
@@ -1668,7 +1668,7 @@ void printThreadInfo(J9JavaVM *vm, J9VMThread *self, char *toFile, BOOLEAN allTh
 
 	if (tracefd != -1) {
 		j9file_close(tracefd);
-		j9tty_err_printf(PORTLIB, "Thread info written to: %s\n", fileName);
+		j9tty_err_printf("Thread info written to: %s\n", fileName);
 	}
 
 	if(exclusiveRequestedLocally) {
@@ -1787,7 +1787,7 @@ static void trace_printf(struct J9PortLibrary *portLib, IDATA tracefd, char * fo
 	if (tracefd != -1)
 		wroteToFile = (j9file_write_text(tracefd, buffer, strlen(buffer)) != -1);
 	if (!wroteToFile)
-		j9tty_err_printf(PORTLIB, buffer);
+		j9tty_err_printf(buffer);
 }
 
 j9object_t

--- a/runtime/vm/xcheck.c
+++ b/runtime/vm/xcheck.c
@@ -138,7 +138,7 @@ processXCheckOptions(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 	nocheckCPIndex = OMR_MAX(OMR_MAX(nocheckCPIndex, noneIndex), helpIndex);
 
 	if (checkCPHelpIndex > nocheckCPIndex) {
-		j9tty_err_printf(PORTLIB, "\nUsage: -Xcheck:classpath[:help|none]\n\n");
+		j9tty_err_printf("\nUsage: -Xcheck:classpath[:help|none]\n\n");
 		rc = -1;
 	}
 	
@@ -163,7 +163,7 @@ processXCheckOptions(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 	dumpNoneIndex = OMR_MAX(OMR_MAX(dumpNoneIndex, noneIndex), helpIndex);
 
 	if (dumpHelpIndex > dumpNoneIndex) {
-		j9tty_err_printf(PORTLIB, "\nUsage: -Xcheck:dump\nRun JVM start-up checks for OS system dump settings\n\n");
+		j9tty_err_printf("\nUsage: -Xcheck:dump\nRun JVM start-up checks for OS system dump settings\n\n");
 		rc = -1;
 	}
 
@@ -183,28 +183,28 @@ processXCheckOptions(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 
 static IDATA printXcheckUsage(J9JavaVM *vm)
 {
-        PORT_ACCESS_FROM_JAVAVM(vm);
- 
-        j9tty_err_printf(PORTLIB, "\n-Xcheck usage:\n\n");
- 
-        j9tty_err_printf(PORTLIB, "  -Xcheck:help                  Print general Xcheck help\n");
-        j9tty_err_printf(PORTLIB, "  -Xcheck:none                  Ignore all previous/default Xcheck options\n");
- 
-        j9tty_err_printf(PORTLIB, "  -Xcheck:<component>:help      Print detailed Xcheck help\n");
-        j9tty_err_printf(PORTLIB, "  -Xcheck:<component>:none      Ignore previous Xcheck options of this type\n");
- 
-        j9tty_err_printf(PORTLIB, "\nXcheck enabled components:\n\n");
+	PORT_ACCESS_FROM_JAVAVM(vm);
 
-        j9tty_err_printf(PORTLIB, "  classpath\n");
-        j9tty_err_printf(PORTLIB, "  dump\n");
-        j9tty_err_printf(PORTLIB, "  gc\n");
-        j9tty_err_printf(PORTLIB, "  jni\n");
-        j9tty_err_printf(PORTLIB, "  memory\n");
-        j9tty_err_printf(PORTLIB, "  vm\n\n");
+	j9tty_err_printf("\n-Xcheck usage:\n\n");
 
-        return JNI_OK;
+	j9tty_err_printf("  -Xcheck:help                  Print general Xcheck help\n");
+	j9tty_err_printf("  -Xcheck:none                  Ignore all previous/default Xcheck options\n");
+
+	j9tty_err_printf("  -Xcheck:<component>:help      Print detailed Xcheck help\n");
+	j9tty_err_printf("  -Xcheck:<component>:none      Ignore previous Xcheck options of this type\n");
+
+	j9tty_err_printf("\nXcheck enabled components:\n\n");
+
+	j9tty_err_printf("  classpath\n");
+	j9tty_err_printf("  dump\n");
+	j9tty_err_printf("  gc\n");
+	j9tty_err_printf("  jni\n");
+	j9tty_err_printf("  memory\n");
+	j9tty_err_printf("  vm\n\n");
+
+	return JNI_OK;
 }
- 
+
 /**
  * Non-consuming search for "-verbose:jni"
  * @param list of arguments
@@ -220,7 +220,7 @@ isVerboseJni(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA *verbose
 	if (NULL != verboseIndexPtr) {
 		*verboseIndexPtr = argIndex;
 	}
-	 if (argIndex >= 0) {
+	if (argIndex >= 0) {
 		return 1;
 	} else {
 		return 0;


### PR DESCRIPTION
There's no need to expect users to provide a pointer to the port library (the macro already assumes access via `PORTLIB`); this avoids possible problems being used with a different, incompatible argument.

At least one parameter must be supplied (so the function in `omrtty.c` receives at least two).

Remove unnecessary casts to `(char *)` of format argument.

This is similar to https://github.com/eclipse-openj9/openj9/pull/21051, but for `j9tty_err_printf()`.