### PR TITLE
Revert the change of error reporting by PR #20387

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2998,7 +2998,7 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 			/* systemClassLoader is already set during the restore run. */
 			if (!IS_RESTORE_RUN(vm)) {
 				if (NULL == (vm->systemClassLoader = allocateClassLoader(vm))) {
-					loadInfo->fatalErrorStr = "cannot allocate system classloader";
+					setErrorJ9dll(PORTLIB, loadInfo, "cannot allocate system classloader", FALSE);
 					goto _error;
 				}
 			}


### PR DESCRIPTION
Restore the change of error reporting

Restore to the standard function setErrorJ9dll() to complete error report(missed J9VMDllLoadInfo.loadFlags).