### PR TITLE
replace os specific labels for mac aarch,x64 with sw.tool.xcode.15_2

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -398,13 +398,9 @@ x86-64_mac:
     8: '--with-toolchain-type=clang'
   openjdk_reference_repo: '/Users/jenkins/openjdk_cache'
   node_labels:
-    build: 'ci.role.build && hw.arch.x86 && sw.os.mac.10_15'
+    build: 'ci.role.build && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2'
   build_env:
     vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
-  extra_test_labels:
-    23: '!sw.os.mac.10_15'
-    24: '!sw.os.mac.10_15'
-    next: '!sw.os.mac.10_15'
   fail_pattern: 'IOException caught during compilation: Resource deadlock avoided'
 #========================================#
 # Mac Aarch64
@@ -424,7 +420,7 @@ aarch64_mac:
     all: '--with-noncompressedrefs'
   openjdk_reference_repo: '/Users/jenkins/openjdk_cache'
   node_labels:
-    build: 'ci.role.build && hw.arch.aarch64 && sw.os.mac'
+    build: 'ci.role.build && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2'
   fail_pattern: 'IOException caught during compilation: Resource deadlock avoided'
 #========================================#
 # Linux PPCLE 64bits /w OpenJDK JSR292


### PR DESCRIPTION
Related changes to build base on XCode level rather os specified version. related: runtimes/infrastructure#8105. Also unnecessary additionalTestLables related to mac_10_11 removes as those nodes are not exists anymore and the fact that test framework set labels in logic. e.g here

Sigend-off-by: mahdi@ibm.com