### PR TITLE
MethodHandleNatives.resolve() should work with a field at offset 0

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -1366,13 +1366,8 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(
 					target = (jlong)offset;
 				}
 			}
-			if (
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-				/* In project Valhalla fields may start at offset 0. */
-				(NULL != new_clazz)
-#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
-				(0 != target)
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+			/* A field may start at offset 0, so no need to check if (0 != target). */
+			if ((NULL != new_clazz)
 				&& ((0 != vmindex) || J9_ARE_ANY_BITS_SET(flags, MN_IS_METHOD | MN_IS_CONSTRUCTOR))
 			) {
 				/* Refetch reference after GC point */

--- a/test/functional/Java11andUp/playlist.xml
+++ b/test/functional/Java11andUp/playlist.xml
@@ -268,6 +268,7 @@
 	<test>
 		<testCaseName>JCL_TEST_Java-Lang-Invoke</testCaseName>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+			--add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
 			-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
 			org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 			-testnames JCL_TEST_Java-Lang-Invoke \

--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -1046,6 +1046,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	--add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED \
 	--add-exports java.base/sun.net.www.protocol.jrt=ALL-UNNAMED \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	--add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
 	--add-opens=java.base/java.security=ALL-UNNAMED \
 	$(ADD_EXPORTS_JDK_INTERNAL_ACCESS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(JAXB_API_JAR)$(Q) \
@@ -1249,6 +1250,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	--add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED \
 	--add-exports java.base/sun.net.www.protocol.jrt=ALL-UNNAMED \
 	--add-opens=java.base/java.lang=ALL-UNNAMED \
+	--add-opens=java.base/java.lang.invoke=ALL-UNNAMED \
 	--add-opens=java.base/java.security=ALL-UNNAMED \
 	$(ADD_EXPORTS_JDK_INTERNAL_ACCESS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(P)$(TEST_RESROOT)$(D)TestResources.jar$(P)$(LIB_DIR)$(D)asm-all.jar$(JAXB_API_JAR)$(Q) \

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/invoke/Test_MethodHandleInfo.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/invoke/Test_MethodHandleInfo.java
@@ -28,6 +28,7 @@ import org.testng.AssertJUnit;
 import java.lang.invoke.*;
 import java.lang.reflect.*;
 import org.openj9.test.java.lang.invoke.helpers.*;
+import org.openj9.test.util.VersionCheck;
 import static java.lang.invoke.MethodHandles.*;
 import static java.lang.invoke.MethodType.*;
 
@@ -688,6 +689,25 @@ public class Test_MethodHandleInfo {
 			IAEThrown = true;
 		}
 		AssertJUnit.assertTrue(IAEThrown);
+	}
+
+	/**
+	 * Check that IMPL_LOOKUP.findGetter() works for an instance field at offset 0.
+	 *
+	 * @throws Throwable
+	 */
+	@Test(groups = { "level.sanity" })
+	public void test_ReflectAs_Field_Offset0() throws Throwable {
+		Class<?> fieldType;
+		if (VersionCheck.major() > 8) {
+			fieldType = byte[].class;
+		} else {
+			fieldType = char[].class;
+		}
+		Field field = MethodHandles.Lookup.class.getDeclaredField("IMPL_LOOKUP");
+		field.setAccessible(true);
+		MethodHandles.Lookup lookup = (MethodHandles.Lookup) field.get(null);
+		System.out.println(lookup.findGetter(String.class, "value", fieldType));
 	}
 
 	enum EnumTest {TEST1, TEST2}


### PR DESCRIPTION
`MethodHandleNatives.resolve()` should work with a field at offset 0

A field at offset has `target` 0, the check `(0 != target)` is invalid;
Added a test.

closes https://github.com/eclipse-openj9/openj9/issues/21180

Signed-off-by: Jason Feng <fengj@ca.ibm.com>