### PR TITLE
(v0.51.0) Fix Object.wait logic

### DIFF
--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -270,6 +270,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/VirtualThread" name="next" signature="Ljava/lang/VirtualThread;" versions="24-"/>
 	<fieldref class="java/lang/VirtualThread" name="notified" signature="Z" versions="24-"/>
 	<fieldref class="java/lang/VirtualThread" name="onWaitingList" signature="Z" versions="24-"/>
+	<fieldref class="java/lang/VirtualThread" name="timeout" signature="J" versions="24-"/>
 
 	<fieldref class="java/lang/Throwable" name="cause" signature="Ljava/lang/Throwable;"/>
 	<fieldref class="java/lang/Throwable" name="detailMessage" signature="Ljava/lang/String;"/>


### PR DESCRIPTION
- Throw InterruptedException on return fom vthread wait if interrupted field is set
- Add timeout value to vthread object

Backport of #21361 