### PR TITLE
Remove functions no longer needed for Java 25+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -178,14 +178,10 @@ jvm_add_exports(jvm
 	_JVM_IsInterface@8
 	_JVM_GetClassSigners@8
 	_JVM_SetClassSigners@12
-	_JVM_IsArrayClass@8
-	_JVM_IsPrimitiveClass@8
 	_JVM_GetComponentType@8
-	_JVM_GetClassModifiers@8
 	_JVM_GetClassDeclaredFields@12
 	_JVM_GetClassDeclaredMethods@12
 	_JVM_GetClassDeclaredConstructors@12
-	_JVM_GetProtectionDomain@8
 	_JVM_SetProtectionDomain@12
 	_JVM_GetDeclaredClasses@8
 	_JVM_GetDeclaringClass@8
@@ -470,6 +466,15 @@ else()
 		JVM_IsStaticallyLinked
 		JVM_VirtualThreadPinnedEvent
 		JVM_TakeVirtualThreadListToUnblock
+	)
+endif()
+
+if(JAVA_SPEC_VERSION LESS 25)
+	jvm_add_exports(jvm
+		_JVM_GetClassModifiers@8
+		_JVM_GetProtectionDomain@8
+		_JVM_IsArrayClass@8
+		_JVM_IsPrimitiveClass@8
 	)
 endif()
 

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -1083,16 +1083,15 @@ JVM_GetClassInterfaces(jint arg0, jint arg1)
 	return NULL;
 }
 
-
-
+#if JAVA_SPEC_VERSION < 25
 jint JNICALL
-JVM_GetClassModifiers(JNIEnv* env, jclass clazz)
+JVM_GetClassModifiers(JNIEnv *env, jclass clazz)
 {
-	J9Class* ramClass = java_lang_Class_vmRef(env, clazz);
-	J9ROMClass* romClass = ramClass->romClass;
+	J9Class *ramClass = java_lang_Class_vmRef(env, clazz);
+	J9ROMClass *romClass = ramClass->romClass;
 
 	if (J9ROMCLASS_IS_ARRAY(romClass)) {
-		J9ArrayClass* arrayClass = (J9ArrayClass*)ramClass;
+		J9ArrayClass *arrayClass = (J9ArrayClass *)ramClass;
 		jint result = 0;
 		J9ROMClass *leafRomClass = arrayClass->leafComponentType->romClass;
 		if (J9_ARE_ALL_BITS_SET(leafRomClass->extraModifiers, J9AccClassInnerClass)) {
@@ -1111,8 +1110,7 @@ JVM_GetClassModifiers(JNIEnv* env, jclass clazz)
 		}
 	}
 }
-
-
+#endif /* JAVA_SPEC_VERSION < 25 */
 
 jobject JNICALL
 JVM_GetClassSigners(jint arg0, jint arg1)
@@ -1344,14 +1342,14 @@ JVM_GetPrimitiveArrayElement(JNIEnv *env, jobject array, jint index, jint wCode)
 	return value;
 }
 
-
-
+#if JAVA_SPEC_VERSION < 25
 jobject JNICALL
 JVM_GetProtectionDomain(jint arg0, jint arg1)
 {
 	assert(!"JVM_GetProtectionDomain() stubbed!");
 	return NULL;
 }
+#endif /* JAVA_SPEC_VERSION < 25 */
 
 #if JAVA_SPEC_VERSION < 24
 jobject JNICALL
@@ -1584,33 +1582,21 @@ JVM_Interrupt(jint arg0, jint arg1)
 	return NULL;
 }
 
-
+#if JAVA_SPEC_VERSION < 25
+jboolean JNICALL
+JVM_IsArrayClass(JNIEnv *env, jclass clazz)
+{
+	J9Class *ramClass = java_lang_Class_vmRef(env, clazz);
+	return J9ROMCLASS_IS_ARRAY(ramClass->romClass) ? JNI_TRUE : JNI_FALSE;
+}
+#endif /* JAVA_SPEC_VERSION < 25 */
 
 jboolean JNICALL
