### PR TITLE
(0.51) Initialize ImageReader during boot

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -173,7 +173,7 @@ final class J9VMInternals {
 			Runtime.getRuntime().addShutdownHook(new Thread(runnable, "CommonCleanerShutdown", true, false, false, null)); //$NON-NLS-1$
 		}
 		/*[ENDIF] JAVA_SPEC_VERSION >= 9 */
-/*[IF CRAC_SUPPORT]*/
+		/*[IF CRAC_SUPPORT]*/
 		if (openj9.internal.criu.InternalCRIUSupport.isCRaCSupportEnabled()) {
 			// export java.base/jdk.crac unconditionally
 			J9VMInternals.class.getModule().implAddExports("jdk.crac"); //$NON-NLS-1$
@@ -184,7 +184,17 @@ final class J9VMInternals {
 				om.get().implAddExports("jdk.crac.management"); //$NON-NLS-1$
 			}
 		}
-/*[ENDIF] CRAC_SUPPORT */
+		/*[ENDIF] CRAC_SUPPORT */
+		/*[IF (11 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION <= 17)]*/
+		/* ImageReader should be initialized before main() is called to
+		 * avoid being affected by a potential invalid java.home path.
+		 */
+		try {
+			jdk.internal.jimage.ImageReaderFactory.getImageReader();
+		} catch (java.io.UncheckedIOException e) {
+			// Ignored deliberately.
+		}
+		/*[ENDIF] (11 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION <= 17) */
 	}
 
 	/**

--- a/test/functional/cmdLineTests/imageReaderInitializationTest/build.xml
+++ b/test/functional/cmdLineTests/imageReaderInitializationTest/build.xml
@@ -1,0 +1,75 @@
+<?xml version="1.0"?>
+
+<!--
+Copyright IBM Corp. and others 2025
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<project name="ImageReader" default="build" basedir=".">
+	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+	<description>
+		Build cmdLineTests_imageReaderInitializationTest
+	</description>
+
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml" />
+
+	<!-- set properties for this build -->
+	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/imageReaderInitializationTest" />
+	<property name="src" location="src" />
+	<property name="build" location="bin" />
+
+	<target name="init">
+		<mkdir dir="${DEST}" />
+		<mkdir dir="${build}" />
+	</target>
+
+	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source">
+		<echo>Ant version is ${ant.version}</echo>
+		<echo>============COMPILER SETTINGS============</echo>
+		<echo>===fork:                         yes</echo>
+		<echo>===executable:                   ${compiler.javac}</echo>
+		<echo>===debug:                        on</echo>
+		<echo>===destdir:                      ${DEST}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${src}" />
+		</javac>
+	</target>
+
+	<target name="dist" depends="compile" description="generate the distribution">
+		<jar jarfile="${DEST}/imageReaderInitializationTest.jar" filesonly="true">
+			<fileset dir="${build}" />
+			<fileset dir="${src}" />
+		</jar>
+		<copy todir="${DEST}">
+			<fileset dir="${src}/../">
+				<include name="**/*.mk" />
+				<include name="**/*.xml" />
+			</fileset>
+		</copy>
+	</target>
+
+	<target name="clean" depends="dist" description="clean up">
+		<!-- Delete the ${build} directory trees -->
+		<delete dir="${build}" />
+	</target>
+
+	<target name="build" depends="buildCmdLineTestTools">
+		<antcall target="clean" inheritall="true" />
+	</target>
+</project>

--- a/test/functional/cmdLineTests/imageReaderInitializationTest/imageReaderInitializationTest.xml
+++ b/test/functional/cmdLineTests/imageReaderInitializationTest/imageReaderInitializationTest.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+Copyright IBM Corp. and others 2025
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="ImageReader Initialization Test" timeout="60">
+	<test id="ImageReader Initialization Test">
+		<command>$EXE$ -cp $RESJAR$ org.openj9.test.ImageReaderInitializationTest</command>
+		<output type="success" caseSensitive="yes" regex="no">IllegalStateException</output>
+		<output type="failure" caseSensitive="yes" regex="no">ExceptionInInitializerError</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/imageReaderInitializationTest/playlist.xml
+++ b/test/functional/cmdLineTests/imageReaderInitializationTest/playlist.xml
@@ -1,0 +1,45 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<!--
+Copyright IBM Corp. and others 2025
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../../TKG/playlist.xsd">
+	<include>../variables.mk</include>
+	<test>
+		<testCaseName>cmdLineTester_imageReaderInitializationTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>
+			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
+			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+			-DRESJAR=$(Q)$(TEST_RESROOT)$(D)imageReaderInitializationTest.jar$(Q) \
+			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)imageReaderInitializationTest.xml$(Q) \
+			-explainExcludes -xids all,$(PLATFORM),$(VARIATION), -nonZeroExitWhenError; \
+			${TEST_STATUS}
+		</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+	</test>
+</playlist>

--- a/test/functional/cmdLineTests/imageReaderInitializationTest/src/org/openj9/test/ImageReaderInitializationTest.java
+++ b/test/functional/cmdLineTests/imageReaderInitializationTest/src/org/openj9/test/ImageReaderInitializationTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test;
+
+/*
+ * This test is to make sure that ImageReader is initialized during boot.
+ * So in case an invalid java.home is set and an exception is thrown in
+ * the code, the exception can be correctly thrown.
+ */
+public class ImageReaderInitializationTest {
+	public static void main(String[] args) {
+		System.setProperty("java.home", "/invalid/path/to/java");
+		String javaHome = System.getProperty("java.home");
+		if (javaHome.equals("/invalid/path/to/java")) {
+			throw new IllegalStateException("Invalid Java home set, throwing expected IllegalStateException");
+		}
+	}
+}


### PR DESCRIPTION
This is to avoid being affected by a potential invalid java.home path

Fixes: https://github.com/eclipse-openj9/openj9/issues/21105