### PR TITLE
Prevent JIT bodies from strictly outliving methods inlined into them

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -125,6 +125,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/env/OMRDebugEnv.cpp \
     omr/compiler/env/OMRObjectModel.cpp \
     omr/compiler/env/OMRPersistentInfo.cpp \
+    omr/compiler/env/OMRRetainedMethodSet.cpp \
     omr/compiler/env/OMRVMEnv.cpp \
     omr/compiler/env/Region.cpp \
     omr/compiler/env/SegmentAllocator.cpp \
@@ -306,6 +307,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/env/J9KnownObjectTable.cpp \
     compiler/env/J9ObjectModel.cpp \
     compiler/env/J9PersistentInfo.cpp \
+    compiler/env/J9RetainedMethodSet.cpp \
     compiler/env/J9SegmentAllocator.cpp \
     compiler/env/J9SegmentCache.cpp \
     compiler/env/J9SegmentProvider.cpp \

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -45,6 +45,7 @@
 #include "env/VMJ9.h"
 #include "env/jittypes.h"
 #include "env/j9method.h"
+#include "env/OMRRetainedMethodSet.hpp"
 #include "il/AutomaticSymbol.hpp"
 #include "il/Block.hpp"
 #include "il/LabelSymbol.hpp"
@@ -4814,11 +4815,13 @@ bool
 J9::CodeGenerator::mustGenerateSwitchToInterpreterPrePrologue()
    {
    TR::Compilation *comp = self()->comp();
+   TR_ResolvedMethod *bondMethod = NULL;
 
    return comp->usesPreexistence() ||
       comp->getOption(TR_EnableHCR) ||
       !comp->fej9()->isAsyncCompilation() ||
-      comp->getOption(TR_FullSpeedDebug);
+      comp->getOption(TR_FullSpeedDebug) ||
+      comp->retainedMethods()->bondMethods().next(&bondMethod);
    }
 
 extern void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceInstruction, TR::CodeGenerator *cg);

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -42,6 +42,7 @@
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/j9method.h"
+#include "env/J9RetainedMethodSet.hpp"
 #include "env/TRMemory.hpp"
 #include "env/VMJ9.h"
 #include "env/VMAccessCriticalSection.hpp"
