### PR TITLE
JEP491: Never Deflate Monitors and Synchronize virtualThreadWaitCount

### DIFF
--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -178,12 +178,7 @@ restart:
 		 *   iff the deflation policy in effect decides it's ok.
 		 */
 		if (monitor->count == 1) {
-			if ((0 == monitor->pinCount)
-#if JAVA_SPEC_VERSION >= 24
-			&& (0 == objectMonitor->virtualThreadWaitCount)
-			&& (NULL == objectMonitor->waitingContinuations)
-#endif /* JAVA_SPEC_VERSION >= 24 */
-			) {
+			if (0 == monitor->pinCount) {
 				if (deflate) {
 					deflate = 0;
 					switch (vmStruct->javaVM->thrDeflationPolicy) {


### PR DESCRIPTION
Currently, there are timing holes between
JVM_TakeVirtualThreadListToUnblock and monitor deflation. A monitor can
be deflated while it is being accessed in
JVM_TakeVirtualThreadListToUnblock. This leads to a NULL dereference
causing a segfault. Adding more synchronization will cause a
significant overhead in the object monitor exit path. Until an
efficient solution is developed, the policy to never deflate will be
employed in order to support JEP491. Since the current JEP491
implementation always inflates monitors before usage, deflating will be
counter-productive.

Also, added a null check for syncObjectMonitor in
JVM_TakeVirtualThreadListToUnblock to ensure that the monitor is
inflated before operations are performed on it.

Operations on J9ObjectMonitor's virtualThreadWaitCount field may
happen out of sequence. To ensure correct ordering and consistency,
atomics have been employed to modify this field.

Related: #20705