### PR TITLE
Add and use new macro MN_GET_REFERENCE_KIND

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4983,7 +4983,7 @@ TR_J9VMBase::getMemberNameMethodInfo(
    out->vmtarget = (TR_OpaqueMethodBlock*)(uintptr_t)tgt;
    out->vmindex = (uintptr_t)ix;
    out->clazz = getClassFromJavaLangClass(jlClass);
-   out->refKind = (flags >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK;
+   out->refKind = MN_GET_REFERENCE_KIND(flags);
    return true;
    }
 

--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -1039,7 +1039,7 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(
 			j9object_t clazzObject = J9VMJAVALANGINVOKEMEMBERNAME_CLAZZ(currentThread, membernameObject);
 			J9Class *resolvedClass = J9VM_J9CLASS_FROM_HEAPCLASS(currentThread, clazzObject);
 
-			jint ref_kind = (flags >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK;
+			jint ref_kind = MN_GET_REFERENCE_KIND(flags);
 
 			J9Class *typeClass = J9OBJECT_CLAZZ(currentThread, typeObject);
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2431,23 +2431,25 @@ typedef struct J9ROMMethodHandleRef {
 #define MH_REF_INVOKEVIRTUAL  5
 #define MH_REF_PUTFIELD  3
 
-/* Constants mapped from java.lang.invoke.MethodHandleNatives$Constants
+/* Constants mapped from java.lang.invoke.MethodHandleNatives$Constants.
  * These constants are validated by the MethodHandleNatives$Constants.verifyConstants()
- * method when Java assertions are enabled
+ * method when Java assertions are enabled.
  */
-#define MN_IS_METHOD		0x00010000
-#define MN_IS_CONSTRUCTOR	0x00020000
-#define MN_IS_FIELD			0x00040000
-#define MN_IS_TYPE			0x00080000
-#define MN_CALLER_SENSITIVE	0x00100000
-#define MN_TRUSTED_FINAL	0x00200000
-#define MN_HIDDEN_MEMBER	0x00400000
+#define MN_IS_METHOD            0x00010000
+#define MN_IS_CONSTRUCTOR       0x00020000
+#define MN_IS_FIELD             0x00040000
+#define MN_IS_TYPE              0x00080000
+#define MN_CALLER_SENSITIVE     0x00100000
+#define MN_TRUSTED_FINAL        0x00200000
+#define MN_HIDDEN_MEMBER        0x00400000
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-#define MN_NULL_RESTRICTED	0x00800000
+#define MN_NULL_RESTRICTED      0x00800000
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-#define MN_REFERENCE_KIND_SHIFT	24
-/* (flag >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK */
-#define MN_REFERENCE_KIND_MASK	(0x0F000000 >> MN_REFERENCE_KIND_SHIFT)
+#define MN_REFERENCE_KIND_SHIFT 24
+#define MN_REFERENCE_KIND_MASK  (0x0F000000 >> MN_REFERENCE_KIND_SHIFT)
+
+#define MN_GET_REFERENCE_KIND(flags) \
+	(((flags) >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK)
 
 typedef struct J9ROMMethodRef {
 	U_32 classRefCPIndex;
@@ -3574,7 +3576,6 @@ typedef struct J9ArrayClass {
 	struct J9Class *companionArray;
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 } J9ArrayClass;
-
 
 #if defined(LINUX) && defined(J9VM_ARCH_X86) && !defined(OSX)
 /* Only enable the assert on linux x86 as not all the versions

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -1821,7 +1821,7 @@ fixMemberNames(J9VMThread *currentThread, j9object_t *memberNamesToFix)
 jlong
 vmindexValueForMethodMemberName(J9JNIMethodID *methodID, J9Class *clazz, jint flags)
 {
-	jint refKind = (flags >> MN_REFERENCE_KIND_SHIFT) & MN_REFERENCE_KIND_MASK;
+	jint refKind = MN_GET_REFERENCE_KIND(flags);
 	jlong result = (jlong)-2; /* Invalid result (must be replaced). */
 
 	Assert_hshelp_true(J9_ARE_ANY_BITS_SET(flags, MN_IS_METHOD | MN_IS_CONSTRUCTOR));


### PR DESCRIPTION
Centralizes expression of extracting the kind of a native method handle from its flags.