### PR TITLE
Redesign preparePinnedVirtualThreadForUnmount logic

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1716,6 +1716,11 @@ slow_jitMonitorEnterImpl(J9VMThread *currentThread, bool forMethod)
 	if ((J9_OBJECT_MONITOR_BLOCKING == monstatus) && VM_ContinuationHelpers::isYieldableVirtualThread(currentThread)) {
 		/* Try to yield the virtual thread if it will be blocked. */
 		monstatus = currentThread->javaVM->internalVMFunctions->preparePinnedVirtualThreadForUnmount(currentThread, (j9object_t)currentThread->floatTemp2, false);
+		if (monstatus > J9_OBJECT_MONITOR_BLOCKING) {
+			/* Monitor has been acquired. */
+			addr = restoreJITResolveFrame(currentThread, oldPC, forMethod, false);
+			goto done;
+		}
 	}
 #endif /* JAVA_SPEC_VERSION >= 24 */
 	if (monstatus < J9_OBJECT_MONITOR_BLOCKING) {

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -4734,7 +4734,8 @@ preparePinnedVirtualThreadForMount(J9VMThread *currentThread, j9object_t continu
  * @param syncObj object to block/wait on
  * @param isObjectWait if the call is from Object.wait()
  *
- * @return J9_OBJECT_MONITOR_YIELD_VIRTUAL if the can be successfully yielded;
+ * @return syncObj if isObjectWait is false and monitor can be acquired;
+ * J9_OBJECT_MONITOR_YIELD_VIRTUAL if the virtual thread can be successfully yielded;
  * otherwise, an error code is returned
  */
 UDATA


### PR DESCRIPTION
Remove use of objectMonitorInflate on lock that current thread doesn't own.
Change to use of FLC bit to signal owner thread to inflate the monitor
when it exits the monitor.

Use CAS operation to ensure only one thread can update the lockword flag bits
to contended flatlock and ignore current lock learning state.

Lock reservation is cancelled before inflation/FLC bit set.