### PR TITLE
Use 32bit compare for array size in inline array allocation sequence

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -7479,7 +7479,8 @@ static void handleOffHeapDataForArrays(
 
       TR::Register *discontiguousDataAddrOffsetReg = srm->findOrCreateScratchRegister();
       generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, discontiguousDataAddrOffsetReg, discontiguousDataAddrOffsetReg, cg);
-      generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 1, cg);
+      // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of of sizeReg.
+      generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, 1, cg);
       generateRegImmInstruction(TR::InstOpCode::ADCRegImm4(), node, discontiguousDataAddrOffsetReg, 0, cg);
 
       dataAddrMR = generateX86MemoryReference(targetReg, discontiguousDataAddrOffsetReg, 3, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
@@ -7490,7 +7491,8 @@ static void handleOffHeapDataForArrays(
       // Clear out tempReg if dealing with 0 length array
       zeroReg = srm->findOrCreateScratchRegister();
       generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, zeroReg, zeroReg, cg);
-      generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 0, cg);
+      // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of of sizeReg.
+      generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
       generateRegRegInstruction(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
       srm->reclaimScratchRegister(zeroReg);
 
@@ -7534,7 +7536,8 @@ static void handleOffHeapDataForArrays(
          // Clear out tempReg if dealing with 0 length array
          zeroReg = srm->findOrCreateScratchRegister();
          generateRegRegInstruction(TR::InstOpCode::XORRegReg(), node, zeroReg, zeroReg, cg);
-         generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg, 0, cg);
+         // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of of sizeReg.
+         generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
          generateRegRegInstruction(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
          srm->reclaimScratchRegister(zeroReg);
          }

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -11045,7 +11045,10 @@ J9::Z::TreeEvaluator::VMnewEvaluator(TR::Node * node, TR::CodeGenerator * cg)
 
                TR::Register *offsetReg = cg->allocateRegister();
                iCursor = generateRRInstruction(cg, TR::InstOpCode::getXORRegOpCode(), node, offsetReg, offsetReg, iCursor);
-               iCursor = generateRILInstruction(cg, TR::InstOpCode::getCmpImmOpCode(), node, enumReg, 0, iCursor);
+               /* Use 32 bit compare because the upper half can either be NULL/garbage/J9class pointer
+                * and array size should always be in 32-63 bits of enumReg.
+                */
+               iCursor = generateRIInstruction(cg, TR::InstOpCode::CHI, node, enumReg, 0, iCursor);
 
                // Load address of first array element
                iCursor = generateRXInstruction(cg,


### PR DESCRIPTION
We need to use 32 bit compare because the top half of the size reg can contain
class pointer. On z, Class pointer is written to top half by IIHF in
genInitObjectHeader. I have updated the compare instruction on x as well to
avoid future issues related to garbage in top half of the size register.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>