@@ -185,6 +186,7 @@ J9::Compilation::Compilation(int32_t id,
    _j9VMThread(j9vmThread),
    _monitorAutos(m),
    _monitorAutoSymRefsInCompiledMethod(getTypedAllocator<TR::SymbolReference*>(self()->allocator())),
+   _keepaliveClasses(heapMemoryRegion),
    _classForOSRRedefinition(m),
    _classForStaticFinalFieldModification(m),
    _profileInfo(NULL),
@@ -229,6 +231,10 @@ J9::Compilation::Compilation(int32_t id,
    for (int i = 0; i < CACHED_CLASS_POINTER_COUNT; i++)
       _cachedClassPointers[i] = NULL;
 
+   if (!self()->ilGenRequest().details().supportsInvalidation())
+      {
+      self()->getOptions()->setOption(TR_DontInlineUnloadableMethods);
+      }
 
    // Add known object index to parm 0 so that other optmizations can be unlocked.
    // It is safe to do so because method and method symbols of a archetype specimen
@@ -1670,6 +1676,59 @@ J9::Compilation::populateAOTMethodDependencies(TR_OpaqueClassBlock *definingClas
    return totalDependencies;
    }
 #endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
+
+OMR::RetainedMethodSet *
+J9::Compilation::createRetainedMethods(TR_ResolvedMethod *method)
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (self()->isRemoteCompilation())
+      {
+      TR_ASSERT_FATAL(false, "client must not use Compilation::retainedMethods()");
+      }
+#endif
+
+   if (mustTrackRetainedMethods())
+      {
+      return J9::RetainedMethodSet::create(self(), method);
+      }
+   else
+      {
+      return OMR::Compilation::createRetainedMethods(method);
+      }
+   }
+
+bool
+J9::Compilation::mustTrackRetainedMethods()
+   {
+   if (self()->compileRelocatableCode())
+      {
+      // AOT: Relationships between class loaders seen at compile time won't
+      // necessarily still hold at load time, so there's no point in tracking
+      // retained method sets. At load, the inlining table will be available,
+      // and bonds will be created as needed.
+      return false;
+      }
+
+   if (TR::Options::getCmdLineOptions()->getOption(TR_NoClassGC))
+      {
+      return false;
+      }
+
+   return !self()->getOption(TR_AllowJitBodyToOutliveInlinedCode)
+      || self()->getOption(TR_DontInlineUnloadableMethods);
+   }
+
+void
+J9::Compilation::addKeepaliveClass(TR_OpaqueClassBlock *c)
+   {
+   _keepaliveClasses.insert(c);
+   if (self()->getOption(TR_TraceRetainedMethods))
+      {
+      int32_t len;
+      const char *name = TR::Compiler->cls.classNameChars(self(), c, len);
+      traceMsg(self(), "Added global keepalive class %p %.*s\n", c, len, name);
+      }
+   }
 
 #if defined(J9VM_OPT_JITSERVER)
 void

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -37,6 +37,7 @@ namespace J9 { typedef J9::Compilation CompilationConnector; }
 #include "compile/CompilationTypes.hpp"
 #include "control/Options.hpp"
 #include "control/Options_inlines.hpp"
+#include "infra/set.hpp"
 #include "infra/Statistics.hpp"
 #include "env/CompilerEnv.hpp"
 #include "env/OMRMemory.hpp"
@@ -44,7 +45,7 @@ namespace J9 { typedef J9::Compilation CompilationConnector; }
 #include "runtime/SymbolValidationManager.hpp"
 #include "env/PersistentCollections.hpp"
 
-
+namespace J9 { class RetainedMethodSet; }
 class TR_AOTGuardSite;
 class TR_FrontEnd;
 class TR_ResolvedMethod;
@@ -396,6 +397,49 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
 
    TR::SymbolValidationManager *getSymbolValidationManager() { return _symbolValidationManager; }
 
+   // overrides OMR::Compilation::createRetainedMethods(TR_ResolvedMethod*)
+   OMR::RetainedMethodSet *createRetainedMethods(TR_ResolvedMethod *method);
+
+   /**
+    * \brief Determine whether retained methods need to be tracked.
+    *
+    * If they do, then J9::RetainedMethodSet will be used. Otherwise, the base
+    * OMR::RetainedMethodSet will be used instead, which does no tracking.
+    *
+    * \return true if tracking is needed, false otherwise
+    */
+   bool mustTrackRetainedMethods();
+
+   /**
+    * \brief Get the set of classes to keep alive.
+    *
+    * During optimization, these are classes that should be kept alive due to
+    * IL transformations, as opposed to the keepalives in retainedMethods(),
+    * which are due to inlining. They are kept separately because the API of
+    * OMR::RetainedMethodSet is designed to avoid assuming that unloading
+    * proceeds at any granularity coarser than per-method.
+    *
+    * \return the set of classes to keep alive
+    */
+   const TR::set<TR_OpaqueClassBlock*> &keepaliveClasses() { return _keepaliveClasses; }
+
+   /**
+    * \brief Add a keepalive class.
+    *
+    * This is only for cases where an IL transformation based on known objects
+    * causes the IL to directly use a class (i.e. with loadaddr) or one of
+    * its members, when it didn't previously. After such a transformation, the
+    * known objects could end up being unused, in which case they wouldn't
+    * guarantee on their own that the class remains loaded at the point of use.
+    *
+    * If the IL is modified to use a member that will necessarily remain loaded
+    * at the point of use anyway, e.g. an instance method, then no keepalive is
+    * needed.
+    *
+    * \param c the class to keep alive
+    */
+   void addKeepaliveClass(TR_OpaqueClassBlock *c);
+
    /**
     * \brief Determine whether it's currently expected to be possible to add
     * OSR assumptions and corresponding fear points somewhere in the method.
@@ -517,6 +561,8 @@ private:
 
    TR_Array<List<TR::RegisterMappedSymbol> *> _monitorAutos;
    TR::list<TR::SymbolReference*>             _monitorAutoSymRefsInCompiledMethod;
+
+   TR::set<TR_OpaqueClassBlock*>        _keepaliveClasses;
 
    TR_Array<TR_OpaqueClassBlock*>       _classForOSRRedefinition;
    // Classes that have their static final fields folded and need assumptions

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8877,6 +8877,15 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                         methodInfo->incrementNumberOfInlinedMethodRedefinition();
                      if (methodInfo->getNumberOfInlinedMethodRedefinition() >= 2)
                         options->setOption(TR_DisableNextGenHCR);
+
+                     // If this method has been invalidated due to unloading of
+                     // inlined code, then from now on we should only inline
+                     // methods that will not be unloaded before this one.
+                     auto invReasons = methodInfo->invalidationReasons();
+                     if (invReasons.contains(TR_JitBodyInvalidations::Unloading))
+                        {
+                        options->setOption(TR_DontInlineUnloadableMethods);
+                        }
                      }
                   }
 

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -30,6 +30,7 @@
 #include "compile/Compilation.hpp"
 #include "control/Options.hpp"
 #include "compile/SymbolReferenceTable.hpp"
+#include "env/OMRRetainedMethodSet.hpp"
 #include "env/VMJ9.h"
 #include "env/VerboseLog.hpp"
 #include "runtime/J9Profiler.hpp"
@@ -456,10 +457,12 @@ J9::Recompilation::createProfilers()
 bool
 J9::Recompilation::couldBeCompiledAgain()
    {
+   TR_ResolvedMethod *bondMethod = NULL;
    return
       self()->shouldBeCompiledAgain() ||
       _compilation->usesPreexistence() ||
-      _compilation->getOption(TR_EnableHCR);
+      _compilation->getOption(TR_EnableHCR) ||
+      _compilation->retainedMethods()->bondMethods().next(&bondMethod);
    }
 
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -35,6 +35,7 @@
 #include "env/j9methodServer.hpp"
 #include "env/JITServerPersistentCHTable.hpp"
 #include "env/JSR292Methods.h"
+#include "env/J9RetainedMethodSet.hpp"
 #include "env/TypeLayout.hpp"
 #include "env/ut_j9jit.h"
 #include "env/VerboseLog.hpp"
@@ -3011,6 +3012,52 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             }
 
          client->write(response, classInfos);
+         }
+         break;
+      case MessageType::RetainedMethodSet_createMirror:
+         {
+         auto recv = client->getRecvData<void*, void*>();
+         auto parent = (J9::RetainedMethodSet*)std::get<0>(recv);
+         auto method = (TR_ResolvedJ9Method*)std::get<1>(recv);
+         J9::RetainedMethodSet *mirror = NULL;
+         J9::RetainedMethodSet::ScanLog scanLog;
+         if (parent == NULL)
+            {
+            mirror = J9::RetainedMethodSet::create(comp, method, &scanLog);
+            }
+         else
+            {
+            mirror = parent->createChild(method, &scanLog);
+            }
+
+         client->write(
+            response, mirror, scanLog._addedAnonClass, scanLog._addedLoaders);
+         }
+         break;
+      case MessageType::RetainedMethodSet_scan:
+         {
+         auto recv = client->getRecvData<void*, J9Class*>();
+         auto mirror = (J9::RetainedMethodSet*)std::get<0>(recv);
+         auto clazz = std::get<1>(recv);
+         J9::RetainedMethodSet::ScanLog scanLog;
+         mirror->scanForClient(clazz, &scanLog);
+         client->write(response, scanLog._addedAnonClass, scanLog._addedLoaders);
+         }
+         break;
+      case MessageType::RetainedMethodSet_keepalive:
+         {
+         auto recv = client->getRecvData<void*>();
+         auto mirror = (J9::RetainedMethodSet*)std::get<0>(recv);
+         mirror->keepalive();
+         client->write(response, JITServer::Void());
+         }
+         break;
+      case MessageType::RetainedMethodSet_bond:
+         {
+         auto recv = client->getRecvData<void*>();
+         auto mirror = (J9::RetainedMethodSet*)std::get<0>(recv);
+         mirror->bond();
+         client->write(response, JITServer::Void());
          }
          break;
       default:

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -78,6 +78,7 @@ class TR_JitBodyInvalidations
       HCR, // outermost method has been obsoleted by HCR
       Preexistence, // preexistence assumption has been invalidated
       PostRestoreExclude, // method is excluded post-restore, should be interpreted
+      Unloading, // an inlined method has been unloaded
       };
 
    bool isEmpty() const { return _flags.getValue() == 0; }

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -38,6 +38,7 @@
 #include "env/PersistentInfo.hpp"
 #include "env/jittypes.h"
 #include "env/j9method.h"
+#include "env/J9RetainedMethodSet.hpp"
 #include "env/ClassTableCriticalSection.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
@@ -59,6 +60,13 @@ void
 TR_PreXRecompile::dumpInfo()
    {
    OMR::RuntimeAssumption::dumpInfo("TR_PreXRecompile");
+   TR_VerboseLog::write(" startPC=%p", _startPC);
+   }
+
+void
+TR_ClassUnloadRecompile::dumpInfo()
+   {
+   OMR::RuntimeAssumption::dumpInfo("TR_ClassUnloadRecompile");
    TR_VerboseLog::write(" startPC=%p", _startPC);
    }
 
@@ -158,6 +166,14 @@ TR_PreXRecompileOnMethodOverride *TR_PreXRecompileOnMethodOverride::make(
    return result;
    }
 
+TR_ClassUnloadRecompile *TR_ClassUnloadRecompile::make(
+   TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, uint8_t *startPC, OMR::RuntimeAssumption **sentinel)
+   {
+   TR_ClassUnloadRecompile *result = new (pm) TR_ClassUnloadRecompile(pm, clazz, startPC);
+   result->addToRAT(pm, RuntimeAssumptionOnClassUnload, fe, sentinel);
+   return result;
+   }
+
 TR_PatchNOPedGuardSiteOnMutableCallSiteChange *TR_PatchNOPedGuardSiteOnMutableCallSiteChange::make(
       TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key, uint8_t *location, uint8_t *destination, OMR::RuntimeAssumption **sentinel)
    {
@@ -253,10 +269,18 @@ void TR_CHTable::cleanupNewlyExtendedInfo(TR::Compilation *comp)
 
 bool TR_CHTable::canSkipCommit(TR::Compilation *comp)
    {
+   TR_ResolvedMethod *bondMethod = NULL;
+
    return comp->compileRelocatableCode() ||
+#if defined(J9VM_OPT_JITSERVER)
+         // Remote compilations use JITClientCHTableCommit() instead. Exclude
+         // them here to avoid calling comp->retainedMethods() on the client.
+         comp->isRemoteCompilation() ||
+#endif
          (comp->getVirtualGuards().empty() &&
           comp->getSideEffectGuardPatchSites()->empty() &&
-          !_preXMethods && !_classes && !_classesThatShouldNotBeNewlyExtended);
+          !_preXMethods && !_classes && !_classesThatShouldNotBeNewlyExtended &&
+          !comp->retainedMethods()->bondMethods().next(&bondMethod));
    }
 
 
@@ -329,7 +353,7 @@ bool TR_CHTable::commit(TR::Compilation *comp)
          }
       }
 
-    if (_classesThatShouldNotBeNewlyExtended)
+   if (_classesThatShouldNotBeNewlyExtended)
       {
       int32_t last = _classesThatShouldNotBeNewlyExtended->lastIndex();
 
@@ -374,6 +398,21 @@ bool TR_CHTable::commit(TR::Compilation *comp)
 
       if (invalidAssumption) return false;
       } //  if (_classesThatShouldNotBeNewlyExtended)
+
+   // Invalidate the body and recompile if any inlined method is unloaded.
+   TR_ResolvedMethod *bondMethod = NULL;
+   auto bondIter = comp->retainedMethods()->bondMethods();
+   while (bondIter.next(&bondMethod))
+      {
+      TR_ClassUnloadRecompile::make(
+         comp->fe(),
+         comp->trPersistentMemory(),
+         bondMethod->containingClass(),
+         startPC,
+         comp->getMetadataAssumptionList());
+
+      comp->setHasClassUnloadAssumptions();
+      }
 
    // Check if the assumptions for static final field are still valid
    // Returning false will cause CHTable opts to be disabled in the next compilation of this method,
@@ -860,6 +899,13 @@ TR_CHTable::computeDataForCHTableCommit(TR::Compilation *comp)
    for (int i = 0; i < compClassesForStaticFinalFieldModification->size(); ++i)
       classesForStaticFinalFieldModification[i] = (*compClassesForStaticFinalFieldModification)[i];
 
+   void *retainedMethodsMirror = NULL;
+   if (comp->mustTrackRetainedMethods())
+      {
+      auto retainedMethods = (J9::RetainedMethodSet*)comp->retainedMethods();
+      retainedMethodsMirror = retainedMethods->remoteMirror();
+      }
+
    uint8_t *startPC = comp->cg()->getCodeStart();
 
    return std::make_tuple(classes,
@@ -871,6 +917,7 @@ TR_CHTable::computeDataForCHTableCommit(TR::Compilation *comp)
                           compClassesThatShouldNotBeNewlyExtended,
                           classesForOSRRedefinition,
                           classesForStaticFinalFieldModification,
+                          retainedMethodsMirror,
                           startPC);
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/env/CHTable.hpp
+++ b/runtime/compiler/env/CHTable.hpp
@@ -304,6 +304,39 @@ class TR_PreXRecompileOnMethodOverride : public TR_PreXRecompile
       TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueMethodBlock *method, uint8_t *startPC, OMR::RuntimeAssumption **sentinel);
    };
 
+class TR_ClassUnloadRecompile : public OMR::LocationRedirectRuntimeAssumption
+   {
+   protected:
+   TR_ClassUnloadRecompile(TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, uint8_t *startPC)
+      : OMR::LocationRedirectRuntimeAssumption(pm, (uintptr_t)clazz), _startPC(startPC) {}
+
+   public:
+   static TR_ClassUnloadRecompile *make(
+      TR_FrontEnd *fe,
+      TR_PersistentMemory *pm,
+      TR_OpaqueClassBlock *clazz,
+      uint8_t *startPC,
+      OMR::RuntimeAssumption **sentinel);
+
+   virtual TR_ClassUnloadRecompile *asCURecompile() { return this; }
+   virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnClassUnload; }
+   virtual void compensate(TR_FrontEnd *vm, bool isSMP, void *newAddress);
+   virtual void dumpInfo();
+
+   virtual bool equals(OMR::RuntimeAssumption &otherAssumption)
+         {
+         TR_ClassUnloadRecompile *other = otherAssumption.asCURecompile();
+         return other != NULL && _startPC == other->_startPC;
+         }
+
+   virtual uint8_t *getFirstAssumingPC() { return getStartPC(); }
+   virtual uint8_t *getLastAssumingPC() { return getStartPC(); }
+   uint8_t *getStartPC() { return _startPC; }
+
+   private:
+   uint8_t *_startPC;
+   };
+
 class TR_CHTable
    {
    public:

--- a/runtime/compiler/env/CMakeLists.txt
+++ b/runtime/compiler/env/CMakeLists.txt
@@ -46,6 +46,7 @@ j9jit_files(
 	env/j9method.cpp
 	env/J9ObjectModel.cpp
 	env/J9PersistentInfo.cpp
+	env/J9RetainedMethodSet.cpp
 	env/J9SegmentAllocator.cpp
 	env/J9SegmentCache.cpp
 	env/J9SegmentProvider.cpp

--- a/runtime/compiler/env/J9RetainedMethodSet.cpp
+++ b/runtime/compiler/env/J9RetainedMethodSet.cpp
@@ -1,0 +1,770 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#include "env/J9RetainedMethodSet.hpp"
+
+#include "j9nonbuilder.h"
+#include "compile/Compilation.hpp"
+#include "compile/ResolvedMethod.hpp"
+#include "env/ClassTableCriticalSection.hpp"
+#include "env/StackMemoryRegion.hpp"
+#include "ilgen/J9ByteCode.hpp"
+#include "ilgen/J9ByteCodeIterator.hpp"
+#include "infra/CriticalSection.hpp"
+#include "infra/Monitor.hpp"
+#include "infra/MonitorTable.hpp"
+#include "infra/TRlist.hpp"
+#include "infra/vector.hpp"
+
+#if defined(J9VM_OPT_JITSERVER)
+#include "env/j9methodServer.hpp"
+#include "net/ServerStream.hpp"
+#endif
+
+static J9Class *
+definingJ9Class(TR_ResolvedMethod *method)
+   {
+   return reinterpret_cast<J9Class*>(method->classOfMethod());
+   }
+
+static void
+traceMethod(TR::Compilation *comp, TR_ResolvedMethod *method)
+   {
+   traceMsg(
+      comp,
+      "%p %.*s.%.*s%.*s in class %p",
+      method->getPersistentIdentifier(),
+      method->classNameLength(),
+      method->classNameChars(),
+      method->nameLength(),
+      method->nameChars(),
+      method->signatureLength(),
+      method->signatureChars(),
+      method->containingClass());
+   }
+
+J9::RetainedMethodSet::RetainedMethodSet(
+   TR::Compilation *comp,
+   TR_ResolvedMethod *method,
+   J9::RetainedMethodSet *parent)
+   : OMR::RetainedMethodSet(comp, method, parent)
+   , _loaders(comp->trMemory()->heapMemoryRegion())
+   , _anonClasses(comp->trMemory()->heapMemoryRegion())
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp->isOutOfProcessCompilation())
+      {
+      _remoteMirror = NULL;
+      }
+   else if (comp->isRemoteCompilation())
+      {
+      _scanLog = NULL;
+      }
+#endif
+
+   if (comp->getOption(TR_TraceRetainedMethods))
+      {
+      traceMsg(comp, "RetainedMethodSet %p: created with parent=%p, method=", this, parent);
+      traceMethod(comp, method);
+      traceMsg(comp, "\n");
+      }
+   }
+
+J9::RetainedMethodSet *
+J9::RetainedMethodSet::create(
+   TR::Compilation *comp,
+   TR_ResolvedMethod *method
+#if defined(J9VM_OPT_JITSERVER)
+   , ScanLog *scanLog
+#endif
+   )
+   {
+   TR::Region &region = comp->trMemory()->heapMemoryRegion();
+   auto *result = new (region) J9::RetainedMethodSet(comp, method, NULL);
+
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp->isRemoteCompilation())
+      {
+      result->initWithScanLog(scanLog);
+      }
+   else
+#endif
+      {
+      result->init();
+      }
+
+   return result;
+   }
+
+J9::RetainedMethodSet *
+J9::RetainedMethodSet::createChild(
+   TR_ResolvedMethod *method
+#if defined(J9VM_OPT_JITSERVER)
+   , ScanLog *scanLog
+#endif
+   )
+   {
+   TR::Region &region = comp()->trMemory()->heapMemoryRegion();
+   auto *result = new (region) J9::RetainedMethodSet(comp(), method, this);
+
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp()->isRemoteCompilation())
+      {
+      result->initWithScanLog(scanLog);
+      }
+   else
+#endif
+      {
+      result->init();
+      }
+
+   return result;
+   }
+
+J9::RetainedMethodSet *
+J9::RetainedMethodSet::withKeepalivesAttested()
+   {
+   J9::RetainedMethodSet *result = createChild(method());
+   auto keepalives = keepaliveMethods();
+   TR_ResolvedMethod *m = NULL;
+   while (keepalives.next(&m))
+      {
+      result->attestWillRemainLoaded(m);
+      }
+
+   return result;
+   }
+
+static void
+traceNamedLoader(
+   TR::Compilation *comp,
+   J9::RetainedMethodSet *s,
+   const char *name,
+   J9ClassLoader *loader)
+   {
+   traceMsg(comp, "RetainedMethodSet %p: %s=%p\n", s, name, loader);
+   }
+
+void
+J9::RetainedMethodSet::init()
+   {
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp()->isOutOfProcessCompilation())
+      {
+      void *remoteParent = parent() == NULL ? NULL : parent()->_remoteMirror;
+      void *remoteMethod =
+         static_cast<TR_ResolvedJ9JITServerMethod*>(method())->getRemoteMirror();
+
+      JITServer::ServerStream *stream = comp()->getStream();
+      stream->write(
+         JITServer::MessageType::RetainedMethodSet_createMirror, remoteParent, remoteMethod);
+
+      auto recv = stream->read<void*, J9Class*, std::vector<J9ClassLoader*>>();
+      _remoteMirror = std::get<0>(recv);
+
+      if (comp()->getOption(TR_TraceRetainedMethods))
+         {
+         traceMsg(
+            comp(),
+            "RetainedMethodSet %p: remote mirror %p\n",
+            this,
+            _remoteMirror);
+         }
+
+      // No need to "log" added items here, since we're on the server.
+      J9Class *anonClass = std::get<1>(recv);
+      if (anonClass != NULL)
+         {
+         _anonClasses.insert(anonClass);
+         }
+
+      auto &loaders = std::get<2>(recv);
+      _loaders.insert(loaders.begin(), loaders.end());
+
+      return;
+      }
+#endif
+
+   if (parent() == NULL)
+      {
+      J9JavaVM *vm = comp()->fej9()->vmThread()->javaVM;
+      addPermanentLoader(vm->systemClassLoader, "system");
+      addPermanentLoader(vm->extensionClassLoader, "extension");
+      addPermanentLoader(vm->applicationClassLoader, "application");
+      }
+
+   attestWillRemainLoaded(method());
+   }
+
+void
+J9::RetainedMethodSet::addPermanentLoader(J9ClassLoader *loader, const char *name)
+   {
+   bool trace = comp()->getOption(TR_TraceRetainedMethods);
+   if (loader == NULL)
+      {
+      if (trace)
+         {
+         traceMsg(comp(), "RetainedMethodSet %p: no %s loader\n", this, name);
+         }
+      }
+   else
+      {
+      if (trace)
+         {
+         traceMsg(comp(), "RetainedMethodSet %p: add %s loader %p\n", this, name, loader);
+         }
+
+      _loaders.insert(loader);
+#if defined(J9VM_OPT_JITSERVER)
+      logAddedLoader(loader);
+#endif
+      }
+   }
+
+template <typename T>
+static T loadBc(
+   TR_ResolvedMethod *m,
+   uint8_t *bcStart,
+   uint32_t bcSize,
+   uint32_t bcIndex,
+   uint32_t offset = 0,
+   const char *instrName = "unknown instruction")
+   {
+   TR_ASSERT_FATAL(
+      bcIndex + offset < bcSize && bcIndex + offset + sizeof(T) <= bcSize,
+      "bc index %d+%d out of range (%d) for %d bytes in %s within %.*s.%.*s%.*s",
+      bcIndex,
+      offset,
+      bcSize,
+      (int32_t)sizeof(T),
+      instrName,
+      m->classNameLength(),
+      m->classNameChars(),
+      m->nameLength(),
+      m->nameChars(),
+      m->signatureLength(),
+      m->signatureChars());
+
+   return *(T*)(bcStart + (bcIndex + offset));
+   }
+
+void
+J9::RetainedMethodSet::attestLinkedCalleeWillRemainLoaded(TR_ByteCodeInfo bci)
+   {
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   TR_ResolvedMethod *caller =
+      bci.getCallerIndex() == -1
+      ? comp()->getMethodBeingCompiled()
+      : comp()->getInlinedResolvedMethod(bci.getCallerIndex());
+
+   if (caller->isNewInstanceImplThunk())
+      {
+      // A typical newInstance thunk contains exactly one call, and it doesn't
+      // occur in the bytecode. In fact, there will appear to be bytecode, but
+      // it won't correspond to the generated IL at all (unless the class for
+      // newInstance isn't suitable, e.g. no default constructor).
+      return;
+      }
+
+   uint8_t *bcStart = caller->bytecodeStart();
+   uint32_t bcSize = caller->maxBytecodeIndex();
+   uint32_t bcIndex = bci.getByteCodeIndex();
+
+   TR_J9ByteCode bcOp =
+      TR_J9ByteCodeIterator::convertOpCodeToByteCodeEnum(
+         loadBc<uint8_t>(caller, bcStart, bcSize, bcIndex));
+
+   TR_ResolvedMethod *linkedCallee = NULL;
+
+   switch (bcOp)
+      {
+      case J9BCinvokevirtual:
+      case J9BCinvokeinterface:
+      case J9BCinvokespecial:
+      case J9BCinvokespecialsplit:
+      case J9BCinvokestatic:
+      case J9BCinvokestaticsplit:
+         // We should almost always have already found the loader that defines
+         // the named callee either in the permanent loaders or by following
+         // the outliving loaders sets, so there's no need to inspect these
+         // call sites.
+         break;
+
+      case J9BCinvokedynamic:
+      case J9BCinvokehandle:
+         {
+         // The callee here will usually (or maybe even always) be an anonymous
+         // class. Make sure to take note of it.
+
+         if (comp()->compileRelocatableCode())
+            {
+            break;
+            }
+
+         uintptr_t *invokeCacheArray = NULL;
+         if (bcOp == J9BCinvokehandle)
+            {
+            uint16_t cpIndex = loadBc<uint16_t>(
+               caller, bcStart, bcSize, bcIndex, 1, "invokehandle");
+
+            if (caller->isUnresolvedMethodTypeTableEntry(cpIndex))
+               {
+               break;
+               }
+
+            invokeCacheArray =
+               (uintptr_t*)caller->methodTypeTableEntryAddress(cpIndex);
+            }
+         else
+            {
+            uint16_t callSiteIndex = loadBc<uint16_t>(
+               caller, bcStart, bcSize, bcIndex, 1, "invokedynamic");
+
+            if (caller->isUnresolvedCallSiteTableEntry(callSiteIndex))
+               {
+               break;
+               }
+
+            invokeCacheArray =
+               (uintptr_t*)caller->callSiteTableEntryAddress(callSiteIndex);
+
+            // We get an exception instead of an array if resolution fails.
+            if (!comp()->fej9()->isInvokeCacheEntryAnArray(invokeCacheArray))
+               {
+               break;
+               }
+            }
+
+         linkedCallee =
+            comp()->fej9()->targetMethodFromInvokeCacheArrayMemberNameObj(
+               comp(), caller, invokeCacheArray);
+
+         break;
+         }
+
+      default:
+         TR_ASSERT_FATAL(
+            false,
+            "unexpected invoke bytecode %d at %d in %.*s.%.*s%.*s",
+            bcOp,
+            bcIndex,
+            caller->classNameLength(),
+            caller->classNameChars(),
+            caller->nameLength(),
+            caller->nameChars(),
+            caller->signatureLength(),
+            caller->signatureChars());
+
+         break;
+      }
+
+   if (linkedCallee != NULL)
+      {
+      attestWillRemainLoaded(linkedCallee);
+      }
+#endif
+   }
+
+void
+J9::RetainedMethodSet::attestWillRemainLoaded(TR_ResolvedMethod *method)
+   {
+   if (comp()->getOption(TR_TraceRetainedMethods))
+      {
+      traceMsg(comp(), "RetainedMethodSet %p: attest method ", this);
+      traceMethod(comp(), method);
+      traceMsg(comp(), "\n");
+      }
+
+   scan(definingJ9Class(method));
+   }
+
+void
+J9::RetainedMethodSet::scan(J9Class *clazz)
+   {
+   J9ClassLoader *loader = getLoader(clazz);
+   bool loaderWillRemain = willRemainLoaded(loader);
+   bool isAnonymous = isAnonymousClass(clazz);
+   bool anonClassWillRemain = isAnonymous && willAnonymousClassRemainLoaded(clazz);
+
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp()->isOutOfProcessCompilation())
+      {
+      if (loaderWillRemain && (!isAnonymous || anonClassWillRemain))
+         {
+         return; // save a round trip if nothing will happen
+         }
+
+      JITServer::ServerStream *stream = comp()->getStream();
+      stream->write(
+         JITServer::MessageType::RetainedMethodSet_scan, _remoteMirror, clazz);
+
+      auto recv = stream->read<J9Class*, std::vector<J9ClassLoader*>>();
+
+      // No need to "log" added items here, since we're on the server.
+      J9Class *anonClass = std::get<0>(recv);
+      if (anonClass != NULL)
+         {
+         _anonClasses.insert(anonClass);
+         }
+
+      auto &loaders = std::get<1>(recv);
+      _loaders.insert(loaders.begin(), loaders.end());
+
+      return;
+      }
+#endif
+
+   if (isAnonymous && !anonClassWillRemain)
+      {
+      if (comp()->getOption(TR_TraceRetainedMethods))
+         {
+         traceMsg(
+            comp(),
+            "RetainedMethodSet %p: add anonymous class %p\n",
+            this,
+            clazz);
+         }
+
+      _anonClasses.insert(clazz);
+#if defined(J9VM_OPT_JITSERVER)
+      if (comp()->isRemoteCompilation() && _scanLog != NULL)
+         {
+         TR_ASSERT_FATAL(
+            _scanLog->_addedAnonClass == NULL,
+            "RetainedMethodSet %p: multiple anonymous classes in the same scan",
+            this);
+
+         _scanLog->_addedAnonClass = clazz;
+         }
+#endif
+      }
+
+   // Scan the class loader graph starting from the loader of clazz.
+
+   if (comp()->getOption(TR_TraceRetainedMethods))
+      {
+      traceMsg(
+         comp(),
+         "RetainedMethodSet %p: class %p has loader %p\n",
+         this,
+         clazz,
+         loader);
+      }
+
+   if (loaderWillRemain)
+      {
+      return;
+      }
+
+   if (comp()->getOption(TR_TraceRetainedMethods))
+      {
+      traceMsg(comp(), "RetainedMethodSet %p: add loader %p\n", this, loader);
+      }
+
+   _loaders.insert(loader);
+#if defined(J9VM_OPT_JITSERVER)
+   logAddedLoader(loader);
+#endif
+
+   TR::StackMemoryRegion stackRegion(*comp()->trMemory());
+
+   TR::vector<J9ClassLoader*, TR::Region&> outlivingLoadersCopy(stackRegion);
+   outlivingLoadersCopy.reserve(16);
+
+   TR::list<J9ClassLoader*, TR::Region&> queue(stackRegion);
+   queue.push_back(loader);
+   while (!queue.empty())
+      {
+      loader = queue.front();
+      queue.pop_front();
+
+      outlivingLoadersCopy.clear();
+
+      // Go ahead and read loader->outlivingLoaders without taking the mutex.
+      // The pointer value changes atomically, and in the likely case that we
+      // have an empty or singleton set, it can be decoded without locking.
+      // It's possible to miss an update this way, if another thread is
+      // concurrently adding the first or second entry, but even if we did take
+      // the mutex, we just as well might have taken it just before the other
+      // thread and missed the update anyway. This is fine because the set is
+      // not required to be exhaustive.
+      void *outlivingLoaders = loader->outlivingLoaders;
+      if (outlivingLoaders == NULL)
+         {
+         // Empty set.
+         }
+      else if (((uintptr_t)outlivingLoaders & J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG) != 0)
+         {
+         // Singleton set.
+         J9ClassLoader *outlivingLoader = reinterpret_cast<J9ClassLoader*>(
+            (uintptr_t)outlivingLoaders & ~(uintptr_t)J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG);
+
+         outlivingLoadersCopy.push_back(outlivingLoader);
+         }
+      else
+         {
+         // Hash table. We need the mutex in order to iterate over it.
+         TR::ClassTableCriticalSection criticalSection(comp()->fej9());
+
+         // Once loader->outlivingLoaders is set to point to a hash table, it
+         // won't be modified again. Instead, the hash table that it points to
+         // will be mutated, and only to add new entries.
+         void *repeatLoadedOutlivingLoaders = loader->outlivingLoaders;
+         TR_ASSERT_FATAL(
+            repeatLoadedOutlivingLoaders == outlivingLoaders,
+            "unexpected change to outlivingLoaders of J9ClassLoader %p: old %p, new %p",
+            loader,
+            outlivingLoaders,
+            repeatLoadedOutlivingLoaders);
+
+         J9HashTable *table = (J9HashTable*)outlivingLoaders;
+         J9HashTableState state;
+         J9ClassLoader **entry = (J9ClassLoader**)hashTableStartDo(table, &state);
+         while (entry != NULL)
+            {
+            outlivingLoadersCopy.push_back(*entry);
+            entry = (J9ClassLoader**)hashTableNextDo(&state);
+            }
+         }
+
+      auto copyEnd = outlivingLoadersCopy.end();
+      for (auto it = outlivingLoadersCopy.begin(); it != copyEnd; it++)
+         {
+         J9ClassLoader *outlivingLoader = *it;
+         if (comp()->getOption(TR_TraceRetainedMethods))
+            {
+            traceMsg(
+               comp(),
+               "RetainedMethodSet %p: loader %p is outlived by loader %p\n",
+               this,
+               loader,
+               outlivingLoader);
+            }
+
+         if (willRemainLoaded(outlivingLoader))
+            {
+            continue;
+            }
+
+         if (comp()->getOption(TR_TraceRetainedMethods))
+            {
+            traceMsg(
+               comp(),
+               "RetainedMethodSet %p: add loader %p\n",
+               this,
+               outlivingLoader);
+            }
+
+         _loaders.insert(outlivingLoader);
+#if defined(J9VM_OPT_JITSERVER)
+         logAddedLoader(outlivingLoader);
+#endif
+
+         queue.push_back(outlivingLoader);
+         }
+      }
+   }
+
+#if defined(J9VM_OPT_JITSERVER)
+void
+J9::RetainedMethodSet::scanForClient(J9Class *clazz, ScanLog *scanLog)
+   {
+   TR_ASSERT_FATAL(
+      comp()->isRemoteCompilation(),
+      "RetainedMethodSet %p: can only scanForClient on the client",
+      this);
+
+   TR_ASSERT_FATAL(
+      scanLog != NULL, "RetainedMethodSet %p: scanForClient missing scanLog", this);
+
+   _scanLog = scanLog;
+   try
+      {
+      scan(clazz);
+      _scanLog = NULL;
+      }
+   catch (...)
+      {
+      _scanLog = NULL;
+      throw;
+      }
+   }
+#endif
+
+bool
+J9::RetainedMethodSet::willRemainLoaded(TR_ResolvedMethod *method)
+   {
+   return willRemainLoaded(definingJ9Class(method));
+   }
+
+bool
+J9::RetainedMethodSet::willRemainLoaded(J9Class *clazz)
+   {
+   if (isAnonymousClass(clazz))
+      {
+      return willAnonymousClassRemainLoaded(clazz);
+      }
+   else
+      {
+      return willRemainLoaded(getLoader(clazz));
+      }
+   }
+
+bool
+J9::RetainedMethodSet::willRemainLoaded(J9ClassLoader *loader)
+   {
+   for (J9::RetainedMethodSet *s = this; s != NULL; s = s->parent())
+      {
+      if (s->_loaders.count(loader) != 0)
+         {
+         return true;
+         }
+      }
+
+   return false;
+   }
+
+bool
+J9::RetainedMethodSet::willAnonymousClassRemainLoaded(J9Class *clazz)
+   {
+   TR_ASSERT_FATAL(isAnonymousClass(clazz), "not anonymous: %p", clazz);
+
+   for (J9::RetainedMethodSet *s = this; s != NULL; s = s->parent())
+      {
+      if (s->_anonClasses.count(clazz) != 0)
+         {
+         return true;
+         }
+      }
+
+   return false;
+   }
+
+void
+J9::RetainedMethodSet::keepalive()
+   {
+   OMR::RetainedMethodSet::keepalive();
+
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp()->isOutOfProcessCompilation())
+      {
+      // Repeat keealive on the client to keep the remote mirrors in sync.
+      JITServer::ServerStream *stream = comp()->getStream();
+      stream->write(
+         JITServer::MessageType::RetainedMethodSet_keepalive, _remoteMirror);
+
+      stream->read<JITServer::Void>();
+      }
+#endif
+   }
+
+void
+J9::RetainedMethodSet::bond()
+   {
+   OMR::RetainedMethodSet::bond();
+
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp()->isOutOfProcessCompilation())
+      {
+      // Repeat bond on the client to keep the remote mirrors in sync.
+      JITServer::ServerStream *stream = comp()->getStream();
+      stream->write(
+         JITServer::MessageType::RetainedMethodSet_bond, _remoteMirror);
+
+      stream->read<JITServer::Void>();
+      }
+#endif
+   }
+
+J9ClassLoader *
+J9::RetainedMethodSet::getLoader(J9Class *clazz)
+   {
+   auto *c = TR::Compiler->cls.convertClassPtrToClassOffset(clazz);
+   return (J9ClassLoader*)comp()->fej9()->getClassLoader(c);
+   }
+
+bool
+J9::RetainedMethodSet::isAnonymousClass(J9Class *clazz)
+   {
+   auto *c = TR::Compiler->cls.convertClassPtrToClassOffset(clazz);
+   return comp()->fej9()->isAnonymousClass(c);
+   }
+
+void
+J9::RetainedMethodSet::mergeIntoParent()
+   {
+   // No need to "log" added items here, since the entire mergeIntoParent()
+   // operation will be repeated on both server and client (because bond() will
+   // be repeated on both server and client), and the sets will be in sync
+   // beforehand, so they will remain in sync afterward.
+   parent()->_loaders.insert(_loaders.begin(), _loaders.end());
+   parent()->_anonClasses.insert(_anonClasses.begin(), _anonClasses.end());
+   _loaders.clear();
+   _anonClasses.clear();
+   }
+
+void *
+J9::RetainedMethodSet::unloadingKey(TR_ResolvedMethod *method)
+   {
+   J9Class *c = definingJ9Class(method);
+   return isAnonymousClass(c) ? (void*)c : (void*)getLoader(c);
+   }
+
+#if defined(J9VM_OPT_JITSERVER)
+void
+J9::RetainedMethodSet::initWithScanLog(ScanLog *scanLog)
+   {
+   TR_ASSERT_FATAL(comp()->isRemoteCompilation(), "client-only path");
+
+   // Usually scanLog is required because we should be creating a remote mirror
+   // of a J9::RetainedMethodSet that was created on the server. However, in an
+   // AOT load, we need to be able to analyze the inlining table independently
+   // of what the server may have been doing.
+   TR_ASSERT_FATAL(
+      scanLog != NULL
+         || comp()->compileRelocatableCode()
+         || comp()->isDeserializedAOTMethod(),
+      "RetainedMethodSet %p: init missing scanLog on client (non-AOT)",
+      this);
+
+   _scanLog = scanLog;
+   try
+      {
+      init();
+      _scanLog = NULL;
+      }
+   catch (...)
+      {
+      _scanLog = NULL;
+      throw;
+      }
+   }
+
+void
+J9::RetainedMethodSet::logAddedLoader(J9ClassLoader *loader)
+   {
+   if (comp()->isRemoteCompilation() && _scanLog != NULL)
+      {
+      _scanLog->_addedLoaders.push_back(loader);
+      }
+   }
+#endif

--- a/runtime/compiler/env/J9RetainedMethodSet.hpp
+++ b/runtime/compiler/env/J9RetainedMethodSet.hpp
@@ -1,0 +1,142 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2024
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef J9_RETAINEDMETHODSET_INCL
+#define J9_RETAINEDMETHODSET_INCL
+
+#include "env/OMRRetainedMethodSet.hpp"
+#include "infra/set.hpp"
+
+#if defined(J9VM_OPT_JITSERVER)
+#include <vector>
+#endif
+
+struct J9Class;
+struct J9ClassLoader;
+namespace TR { class Compilation; }
+class TR_ResolvedMethod;
+
+namespace J9 {
+
+/**
+ * \brief An OMR::RetainedMethodSet that is represented as a set of
+ * J9ClassLoader pointers and a set of anonymous J9Class pointers.
+ *
+ * See OMR::RetainedMethodSet. Virtual methods in this class are just overrides.
+ */
+class RetainedMethodSet : public OMR::RetainedMethodSet
+   {
+   private:
+
+   RetainedMethodSet(
+      TR::Compilation *comp,
+      TR_ResolvedMethod *method,
+      J9::RetainedMethodSet *parent);
+
+   public:
+
+#if defined(J9VM_OPT_JITSERVER)
+   // This is used on the client for collecting any new entries added by scan()
+   // so that they can be sent to the server.
+   struct ScanLog
+      {
+      // NOTE: A single scan will add at most one anonymous class.
+      J9Class *_addedAnonClass; // NULL if none
+      std::vector<J9ClassLoader*> _addedLoaders;
+
+      ScanLog() : _addedAnonClass(NULL) {}
+      };
+#endif
+
+   static J9::RetainedMethodSet *create(
+      TR::Compilation *comp, TR_ResolvedMethod *method
+#if defined(J9VM_OPT_JITSERVER)
+      , ScanLog *scanLog = NULL
+#endif
+      );
+
+#if defined(J9VM_OPT_JITSERVER)
+   virtual J9::RetainedMethodSet *createChild(TR_ResolvedMethod *method)
+      {
+      return createChild(method, NULL);
+      }
+
+   J9::RetainedMethodSet *createChild(TR_ResolvedMethod *method, ScanLog *scanLog);
+#else
+   virtual J9::RetainedMethodSet *createChild(TR_ResolvedMethod *method);
+#endif
+
+   virtual J9::RetainedMethodSet *withKeepalivesAttested();
+
+   virtual bool willRemainLoaded(TR_ResolvedMethod *method);
+   bool willRemainLoaded(J9Class *clazz);
+   bool willRemainLoaded(J9ClassLoader *loader);
+   virtual void attestLinkedCalleeWillRemainLoaded(TR_ByteCodeInfo bci);
+   virtual void keepalive();
+   virtual void bond();
+
+#if defined(J9VM_OPT_JITSERVER)
+   void scanForClient(J9Class *clazz, ScanLog *scanLog);
+   void *remoteMirror() { return _remoteMirror; }
+#endif
+
+   protected:
+
+   J9::RetainedMethodSet *parent()
+      {
+      return static_cast<J9::RetainedMethodSet*>(OMR::RetainedMethodSet::parent());
+      }
+
+   virtual void mergeIntoParent();
+   virtual void *unloadingKey(TR_ResolvedMethod *method);
+
+   private:
+
+   void init();
+   void addPermanentLoader(J9ClassLoader *loader, const char *name);
+   void attestWillRemainLoaded(TR_ResolvedMethod *method);
+   void scan(J9Class *clazz);
+   void scan(J9ClassLoader *loader);
+   bool willAnonymousClassRemainLoaded(J9Class *clazz);
+   J9ClassLoader *getLoader(J9Class *clazz);
+   bool isAnonymousClass(J9Class *clazz);
+
+#if defined(J9VM_OPT_JITSERVER)
+   void initWithScanLog(ScanLog *scanLog);
+   void logAddedLoader(J9ClassLoader *loader);
+#endif
+
+   TR::set<J9ClassLoader*> _loaders;
+   TR::set<J9Class*> _anonClasses;
+
+#if defined(J9VM_OPT_JITSERVER)
+   union
+      {
+      void *_remoteMirror; // used on the server
+      ScanLog *_scanLog; // used on the client
+      };
+#endif
+   };
+
+} // namespace TR
+
+#endif // J9_RETAINEDMETHODSET_INCL

