### PR TITLE
Correct uses of J9_LOAD_LOCKWORD()

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -747,7 +747,7 @@ preparePinnedVirtualThreadForUnmount(J9VMThread *currentThread, j9object_t syncO
 			if (!LN_HAS_LOCKWORD(currentThread, object)) {
 				objectMonitor = monitorTablePeek(currentThread->javaVM, object);
 				if (NULL != objectMonitor) {
-					lock = J9_LOAD_LOCKWORD(currentThread, objectMonitor->alternateLockword);
+					lock = J9_LOAD_LOCKWORD(currentThread, &objectMonitor->alternateLockword);
 				} else {
 					lock = 0;
 				}
@@ -777,7 +777,7 @@ preparePinnedVirtualThreadForUnmount(J9VMThread *currentThread, j9object_t syncO
 			if (!LN_HAS_LOCKWORD(currentThread, object)) {
 				objectMonitor = monitorTablePeek(currentThread->javaVM, object);
 				if (NULL != objectMonitor) {
-					lock = J9_LOAD_LOCKWORD(currentThread, objectMonitor->alternateLockword);
+					lock = J9_LOAD_LOCKWORD(currentThread, &objectMonitor->alternateLockword);
 				} else {
 					lock = 0;
 				}
@@ -802,7 +802,7 @@ preparePinnedVirtualThreadForUnmount(J9VMThread *currentThread, j9object_t syncO
 	if (!LN_HAS_LOCKWORD(currentThread, syncObj)) {
 		syncObjectMonitor = monitorTablePeek(currentThread->javaVM, syncObj);
 		if (NULL != syncObjectMonitor) {
-			lock = J9_LOAD_LOCKWORD(currentThread, syncObjectMonitor->alternateLockword);
+			lock = J9_LOAD_LOCKWORD(currentThread, &syncObjectMonitor->alternateLockword);
 		} else {
 			lock = 0;
 		}
@@ -879,7 +879,7 @@ restart:
 					if (!LN_HAS_LOCKWORD(currentThread, syncObject)) {
 						syncObjectMonitor = vmFuncs->monitorTablePeek(vm, syncObject);
 						if (NULL != syncObjectMonitor){
-							lock = J9_LOAD_LOCKWORD_VM(vm, syncObjectMonitor->alternateLockword);
+							lock = J9_LOAD_LOCKWORD_VM(vm, &syncObjectMonitor->alternateLockword);
 						}
 					} else {
 						lock = J9OBJECT_MONITOR(currentThread, syncObject);


### PR DESCRIPTION
The second argument must be the *address* of a lock word.

Discovered because it wouldn't compile in a compressedrefs-only build:
```
[ 81%] Building CXX object runtime/vm/CMakeFiles/j9vm.dir/ContinuationHelpers.cpp.o
In file included from jdknext/build/compressed/vm/runtime/vmhook.h:26,
                 from jdknext/build/compressed/vm/runtime/vmhook_internal.h:10,
                 from jdknext/openj9/runtime/oti/j9.h:42,
                 from jdknext/openj9/runtime/vm/ContinuationHelpers.cpp:22:
jdknext/openj9/runtime/vm/ContinuationHelpers.cpp: In function ‘UDATA preparePinnedVirtualThreadForUnmount(J9VMThread*, j9object_t, BOOLEAN)’:
jdknext/openj9/runtime/oti/j9accessbarrier.h:697:47: error: cast to pointer from integer of different size [-Werror=int-to-pointer-cast]
   ? (j9objectmonitor_t)*(U_32 volatile *)(lwEA) \
                                               ^
jdknext/openj9/runtime/vm/ContinuationHelpers.cpp:750:13: note: in expansion of macro ‘J9_LOAD_LOCKWORD’
      lock = J9_LOAD_LOCKWORD(currentThread, objectMonitor->alternateLockword);
             ^~~~~~~~~~~~~~~~
```
Introduced in https://github.com/eclipse-openj9/openj9/pull/21064.