### PR TITLE
Add -Xmx512m to -Xcheck:memory GC Regression tests

### DIFF
--- a/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/gcRegressionTests.xml
@@ -348,7 +348,7 @@
   <output regex="no" type="success">version</output>
  </test>
  <test id="-verbose:gc -Xcheck:memory - check for memory corruption">
-  <command>$EXE$ $XINT$ $ARGS_FOR_ALL_TESTS$ -verbose:gc -Dibm.java9.forceCommonCleanerShutdown=true -Xcheck:memory:quick,ignoreUnfreedCallsite=zip/:dbgwrapper:unknown:wrapper -version</command>
+  <command>$EXE$ $XINT$ $ARGS_FOR_ALL_TESTS$ -verbose:gc -Dibm.java9.forceCommonCleanerShutdown=true -Xcheck:memory:quick,ignoreUnfreedCallsite=zip/:dbgwrapper:unknown:wrapper -Xmx512m -version</command>
   <output regex="no" type="required">&lt;/verbosegc&gt;</output>
   <output regex="no" type="success">All allocated blocks were freed.</output>
   <!-- allow memory leaks since the JIT leaks, unfortunately -->
@@ -357,7 +357,7 @@
  </test>
  <test id="-verbose:gc -Xcheck:memory -Xverbosegclog:foo.log - check for memory corruption">
   <exec command="rm foo.*.log" />
-  <command>$EXE$ $XINT$ $ARGS_FOR_ALL_TESTS$ -verbose:gc -Xverbosegclog -Dibm.java9.forceCommonCleanerShutdown=true -Xcheck:memory:quick,ignoreUnfreedCallsite=zip/:dbgwrapper:unknown:wrapper -version</command>
+  <command>$EXE$ $XINT$ $ARGS_FOR_ALL_TESTS$ -verbose:gc -Xverbosegclog -Dibm.java9.forceCommonCleanerShutdown=true -Xcheck:memory:quick,ignoreUnfreedCallsite=zip/:dbgwrapper:unknown:wrapper -Xmx512m -version</command>
   <output regex="no" type="success">All allocated blocks were freed.</output>
   <!-- allow memory leaks since the JIT leaks, unfortunately -->
   <output regex="no" type="success">bytes were not freed before shutdown!</output>


### PR DESCRIPTION
Looks like -Xcheck:memory has a problem on x86 Mac platform preventing to run Balanced with enabled off-heap with default maximum heap size as 25% of RAM available on machine failing with Native OOM. I guess it forces Sparce Heap to be allocated in the physical memory instead of be mostly virtual. Size of the heap is not significant for this particular test, so it can be explicitly set to smaller value to avoid the problem. We are going to investigate -Xcheck:memory behaviour on x86 Mac.