### PR TITLE
(0.51) GC update for supporting yield of pinned VirtualThread(JEP491)

### DIFF
--- a/runtime/gc_base/ReferenceChainWalker.hpp
+++ b/runtime/gc_base/ReferenceChainWalker.hpp
@@ -127,6 +127,9 @@ private:
 	virtual void doStringTableSlot(J9Object **slotPtr, GC_StringTableIterator *stringTableIterator);
 	virtual void doVMClassSlot(J9Class *classPtr);
 	virtual void doVMThreadSlot(J9Object **slotPtr, GC_VMThreadIterator *vmThreadIterator);
+#if JAVA_SPEC_VERSION >= 24
+	virtual void doContinuationSlot(J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
 	virtual void doStackSlot(J9Object **slotPtr, void *walkState, const void* stackLocation);
 	virtual void doSlot(J9Object **slotPtr);
 	virtual void doClassSlot(J9Class *classPtr);

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -35,6 +35,9 @@
 
 #include "BaseVirtual.hpp"
 
+#if JAVA_SPEC_VERSION >= 24
+#include "ContinuationSlotIterator.hpp"
+#endif /* JAVA_SPEC_VERSION >= 24 */
 #include "EnvironmentBase.hpp"
 #include "GCExtensions.hpp"
 #include "JVMTIObjectTagTableIterator.hpp"
@@ -604,6 +607,10 @@ public:
 	 */
 	virtual void doDoubleMappedObjectSlot(J9Object *objectPtr, struct J9PortVmemIdentifier *identifier);
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
+
+#if JAVA_SPEC_VERSION >= 24
+	virtual void doContinuationSlot(J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
 
 	/**
 	 * Called for each object stack slot. Subclasses may override.

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
@@ -46,6 +46,9 @@
 #include "ScanClassesMode.hpp"
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
+#if JAVA_SPEC_VERSION >= 24
+class GC_ContinuationSlotIterator;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 class GC_VMThreadIterator;
 class MM_ConcurrentGC;
 class MM_MarkingScheme;
@@ -87,7 +90,7 @@ public:
 	};
 
 	typedef struct markSchemeStackIteratorData {
-		MM_MarkingScheme *markingScheme;
+		MM_ConcurrentMarkingDelegate *concurrentMarkingDelegate;
 		MM_EnvironmentBase *env;
 	} markSchemeStackIteratorData;
 
@@ -114,6 +117,11 @@ public:
 	 */
 	bool initialize(MM_EnvironmentBase *env, MM_ConcurrentGC *collector);
 
+	MMINLINE void doSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr);
+#if JAVA_SPEC_VERSION >= 24
+	void doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
+	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 	/**
 	 * In the case of Weak Consistency platforms we require this method to bring mutator threads to a safe point. A safe
 	 * point is a point at which a GC may occur.

--- a/runtime/gc_glue_java/MarkingDelegate.hpp
+++ b/runtime/gc_glue_java/MarkingDelegate.hpp
@@ -36,6 +36,9 @@
 #include "ReferenceObjectScanner.hpp"
 #include "PointerArrayObjectScanner.hpp"
 
+#if JAVA_SPEC_VERSION >= 24
+class GC_ContinuationSlotIterator;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 class GC_ObjectScanner;
 class MM_EnvironmentBase;
 class MM_HeapRegionDescriptorStandard;
@@ -128,7 +131,11 @@ public:
 		return 0;
 	}
 
-	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr);
+	MMINLINE void doSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr);
+#if JAVA_SPEC_VERSION >= 24
+	void doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
+	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr, void *walkState, const void* stackLocation);
 	void scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
 
 	MMINLINE GC_ObjectScanner *

--- a/runtime/gc_glue_java/MetronomeDelegate.hpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.hpp
@@ -37,6 +37,9 @@
 #include "Scheduler.hpp"
 #include "StackSlotValidator.hpp"
 
+#if JAVA_SPEC_VERSION >= 24
+class GC_ContinuationSlotIterator;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 class MM_HeapRegionDescriptorRealtime;
 class MM_RealtimeMarkingSchemeRootMarker;
 class MM_RealtimeRootScanner;
@@ -57,6 +60,12 @@ public:
 	void yieldWhenRequested(MM_EnvironmentBase *env);
 	static int J9THREAD_PROC metronomeAlarmThreadWrapper(void *userData);
 	static uintptr_t signalProtectedFunction(J9PortLibrary *privatePortLibrary, void *userData);
+
+	MMINLINE void doSlot(MM_EnvironmentRealtime *env, J9Object **slotPtr);
+#if JAVA_SPEC_VERSION >= 24
+	void doContinuationSlot(MM_EnvironmentRealtime *env, J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
+	void doStackSlot(MM_EnvironmentRealtime *env, J9Object **slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 
 	MM_MetronomeDelegate(MM_EnvironmentBase *env) :
 		_extensions(MM_GCExtensions::getExtensions(env)),
@@ -580,7 +589,7 @@ private:
 };
 
 typedef struct StackIteratorData4RealtimeMarkingScheme {
-	MM_RealtimeMarkingScheme *realtimeMarkingScheme;
+	MM_MetronomeDelegate *metronomeDelegate;
 	MM_EnvironmentRealtime *env;
 	J9Object *fromObject;
 } StackIteratorData4RealtimeMarkingScheme;

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -43,6 +43,9 @@
 #include "MarkingScheme.hpp"
 #include "ScanClassesMode.hpp"
 
+#if JAVA_SPEC_VERSION >= 24
+class GC_ContinuationSlotIterator;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 class GC_ObjectScanner;
 class GC_VMThreadIterator;
 class MM_CompactScheme;
@@ -177,7 +180,11 @@ public:
 	void poisonSlots(MM_EnvironmentBase *env);
 	void healSlots(MM_EnvironmentBase *env);
 #endif /* defined(OMR_ENV_DATA64) && defined(OMR_GC_FULL_POINTERS) */
-	void doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember);
+	MMINLINE void doSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember);
+#if JAVA_SPEC_VERSION >= 24
+	void doContinuationSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
+	void doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember, void *walkState, const void* stackLocation);
 
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);

