### PR TITLE
Use extensions System.initProperties to help init jdk11 properties

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -43,38 +43,6 @@
 #include <_Ccsid.h>
 #endif
 
-
-#if JAVA_SPEC_VERSION == 11
-void JNICALL
-Java_java_lang_System_initJCLPlatformEncoding(JNIEnv *env, jclass clazz)
-{
-	UDATA handle = 0;
-	J9JavaVM * const vm = ((J9VMThread*)env)->javaVM;
-	char dllPath[EsMaxPath] = {0};
-	UDATA written = 0;
-	const char *encoding = NULL;
-	PORT_ACCESS_FROM_ENV(env);
-
-#if defined(OSX)
-	encoding = "UTF-8";
-#else
-	char property[128] = {0};
-	encoding = getPlatformFileEncoding(env, property, sizeof(property), 1); /* platform encoding */
-#endif /* defined(OSX) */
-	/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
-	written = j9str_printf(dllPath, sizeof(dllPath), "%s/../java", vm->j2seRootDirectory);
-	/* Assert the number of characters written (not including the null) fit within the dllPath buffer */
-	Assert_JCL_true(written < (sizeof(dllPath) - 1));
-	if (0 == j9sl_open_shared_library(dllPath, &handle, J9PORT_SLOPEN_DECORATE)) {
-		void (JNICALL *nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
-		if (0 == j9sl_lookup_name(handle, "InitializeEncoding", (UDATA*) &nativeFuncAddrJNU, "VLL")) {
-			/* invoke JCL native to initialize platform encoding explicitly */
-			nativeFuncAddrJNU(env, encoding);
-		}
-	}
-}
-#endif /* JAVA_SPEC_VERSION == 11 */
-
 /**
  * sysPropID
  *    0 - os.version

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -599,12 +599,6 @@ if(NOT JAVA_SPEC_VERSION LESS 9)
 	)
 endif()
 
-if(JAVA_SPEC_VERSION EQUAL 11)
-	omr_add_exports(jclse
-		Java_java_lang_System_initJCLPlatformEncoding
-	)
-endif()
-
 # java 11+
 if(NOT JAVA_SPEC_VERSION LESS 11)
 	omr_add_exports(jclse

--- a/runtime/jcl/uma/se11_exports.xml
+++ b/runtime/jcl/uma/se11_exports.xml
@@ -23,7 +23,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<export name="Java_java_lang_Class_getNestHostImpl"/>
 	<export name="Java_java_lang_Class_getNestMembersImpl"/>
 	<export name="Java_java_lang_invoke_MethodHandleResolver_getCPConstantDynamicAt"/>
-	<export name="Java_java_lang_System_initJCLPlatformEncoding">
-		<exclude-if condition="spec.java12"/>
-	</export>
 </exports>

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -190,9 +190,6 @@ Java_com_ibm_java_lang_management_internal_MemoryManagerMXBeanImpl_isManagedPool
 /* BBjclNativesCommonSystem*/
 void JNICALL Java_java_lang_System_setFieldImpl (JNIEnv * env, jclass cls, jstring name, jobject stream);
 jobject createSystemPropertyList (JNIEnv *env, const char *defaultValues[], int defaultCount);
-#if JAVA_SPEC_VERSION == 11
-void JNICALL Java_java_lang_System_initJCLPlatformEncoding (JNIEnv *env, jclass clazz);
-#endif /* JAVA_SPEC_VERSION == 11 */
 jstring JNICALL Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass clazz, jint sysPropID);
 #if JAVA_SPEC_VERSION < 17
 jobject JNICALL Java_java_lang_System_getPropertyList (JNIEnv *env, jclass clazz);

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1609,7 +1609,7 @@ convertToUTF8(J9PortLibrary *portLibrary, const wchar_t *unicodeString, char *ut
 	return 0;
 }
 
