### PR TITLE
(0.51) Use extensions System.initProperties to help init jdk11 properties

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -363,10 +363,6 @@ public final class System {
 		// Fill in the properties from the VM information.
 		ensureProperties(true);
 
-		/*[IF JAVA_SPEC_VERSION == 11]*/
-		initJCLPlatformEncoding();
-		/*[ENDIF] JAVA_SPEC_VERSION == 11 */
-
 		/*[REM] Initialize the JITHelpers needed in J9VMInternals since the class can't do it itself */
 		try {
 			java.lang.reflect.Field f1 = J9VMInternals.class.getDeclaredField("jitHelpers"); //$NON-NLS-1$
@@ -681,15 +677,9 @@ private static void arraycopy(Object[] A1, int offset1, Object[] A2, int offset2
  */
 public static native long currentTimeMillis();
 
-/*[IF OpenJ9-RawBuild]*/
-	/* This is a JCL native required only by OpenJ9 raw build.
-	 * OpenJ9 raw build is a combination of OpenJ9 and OpenJDK binaries without JCL patches within extension repo.
-	 * Currently OpenJ9 depends on a JCL patch to initialize platform encoding which is not available to raw build.
-	 * A workaround for raw build is to invoke this JCL native which initializes platform encoding.
-	 * This workaround can be removed if that JCL patch is not required.
-	 */
+/*[IF JAVA_SPEC_VERSION == 11]*/
 private static native Properties initProperties(Properties props);
-/*[ENDIF] OpenJ9-RawBuild */
+/*[ENDIF] JAVA_SPEC_VERSION == 11 */
 
 /**
  * If systemProperties is unset, then create a new one based on the values
@@ -697,16 +687,16 @@ private static native Properties initProperties(Properties props);
  */
 @SuppressWarnings("nls")
 private static void ensureProperties(boolean isInitialization) {
-/*[IF OpenJ9-RawBuild]*/
-	// invoke JCL native to initialize platform encoding
-	initProperties(new Properties());
-/*[ENDIF] OpenJ9-RawBuild */
+	/*[IF JAVA_SPEC_VERSION == 11]*/
+	Properties jclProps = new Properties();
+	initProperties(jclProps);
+	/*[ENDIF] JAVA_SPEC_VERSION == 11 */
 
-/*[IF JAVA_SPEC_VERSION > 11]*/
+	/*[IF JAVA_SPEC_VERSION > 11]*/
 	Map<String, String> initializedProperties = new HashMap<>();
-/*[ELSE] JAVA_SPEC_VERSION > 11
+	/*[ELSE] JAVA_SPEC_VERSION > 11
 	Properties initializedProperties = new Properties();
-/*[ENDIF] JAVA_SPEC_VERSION > 11 */
+	/*[ENDIF] JAVA_SPEC_VERSION > 11 */
 
 	/*[IF JAVA_SPEC_VERSION >= 17]*/
 	initializedProperties.put("os.version", sysPropOSVersion); //$NON-NLS-1$
@@ -716,17 +706,13 @@ private static void ensureProperties(boolean isInitialization) {
 		initializedProperties.put("os.encoding", osEncoding); //$NON-NLS-1$
 	}
 	initializedProperties.put("ibm.system.encoding", platformEncoding); //$NON-NLS-1$
-	/*[IF JAVA_SPEC_VERSION < 17]*/
+	/*[IF JAVA_SPEC_VERSION == 8]*/
 	/*[PR The launcher apparently needs sun.jnu.encoding property or it does not work]*/
 	initializedProperties.put("sun.jnu.encoding", platformEncoding); //$NON-NLS-1$
-	/*[ENDIF] JAVA_SPEC_VERSION < 17 */
-	/*[IF JAVA_SPEC_VERSION == 8]*/
 	initializedProperties.put("file.encoding.pkg", "sun.io"); //$NON-NLS-1$ //$NON-NLS-2$
-	/*[ENDIF] JJAVA_SPEC_VERSION == 8 */
-	/*[IF JAVA_SPEC_VERSION < 12]*/
 	/* System property java.specification.vendor is set via VersionProps.init(systemProperties) since JDK12 */
 	initializedProperties.put("java.specification.vendor", "Oracle Corporation"); //$NON-NLS-1$ //$NON-NLS-2$
-	/*[ENDIF] JAVA_SPEC_VERSION < 12 */
+	/*[ENDIF] JAVA_SPEC_VERSION == 8 */
 	initializedProperties.put("java.specification.name", "Java Platform API Specification"); //$NON-NLS-1$ //$NON-NLS-2$
 	initializedProperties.put("com.ibm.oti.configuration", "scar"); //$NON-NLS-1$
 
@@ -757,7 +743,13 @@ private static void ensureProperties(boolean isInitialization) {
 		}
 		initializedProperties.put(key, list[i+1]);
 	}
+	/*[IF JAVA_SPEC_VERSION == 11]*/
+	for (Map.Entry<?, ?> entry : jclProps.entrySet()) {
+		initializedProperties.putIfAbsent(entry.getKey(), entry.getValue());
+	}
+	/*[ELSE] JAVA_SPEC_VERSION == 11 */
 	initializedProperties.put("file.encoding", fileEncoding); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION == 11 */
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 	/*[IF (JAVA_SPEC_VERSION >= 21) & (PLATFORM-mz31 | PLATFORM-mz64)]*/
@@ -1047,13 +1039,6 @@ public static String setProperty(String prop, String value) {
  */
 private static native String [] getPropertyList();
 /*[ENDIF] JAVA_SPEC_VERSION < 17 */
-
-/*[IF JAVA_SPEC_VERSION == 11]*/
-/**
- * Invoke JCL native to initialize platform encoding explicitly.
- */
-private static native void initJCLPlatformEncoding();
-/*[ENDIF] JAVA_SPEC_VERSION == 11 */
 
 /**
  * Before propertiesInitialized is set to true,

--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -43,38 +43,6 @@
 #include <_Ccsid.h>
 #endif
 
-
-#if JAVA_SPEC_VERSION == 11
-void JNICALL
-Java_java_lang_System_initJCLPlatformEncoding(JNIEnv *env, jclass clazz)
-{
-	UDATA handle = 0;
-	J9JavaVM * const vm = ((J9VMThread*)env)->javaVM;
-	char dllPath[EsMaxPath] = {0};
-	UDATA written = 0;
-	const char *encoding = NULL;
-	PORT_ACCESS_FROM_ENV(env);
-
-#if defined(OSX)
-	encoding = "UTF-8";
-#else
-	char property[128] = {0};
-	encoding = getPlatformFileEncoding(env, property, sizeof(property), 1); /* platform encoding */
-#endif /* defined(OSX) */
-	/* libjava.[so|dylib] is in the jdk/lib/ directory, one level up from the default/ & compressedrefs/ directories */
-	written = j9str_printf(dllPath, sizeof(dllPath), "%s/../java", vm->j2seRootDirectory);
-	/* Assert the number of characters written (not including the null) fit within the dllPath buffer */
-	Assert_JCL_true(written < (sizeof(dllPath) - 1));
-	if (0 == j9sl_open_shared_library(dllPath, &handle, J9PORT_SLOPEN_DECORATE)) {
-		void (JNICALL *nativeFuncAddrJNU)(JNIEnv *env, const char *str) = NULL;
-		if (0 == j9sl_lookup_name(handle, "InitializeEncoding", (UDATA*) &nativeFuncAddrJNU, "VLL")) {
-			/* invoke JCL native to initialize platform encoding explicitly */
-			nativeFuncAddrJNU(env, encoding);
-		}
-	}
-}
-#endif /* JAVA_SPEC_VERSION == 11 */
-
 /**
  * sysPropID
  *    0 - os.version

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -599,12 +599,6 @@ if(NOT JAVA_SPEC_VERSION LESS 9)
 	)
 endif()
 
-if(JAVA_SPEC_VERSION EQUAL 11)
-	omr_add_exports(jclse
-		Java_java_lang_System_initJCLPlatformEncoding
-	)
-endif()
-
 # java 11+
 if(NOT JAVA_SPEC_VERSION LESS 11)
 	omr_add_exports(jclse

--- a/runtime/jcl/uma/se11_exports.xml
+++ b/runtime/jcl/uma/se11_exports.xml
@@ -23,7 +23,4 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<export name="Java_java_lang_Class_getNestHostImpl"/>
 	<export name="Java_java_lang_Class_getNestMembersImpl"/>
 	<export name="Java_java_lang_invoke_MethodHandleResolver_getCPConstantDynamicAt"/>
-	<export name="Java_java_lang_System_initJCLPlatformEncoding">
-		<exclude-if condition="spec.java12"/>
-	</export>
 </exports>

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -190,9 +190,6 @@ Java_com_ibm_java_lang_management_internal_MemoryManagerMXBeanImpl_isManagedPool
 /* BBjclNativesCommonSystem*/
 void JNICALL Java_java_lang_System_setFieldImpl (JNIEnv * env, jclass cls, jstring name, jobject stream);
 jobject createSystemPropertyList (JNIEnv *env, const char *defaultValues[], int defaultCount);
-#if JAVA_SPEC_VERSION == 11
-void JNICALL Java_java_lang_System_initJCLPlatformEncoding (JNIEnv *env, jclass clazz);
-#endif /* JAVA_SPEC_VERSION == 11 */
 jstring JNICALL Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass clazz, jint sysPropID);
 #if JAVA_SPEC_VERSION < 17
 jobject JNICALL Java_java_lang_System_getPropertyList (JNIEnv *env, jclass clazz);

--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1609,7 +1609,7 @@ convertToUTF8(J9PortLibrary *portLibrary, const wchar_t *unicodeString, char *ut
 	return 0;
 }
 
-jobject
+static jobject
 getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 {
 	PORT_ACCESS_FROM_ENV(env);
@@ -1623,9 +1623,9 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	char userhome[EsMaxPath];
 	wchar_t unicodeTemp[EsMaxPath];
 	int i = 0;
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	char userdir[EsMaxPath];
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 	wchar_t unicodeHome[EsMaxPath];
 	HANDLE process = 0;
 	HANDLE token = 0;
@@ -1634,7 +1634,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 
 	/* Hard coded file/path separators and other values */
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	strings[propIndex++] = "file.separator";
 	strings[propIndex++] = "\\";
 
@@ -1644,7 +1644,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	/* Get the Temp Dir name */
 	strings[propIndex++] = "java.io.tmpdir";
 	strings[propIndex++] = getTmpDir(env, &tempdir);
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	strings[propIndex++] = "user.home";
 	i = propIndex;
@@ -1711,7 +1711,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 		}
 	}
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	/* Get the directory where the executable was started */
 	strings[propIndex++] = "user.dir";
 	if (0 == GetCurrentDirectoryW(EsMaxPath, unicodeTemp)) {
@@ -1720,13 +1720,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 		convertToUTF8(PORTLIB, unicodeTemp, userdir, EsMaxPath);
 		strings[propIndex++] = userdir;
 	}
-#endif /* JAVA_SPEC_VERSION < 17 */
-
-	if (JAVA_SPEC_VERSION < 12) {
-		/* Get the timezone */
-		strings[propIndex++] = "user.timezone";
-		strings[propIndex++] = "";
-	}
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	result = createSystemPropertyList(env, strings, propIndex);
 	j9mem_free_memory(tempdir);
@@ -1736,16 +1730,16 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 
 #else /* defined(WIN32) */
 
-jobject
+static jobject
 getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 {
 	PORT_ACCESS_FROM_ENV(env);
 	char *charResult = NULL;
 	char *envSpace = NULL;
 	jobject plist = NULL;
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	char userdir[EsMaxPath] = {0};
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 	char home[EsMaxPath] = {0};
 	char *homeAlloc = NULL;
 	J9VMThread *currentThread = (J9VMThread*)env;
@@ -1764,7 +1758,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	}
 #endif /* defined(J9ZOS390) */
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	strings[propIndex++] = "file.separator";
 	strings[propIndex++] = "/";
 
@@ -1779,7 +1773,7 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 	} else {
 		strings[propIndex++] = charResult;
 	}
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	strings[propIndex++] = "user.home";
 	charResult = NULL;
