### PR TITLE
JDK25 added jdk.jfr.internal.JVM.isProduct()Z

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_jdk21andUp.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_jdk21andUp.cpp
@@ -87,4 +87,13 @@ Java_jdk_jfr_internal_JVM_hostTotalMemory(JNIEnv *env, jobject obj)
 	return 0;
 }
 
+#if JAVA_SPEC_VERSION >= 25
+jboolean JNICALL
+Java_jdk_jfr_internal_JVM_isProduct(JNIEnv *env, jclass jlClass)
+{
+	// TODO: implementation
+	return JNI_FALSE;
+}
+#endif /* JAVA_SPEC_VERSION >= 25 */
+
 } /* extern "C" */

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -701,47 +701,54 @@ if(J9VM_OPT_JFR)
 		Java_com_ibm_oti_vm_VM_stopJFR
 		Java_com_ibm_oti_vm_VM_triggerExecutionSample
 	)
+
 	if(JAVA_SPEC_VERSION EQUAL 11)
+		# Java 11 only
 		omr_add_exports(jclse
-			Java_jdk_jfr_internal_JVM_abort
-			Java_jdk_jfr_internal_JVM_addStringConstant
-			Java_jdk_jfr_internal_JVM_beginRecording
-			Java_jdk_jfr_internal_JVM_counterTime
-			Java_jdk_jfr_internal_JVM_createJFR
-			Java_jdk_jfr_internal_JVM_destroyJFR
-			Java_jdk_jfr_internal_JVM_emitEvent
-			Java_jdk_jfr_internal_JVM_emitOldObjectSamples
-			Java_jdk_jfr_internal_JVM_endRecording
 			Java_jdk_jfr_internal_JVM_flush
-			Java_jdk_jfr_internal_JVM_getAllEventClasses
-			Java_jdk_jfr_internal_JVM_getAllowedToDoEventRetransforms
-			Java_jdk_jfr_internal_JVM_getClassId
 			Java_jdk_jfr_internal_JVM_getClassIdNonIntrinsic
-			Java_jdk_jfr_internal_JVM_getEventWriter
-			Java_jdk_jfr_internal_JVM_getPid
-			Java_jdk_jfr_internal_JVM_getStackTraceId
-			Java_jdk_jfr_internal_JVM_getThreadId
-			Java_jdk_jfr_internal_JVM_getTicksFrequency
-			Java_jdk_jfr_internal_JVM_getTimeConversionFactor
 			Java_jdk_jfr_internal_JVM_getTypeId
-			Java_jdk_jfr_internal_JVM_getUnloadedEventClassCount
-			Java_jdk_jfr_internal_JVM_isAvailable
-			Java_jdk_jfr_internal_JVM_log
-			Java_jdk_jfr_internal_JVM_newEventWriter
-			Java_jdk_jfr_internal_JVM_registerNatives
-			Java_jdk_jfr_internal_JVM_retransformClasses
-			Java_jdk_jfr_internal_JVM_setCompressedIntegers
-			Java_jdk_jfr_internal_JVM_setCutoff
-			Java_jdk_jfr_internal_JVM_setEnabled
-			Java_jdk_jfr_internal_JVM_setFileNotification
-			Java_jdk_jfr_internal_JVM_setForceInstrumentation
-			Java_jdk_jfr_internal_JVM_setGlobalBufferCount
-			Java_jdk_jfr_internal_JVM_setGlobalBufferSize
-			Java_jdk_jfr_internal_JVM_setMemorySize
 			Java_jdk_jfr_internal_JVM_setMethodSamplingInterval
+			Java_jdk_jfr_internal_JVM_setSampleThreads
+		)
+	endif()
+	if(NOT JAVA_SPEC_VERSION LESS 11)
+		# Java 11+
+		omr_add_exports(jclse
+			Java_jdk_jfr_internal_JVM_abort
+			Java_jdk_jfr_internal_JVM_addStringConstant
+			Java_jdk_jfr_internal_JVM_beginRecording
+			Java_jdk_jfr_internal_JVM_counterTime
+			Java_jdk_jfr_internal_JVM_createJFR
+			Java_jdk_jfr_internal_JVM_destroyJFR
+			Java_jdk_jfr_internal_JVM_emitEvent
+			Java_jdk_jfr_internal_JVM_emitOldObjectSamples
+			Java_jdk_jfr_internal_JVM_endRecording
+			Java_jdk_jfr_internal_JVM_getAllEventClasses
+			Java_jdk_jfr_internal_JVM_getAllowedToDoEventRetransforms
+			Java_jdk_jfr_internal_JVM_getClassId
+			Java_jdk_jfr_internal_JVM_getEventWriter
+			Java_jdk_jfr_internal_JVM_getPid
+			Java_jdk_jfr_internal_JVM_getStackTraceId
+			Java_jdk_jfr_internal_JVM_getThreadId
+			Java_jdk_jfr_internal_JVM_getTicksFrequency
+			Java_jdk_jfr_internal_JVM_getTimeConversionFactor
+			Java_jdk_jfr_internal_JVM_getUnloadedEventClassCount
+			Java_jdk_jfr_internal_JVM_isAvailable
+			Java_jdk_jfr_internal_JVM_log
+			Java_jdk_jfr_internal_JVM_newEventWriter
+			Java_jdk_jfr_internal_JVM_registerNatives
+			Java_jdk_jfr_internal_JVM_retransformClasses
+			Java_jdk_jfr_internal_JVM_setCompressedIntegers
+			Java_jdk_jfr_internal_JVM_setCutoff
+			Java_jdk_jfr_internal_JVM_setEnabled
+			Java_jdk_jfr_internal_JVM_setFileNotification
+			Java_jdk_jfr_internal_JVM_setForceInstrumentation
+			Java_jdk_jfr_internal_JVM_setGlobalBufferCount
+			Java_jdk_jfr_internal_JVM_setGlobalBufferSize
+			Java_jdk_jfr_internal_JVM_setMemorySize
 			Java_jdk_jfr_internal_JVM_setOutput
 			Java_jdk_jfr_internal_JVM_setRepositoryLocation
-			Java_jdk_jfr_internal_JVM_setSampleThreads
 			Java_jdk_jfr_internal_JVM_setStackDepth
 			Java_jdk_jfr_internal_JVM_setStackTraceEnabled
 			Java_jdk_jfr_internal_JVM_setThreadBufferSize
@@ -751,208 +758,68 @@ if(J9VM_OPT_JFR)
 			Java_jdk_jfr_internal_JVM_subscribeLogLevel
 			Java_jdk_jfr_internal_JVM_uncaughtException
 		)
