### PR TITLE
Use new classfile API to work with bytecode for Java 24+

### DIFF
--- a/jcl/src/java.base/share/classes/module-info.java.extra
+++ b/jcl/src/java.base/share/classes/module-info.java.extra
@@ -47,9 +47,11 @@ exports openj9.management.internal to
     openj9.jvm;
 exports openj9.internal.management to
     java.management;
+/*[IF JAVA_SPEC_VERSION < 24]*/
 exports jdk.internal.org.objectweb.asm to
     openj9.dtfj,
     openj9.dtfjview;
+/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 // Following allows dtfj/dtfjview modules invoke module addReads & addExports programmatically via reflection APIs.
 exports jdk.internal.module to
     openj9.dtfj,

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImageFactory.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/j9/ImageFactory.java
@@ -83,7 +83,9 @@ public class ImageFactory implements com.ibm.dtfj.image.ImageFactory {
 		try {
 			Module baseModule = String.class.getModule();
 
+			/*[IF JAVA_SPEC_VERSION < 24]*/
 			Modules.addExportsToAllUnnamed(baseModule, "jdk.internal.org.objectweb.asm"); //$NON-NLS-1$
+			/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
 			Module thisModule = ImageFactory.class.getModule();
 


### PR DESCRIPTION
This updates reading and generation of class bytecode to use the new classfile API available in Java 24 and up.

Validated by comparing the output of `javap -c -private -v` on all classes in the `com.ibm.j9ddr.vm29.pointer.generated` package before and after this change.

Also:
* Update `BytecodeGenerator` (correct max locals in `subOffset(long)`).
* Encapsulate uses of `objectweb.asm` within `ClassScanner`.

Fixes: #9990.
Fixes: #20938.