### PR TITLE
Propagate known key info to ConcurrentHashMap.get

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -1024,6 +1024,7 @@
    java_util_concurrent_ConcurrentHashMap_tabAt,
    java_util_concurrent_ConcurrentHashMap_casTabAt,
    java_util_concurrent_ConcurrentHashMap_setTabAt,
+   java_util_concurrent_ConcurrentHashMap_get,
 
    java_util_concurrent_ConcurrentHashMap_TreeBin_lockRoot,
    java_util_concurrent_ConcurrentHashMap_TreeBin_contendedLock,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3604,6 +3604,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_util_concurrent_ConcurrentHashMap_tabAt,       "tabAt",        "([Ljava/util/concurrent/ConcurrentHashMap$Node;I)Ljava/util/concurrent/ConcurrentHashMap$Node;")},
       {x(TR::java_util_concurrent_ConcurrentHashMap_casTabAt,    "casTabAt",     "([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;Ljava/util/concurrent/ConcurrentHashMap$Node;)Z")},
       {x(TR::java_util_concurrent_ConcurrentHashMap_setTabAt,    "setTabAt",     "([Ljava/util/concurrent/ConcurrentHashMap$Node;ILjava/util/concurrent/ConcurrentHashMap$Node;)V")},
+      {x(TR::java_util_concurrent_ConcurrentHashMap_get,         "get",          "(Ljava/lang/Object;)Ljava/lang/Object;")},
       {TR::unknownMethod}
       };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -399,6 +399,7 @@ TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::No
       case TR::java_util_HashMap_get:
       case TR::java_util_HashMap_getNode:
       case TR::java_util_HashMap_getNode_Object:
+      case TR::java_util_concurrent_ConcurrentHashMap_get:
       case TR::java_lang_String_getChars_charArray:
       case TR::java_lang_String_getChars_byteArray:
       case TR::java_lang_Integer_toUnsignedLong:

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -753,6 +753,7 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
                TR::RecognizedMethod rm = resolvedMethod->getRecognizedMethod();
                if (rm == TR::java_util_HashMap_put ||
                    rm == TR::java_util_HashMap_get ||
+                   rm == TR::java_util_concurrent_ConcurrentHashMap_get ||
                    rm == TR::java_lang_Object_hashCode)
                   {
                   nph.setNeedsPeekingToTrue();


### PR DESCRIPTION
ConcurrentHashMap.get is similar in nature to HashMap.get operations, and we can benefit from compile-time folding of various queries such as Object.hashCode() if the object being passed as arg is known and fixed. For that to be possible, we need to ensure that the caller method of ConcurrentHashMap.get() undergoes peeking IL-gen so that the object information can be passed down and used.

~In Draft state until further testing is done.~