### PR TITLE
Remove JvmtiMountTransition annotation from Continuation.enter()

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/vm/Continuation.java
@@ -192,7 +192,6 @@ public class Continuation {
 	}
 
 	@Hidden
-	@JvmtiMountTransition
 	private static void enter(Continuation cont) {
 		try {
 			cont.runnable.run();


### PR DESCRIPTION
JvmtiMountTransition was added by mistake in
https://github.com/eclipse-openj9/openj9/pull/21084

Fixes: https://github.com/eclipse-openj9/openj9/issues/21186 https://github.com/eclipse-openj9/openj9/issues/21185