### PR TITLE
(0.51) CRIU: JIT should generate portable code by default

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -1534,7 +1534,7 @@ void J9::Options::preProcessMmf(J9JavaVM *vm, J9JITConfig *jitConfig)
 
    if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE)
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-       || vm->internalVMFunctions->isJVMInPortableRestoreMode(vmThread)
+       || vm->internalVMFunctions->isCheckpointAllowed(vm)
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
        )
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2141,7 +2141,7 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
     * is because, the restore run may not be on the same machine as the one that created
     * the snapshot; thus the JIT code must be portable.
     */
-   if (javaVM->internalVMFunctions->isJVMInPortableRestoreMode(curThread))
+   if (javaVM->internalVMFunctions->isCheckpointAllowed(javaVM))
       {
       TR::Compiler->target.cpu = TR::CPU::detectRelocatable(TR::Compiler->omrPortLib);
       if (!J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PORTABLE_SHARED_CACHE))


### PR DESCRIPTION
Port of #21394 for 0.51

Issue: #21371
