### PR TITLE
Exclude Balanced testing from FFI downcall

### DIFF
--- a/test/functional/Java22andUp/playlist.xml
+++ b/test/functional/Java22andUp/playlist.xml
@@ -51,8 +51,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<testCaseName>Jep454Tests_testLinkerFfi_DownCall_HeapArray</testCaseName>
 		<variations>
 			<variation>NoOptions</variation>
-			<variation>Mode501</variation>
-			<variation>Mode551</variation>
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) $(JAVA_COMMAND) $(JVM_OPTIONS) \
 			-Xmx1G \


### PR DESCRIPTION
This is temporary till this tests works with Balanced Offheap