-	elseif(JAVA_SPEC_VERSION EQUAL 17)
+	endif()
+
+	if(JAVA_SPEC_VERSION EQUAL 17)
+		# Java 17 only
 		omr_add_exports(jclse
-			Java_jdk_jfr_internal_JVM_abort
-			Java_jdk_jfr_internal_JVM_addStringConstant
-			Java_jdk_jfr_internal_JVM_beginRecording
-			Java_jdk_jfr_internal_JVM_counterTime
-			Java_jdk_jfr_internal_JVM_createJFR
-			Java_jdk_jfr_internal_JVM_destroyJFR
-			Java_jdk_jfr_internal_JVM_emitDataLoss
-			Java_jdk_jfr_internal_JVM_emitEvent
-			Java_jdk_jfr_internal_JVM_emitOldObjectSamples
-			Java_jdk_jfr_internal_JVM_endRecording
-			Java_jdk_jfr_internal_JVM_exclude
-			Java_jdk_jfr_internal_JVM_flush__
 			Java_jdk_jfr_internal_JVM_flush__Ljdk_jfr_internal_EventWriter_2II
-			Java_jdk_jfr_internal_JVM_getAllEventClasses
-			Java_jdk_jfr_internal_JVM_getAllowedToDoEventRetransforms
-			Java_jdk_jfr_internal_JVM_getChunkStartNanos
-			Java_jdk_jfr_internal_JVM_getClassId
-			Java_jdk_jfr_internal_JVM_getEventWriter
 			Java_jdk_jfr_internal_JVM_getHandler
-			Java_jdk_jfr_internal_JVM_getPid
-			Java_jdk_jfr_internal_JVM_getStackTraceId
-			Java_jdk_jfr_internal_JVM_getThreadId
-			Java_jdk_jfr_internal_JVM_getTicksFrequency
-			Java_jdk_jfr_internal_JVM_getTimeConversionFactor
-			Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_Class_2
-			Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_String_2
-			Java_jdk_jfr_internal_JVM_getUnloadedEventClassCount
-			Java_jdk_jfr_internal_JVM_include
-			Java_jdk_jfr_internal_JVM_isAvailable
 			Java_jdk_jfr_internal_JVM_isExcluded
-			Java_jdk_jfr_internal_JVM_isRecording
-			Java_jdk_jfr_internal_JVM_log
-			Java_jdk_jfr_internal_JVM_logEvent
-			Java_jdk_jfr_internal_JVM_markChunkFinal
-			Java_jdk_jfr_internal_JVM_newEventWriter
-			Java_jdk_jfr_internal_JVM_registerNatives
-			Java_jdk_jfr_internal_JVM_retransformClasses
-			Java_jdk_jfr_internal_JVM_setCompressedIntegers
-			Java_jdk_jfr_internal_JVM_setCutoff
-			Java_jdk_jfr_internal_JVM_setEnabled
-			Java_jdk_jfr_internal_JVM_setFileNotification
-			Java_jdk_jfr_internal_JVM_setForceInstrumentation
-			Java_jdk_jfr_internal_JVM_setGlobalBufferCount
-			Java_jdk_jfr_internal_JVM_setGlobalBufferSize
 			Java_jdk_jfr_internal_JVM_setHandler
-			Java_jdk_jfr_internal_JVM_setMemorySize
-			Java_jdk_jfr_internal_JVM_setMethodSamplingPeriod
-			Java_jdk_jfr_internal_JVM_setOutput
-			Java_jdk_jfr_internal_JVM_setRepositoryLocation
 			Java_jdk_jfr_internal_JVM_setSampleThreads
-			Java_jdk_jfr_internal_JVM_setStackDepth
-			Java_jdk_jfr_internal_JVM_setStackTraceEnabled
-			Java_jdk_jfr_internal_JVM_setThreadBufferSize
-			Java_jdk_jfr_internal_JVM_setThreshold
-			Java_jdk_jfr_internal_JVM_setThrottle
-			Java_jdk_jfr_internal_JVM_shouldRotateDisk
-			Java_jdk_jfr_internal_JVM_storeMetadataDescriptor
-			Java_jdk_jfr_internal_JVM_subscribeLogLevel
-			Java_jdk_jfr_internal_JVM_uncaughtException
 		)
