### PR TITLE
Suppress inlining identityHashcode and fastIdentityHashcode

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -129,6 +129,7 @@
    java_lang_Object_clone,
    java_lang_Object_newInstancePrototype,
    java_lang_Object_getAddressAsPrimitive,
+   java_lang_Object_hashCode,
    java_lang_ref_Reference_getImpl,
    java_lang_ref_Reference_reachabilityFence,
    java_lang_ref_Reference_refersTo,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2349,6 +2349,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_Object_clone,                "clone",                "()Ljava/lang/Object;")},
       {x(TR::java_lang_Object_newInstancePrototype, "newInstancePrototype", "(Ljava/lang/Class;)Ljava/lang/Object;")},
       {x(TR::java_lang_Object_getAddressAsPrimitive, "getAddressAsPrimitive", "(Ljava/lang/Object;)I")},
+      {x(TR::java_lang_Object_hashCode,             "hashCode",             "()I")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5574,6 +5574,23 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
          return true;
       case TR::java_lang_Class_cast:
          return true; // Call will be transformed into checkcast
+      case TR::java_lang_J9VMInternals_identityHashCode:
+      case TR::java_lang_J9VMInternals_fastIdentityHashCode:
+         {
+         TR_PrexArgInfo *callerArgInfo = comp->getCurrentInlinedCallArgInfo();
+         if (callsite->_callerResolvedMethod->getRecognizedMethod() == TR::java_lang_Object_hashCode &&
+            callerArgInfo &&
+            callerArgInfo->get(0))
+            {
+            if (callerArgInfo->get(0)->hasKnownObjectIndex())
+               {
+               if (comp->trace(OMR::inlining))
+                  traceMsg(comp, "Suppressing inlining identityHashCode helper call as it can be evaluated in VP.\n");
+               return true;
+               }
+            }
+         return false;
+         }
       case TR::java_lang_String_hashCodeImplDecompressed:
          /*
           * X86 and z want to avoid inlining both java_lang_String_hashCodeImplDecompressed and java_lang_String_hashCodeImplCompressed


### PR DESCRIPTION
For helper methods identityHashcode and fastIdentityHashcode,
it may be possible to evaluate their results at compile
time when their enclosing method Object.hashCode() has a known
class object info being passed as an arg which we can evaluate
during compile time. This is done in Value Propagation, but
only if we prevent the inlining of the identityHashcode and
fastIdentityHashcode helper methods.

Also added recognized method java/lang/Object.hashCode().