--- a/runtime/compiler/env/JITServerCHTable.cpp
+++ b/runtime/compiler/env/JITServerCHTable.cpp
@@ -23,6 +23,7 @@
 #include "env/CHTable.hpp"
 #include "env/JITServerPersistentCHTable.hpp"
 #include "env/j9methodServer.hpp"
+#include "env/J9RetainedMethodSet.hpp"
 #include "infra/List.hpp"                      // for TR::list
 #include "compile/VirtualGuard.hpp"            // for TR_VirtualGuard
 #include "il/SymbolReference.hpp"              // for SymbolReference
@@ -100,11 +101,20 @@ bool JITClientCHTableCommit(
    FlatClassExtendCheck &compClassesThatShouldNotBeNewlyExtended = std::get<6>(data);
    std::vector<TR_OpaqueClassBlock*> &classesForOSRRedefinition = std::get<7>(data);
    std::vector<TR_OpaqueClassBlock*> &classesForStaticFinalFieldModification = std::get<8>(data);
-   uint8_t *serverStartPC = std::get<9>(data);
+   auto retainedMethods = (J9::RetainedMethodSet*)std::get<9>(data);
+   uint8_t *serverStartPC = std::get<10>(data);
    uint8_t *startPC = (uint8_t*) metaData->startPC;
 
-   if (vguards.empty() && sideEffectPatchSites.empty() && preXMethods.empty() && classes.empty() && classesThatShouldNotBeNewlyExtended.empty())
+   TR_ResolvedMethod *bondMethod = NULL;
+   if (vguards.empty()
+       && sideEffectPatchSites.empty()
+       && preXMethods.empty()
+       && classes.empty()
+       && classesThatShouldNotBeNewlyExtended.empty()
+       && (retainedMethods == NULL || !retainedMethods->bondMethods().next(&bondMethod)))
+      {
       return true;
+      }
 
    cleanupNewlyExtendedInfo(comp, classesThatShouldNotBeNewlyExtended);
    if (comp->getFailCHTableCommit())
@@ -198,6 +208,23 @@ bool JITClientCHTableCommit(
 
       if (invalidAssumption) return false;
       } //  if (classesThatShouldNotBeNewlyExtended)
+
+   // Invalidate the body and recompile if any inlined method is unloaded.
+   if (retainedMethods != NULL)
+      {
+      auto bondIter = retainedMethods->bondMethods();
+      while (bondIter.next(&bondMethod))
+         {
+         TR_ClassUnloadRecompile::make(
+            comp->fe(),
+            comp->trPersistentMemory(),
+            bondMethod->containingClass(),
+            startPC,
+            comp->getMetadataAssumptionList());
+
+         comp->setHasClassUnloadAssumptions();
+         }
+      }
 
    // Check if the assumptions for static final field are still valid
    // Returning false will cause CHTable opts to be disabled in the next compilation of this method,

--- a/runtime/compiler/env/JITServerCHTable.hpp
+++ b/runtime/compiler/env/JITServerCHTable.hpp
@@ -77,6 +77,7 @@ using CHTableCommitData = std::tuple<
       FlatClassExtendCheck, // comp->getClassesThatShouldNotBeNewlyExtended
       std::vector<TR_OpaqueClassBlock*>, // classesForOSRRedefinition
       std::vector<TR_OpaqueClassBlock*>, // classesForStaticFinalFieldModification
+      void*, // remote mirror of comp->retainedMethods(), if any
       uint8_t*>; // startPC
 
 /** 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5663,6 +5663,16 @@ TR_J9VMBase::reportPrexInvalidation(void * startPC)
    Trc_JIT_MethodPrexInvalidated(vmThread(), startPC);
    }
 
+void
+TR_J9VMBase::reportUnloadInvalidation(void *startPC)
+   {
+   if (!_vmThread)
+      {
+      return;
+      }
+
+   Trc_JIT_MethodUnloadInvalidated(vmThread(), startPC);
+   }
 
 // Multiple codeCache support
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1173,6 +1173,7 @@ public:
    virtual void restoreCompilationPhase(int32_t phase);
 
    virtual void reportPrexInvalidation(void * startPC);
+   virtual void reportUnloadInvalidation(void * startPC);
 
    virtual bool compilationShouldBeInterrupted( TR::Compilation *, TR_CallingContext);
    bool checkForExclusiveAcquireAccessRequest( TR::Compilation *);

--- a/runtime/compiler/env/j9jit.tdf
+++ b/runtime/compiler/env/j9jit.tdf
@@ -134,3 +134,5 @@ TraceEvent=Trc_JITServerClientSessionData1   Overhead=1 Level=1 Test Template="J
 TraceEvent=Trc_JITServerOutOfSequenceMsg1    Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d clientSessionData=%p clientUID=%llu (entry=%p) (seqNo=%u, expectedSeqNo=%u, numActiveThreads=%d) out-of-sequence msg detected (lastProcessedCriticalSeqNo=%u). Parking this thread"
 TraceEvent=Trc_JITServerCompThreadCrashed    Overhead=1 Level=1 Test Template="JITClient: compThreadID=%d server compilation thread crashed while compiling %s @ %s. Requesting JitDump recompilation and switching to local compilations."
 TraceEvent=Trc_JITServerClearCaches    Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d clientSessionData=%p clientUID=%llu clearing all the caches due to class redefinition."
+
+TraceEvent=Trc_JIT_MethodUnloadInvalidated Group=perfmon Overhead=1 Level=1 Test Template="JIT: Compiled body _startPC=%p invalidated by unloading of inlined code"

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 79; // ID: Su+UK1Q5oJlgUkWIBA6f
+   static const uint16_t MINOR_NUMBER = 80; // ID: GTheAB6fYzRQxLjhlUyZ
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -266,7 +266,11 @@ const char *messageNames[] =
    "KnownObjectTable_getFieldAddressData",
    "AOTCache_getROMClassBatch",
    "AOTCacheMap_request",
-   "AOTCacheMap_reply"
+   "AOTCacheMap_reply",
+   "RetainedMethodSet_createMirror",
+   "RetainedMethodSet_scan",
+   "RetainedMethodSet_keepalive",
+   "RetainedMethodSet_bond"
    };
 
    static_assert(sizeof(messageNames) / sizeof(messageNames[0]) == MessageType_MAXTYPE,

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -298,6 +298,10 @@ enum MessageType : uint16_t
    AOTCacheMap_request,
    AOTCacheMap_reply,
 
+   RetainedMethodSet_createMirror,
+   RetainedMethodSet_scan,
+   RetainedMethodSet_keepalive,
+   RetainedMethodSet_bond,
 
    MessageType_MAXTYPE
    };

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1420,11 +1420,13 @@ InterpreterEmulator::visitInvokedynamic()
       if (_currentCallMethod->numberOfExplicitParameters() > 0 && _currentCallMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(_currentCallMethod->numberOfExplicitParameters()))
          allconsts = true;
 
+      OMR::RetainedMethodSet *retainedMethods = _calltarget->_retainedMethods;
+      bool wasRefinedFromKnownObject = false;
       TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_J9MethodHandleCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
                                                                         callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
                                                                         -1, -1, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-                                                                        _recursionDepth, allconsts);
+                                                                        _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
 
       findTargetAndUpdateInfoForCallsite(callsite);
       }
@@ -1469,11 +1471,14 @@ InterpreterEmulator::updateKnotAndCreateCallSiteUsingInvokeCacheArray(TR_Resolve
    bool allconsts = false;
    if (targetMethod->numberOfExplicitParameters() > 0 && targetMethod->numberOfExplicitParameters() <= _pca.getNumPrevConstArgs(targetMethod->numberOfExplicitParameters()))
          allconsts = true;
+
+   OMR::RetainedMethodSet *retainedMethods = _calltarget->_retainedMethods;
+   bool wasRefinedFromKnownObject = false;
    TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(_calltarget->_calleeMethod, callNodeTreeTop,   parent,
                                                                         callNode, interfaceMethod, targetMethod->classOfMethod(),
                                                                         -1, cpIndex, targetMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-                                                                        _recursionDepth, allconsts);
+                                                                        _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
 
    findTargetAndUpdateInfoForCallsite(callsite, idx);
    }
@@ -1577,8 +1582,13 @@ InterpreterEmulator::visitInvokevirtual()
    else if (_currentCallMethod)
       {
       bool isIndirectCall = !_currentCallMethod->isFinal() && !_currentCallMethod->isPrivate();
+      bool wasRefinedFromKnownObject = false;
       if (_iteratorWithState)
+         {
          refineResolvedCalleeForInvokevirtual(_currentCallMethod, isIndirectCall);
+         wasRefinedFromKnownObject =
+            _currentCallMethod != _currentCallMethodUnrefined;
+         }
 
       // Customization logic is not needed in customized thunk or in inlining
       // with known MethodHandle object
@@ -1610,6 +1620,7 @@ InterpreterEmulator::visitInvokevirtual()
       TR::Node *parent = 0;
       TR::Node *callNode = 0;
       TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+      OMR::RetainedMethodSet *retainedMethods = _calltarget->_retainedMethods;
 
       Operand *receiver = NULL;
       if (_iteratorWithState)
@@ -1621,7 +1632,7 @@ InterpreterEmulator::visitInvokevirtual()
                                                                         callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
                                                                         -1, cpIndex, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-                                                                        _recursionDepth, allconsts);
+                                                                        _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
          }
       else if (_currentCallMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact
                || (_currentCallMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeBasic
@@ -1631,7 +1642,7 @@ InterpreterEmulator::visitInvokevirtual()
                                                       callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
                                                       -1, cpIndex, _currentCallMethod,
                                                       resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-                                                      _recursionDepth, allconsts);
+                                                      _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
          if (_currentCallMethod->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeBasic)
             {
             // Set the MCS reference location so that TR_J9MutableCallSite
@@ -1661,7 +1672,7 @@ InterpreterEmulator::visitInvokevirtual()
                                                                         callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
                                                                         (int32_t) _currentCallMethod->virtualCallSelector(), cpIndex, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-                                                                        _recursionDepth, allconsts);
+                                                                        _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
 
          }
       else
@@ -1670,7 +1681,7 @@ InterpreterEmulator::visitInvokevirtual()
                                                                         callNode, interfaceMethod, _currentCallMethod->classOfMethod(),
                                                                         -1, cpIndex, _currentCallMethod,
                                                                         resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-                                                                        _recursionDepth, allconsts);
+                                                                        _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
 
          }
 
@@ -1706,10 +1717,12 @@ InterpreterEmulator::visitInvokespecial()
       TR::Node *parent = 0;
       TR::Node *callNode = 0;
       TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+      OMR::RetainedMethodSet *retainedMethods = _calltarget->_retainedMethods;
+      bool wasRefinedFromKnownObject = false;
       TR_CallSite *callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(_calltarget->_calleeMethod, callNodeTreeTop, parent,
                                                                         callNode, interfaceMethod, _currentCallMethod->classOfMethod(), -1, cpIndex,
                                                                         _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-                                                                        _recursionDepth, allconsts);
+                                                                        _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
       findTargetAndUpdateInfoForCallsite(callsite);
       }
    }
@@ -1737,6 +1750,7 @@ InterpreterEmulator::visitInvokestatic()
       TR::KnownObjectTable::Index mcsIndex = TR::KnownObjectTable::UNKNOWN;
       TR_OpaqueClassBlock *receiverClass = NULL;
       bool isIndirectCall = false;
+      bool wasRefinedFromKnownObject = false;
       if (_iteratorWithState)
          {
          refineResolvedCalleeForInvokestatic(
@@ -1745,6 +1759,9 @@ InterpreterEmulator::visitInvokestatic()
             mhIndex,
             isIndirectCall,
             receiverClass);
+
+         wasRefinedFromKnownObject =
+            _currentCallMethod != _currentCallMethodUnrefined;
          }
 
       if (receiverClass == NULL)
@@ -1757,6 +1774,7 @@ InterpreterEmulator::visitInvokestatic()
       TR::Node *parent = 0;
       TR::Node *callNode = 0;
       TR::ResolvedMethodSymbol *resolvedSymbol = 0;
+      OMR::RetainedMethodSet *retainedMethods = _calltarget->_retainedMethods;
 
       if (_currentCallMethod->convertToMethod()->isArchetypeSpecimen() &&
             _currentCallMethod->getMethodHandleLocation() &&
@@ -1766,7 +1784,7 @@ InterpreterEmulator::visitInvokestatic()
                callNode, interfaceMethod, receiverClass,
                -1, cpIndex, _currentCallMethod,
                resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-               _recursionDepth, allconsts);
+               _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
          }
       else if (_currentCallMethod->convertToMethod()->isArchetypeSpecimen() &&
             _currentCallMethod->getMethodHandleLocation() &&
@@ -1776,7 +1794,7 @@ InterpreterEmulator::visitInvokestatic()
                callNode, interfaceMethod, receiverClass,
                -1, cpIndex, _currentCallMethod,
                resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo, comp(),
-               _recursionDepth, allconsts);
+               _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
          if (mcsIndex != TR::KnownObjectTable::UNKNOWN)
             {
             if (comp()->getKnownObjectTable())
@@ -1791,15 +1809,16 @@ InterpreterEmulator::visitInvokestatic()
                _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
                interfaceMethod, receiverClass, (int32_t) _currentCallMethod->virtualCallSelector(), noCPIndex,
                _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
-               *_newBCInfo, comp(), _recursionDepth, allconsts);
+               *_newBCInfo, comp(), _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
          }
       else
          {
          callsite = new (comp()->trHeapMemory()) TR_DirectCallSite(_calltarget->_calleeMethod, callNodeTreeTop, parent, callNode, interfaceMethod,
                receiverClass, -1, cpIndex, _currentCallMethod, resolvedSymbol,
                isIndirectCall, isInterface, *_newBCInfo, comp(),
-               _recursionDepth, allconsts);
+               _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
          }
+
       findTargetAndUpdateInfoForCallsite(callsite);
       }
 
@@ -1841,6 +1860,8 @@ InterpreterEmulator::visitInvokeinterface()
    if (explicitParams > 0 && explicitParams <= _pca.getNumPrevConstArgs(explicitParams))
       allconsts = true;
 
+   OMR::RetainedMethodSet *retainedMethods = _calltarget->_retainedMethods;
+   bool wasRefinedFromKnownObject = false;
    TR_CallSite *callsite = NULL;
    if (isInterface)
       {
@@ -1849,7 +1870,7 @@ InterpreterEmulator::visitInvokeinterface()
          _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
          interfaceMethod, thisClass, -1, cpIndex, _currentCallMethod,
          resolvedSymbol, isIndirectCall, isInterface, *_newBCInfo,
-         comp(), _recursionDepth, allconsts);
+         comp(), _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
       }
    else if (isIndirectCall)
       {
@@ -1857,7 +1878,7 @@ InterpreterEmulator::visitInvokeinterface()
          _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
          interfaceMethod, _currentCallMethod->classOfMethod(), (int32_t) _currentCallMethod->virtualCallSelector(), cpIndex,
          _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
-         *_newBCInfo, comp(), _recursionDepth, allconsts);
+         *_newBCInfo, comp(), _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
       }
    else
       {
@@ -1865,7 +1886,7 @@ InterpreterEmulator::visitInvokeinterface()
          _calltarget->_calleeMethod, callNodeTreeTop, parent, callNode,
          interfaceMethod, _currentCallMethod->classOfMethod(), -1, cpIndex,
          _currentCallMethod, resolvedSymbol, isIndirectCall, isInterface,
-         *_newBCInfo, comp(), _recursionDepth, allconsts);
+         *_newBCInfo, comp(), _recursionDepth, allconsts, retainedMethods, wasRefinedFromKnownObject);
       }
 
    if(tracer()->debugLevel())

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -30,6 +30,7 @@
 #include "env/CompilerEnv.hpp"
 #include "env/CHTable.hpp"
 #include "env/HeuristicRegion.hpp"
+#include "env/J9RetainedMethodSet.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/VMJ9.h"
 #include "env/jittypes.h"
@@ -158,6 +159,10 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* callNodeTreeTop,
    TR::MethodSymbol *calleeSymbol = symRef->getSymbol()->castToMethodSymbol();
    TR_ResolvedMethod* lCaller = caller ? caller : symRef->getOwningMethod(comp);
 
+   // It could have previously been refined, but since the call is already in
+   // the trees, we must have already taken account of that.
+   bool wasRefinedFromKnownObject = false;
+
    if (callNode->getOpCode().isCallIndirect())
       {
       if (calleeSymbol->isInterface() )
@@ -177,7 +182,9 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* callNodeTreeTop,
                               callNode->getByteCodeInfo(),
                               comp,
                               depth,
-                              allConsts);
+                              allConsts,
+                              comp->retainedMethods(),
+                              wasRefinedFromKnownObject);
          }
       else
          {
@@ -200,7 +207,9 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* callNodeTreeTop,
                      callNode->getByteCodeInfo(),
                      comp,
                      depth,
-                     allConsts) ;
+                     allConsts,
+                     comp->retainedMethods(),
+                     wasRefinedFromKnownObject);
             }
 
          if (calleeSymbol->getResolvedMethodSymbol() && calleeSymbol->getResolvedMethodSymbol()->getRecognizedMethod() == TR::java_lang_invoke_MethodHandle_invokeExact)
@@ -220,7 +229,9 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* callNodeTreeTop,
                   callNode->getByteCodeInfo(),
                   comp,
                   depth,
-                  allConsts) ;
+                  allConsts,
+                  comp->retainedMethods(),
+                  wasRefinedFromKnownObject);
             }
 
          return new (trMemory, kind) TR_J9VirtualCallSite  (lCaller,
@@ -238,7 +249,9 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* callNodeTreeTop,
                               callNode->getByteCodeInfo(),
                               comp,
                               depth,
-                              allConsts) ;
+                              allConsts,
+                              comp->retainedMethods(),
+                              wasRefinedFromKnownObject);
 
          }
       }
@@ -258,7 +271,9 @@ TR_CallSite* TR_CallSite::create(TR::TreeTop* callNodeTreeTop,
                               callNode->getByteCodeInfo(),
                               comp,
                               depth,
-                              allConsts) ;
+                              allConsts,
+                              comp->retainedMethods(),
+                              wasRefinedFromKnownObject);
 
    }
 

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -42,6 +42,7 @@
 #include "il/Symbol.hpp"
 #include "il/SymbolReference.hpp"
 #include "ilgen/J9ByteCodeIterator.hpp"
+#include "env/OMRRetainedMethodSet.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
 #include "env/j9method.h"
@@ -2124,6 +2125,28 @@ J9::TransformUtil::transformIndirectLoadChainImpl(TR::Compilation *comp,
                   TR_OpaqueClassBlock *clazz = *(TR_OpaqueClassBlock**)valuePtr;
                   value = (uintptr_t)clazz;
                   node->setSymbolReference(comp->getSymRefTab()->findOrCreateClassSymbol(comp->getMethodSymbol(), -1, clazz));
+
+                  // This loadaddr came from constant folding, so a keepalive
+                  // is needed in general to ensure that the class will still
+                  // be loaded when we reach this program point at runtime.
+                  //
+                  // It's OK to prevent the class from being unloaded (while
+                  // this JIT body is still valid) because we're allowed to
+                  // remember the original java/lang/Class instance, which
+                  // would do the same.
+                  //
+                  // If node was loading from a J9Class, e.g. if it was loading
+                  // <componentClass>, then it's possible for the J9Class to be
+                  // constant but for no known object to have been involved in
+                  // the determination of that constant. If so, the value must
+                  // have originated from a class ref CP entry in the constant
+                  // pool of some method in this compilation or from the JIT
+                  // fabricating a loaddadr of a class loaded by the bootstrap
+                  // loader. In either of these cases, we already know that the
+                  // class won't be unloaded while this body is still valid, so
+                  // the keepalive is redundant but harmless.
+                  //
+                  comp->addKeepaliveClass(clazz);
                   }
                else
                   {
@@ -2838,6 +2861,26 @@ J9::TransformUtil::specializeInvokeExactSymbol(TR::Compilation *comp, TR::Node *
       return false;
    }
 
+static void
+keepaliveRefinedCallee(TR::Compilation *comp, TR_ResolvedMethod *callee)
+   {
+   // We only need to keepalive static methods this way. For an instance
+   // method, we can't reach the callee without a receiver of the correct type
+   // at runtime, and that receiver will ensure that the method is loaded.
+   if (callee->isStatic() && !comp->retainedMethods()->willRemainLoaded(callee))
+      {
+      // The call has been refined based on known object information, i.e.
+      // constants that we're allowed to retain, and therefore we can also
+      // retain callee.
+      //
+      // Because the call is getting refined in the trees, it's necessary to
+      // take note of the keepalive immediately even if the refined call never
+      // gets inlined.
+      //
+      comp->addKeepaliveClass(callee->containingClass());
+      }
+   }
+
 bool
 J9::TransformUtil::refineMethodHandleInvokeBasic(TR::Compilation* comp, TR::TreeTop* treetop, TR::Node* node, TR::KnownObjectTable::Index mhIndex, bool trace)
    {
@@ -2875,6 +2918,8 @@ J9::TransformUtil::refineMethodHandleInvokeBasic(TR::Compilation* comp, TR::Tree
    auto refinedMethod = fej9->createResolvedMethod(comp->trMemory(), targetMethod, symRef->getOwningMethod(comp));
    if (!performTransformation(comp, "O^O Refine invokeBasic n%dn %p with known MH object\n", node->getGlobalIndex(), node))
       return false;
+
+   keepaliveRefinedCallee(comp, refinedMethod);
 
    // Preserve NULLCHK
    TR::TransformUtil::separateNullCheck(comp, treetop, trace);
@@ -3031,6 +3076,8 @@ J9::TransformUtil::refineMethodHandleLinkTo(TR::Compilation* comp, TR::TreeTop* 
       return false;
 
    auto resolvedMethod = fej9->createResolvedMethodWithVTableSlot(comp->trMemory(), vTableSlot, info.vmtarget, symRef->getOwningMethod(comp));
+   keepaliveRefinedCallee(comp, resolvedMethod);
+
    newSymRef = comp->getSymRefTab()->findOrCreateMethodSymbol(symRef->getOwningMethodIndex(), -1, resolvedMethod, callKind);
    if (callKind == TR::MethodSymbol::Virtual)
       newSymRef->setOffset(jitVTableOffset);

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -41,6 +41,8 @@
 #include "env/CHTable.hpp"
 #include "env/ClassLoaderTable.hpp"
 #include "env/DependencyTable.hpp"
+#include "env/J9RetainedMethodSet.hpp"
+#include "env/OMRRetainedMethodSet.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/jittypes.h"
 #include "env/VMAccessCriticalSection.hpp"
@@ -534,6 +536,121 @@ TR_RelocationRecordGroup::applyRelocations(TR_RelocationRuntime *reloRuntime,
          }
 
       recordPointer = reloRecord->nextBinaryRecord(reloTarget);
+      }
+
+   return checkInliningTable(reloRuntime);
+   }
+
+TR_RelocationErrorCode
+TR_RelocationRecordGroup::checkInliningTable(TR_RelocationRuntime *reloRuntime)
+   {
+   TR::Compilation *comp = TR::comp();
+
+#if defined(J9VM_OPT_JITSERVER)
+   if (comp->isRemoteCompilation()
+       && !comp->compileRelocatableCode()
+       && !comp->isDeserializedAOTMethod())
+      {
+      // We're relocating for a non-AOT remote compilation. The bonds have been
+      // determined during compilation and they will be handled during CH table
+      // commit, just like for an in-process JIT compilation. Only continue to
+      // create bonds below for AOT loads.
+      return TR_RelocationErrorCode::relocationOK;
+      }
+#endif
+
+   bool restrictInlining = comp->getOption(TR_DontInlineUnloadableMethods);
+   bool createBonds = !comp->getOption(TR_AllowJitBodyToOutliveInlinedCode);
+   if (!restrictInlining && !createBonds)
+      {
+      return TR_RelocationErrorCode::relocationOK;
+      }
+
+   J9JITExceptionTable *metadata = reloRuntime->exceptionTable();
+   uint32_t numSites = getNumInlinedCallSites(metadata);
+   if (numSites == 0)
+      {
+      return TR_RelocationErrorCode::relocationOK;
+      }
+
+   // Don't use comp->retainedMethods(). If we're relocating immediately
+   // after an AOT compilation (disableDelayRelocationForAOTCompilations)
+   // then it will be the OMR base implementation, which does no actual
+   // tracking.
+   OMR::RetainedMethodSet *root =
+      J9::RetainedMethodSet::create(comp, comp->getMethodBeingCompiled());
+
+   TR::vector<OMR::RetainedMethodSet*, TR::Region&> retainedMethods(comp->region());
+   retainedMethods.resize(numSites, NULL);
+
+   TR::vector<bool, TR::Region&> needsBond(comp->region());
+   needsBond.resize(numSites, false);
+
+   // Build the tree of RetainedMethodSets that would exist during inlining if
+   // this were a regular JIT compilation.
+   for (uint32_t i = 0; i < numSites; i++)
+      {
+      auto *site = (TR_InlinedCallSite *)getInlinedCallSiteArrayElement(metadata, i);
+      TR_OpaqueMethodBlock *opaqueCallee = site->_methodInfo;
+      TR_ByteCodeInfo bci = site->_byteCodeInfo;
+
+      int32_t caller = bci.getCallerIndex();
+      OMR::RetainedMethodSet *parent = caller < 0 ? root : retainedMethods[caller];
+
+      // NOTE: Don't attestLinkedCalleeWillRemainLoaded(bci). That would try to
+      // get the inlined site from comp, which doesn't have it. Attesting here
+      // would require some way to make the attestation get the inlined site
+      // from metadata instead. For now, just skip it because it should only
+      // make a difference when an invokehandle/invokedynamic call site adapter
+      // method is inlined. So far (at time of writing), AOT compilations have
+      // only experimental support for resolved invokehandle/invokedynamic,
+      // enabled by a debug option -Xshareclasses:shareLambdaForm. Even if a
+      // call site adapter method is inlined, skipping the attestation will
+      // only cause an unnecessary bond.
+
+      TR_ResolvedMethod *callee = new (comp->trHeapMemory())
+         TR_ResolvedJ9Method(opaqueCallee, comp->fe(), comp->trMemory());
+
+      if (parent->willRemainLoaded(callee))
+         {
+         retainedMethods[i] = parent;
+         }
+      else if (restrictInlining)
+         {
+         return TR_RelocationErrorCode::inlinedMethodRelocationFailure;
+         }
+      else
+         {
+         retainedMethods[i] = parent->createChild(callee);
+         needsBond[i] = true;
+         }
+      }
+
+   // Collapse the tree to collect bonds. Iterate in reverse to ensure
+   // that the collapse is bottom-up.
+   for (uint32_t i = numSites; i != 0;)
+      {
+      i--;
+      if (needsBond[i])
+         {
+         retainedMethods[i]->bond();
+         }
+      }
+
+   // Create an assumption for each bond.
+   if (createBonds)
+      {
+      TR_ResolvedMethod *bondMethod = NULL;
+      auto bondMethods = root->bondMethods();
+      while (bondMethods.next(&bondMethod))
+         {
+         TR_ClassUnloadRecompile::make(
+            reloRuntime->fej9(),
+            reloRuntime->trMemory()->trPersistentMemory(),
+            bondMethod->containingClass(),
+            (uint8_t *)metadata->startPC,
+            (OMR::RuntimeAssumption**)&metadata->runtimeAssumptionList);
+         }
       }
 
    return TR_RelocationErrorCode::relocationOK;

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -57,6 +57,8 @@ class TR_RelocationRecordGroup
                                               TR_RelocationTarget *reloTarget,
                                               uint8_t *reloOrigin);
    private:
+      TR_RelocationErrorCode checkInliningTable(TR_RelocationRuntime *reloRuntime);
+
       TR_RelocationErrorCode handleRelocation(TR_RelocationRuntime *reloRuntime,
                                               TR_RelocationTarget *reloTarget,
                                               TR_RelocationRecord *reloRecord,

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -140,6 +140,17 @@ TR_PreXRecompile::compensate(TR_FrontEnd *fe, bool, void *)
 
 
 void
+TR_ClassUnloadRecompile::compensate(TR_FrontEnd *fe, bool, void *)
+   {
+   TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
+   TR::Recompilation::invalidateMethodBody(
+      _startPC, fe, TR_JitBodyInvalidations::Unloading);
+
+   fej9->reportUnloadInvalidation(_startPC);
+   }
+
+
+void
 TR_PatchJNICallSite::compensate(
       TR_FrontEnd *fe,
       bool isSMP,

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3639,6 +3639,32 @@ typedef struct J9ClassLoader {
 #if defined(J9VM_OPT_JFR)
 	J9HashTable *typeIDs;
 #endif /* defined(J9VM_OPT_JFR) */
+
+	/**
+	 * The set of class loaders directly observed to outlive this one.
+	 *
+	 * These are the defining loaders of classes for which this loader is an
+	 * initiating loader but not itself the defining loader. As long as this
+	 * loader remains live, such classes and therefore their defining loaders
+	 * are also live. Every loader in the transitive closure will outlive this
+	 * loader.
+	 *
+	 * Here the term "outlive" should be understood to be non-strict. That is,
+	 * two loaders with the exact same lifetime outlive each other.
+	 *
+	 * Permanent loaders are excluded, since they would be uninformative
+	 * (systemClassLoader, applicationClassLoader, and extensionClassLoader).
+	 * Similarly, there's no need to maintain a graph of the permanent loaders,
+	 * so they have an empty outliving loader set.
+	 *
+	 * The value is one of the following representations:
+	 * - empty set: null
+	 * - singleton set: J9ClassLoader pointer tagged with J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG
+	 * - set of two or more: untagged pointer to J9HashTable of J9ClassLoader pointers
+	 *
+	 * Protected by J9JavaVM.classTableMutex.
+	 */
+	void *outlivingLoaders;
 } J9ClassLoader;
 
 #define J9CLASSLOADER_SHARED_CLASSES_ENABLED  8
