### PR TITLE
(0.51) Fix issue with waiting vthreads

### DIFF
--- a/runtime/oti/ContinuationHelpers.hpp
+++ b/runtime/oti/ContinuationHelpers.hpp
@@ -290,6 +290,39 @@ public:
 				&& (0 == vmThread->continuationPinCount)
 				&& (0 == vmThread->callOutCount));
 	}
+
+	/**
+	 * Remove a continuation from the provided list.
+	 *
+	 * @param[in] list the list from which the continuation should be removed
+	 * @param[in] continuation the continuation to be removed
+	 *
+	 * @return true if the continuation is found and removed from the list, otherwise false
+	 */
+	static bool
+	removeContinuationFromList(J9VMContinuation **list, J9VMContinuation *continuation)
+	{
+		bool foundInList = false;
+		J9VMContinuation *previous = NULL;
+		J9VMContinuation *current = *list;
+
+		while (NULL != current) {
+			if (continuation == current) {
+				foundInList = true;
+				if (NULL == previous) {
+					*list = current->nextWaitingContinuation;
+				} else {
+					previous->nextWaitingContinuation = current->nextWaitingContinuation;
+				}
+				current->nextWaitingContinuation = NULL;
+				break;
+			}
+			previous = current;
+			current = current->nextWaitingContinuation;
+		}
+
+		return foundInList;
+	}
 #endif /* JAVA_SPEC_VERSION >= 24 */
 };
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5460,6 +5460,7 @@ typedef struct J9VMContinuation {
 	struct J9MonitorEnterRecord* jniMonitorEnterRecords;
 	j9object_t vthread;
 	struct J9VMContinuation* nextWaitingContinuation;
+	struct J9ObjectMonitor* objectWaitMonitor;
 #endif /* JAVA_SPEC_VERSION >= 24 */
 } J9VMContinuation;
 #endif /* JAVA_SPEC_VERSION >= 19 */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -2952,14 +2952,14 @@ done:
 								J9VMJAVALANGVIRTUALTHREAD_SET_NOTIFIED(_currentThread, head->vthread, JNI_TRUE);
 							} else {
 								J9VMContinuation *next = head;
-								J9VMJAVALANGVIRTUALTHREAD_SET_ONWAITINGLIST(_currentThread, head->vthread, JNI_TRUE);
-								J9VMJAVALANGVIRTUALTHREAD_SET_NOTIFIED(_currentThread, head->vthread, JNI_TRUE);
-								while (NULL != next->nextWaitingContinuation) {
+								J9VMContinuation *prev = NULL;
+								while (NULL != next) {
 									J9VMJAVALANGVIRTUALTHREAD_SET_ONWAITINGLIST(_currentThread, next->vthread, JNI_TRUE);
 									J9VMJAVALANGVIRTUALTHREAD_SET_NOTIFIED(_currentThread, next->vthread, JNI_TRUE);
+									prev = next;
 									next = next->nextWaitingContinuation;
 								}
-								next->nextWaitingContinuation = _vm->blockedContinuations;
+								prev->nextWaitingContinuation = _vm->blockedContinuations;
 								_vm->blockedContinuations = head;
 								objectMonitor->waitingContinuations = NULL;
 							}
@@ -5174,7 +5174,7 @@ done:
 			VMStructHasBeenUpdated(REGISTER_ARGS);
 			if (J9_OBJECT_MONITOR_OOM != result) {
 				restoreInternalNativeStackFrame(REGISTER_ARGS);
-				/* Handle the virutal thread Object.wait call. */
+				/* Handle the virtual thread Object.wait call. */
 				J9VMJAVALANGVIRTUALTHREAD_SET_NOTIFIED(_currentThread, _currentThread->threadObject, JNI_FALSE);
 				rc = yieldPinnedContinuation(REGISTER_ARGS, newState, J9VM_CONTINUATION_RETURN_FROM_OBJECT_WAIT);
 			} else {


### PR DESCRIPTION
When a vthread is in a timed wait, it is added to the running queue by a Java thread directly if the timeout elapses. In this case, we need to ensure it is removed from any waiting list, as it will not pass through the takeVirtualThreadListToUnblock path.