### PR TITLE
Support heap memory for ffi CaptureCallState

### DIFF
--- a/runtime/vm/bindnatv.cpp
+++ b/runtime/vm/bindnatv.cpp
@@ -301,7 +301,9 @@ static inlMapping mappings[] = {
 	{ "Java_sun_reflect_Reflection_getClassAccessFlags__Ljava_lang_Class_2", J9_BCLOOP_SEND_TARGET_INL_REFLECTION_GETCLASSACCESSFLAGS },
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
-#if JAVA_SPEC_VERSION >= 22
+#if JAVA_SPEC_VERSION >= 24
+	{ "Java_openj9_internal_foreign_abi_InternalDowncallHandler_invokeNative__Ljava_lang_Object_2_3Ljava_lang_Object_2_3JZJJJJ_3J", J9_BCLOOP_SEND_TARGET_INL_INTERNALDOWNCALLHANDLER_INVOKENATIVE },
+#elif JAVA_SPEC_VERSION >= 22
 	{ "Java_openj9_internal_foreign_abi_InternalDowncallHandler_invokeNative___3Ljava_lang_Object_2_3JZJJJJ_3J", J9_BCLOOP_SEND_TARGET_INL_INTERNALDOWNCALLHANDLER_INVOKENATIVE },
 #elif JAVA_SPEC_VERSION == 21
 	{ "Java_openj9_internal_foreign_abi_InternalDowncallHandler_invokeNative__ZJJJJ_3J", J9_BCLOOP_SEND_TARGET_INL_INTERNALDOWNCALLHANDLER_INVOKENATIVE },


### PR DESCRIPTION
Starting in Java 24 the ffi CaptureCallState and Critical options can be used together. When heap memory use is allowed through the critical option the captured call state should be returned to the given heap memory segment.

Related: https://github.com/eclipse-openj9/openj9/issues/21018
Related: https://github.com/eclipse-openj9/openj9/issues/21019

OpenJDK foreign test suite (failure is related to https://github.com/eclipse-openj9/openj9/issues/21018): https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/48403/

