### PR TITLE
(0.51) JEP491: Never Deflate Monitors and Synchronize virtualThreadWaitCount

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -1024,7 +1024,7 @@ preparePinnedVirtualThreadForUnmount(J9VMThread *currentThread, j9object_t syncO
 			currentThread->currentContinuation->objectWaitMonitor = syncObjectMonitor;
 			omrthread_monitor_exit(vm->blockedVirtualThreadsMutex);
 		} else {
-			syncObjectMonitor->virtualThreadWaitCount += 1;
+			VM_AtomicSupport::addU32(&syncObjectMonitor->virtualThreadWaitCount, 1);
 		}
 
 		/* Clear the blocking object on the carrier thread. */
@@ -1095,15 +1095,20 @@ restart:
 						}
 					} else {
 						lock = J9OBJECT_MONITOR(currentThread, syncObject);
-						syncObjectMonitor = J9_INFLLOCK_OBJECT_MONITOR(lock);
-					}
-					omrthread_monitor_t monitor = syncObjectMonitor->monitor;
-					if (0 == monitor->count) {
-						unblocked = true;
-						if (syncObjectMonitor->virtualThreadWaitCount >= 1) {
-							syncObjectMonitor->virtualThreadWaitCount -= 1;
+						if (J9_LOCK_IS_INFLATED(lock)) {
+							syncObjectMonitor = J9_INFLLOCK_OBJECT_MONITOR(lock);
 						}
-						J9VMJAVALANGVIRTUALTHREAD_SET_ONWAITINGLIST(currentThread, current->vthread, JNI_TRUE);
+					}
+					/* Only perform the below operations for inflated monitors. */
+					if (NULL != syncObjectMonitor) {
+						omrthread_monitor_t monitor = syncObjectMonitor->monitor;
+						if (0 == monitor->count) {
+							unblocked = true;
+							if (syncObjectMonitor->virtualThreadWaitCount >= 1) {
+								VM_AtomicSupport::subtractU32(&syncObjectMonitor->virtualThreadWaitCount, 1);
+							}
+							J9VMJAVALANGVIRTUALTHREAD_SET_ONWAITINGLIST(currentThread, current->vthread, JNI_TRUE);
+						}
 					}
 				}
 

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -178,12 +178,7 @@ restart:
 		 *   iff the deflation policy in effect decides it's ok.
 		 */
 		if (monitor->count == 1) {
-			if ((0 == monitor->pinCount)
-#if JAVA_SPEC_VERSION >= 24
-			&& (0 == objectMonitor->virtualThreadWaitCount)
-			&& (NULL == objectMonitor->waitingContinuations)
-#endif /* JAVA_SPEC_VERSION >= 24 */
-			) {
+			if (0 == monitor->pinCount) {
 				if (deflate) {
 					deflate = 0;
 					switch (vmStruct->javaVM->thrDeflationPolicy) {


### PR DESCRIPTION
Currently, there are timing holes between
JVM_TakeVirtualThreadListToUnblock and monitor deflation. A monitor can
be deflated while it is being accessed in
JVM_TakeVirtualThreadListToUnblock. This leads to a NULL dereference
causing a segfault. Adding more synchronization will cause a
significant overhead in the object monitor exit path. Until an
efficient solution is developed, the policy to never deflate will be
employed in order to support JEP491. Since the current JEP491
implementation always inflates monitors before usage, deflating will be
counter-productive.

Also, added a null check for syncObjectMonitor in
JVM_TakeVirtualThreadListToUnblock to ensure that the monitor is
inflated before operations are performed on it.

Operations on J9ObjectMonitor's virtualThreadWaitCount field may
happen out of sequence. To ensure correct ordering and consistency,
atomics have been employed to modify this field.

Related: #20705

Backport of #21384