@@ -3654,6 +3680,8 @@ typedef struct J9ClassLoader {
 #define J9CLASSLOADER_CLASSLOADEROBJECT(currentThread, object) J9VMTHREAD_JAVAVM(currentThread)->memoryManagerFunctions->j9gc_objaccess_readObjectFromInternalVMSlot((currentThread), J9VMTHREAD_JAVAVM(currentThread), (j9object_t*)&((object)->classLoaderObject))
 #define J9CLASSLOADER_SET_CLASSLOADEROBJECT(currentThread, object, value) J9VMTHREAD_JAVAVM(currentThread)->memoryManagerFunctions->j9gc_objaccess_storeObjectToInternalVMSlot((currentThread), (j9object_t*)&((object)->classLoaderObject), (value))
 #define TMP_J9CLASSLOADER_CLASSLOADEROBJECT(object) ((object)->classLoaderObject)
+
+#define J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG 1
 
 #if defined(_MSC_VER)
 #pragma warning(push)

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2223,6 +2223,28 @@ hashClassLocationTableNew(J9JavaVM *javaVM, U_32 initialSize);
 J9ClassLocation *
 findClassLocationForClass(J9VMThread *currentThread, J9Class *clazz);
 
+/**
+ * @brief Add outlivingLoader to the set of loaders known to outlive classLoader.
+ *
+ * The addition could fail due to OOM, but such failures are ignored because the
+ * set of outliving loaders is not required to be complete.
+ *
+ * If outlivingLoader is permanent, then it is ignored because the few permanent
+ * loaders trivially outlive all loaders.
+ *
+ * If classLoader is permanent, then it is outlived only by permanent loaders,
+ * so its set of outliving loaders will always be empty, so no attempt is made
+ * to add to it.
+ *
+ * The caller must hold the classTableMutex.
+ *
+ * @param currentThread the J9VMThread of the current thread
+ * @param classLoader the initiating class loader
+ * @param outlivingLoader the loader that will outlive classLoader
+ */
+void
+addOutlivingLoader(J9VMThread *currentThread, J9ClassLoader *classLoader, J9ClassLoader *outlivingLoader);
+
 /* ---------------- ModularityHashTables.c ---------------- */
 
 /**

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -90,6 +90,7 @@ UDATA writeExceptionFrameCallBack (J9VMThread* vmThread, void* userData, UDATA b
 void  writeLoaderCallBack         (void* classLoader, void* userData);
 void  writeLibrariesCallBack      (void* classLoader, void* userData);
 void  writeClassesCallBack        (void* classLoader, void* userData);
+void  writeOutlivingLoadersCallBack   (void *classLoader, void *userData);
 static UDATA outerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state);
 static UDATA innerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state);
 
@@ -244,6 +245,7 @@ private :
 	friend void  writeLoaderCallBack         (void* classLoader, void* userData);
 	friend void  writeLibrariesCallBack      (void* classLoader, void* userData);
 	friend void  writeClassesCallBack        (void* classLoader, void* userData);
+	friend void  writeOutlivingLoadersCallBack (void *classLoader, void *userData);
 	friend UDATA outerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state);
 	friend UDATA innerMemCategoryCallBack (U_32 categoryCode, const char * categoryName, UDATA liveBytes, UDATA liveAllocations, BOOLEAN isRoot, U_32 parentCategoryCode, OMRMemCategoryWalkState * state);
 
@@ -346,6 +348,7 @@ private :
 	void        writeLoader                  (J9ClassLoader* classLoader);
 	void        writeLibraries               (J9ClassLoader* classLoader);
 	void        writeClasses                 (J9ClassLoader* classLoader);
+	void        writeOutlivingLoaders        (J9ClassLoader* classLoader);
 	void        writeEventDrivenTitle        (void);
 	void        writeUserRequestedTitle      (void);
 	void        writeNativeAllocator         (const char * name, U_32 depth, BOOLEAN isRoot, UDATA liveBytes, UDATA liveAllocations);
@@ -2799,6 +2802,16 @@ JavaCoreDumpWriter::writeClassSection(void)
 	);
 
 	pool_do(_VirtualMachine->classLoaderBlocks, writeClassesCallBack, this);
+
+	/* Write the sub-section header */
+	_OutputStream.writeCharacters(
+		"1CLTEXTCLOLL   \tClassLoader outliving loaders\n"
+	);
+
+	if (!avoidLocks() && !omrthread_monitor_try_enter(_VirtualMachine->classTableMutex)) {
+		pool_do(_VirtualMachine->classLoaderBlocks, writeOutlivingLoadersCallBack, this);
+		omrthread_monitor_exit(_VirtualMachine->classTableMutex);
+	}
 
 	/* Write the section trailer */
 	_OutputStream.writeCharacters(
@@ -5525,6 +5538,49 @@ JavaCoreDumpWriter::writeClasses(J9ClassLoader* classLoader)
 
 /**************************************************************************************************/
 /*                                                                                                */
+/* JavaCoreDumpWriter::writeOutlivingLoaders() method implementation                              */
+/*                                                                                                */
+/**************************************************************************************************/
+void
+JavaCoreDumpWriter::writeOutlivingLoaders(J9ClassLoader *classLoader)
+{
+	_OutputStream.writeCharacters("2CLTEXTJ9CLLOAD\t\t");
+
+	_OutputStream.writeCharacters("J9ClassLoader(");
+	_OutputStream.writePointer(classLoader);
+	_OutputStream.writeCharacters(") obj(");
+	_OutputStream.writePointer(getClassLoaderObject(classLoader));
+	_OutputStream.writeCharacters(")");
+	if (classLoader == _VirtualMachine->systemClassLoader) {
+		_OutputStream.writeCharacters(" system");
+	} else if (classLoader == _VirtualMachine->applicationClassLoader) {
+		_OutputStream.writeCharacters(" application");
+	} else if (classLoader == _VirtualMachine->extensionClassLoader) {
+		_OutputStream.writeCharacters(" extension");
+	} else if (classLoader == _VirtualMachine->anonClassLoader) {
+		_OutputStream.writeCharacters(" anonymous");
+	}
+
+	_OutputStream.writeCharacters("\n");
+	if (J9_ARE_ANY_BITS_SET((UDATA)classLoader->outlivingLoaders, J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG)) {
+		_OutputStream.writeCharacters("3CLTEXTOUTLIVIN\t\t\t");
+		_OutputStream.writePointer((J9ClassLoader *)((UDATA)classLoader->outlivingLoaders & ~(UDATA)J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG));
+		_OutputStream.writeCharacters("\n");
+	} else if (NULL != classLoader->outlivingLoaders) {
+		J9HashTable *table = (J9HashTable *)classLoader->outlivingLoaders;
+		J9HashTableState state;
+		J9ClassLoader **entry = (J9ClassLoader **)hashTableStartDo(table, &state);
+		while (NULL != entry) {
+			_OutputStream.writeCharacters("3CLTEXTOUTLIVIN\t\t\t");
+			_OutputStream.writePointer(*entry);
+			_OutputStream.writeCharacters("\n");
+			entry = (J9ClassLoader**)hashTableNextDo(&state);
+		}
+	}
+}
+
+/**************************************************************************************************/
+/*                                                                                                */
 /* JavaCoreDumpWriter::getClassLoaderObject() method implementation                               */
 /*                                                                                                */
 /**************************************************************************************************/
@@ -5748,6 +5804,12 @@ void
 writeClassesCallBack(void* classLoader, void* userData)
 {
 	((JavaCoreDumpWriter*)(userData))->writeClasses((J9ClassLoader*)classLoader);
+}
+
+void
+writeOutlivingLoadersCallBack(void *classLoader, void *userData)
+{
+	((JavaCoreDumpWriter *)userData)->writeOutlivingLoaders((J9ClassLoader *)classLoader);
 }
 
 UDATA

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -851,3 +851,58 @@ findClassLocationForClass(J9VMThread *currentThread, J9Class *clazz)
 
 	return targetPtr;
 }
+
+static UDATA
+classLoaderPtrHashFn(void *entry, void *userData)
+{
+	return (UDATA)*(J9ClassLoader **)entry;
+}
+
+static UDATA
+classLoaderPtrHashEqualFn(void *a, void *b, void *userData)
+{
+	return *(J9ClassLoader **)a == *(J9ClassLoader **)b;
+}
+
+static J9HashTable *
+outlivingLoadersTableNew(J9JavaVM *javaVM, U_32 initialSize)
+{
+	return hashTableNew(OMRPORT_FROM_J9PORT(javaVM->portLibrary), J9_GET_CALLSITE(), initialSize, sizeof(J9ClassLoader *), sizeof(J9ClassLoader *), 0, J9MEM_CATEGORY_CLASSES, classLoaderPtrHashFn, classLoaderPtrHashEqualFn, NULL, NULL);
+}
+
+static BOOLEAN
+isLoaderPermanent(J9JavaVM *vm, J9ClassLoader *loader)
+{
+	return loader == vm->systemClassLoader || loader == vm->extensionClassLoader || loader == vm->applicationClassLoader;
+}
+
+void
+addOutlivingLoader(J9VMThread *currentThread, J9ClassLoader *classLoader, J9ClassLoader *outlivingLoader)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+
+	Assert_VM_false(outlivingLoader == classLoader);
+	Assert_VM_mustOwnMonitor(vm->classTableMutex);
+
+	if (!isLoaderPermanent(vm, classLoader) && !isLoaderPermanent(vm, outlivingLoader)) {
+		if (NULL == classLoader->outlivingLoaders) {
+			classLoader->outlivingLoaders = (void *)((UDATA)outlivingLoader | J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG);
+		} else if (J9_ARE_ANY_BITS_SET((UDATA)classLoader->outlivingLoaders, J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG)) {
+			J9ClassLoader *existing = (J9ClassLoader *)((UDATA)classLoader->outlivingLoaders & ~(UDATA)J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG);
+			if (existing != outlivingLoader) {
+				J9HashTable *table = outlivingLoadersTableNew(vm, 2);
+				if (NULL != table) {
+					J9ClassLoader **entry0 = (J9ClassLoader **)hashTableAdd(table, &existing);
+					J9ClassLoader **entry1 = (J9ClassLoader **)hashTableAdd(table, &outlivingLoader);
+					if ((NULL != entry0) && (NULL != entry1)) {
+						classLoader->outlivingLoaders = table;
+					} else {
+						hashTableFree(table);
+					}
+				}
+			}
+		} else {
+			hashTableAdd((J9HashTable *)classLoader->outlivingLoaders, &outlivingLoader);
+		}
+	}
+}

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -747,6 +747,7 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 {
 	j9object_t classNameString, sendLoadClassResult;
 	J9Class *foundClass = NULL;
+	BOOLEAN addedClassToInitiatingLoader = FALSE;
 
 	Assert_VM_mustHaveVMAccess(vmThread);
 
@@ -838,6 +839,8 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 								omrthread_monitor_exit(vm->classTableMutex);
 								setNativeOutOfMemoryError(vmThread, 0, 0);
 								return NULL;
+							} else {
+								addedClassToInitiatingLoader = TRUE;
 							}
 						} else {
 							/* If the existing class in the table is different than the value from loadClass, fail */
@@ -846,6 +849,8 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 								foundClass = NULL;
 							}
 						}
