### PR TITLE
Revert "Add unused macro to access barrier helpers"

### DIFF
--- a/runtime/oti/j9accessbarrierhelpers.h
+++ b/runtime/oti/j9accessbarrierhelpers.h
@@ -71,8 +71,7 @@ static UDATA j9javaArray_BA(J9VMThread *vmThread, J9IndexableObject *array, UDAT
 }
 
 #define J9JAVAARRAY_C_EA(elemType)																					\
-__attribute__ ((__unused__)) VMINLINE static elemType																\
-*j9javaArray_##elemType##_EA(J9VMThread *vmThread, J9IndexableObject *array, UDATA index)							\
+VMINLINE static elemType *j9javaArray_##elemType##_EA(J9VMThread *vmThread, J9IndexableObject *array, UDATA index)	\
 {																													\
 	UDATA baseAddress = j9javaArray_BA(vmThread, array, &index, (U_8)sizeof(elemType));								\
 	/* Intentionally inlining this to treat sizeof value as an immediate value */									\
@@ -108,10 +107,10 @@ J9JAVAARRAY_C_EA(UDATA)
  * Note that Microsoft compilers do not allow this attribute.
  */
 VMINLINE static j9object_t
-j9javaArrayOfObject_load(J9VMThread *vmThread, J9IndexableObject *array, I_32 index) __attribute__ ((__unused__));
+j9javaArrayOfObject_load(J9VMThread *vmThread, J9IndexableObject *array, I_32 index)   __attribute__ ((__unused__));
 
 VMINLINE static j9object_t
-j9javaArrayOfObject_load_VM(J9JavaVM *vm, J9IndexableObject *array, I_32 index) __attribute__ ((__unused__));
+j9javaArrayOfObject_load_VM(J9JavaVM *vm, J9IndexableObject *array, I_32 index)  __attribute__ ((__unused__));
 #endif /* __GNUC__ */
 
 VMINLINE static j9object_t
@@ -138,7 +137,7 @@ j9javaArrayOfObject_load_VM(J9JavaVM *vm, J9IndexableObject *array, I_32 index)
 	} else {
 		UDATA *loadAddress = J9JAVAARRAY_EA_VM(vm, array, index, UDATA);
 		J9OBJECT__PRE_OBJECT_LOAD_ADDRESS_VM(vm, array, loadAddress);
-		return (j9object_t)*loadAddress;
+		return (j9object_t)*loadAddress;	
 	}
 }
 


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#21153.

Until we can find a way to express the intent in #21153 that works with all compilers (including those used in IBM Java 8) I suggest that those that want to use `-O0` can configure using `--disable-warnings-as-errors-openj9` to ignore the resulting warnings.