### PR TITLE
Add inline iTable walk for Checkcast on Z

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -420,6 +420,11 @@ public:
    bool supportsInliningOfIsAssignableFrom() { return false; } // no virt, default
 
    /** \brief
+    *    Determines whether code generators support an inline iTable walk for checkcast
+    */
+   bool supportsCheckcastInlineItableWalk() { return false; } // no virt, default
+
+   /** \brief
     *     Determines whether the code generator must generate the switch to interpreter snippet in the preprologue.
     */
    bool mustGenerateSwitchToInterpreterPrePrologue();

--- a/runtime/compiler/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.cpp
@@ -1523,6 +1523,8 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
                {
                sequences[i++] = CastClassCacheTest;
                }
+            if (instanceOfOrCheckCastNode->getOpCode().isCheckCast() && cg->supportsCheckcastInlineItableWalk())
+               sequences[i++] = InterfaceTest;
             if (createDynamicCacheTests)
                sequences[i++] = DynamicCacheObjectClassTest;
             sequences[i++] = HelperCall;
@@ -1601,7 +1603,8 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
              s == ArrayOfJavaLangObjectTest ||
              s == ClassEqualityTest ||
              s == SuperClassTest ||
-             s == CastClassCacheTest)
+             s == CastClassCacheTest ||
+             s == InterfaceTest)
             {
             if (!objectClassLoaded)
                {
@@ -1616,7 +1619,8 @@ uint32_t J9::TreeEvaluator::calculateInstanceOfOrCheckCastSequences(TR::Node *in
          //
          if (s == ClassEqualityTest ||
              s == SuperClassTest ||
-             s == CastClassCacheTest)
+             s == CastClassCacheTest ||
+             s == InterfaceTest)
             {
             if (!castClassEvaluated)
                {

--- a/runtime/compiler/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/codegen/J9TreeEvaluator.hpp
@@ -58,6 +58,7 @@ class OMR_EXTENSIBLE TreeEvaluator: public OMR::TreeEvaluatorConnector
       DynamicCacheObjectClassTest,      // Needs object class: y, needs cast class: n
       DynamicCacheDynamicCastClassTest, // Needs object class: y, needs cast class: y
       HelperCall,                       // Needs object class: n, needs cast class: y
+      InterfaceTest,                    // Needs object class: y, needs cast class: y
 
       InstanceOfOrCheckCastMaxSequences
       };

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -64,6 +64,8 @@ void J9::RecognizedCallTransformer::processConvertingUnaryIntrinsicFunction(TR::
 
 void J9::RecognizedCallTransformer::process_java_lang_Class_IsAssignableFrom(TR::TreeTop* treetop, TR::Node* node)
    {
+   static char *use_new= feGetEnv("use_new");
+   if (use_new == NULL) return;
    auto toClass = node->getChild(0);
    auto fromClass = node->getChild(1);
    auto nullchk = comp()->getSymRefTab()->findOrCreateNullCheckSymbolRef(comp()->getMethodSymbol());

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4314,3 +4314,17 @@ J9::Z::CodeGenerator::supportsTrapsInTMRegion()
    {
    return self()->comp()->target().isZOS();
    }
+
+bool
+J9::Z::CodeGenerator::supportsInliningOfIsAssignableFrom()
+   {
+   static const bool disableInliningOfIsAssignableFrom = feGetEnv("TR_disableInlineIsAssignableFrom") != NULL;
+   return !disableInliningOfIsAssignableFrom;
+   }
+
+bool 
+J9::Z::CodeGenerator::supportsCheckcastInlineItableWalk()
+   {
+   static const bool disableCheckcastItableWalk = feGetEnv("TR_disableCheckcastItableWalk") != NULL;
+   return !disableCheckcastItableWalk;
+   }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -113,6 +113,8 @@ public:
    bool constLoadNeedsLiteralFromPool(TR::Node *node);
 
    bool supportsTrapsInTMRegion();
+   bool supportsInliningOfIsAssignableFrom();
+   bool supportsCheckcastInlineItableWalk();
 
    using J9::CodeGenerator::addAllocatedRegister;
    void addAllocatedRegister(TR_PseudoRegister * temp);

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -3363,7 +3363,7 @@ genTestIsSuper(TR::CodeGenerator * cg, TR::Node * node,
          cursor = generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BNH, node, failLabel, cursor);
 
       if (debugObj)
-         debugObj->addInstructionComment(cursor, "Fail if depth(obj) > depth(castClass)");
+         debugObj->addInstructionComment(cursor, "Fail if depth(obj) <= depth(castClass)");
 
       }
 
@@ -11508,6 +11508,62 @@ J9::Z::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::CodeGenerator *c
    return 0;
    }
 
+
+static bool isInterfaceOrAbstract(TR::Node *clazz, TR::Compilation *comp)
+   {
+   while (clazz->getOpCodeValue() == TR::aloadi && clazz->getNumChildren() > 0)
+      {
+      clazz = clazz->getFirstChild();
+      }
+
+   // the next check will not work if we do not have a loadaddr node
+   if (clazz->getOpCodeValue() != TR::loadaddr) return false;
+
+   TR::SymbolReference *thisClassSymRef = clazz->getSymbolReference();
+   return thisClassSymRef->isClassInterface(comp) || thisClassSymRef->isClassAbstract(comp);
+   }
+
+static int32_t getCompileTimeClassDepth(TR::Node *clazz, TR::Compilation *comp)
+   {
+   int32_t classDepth = -1;
+
+   /*
+    * loop finds loadaddr node that is a child of an aloadi node
+    *
+    * (jitCheckAssignable call node could have child of the form
+    * aloadi
+    *    aloadi <javaLangClassFromClass>
+    *       loadaddr
+    * )
+    */
+   while (clazz->getOpCodeValue() == TR::aloadi && clazz->getNumChildren() > 0 && clazz->getFirstChild()->getOpCodeValue() == TR::aloadi)
+      {
+      clazz = clazz->getFirstChild();
+      }
+
+   if (clazz->getOpCodeValue() != TR::aloadi || clazz->getSymbolReference() != comp->getSymRefTab()->findJavaLangClassFromClassSymbolRef() ||
+   clazz->getFirstChild()->getOpCodeValue() != TR::loadaddr) return classDepth;
+
+   TR::Node   *castClassRef = clazz->getFirstChild();
+
+   TR::SymbolReference *castClassSymRef = NULL;
+   if(castClassRef->getOpCode().hasSymbolReference())
+      castClassSymRef= castClassRef->getSymbolReference();
+
+   TR::StaticSymbol    *castClassSym = NULL;
+   if (castClassSymRef && !castClassSymRef->isUnresolved())
+      castClassSym= castClassSymRef ? castClassSymRef->getSymbol()->getStaticSymbol() : NULL;
+
+   TR_OpaqueClassBlock * clazzz = NULL;
+   if (castClassSym)
+      clazzz = (TR_OpaqueClassBlock *) castClassSym->getStaticAddress();
+
+   if(clazzz)
+      classDepth = (int32_t)TR::Compiler->cls.classDepthOf(clazzz);
+
+   return classDepth;
+   }
+
 /////////////////////////////////////////////////////////////////////////////////
 /////////////////////////////////////////////////////////////////////////////////
 static bool inlineIsAssignableFrom(TR::Node *node, TR::CodeGenerator *cg)
@@ -11662,29 +11718,43 @@ static bool inlineIsAssignableFrom(TR::Node *node, TR::CodeGenerator *cg)
 
 TR::Register *J9::Z::TreeEvaluator::inlineCheckAssignableFromEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   TR::Register *fromClassReg = cg->evaluate(node->getFirstChild());
-   TR::Register *toClassReg = cg->evaluate(node->getSecondChild());
+   TR::Node *fromClass = node->getFirstChild();
+   TR::Node *toClass = node->getSecondChild();
+   TR::Register *fromClassReg = cg->evaluate(fromClass);
+   TR::Register *toClassReg = cg->evaluate(toClass);
 
-   TR::Register *resultReg = cg->allocateRegister();
    TR::LabelSymbol *helperCallLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *failLabel = generateLabelSymbol(cg);
    TR::LabelSymbol *successLabel = generateLabelSymbol(cg);
 
    TR::LabelSymbol* cFlowRegionStart = generateLabelSymbol(cg);
+   TR_S390ScratchRegisterManager *srm = cg->generateScratchRegisterManager(2);
+   TR::Register *sr1 =  srm->findOrCreateScratchRegister();
+   TR::Register *sr2 = srm->findOrCreateScratchRegister();
+
+   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 5, cg);
+   deps->addPostCondition(fromClassReg, TR::RealRegister::AssignAny);
+   deps->addPostConditionIfNotAlreadyInserted(toClassReg, TR::RealRegister::AssignAny);
+   srm->addScratchRegistersToDependencyList(deps);
+
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, cFlowRegionStart);
    cFlowRegionStart->setStartInternalControlFlow();
-
-   /*
-    * check for class equality
-    * if equal, we are done. If not, fall through to helper call
-    */
    generateS390CompareAndBranchInstruction(cg, TR::InstOpCode::getCmpRegOpCode(), node, toClassReg, fromClassReg, TR::InstOpCode::COND_BE, successLabel, false, false);
-
-   /*
-    * TODO: add inlined tests (SuperclassTest, cast class cache, etc)
-    * Inlined tests will be used when possible, or will jump to the OOL section
-    * and perform the tests using the CHelper when not possible
-    */
+   if (!isInterfaceOrAbstract(toClass, cg->comp()))
+      {
+      auto toClassDepth = getCompileTimeClassDepth(toClass, cg->comp());
+      if (!isInterfaceOrAbstract(fromClass, cg->comp()))
+         {
+         auto fromClassDepth = getCompileTimeClassDepth(fromClass, cg->comp());
+         if (toClassDepth > -1 && fromClassDepth > -1 && toClassDepth > fromClassDepth)
+            {
+            generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, failLabel);
+            }
+         }
+      genTestIsSuper(cg, node, fromClassReg, toClassReg, sr1, sr2, NULL, NULL, toClassDepth, failLabel, successLabel, helperCallLabel, deps, NULL, false, NULL, NULL);
+      generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BE, node, successLabel);
+      }
 
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, helperCallLabel);
    TR_S390OutOfLineCodeSection *outlinedSlowPath = new (cg->trHeapMemory()) TR_S390OutOfLineCodeSection(helperCallLabel, doneLabel, cg);
