### PR TITLE
JDK25 JavaLangAccess removed exit(int status)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -594,10 +594,12 @@ final class Access implements JavaLangAccess {
 		return ClassLoader.findNative0(loader, entryName);
 	}
 
+	/*[IF (JAVA_SPEC_VERSION < 25) | INLINE-TYPES]*/
 	@Override
 	public void exit(int status) {
 		Shutdown.exit(status);
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION < 25) | INLINE-TYPES */
 
 	public int encodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
 		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);


### PR DESCRIPTION
JDK25 JavaLangAccess removed `exit(int status)`

Accommodate upstream change https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/6e164eab87017808b9e066c0b8c3b07407f1c68f

Signed-off-by: Jason Feng <fengj@ca.ibm.com>