@@ -1850,17 +1844,11 @@ getPlatformPropertyList(JNIEnv *env, const char *strings[], int propIndex)
 		propIndex += 1;
 	}
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	/* Get the Temp Dir name */
 	strings[propIndex++] = "java.io.tmpdir";
 	strings[propIndex++] = getTmpDir(env, &envSpace);
-#endif /* JAVA_SPEC_VERSION < 17 */
-
-	if (JAVA_SPEC_VERSION < 12) {
-		/* Get the timezone */
-		strings[propIndex++] = "user.timezone";
-		strings[propIndex++] = "";
-	}
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	plist = createSystemPropertyList(env, strings, propIndex);
 	if (NULL != envSpace) {
@@ -1888,12 +1876,12 @@ getSystemPropertyList(JNIEnv *env)
 	int propIndex = 0;
 	jobject propertyList = NULL;
 #define PROPERTY_COUNT 137
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	char *propertyKey = NULL;
 	const char *language = NULL;
 	const char *region = NULL;
 	const char *variant = NULL;
-#endif /* JAVA_SPEC_VERSION < 17 */
+#endif /* JAVA_SPEC_VERSION < 11 */
 	const char *strings[PROPERTY_COUNT] = {0};
 #define USERNAME_LENGTH 128
 	char username[USERNAME_LENGTH] = {0};
@@ -1967,7 +1955,7 @@ getSystemPropertyList(JNIEnv *env)
 	strings[propIndex++] = "big";
 #endif /* defined(J9VM_ENV_LITTLE_ENDIAN) */
 
-#if JAVA_SPEC_VERSION < 17
+#if JAVA_SPEC_VERSION < 11
 	strings[propIndex++] = "sun.cpu.endian";
 #if defined(J9VM_ENV_LITTLE_ENDIAN)
 	strings[propIndex++] = "little";
@@ -1998,7 +1986,11 @@ getSystemPropertyList(JNIEnv *env)
 	/* Get the variant */
 	strings[propIndex++] = "user.variant";
 	strings[propIndex++] = variant;
-#endif /* JAVA_SPEC_VERSION < 17 */
+
+	/* Get the timezone */
+	strings[propIndex++] = "user.timezone";
+	strings[propIndex++] = "";
+#endif /* JAVA_SPEC_VERSION < 11 */
 
 	/* Get the User name */
 	strings[propIndex++] = "user.name";


### PR DESCRIPTION
Depends on https://github.com/ibmruntimes/openj9-openjdk-jdk11/pull/880

Related to https://github.com/eclipse-openj9/openj9/issues/21189

Cherry pick https://github.com/eclipse-openj9/openj9/pull/21357