-	elseif(JAVA_SPEC_VERSION EQUAL 21)
+	endif()
+	if(NOT JAVA_SPEC_VERSION LESS 17)
+		# Java 17+
 		omr_add_exports(jclse
-			Java_jdk_jfr_internal_JVM_abort
-			Java_jdk_jfr_internal_JVM_addStringConstant
-			Java_jdk_jfr_internal_JVM_beginRecording
-			Java_jdk_jfr_internal_JVM_commit
-			Java_jdk_jfr_internal_JVM_counterTime
-			Java_jdk_jfr_internal_JVM_createJFR
-			Java_jdk_jfr_internal_JVM_destroyJFR
 			Java_jdk_jfr_internal_JVM_emitDataLoss
-			Java_jdk_jfr_internal_JVM_emitEvent
-			Java_jdk_jfr_internal_JVM_emitOldObjectSamples
-			Java_jdk_jfr_internal_JVM_endRecording
 			Java_jdk_jfr_internal_JVM_exclude
 			Java_jdk_jfr_internal_JVM_flush__
-			Java_jdk_jfr_internal_JVM_flush__Ljdk_jfr_internal_event_EventWriter_2II
-			Java_jdk_jfr_internal_JVM_getAllEventClasses
-			Java_jdk_jfr_internal_JVM_getAllowedToDoEventRetransforms
 			Java_jdk_jfr_internal_JVM_getChunkStartNanos
-			Java_jdk_jfr_internal_JVM_getClassId
-			Java_jdk_jfr_internal_JVM_getConfiguration
-			Java_jdk_jfr_internal_JVM_getDumpPath
-			Java_jdk_jfr_internal_JVM_getEventWriter
-			Java_jdk_jfr_internal_JVM_getPid
-			Java_jdk_jfr_internal_JVM_getStackTraceId
-			Java_jdk_jfr_internal_JVM_getThreadId
-			Java_jdk_jfr_internal_JVM_getTicksFrequency
-			Java_jdk_jfr_internal_JVM_getTimeConversionFactor
 			Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_Class_2
 			Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_String_2
-			Java_jdk_jfr_internal_JVM_getUnloadedEventClassCount
-			Java_jdk_jfr_internal_JVM_hostTotalMemory
 			Java_jdk_jfr_internal_JVM_include
-			Java_jdk_jfr_internal_JVM_isAvailable
+			Java_jdk_jfr_internal_JVM_isRecording
+			Java_jdk_jfr_internal_JVM_logEvent
+			Java_jdk_jfr_internal_JVM_markChunkFinal
+			Java_jdk_jfr_internal_JVM_setMethodSamplingPeriod
+			Java_jdk_jfr_internal_JVM_setThrottle
+		)
+	endif()
+
+	if(NOT JAVA_SPEC_VERSION LESS 21)
+		# Java 21+
+		omr_add_exports(jclse
+			Java_jdk_jfr_internal_JVM_commit
+			Java_jdk_jfr_internal_JVM_flush__Ljdk_jfr_internal_event_EventWriter_2II
+			Java_jdk_jfr_internal_JVM_getConfiguration
+			Java_jdk_jfr_internal_JVM_getDumpPath
+			Java_jdk_jfr_internal_JVM_hostTotalMemory
 			Java_jdk_jfr_internal_JVM_isContainerized
 			Java_jdk_jfr_internal_JVM_isExcluded__Ljava_lang_Class_2
 			Java_jdk_jfr_internal_JVM_isExcluded__Ljava_lang_Thread_2
 			Java_jdk_jfr_internal_JVM_isInstrumented
-			Java_jdk_jfr_internal_JVM_isRecording
-			Java_jdk_jfr_internal_JVM_log
-			Java_jdk_jfr_internal_JVM_logEvent
-			Java_jdk_jfr_internal_JVM_markChunkFinal
-			Java_jdk_jfr_internal_JVM_newEventWriter
-			Java_jdk_jfr_internal_JVM_registerNatives
-			Java_jdk_jfr_internal_JVM_retransformClasses
-			Java_jdk_jfr_internal_JVM_setCompressedIntegers
 			Java_jdk_jfr_internal_JVM_setConfiguration
-			Java_jdk_jfr_internal_JVM_setCutoff
 			Java_jdk_jfr_internal_JVM_setDumpPath
-			Java_jdk_jfr_internal_JVM_setEnabled
-			Java_jdk_jfr_internal_JVM_setFileNotification
-			Java_jdk_jfr_internal_JVM_setForceInstrumentation
-			Java_jdk_jfr_internal_JVM_setGlobalBufferCount
-			Java_jdk_jfr_internal_JVM_setGlobalBufferSize
-			Java_jdk_jfr_internal_JVM_setMemorySize
-			Java_jdk_jfr_internal_JVM_setMethodSamplingPeriod
-			Java_jdk_jfr_internal_JVM_setOutput
-			Java_jdk_jfr_internal_JVM_setRepositoryLocation
-			Java_jdk_jfr_internal_JVM_setStackDepth
-			Java_jdk_jfr_internal_JVM_setStackTraceEnabled
-			Java_jdk_jfr_internal_JVM_setThreadBufferSize
-			Java_jdk_jfr_internal_JVM_setThreshold
-			Java_jdk_jfr_internal_JVM_setThrottle
-			Java_jdk_jfr_internal_JVM_shouldRotateDisk
-			Java_jdk_jfr_internal_JVM_storeMetadataDescriptor
-			Java_jdk_jfr_internal_JVM_subscribeLogLevel
-			Java_jdk_jfr_internal_JVM_uncaughtException
 		)
