### PR TITLE
Re-introduce double-mapping for non off-heap case

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.hpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.hpp
@@ -149,6 +149,25 @@ public:
 	 */
 	bool initializeAllocateDescription(MM_EnvironmentBase *env);
 
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	/**
+	 * For non-contiguous arraylets (discontiguous arraylets, hybrid not allowed
+	 * when double map is enabled), double maps the arraylet leaves to a contiguous
+	 * region outside the heap, making a discontiguous arraylet look contiguous.
+	 * Double map is enabled by default, if one wants to disable it, manually pass
+	 * command line option -Xgc:disableArrayletDoubleMapping; however, if the
+	 * system supports huge pages then double map will be disabled. That's because
+	 * double map does support huge pages yet. If one still wants to enable double
+	 * map in such systems, one must manually force the application to use the
+	 * small system page size
+	 *
+	 * @param env thread GC Environment
+	 * @param objectPtr indexable object spine
+	 * @return the contiguous address pointer
+	 */
+	void *doubleMapArraylets(MM_EnvironmentBase *env, J9Object *objectPtr, void *preferredAddress);
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+
 	/**
 	 * Initializer.
 	 */

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -254,6 +254,59 @@ public:
 		return getSpineSizeWithoutHeader(layout, numberArraylets, dataSize, alignData);
 	}
 
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	/**
+	 * Checks if arraylet falls into corner case of discontiguous data
+	 * Arraylet possible cases:
+	 * 0: Empty arraylets, in this case the array is represented as
+	 *		an arraylet however it does not contain any data, but it
+	 *		does contain an arrayoid (leaf pointer) that points to NULL.
+	 *		Even though this case is represented as a discontiguous arraylet
+	 *		internally due to its implementation, it is actually a contiguous
+	 *		array with length zero.
+	 * 1: The total data size in arraylet is between 0 and region
+	 *		size. Small enough to make the arraylet layout contiguous,
+	 *		in which case this function is unreachable.
+	 * 2: The total data size in arraylet is exacly the same size
+	 *		of a region. In this case we do not need to double
+	 *		map since we already have a contiguous representation of the
+	 *		data at first leaf.
+	 * 3: Similar to first case, the data portion is slightly smaller than
+	 *		a region size, however not small enough to include header and data
+	 *		at the same region to make it contiguous. In which case we would
+	 *		have one leaf, where we also do not need to double map.
+	 * 4: The total data size in arraylet is stricly greater than one region;
+	 *		however, not multiple of region size. Since with enabled double map
+	 *		layout is always discontiguous, we would have 2 or more arraylet leaves
+	 *		therefore we always double map.
+	 * 5: The total data size in arraylet is stricly greater than one region and
+	 *		multiple of region size. Here we would have 2 or more arraylet leaves
+	 *		containing data. We always double map in this case.
+	 *
+	 * @param spine Pointer to an array indexable object spine
+	 * @return false in case corner cases 0, 2 or 3 are valid. On the other hand,
+	 *		if cases 4 or 5 are true, the function returns true.
+	 */
+	MMINLINE bool
+	isArrayletDataDiscontiguous(J9IndexableObject *spine)
+	{
+		return numArraylets(spine) > 1;
+	}
+
+	/**
+	 * Checks if arraylet falls into corner case of contiguous data
+	 *
+	 * @param spine Pointer to an array indexable object spine
+	 * @return true in case corner cases 2 or 3 are valid. On the other hand,
+	 * 		if cases 0, 4 or 5 are true, the function returns false.
+	 */
+	MMINLINE bool
+	isArrayletDataContiguous(J9IndexableObject *spine)
+	{
+		return (1 == numArraylets(spine)) && (getSizeInElements(spine) > 0);
+	}
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+
 	/**
 	 * We can't use memcpy because it may be not atomic for pointers, use this function instead
 	 * Copy data in uintptr_t words

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.cpp
@@ -113,8 +113,15 @@ GC_ArrayletObjectModelBase::getSpineSizeWithoutHeader(ArrayLayout layout, uintpt
 		if (isVirtualLargeObjectHeapEnabled) {
 			extensions->indexableObjectModel.AssertContiguousArrayDataUnreachable();
 		}
-		/* Last arraylet in spine */
-		spineDataSize = (dataSize & (_omrVM->_arrayletLeafSize - 1));
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		else if (extensions->indexableObjectModel.isDoubleMappingEnabled()) {
+			spineDataSize = 0;
+		} else
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+		{
+			/* Last arraylet in spine */
+			spineDataSize = (dataSize & (_omrVM->_arrayletLeafSize - 1));
+		}
 	}
 
 	return spinePaddingSize + spineArrayoidSize + spineDataSize;

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
@@ -164,6 +164,19 @@ public:
 
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	/**
+	 * Sets enable double mapping status. Note that the double map
+	 * status value may differ from the requested one in certain
+	 * circuntances.
+	 *
+	 * @param enableDoubleMapping
+	 */
+	MMINLINE void
+	setEnableDoubleMapping(bool enableDoubleMapping)
+	{
+		_enableDoubleMapping = enableDoubleMapping;
+	}
+
+	/**
 	 * Returns enable double mapping status
 	 * 
 	 * @return true if double mapping status is set to true, false otherwise.

--- a/runtime/gc_stats/CopyForwardStats.hpp
+++ b/runtime/gc_stats/CopyForwardStats.hpp
@@ -74,6 +74,10 @@ public:
 	uintptr_t _offHeapRegionsCleared; /**< The number of sparse heap allocated regions that have been cleared during marking */
 	uintptr_t _offHeapRegionCandidates; /**< The number of sparse heap allocated regions that have been visited during marking */
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	uintptr_t _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
+	uintptr_t _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 	uint64_t _cycleStartTime; /**< The start time of a copy forward cycle */
 
