### PR TITLE
(0.51) Reorder is-present and should-be-adjacent checks in alloc path

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.cpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.cpp
@@ -161,22 +161,19 @@ MM_IndexableObjectAllocationModel::initializeIndexableObject(MM_EnvironmentBase 
 #endif /* defined(J9VM_ENV_DATA64) */
 		} else {
 			indexableObjectModel->setSizeInElementsForContiguous(spine, _numberOfIndexedFields);
-			shouldDataBeAdjacentToHeader = indexableObjectModel->shouldDataBeAdjacentToHeader(spine);
-			if (shouldDataBeAdjacentToHeader) {
 #if defined(J9VM_ENV_DATA64)
-				if (((J9JavaVM *)env->getLanguageVM())->isIndexableDataAddrPresent) {
+			if (((J9JavaVM *)env->getLanguageVM())->isIndexableDataAddrPresent) {
+				shouldDataBeAdjacentToHeader = indexableObjectModel->shouldDataBeAdjacentToHeader(spine);
+				if (shouldDataBeAdjacentToHeader) {
 					indexableObjectModel->setDataAddrForContiguous(spine);
+				} else {
+					/* Set NULL temporarily to avoid possible complication with GC occurring while the object is partially initialized. */
+					indexableObjectModel->setDataAddrForContiguous(spine, NULL);
 				}
-#endif /* defined(J9VM_ENV_DATA64) */
-			} else if (isVirtualLargeObjectHeapEnabled) {
-#if defined(J9VM_ENV_DATA64)
-				/* Set NULL temporarily to avoid possible complication with GC occurring while the object is partially initialized? */
-				indexableObjectModel->setDataAddrForContiguous(spine, NULL);
-#endif /* defined(J9VM_ENV_DATA64) */
 			}
+#endif /* defined(J9VM_ENV_DATA64) */
 		}
 	}
-
 
 	/* Lay out arraylet and arrayoid pointers */
 	switch (_layout) {


### PR DESCRIPTION
During slow path allocation, when we initialize dataAddr field for adjacent data case, we now check if dataAddr is present first, before checking if data should be adjacent.

Previously, we would check adjacency first, which could read bogus value. Relatively benign, since we would still correctly skip initializing dataAddr, because it's not present.

But in abnormal cases with say class slot corruption, we could end up crashing prematurely in adjacency check even if dataAddr is not present (what would be confusing), rather then asserting later that class slot is corrupted.

Cherry pick https://github.com/eclipse-openj9/openj9/pull/21493