### PR TITLE
(0.51) CRIU restores CRIUSupport(Path imageDir) constructor

### DIFF
--- a/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
+++ b/jcl/src/openj9.criu/share/classes/org/eclipse/openj9/criu/CRIUSupport.java
@@ -113,6 +113,7 @@ public final class CRIUSupport {
 	@Deprecated(forRemoval=true)
 	public CRIUSupport(Path imageDir) {
 		System.err.println("WARNING: CRIUSupport(imageDir) constructor is deprecated, please use CRIUSupport.getCRIUSupport() and setImageDir(imageDir)"); //$NON-NLS-1$
+		singletonInternalCRIUSupport.setImageDir(imageDir);
 	}
 
 	/**


### PR DESCRIPTION
CRIU restores `CRIUSupport(Path imageDir)` constructor

Support the original `CRIUSupport(Path imageDir)` constructor API with a singleton `InternalCRIUSupport` instance.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/21401

Signed-off-by: Jason Feng <fengj@ca.ibm.com>