### PR TITLE
JDK25 removed jdk.internal.org.objectweb.asm package and classes

### DIFF
--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -31,9 +31,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<property name="REPORTDIR" value="${REPORTDIR}" />
 	<property name="JDK_VERSION" value="${JDK_VERSION}" />
 	<property name="EXTRADUMPOPT" value="" />
-	<condition property="ADDITIONALEXPORTS" value="" else="--add-exports=java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED">
-		<equals arg1="${JDK_VERSION}" arg2="8" />
-	</condition>
 	<property name="JVM_OPTIONS" value="" />
 	<property name="TESTNUM" value="" />
 	<property name="COREGEN" value="j9vm.test.corehelper.CoreGen" />
@@ -143,7 +140,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<java-wrapper fork="true" jvm="${JAVA_COMMAND}" classname="j9vm.test.ddrext.AutoRun"
 			timeout="1200000" failonerror="true">
 			<common-elements>
-				<jvmarg line="${ADDITIONALEXPORTS} ${StartOnFirstThread}" />
+				<jvmarg line="${StartOnFirstThread}" />
 				<arg value="${system.dump}" />
 				<arg value="${test.list}" />
 				<arg value="${TEST_RESROOT}/ddrplugin.jar" />

--- a/test/functional/Java14andUp/build.xml
+++ b/test/functional/Java14andUp/build.xml
@@ -56,7 +56,7 @@
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<src path="${TestUtilities}" />
-			<compilerarg line='--source ${JDK_VERSION} --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
+			<compilerarg line='--source ${JDK_VERSION}' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>
@@ -77,7 +77,7 @@
 		<javac srcdir="${src}" destdir="${build-noDebugInfo}" debug="false" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}"/>
 			<src path="${TestUtilities}" />
-			<compilerarg line='--source ${JDK_VERSION} --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED' />
+			<compilerarg line='--source ${JDK_VERSION}' />
 			<classpath>
 				<pathelement location="${LIB_DIR}/testng.jar"/>
 				<pathelement location="${LIB_DIR}/jcommander.jar"/>

--- a/test/functional/Java14andUp/playlist.xml
+++ b/test/functional/Java14andUp/playlist.xml
@@ -71,10 +71,10 @@
 	<test>
 		<testCaseName>JEP358NPEMessageTests</testCaseName>
 		<variations>
-			<variation>-XX:+ShowCodeDetailsInExceptionMessages --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</variation>
+			<variation>-XX:+ShowCodeDetailsInExceptionMessages</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DhasDebugInfo=true \
-            -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+            -cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
             org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames JEP358NPEMessageTests \
             -groups $(TEST_GROUP) \
             -excludegroups $(DEFAULT_EXCLUDE); \
@@ -97,10 +97,10 @@
 	<test>
 		<testCaseName>JEP358NPEMessageTests-noDebugInfo</testCaseName>
 		<variations>
-			<variation>-XX:+ShowCodeDetailsInExceptionMessages --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED</variation>
+			<variation>-XX:+ShowCodeDetailsInExceptionMessages</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) -DhasDebugInfo=false \
-            -cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest-noDebugInfo.jar$(Q) \
+            -cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest-noDebugInfo.jar$(Q) \
             org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames JEP358NPEMessageTests \
             -groups $(TEST_GROUP) \
             -excludegroups $(DEFAULT_EXCLUDE); \

--- a/test/functional/Java14andUp/src/org/openj9/test/jep358/NPEMessageTests.java
+++ b/test/functional/Java14andUp/src/org/openj9/test/jep358/NPEMessageTests.java
@@ -26,26 +26,26 @@ import org.testng.annotations.Test;
 
 import org.testng.Assert;
 
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.Label;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.Opcodes;
-import jdk.internal.org.objectweb.asm.Type;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 import static java.lang.invoke.MethodHandles.lookup;
 
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_SUPER;
-import static jdk.internal.org.objectweb.asm.Opcodes.ACONST_NULL;
-import static jdk.internal.org.objectweb.asm.Opcodes.ALOAD;
-import static jdk.internal.org.objectweb.asm.Opcodes.ASTORE;
-import static jdk.internal.org.objectweb.asm.Opcodes.GETFIELD;
-import static jdk.internal.org.objectweb.asm.Opcodes.GETSTATIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.ICONST_1;
-import static jdk.internal.org.objectweb.asm.Opcodes.INVOKESPECIAL;
-import static jdk.internal.org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
-import static jdk.internal.org.objectweb.asm.Opcodes.IRETURN;
-import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ACONST_NULL;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.GETFIELD;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.ICONST_1;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.IRETURN;
+import static org.objectweb.asm.Opcodes.RETURN;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/test/functional/JavaAgentTest/build.xml
+++ b/test/functional/JavaAgentTest/build.xml
@@ -71,18 +71,26 @@
 				</javac>
 			</then>
 			<else>