+					} else {
+						addedClassToInitiatingLoader = TRUE;
 					}
 				} else {
 					/* If the existing class in the table is different than the value from loadClass, fail */
@@ -855,6 +860,11 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 					}
 				}
 			}
+
+			if (addedClassToInitiatingLoader) {
+				addOutlivingLoader(vmThread, classLoader, foundClass->classLoader);
+			}
+
 			omrthread_monitor_exit(vm->classTableMutex);
  		}
 	} else {

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -482,6 +482,10 @@ cleanUpClassLoader(J9VMThread *vmThread, J9ClassLoader* classLoader)
 		}
 	}
 
+	if ((NULL != classLoader->outlivingLoaders) && J9_ARE_NO_BITS_SET((UDATA)classLoader->outlivingLoaders, J9CLASSLOADER_OUTLIVING_LOADERS_SINGLE_TAG)) {
+		hashTableFree((J9HashTable *)classLoader->outlivingLoaders);
+	}
+
 	Trc_VM_cleanUpClassLoaders_Exit(vmThread);
 }
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */


### PR DESCRIPTION
This PR will need a coordinated merge with eclipse-omr/omr#7673.

This is largely in preparation for constant references, but it should also have benefits for code motion. For more detail, see the Motivation section of the doc comment for `OMR::RetainedMethodSet`.

