### PR TITLE
RootScanner awareness for array displacement API

### DIFF
--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -1395,7 +1395,6 @@ void walkJITFrameSlotsForInternalPointers(J9StackWalkState * walkState,  U_8 ** 
       internalPointersInRegisters = 1;
 
 
-   BOOLEAN offHeapAllocationEnabled = walkState->walkThread->javaVM->memoryManagerFunctions->j9gc_off_heap_allocation_enabled(walkState->walkThread->javaVM);
    while (i < numDistinctPinningArrays)
       {
       U_8 currPinningArrayIndex = *(tempJitDescriptionCursor++);
@@ -1413,8 +1412,9 @@ void walkJITFrameSlotsForInternalPointers(J9StackWalkState * walkState,  U_8 ** 
 
       IDATA displacement = 0;
 
-      if (newPinningArrayAddress)
-         displacement = walkState->walkThread->javaVM->memoryManagerFunctions->j9gc_objaccess_indexableDataDisplacement(walkState->walkThread, (J9IndexableObject*)oldPinningArrayAddress, (J9IndexableObject*)newPinningArrayAddress);
+      /* ignore walkers that don't move objects - if object has not moved, displacement for sure won't change */
+      if (oldPinningArrayAddress != newPinningArrayAddress)
+         displacement = walkState->walkThread->javaVM->memoryManagerFunctions->j9gc_objaccess_indexableDataDisplacement(walkState, (J9IndexableObject*)oldPinningArrayAddress, (J9IndexableObject*)newPinningArrayAddress);
 
       ++(walkState->slotIndex);
 

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -269,7 +269,7 @@ public:
 	virtual void staticStoreU64(J9VMThread *vmThread, J9Class *clazz, U_64 *destSlot, U_64 value, bool isVolatile=false);
 	virtual void staticStoreI64(J9VMThread *vmThread, J9Class *clazz, I_64 *destSlot, I_64 value, bool isVolatile=false);
 
-	MMINLINE virtual IDATA indexableDataDisplacement(J9VMThread *vmThread, J9IndexableObject *src, J9IndexableObject *dst)
+	MMINLINE virtual IDATA indexableDataDisplacement(J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst)
 	{
 		return (IDATA)(((UDATA)dst) - ((UDATA)src));
 	}

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -551,6 +551,28 @@ public:
 	virtual void doObjectInVirtualLargeObjectHeap(J9Object *objectPtr, bool *sparseHeapAllocation);
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	
+#if defined(J9VM_ENV_DATA64)
+	/**
+	 * Check if data is adjacent to array header, based on dataAddr value.
+	 * This is used during stack slots scanning, when object can move.
+	 * It is called after the object movement (stack slot has been fixed,
+	 * although copying operation may not be necessarily completed yet).
+	 * Specific RootScanner that can move objects will use either src or dst to perform adjacency check,
+	 * whichever is safe. Scanners that not move objects should not be calling it, otherwise will assert.
+	 * Should really be called only for Offheap and only for contiguous arrays (non-zero sized objects),
+	 * although that is not asserted.
+	 *
+	 * @param src array address before movement
+	 * @param dst array address after movement
+	 *
+	 * @return true if data is next to the header, and false if its in Offheap
+	 */
+
+	virtual bool isDataAdjacentToHeader(J9IndexableObject *src, J9IndexableObject *dst) {
+		Assert_MM_unreachable();
+		return true;
+	}
+#endif /* defined(J9VM_ENV_DATA64) */
 	/**
 	 * Called for each object stack slot. Subclasses may override.
 	 * 

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -353,11 +353,10 @@ j9gc_objaccess_staticStoreU64Split(J9VMThread *vmThread, J9Class *clazz, U_64 *d
  * @return displacement
  */
 IDATA
-j9gc_objaccess_indexableDataDisplacement(J9VMThread *vmThread, J9IndexableObject *src, J9IndexableObject *dst)
+j9gc_objaccess_indexableDataDisplacement(J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst)
 {
-	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
-	return barrier->indexableDataDisplacement(vmThread, src, dst);
-
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(walkState->walkThread)->accessBarrier;
+	return barrier->indexableDataDisplacement(walkState, src, dst);
 }
 
 /* TODO: After all array accesses in the VM have been made arraylet safe, 

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -101,7 +101,7 @@ extern J9_CFUNC BOOLEAN j9gc_hot_reference_field_required(J9JavaVM *javaVM);
 extern J9_CFUNC BOOLEAN j9gc_off_heap_allocation_enabled(J9JavaVM *javaVM);
 extern J9_CFUNC uint32_t j9gc_max_hot_field_list_length(J9JavaVM *javaVM);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreAddress(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, void *value, UDATA isVolatile);
-extern J9_CFUNC IDATA j9gc_objaccess_indexableDataDisplacement(J9VMThread *vmThread, J9IndexableObject *src, J9IndexableObject *dst);
+extern J9_CFUNC IDATA j9gc_objaccess_indexableDataDisplacement(J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst);
 extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreAddress(J9VMThread *vmThread, j9object_t destObject, UDATA offset, void *value, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_cloneObject(J9VMThread *vmThread, j9object_t srcObject, j9object_t destObject);
 extern J9_CFUNC void j9gc_objaccess_copyObjectFields(J9VMThread *vmThread, J9Class *valueClass, J9Object *srcObject, UDATA srcOffset, J9Object *destObject, UDATA destOffset, MM_objectMapFunction objectMapFunction, void *objectMapData, UDATA initializeLockWord);

--- a/runtime/gc_glue_java/ArrayletObjectModel.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.cpp
@@ -68,12 +68,6 @@ GC_ArrayletObjectModel::AssertArrayletIsDiscontiguous(J9IndexableObject *objPtr)
 }
 
 void
-GC_ArrayletObjectModel::AssertContiguousArrayletLayout(J9IndexableObject *objPtr)
-{
-	Assert_MM_true(InlineContiguous == getArrayLayout(objPtr));
-}
-
-void
 GC_ArrayletObjectModel::AssertVirtualLargeObjectHeapEnabled()
 {
 	Assert_MM_true(isVirtualLargeObjectHeapEnabled());

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -809,7 +809,7 @@ public:
 	MMINLINE void **
 	dataAddrSlotForContiguous(J9IndexableObject *arrayPtr)
 	{
-		AssertContiguousArrayletLayout(arrayPtr);
+		/* Not safe to access class data or size - this may be a forwarded object! */
 		bool const compressed = compressObjectReferences();
 		void **dataAddrPtr = NULL;
 		if (compressed) {
@@ -1310,11 +1310,6 @@ public:
 	 * Asserts that an Arraylet has indeed discontiguous layout
 	 */
 	void AssertArrayletIsDiscontiguous(J9IndexableObject *objPtr);
-
-	/**
-	 * Asserts that an Arraylet has true contiguous layout
-	 */
-	void AssertContiguousArrayletLayout(J9IndexableObject *objPtr);
 
 	/**
 	 * Asserts that an Arraylet has true discontiguous layout

--- a/runtime/gc_realtime/RealtimeAccessBarrier.hpp
+++ b/runtime/gc_realtime/RealtimeAccessBarrier.hpp
@@ -157,7 +157,7 @@ public:
 	virtual I_32 forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
 
 	virtual IDATA
-	indexableDataDisplacement(J9VMThread *vmThread, J9IndexableObject *src, J9IndexableObject *dst)
+	indexableDataDisplacement(J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst)
 	{
 		Assert_MM_unreachable();
 		return 0;

--- a/runtime/gc_structs/VMThreadStackSlotIterator.cpp
+++ b/runtime/gc_structs/VMThreadStackSlotIterator.cpp
@@ -45,8 +45,8 @@ extern "C" {
  * Simply massages the arguments and calls the function that was passed by the user into
  * GC_VMThreadStackSlotIterator::scanSlots()
  */
-static void
-vmThreadStackDoOSlotIterator(J9VMThread *vmThread, J9StackWalkState *walkState, j9object_t *oSlotPointer, const void * stackLocation) 
+void
+gc_vmThreadStackDoOSlotIterator(J9VMThread *vmThread, J9StackWalkState *walkState, j9object_t *oSlotPointer, const void * stackLocation)
 {
 	J9MODRON_OSLOTITERATOR *oSlotIterator = (J9MODRON_OSLOTITERATOR*)walkState->userData1;
 
@@ -79,7 +79,7 @@ GC_VMThreadStackSlotIterator::initializeStackWalkState(
 {
 	J9JavaVM *vm = vmThread->javaVM;
 
-	stackWalkState->objectSlotWalkFunction = vmThreadStackDoOSlotIterator;
+	stackWalkState->objectSlotWalkFunction = gc_vmThreadStackDoOSlotIterator;
 	stackWalkState->userData1 = (void *)oSlotIterator;
 	stackWalkState->userData2 = (void *)vm;
 	stackWalkState->userData3 = userData;

--- a/runtime/gc_structs/VMThreadStackSlotIterator.hpp
+++ b/runtime/gc_structs/VMThreadStackSlotIterator.hpp
@@ -37,6 +37,13 @@
  */
 typedef void J9MODRON_OSLOTITERATOR(J9JavaVM *javaVM, J9Object **objectIndirect, void *localData, J9StackWalkState *walkState, const void *stackLocation);
 
+extern "C" {
+
+void gc_vmThreadStackDoOSlotIterator(J9VMThread *vmThread, J9StackWalkState *walkState, j9object_t *oSlotPointer, const void * stackLocation);
+
+} /* extern "C" */
+
+
 /**
  * Iterate over all slots on the stack of a given thread which contain object references.
  * @ingroup GC_Structs

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -3875,6 +3875,13 @@ private:
 	}
 #endif /* J9VM_GC_FINALIZATION */
 
+#if defined(J9VM_ENV_DATA64)
+	virtual bool isDataAdjacentToHeader(J9IndexableObject *src, J9IndexableObject *dst) {
+		/* Checking against src object since dst is not guarantied to be completely copied (by a racing thread that won f/w operaton). */
+		return _extensions->indexableObjectModel.isDataAdjacentToHeader(src);
+	}
+#endif /* defined(J9VM_ENV_DATA64) */
+
 public:
 	MM_CopyForwardSchemeRootScanner(MM_EnvironmentVLHGC *env, MM_CopyForwardScheme *copyForwardScheme) :
 		MM_RootScanner(env),

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
@@ -76,7 +76,7 @@ public:
 	virtual I_32 backwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
 	virtual I_32 forwardReferenceArrayCopyIndex(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, I_32 srcIndex, I_32 destIndex, I_32 lengthInSlots);
 
-	virtual IDATA indexableDataDisplacement(J9VMThread *vmThread, J9IndexableObject *src, J9IndexableObject *dst);
+	virtual IDATA indexableDataDisplacement(J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst);
 
 	virtual void* jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jarray array, jboolean *isCopy);
 	virtual void jniReleasePrimitiveArrayCritical(J9VMThread* vmThread, jarray array, void * elems, jint mode);

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1714,6 +1714,14 @@ public:
 		}
 	}
 #endif /* J9VM_GC_FINALIZATION */
+
+#if defined(J9VM_ENV_DATA64)
+	virtual bool isDataAdjacentToHeader(J9IndexableObject *src, J9IndexableObject *dst) {
+		/* Checking against dst object since src object may be overwritten. */
+		return _extensions->indexableObjectModel.isDataAdjacentToHeader(dst);
+	}
+#endif /* defined(J9VM_ENV_DATA64) */
+
 };
 
 void

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4736,7 +4736,7 @@ typedef struct J9MemoryManagerFunctions {
 #endif /* !defined(J9VM_ENV_DATA64) */
 	void  ( *j9gc_objaccess_indexableStoreObject)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, j9object_t value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_indexableStoreAddress)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, void *value, UDATA isVolatile) ;
-	IDATA  ( *j9gc_objaccess_indexableDataDisplacement)(struct J9VMThread *vmThread, J9IndexableObject *src, J9IndexableObject *dst) ;
+	IDATA  ( *j9gc_objaccess_indexableDataDisplacement)(struct J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst) ;
 	IDATA  ( *j9gc_objaccess_mixedObjectReadI32)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
 	UDATA  ( *j9gc_objaccess_mixedObjectReadU32)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
 	I_64  ( *j9gc_objaccess_mixedObjectReadI64)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;


### PR DESCRIPTION
When calculating data displacement during array movement in root scanning, data adjacency check has to be aware what type of movement it is.

For Copy-Forward scanner, adjacency check has to be peformed against source object, since destination one may not be fully copied yet.

For WOC scanner, adjacency check has to be peformed against dst object, since source one may be overwritten.