### PR TITLE
Kill MM_SparseVirtualMemory at shutdown

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -404,6 +404,13 @@ MM_ConfigurationIncrementalGenerational::tearDown(MM_EnvironmentBase *env)
 	}
 #endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
 
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+	if (NULL != extensions->largeObjectVirtualMemory) {
+		extensions->largeObjectVirtualMemory->kill(env);
+		extensions->largeObjectVirtualMemory = NULL;
+	}
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+
 	MM_Configuration::tearDown(env);
 
 	// cleanup after extensions->heapRegionManager


### PR DESCRIPTION
Class MM_SparseVirtualMemory shouldbe killed at shutdown