### PR TITLE
Displacement API for offheap using region flags

### DIFF
--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -570,29 +570,6 @@ public:
 	virtual void doObjectInVirtualLargeObjectHeap(J9Object *objectPtr, bool *sparseHeapAllocation);
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	
-#if defined(J9VM_ENV_DATA64)
-	/**
-	 * Check if data is adjacent to array header, based on dataAddr value.
-	 * This is used during stack slots scanning, when object can move.
-	 * It is called after the object movement (stack slot has been fixed,
-	 * although copying operation may not be necessarily completed yet).
-	 * Specific RootScanner that can move objects will use either src or dst to perform adjacency check,
-	 * whichever is safe. Scanners that not move objects should not be calling it, otherwise will assert.
-	 * Should really be called only for Offheap and only for contiguous arrays (non-zero sized objects),
-	 * although that is not asserted.
-	 *
-	 * @param src array address before movement
-	 * @param dst array address after movement
-	 *
-	 * @return true if data is next to the header, and false if its in Offheap
-	 */
-
-	virtual bool isDataAdjacentToHeader(J9IndexableObject *src, J9IndexableObject *dst) {
-		Assert_MM_unreachable();
-		return true;
-	}
-#endif /* defined(J9VM_ENV_DATA64) */
-
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	/**
 	 * Frees double mapped region associated to objectPtr (arraylet spine) if objectPtr

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -355,8 +355,14 @@ j9gc_objaccess_staticStoreU64Split(J9VMThread *vmThread, J9Class *clazz, U_64 *d
 IDATA
 j9gc_objaccess_indexableDataDisplacement(J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst)
 {
-	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(walkState->walkThread)->accessBarrier;
-	return barrier->indexableDataDisplacement(walkState, src, dst);
+	IDATA displacement = 0;
+
+	if (src != dst) {
+		MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(walkState->walkThread)->accessBarrier;
+		displacement = barrier->indexableDataDisplacement(walkState, src, dst);
+	}
+
+	return displacement;
 }
 
 /* TODO: After all array accesses in the VM have been made arraylet safe, 

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -3875,13 +3875,6 @@ private:
 	}
 #endif /* J9VM_GC_FINALIZATION */
 
-#if defined(J9VM_ENV_DATA64)
-	virtual bool isDataAdjacentToHeader(J9IndexableObject *src, J9IndexableObject *dst) {
-		/* Checking against src object since dst is not guarantied to be completely copied (by a racing thread that won f/w operaton). */
-		return _extensions->indexableObjectModel.isDataAdjacentToHeader(src);
-	}
-#endif /* defined(J9VM_ENV_DATA64) */
-
 public:
 	MM_CopyForwardSchemeRootScanner(MM_EnvironmentVLHGC *env, MM_CopyForwardScheme *copyForwardScheme) :
 		MM_RootScanner(env),

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1715,13 +1715,6 @@ public:
 	}
 #endif /* J9VM_GC_FINALIZATION */
 
-#if defined(J9VM_ENV_DATA64)
-	virtual bool isDataAdjacentToHeader(J9IndexableObject *src, J9IndexableObject *dst) {
-		/* Checking against dst object since src object may be overwritten. */
-		return _extensions->indexableObjectModel.isDataAdjacentToHeader(dst);
-	}
-#endif /* defined(J9VM_ENV_DATA64) */
-
 };
 
 void


### PR DESCRIPTION
Improve API for displacement calculation of stack referenced arrays for offheap to rely on region flags to determine the type of the movement (evacuate vs sliding). Previously the movement type was determined by RootScanner. But unlike standard platform threads, Virtual Threads (Continuations) are not roots and their stack walker does not instantiate RootScanner.

Relying on region flags (of source object) works for both types of threads.