### PR TITLE
Prevent callers of big callees getting marked as big during ECS

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1799,8 +1799,13 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                         }
                      }
 
-
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
                   int32_t bigCalleesSizeBelowMe = _bigCalleesSize - origBigCalleesSize;
+#else
+                  // Temporarily disable bigCalleeSize adjustment for OpenJ9 MethodHandle implementation as it exposes a functional issue
+                  // with the change in inlining behaviour resulting from this big callee adjustment.
+                  int32_t bigCalleesSizeBelowMe = 0;
+#endif /* J9VM_OPT_OPENJDK_METHODHANDLE */
                   if ((_analyzedSize - origAnalyzedSize - bigCalleesSizeBelowMe) > bigCalleeThreshold)
                      {
                      ///printf("set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo._byteCodeIndex);fflush(stdout);

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1754,6 +1754,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
 
                int32_t origAnalyzedSize = _analyzedSize;
                int32_t origRealSize = _realSize;
+               int32_t origBigCalleesSize = _bigCalleesSize;
                bool prevNonColdCalls = _hasNonColdCalls;
                bool estimateSuccess = estimateCodeSize(targetCallee, &callStack); //recurseDown = true
                bool calltargetSetTooBig = false;
@@ -1799,10 +1800,12 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                      }
 
 
-                  if (_analyzedSize - origAnalyzedSize > bigCalleeThreshold)
+                  int32_t bigCalleesSizeBelowMe = _bigCalleesSize - origBigCalleesSize;
+                  if ((_analyzedSize - origAnalyzedSize - bigCalleesSizeBelowMe) > bigCalleeThreshold)
                      {
                      ///printf("set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo._byteCodeIndex);fflush(stdout);
                      calltarget->_calleeMethod->setWarmCallGraphTooBig( newBCInfo.getByteCodeIndex(), comp());
+                     _bigCalleesSize = _bigCalleesSize + _analyzedSize - origAnalyzedSize - bigCalleesSizeBelowMe;
                      heuristicTrace(tracer(), "set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo.getByteCodeIndex());
                      //_analyzedSize = origAnalyzedSize;
                      //_realSize = origRealSize;

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
@@ -43,7 +43,7 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
    {
    public:
 
-      TR_J9EstimateCodeSize() : TR_EstimateCodeSize(), _analyzedSize(0), _lastCallBlockFrequency(-1) { }
+      TR_J9EstimateCodeSize() : TR_EstimateCodeSize(), _analyzedSize(0), _bigCalleesSize(0), _lastCallBlockFrequency(-1) { }
 
       int32_t getOptimisticSize()       { return _analyzedSize; }
 
@@ -165,6 +165,7 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
 
       int32_t _lastCallBlockFrequency;
       int32_t _analyzedSize;          // size if we assume we are doing a partial inline
+      int32_t _bigCalleesSize;
    };
 
 #define NUM_PREV_BC 5


### PR DESCRIPTION
This PR re-introduces changes in #21364, with a workaround in place to address a functional issue observed with OpenJ9 MethodHandle implementation exposed by the changes in inlining behaviour caused by making adjustments to account for callees marked as too big. Given that this change in ECS heuristics addresses sub-optimal inlining outcome in several workloads, this temporary workaround to deal with OpenJ9 MHs is justifiable until the root functional issue can be addressed or the switchover to using OpenJDK MethodHandle implementation is completed for JDK8 and 11.