-				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.util=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.commons=ALL-UNNAMED"/>				
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_version}" />
-					<src path="${transformerListener}" />
-					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/asm-all.jar"/>
-					</classpath>
-				</javac>
+				<if>
+					<matches string="${JDK_VERSION}" pattern="^(1[1-9]|2[0-4])$$" />
+					<then>
+						<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.util=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.commons=ALL-UNNAMED"/>
+						<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+							<src path="${src}" />
+							<src path="${src_version}" />
+							<src path="${transformerListener}" />
+							<compilerarg line='${addExports}' />
+							<classpath>
+								<pathelement location="${LIB_DIR}/testng.jar" />
+								<pathelement location="${LIB_DIR}/jcommander.jar" />
+								<pathelement location="${LIB_DIR}/asm-all.jar"/>
+							</classpath>
+						</javac>
+					</then>
+					<else>
+						<!-- Java 25+ is disabled temporarily - https://github.com/eclipse-openj9/openj9/issues/21463 -->
+					</else>
+				</if>
 			</else>
 		</if>
 	</target>

--- a/test/functional/JavaAgentTest/playlist.xml
+++ b/test/functional/JavaAgentTest/playlist.xml
@@ -44,7 +44,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,24]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -73,7 +73,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,24]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -101,7 +101,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,24]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -132,7 +132,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,24]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -163,7 +163,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,24]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -199,7 +199,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,24]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>
@@ -234,7 +234,7 @@
 			<group>functional</group>
 		</groups>
 		<versions>
-			<version>11+</version>
+			<version>[11,24]</version>
 		</versions>
 		<impls>
 			<impl>openj9</impl>

--- a/test/functional/UnsafeTest/build.xml
+++ b/test/functional/UnsafeTest/build.xml
@@ -60,6 +60,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 					<src path="${transformerListener}" />
 					<classpath>
 						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar"/>
 					</classpath>
 				</javac>
 			</then>
@@ -83,11 +84,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 					<src path="${src_util}" />
 					<classpath>
 						<pathelement location="${LIB_DIR}/testng.jar" />
+						<pathelement location="${LIB_DIR}/asm.jar"/>
 					</classpath>
 					<compilerarg value="--add-exports" />
 					<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
-					<compilerarg value="--add-exports" />
-					<compilerarg value="java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED" />
 				</javac>
 			</else>
 		</if>

--- a/test/functional/UnsafeTest/playlist.xml
+++ b/test/functional/UnsafeTest/playlist.xml
@@ -59,8 +59,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</variations>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	$(JAVA_COMMAND) $(JVM_OPTIONS) \
-	--add-opens java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
-	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
+	--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+	-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)OpenJ9Unsafe.jar$(P).$(Q) \
 	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) \
 	-testnames UnsafeTests \
 	-groups $(TEST_GROUP) \

--- a/test/functional/UnsafeTest/src_90/org/openj9/test/unsafe/UnsafeTestBase.java
+++ b/test/functional/UnsafeTest/src_90/org/openj9/test/unsafe/UnsafeTestBase.java
@@ -31,11 +31,11 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.log4testng.Logger;
 
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.MethodVisitor;
 
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.RETURN;
 
 import jdk.internal.misc.Unsafe;
 

--- a/test/functional/cmdLineTests/J9security/build.xml
+++ b/test/functional/cmdLineTests/J9security/build.xml
@@ -51,19 +51,8 @@
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 	
-		<if>
-			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<property name="addExports" value="" />
-			</then>
-			<else>
-				<property name="addExports" value="--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED" />
-			</else>
-		</if>
-
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
-			<compilerarg line="${addExports}" />
 			<classpath>
 				<pathelement location="${LIB_DIR}/asm-all.jar" />
 			</classpath>