@@ -111,6 +115,10 @@ public:
 		_offHeapRegionsCleared = 0;
 		_offHeapRegionCandidates = 0;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		_doubleMappedArrayletsCleared = 0;
+		_doubleMappedArrayletsCandidates = 0;
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	}
 	
 	/**
@@ -140,6 +148,10 @@ public:
 		_offHeapRegionsCleared += stats->_offHeapRegionsCleared;
 		_offHeapRegionCandidates += stats->_offHeapRegionCandidates;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		_doubleMappedArrayletsCleared += stats->_doubleMappedArrayletsCleared;
+		_doubleMappedArrayletsCandidates += stats->_doubleMappedArrayletsCandidates;
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	}
 
 	MM_CopyForwardStats() :
@@ -161,6 +173,10 @@ public:
 		, _offHeapRegionsCleared(0)
 		, _offHeapRegionCandidates(0)
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		, _doubleMappedArrayletsCleared(0)
+		, _doubleMappedArrayletsCandidates(0)
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	{}
 };
 

--- a/runtime/gc_stats/MarkVLHGCStats.hpp
+++ b/runtime/gc_stats/MarkVLHGCStats.hpp
@@ -78,6 +78,10 @@ public:
 	uintptr_t _offHeapRegionsCleared; /**< The number of or sparse heap allocated regions that have been cleared during marking */
 	uintptr_t _offHeapRegionCandidates; /**< The number of or sparse heap allocated regions that have been visited during marking */
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	uintptr_t _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
+	uintptr_t _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	uintptr_t _splitArraysProcessed; /**< The number of array chunks (not counting parts smaller than the split size) processed by this thread */
@@ -118,6 +122,10 @@ public:
 		_offHeapRegionsCleared = 0;
 		_offHeapRegionCandidates = 0;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		_doubleMappedArrayletsCleared = 0;
+		_doubleMappedArrayletsCandidates = 0;
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		_splitArraysProcessed = 0;
@@ -156,6 +164,10 @@ public:
 		_offHeapRegionsCleared += statsToMerge->_offHeapRegionsCleared;
 		_offHeapRegionCandidates += statsToMerge->_offHeapRegionCandidates;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		_doubleMappedArrayletsCleared += statsToMerge->_doubleMappedArrayletsCleared;
+		_doubleMappedArrayletsCandidates += statsToMerge->_doubleMappedArrayletsCandidates;
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 		_concurrentGCThreadsCPUStartTimeSum += statsToMerge->_concurrentGCThreadsCPUStartTimeSum;
 		_concurrentGCThreadsCPUEndTimeSum += statsToMerge->_concurrentGCThreadsCPUEndTimeSum;
@@ -187,6 +199,10 @@ public:
 		,_offHeapRegionsCleared(0)
 		,_offHeapRegionCandidates(0)
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+		,_doubleMappedArrayletsCleared(0)
+		,_doubleMappedArrayletsCandidates(0)
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		,_splitArraysProcessed(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -4123,6 +4123,24 @@ private:
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	virtual void doDoubleMappedObjectSlot(J9Object *objectPtr, struct J9PortVmemIdentifier *identifier) {
+		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(_env);
+		env->_copyForwardStats._doubleMappedArrayletsCandidates += 1;
+		if (!_copyForwardScheme->isLiveObject(objectPtr)) {
+			Assert_MM_true(_copyForwardScheme->isObjectInEvacuateMemory(objectPtr));
+			MM_ForwardedHeader forwardedHeader(objectPtr, _extensions->compressObjectReferences());
+			objectPtr = forwardedHeader.getForwardedObject();
+			if (NULL == objectPtr) {
+				Assert_MM_mustBeClass(_extensions->objectModel.getPreservedClass(&forwardedHeader));
+				env->_copyForwardStats._doubleMappedArrayletsCleared += 1;
+				OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
+				omrvmem_release_double_mapped_region(identifier->address, identifier->size, identifier);
+			}
+		}
+	}
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+
 	/**
 	 * @Clear the string table cache slot if the object is not marked
 	 */

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1386,6 +1386,17 @@ private:
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	virtual void doDoubleMappedObjectSlot(J9Object *objectPtr, struct J9PortVmemIdentifier *identifier) {
+		MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCandidates += 1;
+		if (!_markingScheme->isMarked(objectPtr)) {
+			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCleared += 1;
+			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
+			omrvmem_release_double_mapped_region(identifier->address, identifier->size, identifier);
+		}
+    }
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+
 	/**
 	 * @Clear the string table cache slot if the object is not marked
 	 */

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
@@ -88,7 +88,9 @@ public:
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	bool _sparseHeapAllocation;		/**< indicates whether this region is related with sparse heap allocation(the first region has reserved for off-heap) */
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-
+#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+	J9PortVmemIdentifier _arrayletDoublemapID;	/**< Contiguous address identifier associate with double mapped region of arraylet */
+#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	bool _defragmentationTarget;		/**< indicates whether this region should be considered for defragmentation, currently this means the region has been GMPed but not collected yet */
 
 protected:


### PR DESCRIPTION
Along with new off-heap feature, double-mapping has been removed (off-heap can cover all of double-mapping cases with better performance), but in case enabling off-heap could not be set as default, re-introduce double-mapping as alternative backup.

1, double mapping is still part of array Discontiguous layout 
2, no share code between off-heap and double-mapping