### PR TITLE
Set OSX argument encoding default to UTF-8 to match ri

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1413,11 +1413,11 @@ getMUtf8String(J9JavaVM *vm, const char *userString, UDATA stringLength)
 		}
 		result = mutf8Buffer;
 	} else {
-#if defined(WIN32)
+#if defined(OSX) || defined(WIN32)
 		I_32 fromCode = J9STR_CODE_UTF8; /* command-line arguments should be in UTF-8 */
-#else /* defined(WIN32) */
+#else /* defined(OSX) || defined(WIN32) */
 		I_32 fromCode = J9STR_CODE_PLATFORM_RAW;
-#endif /* defined(WIN32) */
+#endif /* defined(OSX) || defined(WIN32) */
 		if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_ARGENCODING_UTF8)) {
 			fromCode = J9STR_CODE_UTF8;
 		} else if (J9_ARE_ANY_BITS_SET(vm->runtimeFlags, J9_RUNTIME_ARGENCODING_LATIN)) {


### PR DESCRIPTION
Enable ConfigFileTest: https://github.com/adoptium/aqa-tests/pull/5967

Related: https://github.com/eclipse-openj9/openj9/issues/20357

Personal build: https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/26570/
jdk_security1 tests: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/48237/