-jobject
+static jobject
 getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 {
 	PORT_ACCESS_FROM_ENV(env);
@@ -1623,9 +1623,9 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	char userhome[EsMaxPath];
 	wchar_t unicodeTemp[EsMaxPath];
 	int i = 0;
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	char userdir[EsMaxPath];
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 	wchar_t unicodeHome[EsMaxPath];
 	HANDLE process = 0;
 	HANDLE token = 0;
@@ -1634,7 +1634,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 
 	/* Hard coded file/path separators and other values */
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	strings[propIndex++] = "file.separator";
 	strings[propIndex++] = "\\";
 
@@ -1644,7 +1644,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	/* Get the Temp Dir name */
 	strings[propIndex++] = "java.io.tmpdir";
 	strings[propIndex++] = getTmpDir(env, &tempdir);
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	strings[propIndex++] = "user.home";
 	i = propIndex;
@@ -1711,7 +1711,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 		}
 	}
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	/* Get the directory where the executable was started */
 	strings[propIndex++] = "user.dir";
 	if (0 == GetCurrentDirectoryW(EsMaxPath, unicodeTemp)) {
@@ -1720,13 +1720,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 		convertToUTF8(PORTLIB, unicodeTemp, userdir, EsMaxPath);
 		strings[propIndex++] = userdir;
 	}
-#endif /* JAVA_SPEC_VERSION < 17 */
-
-	if (JAVA_SPEC_VERSION < 12) {
-		/* Get the timezone */
-		strings[propIndex++] = "user.timezone";
-		strings[propIndex++] = "";
-	}
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	result = createSystemPropertyList(env, strings, propIndex);
 	j9mem_free_memory(tempdir);
@@ -1736,16 +1730,16 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 
 #else /* defined(WIN32) */
 
-jobject
+static jobject
 getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 {
 	PORT_ACCESS_FROM_ENV(env);
 	char *charResult = NULL;
 	char *envSpace = NULL;
 	jobject plist = NULL;
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	char userdir[EsMaxPath] = {0};
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 	char home[EsMaxPath] = {0};
 	char *homeAlloc = NULL;
 	J9VMThread *currentThread = (J9VMThread*)env;
@@ -1764,7 +1758,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	}
 #endif /* defined(J9ZOS390) */
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	strings[propIndex++] = "file.separator";
 	strings[propIndex++] = "/";
 
@@ -1779,7 +1773,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	} else {
 		strings[propIndex++] = charResult;
 	}
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	strings[propIndex++] = "user.home";
 	charResult = NULL;
@@ -1850,17 +1844,11 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 		propIndex += 1;
 	}
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	/* Get the Temp Dir name */
 	strings[propIndex++] = "java.io.tmpdir";
 	strings[propIndex++] = getTmpDir(env, &envSpace);
-#endif /* JAVA_SPEC_VERSION < 17 */
-
-	if (JAVA_SPEC_VERSION < 12) {
-		/* Get the timezone */
-		strings[propIndex++] = "user.timezone";
-		strings[propIndex++] = "";
-	}
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	plist = createSystemPropertyList(env, strings, propIndex);
 	if (NULL != envSpace) {
@@ -1888,12 +1876,12 @@ getSystemPropertyList(JNIEnv *env)
 	int propIndex = 0;
 	jobject propertyList = NULL;
 #define PROPERTY_COUNT 137
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	char *propertyKey = NULL;
 	const char *language = NULL;
 	const char *region = NULL;
 	const char *variant = NULL;
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 	const char *strings[PROPERTY_COUNT] = {0};
 #define USERNAME_LENGTH 128
 	char username[USERNAME_LENGTH] = {0};
@@ -1967,7 +1955,7 @@ getSystemPropertyList(JNIEnv *env)
 	strings[propIndex++] = "big";
 #endif /* defined(J9VM_ENV_LITTLE_ENDIAN) */
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	strings[propIndex++] = "sun.cpu.endian";
 #if defined(J9VM_ENV_LITTLE_ENDIAN)
 	strings[propIndex++] = "little";
@@ -1998,7 +1986,11 @@ getSystemPropertyList(JNIEnv *env)
 	/* Get the variant */
 	strings[propIndex++] = "user.variant";
 	strings[propIndex++] = variant;
-#endif /* JAVA_SPEC_VERSION < 17 */
+
+	/* Get the timezone */
+	strings[propIndex++] = "user.timezone";
+	strings[propIndex++] = "";
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	/* Get the User name */
 	strings[propIndex++] = "user.name";


### PR DESCRIPTION
Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/880

Related to https://github.com/eclipse-openj9/openj9/issues/21189