### PR TITLE
(0.51) Exclude Jep425Tests_testVirtualThread on plinux,aix for jdk24+

### DIFF
--- a/test/functional/Java21andUp/playlist.xml
+++ b/test/functional/Java21andUp/playlist.xml
@@ -23,6 +23,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <playlist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="../../TestConfig/playlist.xsd">
 	<test>
 		<testCaseName>Jep425Tests_testVirtualThread</testCaseName>
+		<disables>
+			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/21477</comment>
+				<platform>(.*aix.*|ppc64le.*)</platform>
+				<version>24+</version>
+			</disable>
+		</disables>
 		<variations>
 			<variation>--enable-preview -Xgcpolicy:optthruput</variation>
 			<variation>--enable-preview -Xgcpolicy:gencon</variation>


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/21477

Cherry pick https://github.com/eclipse-openj9/openj9/pull/21478