### PR TITLE
Fix JFR data not being flushed during VM shutdown

### DIFF
--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -186,7 +186,7 @@ writeOutGlobalBuffer(J9VMThread *currentThread, bool finalWrite, bool dumpCalled
 	j9tty_printf(PORTLIB, "\n!!! writing global buffer %p of size %p\n", currentThread, vm->jfrBuffer.bufferSize - vm->jfrBuffer.bufferRemaining);
 #endif /* defined(DEBUG) */
 
-	if (areJFRBuffersReadyForWrite(currentThread)) {
+	if (vm->jfrState.isStarted && (NULL != vm->jfrBuffer.bufferCurrent)) {
 		VM_JFRWriter::flushJFRDataToFile(currentThread, finalWrite, dumpCalled);
 
 		/* Reset the buffer */
@@ -209,7 +209,7 @@ writeOutGlobalBuffer(J9VMThread *currentThread, bool finalWrite, bool dumpCalled
  * paused (e.g. by exclusive VM access).
  *
  * @param currentThread[in] the current J9VMThread
- * @param flushThread[in] the J9VMThread to fluah
+ * @param flushThread[in] the J9VMThread to flush
  *
  * @returns true on success, false on failure
  */
@@ -477,7 +477,7 @@ jfrVMShutdown(J9HookInterface **hook, UDATA eventNum, void *eventData, void *use
 
 	/* Flush and free all the thread buffers and write out the global buffer */
 	flushAllThreadBuffers(currentThread, true);
-	writeOutGlobalBuffer(currentThread, true, false);
+	writeOutGlobalBuffer(currentThread, true, true);
 
 	if (acquiredExclusive) {
 		releaseExclusiveVMAccess(currentThread);


### PR DESCRIPTION
areJFRBuffersReadyForWrite checks the thread local JFR buffer which has
already been free'd during shutdown, so that is replaced by the other
two checks directly.