--- a/runtime/gc_glue_java/ScavengerRootScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.hpp
@@ -110,6 +110,22 @@ public:
 		}
 	}
 
+#if JAVA_SPEC_VERSION >= 24
+	/*
+	 * Handle continuation slots specially so that we can auto-remember referenced objects
+	 */
+	virtual void
+	doContinuationSlot(J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator)
+	{
+		MM_EnvironmentStandard *envStandard = MM_EnvironmentStandard::getEnvironment(_env);
+		if (_scavenger->isHeapObject(*slotPtr) && !_extensions->heap->objectIsInGap(*slotPtr)) {
+			_scavenger->copyAndForwardThreadSlot(envStandard, slotPtr);
+		} else if (NULL != *slotPtr) {
+			Assert_MM_true(GC_ContinuationSlotIterator::state_monitor_records == continuationSlotIterator->getState());
+		}
+	}
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
 	/*
 	 * Handle stack and thread slots specially so that we can auto-remember stack-referenced objects
 	 */

--- a/runtime/gc_glue_java/ScavengerThreadRescanner.hpp
+++ b/runtime/gc_glue_java/ScavengerThreadRescanner.hpp
@@ -54,6 +54,12 @@ public:
 		_scavenger->rescanThreadSlot(MM_EnvironmentStandard::getEnvironment(_env), slotPtr);
 	}
 
+#if JAVA_SPEC_VERSION >= 24
+	virtual void doContinuationSlot(J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator) {
+		_scavenger->rescanThreadSlot(MM_EnvironmentStandard::getEnvironment(_env), slotPtr);
+	}
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
 	virtual void doVMThreadSlot(omrobjectptr_t *slotPtr, GC_VMThreadIterator *vmThreadIterator) {
 		_scavenger->rescanThreadSlot(MM_EnvironmentStandard::getEnvironment(_env), slotPtr);
 	}

