### PR TITLE
(0.51)Fix assertion in WriteOnceCompactor stackslot process

### DIFF
--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1216,7 +1216,7 @@ void
 MM_WriteOnceCompactor::doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slot)
 {
 	J9Object *pointer = *slot;
-	if (NULL != pointer) {
+	if (isHeapObject(pointer)) {
 		J9Object *forwardedPtr = getForwardingPtr(pointer);
 		if (pointer != forwardedPtr) {
 			*slot = forwardedPtr;

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -547,6 +547,14 @@ private:
 	void clearClassLoaderRememberedSetsForCompactSet(MM_EnvironmentVLHGC *env);
 	
 	/**
+	 * Determine whether the object pointer is found within the heap proper.
+	 * @return Boolean indicating if the object pointer is within the heap boundaries.
+	 */
+	MMINLINE bool isHeapObject(J9Object *objectPtr)
+	{
+		return (_heapBase <= (uint8_t *)objectPtr) && (_heapTop > (uint8_t *)objectPtr);
+	}
+	/**
 	 * Create a WriteOnceCompactor object.
 	 */
 	MM_WriteOnceCompactor(MM_EnvironmentVLHGC *env);


### PR DESCRIPTION
java stack slots in continuation structure can be
stack allocated reference (non heap reference), fixup non heap reference slot cpuld cause the assertion, so WriteOnceCompactor fixup java stack slots need to
check if the slot is heap reference.