-JVM_IsArrayClass(JNIEnv* env, jclass clazz)
+JVM_IsInterface(JNIEnv *env, jclass clazz)
 {
-	J9Class * ramClass = java_lang_Class_vmRef(env, clazz);
-	if (J9ROMCLASS_IS_ARRAY(ramClass->romClass)) {
-		return JNI_TRUE;
-	} else {
-		return JNI_FALSE;
-	}
+	J9Class *ramClass = java_lang_Class_vmRef(env, clazz);
+	return J9ROMCLASS_IS_INTERFACE(ramClass->romClass) ? JNI_TRUE : JNI_FALSE;
 }
-
-
-
-jboolean JNICALL
-JVM_IsInterface(JNIEnv* env, jclass clazz)
-{
-	J9Class * ramClass = java_lang_Class_vmRef(env, clazz);
-	if (J9ROMCLASS_IS_INTERFACE(ramClass->romClass)) {
-		return JNI_TRUE;
-	} else {
-		return JNI_FALSE;
-	}
-}
-
-
 
 jboolean JNICALL
 JVM_IsInterrupted(JNIEnv* env, jobject thread, jboolean unknown)
@@ -1639,19 +1625,14 @@ JVM_IsInterrupted(JNIEnv* env, jobject thread, jboolean unknown)
 	}
 }
 
-
-
+#if JAVA_SPEC_VERSION < 25
 jboolean JNICALL
-JVM_IsPrimitiveClass(JNIEnv* env, jclass clazz)
+JVM_IsPrimitiveClass(JNIEnv *env, jclass clazz)
 {
-	J9Class * ramClass = java_lang_Class_vmRef(env, clazz);
-	if (J9ROMCLASS_IS_PRIMITIVE_TYPE(ramClass->romClass)) {
-		return JNI_TRUE;
-	} else {
-		return JNI_FALSE;
-	}
+	J9Class *ramClass = java_lang_Class_vmRef(env, clazz);
+	return J9ROMCLASS_IS_PRIMITIVE_TYPE(ramClass->romClass) ? JNI_TRUE : JNI_FALSE;
 }
