### PR TITLE
Optimize handling enableVirtualLargeObjectHeap cmdline option

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -201,6 +201,8 @@ public:
 
 	bool tlhMaximumSizeSpecified; /**< true, if tlhMaximumSize specified by a command line option */
 
+	MM_UserSpecifiedParameterBool virtualLargeObjectHeap; /**< off heap option */
+
 	bool dynamicHeapAdjustmentForRestore; /**< If set to true, the default heuristic-calculated softmx is prioritized over the user-specified values. */
 	/**
 	 * Values for com.ibm.oti.vm.VM.J9_JIT_STRING_DEDUP_POLICY
@@ -427,6 +429,7 @@ public:
 		, numaCommonThreadClassNamePatterns(NULL)
 		, userSpecifiedParameters()
 		, tlhMaximumSizeSpecified(false)
+		, virtualLargeObjectHeap()
 		, dynamicHeapAdjustmentForRestore(false)
 		, stringDedupPolicy(J9_JIT_STRING_DEDUP_POLICY_UNDEFINED)
 		, _asyncCallbackKey(-1)

--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1072,12 +1072,14 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 		if (try_scan(&scan_start, "enableVirtualLargeObjectHeap")) {
-			extensions->isVirtualLargeObjectHeapRequested = true;
+			extensions->virtualLargeObjectHeap._wasSpecified = true;
+			extensions->virtualLargeObjectHeap._valueSpecified = true;
 			continue;
 		}
 
 		if (try_scan(&scan_start, "disableVirtualLargeObjectHeap")) {
-			extensions->isVirtualLargeObjectHeapRequested = false;
+			extensions->virtualLargeObjectHeap._wasSpecified = true;
+			extensions->virtualLargeObjectHeap._valueSpecified = false;
 			continue;
 		}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */

--- a/runtime/gc_realtime/ConfigurationRealtime.cpp
+++ b/runtime/gc_realtime/ConfigurationRealtime.cpp
@@ -32,8 +32,8 @@
 #include "ConfigurationRealtime.hpp"
 
 #include "EnvironmentRealtime.hpp"
+#include "GCExtensions.hpp"
 #include "GlobalAllocationManagerRealtime.hpp"
-#include "GCExtensionsBase.hpp"
 #include "HeapVirtualMemory.hpp"
 #include "HeapRegionDescriptorRealtime.hpp"
 #include "HeapRegionManagerTarok.hpp"
@@ -107,7 +107,7 @@ MM_ConfigurationRealtime::tearDown(MM_EnvironmentBase* env)
 MM_Heap *
 MM_ConfigurationRealtime::createHeapWithManager(MM_EnvironmentBase *env, uintptr_t heapBytesRequested, MM_HeapRegionManager *regionManager)
 {
-	MM_GCExtensionsBase *extensions = env->getExtensions();
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
 #if defined(J9VM_ENV_DATA64)
 	J9JavaVM *vm = (J9JavaVM *)extensions->getOmrVM()->_language_vm;
 	/* Let VM know that Metronome GC has discontiguous indexable object (arraylet layout) */
@@ -116,7 +116,7 @@ MM_ConfigurationRealtime::createHeapWithManager(MM_EnvironmentBase *env, uintptr
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 
-	if (extensions->isVirtualLargeObjectHeapRequested) {
+	if (extensions->virtualLargeObjectHeap._wasSpecified && extensions->virtualLargeObjectHeap._valueSpecified) {
 		j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_GC_OPTIONS_VIRTUAL_LARGE_OBJECT_HEAP_NOT_SUPPORTED_WARN, "metronome");
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -98,6 +98,9 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 	if (NULL == heap) {
 		return NULL;
 	}
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	/* set off-heap disabled as default for balanced GC */
+	extensions->isVirtualLargeObjectHeapEnabled = false;
 
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	/* Enable double mapping if glibc version 2.27 or newer is found. For double map to
@@ -113,7 +116,7 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 	 * also need to check if region size is a bigger or equal to multiple of page size.
 	 *
 	 */
-	if (!extensions->isVirtualLargeObjectHeapRequested && extensions->isArrayletDoubleMapRequested && extensions->isArrayletDoubleMapAvailable) {
+	if (!extensions->isVirtualLargeObjectHeapEnabled && extensions->isArrayletDoubleMapRequested && extensions->isArrayletDoubleMapAvailable) {
 		uintptr_t pagesize = heap->getPageSize();
 		if (!extensions->memoryManager->isLargePage(env, pagesize) || (pagesize <= extensions->getOmrVM()->_arrayletLeafSize)) {
 			extensions->indexableObjectModel.setEnableDoubleMapping(true);
@@ -164,13 +167,12 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 	 */
 	vm->indexableObjectLayout = J9IndexableObjectLayout_DataAddr_Arraylet;
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-	if (extensions->isVirtualLargeObjectHeapRequested) {
+	if (extensions->isVirtualLargeObjectHeapEnabled) {
 		/* Create off-heap */
 		MM_SparseVirtualMemory *largeObjectVirtualMemory = MM_SparseVirtualMemory::newInstance(env, OMRMEM_CATEGORY_MM_RUNTIME_HEAP, heap);
 		if (NULL != largeObjectVirtualMemory) {
 			extensions->largeObjectVirtualMemory = largeObjectVirtualMemory;
 			extensions->indexableObjectModel.setEnableVirtualLargeObjectHeap(true);
-			extensions->isVirtualLargeObjectHeapEnabled = true;
 			/* Overriding the original assumption that Balanced has arraylets. */
 			vm->indexableObjectLayout = J9IndexableObjectLayout_DataAddr_NoArraylet;
 			/* reset vm->unsafeIndexableHeaderSize for off-heap case */


### PR DESCRIPTION

1, isVirtualLargeObjectHeapEnabled = false on all gcpolicies.
2, if user specify -XXgc:enableVirtualLargeObjectHeap on
Balanced GC, off heap can be enabled.
3, -XXgc:disableVirtualLargeObjectHeap/
enableVirtualLargeObjectHeap would be ignored on the rest of gcpolicies.
4, if user specify -XXgc:enableVirtualLargeObjectHeap on
gcpolicy:metronome, JVM would output warning message.

Signed-off-by: lhu <linhu@ca.ibm.com>

