### PR TITLE
Fix P allocationInlining OffHeap len cmp to use cmp4 instead of cmp8

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -6525,7 +6525,7 @@ TR::Register *J9::Power::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeG
                TR::LabelSymbol *dataAddrInitDoneLabel = generateLabelSymbol(cg);
                TR::LabelSymbol *nonZeroArrayLabel = generateLabelSymbol(cg);
 
-               iCursor = generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::cmpi8, node, condReg, enumReg, 0, iCursor);
+               iCursor = generateTrg1Src1ImmInstruction(cg,TR::InstOpCode::cmpli4, node, condReg, enumReg, 0, iCursor);
                iCursor = generateConditionalBranchInstruction(cg, TR::InstOpCode::bgt, node, nonZeroArrayLabel, condReg, iCursor);
                // Clear dataAddr field of 0 size array
                if (needZeroInit)


### PR DESCRIPTION
The array allocation length is a int node/value, using a cmp8 on it can result in the wrong result if it the register has undefined value in the upper 4-bytes.

Current code show proper cmp instruction compared to the added offheap check.
<img width="1374" alt="Screenshot 2025-02-25 at 12 32 04 PM" src="https://github.com/user-attachments/assets/211a8e1b-55ab-46e2-8410-81cf3a54fe3e" />


WIP: finishing tests
