### PR TITLE
Virtual Threads: Bug fixes for JEP491

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2943,7 +2943,7 @@ done:
 					if ((NULL != objectMonitor) && (NULL != objectMonitor->waitingContinuations)) {
 						omrthread_monitor_enter(_vm->blockedVirtualThreadsMutex);
 						J9VMContinuation *head = objectMonitor->waitingContinuations;
-						if (NULL != head) {
+						if ((NULL != head) && (NULL != head->vthread)) {
 							if (omrthread_monitor_notify == notifyFunction) {
 								objectMonitor->waitingContinuations = head->nextWaitingContinuation;
 								head->nextWaitingContinuation = _vm->blockedContinuations;

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -845,6 +845,8 @@ preparePinnedVirtualThreadForUnmount(J9VMThread *currentThread, j9object_t syncO
 						result = J9_OBJECT_MONITOR_OOM;
 						goto done;
 					}
+				} else {
+					objectMonitor = J9_INFLLOCK_OBJECT_MONITOR(lock);
 				}
 
 				detachMonitorInfo(currentThread, objectMonitor);
@@ -877,6 +879,8 @@ preparePinnedVirtualThreadForUnmount(J9VMThread *currentThread, j9object_t syncO
 						result = J9_OBJECT_MONITOR_OOM;
 						goto done;
 					}
+				} else {
+					objectMonitor = J9_INFLLOCK_OBJECT_MONITOR(lock);
 				}
 
 				detachMonitorInfo(currentThread, objectMonitor);


### PR DESCRIPTION
[Correctly derive an inflated object monitor](https://github.com/eclipse-openj9/openj9/commit/52f247c234926f7094702b4447ff0be981b4bda4)

A null object monitor is being passed to `detachMonitorInfo`, which
leads to a segfault. In the inflated case, the object monitor is
correctly derived to prevent the segfault.

This fix helps the `LotsOfContendedMonitorEnter` test in #20705.

[Correctly handle notify before wait for virtual threads](https://github.com/eclipse-openj9/openj9/commit/539c353763f993e1450cc23346fbb9067662be9a)

If a notify is issued before wait, then there `waitingContinuations`
will be `NULL`. In this case, the notify steps should not be executed
since there are no virtual threads waiting, and
`waitingContinuations->vthread` will be NULL.

Addresses point 3 in the below Github comment:
https://github.com/eclipse-openj9/openj9/issues/20369#issuecomment-2715488932.

Signed-off-by: Babneet Singh <sbabneet@ca.ibm.com>