### PR TITLE
Exclude jfr event tests on JDK11

### DIFF
--- a/test/functional/cmdLineTests/jfr/playlist.xml
+++ b/test/functional/cmdLineTests/jfr/playlist.xml
@@ -79,9 +79,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- For the time being, JFR tests are only limited to JDK11+. -->
+		<!-- For the time being, these tests are limited to JDK17+. -->
 		<versions>
-			<version>11+</version>
+			<version>17+</version>
 		</versions>
 		<features>
 			<feature>JFR:required</feature>


### PR DESCRIPTION
Related to: https://github.com/eclipse-openj9/openj9/issues/21242