### PR TITLE
(0.51) Unprotect header when modifying extraStartupHints

### DIFF
--- a/runtime/shared_common/CompositeCache.cpp
+++ b/runtime/shared_common/CompositeCache.cpp
@@ -6809,6 +6809,8 @@ SH_CompositeCacheImpl::setExtraStartupHints(J9VMThread* currentThread, U_32 val)
 		return;
 	}
 	Trc_SHR_Assert_True(hasWriteMutex(currentThread));
+	unprotectHeaderReadWriteArea(currentThread, false);
 	_theca->extraStartupHints = val;
+	protectHeaderReadWriteArea(currentThread, false);
 	Trc_SHR_CC_setExtraStartupHints_Event(currentThread, val);
 }


### PR DESCRIPTION
Port of https://github.com/eclipse-openj9/openj9/pull/21333

Fixes #21315