### PR TITLE
Remove unwanted type names found in superset.dat

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureReader.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -580,6 +581,20 @@ public final class StructureReader {
 				break;
 			default:
 				throw new IllegalArgumentException("Superset stream contains unknown line: " + line);
+			}
+		}
+	}
+
+	public void removeReservedTypeNames() {
+		for (Iterator<String> names = structures.keySet().iterator(); names.hasNext();) {
+			switch (names.next()) {
+			case "module":
+			case "record":
+			case "var":
+				names.remove();
+				break;
+			default:
+				break;
 			}
 		}
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
@@ -145,6 +145,8 @@ public class PointerGenerator {
 			return;
 		}
 
+		structureReader.removeReservedTypeNames();
+
 		String auxFieldInfo = opts.get("-a");
 
 		if (auxFieldInfo != null) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/StructureStubGenerator.java
@@ -96,6 +96,8 @@ public class StructureStubGenerator {
 			return;
 		}
 
+		structureReader.removeReservedTypeNames();
+
 		adjustForCompatibility();
 		adjustForOptionalFields();
 


### PR DESCRIPTION
On AIX, `/usr/include/sys/var.h` includes a declaration of `struct var`; without this change, that would lead to the generation of `var.java` containing `class var ...` which would not compile.