### PR TITLE
Change KEEP_REPORTDIR param to bool

### DIFF
--- a/buildenv/jenkins/common/pipeline-functions.groovy
+++ b/buildenv/jenkins/common/pipeline-functions.groovy
@@ -237,7 +237,7 @@ def test(JOB_NAME, UPSTREAM_JOB_NAME, UPSTREAM_JOB_NUMBER, NODE, OPENJ9_REPO, OP
             string(name: 'VENDOR_TEST_DIRS', value: VENDOR_TEST_DIRS),
             string(name: 'USER_CREDENTIALS_ID', value: USER_CREDENTIALS_ID),
             string(name: 'TEST_FLAG', value: TEST_FLAG),
-            string(name: 'KEEP_REPORTDIR', value: keepReportDir),
+            booleanParam(name: 'KEEP_REPORTDIR', value: keepReportDir.toBoolean()),
             string(name: 'BUILD_IDENTIFIER', value: BUILD_IDENTIFIER),
             string(name: 'PARALLEL', value: PARALLEL),
             string(name: 'NUM_MACHINES', value: NUM_MACHINES),


### PR DESCRIPTION
Test pipelines expect this to be a bool. There is a warning printed in the pipelines currently that the type doesn't match and it converts it.

https://github.ibm.com/runtimes/aqa-tests/blob/3f58e11aa281ae1c673e5a2659e0c2884c097929/buildenv/jenkins/testJobTemplate#L445

Current output
```
00:39:15.880  Scheduling project: [Test_openjdk21_j9_sanity.functional_aarch64_linux_Nightly](https://openj9-jenkins.osuosl.org/job/Test_openjdk21_j9_sanity.functional_aarch64_linux_Nightly/)
00:39:15.880  The parameter 'KEEP_REPORTDIR' did not have the type expected by [Test_openjdk21_j9_sanity.functional_aarch64_linux_Nightly](https://openj9-jenkins.osuosl.org/job/Test_openjdk21_j9_sanity.functional_aarch64_linux_Nightly/). Converting to Boolean Parameter.
```
Now
```
00:15:49.006  Scheduling project: [Test_openjdk11_j9_sanity.functional_aarch64_mac_Personal](https://openj9-jenkins.osuosl.org/job/Test_openjdk11_j9_sanity.functional_aarch64_mac_Personal/)
00:15:55.951  Starting building: [Test_openjdk11_j9_sanity.functional_aarch64_mac_Personal #241](https://openj9-jenkins.osuosl.org/job/Test_openjdk11_j9_sanity.functional_aarch64_mac_Personal/241/)
```