### PR TITLE
Enable peeking ILGen for inlined methods related to java/util/HashMap get/put operations.

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -345,6 +345,8 @@
    java_util_HashMap_getNode,
    java_util_HashMap_getNode_Object,
    java_util_HashMap_findNonNullKeyEntry,
+   java_util_HashMap_hash,
+   java_util_HashMap_put,
    java_util_HashMap_putImpl,
    java_util_HashMap_resize,
    java_util_HashMap_prepareArray,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2183,6 +2183,8 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_util_HashMap_get,                   "get",           "(Ljava/lang/Object;)Ljava/lang/Object;")},
       {x(TR::java_util_HashMap_getNode,               "getNode",       "(ILjava/lang/Object;)Ljava/util/HashMap$Node;")},
       {x(TR::java_util_HashMap_getNode_Object,        "getNode",       "(Ljava/lang/Object;)Ljava/util/HashMap$Node;")},
+      {x(TR::java_util_HashMap_hash,                  "hash",          "(Ljava/lang/Object;)I")},
+      {x(TR::java_util_HashMap_put,                   "put",           "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")},
       {x(TR::java_util_HashMap_putImpl,               "putImpl",       "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;")},
       {x(TR::java_util_HashMap_findNonNullKeyEntry,   "findNonNullKeyEntry",         "(Ljava/lang/Object;II)Ljava/util/HashMap$Entry;")},
       {x(TR::java_util_HashMap_resize,                "resize",         "()[Ljava/util/HashMap$Node;")},

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -128,6 +128,20 @@ class TR_MultipleCallTargetInliner : public TR_InlinerBase
        *    True if the given calltarget should be inlined
        */
       bool inlineSubCallGraph(TR_CallTarget* calltarget);
+
+      /*
+       * \brief
+       *   For some call targets and their sub call graphs, it may be possible to simplify them into simple operations in
+       *   certain situations, such as when known object info is being passed as arg. In such cases, the node count
+       *   obtained via generateNodeEstimate would not truly reflect the number of nodes that are actually introduced. This
+       *   function provides a mechanism for examining call targets and evaluating whether it is safe to skip counting nodes.
+       *
+       * \param callTarget
+       *    the call target to examine
+       * \return
+       *    true if node counting can be skipped for callTarget, false otherwise
+       */
+      bool canSkipCountingNodes(TR_CallTarget* callTarget);
    };
 
 class TR_J9InlinerUtil: public OMR_InlinerUtil


### PR DESCRIPTION
To propagate arg info from callers of `HashMap.put`, `HashMap.get`, `HashMap.hash`, `Map.get`, `Map.put` and `Object.hashCode`, generating IL of their callers is necessary when called from an inlined method. This allows us to propagate prex arg info from caller and enable compile-time folding of fastIdentityHashCode calls during Value Propagation.