### PR TITLE
Reduce number of VM_getReferenceSlotsInClass messages for JITServer

### DIFF
--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -425,7 +425,8 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory) :
    _fieldOrStaticDefiningClassCache(decltype(_fieldOrStaticDefiningClassCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _J9MethodNameCache(decltype(_J9MethodNameCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
    _isStableCache(decltype(_isStableCache)::allocator_type(persistentMemory->_persistentAllocator.get())),
-   _referencingClassLoaders(decltype(_referencingClassLoaders)::allocator_type(persistentMemory->_persistentAllocator.get()))
+   _referencingClassLoaders(decltype(_referencingClassLoaders)::allocator_type(persistentMemory->_persistentAllocator.get())),
+   _referenceSlotsInClass(decltype(_referenceSlotsInClass)::allocator_type(persistentMemory->_persistentAllocator.get()))
    {
    }
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -227,6 +227,13 @@ public:
       PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
       PersistentUnorderedMap<int32_t, bool> _isStableCache; // Store the presence of the Stable annotation for the field indicated by a cpIndex
       PersistentUnorderedSet<J9ClassLoader *> _referencingClassLoaders;
+      // The following vector caches information about the offsets of the reference slots in the class.
+      // An empty vector means I don't have any information yet.
+      // The information is encoded with a zero terminator element. Thus, if the vector contains
+      // exactly one element (which must be the 0 terminator), it means that the class contains no reference fields.
+      // This information is not collected when the class is sent from the client to server. Rather, it is
+      // populated when the server needs it.
+      PersistentVector<int32_t> _referenceSlotsInClass; // Array of N int32_t values. The last one has a value of 0.
       }; // struct ClassInfo
 
    /**


### PR DESCRIPTION
These messages are sent by the server to inquire about the offsets of the reference slots in a j9class.
This commit implements caching at the JITServer of the information received from the client. This change reduces the number of VM_getReferenceSlotsInClass by a factor of 10.