### PR TITLE
Move location of incGlobalClassUnloadID()

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2052,6 +2052,7 @@ static void jitHookClassesUnload(J9HookInterface * * hookInterface, UDATA eventN
    TR::PersistentInfo * persistentInfo = compInfo->getPersistentInfo();
 
    persistentInfo->incNumUnloadedClasses(classUnloadCount);
+   persistentInfo->incGlobalClassUnloadID();
 
    if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerboseClassUnloading))
       {
@@ -2244,7 +2245,6 @@ static void jitHookAnonClassesUnload(J9HookInterface * * hookInterface, UDATA ev
 
    compInfo->getLowPriorityCompQueue().purgeEntriesOnClassLoaderUnloading(&dummyClassLoader);
 
-   compInfo->getPersistentInfo()->incGlobalClassUnloadID();
 #if defined(J9VM_INTERP_PROFILING_BYTECODES)
    if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableIProfilerThread))
       {
@@ -2406,7 +2406,6 @@ static void jitHookClassLoaderUnload(J9HookInterface * * hookInterface, UDATA ev
       {
       TR_VerboseLog::writeLineLocked(TR_Vlog_HD, "Class unloading for classLoader=0x%p", classLoader);
       }
-   compInfo->getPersistentInfo()->incGlobalClassUnloadID();
 
    PORT_ACCESS_FROM_JAVAVM(vmThread->javaVM);
 


### PR DESCRIPTION
incGlobalClassUnloadID() function is used to increment a counter every time a class unload event happens. This is used by the interpreter profiler to determine if it needs to re-examine the validity of the entries it looks at. If there was no class unload operation since the last time it looked at an entry, it doesn't have to check again.
Currently, incGlobalClassUnloadID() is called in jitHookAnonClassesUnload() and jitHookClassLoaderUnload(), but we only have to do it once per class unload cycle. This commit moves the location of incGlobalClassUnloadID() to jitHookClassesUnload() which is called only once per class unload cycle.