### PR TITLE
(0.51) Remove -Xdump option from cmdLineTester_imageReaderInitializationTest

### DIFF
--- a/test/functional/cmdLineTests/imageReaderInitializationTest/playlist.xml
+++ b/test/functional/cmdLineTests/imageReaderInitializationTest/playlist.xml
@@ -28,7 +28,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>NoOptions</variation>
 		</variations>
 		<command>
-			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
+			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
 			-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
 			-DRESJAR=$(Q)$(TEST_RESROOT)$(D)imageReaderInitializationTest.jar$(Q) \
 			-jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)imageReaderInitializationTest.xml$(Q) \


### PR DESCRIPTION
Afaik `-Xdump` by itself doesn't do anything.

Issue https://github.com/eclipse-openj9/openj9/issues/21471

Cherry pick https://github.com/eclipse-openj9/openj9/pull/21472