### PR TITLE
(0.51) Exclude a couple of tests on plinux jdk24+

### DIFF
--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -490,6 +490,13 @@
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_criu_nonPortableRestoreJDK20Up</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21443</comment>
+				<platform>ppc64le.*</platform>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -787,6 +787,13 @@
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_jvmtitests_Java21andUp</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21444</comment>
+				<platform>ppc64le.*</platform>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode110</variation>


### PR DESCRIPTION
cmdLineTester_criu_nonPortableRestoreJDK20Up
cmdLineTester_jvmtitests_Java21andUp

Issues
https://github.com/eclipse-openj9/openj9/issues/21443 https://github.com/eclipse-openj9/openj9/issues/21444

Cherry pick https://github.com/eclipse-openj9/openj9/pull/21467