### PR TITLE
Narrow scope of TR::StackMemoryRegion during SPMD parallelization

### DIFF
--- a/runtime/compiler/optimizer/SPMDParallelizer.cpp
+++ b/runtime/compiler/optimizer/SPMDParallelizer.cpp
@@ -1504,9 +1504,6 @@ bool TR_SPMDKernelParallelizer::processSPMDKernelLoopForSIMDize(TR::Compilation 
    // need scalar loop for handling residual iterations
    // piggybacking on loop unroller implementation
 
-   //void *stackMark = trMemory()->markStack();
-   TR::StackMemoryRegion stackMemoryRegion(*trMemory());
-
    unroller.unroll(loop, branchNode);
 
 #if 0
@@ -1516,11 +1513,14 @@ bool TR_SPMDKernelParallelizer::processSPMDKernelLoopForSIMDize(TR::Compilation 
    unroller._optimizer->setEnableOptimization(inductionVariableAnalysis, true, NULL);
 #endif
 
-   //trMemory()->releaseStack(stackMark);
-
    TR_ScratchList<TR::Block> blocksInLoop(trMemory());
    loop->getBlocks(&blocksInLoop);
    ListIterator<TR::Block> blocksIt1(&blocksInLoop);
+
+   {
+   // Narrow scope of StackMemoryRegion for manipulation of TR_HashTab pointed to by entries
+   //
+   TR::StackMemoryRegion stackMemoryRegion(*trMemory());
 
    TR_HashTab* entries = new (comp->trStackMemory()) TR_HashTab(comp->trMemory(), stackAlloc);
 
@@ -1625,6 +1625,7 @@ bool TR_SPMDKernelParallelizer::processSPMDKernelLoopForSIMDize(TR::Compilation 
          }
          entries->clear();
       }
+   }
 
    ListIterator<TR::Block> blocksIt(&blocksInLoop);
 


### PR DESCRIPTION
`TR_SPMDKernelParallelizer::processSPMDKernelLoopForSIMDize` creates a `TR::StackMemoryRegion` object that's used to allocate space for a `TR_ScratchList` and a `TR_HashTab`.  However, while that `TR::StackMemoryRegion` is still in scope, another `TR_HashTab` - `_loopDataType` - that was allocated in an earlier `TR::StackMemoryRegion` is used and potentially has more entries added to it.  Once `processSPMDKernelLoopForSIMDize`'s `TR::StackMemoryRegion` goes out of scope and then comes back into scope, the contents of `_loopDataType` could become corrupted.

Fixed this by narrowing the scope of the `TR::StackMemoryRegion` object in `processSPMDKernelLoopForSIMDize` to ensure it goes out of scope before `_loopDataType` might be manipulated again.

Note that with this change the `TR_ScratchList<TR::Block>` object, `blocksInLoop`, is allocated outside the scope of the `processSPMDKernelLoopForSIMDize`'s `TR::StackMemoryRegion`, as code later in the method needs to iterate over those blocks while calling `visitTreeTopToSIMDize`.  `visitTreeTopToSIMDize` is where new entries might be added to `_loopDataType`.  That potentially increases memory consumed by those `TR_ScratchList` objects.

Fixes #21124 