--- a/runtime/gc_include/j9modron.h
+++ b/runtime/gc_include/j9modron.h
@@ -131,6 +131,8 @@ typedef jvmtiIterationControl J9MODRON_REFERENCE_CHAIN_WALKER_CALLBACK(J9Object 
 #define J9GC_ROOT_TYPE_JVMTI_TAG_REF 21
 #define J9GC_ROOT_TYPE_OWNABLE_SYNCHRONIZER_OBJECT 22
 #define J9GC_ROOT_TYPE_CONTINUATION_OBJECT 23
+#define J9GC_ROOT_TYPE_CONTINUATION_MONITOR 24
+#define J9GC_ROOT_TYPE_CONTINUATION_VTHREAD 25
 
 #define J9GC_REFERENCE_TYPE_UNKNOWN -1 /**< reference to an object that fell through a default state in an iterator */
 #define J9GC_REFERENCE_TYPE_FIELD -2	/**< field reference to an object */

--- a/runtime/gc_structs/CMakeLists.txt
+++ b/runtime/gc_structs/CMakeLists.txt
@@ -38,6 +38,7 @@ set(gc_structs_sources
 	ConstantDynamicSlotIterator.cpp
 	ConstantPoolClassSlotIterator.cpp
 	ConstantPoolObjectSlotIterator.cpp
+	ContinuationSlotIterator.cpp
 	JVMTIObjectTagTableIterator.cpp
 	MethodTypesIterator.cpp
 	MixedObjectDeclarationOrderIterator.cpp

--- a/runtime/gc_structs/ContinuationSlotIterator.hpp
+++ b/runtime/gc_structs/ContinuationSlotIterator.hpp
@@ -1,0 +1,96 @@
+
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+/**
+ * @file
+ * @ingroup GC_Structs
+ */
+
+#if !defined(CONTINUATIONSLOTITERATOR_HPP_)
+#define CONTINUATIONSLOTITERATOR_HPP_
+#if JAVA_SPEC_VERSION >= 24
+
+#include "j9.h"
+#include "j9cfg.h"
+#include "modron.h"
+
+/**
+ * Iterate over monitor records slots and vthread slot in a J9VMContinuation.
+ * Used by ScanContinuationNativeSlots() (JAVA_SPEC_VERSION >= 24 only).
+ * @ingroup GC_Structs
+ */
+class GC_ContinuationSlotIterator
+{
+public:
+	/**
+	 * State constants representing the current stage of the iteration process
+	 */
+	enum State {
+		state_start = 0,
+		state_monitor_records,
+		state_vthread,
+		state_end
+	};
+
+protected:
+	J9VMThread *_vmThread;
+	State _state;
+
+	j9object_t *_vthread;
+	J9MonitorEnterRecord *_monitorRecord;
+	J9MonitorEnterRecord *_jniMonitorRecord;
+
+public:
+	GC_ContinuationSlotIterator(J9VMThread *vmThread, J9VMContinuation *continuation)
+		: _vmThread(vmThread)
+		, _state(state_start)
+		, _vthread(&continuation->vthread)
+		, _monitorRecord(continuation->monitorEnterRecords)
+		, _jniMonitorRecord(continuation->jniMonitorEnterRecords)
+	{};
+
+	/**
+	 * @return @ref ContinuationSlotIteratorState representing the current state (stage
+	 * of the iteration process)
+	 */
+	MMINLINE int
+	getState()
+	{
+		return _state;
+	}
+
+	/**
+	 * Get the J9VMThread * for the thread being iterated
+	 * @return _vmThread - the J9VMThread being iterated.
+	 */
+	MMINLINE J9VMThread *
+	getVMThread()
+	{
+		return _vmThread;
+	}
+
+	j9object_t *nextSlot();
+};
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
+#endif /* CONTINUATIONSLOTITERATOR_HPP_ */

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -39,6 +39,9 @@
 #include "GCExtensions.hpp"
 #include "ModronTypes.hpp"
 
+#if JAVA_SPEC_VERSION >= 24
+class GC_ContinuationSlotIterator;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 class GC_SlotObject;
 class MM_AllocationContextTarok;
 class MM_CardCleaner;
@@ -1129,6 +1132,11 @@ public:
 	}
 
 	void abandonTLHRemainders(MM_EnvironmentVLHGC *env);
+
+	MMINLINE void doSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr);
+#if JAVA_SPEC_VERSION >= 24
+	void doContinuationSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
 	void doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 
 	friend class MM_CopyForwardGMPCardCleaner;

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
@@ -44,6 +44,9 @@
 /**
  * @}
  */