Much of this commit is `J9::RetainedMethodSet`, the OpenJ9 implementation of `OMR::RetainedMethodSet`, which describes a set of methods that will remain loaded under certain assumptions. It's represented as a set of class loaders together with a set of anonymous classes, since most classes are unloaded at class loader granularity, but anonymous classes can be unloaded individually.

Each `J9ClassLoader` now maintains a set of class loaders known to live at least as long at it (`outlivingLoaders`). When a class is looked up in a loader *L1*, and the class that's found was defined by a different loader *L2*, *L1* adds the class to its hash table, guaranteeing that *L2* will outlive *L1*. Now when this occurs, *L1* will additionally take note that *L2* outlives it. In this way we construct a graph of loaders describing the lifetime relationships that have been observed so far. This graph can be searched to determine the full set of loaders that are known to outlive any particular loader. It would be possible to skip reifying this graph and to get the same result instead by scanning through the (potentially much larger) class hash tables.

Given a particular method to assume, `J9::RetainedMethodSet` uses the graph of loaders to determine which other loaders can be inferred to remain loaded at least as long as the assumed method.

During inlining, each `TR_CallSite` and `TR_CallTarget` will now have an associated `RetainedMethodSet`, which may be used to arrange to establish certain lifetime relationships between the JIT body and inlined methods. It can extend the lifetime of an inlined method (keepalive) or restrict the lifetime of the JIT body (bond) to make sure that it won't run once an inlined method has been unloaded. See the corresponding OMR commit for more.

Keepalives are determined but not yet actually put into effect since we don't yet have any way to create the necessary references. Again see the OMR commit for more.

A bond is put into effect by creating an unload assumption so that when the inlined method is unloaded, the JIT body will be invalidated in much the same way as for preexistence. Once a JIT body has been invalidated for this reason, any later recompilation of the same method will set the JIT option `dontInlineUnloadableMethods`, which will cause the compiler to refuse to inline any target that would require a bond. This way, invalidation due to unloading can't cause more than one recompilation of a given method.

In AOT compilations, the compile-time analysis is skipped because its results can't be expected to hold at load time. Instead the analysis is done and runtime assumptions are created as necessary during AOT load, after all of the usual validations and relocations have succeeded, based on the inlining table in the `J9JITExceptionTable`. There are no missing entries because loads can only succeed if all inlined methods are found.

In addition to the keepalives mentioned above, the compilation object has a separate set of keepalive classes to be used for cases in which non-inlining transformations cause the IL to directly mention classes (or data belonging to classes) that might not be guaranteed to exist for the entire lifetime of the JIT body. This is used when refining `linkTo*` and `invokeBasic` calls in the trees and when `transformIndirectLoadChain()` transmutes a node into a class pointer `loadaddr`.