### PR TITLE
Remove J9JavaVM from takeVirtualThreadListToUnblock's parameter list

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -735,7 +735,7 @@ JVM_TakeVirtualThreadListToUnblock(JNIEnv *env, jclass ignored)
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
 
-	return vm->internalVMFunctions->takeVirtualThreadListToUnblock(currentThread, vm);
+	return vm->internalVMFunctions->takeVirtualThreadListToUnblock(currentThread);
 }
 #endif /* JAVA_SPEC_VERSION >= 24 */
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5345,7 +5345,7 @@ typedef struct J9InternalVMFunctions {
 #endif /* defined(J9VM_OPT_SNAPSHOTS) */
 #if JAVA_SPEC_VERSION >= 24
 	struct J9ObjectMonitor * (*monitorTablePeek)(struct J9JavaVM *vm, j9object_t object);
-	jobject (*takeVirtualThreadListToUnblock)(struct J9VMThread *currentThread, struct J9JavaVM *vm);
+	jobject (*takeVirtualThreadListToUnblock)(struct J9VMThread *currentThread);
 #endif /* JAVA_SPEC_VERSION >= 24 */
 } J9InternalVMFunctions;
 

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4718,12 +4718,11 @@ preparePinnedVirtualThreadForUnmount(J9VMThread *currentThread, j9object_t syncO
  * JVM_TakeVirtualThreadListToUnblock (see javanextvmi.cpp).
  *
  * @param currentThread the current thread
- * @param vm pointer to J9JavaVM
  *
  * @return a list of virtual threads to be unblocked
  */
 jobject
-takeVirtualThreadListToUnblock(J9VMThread *currentThread, J9JavaVM *vm);
+takeVirtualThreadListToUnblock(J9VMThread *currentThread);
 #endif /* JAVA_SPEC_VERSION >= 24 */
 /* ---------------- hookableAsync.c ---------------- */
 

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -852,10 +852,11 @@ done:
 }
 
 jobject
-takeVirtualThreadListToUnblock(J9VMThread *currentThread, J9JavaVM *vm)
+takeVirtualThreadListToUnblock(J9VMThread *currentThread)
 {
 	j9object_t unblockedList = NULL;
 	jobject result = NULL;
+	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
 
 	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)


### PR DESCRIPTION
J9JavaVM is now retrieved from currentThread, simplifying the code.