### PR TITLE
Fix hang on vthread unmount when -XX:+YieldPinnedVirtualThreads is enabled

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -303,8 +303,11 @@ typedef void(*j9_tls_finalizer_t)(void *);
  * The full mapping is under jvmtiInternals.h <JVMTI_VTHREAD_STATE_*>.
  */
 #define JAVA_LANG_VIRTUALTHREAD_BLOCKING 12
+#define JAVA_LANG_VIRTUALTHREAD_BLOCKED  13
 #define JAVA_LANG_VIRTUALTHREAD_WAITING  15
+#define JAVA_LANG_VIRTUALTHREAD_WAIT     16
 #define JAVA_LANG_VIRTUALTHREAD_TIMED_WAITING 17
+#define JAVA_LANG_VIRTUALTHREAD_TIMED_WAIT 18
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
 typedef enum {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -303,7 +303,7 @@ typedef void(*j9_tls_finalizer_t)(void *);
  * The full mapping is under jvmtiInternals.h <JVMTI_VTHREAD_STATE_*>.
  */
 #define JAVA_LANG_VIRTUALTHREAD_BLOCKING 12
-#define JAVA_LANG_VIRTUALTHREAD_WAITING  13
+#define JAVA_LANG_VIRTUALTHREAD_WAITING  15
 #define JAVA_LANG_VIRTUALTHREAD_TIMED_WAITING 17
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
@@ -5311,6 +5311,8 @@ typedef struct J9InternalVMFunctions {
 	UDATA (*walkAllStackFrames)(struct J9VMThread *currentThread, J9StackWalkState *walkState);
 	BOOLEAN (*acquireVThreadInspector)(struct J9VMThread *currentThread, jobject thread, BOOLEAN spin);
 	void (*releaseVThreadInspector)(struct J9VMThread *currentThread, jobject thread);
+	void (*enterVThreadTransitionCritical)(struct J9VMThread *currentThread, jobject thread);
+	void (*exitVThreadTransitionCritical)(struct J9VMThread *currentThread, jobject thread);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	UDATA (*checkArgsConsumed)(struct J9JavaVM * vm, struct J9PortLibrary* portLibrary, struct J9VMInitArgs* j9vm_args);
 #if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4688,6 +4688,24 @@ acquireVThreadInspector(J9VMThread *currentThread, jobject thread, BOOLEAN spin)
  */
 void
 releaseVThreadInspector(J9VMThread *currentThread, jobject thread);
+
+/**
+ * @brief Enter VirtualThread's critical section for transitions.
+ *
+ * @param currentThread the current thread
+ * @param thread target VirtualThread that is transitioning
+ */
+void
+enterVThreadTransitionCritical(J9VMThread *currentThread, jobject thread);
+
+/**
+ * @brief Exit VirtualThread's critical section for transitions.
+ *
+ * @param currentThread the current thread
+ * @param thread target VirtualThread that is transitioning
+ */
+void
+exitVThreadTransitionCritical(J9VMThread *currentThread, jobject thread);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
 #if JAVA_SPEC_VERSION >= 24

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4714,9 +4714,10 @@ exitVThreadTransitionCritical(J9VMThread *currentThread, jobject thread);
  *
  * @param currentThread the current thread
  * @param continuationObject the Continuation object
+ * @param isObjectWait if the call is from Object.wait()
  */
 void
-preparePinnedVirtualThreadForMount(J9VMThread *currentThread, j9object_t continuationObject);
+preparePinnedVirtualThreadForMount(J9VMThread *currentThread, j9object_t continuationObject, BOOLEAN isObjectWait);
 
 /**
  * @brief Inflate all monitors and prepare the VirtualThread to yield.

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -268,6 +268,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<!-- Field references for Synchronize Virtual Threads without Pinning (JEP491). -->
 	<fieldref class="java/lang/VirtualThread" name="blockPermit" signature="Z" versions="24-"/>
 	<fieldref class="java/lang/VirtualThread" name="next" signature="Ljava/lang/VirtualThread;" versions="24-"/>
+	<fieldref class="java/lang/VirtualThread" name="notified" signature="Z" versions="24-"/>
 	<fieldref class="java/lang/VirtualThread" name="onWaitingList" signature="Z" versions="24-"/>
 
 	<fieldref class="java/lang/Throwable" name="cause" signature="Ljava/lang/Throwable;"/>

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1525,7 +1525,6 @@ obj:
 
 		/* Store the current Continuation state and swap to the carrier thread stack. */
 		yieldContinuation(_currentThread, FALSE, returnState);
-
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 		restoreInternalNativeStackFrame(REGISTER_ARGS);
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5770,7 +5770,14 @@ ffi_OOM:
 
 		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
-
+#if JAVA_SPEC_VERSION >= 24
+		if (J9_ARE_ANY_BITS_SET(_vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)
+		&& (_currentThread->ownedMonitorCount > 0)
+		&& !isFinished
+		) {
+			preparePinnedVirtualThreadForUnmount(_currentThread, NULL, false);
+		}
+#endif /* JAVA_SPEC_VERSION >= 24 */
 		/* Store the current Continuation state and swap to the carrier thread stack. */
 		yieldContinuation(_currentThread, isFinished, J9VM_CONTINUATION_RETURN_FROM_YIELD);
 

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -459,6 +459,8 @@ J9InternalVMFunctions J9InternalFunctions = {
 	walkAllStackFrames,
 	acquireVThreadInspector,
 	releaseVThreadInspector,
+	enterVThreadTransitionCritical,
+	exitVThreadTransitionCritical,
 #endif /* JAVA_SPEC_VERSION >= 19 */
 	checkArgsConsumed,
 #if defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17)

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -181,6 +181,7 @@ restart:
 			if ((0 == monitor->pinCount)
 #if JAVA_SPEC_VERSION >= 24
 			&& (0 == objectMonitor->virtualThreadWaitCount)
+			&& (NULL == objectMonitor->waitingContinuations)
 #endif /* JAVA_SPEC_VERSION >= 24 */
 			) {
 				if (deflate) {


### PR DESCRIPTION
- Enter/exit critical transition when preparing for unmount/re-mount pinned vthread.
- Fix Object.wait/notify logic.
- Allow pinned vthread to yield in normal path.

#20709 passed with this change using `-Xint -XX:+YieldPinnedVirtualThreads`