--- a/test/functional/cmdLineTests/J9security/j9SecurityTest.xml
+++ b/test/functional/cmdLineTests/J9security/j9SecurityTest.xml
@@ -28,14 +28,12 @@
 
 	<variable name="CLASSPATH" value="-cp $Q$$TESTJ9SECURITYJARPATH$$Q$j9security.jar" />
 	<variable name="CLASSPATH_JEP140" value="-cp $Q$$TESTJ9SECURITYJARPATH$$Q$j9JEP140Tests.jar" />
-	<variable name="CLASSPATH_JSR292" value="-cp $Q$$TESTJ9SECURITYJARPATH$$Q$TestJSR292Security.jar" />
+	<variable name="CLASSPATH_JSR292" value="-cp $Q$$ASMJARPATH$$TESTJ9SECURITYJARPATH$$Q$TestJSR292Security.jar" />
 	<variable name="BOOTCLASSPATH_CodeNotTrusted" value="-Xbootclasspath/a:$Q$$TESTJ9SECURITYJARPATH$$Q$CodeNotTrusted.jar" />
 	<variable name="BOOTCLASSPATH_CodeTrusted_JEP140" value="-Xbootclasspath/a:$Q$$TESTJ9SECURITYJARPATH$$Q$j9JEP140CodeTrusted.jar" />
 	<variable name="BOOTCLASSPATH_CodeTrusted_doPrivilegedWithCombiner" value="-Xbootclasspath/a:$Q$$TESTJ9SECURITYJARPATH$$Q$CodeTrusted.jar" />
 	<variable name="SECURITYMANAGER" value="-Djava.security.manager" />
 	<variable name="JSR292_PERMISSION_POLICY" value="-Djava.security.policy=$Q$$TESTJ9SECURITYJARPATH$$Q$jsr292.policy" />
-	<variable name="ADDEXPORTS_OPTION" value="$Q$$MODULE_ADDEXPORTS_OPTION$$Q$" />
-	<variable name="ADDEXPORTS_VALUE" value="$Q$$MODULE_ADDEXPORTS_VALUE$$Q$" />
 
 	<test id="testJ9Security">
 		<command>$EXE$ $CLASSPATH$ com.ibm.j9.security.TestImplies</command>
@@ -87,7 +85,7 @@
 	</test>
 
 	<test id="testJSR292Permissions">
-		<command>$EXE$ $SECURITYMANAGER$ $JSR292_PERMISSION_POLICY$ $ADDEXPORTS_OPTION$ $ADDEXPORTS_VALUE$ $BOOTCLASSPATH_CodeNotTrusted$ $CLASSPATH_JSR292$ com.ibm.j9.jsr292.indyn.TestJSR292</command>
+		<command>$EXE$ $SECURITYMANAGER$ $JSR292_PERMISSION_POLICY$ $BOOTCLASSPATH_CodeNotTrusted$ $CLASSPATH_JSR292$ com.ibm.j9.jsr292.indyn.TestJSR292</command>
 		<output type="success" caseSensitive="no" regex="no">AccessControlException</output>
 		<output type="failure" caseSensitive="no" regex="no">Expected exception wasn't thrown, the test failed!</output>
 		<output type="failure" caseSensitive="no" regex="no">ClassNotFoundException</output>

--- a/test/functional/cmdLineTests/J9security/jsr292.policy
+++ b/test/functional/cmdLineTests/J9security/jsr292.policy
@@ -22,5 +22,4 @@
 
 grant {
     permission java.lang.RuntimePermission "createClassLoader";
-    permission java.lang.RuntimePermission "accessClassInPackage.jdk.internal.org.objectweb.asm";
 };

--- a/test/functional/cmdLineTests/J9security/playlist.xml
+++ b/test/functional/cmdLineTests/J9security/playlist.xml
@@ -28,8 +28,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
-		-DMODULE_ADDEXPORTS_OPTION= -DMODULE_ADDEXPORTS_VALUE= \
-		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DASMJARPATH=$(Q)$(LIB_DIR)$(D)asm.jar$(P)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
 		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
 		-explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>
@@ -54,8 +53,7 @@
 			<variation>NoOptions</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xdump \
-		-DMODULE_ADDEXPORTS_OPTION=$(Q)--add-exports$(Q) -DMODULE_ADDEXPORTS_VALUE=$(Q)java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED$(Q) \
-		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DTESTJ9SECURITYJARPATH=$(Q)$(TEST_RESROOT)$(D)$(Q) -DASMJARPATH=$(Q)$(LIB_DIR)$(D)asm.jar$(P)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
 		-DEXE=$(SQ)$(JAVA_COMMAND) $(JAVA_SECURITY_MANAGER) $(JVM_OPTIONS) -Xdump$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)j9SecurityTest.xml$(Q) \
 		-explainExcludes -nonZeroExitWhenError; \
 		$(TEST_STATUS)</command>

