### PR TITLE
JDK25 adds JVM_NeedsClassInitBarrierForCDS

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -477,6 +477,10 @@ if(JAVA_SPEC_VERSION LESS 25)
 		_JVM_IsArrayClass@8
 		_JVM_IsPrimitiveClass@8
 	)
+else()
+	jvm_add_exports(jvm
+		JVM_NeedsClassInitBarrierForCDS
+	)
 endif()
 
 if(J9VM_OPT_JITSERVER)

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -678,4 +678,13 @@ JVM_TakeVirtualThreadListToUnblock(JNIEnv *env, jclass ignored)
 }
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
+#if JAVA_SPEC_VERSION >= 25
+JNIEXPORT jboolean JNICALL
+JVM_NeedsClassInitBarrierForCDS(JNIEnv *env, jclass cls)
+{
+	Assert_SC_true(!"JVM_NeedsClassInitBarrierForCDS unimplemented");
+	return JNI_FALSE;
+}
+#endif /* JAVA_SPEC_VERSION >= 25 */
+
 } /* extern "C" */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -456,3 +456,5 @@ _IF([JAVA_SPEC_VERSION >= 24],
 	[_X(JVM_VirtualThreadPinnedEvent, JNICALL, false, void, JNIEnv* env, jclass clazz, jstring op)])
 _IF([JAVA_SPEC_VERSION >= 24],
 	[_X(JVM_TakeVirtualThreadListToUnblock, JNICALL, false, jobject, JNIEnv* env, jclass ignored)])
+_IF([JAVA_SPEC_VERSION >= 25],
+	[_X(JVM_NeedsClassInitBarrierForCDS, JNICALL, false, jboolean, JNIEnv *env, jclass clazz)])


### PR DESCRIPTION
JDK25 adds `JVM_NeedsClassInitBarrierForCDS`

No implementation is required for OpenJ9.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/971

Signed-off-by: Jason Feng <fengj@ca.ibm.com>