@@ -11692,21 +11762,23 @@ TR::Register *J9::Z::TreeEvaluator::inlineCheckAssignableFromEvaluator(TR::Node 
    outlinedSlowPath->swapInstructionListsWithCompilation();
 
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, helperCallLabel);
-   resultReg = TR::TreeEvaluator::performCall(node, false, cg);
+   TR::Register *resultReg = TR::TreeEvaluator::performCall(node, false, cg);
 
    generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, doneLabel); // exit OOL section
    outlinedSlowPath->swapInstructionListsWithCompilation();
 
+   generateS390LabelInstruction(cg, TR::InstOpCode::label, node, failLabel);
+   generateRIInstruction(cg, TR::InstOpCode::LHI, node, resultReg, 0);
+   generateS390BranchInstruction(cg, TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, node, doneLabel);
+
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, successLabel);
-   generateRIInstruction(cg, TR::InstOpCode::getLoadHalfWordImmOpCode(), node, resultReg, 1);
+   generateRIInstruction(cg, TR::InstOpCode::LHI, node, resultReg, 1);
 
-   TR::RegisterDependencyConditions* deps = new (cg->trHeapMemory()) TR::RegisterDependencyConditions(0, 3, cg);
-   deps->addPostCondition(fromClassReg, TR::RealRegister::AssignAny);
-   deps->addPostConditionIfNotAlreadyInserted(toClassReg, TR::RealRegister::AssignAny);
    deps->addPostCondition(resultReg, TR::RealRegister::AssignAny);
-
    generateS390LabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, deps);
    doneLabel->setEndInternalControlFlow();
+
+   srm->stopUsingRegisters();
    node->setRegister(resultReg);
    return resultReg;
    }


### PR DESCRIPTION
Implements an iTable walk inline for `checkcast` nodes on Z instead of calling out to the helper
- adds `supportsCheckcastInlineItableWalk()` method to `J9CodeGenerator`
    - defaults to false
    - only Z has a non-default implementation
- adds `InterfaceTest` to the `checkcast` generated sequences when the `toClass` is known to be an interface at compile time
    - guarded by `isCheckcast()` and `supportsCheckcastInlineItableWalk()`