--- a/test/functional/cmdLineTests/J9security/src/com/ibm/j9/jsr292/indyn/TestJSR292.java
+++ b/test/functional/cmdLineTests/J9security/src/com/ibm/j9/jsr292/indyn/TestJSR292.java
@@ -22,19 +22,19 @@
 
 package com.ibm.j9.jsr292.indyn;
 
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_STATIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_SUPER;
-import static jdk.internal.org.objectweb.asm.Opcodes.H_INVOKESTATIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
-import static jdk.internal.org.objectweb.asm.Opcodes.V1_7;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.H_INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_7;
 
 import java.lang.reflect.Method;
 
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.Handle;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.Type;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Type;
 
 public class TestJSR292 {
 

--- a/test/functional/cmdLineTests/lockWordAlignment/alignment.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/alignment.xml
@@ -61,13 +61,14 @@
  <echo value="#######################################################"/>
  <echo value=" "/>
 
- <test id="Check whether Object contains necessary private fields if any">
+ <!-- disable temporarily - https://github.com/eclipse-openj9/openj9/issues/21463 -->
+ <!-- test id="Check whether Object contains necessary private fields if any">
 	<command>$EXEP$ -p $JAVAPBOOTCLASSPATH$ java/lang/Object</command>
 	<return value="0" />
 	<output type="required" caseSensitive="yes" regex="yes">$PRIV_FIELD1$</output>
 	<output type="required" caseSensitive="yes" regex="yes">$PRIV_FIELD2$</output>
 	<output type="required" caseSensitive="yes" regex="yes">$PRIV_FIELD3$</output>
- </test>
+ </test -->
 
  <test id="Check Object is aligned">
 	<command>$EXE$ $TESTSBOOTCLASSPATH$ $OBJECTTESTSBOOTCLASSPATH$ main java.lang.Object</command>

--- a/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
+++ b/test/functional/cmdLineTests/lockWordAlignment/alignmentSettings.mk
@@ -21,10 +21,8 @@
 ##############################################################################
 
 ADD_EXPORTS_VM=
-ADD_EXPORTS_ASM=
 # ADD_EXPORTS needs to set for JDK9 and up
 # if JDK_VERSION is not 8
 ifeq ($(filter 8, $(JDK_VERSION)),)
  ADD_EXPORTS_VM=--add-exports=java.base/com.ibm.oti.vm=ALL-UNNAMED
- ADD_EXPORTS_ASM=--add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED
 endif

--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -54,13 +54,19 @@
 			<then>
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
+					<classpath>
+						<pathelement location="${LIB_DIR}/asm.jar"/>
+					</classpath>
 				</javac>
 			</then>
 			<else>
-				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED" />
+				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED" />
 				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 					<src path="${src}" />
 					<compilerarg line='${addExports}' />
+					<classpath>
+						<pathelement location="${LIB_DIR}/asm.jar"/>
+					</classpath>
 				</javac>
 			</else>
 		</if>
@@ -73,7 +79,7 @@
 				<property name="addExports" value="" />
 			</then>
 			<else>
-				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED" />
+				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED" />
 			</else>
 		</if>			
 		<property name="build.javaexecutable" value="${TEST_JDK_HOME}/bin/java"/>
@@ -81,6 +87,7 @@
 			<jvmarg line='${addExports}' />
 			<classpath>
 				<pathelement path="${build}"/>
+				<pathelement location="${LIB_DIR}/asm.jar"/>
 			</classpath>
 		</java>
 	</target>

--- a/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/playlist.xml
@@ -52,7 +52,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) i; \
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) i; \
 		$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=i -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
@@ -77,7 +77,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) ii; \
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) ii; \
 		$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=ii -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
@@ -102,7 +102,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) iii; \
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) iii; \
 		$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=iii -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \
@@ -127,7 +127,7 @@
 		<variations>
 			<variation>NoOptions</variation>
 		</variations>
