### PR TITLE
Make some minor improvements to tryToInlineTrivialMethod()

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -3072,6 +3072,15 @@ bool TR_J9InlinerPolicy::tryToInlineTrivialMethod (TR_CallStack* callStack, TR_C
    }
 
 bool
+TR_J9InlinerPolicy::trivialInliningOnly(
+   TR_CallStack *callStack, TR_CallTarget *callTarget)
+   {
+   TR::Node *callNode = callTarget->_myCallSite->_callNode;
+   TR::ResolvedMethodSymbol *calleeSymbol = callTarget->_calleeSymbol;
+   return isInlineableJNI(calleeSymbol->getResolvedMethod(), callNode);
+   }
+
+bool
 TR_J9InlinerPolicy::adjustFanInSizeInExceedsSizeThreshold(int bytecodeSize,
                                                       uint32_t& calculatedSize,
                                                       TR_ResolvedMethod* callee,

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -194,6 +194,7 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
       TR_J9InlinerPolicy(TR::Compilation *comp);
       virtual bool inlineRecognizedMethod(TR::RecognizedMethod method);
       virtual bool tryToInlineTrivialMethod (TR_CallStack* callStack, TR_CallTarget* calltarget);
+      virtual bool trivialInliningOnly(TR_CallStack *callStack, TR_CallTarget *callTarget);
       bool isInlineableJNI(TR_ResolvedMethod *method,TR::Node *callNode);
       virtual bool alwaysWorthInlining(TR_ResolvedMethod * calleeMethod, TR::Node *callNode);
       bool adjustFanInSizeInExceedsSizeThreshold(int bytecodeSize,


### PR DESCRIPTION
- Return true only if the call is actually transformed.
- Skip `performTransformation()` for indirect calls.
- Trace if inlining fails after `performTransformation()`.

In a separate preparatory commit, `trivialInliningOnly()` is overridden to return true for targets satisfying `isInlineableJNI()`, which is required to allow `tryToInlineTrivialMethod()` to return false when it fails to transform calls to those targets.

This depends on eclipse-omr/omr#7702