### PR TITLE
SoftMx test, touch memory

### DIFF
--- a/test/functional/JLM_Tests/src/j9vm/test/softmx/MemoryExhauster.java
+++ b/test/functional/JLM_Tests/src/j9vm/test/softmx/MemoryExhauster.java
@@ -61,7 +61,14 @@ public class MemoryExhauster {
 		try {
 			while ( ibmMemoryMBean.getHeapMemoryUsage().getCommitted() < ((long) ( original_softmx_value * percentage ))){
 				try {
-					myObjects[i] = new byte[OBJECT_SIZE];
+					byte myObject[] = new byte[OBJECT_SIZE];
+
+					myObjects[i] = myObject;
+
+					for (int j = 0; j < OBJECT_SIZE; j += 4 * 1024) {
+						myObject[j] = (byte)(i + 1);
+					}
+
 					i++;
 				} catch (OutOfMemoryError e){
 					// at this point we stop


### PR DESCRIPTION
When allocating large arrays we now touch memory. This should help with more precise/deterministic calculation of OS physical free memory.

This is particularly important for Balanced Offheap, which has lazy commit of newly allocated Offheap arrays.