### PR TITLE
Guard ArrayStoreCHK early subtree eval tree shape

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -7228,10 +7228,14 @@ J9::Z::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node * node, TR::CodeGenerator 
       */
       if (firstChild->getFirstChild()->isDataAddrPointer())
          dstArrayNode = firstChild->getFirstChild()->getFirstChild();
-      else
+      else if (firstChild->getFirstChild()->getOpCodeValue() == TR::aladd && firstChild->getFirstChild()->getFirstChild()->isDataAddrPointer())
          {
          dstArrayNode = firstChild->getFirstChild()->getFirstChild()->getFirstChild();
          offsetNode = firstChild->getFirstChild()->getSecondChild();
+         }
+      else
+         {
+         TR_ASSERT_FATAL(false, "Unexpected array access tree shape for OffHeap in ArrayStoreCHKEvaluator");
          }
 
       cg->evaluate(dstArrayNode);


### PR DESCRIPTION
Following https://github.com/eclipse-openj9/openj9/pull/21195#discussion_r1986140734, this PR includes better checks for tree shapes for ArrayStoreCHK evaluation with OffHeap.

It also adds an assert for unexpected shapes this ensures if tree shapes change in the future (eg enabling commoning) this can be updated (revert the `deferDestinationEvaluation` code).

Testing...