### PR TITLE
CRIUSupport supports only one singleton instance

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/crac/Core.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/Core.java
@@ -73,8 +73,8 @@ public class Core {
 class CRIUSupportContext<R extends Resource> extends Context<R> {
 	// InternalCRIUSupport.getCRaCCheckpointToDir() is not null if
 	// InternalCRIUSupport.isCRaCSupportEnabled() returns true before creating CRIUSupportContext<>().
-	private final InternalCRIUSupport internalCRIUSupport = new InternalCRIUSupport(
-			Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir()))
+	private final InternalCRIUSupport internalCRIUSupport = InternalCRIUSupport.getInternalCRIUSupport()
+			.setImageDir(Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir()))
 			.setLeaveRunning(false)
 			.setShellJob(true)
 			.setTCPEstablished(true)

--- a/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/criu/InternalCRIUSupport.java
@@ -87,6 +87,55 @@ public final class InternalCRIUSupport {
 /*[ENDIF] CRAC_SUPPORT */
 
 	/**
+	 * A singleton {@code InternalCRIUSupport} instance.
+	 *
+	 * The default CRIU dump options are:
+	 * <p>
+	 * {@code imageDir} = CWD, current Java process working directory.
+	 * <p>
+	 * {@code leaveRunning} = false
+	 * <p>
+	 * {@code shellJob} = false
+	 * <p>
+	 * {@code extUnixSupport} = false
+	 * <p>
+	 * {@code logLevel} = 2
+	 * <p>
+	 * {@code logFile} = criu.log
+	 * <p>
+	 * {@code fileLocks} = false
+	 * <p>
+	 * {@code ghostFileLimit} = 1 MB
+	 * <p>
+	 * {@code workDir} = imageDir, the directory where the images are to be created.
+	 */
+	private static final InternalCRIUSupport singletonInternalCRIUSupport = new InternalCRIUSupport();
+
+	// no public construtors
+	private InternalCRIUSupport() {
+		/*[IF JAVA_SPEC_VERSION < 24]*/
+		SecurityManager manager = System.getSecurityManager();
+		if (manager != null) {
+			manager.checkPermission(CRIU_DUMP_PERMISSION);
+		}
+		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+		// use current working directory
+		setImageDir(java.nio.file.FileSystems.getDefault().getPath("").toAbsolutePath());
+	}
+
+	/**
+	 * Returns the singleton InternalCRIUSupport object.
+	 *
+	 * Most methods of class {@code InternalCRIUSupport} are instance methods and
+	 * must be invoked via this object.
+	 *
+	 * @return the singleton {@code InternalCRIUSupport} object
+	 */
+	public static InternalCRIUSupport getInternalCRIUSupport() {
+		return singletonInternalCRIUSupport;
+	}
+
+	/**
 	 * Retrieve the elapsed time between Checkpoint and Restore.
 	 * Only support one Checkpoint.
 	 *
@@ -297,47 +346,6 @@ public final class InternalCRIUSupport {
 			loadNativeLibrary();
 			initComplete = true;
 		}
-	}
-
-	/**
-	 * Constructs a new {@code InternalCRIUSupport}.
-	 *
-	 * The default CRIU dump options are:
-	 * <p>
-	 * {@code imageDir} = imageDir, the directory where the images are to be
-	 * created.
-	 * <p>
-	 * {@code leaveRunning} = false
-	 * <p>
-	 * {@code shellJob} = false
-	 * <p>
-	 * {@code extUnixSupport} = false
-	 * <p>
-	 * {@code logLevel} = 2
-	 * <p>
-	 * {@code logFile} = criu.log
-	 * <p>
-	 * {@code fileLocks} = false
-	 * <p>
-	 * {@code workDir} = imageDir, the directory where the images are to be created.
-	 *
-	 * @param imageDir the directory that will hold the dump files as a
-	 *                 java.nio.file.Path
-	 * @throws NullPointerException     if imageDir is null
-	/*[IF JAVA_SPEC_VERSION < 24]
-	 * @throws SecurityException        if no permission to access imageDir or no
-	 *                                  CRIU_DUMP_PERMISSION
-	/*[ENDIF] JAVA_SPEC_VERSION < 24
-	 * @throws IllegalArgumentException if imageDir is not a valid directory
-	 */
-	public InternalCRIUSupport(Path imageDir) {
-		/*[IF JAVA_SPEC_VERSION < 24]*/
-		SecurityManager manager = System.getSecurityManager();
-		if (manager != null) {
-			manager.checkPermission(CRIU_DUMP_PERMISSION);
-		}
-		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
-		setImageDir(imageDir);
 	}
 
 	/**

--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -54,15 +54,12 @@ public final class CRIUSupport {
 		CONCURRENT_MODE
 	}
 
-	private InternalCRIUSupport internalCRIUSupport;
-
 	/**
-	 * Constructs a new {@code CRIUSupport}.
+	 * A singleton {@code CRIUSupport} instance.
 	 *
 	 * The default CRIU dump options are:
 	 * <p>
-	 * {@code imageDir} = imageDir, the directory where the images are to be
-	 * created.
+	 * {@code imageDir} = CWD, current Java process working directory.
 	 * <p>
 	 * {@code leaveRunning} = false
 	 * <p>
@@ -79,6 +76,30 @@ public final class CRIUSupport {
 	 * {@code ghostFileLimit} = 1 MB
 	 * <p>
 	 * {@code workDir} = imageDir, the directory where the images are to be created.
+	 */
+	private static final CRIUSupport singletonCRIUSupport = new CRIUSupport();
+
+	private static final InternalCRIUSupport singletonInternalCRIUSupport = InternalCRIUSupport
+			.getInternalCRIUSupport();
+
+	// no public construtors
+	private CRIUSupport() {
+	}
+
+	/**
+	 * Returns the singleton CRIUSupport object.
+	 *
+	 * Most methods of class {@code CRIUSupport} are instance methods and must be
+	 * invoked via this object.
+	 *
+	 * @return the singleton {@code CRIUSupport} object
+	 */
+	public static CRIUSupport getCRIUSupport() {
+		return singletonCRIUSupport;
+	}
+
+	/**
+	 * Constructs a new {@code CRIUSupport}.
 	 *
 	 * @param imageDir the directory that will hold the dump files as a
 	 *                 java.nio.file.Path
@@ -89,8 +110,9 @@ public final class CRIUSupport {
 	/*[ENDIF] JAVA_SPEC_VERSION < 24
 	 * @throws IllegalArgumentException if imageDir is not a valid directory
 	 */
+	@Deprecated(forRemoval=true)
 	public CRIUSupport(Path imageDir) {
-		internalCRIUSupport = new InternalCRIUSupport(imageDir);
+		System.err.println("WARNING: CRIUSupport(imageDir) constructor is deprecated, please use CRIUSupport.getCRIUSupport() and setImageDir(imageDir)"); //$NON-NLS-1$
 	}
 
 	/**
@@ -146,7 +168,7 @@ public final class CRIUSupport {
 	 * @throws IllegalArgumentException if imageDir is not a valid directory
 	 */
 	public CRIUSupport setImageDir(Path imageDir) {
-		internalCRIUSupport = internalCRIUSupport.setImageDir(imageDir);
+		singletonInternalCRIUSupport.setImageDir(imageDir);
 		return this;
 	}
 
@@ -159,7 +181,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setLeaveRunning(boolean leaveRunning) {
-		internalCRIUSupport = internalCRIUSupport.setLeaveRunning(leaveRunning);
+		singletonInternalCRIUSupport.setLeaveRunning(leaveRunning);
 		return this;
 	}
 
@@ -172,7 +194,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setShellJob(boolean shellJob) {
-		internalCRIUSupport = internalCRIUSupport.setShellJob(shellJob);
+		singletonInternalCRIUSupport.setShellJob(shellJob);
 		return this;
 	}
 
@@ -185,7 +207,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setExtUnixSupport(boolean extUnixSupport) {
-		internalCRIUSupport = internalCRIUSupport.setExtUnixSupport(extUnixSupport);
+		singletonInternalCRIUSupport.setExtUnixSupport(extUnixSupport);
 		return this;
 	}
 
@@ -205,7 +227,7 @@ public final class CRIUSupport {
 	 * @throws IllegalArgumentException if logLevel is not valid
 	 */
 	public CRIUSupport setLogLevel(int logLevel) {
-		internalCRIUSupport = internalCRIUSupport.setLogLevel(logLevel);
+		singletonInternalCRIUSupport.setLogLevel(logLevel);
 		return this;
 	}
 
@@ -220,7 +242,7 @@ public final class CRIUSupport {
 	 * @throws IllegalArgumentException if logFile is null or a path
 	 */
 	public CRIUSupport setLogFile(String logFile) {
-		internalCRIUSupport = internalCRIUSupport.setLogFile(logFile);
+		singletonInternalCRIUSupport.setLogFile(logFile);
 		return this;
 	}
 
@@ -233,7 +255,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setFileLocks(boolean fileLocks) {
-		internalCRIUSupport = internalCRIUSupport.setFileLocks(fileLocks);
+		singletonInternalCRIUSupport.setFileLocks(fileLocks);
 		return this;
 	}
 
@@ -246,7 +268,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setTCPEstablished(boolean tcpEstablished) {
-		internalCRIUSupport = internalCRIUSupport.setTCPEstablished(tcpEstablished);
+		singletonInternalCRIUSupport.setTCPEstablished(tcpEstablished);
 		return this;
 	}
 
@@ -259,7 +281,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setAutoDedup(boolean autoDedup) {
-		internalCRIUSupport = internalCRIUSupport.setAutoDedup(autoDedup);
+		singletonInternalCRIUSupport.setAutoDedup(autoDedup);
 		return this;
 	}
 
@@ -272,7 +294,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setTrackMemory(boolean trackMemory) {
-		internalCRIUSupport = internalCRIUSupport.setTrackMemory(trackMemory);
+		singletonInternalCRIUSupport.setTrackMemory(trackMemory);
 		return this;
 	}
 
@@ -290,7 +312,7 @@ public final class CRIUSupport {
 	 * @throws IllegalArgumentException if workDir is not a valid directory
 	 */
 	public CRIUSupport setWorkDir(Path workDir) {
-		internalCRIUSupport = internalCRIUSupport.setWorkDir(workDir);
+		singletonInternalCRIUSupport.setWorkDir(workDir);
 		return this;
 	}
 
@@ -303,7 +325,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setUnprivileged(boolean unprivileged) {
-		internalCRIUSupport = internalCRIUSupport.setUnprivileged(unprivileged);
+		singletonInternalCRIUSupport.setUnprivileged(unprivileged);
 		return this;
 	}
 
@@ -318,7 +340,7 @@ public final class CRIUSupport {
 	 * @throws UnsupportedOperationException if file limit is greater than 2^32 - 1 or negative.
 	 */
 	public CRIUSupport setGhostFileLimit(long limit) {
-		internalCRIUSupport = internalCRIUSupport.setGhostFileLimit(limit);
+		singletonInternalCRIUSupport.setGhostFileLimit(limit);
 		return this;
 	}
 
@@ -331,7 +353,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setTCPClose(boolean tcpClose) {
-		internalCRIUSupport = internalCRIUSupport.setTCPClose(tcpClose);
+		singletonInternalCRIUSupport.setTCPClose(tcpClose);
 		return this;
 	}
 
@@ -344,7 +366,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport setTCPSkipInFlight(boolean tcpSkipInFlight) {
-		internalCRIUSupport = internalCRIUSupport.setTCPSkipInFlight(tcpSkipInFlight);
+		singletonInternalCRIUSupport.setTCPSkipInFlight(tcpSkipInFlight);
 		return this;
 	}
 
@@ -365,7 +387,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport registerRestoreEnvFile(Path envFile) {
-		internalCRIUSupport = internalCRIUSupport.registerRestoreEnvFile(envFile);
+		singletonInternalCRIUSupport.registerRestoreEnvFile(envFile);
 		return this;
 	}
 
@@ -381,7 +403,7 @@ public final class CRIUSupport {
 	 * @return this
 	 */
 	public CRIUSupport registerRestoreOptionsFile(Path optionsFile) {
-		internalCRIUSupport = internalCRIUSupport.registerRestoreOptionsFile(optionsFile);
+		singletonInternalCRIUSupport.registerRestoreOptionsFile(optionsFile);
 		return this;
 	}
 
@@ -402,7 +424,7 @@ public final class CRIUSupport {
 	 */
 	public CRIUSupport registerPostRestoreHook(Runnable hook) {
 		try {
-			internalCRIUSupport = internalCRIUSupport.registerPostRestoreHook(hook);
+			singletonInternalCRIUSupport.registerPostRestoreHook(hook);
 		} catch (openj9.internal.criu.JVMCheckpointException jce) {
 			throw new JVMCheckpointException(jce.getMessage(), 0, jce);
 		} catch (openj9.internal.criu.JVMRestoreException jre) {
@@ -455,7 +477,7 @@ public final class CRIUSupport {
 			internalMode = InternalCRIUSupport.HookMode.CONCURRENT_MODE;
 		}
 		try {
-			internalCRIUSupport = internalCRIUSupport.registerPostRestoreHook(hook, internalMode, priority);
+			singletonInternalCRIUSupport.registerPostRestoreHook(hook, internalMode, priority);
 		} catch (openj9.internal.criu.JVMCheckpointException jce) {
 			throw new JVMCheckpointException(jce.getMessage(), 0, jce);
 		} catch (openj9.internal.criu.JVMRestoreException jre) {
@@ -482,7 +504,7 @@ public final class CRIUSupport {
 	 */
 	public CRIUSupport registerPreCheckpointHook(Runnable hook) {
 		try {
-			internalCRIUSupport = internalCRIUSupport.registerPreCheckpointHook(hook);
+			singletonInternalCRIUSupport.registerPreCheckpointHook(hook);
 		} catch (openj9.internal.criu.JVMCheckpointException jce) {
 			throw new JVMCheckpointException(jce.getMessage(), 0, jce);
 		} catch (openj9.internal.criu.JVMRestoreException jre) {
@@ -535,7 +557,7 @@ public final class CRIUSupport {
 			internalMode = InternalCRIUSupport.HookMode.CONCURRENT_MODE;
 		}
 		try {
-			internalCRIUSupport = internalCRIUSupport.registerPreCheckpointHook(hook, internalMode, priority);
+			singletonInternalCRIUSupport.registerPreCheckpointHook(hook, internalMode, priority);
 		} catch (openj9.internal.criu.JVMCheckpointException jce) {
 			throw new JVMCheckpointException(jce.getMessage(), 0, jce);
 		} catch (openj9.internal.criu.JVMRestoreException jre) {
@@ -559,7 +581,7 @@ public final class CRIUSupport {
 	public synchronized void checkpointJVM() {
 		if (isCRIUSupportEnabled()) {
 			try {
-				internalCRIUSupport.checkpointJVM();
+				singletonInternalCRIUSupport.checkpointJVM();
 			} catch (openj9.internal.criu.JVMCheckpointException jce) {
 				throw new JVMCheckpointException(jce.getMessage(), 0, jce);
 			} catch (openj9.internal.criu.JVMRestoreException jre) {

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/CRIUTestUtils.java
@@ -86,7 +86,7 @@ public class CRIUTestUtils {
 			createCheckpointDirectory(path);
 			try {
 				if (criu == null) {
-					criu = new CRIUSupport(path);
+					criu = CRIUSupport.getCRIUSupport().setImageDir(path);
 				}
 				showThreadCurrentTime("Performing CRIUSupport.checkpointJVM()");
 				criu.setLogLevel(4).setLeaveRunning(false).setShellJob(true).setFileLocks(true).checkpointJVM();
@@ -108,7 +108,7 @@ public class CRIUTestUtils {
 		if (CRIUSupport.isCRIUSupportEnabled()) {
 			deleteCheckpointDirectory(path);
 			createCheckpointDirectory(path);
-			return (new CRIUSupport(path)).setLeaveRunning(false).setShellJob(true).setFileLocks(true);
+			return CRIUSupport.getCRIUSupport().setImageDir(path).setLeaveRunning(false).setShellJob(true).setFileLocks(true);
 		} else {
 			throw new RuntimeException("CRIU is not enabled");
 		}

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/DeadlockTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/DeadlockTest.java
@@ -92,8 +92,7 @@ public class DeadlockTest {
 
 		t1.start();
 
-		CRIUSupport criuSupport = new CRIUSupport(path);
-		criuSupport.registerPreCheckpointHook(() -> {
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(path).registerPreCheckpointHook(() -> {
 			synchronized (lock) {
 				CRIUTestUtils.showThreadCurrentTime("Precheckpoint hook inside monitor with testResult.lockStatus = "
 						+ testResult.lockStatus.get());
@@ -178,7 +177,7 @@ public class DeadlockTest {
 
 		t1.start();
 
-		CRIUSupport criuSupport = new CRIUSupport(path);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(path);
 
 		while (testResult.lockStatus.get() == 0) {
 			Thread.yield();
@@ -243,8 +242,7 @@ public class DeadlockTest {
 		byte[] bytes = getClassBytesFromResource(A.class);
 		Class clazz = unsafe.defineClass(A.class.getName(), bytes, 0, bytes.length, loader, null);
 
-		CRIUSupport criuSupport = new CRIUSupport(path);
-		criuSupport.registerPreCheckpointHook(()->{
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(path).registerPreCheckpointHook(() -> {
 			MethodType type = MethodType.methodType(clazz);
 		});
 

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/EnvVarFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/EnvVarFileTest.java
@@ -98,8 +98,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -124,8 +124,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.setProperty("prop1", "val1");
 		System.setProperty("prop2", "val2");
@@ -154,8 +154,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -180,8 +180,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -197,8 +197,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -211,8 +211,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -225,8 +225,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -241,8 +241,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -256,8 +256,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -286,8 +286,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -303,8 +303,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -329,8 +329,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -355,8 +355,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -370,8 +370,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -385,8 +385,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -399,8 +399,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -413,8 +413,8 @@ public class EnvVarFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreEnvFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreEnvFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -86,8 +86,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -112,8 +112,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.setProperty("prop1", "val1");
 		System.setProperty("prop2", "val2");
@@ -142,8 +142,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -168,8 +168,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -189,8 +189,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -211,8 +211,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -231,8 +231,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -246,8 +246,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -262,7 +262,7 @@ public class OptionsFileTest {
 	static void criuDumpOptionsTest() {
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -275,8 +275,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -291,8 +291,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -320,8 +320,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
@@ -341,8 +341,8 @@ public class OptionsFileTest {
 
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/SoftmxTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/SoftmxTest.java
@@ -96,8 +96,8 @@ public class SoftmxTest {
 		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
 		Path imagePath = Paths.get("cpData");
 		CRIUTestUtils.createCheckpointDirectory(imagePath);
-		CRIUSupport criuSupport = new CRIUSupport(imagePath);
-		criuSupport.registerRestoreOptionsFile(optionsFilePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
 
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestCRIUFailurePath.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestCRIUFailurePath.java
@@ -52,7 +52,7 @@ public class TestCRIUFailurePath {
 		Path path = Paths.get("badDir");
 		path.toFile().mkdir();
 		Files.setPosixFilePermissions(path, PosixFilePermissions.fromString("r--r--r--"));
-		CRIUSupport criu = new CRIUSupport(path);
+		CRIUSupport criu = CRIUSupport.getCRIUSupport().setImageDir(path);
 
 		try {
 			CRIUTestUtils.checkPointJVMNoSetup(criu, path, true);

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestDelayedOperations.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/TestDelayedOperations.java
@@ -38,7 +38,7 @@ public class TestDelayedOperations {
 			Path imagePath = Paths.get("cpData");
 			CRIUTestUtils.deleteCheckpointDirectory(imagePath);
 			CRIUTestUtils.createCheckpointDirectory(imagePath);
-			CRIUSupport criu = new CRIUSupport(imagePath);
+			CRIUSupport criu = CRIUSupport.getCRIUSupport().setImageDir(imagePath);
 			final Thread currentThread = Thread.currentThread();
 			CRIUTestUtils.showThreadCurrentTime(
 					"currentThread : " + currentThread + " with name : " + currentThread.getName());


### PR DESCRIPTION
`CRIUSupport` supports only one singleton instance

`InternalCRIUSupport` has only one singleton instance as well;
Updated test usages.

Related to
* https://github.com/eclipse-openj9/openj9/issues/21161

Signed-off-by: Jason Feng <fengj@ca.ibm.com>