### PR TITLE
(0.51) Fix owner for JFR monitor enter

### DIFF
--- a/runtime/vm/JFRChunkWriter.hpp
+++ b/runtime/vm/JFRChunkWriter.hpp
@@ -596,13 +596,13 @@ done:
 		VM_BufferWriter *_bufferWriter = (VM_BufferWriter *)userData;
 
 		/* reserve size field */
-		U_8 *dataStart = _bufferWriter->getAndIncCursor(sizeof(U_32));
+		U_8 *dataStart = reserveEventSize(_bufferWriter);
 
 		/* write event type */
 		_bufferWriter->writeLEB128(MonitorEnterID);
 
-		/* write start time - this is when the sleep started not when it ended so we
-		 * need to subtract the duration since the event is emitted when the sleep ends.
+		/* write start time - this is when the monitor enter started not when it ended so we
+		 * need to subtract the duration since the event is emitted when the monitor enter ends.
 		 */
 		_bufferWriter->writeLEB128(entry->ticks - entry->duration);
 

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -696,6 +696,7 @@ jfrVMMonitorEntered(J9HookInterface **hook, UDATA eventNum, void *eventData, voi
 		jfrEvent->duration = j9time_nano_time() - event->startTicks;
 		jfrEvent->monitorClass = event->monitorClass;
 		jfrEvent->monitorAddress = (UDATA)event->monitor;
+		jfrEvent->previousOwner = event->previousOwner;
 	}
 }
 

--- a/test/functional/cmdLineTests/jfr/jfrevents.xml
+++ b/test/functional/cmdLineTests/jfr/jfrevents.xml
@@ -64,4 +64,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="success" caseSensitive="yes" regex="no">stackTrace</output>
 		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
 	</test>
+	<test id="test jfr monitor enter - approx 30seconds">
+		<command>$JFR_EXE$ print --xml --events "JavaMonitorEnter" --stack-depth 1 defaultJ9recording.jfr</command>
+		<output type="required" caseSensitive="yes" regex="no">http://www.w3.org/2001/XMLSchema-instance</output>
+		<output type="required" caseSensitive="yes" regex="no">jdk.JavaMonitorEnter</output>
+		<output type="required" caseSensitive="yes" regex="no">eventThread</output>
+		<output type="required" caseSensitive="yes" regex="no">osName</output>
+		<output type="required" caseSensitive="yes" regex="no">osThreadId</output>
+		<output type="required" caseSensitive="yes" regex="no">javaName</output>
+		<output type="success" caseSensitive="yes" regex="no">stackTrace</output>
+		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
+	</test>
 </suite>

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
@@ -35,6 +35,10 @@ public class WorkLoad {
 	public static double average;
 	public static double stdDev;
 
+	private static long globalCounter = 0;
+	static interface GlobalLoack {};
+	private static Object globalLock = new GlobalLoack(){};
+
 	public WorkLoad(int numberOfThreads, int sizeOfNumberList, int repeats) {
 		this.numberOfThreads = numberOfThreads;
 		this.sizeOfNumberList = sizeOfNumberList;
@@ -93,7 +97,19 @@ public class WorkLoad {
 			generateTimedSleep();
 			generateTimedWait();
 			throwThrowables();
+			contendOnLock();
 			burnCPU();
+		}
+	}
+
+	private void contendOnLock() {
+		synchronized (globalLock) {
+			globalCounter++;
+			try {
+				Thread.sleep(1);
+			} catch (InterruptedException e) {
+				e.printStackTrace();
+			}
 		}
 	}
 


### PR DESCRIPTION
- Fix Owner for JFR monitor enter
- Add tests to validate monitor enter events

Backport of https://github.com/eclipse-openj9/openj9/pull/21340