### PR TITLE
(0.51) Fix JFR ThreadPark support

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -430,7 +430,6 @@ typedef struct J9JFRMonitorWaited {
 
 typedef struct J9JFRThreadParked {
 	J9JFR_EVENT_WITH_STACKTRACE_FIELDS
-	I_64 time;
 	I_64 duration;
 	struct J9VMThread *thread;
 	struct J9Class *parkedClass;

--- a/runtime/vm/JFRChunkWriter.hpp
+++ b/runtime/vm/JFRChunkWriter.hpp
@@ -632,7 +632,7 @@ done:
 	writeThreadParkEvent(void *anElement, void *userData)
 	{
 		ThreadParkEntry *entry = (ThreadParkEntry *)anElement;
-		VM_BufferWriter *_bufferWriter = (VM_BufferWriter *) userData;
+		VM_BufferWriter *_bufferWriter = (VM_BufferWriter *)userData;
 
 		/* reserve size field */
 		U_8 *dataStart = reserveEventSize(_bufferWriter);
@@ -658,10 +658,10 @@ done:
 		_bufferWriter->writeLEB128(entry->parkedClass);
 
 		/* timeout value which is always in millis */
-		_bufferWriter->writeLEB128(entry->timeOut/1000000);
+		_bufferWriter->writeLEB128(entry->timeOut / 1000000);
 
 		/* until value which is always in millis */
-		_bufferWriter->writeLEB128(entry->untilTime/1000000);
+		_bufferWriter->writeLEB128(entry->untilTime / 1000000);
 
 		/* address of monitor */
 		_bufferWriter->writeLEB128(entry->parkedAddress);

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -721,10 +721,12 @@ jfrVMThreadParked(J9HookInterface **hook, UDATA eventNum, void *eventData, void*
 	J9JFRThreadParked *jfrEvent = (J9JFRThreadParked*)reserveBufferWithStackTrace(currentThread, currentThread, J9JFR_EVENT_TYPE_THREAD_PARK, sizeof(*jfrEvent));
 	if (NULL != jfrEvent) {
 		// TODO: worry about overflow?
-		jfrEvent->time = (event->millis * 1000000) + event->nanos;
-		jfrEvent->duration = j9time_nano_time() - event->startTicks;
-		jfrEvent->parkedAddress = event->parkedAddress;
+		I_64 currentTime = j9time_nano_time();
+		jfrEvent->duration = currentTime - event->startTicks;
 		jfrEvent->parkedClass = event->parkedClass;
+		jfrEvent->timeOut = (event->millis * 1000000) + event->nanos;
+		jfrEvent->untilTime = currentTime;
+		jfrEvent->parkedAddress = event->parkedAddress;
 	}
 }
 

--- a/test/functional/cmdLineTests/jfr/playlist.xml
+++ b/test/functional/cmdLineTests/jfr/playlist.xml
@@ -76,9 +76,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<impl>openj9</impl>
 			<impl>ibm</impl>
 		</impls>
-		<!-- For the time being, these tests are limited to JDK17+. -->
+		<!-- For the time being, these tests are limited to JDK11+. -->
 		<versions>
-			<version>17+</version>
+			<version>11+</version>
 		</versions>
 	</test>
 </playlist>


### PR DESCRIPTION
The "timeout" and "until" fields weren't correctly initialized.

Fixes: https://github.com/eclipse-openj9/openj9/issues/21242
Related: https://github.com/eclipse-openj9/openj9/pull/20885