### PR TITLE
(0.51) Pin virtual threads while they hold raw monitors

### DIFF
--- a/runtime/jvmti/jvmtiRawMonitor.c
+++ b/runtime/jvmti/jvmtiRawMonitor.c
@@ -135,7 +135,9 @@ block:
 				}
 			}
 #if JAVA_SPEC_VERSION >= 19
-			currentThread->ownedMonitorCount += 1;
+			if (UDATA_MAX != currentThread->continuationPinCount) {
+				currentThread->continuationPinCount += 1;
+			}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 		} else {
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
@@ -174,7 +176,9 @@ jvmtiRawMonitorExit(jvmtiEnv* env,
 			rc = JVMTI_ERROR_NOT_MONITOR_OWNER;
 #if JAVA_SPEC_VERSION >= 19
 		} else {
-			currentThread->ownedMonitorCount -= 1;
+			if (0 != currentThread->continuationPinCount) {
+				currentThread->continuationPinCount -= 1;
+			}
 #endif /* JAVA_SPEC_VERSION >= 19 */
 		}
 


### PR DESCRIPTION
Our current implementation uses `J9VMThread->ownedMonitorCount` to
track both object monitors and raw monitors owned by a virtual thread.

The RI pins a virtual thread while it holds a raw monitor. Our current
implementation allows a virtual thread to be unmounted and remounted
while holding a raw monitor. This causes `J9ThreadMonitor->owner` to
become invalid, as the virtual thread's `J9Thread` changes during the
unmount and remount phases.

Currently, there is no way to track which raw monitors a virtual
thread owns. This prevents us from fixing `J9ThreadMonitor->owner`
for raw monitors when a virtual thread is unmounted and remounted.

To match the RI, `continuationPinCount` will be used instead of
`ownedMonitorCount` to pin a virtual thread when it acquires a raw
monitor.

Fixes: #21409

Backport of https://github.com/eclipse-openj9/openj9/pull/21503