### PR TITLE
Remove unused function declaration

### DIFF
--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -1047,9 +1047,6 @@ computeFinalBootstrapClassPath(J9JavaVM *vm)
 
 #endif /* OPT_DYNAMIC_LOAD_SUPPORT */
 
-/* Prototype properties helper */
-jobject getPropertyList(JNIEnv *env);
-
 jint
 completeInitialization(J9JavaVM * vm)
 {


### PR DESCRIPTION
`getPropertyList()` is declared but not used; noticed while considering #21200.