### PR TITLE
Fix bug in TR_IPBCDataFourBytes::getSumBranchCount

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -2683,11 +2683,11 @@ TR_IPBCDataFourBytes::copyFromEntry(TR_IPBytecodeHashTableEntry* originalEntry, 
    data = entry->data;
    }
 
-int16_t
+int32_t
 TR_IPBCDataFourBytes::getSumBranchCount()
    {
-   uint16_t fallThroughCount = (uint16_t)(data & 0x0000FFFF) | 0x1;
-   uint16_t branchToCount = (uint16_t)((data & 0xFFFF0000)>>16) | 0x1;
+   int32_t fallThroughCount = (int32_t)(data & 0x0000FFFF) | 0x1;
+   int32_t branchToCount = (int32_t)((data & 0xFFFF0000)>>16) | 0x1;
    return (fallThroughCount + branchToCount);
    }
 

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -322,7 +322,7 @@ public:
 #endif
    virtual void createPersistentCopy(TR_J9SharedCache *sharedCache, TR_IPBCDataStorageHeader *storage, TR::PersistentInfo *info);
    virtual void loadFromPersistentCopy(TR_IPBCDataStorageHeader *storage, TR::Compilation *comp);
-   int16_t getSumBranchCount();
+   int32_t getSumBranchCount();
    virtual void copyFromEntry(TR_IPBytecodeHashTableEntry * originalEntry, TR::Compilation *comp);
 private:
    uint32_t data;


### PR DESCRIPTION
TR_IPBCDataFourBytes::getSumBranchCount returns the sum of the two branch counters. Internally these are stored as two 16 bit integers. getSumBranchCount is called only by TR_IProfiler::getSamplingCount which returns a int32_t. However, TR_IPBCDataFourBytes::getSumBranchCount sums up the two 16 bit integers as uint16_ts and returns a int16_t. This has the consequence of sometimes returning a negative number because of overflow.

This PR fixes this by consistently using int32_t.