### PR TITLE
Remove obsolete code from getPlatformFileEncoding

### DIFF
--- a/runtime/jcl/unix/syshelp.c
+++ b/runtime/jcl/unix/syshelp.c
@@ -252,11 +252,6 @@ char *getPlatformFileEncoding(JNIEnv * env, char *codepageProp, int propSize, in
 	PORT_ACCESS_FROM_ENV(env);
 #endif /* defined(LINUX) || defined(OSX) */
 
-	/* Called with codepageProp == NULL to initialize the locale */
-	if (NULL == codepageProp) {
-		return NULL;
-	}
-
 #if defined(LINUX)
 	/*[PR 104520] Return EUC_JP when LC_CTYPE is not set, and the LANG environment variable is "ja" */
 	ctype = setlocale(LC_CTYPE, NULL);

--- a/runtime/jcl/win32/syshelp.c
+++ b/runtime/jcl/win32/syshelp.c
@@ -186,9 +186,6 @@ char* getPlatformFileEncoding(JNIEnv *env, char *codepage, int size, int encodin
 #endif
 	int length;
 
-	/* Called with codepage == NULL to initialize the locale */
-	if (!codepage) return NULL;
-
     if (encodingType == 2) {
     	/* file.encoding */
     	threadLocale = GetUserDefaultLCID();


### PR DESCRIPTION
There are no callers with codepageProp NULL, and making this call wouldn't do anything anyway.