### PR TITLE
Build frame in blocking vthread monenter

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1201,7 +1201,13 @@ obj:
 #if JAVA_SPEC_VERSION >= 24
 				if (VM_ContinuationHelpers::isYieldableVirtualThread(_currentThread)) {
 					/* Try to yield the virtual thread if it will be blocked. */
+					buildInternalNativeStackFrame(REGISTER_ARGS);
+					updateVMStruct(REGISTER_ARGS);
+
 					rc = preparePinnedVirtualThreadForUnmount(_currentThread, obj, false);
+
+					VMStructHasBeenUpdated(REGISTER_ARGS);
+					restoreInternalNativeStackFrame(REGISTER_ARGS);
 				} else
 #endif /* JAVA_SPEC_VERSION >= 24 */
 				{


### PR DESCRIPTION
A frame needs to be built before attempting a stack walk in vthread monenter to find owned monitors. Failure to do so may result in a crash.