### PR TITLE
OpenJDK java/foreign/TestLinker crash fix

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
@@ -216,11 +216,13 @@ final class LayoutStrPreprocessor {
 			long elementCount = arrayLayout.elementCount().getAsLong();
 			/*[ENDIF] JAVA_SPEC_VERSION >= 21 */
 
-			/* The padding bytes is required in the native signature for upcall thunk generation. */
-			if (isPaddingLayout(elementLayout) && !isDownCall) {
-				targetLayoutStr.append('(').append(arrayLayout.byteSize()).append(')');
-			} else {
-				targetLayoutStr.append(elementCount).append(':').append(preprocessLayout(elementLayout, isDownCall));
+			if (0 < elementCount) {
+				/* The padding bytes is required in the native signature for upcall thunk generation. */
+				if (isPaddingLayout(elementLayout) && !isDownCall) {
+					targetLayoutStr.append('(').append(arrayLayout.byteSize()).append(')');
+				} else {
+					targetLayoutStr.append(elementCount).append(':').append(preprocessLayout(elementLayout, isDownCall));
+				}
 			}
 		/*[IF JAVA_SPEC_VERSION >= 21]*/
 		} else if (targetLayout instanceof UnionLayout unionLayout) { /* Intended for the nested union since JDK21. */

--- a/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler.cpp
+++ b/runtime/vm/OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler.cpp
@@ -104,6 +104,7 @@ OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler_initCifNativeTh
 	UDATA returnLayoutSize = 0;
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	VM_OutOfLineINL_Helpers::buildInternalNativeStackFrame(currentThread, method);
 
 	/* Set up the ffi_type of the return layout in the case of primitive or struct */
 	returnLayoutSize = ffiTypeHelpers.getLayoutFFIType(&returnType, retLayoutStrObject);
@@ -220,6 +221,7 @@ OutOfLineINL_openj9_internal_foreign_abi_InternalDowncallHandler_initCifNativeTh
 	J9VMOPENJ9INTERNALFOREIGNABIINTERNALDOWNCALLHANDLER_SET_CIFNATIVETHUNKADDR(currentThread, nativeInvoker, (intptr_t)cif);
 
 done:
+	VM_OutOfLineINL_Helpers::restoreInternalNativeStackFrame(currentThread);
 	VM_OutOfLineINL_Helpers::returnVoid(currentThread, 5);
 	return rc;
 


### PR DESCRIPTION
The changes reflect the fix for issue https://github.com/eclipse-openj9/openj9/issues/21017.

buildInternalNativeStackFrame before setting exception.
Added check for sequence layout of zero length.

Closes: https://github.com/eclipse-openj9/openj9/issues/21017
Signed-off-by: Nick Kamal <[nick.kamal@ibm.com](mailto:nick.kamal@ibm.com)>