### PR TITLE
Revert "Prevent callers of big callees getting marked as big during ECS"

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1754,7 +1754,6 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
                int32_t origAnalyzedSize = _analyzedSize;
                int32_t origRealSize = _realSize;
-               int32_t origBigCalleesSize = _bigCalleesSize;
                bool prevNonColdCalls = _hasNonColdCalls;
                bool estimateSuccess = estimateCodeSize(targetCallee, &callStack); //recurseDown = true
                bool calltargetSetTooBig = false;
@@ -1800,12 +1799,10 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                      }
 
 
-                  int32_t bigCalleesSizeBelowMe = _bigCalleesSize - origBigCalleesSize;
-                  if ((_analyzedSize - origAnalyzedSize - bigCalleesSizeBelowMe) > bigCalleeThreshold)
+                  if (_analyzedSize - origAnalyzedSize > bigCalleeThreshold)
                      {
                      ///printf("set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo._byteCodeIndex);fflush(stdout);
                      calltarget->_calleeMethod->setWarmCallGraphTooBig( newBCInfo.getByteCodeIndex(), comp());
-                     _bigCalleesSize = _bigCalleesSize + _analyzedSize - origAnalyzedSize - bigCalleesSizeBelowMe;
                      heuristicTrace(tracer(), "set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo.getByteCodeIndex());
                      //_analyzedSize = origAnalyzedSize;
                      //_realSize = origRealSize;

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
@@ -43,7 +43,7 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
    {
    public:
 
-      TR_J9EstimateCodeSize() : TR_EstimateCodeSize(), _analyzedSize(0), _bigCalleesSize(0), _lastCallBlockFrequency(-1) { }
+      TR_J9EstimateCodeSize() : TR_EstimateCodeSize(), _analyzedSize(0), _lastCallBlockFrequency(-1) { }
 
       int32_t getOptimisticSize()       { return _analyzedSize; }
 
@@ -165,7 +165,6 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
 
       int32_t _lastCallBlockFrequency;
       int32_t _analyzedSize;          // size if we assume we are doing a partial inline
-      int32_t _bigCalleesSize;
    };
 
 #define NUM_PREV_BC 5


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#21364

See https://github.com/eclipse-openj9/openj9/issues/21397