+#if JAVA_SPEC_VERSION >= 24
+class GC_ContinuationSlotIterator;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 class MM_CardCleaner;
 class MM_Collector;
 class MM_CycleState;
@@ -513,6 +516,10 @@ public:
 	 */
 	void flushBuffers(MM_EnvironmentVLHGC *env);
 	
+	MMINLINE void doSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr);
+#if JAVA_SPEC_VERSION >= 24
+	void doContinuationSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
 	void doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 	/**
 	 * Create a GlobalMarkingScheme object.

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -45,6 +45,9 @@
 #include "CompactGroupManager.hpp"
 #include "ContinuationObjectBuffer.hpp"
 #include "ContinuationObjectList.hpp"
+#if JAVA_SPEC_VERSION >= 24
+#include "ContinuationSlotIterator.hpp"
+#endif /* JAVA_SPEC_VERSION >= 24 */
 #include "VMHelpers.hpp"
 #include "WriteOnceCompactor.hpp"
 #include "Debug.hpp"
@@ -81,6 +84,7 @@
 #include "SparseVirtualMemory.hpp"
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 #include "SlotObject.hpp"
+#include "StackSlotValidator.hpp"
 #include "SublistPool.hpp"
 #include "SublistPuddle.hpp"
 #include "ParallelTask.hpp"
@@ -1213,15 +1217,33 @@ MM_WriteOnceCompactor::fixupMixedObject(MM_EnvironmentVLHGC* env, J9Object *obje
 }
 
 void
-MM_WriteOnceCompactor::doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slot)
+MM_WriteOnceCompactor::doSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr)
 {
-	J9Object *pointer = *slot;
-	if (isHeapObject(pointer)) {
-		J9Object *forwardedPtr = getForwardingPtr(pointer);
-		if (pointer != forwardedPtr) {
-			*slot = forwardedPtr;
-		}
-		_interRegionRememberedSet->rememberReferenceForCompact(env, fromObject, forwardedPtr);
+	J9Object *pointer = *slotPtr;
+	J9Object *forwardedPtr = getForwardingPtr(pointer);
+	if (pointer != forwardedPtr) {
+		*slotPtr = forwardedPtr;
+	}
+	_interRegionRememberedSet->rememberReferenceForCompact(env, fromObject, forwardedPtr);
+}
+
+#if JAVA_SPEC_VERSION >= 24
+void
+MM_WriteOnceCompactor::doContinuationSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator)
+{
+	if (isHeapObject(*slotPtr)) {
+		doSlot(env, fromObject, slotPtr);
+	} else if (NULL != *slotPtr) {
+		Assert_MM_true(GC_ContinuationSlotIterator::state_monitor_records == continuationSlotIterator->getState());
+	}
+}
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
+void
+MM_WriteOnceCompactor::doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr, J9StackWalkState *walkState, const void *stackLocation)
+{
+	if (isHeapObject(*slotPtr)) {
+		doSlot(env, fromObject, slotPtr);
 	}
 }
 
