### PR TITLE
Fix a memory leak in a corner case j9sysinfo_get_env("PATH") failed

### DIFF
--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -863,6 +863,8 @@ addJavaLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 		substringLength += strlen(pathBuffer);
 		substringIndex;
 		substringIndex += 1;
+	} else {
+		j9mem_free_memory(pathBuffer);
 	}
 
 #else /* defined(J9UNIX) || defined(J9ZOS390) */


### PR DESCRIPTION
Fix a memory leak in a corner case `j9sysinfo_get_env("PATH")` failed

Passed [a personal build openjdk24_j9_sanity.functional_x86-64_windows](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdk24_j9_sanity.functional_x86-64_windows_Personal_testList_1/10/consoleFull)

closes https://github.com/eclipse-openj9/openj9/issues/21181

Signed-off-by: Jason Feng <fengj@ca.ibm.com>