-	else()
+	endif()
+
+	if(NOT JAVA_SPEC_VERSION LESS 24)
+		# Java 24+
 		omr_add_exports(jclse
-			Java_jdk_jfr_internal_JVM_abort
-			Java_jdk_jfr_internal_JVM_addStringConstant
-			Java_jdk_jfr_internal_JVM_beginRecording
-			Java_jdk_jfr_internal_JVM_commit
-			Java_jdk_jfr_internal_JVM_counterTime
-			Java_jdk_jfr_internal_JVM_createJFR
-			Java_jdk_jfr_internal_JVM_destroyJFR
-			Java_jdk_jfr_internal_JVM_emitDataLoss
-			Java_jdk_jfr_internal_JVM_emitEvent
-			Java_jdk_jfr_internal_JVM_emitOldObjectSamples
-			Java_jdk_jfr_internal_JVM_endRecording
-			Java_jdk_jfr_internal_JVM_exclude
-			Java_jdk_jfr_internal_JVM_flush__
-			Java_jdk_jfr_internal_JVM_flush__Ljdk_jfr_internal_event_EventWriter_2II
-			Java_jdk_jfr_internal_JVM_getAllEventClasses
-			Java_jdk_jfr_internal_JVM_getAllowedToDoEventRetransforms
-			Java_jdk_jfr_internal_JVM_getChunkStartNanos
-			Java_jdk_jfr_internal_JVM_getClassId
-			Java_jdk_jfr_internal_JVM_getConfiguration
-			Java_jdk_jfr_internal_JVM_getDumpPath
-			Java_jdk_jfr_internal_JVM_getEventWriter
-			Java_jdk_jfr_internal_JVM_getPid
-			Java_jdk_jfr_internal_JVM_getStackTraceId
-			Java_jdk_jfr_internal_JVM_getThreadId
-			Java_jdk_jfr_internal_JVM_getTicksFrequency
-			Java_jdk_jfr_internal_JVM_getTimeConversionFactor
-			Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_Class_2
-			Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_String_2
-			Java_jdk_jfr_internal_JVM_getUnloadedEventClassCount
-			Java_jdk_jfr_internal_JVM_hostTotalMemory
 			Java_jdk_jfr_internal_JVM_hostTotalSwapMemory
-			Java_jdk_jfr_internal_JVM_include
-			Java_jdk_jfr_internal_JVM_isAvailable
-			Java_jdk_jfr_internal_JVM_isContainerized
-			Java_jdk_jfr_internal_JVM_isExcluded__Ljava_lang_Class_2
-			Java_jdk_jfr_internal_JVM_isExcluded__Ljava_lang_Thread_2
-			Java_jdk_jfr_internal_JVM_isInstrumented
-			Java_jdk_jfr_internal_JVM_isRecording
-			Java_jdk_jfr_internal_JVM_log
-			Java_jdk_jfr_internal_JVM_logEvent
-			Java_jdk_jfr_internal_JVM_markChunkFinal
 			Java_jdk_jfr_internal_JVM_nanosNow
-			Java_jdk_jfr_internal_JVM_newEventWriter
-			Java_jdk_jfr_internal_JVM_registerNatives
 			Java_jdk_jfr_internal_JVM_registerStackFilter
-			Java_jdk_jfr_internal_JVM_retransformClasses
-			Java_jdk_jfr_internal_JVM_setCompressedIntegers
-			Java_jdk_jfr_internal_JVM_setConfiguration
-			Java_jdk_jfr_internal_JVM_setCutoff
-			Java_jdk_jfr_internal_JVM_setDumpPath
-			Java_jdk_jfr_internal_JVM_setEnabled
-			Java_jdk_jfr_internal_JVM_setFileNotification
-			Java_jdk_jfr_internal_JVM_setForceInstrumentation
-			Java_jdk_jfr_internal_JVM_setGlobalBufferCount
-			Java_jdk_jfr_internal_JVM_setGlobalBufferSize
-			Java_jdk_jfr_internal_JVM_setMemorySize
-			Java_jdk_jfr_internal_JVM_setMethodSamplingPeriod
 			Java_jdk_jfr_internal_JVM_setMiscellaneous
-			Java_jdk_jfr_internal_JVM_setOutput
-			Java_jdk_jfr_internal_JVM_setRepositoryLocation
-			Java_jdk_jfr_internal_JVM_setStackDepth
-			Java_jdk_jfr_internal_JVM_setStackTraceEnabled
-			Java_jdk_jfr_internal_JVM_setThreadBufferSize
-			Java_jdk_jfr_internal_JVM_setThreshold
-			Java_jdk_jfr_internal_JVM_setThrottle
-			Java_jdk_jfr_internal_JVM_shouldRotateDisk
-			Java_jdk_jfr_internal_JVM_storeMetadataDescriptor
-			Java_jdk_jfr_internal_JVM_subscribeLogLevel
-			Java_jdk_jfr_internal_JVM_uncaughtException
 			Java_jdk_jfr_internal_JVM_unregisterStackFilter
+		)
+	endif()
+
+	if(NOT JAVA_SPEC_VERSION LESS 25)
+		# Java 25+
+		omr_add_exports(jclse
+			Java_jdk_jfr_internal_JVM_isProduct
 		)
 	endif()
 endif()


### PR DESCRIPTION
JDK25 added `jdk.jfr.internal.JVM.isProduct()Z`

Re-group the existing JFR exports.

closes https://github.com/eclipse-openj9/openj9/issues/21496

Signed-off-by: Jason Feng <fengj@ca.ibm.com>