### PR TITLE
No need to check file.encoding.pkg during boot since it's not used

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1043,7 +1043,6 @@ public static String getProperty(String prop, String defaultValue) {
 
 	if (!propertiesInitialized
 			&& !prop.equals("com.ibm.IgnoreMalformedInput") //$NON-NLS-1$
-			&& !prop.equals("file.encoding.pkg") //$NON-NLS-1$
 			&& !prop.equals("sun.nio.cs.map") //$NON-NLS-1$
 	) {
 		/*[IF JAVA_SPEC_VERSION >= 17]*/


### PR DESCRIPTION
Related to https://github.com/eclipse-openj9/openj9/pull/21172