### PR TITLE
(0.51) Fix a memory leak in a corner case j9sysinfo_get_env("PATH") failed

### DIFF
--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -863,6 +863,8 @@ addJavaLibraryPath(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList
 		substringLength += strlen(pathBuffer);
 		substringIndex;
 		substringIndex += 1;
+	} else {
+		j9mem_free_memory(pathBuffer);
 	}
 
 #else /* defined(J9UNIX) || defined(J9ZOS390) */


### PR DESCRIPTION
Fix a memory leak in a corner case `j9sysinfo_get_env("PATH")` failed

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/21231

Signed-off-by: Jason Feng <fengj@ca.ibm.com>