@@ -1232,7 +1254,7 @@ void
 stackSlotIteratorForWriteOnceCompactor(J9JavaVM *javaVM, J9Object **slotPtr, void *localData, J9StackWalkState *walkState, const void *stackLocation)
 {
 	StackIteratorData4WriteOnceCompactor *data = (StackIteratorData4WriteOnceCompactor *)localData;
-	data->writeOnceCompactor->doStackSlot(data->env, data->fromObject, slotPtr);
+	data->writeOnceCompactor->doStackSlot(data->env, data->fromObject, slotPtr, walkState, stackLocation);
 }
 
 void
@@ -1253,6 +1275,16 @@ MM_WriteOnceCompactor::fixupContinuationNativeSlots(MM_EnvironmentVLHGC* env, J9
 		localData.fromObject = objectPtr;
 
 		GC_VMThreadStackSlotIterator::scanContinuationSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForWriteOnceCompactor, false, false);
+
+#if JAVA_SPEC_VERSION >= 24
+		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, objectPtr);
+		GC_ContinuationSlotIterator continuationSlotIterator(currentThread, continuation);
+
+		while (J9Object **slotPtr = continuationSlotIterator.nextSlot()) {
+			doContinuationSlot(env, objectPtr, slotPtr, &continuationSlotIterator);
+		}
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
 	}
 }
 
@@ -1664,7 +1696,7 @@ public:
 
 	}
 	
-	virtual void doSlot(J9Object** slot)
+	virtual void doSlot(J9Object **slot)
 	{
 		J9Object *pointer = *slot;
 		if ((pointer >= _heapBase) && (pointer < _heapTop)) {
@@ -1844,7 +1876,7 @@ public:
 		_typeId = __FUNCTION__;
 	}
 
-	virtual void doSlot(J9Object** slot)
+	virtual void doSlot(J9Object **slot)
 	{
 	}
 

--- a/runtime/gc_vlhgc/WriteOnceCompactor.hpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.hpp
@@ -47,6 +47,9 @@
 
 #if defined(J9VM_GC_MODRON_COMPACTION)
 
+#if JAVA_SPEC_VERSION >= 24
+class GC_ContinuationSlotIterator;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 class MM_AllocateDescription;
 class MM_WriteOnceCompactor;
 class MM_ParallelDispatcher;
@@ -608,7 +611,11 @@ public:
 	 * @param workStackBaseHighPriority[in/out] The "high priority" work stack base.  This reference parameter will be updated before the function returns is region is high priority
 	 */
 	void pushRegionOntoWorkStack(MM_HeapRegionDescriptorVLHGC **workStackBase, MM_HeapRegionDescriptorVLHGC **workStackBaseHighPriority, MM_HeapRegionDescriptorVLHGC *region);
-	void doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slot);
+	MMINLINE void doSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr);
+#if JAVA_SPEC_VERSION >= 24
+	void doContinuationSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+#endif /* JAVA_SPEC_VERSION >= 24 */
+	void doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 
 	friend class MM_WriteOnceCompactFixupRoots;
 	friend class MM_ParallelWriteOnceCompactTask;


### PR DESCRIPTION
In order to supporting yield of pinned VirtualThread a couple of heap references have been added in chain of continuation structures, GC need to maintain(scan/update) these references.

1, new ContunuationSlotIterator to iterate all of the references
 list of monitorRecord
 list of jniMonitorRecord
 vthread reference
ContunuationSlotIterator also contains state and related vmThread state (can be state_monitor_records or state_vthread) for assert check in doContinuationSlot() (monitor_records can be non heap reference), vmThread is for retrieving related carrier context during rootscanning.

2, two new methods doSlot() and doContinuationSlot() are introduced doSlot() would handle basic processing, which can be shared between doContinuationSlot() and doStackSlot().
doContinuationSlot() would have condition check for heap reference and also get ContunuationSlotIterator as a parameter for the extra assert checks.

3, mounted continuations are scanned during rootscan/scanOneThread unmounted continuations are scanned during ContinuationNativeSlots

4, for doContinuationSlot in CopyForwardScheme case the reservingContext (numa node related) can be retrieved via ContunuationSlotIterator (carrier thread context) for root scanning phase, and retrieved via the region of related Continuation Object for heap scanning phase.