### PR TITLE
Relax SoftMx test passing criteria

### DIFF
--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/SoftmxAdvanceTest.java
@@ -134,7 +134,7 @@ public class SoftmxAdvanceTest {
 
 		//waiting for maximum 5 min (300000ms)
 		while ((System.currentTimeMillis() - startTime) < 300000) {
-			if (ibmMemoryMBean.getHeapMemoryUsage().getCommitted() < new_softmx_value) {
+			if (ibmMemoryMBean.getHeapMemoryUsage().getCommitted() <= new_softmx_value) {
 				if (enableDisclaimMemory) {
 					if (ibmOSMBean.getFreePhysicalMemorySize() > preMemSize) {
 						isShrink = true;


### PR DESCRIPTION
Allow that test passes if heap contracts to exact SoftMx value (previously, required to be `less then`, what was unnecessarily strict)