### PR TITLE
Add forward declaration to avoid compiler warnings

### DIFF
--- a/runtime/oti/util_api.h
+++ b/runtime/oti/util_api.h
@@ -47,6 +47,9 @@
 extern "C" {
 #endif
 
+/* Forward declaration. */
+struct jvmtiClassDefinition;
+
 typedef enum
 {
 	ONLY_SPEC_MODIFIERS,


### PR DESCRIPTION
Building with the change in https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/789, the compiler warns:
```
In file included from openj9/runtime/oti/j9protos.h:123,
                 from openj9/runtime/util/tracehelp.c:23,
                 from jdk08/jdk/src/share/native/common/check_version.c:36:
openj9/runtime/oti/util_api.h:2334:88: warning: ‘struct jvmtiClassDefinition’ declared inside parameter list will not be visible outside of this definition or declaration
 verifyClassesCanBeReplaced (J9VMThread * currentThread, jint class_count, const struct jvmtiClassDefinition * class_definitions);
                                                                                        ^~~~~~~~~~~~~~~~~~~~
openj9/runtime/oti/util_api.h:2337:78: warning: ‘struct jvmtiClassDefinition’ declared inside parameter list will not be visible outside of this definition or declaration
 reloadROMClasses (J9VMThread * currentThread, jint class_count, const struct jvmtiClassDefinition * class_definitions, J9JVMTIClassPair * classPairs, UDATA options);
                                                                              ^~~~~~~~~~~~~~~~~~~~
```