-		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) $(ADD_EXPORTS_ASM) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) d; \
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -cp $(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) CreateTestObjectJar $(Q)$(TEST_RESROOT)$(D)$(Q) d; \
 		$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -DJVM_TEST_ROOT=$(JVM_TEST_ROOT) -DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) $(ADD_EXPORTS_VM)$(SQ) \
 		-DEXEP=$(SQ)$(TEST_JDK_HOME)$(D)bin$(D)javap$(SQ) -DOLWMODE=d -DJDK_VERSION=$(JDK_VERSION) \
 		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)alignment.jar$(Q) \

--- a/test/functional/cmdLineTests/lockWordAlignment/src/CreateTestObjectJar.java
+++ b/test/functional/cmdLineTests/lockWordAlignment/src/CreateTestObjectJar.java
@@ -23,16 +23,16 @@
 import java.lang.IllegalArgumentException;
 import java.io.File;
 
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
 
 import java.io.FileOutputStream;
 import java.io.ByteArrayInputStream;
 import java.util.zip.ZipOutputStream;
 import java.util.zip.ZipEntry;
 
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.FieldVisitor;
-import jdk.internal.org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.ClassReader;
 
 public class CreateTestObjectJar {
 

--- a/test/functional/cmdLineTests/lockWordAlignment/src/IntLongObjectAlignmentTestGenerator.java
+++ b/test/functional/cmdLineTests/lockWordAlignment/src/IntLongObjectAlignmentTestGenerator.java
@@ -20,35 +20,35 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
 
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PRIVATE;
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_PUBLIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_STATIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.ACC_SUPER;
-import static jdk.internal.org.objectweb.asm.Opcodes.ALOAD;
-import static jdk.internal.org.objectweb.asm.Opcodes.ASTORE;
-import static jdk.internal.org.objectweb.asm.Opcodes.GETSTATIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.IFEQ;
-import static jdk.internal.org.objectweb.asm.Opcodes.INVOKESPECIAL;
-import static jdk.internal.org.objectweb.asm.Opcodes.INVOKESTATIC;
-import static jdk.internal.org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
-import static jdk.internal.org.objectweb.asm.Opcodes.LCMP;
-import static jdk.internal.org.objectweb.asm.Opcodes.LCONST_0;
-import static jdk.internal.org.objectweb.asm.Opcodes.LLOAD;
-import static jdk.internal.org.objectweb.asm.Opcodes.LREM;
-import static jdk.internal.org.objectweb.asm.Opcodes.LSTORE;
-import static jdk.internal.org.objectweb.asm.Opcodes.RETURN;
-import static jdk.internal.org.objectweb.asm.Opcodes.V1_7;
+import static org.objectweb.asm.Opcodes.ACC_PRIVATE;
+import static org.objectweb.asm.Opcodes.ACC_PUBLIC;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SUPER;
+import static org.objectweb.asm.Opcodes.ALOAD;
+import static org.objectweb.asm.Opcodes.ASTORE;
+import static org.objectweb.asm.Opcodes.GETSTATIC;
+import static org.objectweb.asm.Opcodes.IFEQ;
+import static org.objectweb.asm.Opcodes.INVOKESPECIAL;
+import static org.objectweb.asm.Opcodes.INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
+import static org.objectweb.asm.Opcodes.LCMP;
+import static org.objectweb.asm.Opcodes.LCONST_0;
+import static org.objectweb.asm.Opcodes.LLOAD;
+import static org.objectweb.asm.Opcodes.LREM;
+import static org.objectweb.asm.Opcodes.LSTORE;
+import static org.objectweb.asm.Opcodes.RETURN;
+import static org.objectweb.asm.Opcodes.V1_7;
 
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
 
-import jdk.internal.org.objectweb.asm.ClassWriter;
-import jdk.internal.org.objectweb.asm.FieldVisitor;
-import jdk.internal.org.objectweb.asm.Label;
-import jdk.internal.org.objectweb.asm.MethodVisitor;
-import jdk.internal.org.objectweb.asm.Opcodes;
-import jdk.internal.org.objectweb.asm.Type;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
 
 public class IntLongObjectAlignmentTestGenerator {
 


### PR DESCRIPTION
JDK25 removed `jdk.internal.org.objectweb.asm` package and classes

Modified the tests to use `asm` jar and its `org.objectweb.asm.*` classes to accommodate all Java levels;
Disabled `JavaAgentTest` for JDK25+ temporarily;
Disabled `lockWordAlignment` `Check whether Object contains necessary private fields if any` temporarily.

Related to
* https://github.com/eclipse-openj9/openj9/issues/21463

Signed-off-by: Jason Feng <fengj@ca.ibm.com>