### PR TITLE
Should-be-adjacent vs is-adjacent data API cleanup

### DIFF
--- a/runtime/gc_glue_java/ArrayletObjectModel.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.cpp
@@ -186,14 +186,14 @@ GC_ArrayletObjectModel::shouldFixupDataAddrForContiguous(MM_ForwardedHeader *for
 }
 
 bool
-GC_ArrayletObjectModel::isDataAdjacentToHeader(J9IndexableObject *arrayPtr)
+GC_ArrayletObjectModel::shouldDataBeAdjacentToHeader(J9IndexableObject *arrayPtr)
 {
 	uintptr_t dataSizeInBytes = getDataSizeInBytes(arrayPtr);
-	return isDataAdjacentToHeader(dataSizeInBytes);
+	return shouldDataBeAdjacentToHeader(dataSizeInBytes);
 }
 
 bool
-GC_ArrayletObjectModel::isDataAdjacentToHeader(uintptr_t dataSizeInBytes)
+GC_ArrayletObjectModel::shouldDataBeAdjacentToHeader(uintptr_t dataSizeInBytes)
 {
 	MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(_omrVM);
 	uintptr_t minimumSpineSizeAfterGrowing = extensions->getObjectAlignmentInBytes();

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.cpp
@@ -106,7 +106,7 @@ GC_ArrayletObjectModelBase::getSpineSizeWithoutHeader(ArrayLayout layout, uintpt
 
 	uintptr_t spineDataSize = 0;
 	if (InlineContiguous == layout) {
-		if (!isVirtualLargeObjectHeapEnabled || extensions->indexableObjectModel.isDataAdjacentToHeader(dataSize)) {
+		if (!isVirtualLargeObjectHeapEnabled || extensions->indexableObjectModel.shouldDataBeAdjacentToHeader(dataSize)) {
 			spineDataSize = dataSize; // All data in spine
 		}
 	} else if (Hybrid == layout) {


### PR DESCRIPTION
In array object model distinguish between APIs:
- should be adjacent
- is adjacent

The former is used early when the object is being constructed, and dataAddr is yet to be initialized. API makes a decision based on size in bytes explicitely provided or read from the array heder, and is used to determine if data should be allocated in main heap or offheap.

The latter is used at later points in time (like GC, JNI Critical API) when object is fully initialized. Then the check is about actual dataAddr value (if it points to the end of the header or not). This is faster and simpler check and is preferred, unless dataAddr is not initialized yet.