### PR TITLE
Remove references to '--with-mixedrefs' configuration option

### DIFF
--- a/doc/build-instructions/Build_Instructions_V11.md
+++ b/doc/build-instructions/Build_Instructions_V11.md
@@ -152,10 +152,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -285,10 +282,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -442,10 +436,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|path_to_library}`
@@ -584,10 +575,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **AArch64 macOS only:**
@@ -744,10 +732,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 ::pencil: **OpenSSL support:** If you want to build an OpenJDK that uses OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`

--- a/doc/build-instructions/Build_Instructions_V17.md
+++ b/doc/build-instructions/Build_Instructions_V17.md
@@ -151,10 +151,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -286,10 +283,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -443,10 +437,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|path_to_library}`
@@ -585,10 +576,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **AArch64 macOS only:**
@@ -744,10 +732,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that uses OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`

--- a/doc/build-instructions/Build_Instructions_V21.md
+++ b/doc/build-instructions/Build_Instructions_V21.md
@@ -151,10 +151,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -286,10 +283,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -443,10 +437,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|path_to_library}`
@@ -585,10 +576,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **AArch64 macOS only:**
@@ -744,10 +732,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that uses OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`

--- a/doc/build-instructions/Build_Instructions_V8.md
+++ b/doc/build-instructions/Build_Instructions_V8.md
@@ -153,10 +153,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -282,10 +279,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`
@@ -452,10 +446,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|path_to_library}`
@@ -619,10 +610,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that includes OpenSSL, you must specify `--with-openssl={fetched|path_to_library}`
@@ -739,10 +727,7 @@ For more information see [OpenJDK build troubleshooting](https://htmlpreview.git
 - mixed references, either compressed or non-compressed references is selected when starting Java
 
 Mixed references is the default to build when no options are specified. `configure` options include:
-- `--with-mixedrefs` create a mixed references static build (equivalent to `--with-mixedrefs=static`)
-- `--with-mixedrefs=no` create a build supporting compressed references only
-- `--with-mixedrefs=dynamic` create a mixed references build that uses runtime checks
-- `--with-mixedrefs=static` (this is the default) create a mixed references build which avoids runtime checks by compiling source twice
+- `--with-noncompressedrefs=no` create a build supporting compressed references only
 - `--with-noncompressedrefs` create a build supporting non-compressed references only
 
 :pencil: **OpenSSL support:** If you want to build an OpenJDK that uses OpenSSL, you must specify `--with-openssl={fetched|system|path_to_library}`


### PR DESCRIPTION
Support is removed by
* https://github.com/ibmruntimes/openj9-openjdk-jdk8/pull/797
* https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/871
* https://github.com/ibmruntimes/openj9-openjdk-jdk17/pull/444
* https://github.com/ibmruntimes/openj9-openjdk-jdk21/pull/257
* https://github.com/ibmruntimes/openj9-openjdk-jdk24/pull/33
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/951