-
+#endif /* JAVA_SPEC_VERSION < 25 */
 
 /**
  * Check whether the JNI version is supported.

--- a/runtime/j9vm/j9vmnatives.xml
+++ b/runtime/j9vm/j9vmnatives.xml
@@ -216,14 +216,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<export name="_JVM_IsInterface@8"/>
 		<export name="_JVM_GetClassSigners@8"/>
 		<export name="_JVM_SetClassSigners@12"/>
-		<export name="_JVM_IsArrayClass@8"/>
-		<export name="_JVM_IsPrimitiveClass@8"/>
+		<export name="_JVM_GetClassModifiers@8">
+			<exclude-if condition="spec.java25"/>
+		</export>
+		<export name="_JVM_GetProtectionDomain@8">
+			<exclude-if condition="spec.java25"/>
+		</export>
+		<export name="_JVM_IsArrayClass@8">
+			<exclude-if condition="spec.java25"/>
+		</export>
+		<export name="_JVM_IsPrimitiveClass@8">
+			<exclude-if condition="spec.java25"/>
+		</export>
 		<export name="_JVM_GetComponentType@8"/>
-		<export name="_JVM_GetClassModifiers@8"/>
 		<export name="_JVM_GetClassDeclaredFields@12"/>
 		<export name="_JVM_GetClassDeclaredMethods@12"/>
 		<export name="_JVM_GetClassDeclaredConstructors@12"/>
-		<export name="_JVM_GetProtectionDomain@8"/>
 		<export name="_JVM_SetProtectionDomain@12"/>
 		<export name="_JVM_GetDeclaredClasses@8"/>
 		<export name="_JVM_GetDeclaringClass@8"/>

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -165,7 +165,8 @@ _X(JVM_GetClassDeclaredConstructors,JNICALL,true,jobject,JNIEnv *env, jclass cla
 _X(JVM_GetClassDeclaredFields,JNICALL,true,jobject,JNIEnv *env, jobject clazz, jint arg2)
 _X(JVM_GetClassDeclaredMethods,JNICALL,true,jobject,JNIEnv *env, jobject clazz, jboolean unknown)
 _X(JVM_GetClassInterfaces,JNICALL,true,jobject,jint arg0, jint arg1)
-_X(JVM_GetClassModifiers,JNICALL,true,jint,JNIEnv *env, jclass clazz)
+_IF([JAVA_SPEC_VERSION < 25],
+	[_X(JVM_GetClassModifiers,JNICALL,true,jint,JNIEnv *env, jclass clazz)])
 _X(JVM_GetClassSigners,JNICALL,true,jobject,jint arg0, jint arg1)
 _X(JVM_GetComponentType,JNICALL,true,jobject,JNIEnv *env, jclass cls)
 _X(JVM_GetDeclaredClasses,JNICALL,true,jobject,jint arg0, jint arg1)
@@ -173,7 +174,8 @@ _X(JVM_GetDeclaringClass,JNICALL,true,jobject,jint arg0, jint arg1)
 _IF([JAVA_SPEC_VERSION < 24],
 	[_X(JVM_GetInheritedAccessControlContext,JNICALL,true,jobject,jint arg0, jint arg1)])
 _X(JVM_GetPrimitiveArrayElement,JNICALL,true,jvalue,JNIEnv *env, jobject arr, jint index, jint wCode)
-_X(JVM_GetProtectionDomain,JNICALL,true,jobject,jint arg0, jint arg1)
+_IF([JAVA_SPEC_VERSION < 25],
+	[_X(JVM_GetProtectionDomain,JNICALL,true,jobject,jint arg0, jint arg1)])
 _IF([JAVA_SPEC_VERSION < 24],
 	[_X(JVM_GetStackAccessControlContext,JNICALL,true,jobject,JNIEnv *env, jclass java_security_AccessController)])
 _X(JVM_GetStackTraceDepth,JNICALL,true,jint,JNIEnv *env, jobject throwable)
@@ -183,10 +185,12 @@ _X(JVM_IHashCode,JNICALL,true,jint,JNIEnv *env, jobject obj)
 _X(JVM_InitProperties,JNICALL,true,jobject,JNIEnv *env, jobject properties)
 _X(JVM_InternString,JNICALL,true,jstring,JNIEnv *env, jstring str)
 _X(JVM_Interrupt,JNICALL,true,jobject,jint arg0, jint arg1)
-_X(JVM_IsArrayClass,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)
+_IF([JAVA_SPEC_VERSION < 25],
+	[_X(JVM_IsArrayClass,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)])
 _X(JVM_IsInterface,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)
 _X(JVM_IsInterrupted,JNICALL,true,jboolean,JNIEnv *env, jobject thread, jboolean unknown)
-_X(JVM_IsPrimitiveClass,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)
+_IF([JAVA_SPEC_VERSION < 25],
+	[_X(JVM_IsPrimitiveClass,JNICALL,true,jboolean,JNIEnv *env, jclass clazz)])
 _X(JVM_IsSupportedJNIVersion,JNICALL,true,jboolean,jint jniVersion)
 _IF([JAVA_SPEC_VERSION < 17],
 	[_X(JVM_IsThreadAlive,JNICALL,true,jboolean,JNIEnv *env, jobject targetThread)])


### PR DESCRIPTION
The head stream no longer uses these functions:
* `jint JVM_GetClassModifiers(JNIEnv *env, jclass cls);`
* `jobject JVM_GetProtectionDomain(JNIEnv *env, jclass cls);`
* `jboolean JVM_IsArrayClass(JNIEnv *env, jclass cls);`
* `jboolean JVM_IsPrimitiveClass(JNIEnv *env, jclass cls);`

See:
* [8349860: Make Class.isArray(), Class.isInterface() and Class.isPrimitive() non-native](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/56ae974ad13bba8e9a0ae38720ae254bc67ef108)