### PR TITLE
Enable off-heap as default on Balanced GC

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -99,10 +99,10 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 		return NULL;
 	}
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-#if defined(J9HAMMER) || defined(PPC64) || defined(AARCH64)
-	/* Set off-heap enabled as default for balanced GC */
+#if !defined(J9ZTPF)
+	/* set off-heap enabled as default for balanced GC */
 	extensions->isVirtualLargeObjectHeapEnabled = true;
- #endif /* defined(J9HAMMER) || defined(PPC64) || defined(AARCH64) */
+#endif /* !defined(J9ZTPF) */
 
 	if (extensions->virtualLargeObjectHeap._wasSpecified) {
 		extensions->isVirtualLargeObjectHeapEnabled = extensions->virtualLargeObjectHeap._valueSpecified;


### PR DESCRIPTION
Enable off-heap as default on Balanced GC except zTPF platform.

1, global flag isVirtualLargeObjectHeapEnabled = true on Balanced GC by default.
2, there is no virtual memory support in ZTPF S390 64bit platform, keep off-heap off on this platform as default.

Signed-off-by: lhu linhu@ca.ibm.com