### PR TITLE
Improve definition of j9str_set_token()

### DIFF
--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -623,7 +623,7 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9str_printf(param1,param2,param3,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_printf(OMRPORT_FROM_J9PORT(privatePortLibrary), param1, param2, param3, ## __VA_ARGS__)
 #define j9str_vprintf(param1,param2,param3,param4) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_vprintf(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4)
 #define j9str_create_tokens(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_create_tokens(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
-#define j9str_set_token(param1,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_set_token(OMRPORT_FROM_J9PORT(param1), ## __VA_ARGS__)
+#define j9str_set_token(param1,param2,param3,...) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_set_token(OMRPORT_FROM_J9PORT(privatePortLibrary), param1, param2, param3, ## __VA_ARGS__)
 #define j9str_subst_tokens(param1,param2,param3,param4) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_subst_tokens(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2,param3,param4)
 #define j9str_free_tokens(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_free_tokens(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
 #define j9str_set_time_tokens(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->str_set_time_tokens(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -235,7 +235,7 @@ static const J9RASdumpSpec rasDumpSpecs[] =
 		  NULL,
 		  NULL,
 		  5,
-		  J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS, 
+		  J9RAS_DUMP_DO_EXCLUSIVE_VM_ACCESS,
 		  NULL }
 	},
 	{
@@ -277,7 +277,7 @@ static const J9RASdumpSpec rasDumpSpecs[] =
 		  NULL,
 #else
 		  "%uid.JVM.TDUMP.%job.D%y%m%d.T%H" "%M" "%S",
-		  NULL,		  
+		  NULL,
 #endif
 #else
 		  "core.%Y" "%m%d.%H" "%M" "%S.%pid.%seq.dmp",
@@ -445,7 +445,7 @@ static const J9RASdumpSpec rasDumpSpecs[] =
 		doJavaVMExit,
 		{ 0,
 		  NULL,
-		  1, 0, 
+		  1, 0,
 		  NULL,
 		  NULL,
 		  0,
@@ -469,21 +469,21 @@ static void
 updatePercentLastToken(J9JavaVM *vm, char *label)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	
+
 	struct J9StringTokens* stringTokens;
 
-	/* write the label into the %last token */ 
+	/* write the label into the %last token */
 	if (NULL != vm->j9rasdumpGlobalStorage) {
 		RasDumpGlobalStorage* dump_storage = (RasDumpGlobalStorage*)vm->j9rasdumpGlobalStorage;
 
-        /* lock access to the tokens */
-        omrthread_monitor_enter(dump_storage->dumpLabelTokensMutex);
-        stringTokens = dump_storage->dumpLabelTokens;
-        
-        j9str_set_token(PORTLIB, stringTokens, "last", "%s", label);
-        
-        /* release access to the tokens */
-        omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
+		/* lock access to the tokens */
+		omrthread_monitor_enter(dump_storage->dumpLabelTokensMutex);
+		stringTokens = dump_storage->dumpLabelTokens;
+
+		j9str_set_token(stringTokens, "last", "%s", label);
+
+		/* release access to the tokens */
+		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 	}
 }
 
@@ -696,7 +696,7 @@ doJavaVMExit(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 		j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_EXIT_SHUTDOWN_UNKNOWN);
 	}
 	vm->internalVMFunctions->exitJavaVM(vmThread, 3);
-	
+
 	return OMR_ERROR_NONE;
 }
 
@@ -726,7 +726,7 @@ doSystemDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 
 #if defined(J9VM_OPT_SHARED_CLASSES) && (defined(LINUX) || defined(OSX))
 	J9SharedClassJavacoreDataDescriptor sharedClassData;
-	
+
 	/* set up cacheDir with the Shared Classes Cache file if it is in use. */
 	if ((NULL != vm->sharedClassConfig) && (NULL != vm->sharedClassConfig->getJavacoreData)) {
 		if (1 == vm->sharedClassConfig->getJavacoreData(vm, &sharedClassData)) {
@@ -739,7 +739,7 @@ doSystemDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 #endif /* defined(J9VM_OPT_SHARED_CLASSES) && (defined(LINUX) || defined(OSX)) */
 
 	reportDumpRequest(privatePortLibrary,context,"System",label);
-	
+
 	if ( *label != '-' ) {
 		UDATA retVal;
 
@@ -795,7 +795,7 @@ doSystemDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 }
 /*
  * Function: doToolDump - launches a tool command as specified via a -Xdump:tool agent
- * 
+ *
  * Parameters:
  *  agent [in]	 - dump agent structure
  *  label [in]	 - tool command to be executed
@@ -832,11 +832,11 @@ doToolDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 			PROCESS_INFORMATION pinfo;
 			wchar_t localUnicodePath[J9_MAX_DUMP_PATH];
 			wchar_t *unicodePath = localUnicodePath;
-	
+
 			memset( &sinfo, 0, sizeof(sinfo) );
 			memset( &pinfo, 0, sizeof(pinfo) );
 			sinfo.cb = sizeof(sinfo);
-			
+
 			/* Copy the tool command line into a unicode string, allocating additional memory if needed */
 			if (strlen(label) >= J9_MAX_DUMP_PATH) {
 				unicodePath = j9mem_allocate_memory((strlen(label) + 1) * sizeof(wchar_t), OMRMEM_CATEGORY_VM);
@@ -845,25 +845,25 @@ doToolDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 				}
 			}
 			MultiByteToWideChar(OS_ENCODING_CODE_PAGE, OS_ENCODING_MB_FLAGS, label, -1, unicodePath, (int)strlen(label) + 1);
-	
+
 			retVal = CreateProcessW(NULL, unicodePath, NULL, NULL, TRUE, 0, NULL, NULL, &sinfo, &pinfo);
-	
+
 			if (retVal) {
 				j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_SPAWNED_DUMP_STR, "Tool", pinfo.dwProcessId);
-	
+
 				/* Give it a chance to start */
 				if (async == FALSE) {
 					WaitForSingleObject(pinfo.hProcess, INFINITE);
 				}
 				omrthread_sleep(msec);
-	
+
 				/* Clean up unused handles */
 				CloseHandle(pinfo.hThread);
 				CloseHandle(pinfo.hProcess);
 			} else {
 				j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_DMP_ERROR_IN_DUMP_STR_RC, "Tool", "CreateProcessW()", GetLastError());
 			}
-			
+
 			if (unicodePath != localUnicodePath) {
 				j9mem_free_memory(unicodePath);
 			}
@@ -873,15 +873,15 @@ doToolDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 			IDATA retVal;
 
 			if ( (retVal = fork()) == 0 ) {
-	
+
 				retVal = execl("/bin/sh", "/bin/sh", "-c", label, NULL);
-	
+
 				j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_DMP_ERROR_IN_DUMP_STR_RC, "Tool", "execl()", errno);
 				exit( (int)retVal );
-	
+
 			} else {
 				j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_SPAWNED_DUMP_STR, "Tool", retVal);
-	
+
 				/* Give it a chance to start */
 				if (async == FALSE) {
 					waitpid(retVal, NULL, 0);
@@ -894,21 +894,21 @@ doToolDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 			const char *argv[] = {"/bin/sh", "-c", NULL, NULL};
 			extern const char **environ;
 			IDATA retVal;
-	
+
 			struct inheritance inherit;
 			memset( &inherit, 0, sizeof(inherit) );
-	
+
 			/* Set actual command */
 			argv[2] = label;
-	
+
 			/* Use spawn instead of fork on z/OS */
 			retVal = spawnp("/bin/sh", 0, NULL, &inherit, argv, environ);
-	
+
 			if ( retVal == -1) {
 				j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_DMP_ERROR_IN_DUMP_STR_RC, "Tool", "spawnp()", errno);
 			} else {
 				j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_SPAWNED_DUMP_STR, "Tool", retVal);
-	
+
 				/* Give it a chance to start */
 				if (async == FALSE) {
 					waitpid(retVal, NULL, 0);
@@ -941,7 +941,7 @@ doJavaDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 			return OMR_ERROR_INTERNAL;
 		}
 	}
-	
+
 	runJavadump(label, context, agent);
 
 	return OMR_ERROR_NONE;
@@ -1048,7 +1048,7 @@ doCEEDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 
 /*
  * Function: doJitDump - runs a JIT dump
- * 
+ *
  * Parameters:
  *  agent [in]	 - dump agent structure
  *  label [in]	 - tool command to be executed
@@ -1062,7 +1062,7 @@ doJitDump(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 	J9JavaVM *vm = context->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	omr_error_t result = OMR_ERROR_NONE;
-	
+
 #ifdef J9VM_INTERP_NATIVE_SUPPORT
 	if (NULL != vm->jitConfig) {
 		if (makePath(vm, label) == OMR_ERROR_INTERNAL) {
@@ -1256,11 +1256,11 @@ void
 setAllocationThreshold(J9VMThread *vmThread, UDATA min, UDATA max)
 {
 	J9MemoryManagerFunctions *fns;
-	
+
 	if (vmThread == NULL) {
 		return;
 	}
-	
+
 	fns = vmThread->javaVM->memoryManagerFunctions;
 	if (fns) {
 		fns->j9gc_set_allocation_threshold(vmThread, min, max);
@@ -1272,28 +1272,28 @@ scanFilter(J9JavaVM *vm, const J9RASdumpSettings *settings, const char **cursor,
 {
 	UDATA eventMask = settings->eventMask;
 	char *filter = NULL;
-	
+
 	filter = scanString(vm, cursor);
-	
+
 	if (eventMask & J9RAS_DUMP_ON_OBJECT_ALLOCATION) {
 		RasDumpGlobalStorage *dumpGlobal = vm->j9rasdumpGlobalStorage;
 		UDATA min, max;
-		
+
 		if (!filter) {
 			/* Filter must be supplied for this event */
 			goto err;
 		}
-		
+
 		if (eventMask != J9RAS_DUMP_ON_OBJECT_ALLOCATION) {
 			/* Filter cannot be applied to more than one event type */
 			goto err;
 		}
-		
+
 		/* Parse the filter */
 		if (!parseAllocationRange(filter, &min, &max)) {
 			goto err;
 		}
-		
+
 		if (dumpGlobal->allocationRangeMin || dumpGlobal->allocationRangeMax) {
 			/* A range has already been set. Widen it if necessary */
 			if (min < dumpGlobal->allocationRangeMin) {
@@ -1551,11 +1551,11 @@ processSettings(J9JavaVM *vm, IDATA kind, char *optionString, J9RASdumpSettings 
 			settings->subFilter = scanSubFilter(vm, settings, (const char **)cursor, &action);
 		}
 	} while ( try_scan(cursor, ",") );
-	
+
 	if( action == REMOVE_DUMP_AGENTS ) {
 		if( settings->eventMask == 0 ) {
 			/* For removal, we want to mask out *all* events if none were specified.*/
-			settings->eventMask = ~0; 
+			settings->eventMask = ~0;
 		}
 	}
 
@@ -1563,11 +1563,11 @@ processSettings(J9JavaVM *vm, IDATA kind, char *optionString, J9RASdumpSettings 
 		j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_INVALID_OR_MISSING_FILTER);
 		action = BOGUS_DUMP_OPTION;
 	}
-	
+
 	if ( action != REMOVE_DUMP_AGENTS && (0 == (settings->eventMask & J9RAS_DUMP_EXCEPTION_EVENT_GROUP)) && (settings->subFilter != NULL)) {
-        j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_INCORRECT_USE_MSG_FILTER);
-        action = BOGUS_DUMP_OPTION;
-    }	
+		j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_INCORRECT_USE_MSG_FILTER);
+		action = BOGUS_DUMP_OPTION;
+	}
 
 	/* verify start..stop range (allow n..n-1 to indicate open-ended range) */
 	if ( settings->stopOnCount < settings->startOnCount ) {
@@ -1605,23 +1605,23 @@ findAgent(J9JavaVM *vm, IDATA kind, const J9RASdumpSettings *settings)
 		/* Event mask can always be merged UNLESS there is no overlap and agent has a limited range, otherwise */
 		/*   -Xdump:java:events=load,range=1..4  and  -Xdump:java:events=thrstart,range=1..4  would get merged */
 		if ( (agent->eventMask != settings->eventMask) &&
-		     (agent->startOnCount <= agent->stopOnCount) ) {
+			(agent->startOnCount <= agent->stopOnCount) ) {
 			continue;
 		}
 
 		/* Can't merge different detail filters */
-		if ( ((agent->detailFilter != NULL) && (settings->detailFilter == NULL)                                                              ) || 
-         ((agent->detailFilter == NULL) && (settings->detailFilter != NULL)                                                              ) || 
-		     ((agent->detailFilter != NULL) && (settings->detailFilter != NULL) && (strcmp(agent->detailFilter, settings->detailFilter) != 0))    ) {
+		if ( ((agent->detailFilter != NULL) && (settings->detailFilter == NULL)                                                              ) ||
+			((agent->detailFilter == NULL) && (settings->detailFilter != NULL)                                                              ) ||
+			((agent->detailFilter != NULL) && (settings->detailFilter != NULL) && (strcmp(agent->detailFilter, settings->detailFilter) != 0))    ) {
 			continue;
 		}
-		
+
 		/* Can't merge different sub filters */
 		if ( ((agent->subFilter != NULL) && (settings->subFilter == NULL)) ||
-		     ((agent->subFilter == NULL) && (settings->subFilter != NULL)) ||
-		     ((agent->subFilter != NULL) && (settings->subFilter != NULL) && (strcmp(agent->subFilter, settings->subFilter) != 0))) {
-		     	continue;
-		}		 
+			((agent->subFilter == NULL) && (settings->subFilter != NULL)) ||
+			((agent->subFilter != NULL) && (settings->subFilter != NULL) && (strcmp(agent->subFilter, settings->subFilter) != 0))) {
+			continue;
+		}
 
 		/* Can't merge different ranges */
 		if ( agent->startOnCount != settings->startOnCount ) {
@@ -1634,16 +1634,16 @@ findAgent(J9JavaVM *vm, IDATA kind, const J9RASdumpSettings *settings)
 		}
 
 		/* Can't merge different labels */
-		if ( ((agent->labelTemplate != NULL) && (settings->labelTemplate == NULL)                                                                ) || 
-         ((agent->labelTemplate == NULL) && (settings->labelTemplate != NULL)                                                                ) || 
-		     ((agent->labelTemplate != NULL) && (settings->labelTemplate != NULL) && (strcmp(agent->labelTemplate, settings->labelTemplate) != 0))    ) {
+		if ( ((agent->labelTemplate != NULL) && (settings->labelTemplate == NULL)                                                                ) ||
+			((agent->labelTemplate == NULL) && (settings->labelTemplate != NULL)                                                                ) ||
+			((agent->labelTemplate != NULL) && (settings->labelTemplate != NULL) && (strcmp(agent->labelTemplate, settings->labelTemplate) != 0))    ) {
 			continue;
 		}
 
 		/* Can't merge different dump options */
-		if ( ((agent->dumpOptions != NULL) && (settings->dumpOptions == NULL)                                                            ) || 
-         ((agent->dumpOptions == NULL) && (settings->dumpOptions != NULL)                                                            ) || 
-		     ((agent->dumpOptions != NULL) && (settings->dumpOptions != NULL) && (strcmp(agent->dumpOptions, settings->dumpOptions) != 0))    ) {
+		if ( ((agent->dumpOptions != NULL) && (settings->dumpOptions == NULL)                                                            ) ||
+			((agent->dumpOptions == NULL) && (settings->dumpOptions != NULL)                                                            ) ||
+			((agent->dumpOptions != NULL) && (settings->dumpOptions != NULL) && (strcmp(agent->dumpOptions, settings->dumpOptions) != 0))    ) {
 			continue;
 		}
 
@@ -1724,12 +1724,12 @@ findAgentToDelete(J9JavaVM *vm, IDATA kind, J9RASdumpAgent *agent, const J9RASdu
 		/* Check the ranges are set and match */
 		if ( settings->startOnCount != 0 && agent->stopOnCount != settings->stopOnCount ) {
 			continue;
-		} 
+		}
 
 		/* Check the priority is set and matches */
 		if ( settings->priority != 0 && agent->priority != settings->priority ) {
 			continue;
-		} 
+		}
 
 		/* Passed all tests, matched. */
 		matchingAgent = agent;
@@ -1795,8 +1795,8 @@ mergeAgent(J9JavaVM *vm, J9RASdumpAgent *agent, const J9RASdumpSettings *setting
 		agent->dumpOptions = settings->dumpOptions;
 	}
 	if (settings->subFilter) {
-        agent->subFilter = settings->subFilter;
-    }
+		agent->subFilter = settings->subFilter;
+	}
 
 	/* Merge request bitmask */
 	agent->requestMask |= settings->requestMask;
@@ -1920,7 +1920,7 @@ printDumpEvents(struct J9JavaVM *vm, UDATA bits, IDATA verbose)
 	UDATA i;
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	
+
 	if (verbose) {
 		/* Find the lengths of the longest dump event name and detail */
 		for (i = 0; i < J9RAS_DUMP_KNOWN_EVENTS; i++) {
@@ -2010,7 +2010,7 @@ writeIntoBuffer(void* buffer, IDATA buffer_length, IDATA* index, char* data) {
 	IDATA len;
 	IDATA next_char = *index;
 	char* cbuffer = (char*)buffer;
-	
+
 	len = strlen(data);
 	if ((next_char + len) < buffer_length) {
 		strcpy(&cbuffer[next_char], data);
@@ -2058,7 +2058,7 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 		/* no space in buffer, so abandon at this point */
 		return rc;
 	}
-	
+
 	/* copy in the events */
 	separator = "";
 	len = j9str_printf(temp_buf, sizeof(temp_buf), "%s", ":events=");
@@ -2097,15 +2097,15 @@ queryAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent, IDATA buffer_size,
 
 	/* copy in the subfilters */
 	len = 0;
-	if (agent->subFilter != NULL) {                
+	if (agent->subFilter != NULL) {
 		len = j9str_printf(temp_buf, sizeof(temp_buf), "msg_filter=%.1000s,", agent->subFilter);
 	}
 	if (len > 0) {
 		rc = writeIntoBuffer(buffer, buffer_size, &next_char, temp_buf);
-		if (rc == FALSE) {                        
+		if (rc == FALSE) {
 			return rc;
 		}
-	}	
+	}
 
 	/* copy in the label, range and priority */
 	len = 0;
@@ -2200,7 +2200,7 @@ printDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent)
 	if (agent->detailFilter != NULL) {
 		j9tty_err_printf("\n    filter=%s,",	agent->detailFilter);
 	}
-	
+
 	if (agent->subFilter != NULL) {
 		j9tty_err_printf("\n    msg_filter=%s,", agent->subFilter);
 	}
@@ -2264,7 +2264,7 @@ copyDumpSettings(struct J9JavaVM *vm, J9RASdumpSettings *src, J9RASdumpSettings 
 	} else {
 		dst->detailFilter = NULL;
 	}
-	
+
 	if (src->subFilter != NULL){
 		dst->subFilter = allocString(vm, strlen(src->subFilter) + 1);
 		if (dst->subFilter == NULL){
@@ -2274,10 +2274,10 @@ copyDumpSettings(struct J9JavaVM *vm, J9RASdumpSettings *src, J9RASdumpSettings 
 	} else {
 		dst->subFilter = NULL;
 	}
-        
+
 	dst->startOnCount = src->startOnCount;
 	dst->stopOnCount = src->stopOnCount;
-	
+
 	if (src->labelTemplate != NULL){
 		dst->labelTemplate  = allocString(vm, strlen(src->labelTemplate ) + 1);
 		if (dst->labelTemplate  == NULL){
@@ -2289,7 +2289,7 @@ copyDumpSettings(struct J9JavaVM *vm, J9RASdumpSettings *src, J9RASdumpSettings 
 	} else {
 		dst->labelTemplate = NULL;
 	}
-	
+
 	if (src->dumpOptions != NULL){
 		dst->dumpOptions = allocString(vm, strlen(src->dumpOptions) + 1);
 		if (dst->dumpOptions == NULL){
@@ -2301,7 +2301,7 @@ copyDumpSettings(struct J9JavaVM *vm, J9RASdumpSettings *src, J9RASdumpSettings 
 	} else {
 		dst->dumpOptions = NULL;
 	}
-	
+
 	dst->priority = src->priority;
 	dst->requestMask = src->requestMask;
 
@@ -2315,7 +2315,7 @@ copyDumpSettingsQueue(J9JavaVM *vm, J9RASdumpSettings *toCopy)
 	int i;
 	omr_error_t retVal = OMR_ERROR_NONE;
 	J9RASdumpSettings *queue = (J9RASdumpSettings *)j9mem_allocate_memory( sizeof(J9RASdumpSettings) * J9RAS_DUMP_KNOWN_SPECS , OMRMEM_CATEGORY_VM);
-	
+
 	if (queue == NULL){
 		return NULL;
 	}
@@ -2325,7 +2325,7 @@ copyDumpSettingsQueue(J9JavaVM *vm, J9RASdumpSettings *toCopy)
 			return NULL;
 		}
 	}
-	
+
 	return queue;
 }
 
@@ -2422,8 +2422,8 @@ scanDumpType(char **optionStringPtr)
 
 			/* Check well-formed dump option */
 			if ( try_scan(optionStringPtr, "+") ||
-			     try_scan(optionStringPtr, ":") ||
-			     *optionStringPtr[0] == '\0' ) {
+				 try_scan(optionStringPtr, ":") ||
+				 *optionStringPtr[0] == '\0' ) {
 				retVal = kind;
 			/* Not well-formed, so backtrack */
 			} else {
@@ -2442,63 +2442,63 @@ copyDumpAgent(struct J9JavaVM *vm, J9RASdumpAgent *src, J9RASdumpAgent *dst)
 {
 	memset(dst, 0, sizeof(*dst));
 
-    dst->nextPtr = NULL;
-    dst->shutdownFn = src->shutdownFn;
-    dst->eventMask = src->eventMask;
-    
-    if (src->detailFilter != NULL){
-    	dst->detailFilter = allocString(vm, strlen(src->detailFilter) + 1);
-    	if (dst->detailFilter == NULL){
-    		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
-    	}
-    	strcpy(dst->detailFilter, src->detailFilter);
-    } else {
-    	dst->detailFilter = NULL;
-    }
-    
-	if (src->subFilter != NULL){
+	dst->nextPtr = NULL;
+	dst->shutdownFn = src->shutdownFn;
+	dst->eventMask = src->eventMask;
+
+	if (src->detailFilter != NULL) {
+		dst->detailFilter = allocString(vm, strlen(src->detailFilter) + 1);
+		if (dst->detailFilter == NULL){
+			return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
+		}
+		strcpy(dst->detailFilter, src->detailFilter);
+	} else {
+		dst->detailFilter = NULL;
+	}
+
+	if (src->subFilter != NULL) {
 		dst->subFilter = allocString(vm, strlen(src->subFilter) + 1);
-		if (dst->subFilter == NULL){
+		if (dst->subFilter == NULL) {
 			return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 		}
 		strcpy(dst->subFilter, src->subFilter);
-    } else {
-        dst->subFilter = NULL;
-    }
+	} else {
+		dst->subFilter = NULL;
+	}
 
-    dst->startOnCount = src->startOnCount;
-    dst->stopOnCount = src->stopOnCount;
+	dst->startOnCount = src->startOnCount;
+	dst->stopOnCount = src->stopOnCount;
 
-    if (src->labelTemplate != NULL){
+	if (src->labelTemplate != NULL) {
 		dst->labelTemplate  = allocString(vm, strlen(src->labelTemplate ) + 1);
-		if (dst->labelTemplate  == NULL){
-			/* previous strings alloc'ed in this func are stored in the dump string 
+		if (dst->labelTemplate  == NULL) {
+			/* previous strings alloc'ed in this func are stored in the dump string
 			 * table and so will be freed automatically at shutdown */
 			return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 		}
 		strcpy(dst->labelTemplate , src->labelTemplate );
-    } else {
-    	dst->labelTemplate = NULL;
-    }
-	
-    dst->dumpFn = src->dumpFn;
-    
-    if (src->dumpOptions != NULL){
-	    dst->dumpOptions = allocString(vm, strlen(src->dumpOptions) + 1);
+	} else {
+		dst->labelTemplate = NULL;
+	}
+
+	dst->dumpFn = src->dumpFn;
+
+	if (src->dumpOptions != NULL){
+		dst->dumpOptions = allocString(vm, strlen(src->dumpOptions) + 1);
 		if (dst->dumpOptions == NULL){
-			/* previous strings alloc'ed in this func are stored in the dump string 
+			/* previous strings alloc'ed in this func are stored in the dump string
 			 * table and so will be freed automatically at shutdown */
 			return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 		}
 		strcpy(dst->dumpOptions, src->dumpOptions);
-    } else {
-    	dst->dumpOptions = NULL;
-    }
-    
-    dst->userData = src->userData;
-    dst->priority = src->priority;
-    dst->requestMask = src->requestMask;
-    
+	} else {
+		dst->dumpOptions = NULL;
+	}
+
+	dst->userData = src->userData;
+	dst->priority = src->priority;
+	dst->requestMask = src->requestMask;
+
 	return OMR_ERROR_NONE;
 }
 
@@ -2506,7 +2506,7 @@ static void
 freeQueueWithoutRunningShutdown(J9JavaVM *vm, J9RASdumpAgent *toFree)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	
+
 	J9RASdumpAgent *currentAgent = toFree;
 	if (currentAgent != NULL){
 		J9RASdumpAgent *nextAgent = currentAgent->nextPtr;
@@ -2521,7 +2521,7 @@ copyDumpAgentsQueue(J9JavaVM *vm, J9RASdumpAgent *toCopy)
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	J9RASdumpAgent *queue = NULL;
 	J9RASdumpAgent **queueNextPtr = &queue;
-	
+
 	while (toCopy != NULL) {
 		omr_error_t retVal = OMR_ERROR_NONE;
 		J9RASdumpAgent *newAgent = (J9RASdumpAgent *)j9mem_allocate_memory(sizeof(J9RASdumpAgent), OMRMEM_CATEGORY_VM);
@@ -2529,19 +2529,19 @@ copyDumpAgentsQueue(J9JavaVM *vm, J9RASdumpAgent *toCopy)
 			freeQueueWithoutRunningShutdown(vm, queue);
 			return NULL;
 		}
-		
+
 		retVal = copyDumpAgent(vm, toCopy, newAgent);
 		if (OMR_ERROR_NONE != retVal) {
 			freeQueueWithoutRunningShutdown(vm, queue);
 			return NULL;
 		}
-		
+
 		newAgent->nextPtr = NULL;
 		*queueNextPtr = newAgent;
 		queueNextPtr = &newAgent->nextPtr;
 		toCopy = toCopy->nextPtr;
 	}
-	
+
 	return queue;
 }
 
@@ -2646,15 +2646,15 @@ unloadDumpAgent(struct J9JavaVM *vm, IDATA kind)
 
 /*
  * Function: createAndRunOneOffDumpAgent - creates a temporary dump agent and runs it
- * 
- * A wrapper around runDumpAgent used for triggering one-off dumps. 
- * 
+ *
+ * A wrapper around runDumpAgent used for triggering one-off dumps.
+ *
  * Parameters:
- * 
+ *
  * vm [in] - VM pointer
  * context [in] - dump context
  * kind [in] - type code for dump being produced
- * 
+ *
  * Returns: OMR_ERROR_NONE on success, OMR_ERROR_INTERNAL or OMR_ERROR_OUT_OF_NATIVE_MEMORY if there was a problem.
  */
 omr_error_t
@@ -2668,7 +2668,7 @@ createAndRunOneOffDumpAgent(struct J9JavaVM *vm,J9RASdumpContext * context,IDATA
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	U_64 now = j9time_current_time_millis();
 	omr_error_t rc = OMR_ERROR_NONE;
-	
+
 	/* Need temporary agent */
 	action = processSettings(vm, kind, optionString, &tmpSettings);
 	if( action == BOGUS_DUMP_OPTION ) {
@@ -2678,13 +2678,13 @@ createAndRunOneOffDumpAgent(struct J9JavaVM *vm,J9RASdumpContext * context,IDATA
 
 	if ( agent ) {
 		rc = runDumpAgent(vm,agent,context,&state,"",now);
-					
+
 		/*Undo state, release locks*/
 		state = unwindAfterDump(vm, context, state);
-					
+
 		/* Clean up temporary agent */
 		agent->shutdownFn(vm, &agent);
-		
+
 		return rc;
 	} else {
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
@@ -2693,17 +2693,17 @@ createAndRunOneOffDumpAgent(struct J9JavaVM *vm,J9RASdumpContext * context,IDATA
 
 /*
  * Function: runDumpAgent - executes a single dump agent
- * 
+ *
  * Takes care of acquiring exclusive, performing prepwalk & compact and some final validation/warning
- * messages. 
- * 
+ * messages.
+ *
  * Parameters:
  * vm [in] -       VM pointer
  * agent [in] -    Agent to be executed
  * context [in] -  Dump context (what triggered the dump)
- * state [inout] - State bit flags. Used to maintain state between multiple calls of runDumpAgent. 
+ * state [inout] - State bit flags. Used to maintain state between multiple calls of runDumpAgent.
  *                 When you've performed all runDumpAgent calls you must call unwindAfterDump passing
- *                 the state variable to make sure all locks are cleaned up. The first time runDumpAgent 
+ *                 the state variable to make sure all locks are cleaned up. The first time runDumpAgent
  *                 is called, state should be initialized to 0.
  * detail    -     Detail string for dump cause
  * timeNow [in] -  Time value as returned from j9time_current_time_millis. Used to timestamp the dumps.
@@ -2749,13 +2749,13 @@ runDumpAgent(struct J9JavaVM *vm, J9RASdumpAgent * agent, J9RASdumpContext * con
 		gotExclusive = *state & J9RAS_DUMP_GOT_EXCLUSIVE_VM_ACCESS;
 
 		/* If the dump is a system dump and the customer either requested exclusive and we couldn't get it, or they requested
-		 * prepwalk or compact without exclusive, print a warning message (although, unlike heapdump, we still take the dump). 
+		 * prepwalk or compact without exclusive, print a warning message (although, unlike heapdump, we still take the dump).
 		 */
 		if (agent->dumpFn == doSystemDump) {
 			if (userRequestedExclusive && !gotExclusive) {
 				j9nls_printf(PORTLIB, J9NLS_WARNING | J9NLS_STDERR, J9NLS_DMP_SYSTEM_DUMP_EXCLUSIVE_FAILED);
 			}
-									
+
 			if (userRequestedPrepwalkOrCompact && !userRequestedExclusive) {
 				j9nls_printf(PORTLIB, J9NLS_WARNING | J9NLS_STDERR, J9NLS_DMP_SYSTEM_DUMP_COMPACT_PREPWALK_WITHOUT_EXCLUSIVE);
 			}
@@ -2806,7 +2806,7 @@ runDumpAgent(struct J9JavaVM *vm, J9RASdumpAgent * agent, J9RASdumpContext * con
 			/* cjvm_dumpagent_finished_hook will be removed in the future (currently deprecated). */
 			cjvm_dumpagent_finished_hook((jvmDumpAgentInfo *)agent, label, (jvmDumpContext *)context);
 #endif /* defined(J9ZTPF) */
-			
+
 			if (context->dumpList) {
 				if (agent->dumpFn == doHeapDump) {
 					if (agent->dumpOptions && strstr(agent->dumpOptions, "PHD")) {
@@ -2845,7 +2845,7 @@ runDumpAgent(struct J9JavaVM *vm, J9RASdumpAgent * agent, J9RASdumpContext * con
 		}
 
 	}
-	
+
 	/* If we allocated a longer label (actually only for tool dumps) then free it now */
 	if (label != localLabel) {
 		j9mem_free_memory(label);
@@ -2873,13 +2873,13 @@ runDumpFunction(J9RASdumpAgent *agent, char *label, J9RASdumpContext *context)
 		dumpData.agent = agent;
 		dumpData.label = label;
 		dumpData.context = context;
-		
+
 		protectedResult = j9sig_protect(
-			protectedDumpFunction, &dumpData, 
-			signalHandler, NULL, 
-			J9PORT_SIG_FLAG_MAY_RETURN | J9PORT_SIG_FLAG_SIGALLSYNC, 
+			protectedDumpFunction, &dumpData,
+			signalHandler, NULL,
+			J9PORT_SIG_FLAG_MAY_RETURN | J9PORT_SIG_FLAG_SIGALLSYNC,
 			&rc);
-		
+
 		if (protectedResult != 0) {
 			return OMR_ERROR_INTERNAL;
 		} else {
@@ -2911,7 +2911,7 @@ signalHandler(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo, void
 /**
  * Writes the appropriate "we're about to write a dump" message to the console depending on whether the
  * dump was event driven or user requested.
- * 
+ *
  * Parameters:
  * portLibrary [in] library to use to write dump
  * context [in] context that dump was taken in
@@ -2928,16 +2928,16 @@ reportDumpRequest(struct J9PortLibrary* portLibrary, J9RASdumpContext * context,
 			/*User driven dump*/
 			j9nls_printf(PORTLIB,
 				J9NLS_INFO | J9NLS_STDERR | J9NLS_VITAL,
-				J9NLS_DMP_USER_REQUESTED_DUMP_STR, 
-				dumpType, 
-				fileName, 
+				J9NLS_DMP_USER_REQUESTED_DUMP_STR,
+				dumpType,
+				fileName,
 				context->eventData != NULL ? context->eventData->detailData : NULL);
-			
+
 			Trc_dump_reportDumpStart_FromUser(dumpType,fileName,context->eventData != NULL ? context->eventData->detailData : NULL);
 		} else {
 			/*Event driven dump*/
 			j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR | J9NLS_VITAL, J9NLS_DMP_EVENT_TRIGGERED_DUMP_STR, dumpType, fileName);
-			
+
 			Trc_dump_reportDumpStart_FromEvent(dumpType,fileName);
 		}
 	} else {
@@ -2945,15 +2945,15 @@ reportDumpRequest(struct J9PortLibrary* portLibrary, J9RASdumpContext * context,
 			/*User driven dump*/
 			j9nls_printf(PORTLIB,
 				J9NLS_INFO | J9NLS_STDERR | J9NLS_VITAL,
-				J9NLS_DMP_USER_REQUESTED_DUMP_STR_NOFILE, 
-				dumpType,  
+				J9NLS_DMP_USER_REQUESTED_DUMP_STR_NOFILE,
+				dumpType,
 				context->eventData != NULL ? context->eventData->detailData : NULL);
-			
+
 			Trc_dump_reportDumpStart_FromUser_NoFile(dumpType,context->eventData != NULL ? context->eventData->detailData : NULL);
 		} else {
 			/*Event driven dump*/
 			j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR | J9NLS_VITAL, J9NLS_DMP_EVENT_TRIGGERED_DUMP_STR_NOFILE, dumpType);
-			
+
 			Trc_dump_reportDumpStart_FromEvent_NoFile(dumpType);
 		}
 	}

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -495,11 +495,11 @@ matchesFilter(J9VMThread *vmThread, J9RASdumpEventData *eventData, UDATA eventFl
 	/* For exception specific events the filter and subfilter default(null) matches to all
 	 * For non exception specific events the filter default(null) matches to all
 	 */
-    if (((0 != (eventFlags & J9RAS_DUMP_EXCEPTION_EVENT_GROUP)) && NULL == filter && NULL == subFilter) ||
-        ((0 == (eventFlags & J9RAS_DUMP_EXCEPTION_EVENT_GROUP)) && NULL == filter))
-    {
-    	return J9RAS_DUMP_MATCH;
-    }
+	if (((0 != (eventFlags & J9RAS_DUMP_EXCEPTION_EVENT_GROUP)) && NULL == filter && NULL == subFilter) ||
+		((0 == (eventFlags & J9RAS_DUMP_EXCEPTION_EVENT_GROUP)) && NULL == filter))
+	{
+		return J9RAS_DUMP_MATCH;
+	}
 
 	if (eventFlags & J9RAS_DUMP_ON_SLOW_EXCLUSIVE_ENTER) {
 		return matchesSlowExclusiveEnterFilter(eventData, filter);
@@ -804,28 +804,28 @@ dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context,
 
 	seqNum += 1; /* Atomicity guaranteed as we are inside the dumpLabelTokensMutex */
 
-	if (j9str_set_token(PORTLIB, stringTokens, "seq", "%04u", seqNum)) {
+	if (0 != j9str_set_token(stringTokens, "seq", "%04u", seqNum)) {
 		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 		return OMR_ERROR_INTERNAL;
 	}
 
-	if (j9str_set_token(PORTLIB, stringTokens, "home", "%s", (vm->javaHome == NULL) ? "" : (char *)vm->javaHome)) {
+	if (0 != j9str_set_token(stringTokens, "home", "%s", (vm->javaHome == NULL) ? "" : (const char *)vm->javaHome)) {
 		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 		return OMR_ERROR_INTERNAL;
 	}
 
-	if (j9str_set_token(PORTLIB, stringTokens, "event", "%s", mapDumpEvent(context->eventFlags))) {
+	if (0 != j9str_set_token(stringTokens, "event", "%s", mapDumpEvent(context->eventFlags))) {
 		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 		return OMR_ERROR_INTERNAL;
 	}
 
-	if (j9str_set_token(PORTLIB, stringTokens, "list", "%s", (context->dumpList == NULL) ? "" : context->dumpList)) {
+	if (0 != j9str_set_token(stringTokens, "list", "%s", (context->dumpList == NULL) ? "" : context->dumpList)) {
 		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 		return OMR_ERROR_INTERNAL;
 	}
 
 	/* %vmbin is not listed in printLabelSpec as it is only useful for loading internal tools that live in the vm directory. */
-	if (j9str_set_token(PORTLIB, stringTokens, "vmbin", "%s", (vm->j2seRootDirectory == NULL) ? "" : (char *)vm->j2seRootDirectory)) {
+	if (0 != j9str_set_token(stringTokens, "vmbin", "%s", (vm->j2seRootDirectory == NULL) ? "" : (const char *)vm->j2seRootDirectory)) {
 		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 		return OMR_ERROR_INTERNAL;
 	}
@@ -842,12 +842,12 @@ dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context,
 		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 	}
 
-	 if (agent->dumpFn != doToolDump ) {
-		 /* Cache last dump label (but not for tool dumps!) */
-		 if (j9str_set_token(PORTLIB, stringTokens, "last", "%s", buf)) {
-			 omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-			 return OMR_ERROR_INTERNAL;
-		 }
+	if (agent->dumpFn != doToolDump) {
+		/* Cache last dump label (but not for tool dumps!) */
+		if (0 != j9str_set_token(stringTokens, "last", "%s", buf)) {
+			omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
+			return OMR_ERROR_INTERNAL;
+		}
 	}
 
 	/* release access to the tokens */

--- a/runtime/rastrace/trclog.c
+++ b/runtime/rastrace/trclog.c
@@ -51,7 +51,7 @@ extern omrthread_tls_key_t j9rasTLSKey;
  * returns     - int32_t
  ******************************************************************************/
 omr_error_t
-initEvent(UtEventSem **sem, char* name) 
+initEvent(UtEventSem **sem, char* name)
 {
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 	omr_error_t ret = OMR_ERROR_NONE;
@@ -148,7 +148,7 @@ postEvent(UtEventSem * sem)
  * returns     - void
  ******************************************************************************/
 void
-postEventAll(UtEventSem * sem) 
+postEventAll(UtEventSem * sem)
 {
 
 	UT_DBGOUT(2, ("<UT> postEventAll called for semaphore %p\n", sem));
@@ -438,7 +438,7 @@ freeBuffers(qMessage *msg)
 		}
 
 		omrthread_monitor_enter(UT_GLOBAL(freeQueueLock));
-		
+
 		trcBuf->next = UT_GLOBAL(freeQueue);
 		UT_GLOBAL(freeQueue) = nextBuf;
 
@@ -598,8 +598,8 @@ openSnap(char *label)
 		int64_t curTime = j9time_current_time_millis();
 		struct J9StringTokens* stringTokens = j9str_create_tokens(curTime);
 
-		j9str_set_token(PORTLIB, stringTokens, "pid", "%lld", pid);
-		j9str_set_token(PORTLIB, stringTokens, "sid", "%04.4d", UT_GLOBAL(snapSequence));
+		j9str_set_token(stringTokens, "pid", "%lld", pid);
+		j9str_set_token(stringTokens, "sid", "%04.4d", UT_GLOBAL(snapSequence));
 
 		j9str_subst_tokens(fileName, FILENAMELEN, "Snap%sid.%Y%m%d%H%M%S.%pid.trc", stringTokens);
 		j9str_free_tokens(stringTokens);
@@ -729,7 +729,7 @@ cleanup:
 	} else {
 		destroyRecordSubscriber(thr, subscription);
 	}
-	
+
 	UT_DBGOUT(5, ("<UT thr="UT_POINTER_SPEC"> Releasing lock for cleanup on handler exit\n", thr));
 
 	/* Need to exit the trace lock first as detaching a thread needs the vm thread list lock.
@@ -830,7 +830,7 @@ writeBuffer(UtSubscription *subscription)
 		if (*wrap != 0 && *fileSize >= *wrap) {
 			/* Trace options may have changed, re-initialize the trace file header data if necessary */
 			initTraceHeader();
-			
+
 			if ((bufferType == UT_NORMAL_BUFFER) && (UT_GLOBAL(traceGenerations) > 1)) {
 				/* For multiple-generation file mode, open the next file */
 				j9file_close(outputFile);
@@ -847,7 +847,7 @@ writeBuffer(UtSubscription *subscription)
 					return OMR_ERROR_INTERNAL;
 				}
 			} else {
-				/* For single file wrap mode, seek back to start of file */ 
+				/* For single file wrap mode, seek back to start of file */
 				*maxFileSize = *fileSize;
 				*fileSize = j9file_seek(outputFile, 0, SEEK_SET);
 				if (*fileSize != 0 ) {
@@ -863,7 +863,7 @@ writeBuffer(UtSubscription *subscription)
 					*fileSize = -1;
 					return OMR_ERROR_INTERNAL;
 				}
-			} 
+			}
 		}
 
 		if (*fileSize > *maxFileSize) {
@@ -988,14 +988,14 @@ getTrcBuf(UtThreadData **thr, UtTraceBuffer * oldBuf, int bufferType)
 	 * Reuse buffer if there is one
 	 */
 	omrthread_monitor_enter(UT_GLOBAL(freeQueueLock));
-	
+
 	trcBuf = UT_GLOBAL(freeQueue);
 	if (NULL != trcBuf) {
 		UT_GLOBAL(freeQueue) = trcBuf->next;
 	}
-	
+
 	omrthread_monitor_exit(UT_GLOBAL(freeQueueLock));
-	
+
 	if (trcBuf != NULL) {
 		DBG_ASSERT(trcBuf->queueData.next == NULL || trcBuf->queueData.next == CLEANING_MSG_FLAG);
 		DBG_ASSERT(trcBuf->queueData.referenceCount == 0);
@@ -1201,7 +1201,7 @@ copyToBuffer(UtThreadData **thr,
 
 			if (nextBuf != NULL) {
 				*trcBuf = nextBuf; /* update caller's trace buffer pointer to point to next buffer */
-				
+
 				/* we're about to copy stuff into it so mark the buffer as not new so it can be queued */
 				UT_ATOMIC_AND((volatile uint32_t *)(&(*trcBuf)->flags), ~UT_TRC_BUFFER_NEW);
 				(*trcBuf)->thr = thr;
@@ -1678,7 +1678,7 @@ traceV(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, const char *
 
 		/* write name to buffer */
 		copyToBuffer(thr, bufferType, stringVar, &p,
-				 	 (int)stringVarLen, &entryLength, &trcBuf);
+					 (int)stringVarLen, &entryLength, &trcBuf);
 
 		if (containerModuleVar != NULL){
 			copyToBuffer(thr, bufferType, "(", &p, 1, &entryLength, &trcBuf);
@@ -1763,14 +1763,14 @@ traceV(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, const char *
 					/*
 					 *  Doubles
 					 */
-		        	 /* CMVC 164940 All %f tracepoints are internally promoted to double.
-		        	  * Affects:
-		        	  *  TraceFormat  com/ibm/jvm/format/Message.java
-		        	  *  TraceFormat  com/ibm/jvm/trace/format/api/Message.java
-		        	  *  runtime    ute/ut_trace.c
-		        	  *  TraceGen     OldTrace.java
-		        	  * Intentional fall through to next case. 
-		        	  */
+					/* CMVC 164940 All %f tracepoints are internally promoted to double.
+					 * Affects:
+					 *  TraceFormat  com/ibm/jvm/format/Message.java
+					 *  TraceFormat  com/ibm/jvm/trace/format/api/Message.java
+					 *  runtime    ute/ut_trace.c
+					 *  TraceGen     OldTrace.java
+					 * Intentional fall through to next case.
+					 */
 
 				case UT_TRACE_DATA_TYPE_DOUBLE:
 					{
@@ -2095,7 +2095,7 @@ static void logTracePoint(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t tr
 				traceExternal(thr, listener->listener, listener->userData, modInfo->name, traceId >> 8, spec, var);
 			}
 		}
-		
+
 		/* Find and call all registered tracepoint subscribers (public JVMTI interface) */
 		getTraceLock(thr);
 		for (subscription = UT_GLOBAL(tracePointSubscribers); subscription != NULL; subscription = subscription->next) {
@@ -2190,8 +2190,8 @@ doTracePoint(UtThreadData **thr, UtModuleInfo *modInfo, uint32_t traceId, const 
 	} else {
 		/* This block only executed for auxiliary tracepoints*/
 
-		/* The primary user of auxiliary tracepoints is jstacktrace. Sending jstacktrace data to 
-		 * minimal (i.e. throwing away all the stack data) makes no sense - so it is converted to 
+		/* The primary user of auxiliary tracepoints is jstacktrace. Sending jstacktrace data to
+		 * minimal (i.e. throwing away all the stack data) makes no sense - so it is converted to
 		 * maximal. currentOutputMask is reset below.
 		 */
 		savedOutputMask = (*thr)->currentOutputMask;
@@ -2656,7 +2656,7 @@ callSubscriber(UtThreadData **thr, UtSubscription *subscription, UtModuleInfo *m
 	PORT_ACCESS_FROM_PORT(UT_GLOBAL(portLibrary));
 
 	getTimestamp(j9time_current_time_millis(), &hours, &mins, &secs, &msecs);
-	
+
 	/* Format the tracepoint module name, includes support for submodules */
 	memset(qualifiedModuleName, '\0', sizeof(qualifiedModuleName));
 	if (modInfo == NULL){
@@ -2681,7 +2681,7 @@ callSubscriber(UtThreadData **thr, UtSubscription *subscription, UtModuleInfo *m
 	/* Calculate the size of buffer we need to hold the tracepoint header plus formatted tracepoint data */
 	headerSize = j9str_printf(NULL, 0, "%02d:%02d:%02d.%03d 0x%x %s.%3d", hours, mins, secs, msecs, (*thr)->id, qualifiedModuleName, id);
 	COPY_VA_LIST(argsCopy, args);
-	dataSize = j9str_vprintf(NULL, 0, format, argsCopy); 
+	dataSize = j9str_vprintf(NULL, 0, format, argsCopy);
 
 	/* Allocate a temporary buffer for the formatted tracepoint */
 	buffer = j9mem_allocate_memory(headerSize + dataSize + 1, OMRMEM_CATEGORY_TRACE);
@@ -2696,7 +2696,7 @@ callSubscriber(UtThreadData **thr, UtSubscription *subscription, UtModuleInfo *m
 	j9str_printf(cursor, headerSize, "%02d:%02d:%02d.%03d 0x%x %s.%3d", hours, mins, secs, msecs, (*thr)->id, qualifiedModuleName, id);
 	cursor += headerSize - 1;
 	COPY_VA_LIST(argsCopy, args);
-	j9str_vprintf(cursor, dataSize, format, argsCopy); 
+	j9str_vprintf(cursor, dataSize, format, argsCopy);
 
 	/* Update the subscription data with the buffer location and length */
 	subscription->data = buffer;

--- a/runtime/tests/port/j9strTest.c
+++ b/runtime/tests/port/j9strTest.c
@@ -30,12 +30,12 @@
  * @file
  * @ingroup PortTest
  * @brief Verify port library string operations.
- * 
- * Exercise the API for port library string operations.  These functions 
- * can be found in the file @ref j9str.c and in file @ref j9strftime.c 
- * 
+ *
+ * Exercise the API for port library string operations.  These functions
+ * can be found in the file @ref j9str.c and in file @ref j9strftime.c
+ *
  * @note port library string operations are not optional in the port library table.
- * 
+ *
  */
 #if defined(WIN32)
 #include <windows.h>
@@ -73,10 +73,10 @@ typedef UDATA (* J9STR_VPRINTF_FUNC) (struct OMRPortLibrary *portLibrary, char *
 
 /**
  * Verify helpers functions call correct functions.
- * 
+ *
  * Override @ref j9str.c::j9str_vprintf "j9str_vprintf()" and return a known value to verify any helper
  * functions that  should be calling this function truly are.
- * 
+ *
  * @param[in] portLibrary The port library.
  * @param[in, out] buf The string buffer to be written.
  * @param[in] bufLen The size of the string buffer to be written.
@@ -91,13 +91,13 @@ fake_j9str_vprintf(struct OMRPortLibrary *portLibrary, char *buf, UDATA bufLen, 
 	return J9STR_PRIVATE_RETURN_VALUE;
 }
 
-/** 
+/**
  * @internal
  * Helper function for string verification.
- * 
+ *
  * Given a format string and it's arguments create the requested output message and
  * put it in the provided buffer.
- * 
+ *
  * @param[in] portLibrary The port library under test
  * @param[in] testName The name of the test requesting this functionality
  * @param[in,out] buffer buffer to write to
@@ -130,10 +130,10 @@ validate_j9str_vprintf(struct J9PortLibrary *portLibrary, const char *testName, 
 /**
  * @internal
  * Helper function for string verification.
- * 
+ *
  * Given a format string and it's arguments create the requested output message and
  * try to store it in a null buffer.
- * 
+ *
  * @param[in] portLibrary The port library under test
  * @param[in] testName The name of the test requesting this functionality
  * @param[in,out] buffer buffer to write to
@@ -158,12 +158,12 @@ validate_j9str_vprintf_with_NULL(struct J9PortLibrary *portLibrary, const char *
 /**
  * @internal
  * Helper function for string verification.
- * 
+ *
  * Given a format string and it's arguments verify the following behaviour
  * \args Given a larger buffer formatting is correct
  * \args Given a buffer of exact size the formatting is correct
  * \args Given a smaller buffer the formatting is truncated
- * 
+ *
  * @param[in] portLibrary The port library under test
  * @param[in] testName The name of the test requesting this functionality
  * @param[in] format The format string
@@ -171,10 +171,10 @@ validate_j9str_vprintf_with_NULL(struct J9PortLibrary *portLibrary, const char *
  * @param[in] ... arguments for format
  */
 static void
-test_j9str_vprintf(struct J9PortLibrary *portLibrary, const char *testName, const char *format, const char *expectedResult, ...) 
+test_j9str_vprintf(struct J9PortLibrary *portLibrary, const char *testName, const char *format, const char *expectedResult, ...)
 {
 	char truncatedExpectedResult[512];
-	char actualResult[512]; 
+	char actualResult[512];
 	va_list args;
 
 	/* Buffer larger than required */
@@ -227,11 +227,11 @@ test_j9str_vprintf(struct J9PortLibrary *portLibrary, const char *testName, cons
 /**
  * @internal
  * Helper function for string verification.
- * 
+ *
  * @param[in] portLibrary The port library under test
  * @param[in] testName The name of the test requesting this functionality
  * @param[in] ... arguments for format string
- * 
+ *
  * @note Pretty bogus to pass an argument for a format string you don't know about
  */
 static void
@@ -243,18 +243,18 @@ test_j9str_vprintfNulChar(struct J9PortLibrary *portLibrary, const char* testNam
 	const char* format = "ab%cde";
 	const char* expectedResult = "ab";
 	va_list args;
-	
+
 	va_start(args, testName);
 	rc = j9str_vprintf(actualResult, sizeof(actualResult), format, args);
 	va_end(args);
 	if (5 != rc) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9str_vprintf(\"%s\") returned %d expected 5\n", format, rc);
 	}
-	
+
 	if (strlen(actualResult) != 2) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9str_vprintf(\"%s\") returned %d expected 2\n", format, rc);
 	}
-	
+
 	if (strcmp(actualResult, expectedResult) != 0) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "j9str_vprintf(\"%s\") returned \"%s\" expected \"%s\"\n", format, expectedResult, actualResult);
 	}
@@ -319,11 +319,11 @@ test_j9str_tokens(struct J9PortLibrary *portLibrary, const char *testName, char 
 
 /**
  * Verify port library string operations.
- * 
+ *
  * Ensure the port library is properly setup to run string operations.
- * 
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
 int
@@ -332,9 +332,9 @@ j9str_test0(struct J9PortLibrary *portLibrary)
 	const char* testName = "j9str_test0";
 
 	reportTestEntry(portLibrary, testName);
-	 
+
 	/* Verify that the string function pointers are non NULL */
-	
+
 	/* Not tested, implementation dependent.  No known functionality.
 	 * Startup is private to the portlibrary, it is not re-entrant safe
 	 */
@@ -363,24 +363,24 @@ j9str_test0(struct J9PortLibrary *portLibrary)
 /**
  * Verify port library string operations.
  *
- * @ref j9str.c::j9str_printf "j9str_printf()" is a helper function for 
+ * @ref j9str.c::j9str_printf "j9str_printf()" is a helper function for
  * j9str.c::j9str_vprintf "j9str_vprintf().  It only makes sense to implement
- * one in terms of the other.  To verify this has indeed been done, replace 
+ * one in terms of the other.  To verify this has indeed been done, replace
  * j9str_printf with a fake one that returns a known value.  If that value is
  * not returned then fail the test.
- * 
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
 int
-j9str_test1(struct J9PortLibrary *portLibrary) 
+j9str_test1(struct J9PortLibrary *portLibrary)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
 	const char* testName = "j9str_test1";
 	UDATA j9strRC;
 	J9STR_VPRINTF_FUNC realVprintf;
-	
+
 	reportTestEntry(portLibrary, testName);
 
 	/* Save the real function, put in a fake one, call it, restore old one */
@@ -406,13 +406,13 @@ j9str_test1(struct J9PortLibrary *portLibrary)
  *
  * Run various format strings through @ref j9str.c::j9str_vprintf "j9str_vprintf()".
  * Tests include basic printing of characters, strings, numbers and Unicode characters.
- * 
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
 int
-j9str_test2(struct J9PortLibrary *portLibrary) 
+j9str_test2(struct J9PortLibrary *portLibrary)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);
 	const char* testName = "j9str_test2";
@@ -516,17 +516,17 @@ j9str_test2(struct J9PortLibrary *portLibrary)
  * Verify port library string operations.
  *
  * Exercise @ref j9strftime.c::j9strftime "j9strftime()" with various format strings and times.
- * Tests include 
+ * Tests include
  * 	1. too short a dest buffer
- * 	2. ime 0 
+ * 	2. ime 0
  * 	3. a known time (February 29th 2004 01:23:45)
- * 	4. Tokens that are not valid for str_ftime but are set by default in j9str_create_tokens. 
+ * 	4. Tokens that are not valid for str_ftime but are set by default in j9str_create_tokens.
  * 		Check that these are not substituted.
  *  5. Tokens that are not valid by default anywhere.
- * 
- * 
+ *
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
 int
@@ -539,11 +539,11 @@ j9str_test3(struct J9PortLibrary *portLibrary)
 	char expected[J9STR_BUFFER_SIZE];
 	U_64 timeMillis;
 	UDATA ret;
-	
+
 	reportTestEntry(portLibrary, testName);
-	
+
 	/* First test: The epoch */
-	j9tty_printf(PORTLIB, "\t This test could fail if you abut the international dateline (westside of dateline)\n"); 
+	j9tty_printf(PORTLIB, "\t This test could fail if you abut the international dateline (westside of dateline)\n");
 	timeMillis = 0;
 	strncpy(expected, "1970 01 Jan 01 XX:00:00", J9STR_BUFFER_SIZE);
 	test_str_ftime(portLibrary, testName, buf, J9STR_BUFFER_SIZE, "%Y %m %b %d XX:%M:%S", timeMillis, OMRSTR_FTIME_FLAG_LOCAL, expected);
@@ -564,19 +564,19 @@ j9str_test3(struct J9PortLibrary *portLibrary)
 	timeMillis = J9CONST64(1078056000000);
 	strncpy(expected, "2004 02 Feb 29 00 %pid %uid %job %home %last %seq", J9STR_BUFFER_SIZE);
 	test_str_ftime(portLibrary, testName, buf, J9STR_BUFFER_SIZE, "%Y %m %b %d %S %pid %uid %job %home %last %seq", timeMillis, OMRSTR_FTIME_FLAG_LOCAL, expected);
-		
+
 	/* Fifth Test: Pass in Tokens that are not valid by default anywhere.
 	 * Use the time February 29th, 2004, 12:00:00, UTC. */
 	timeMillis = J9CONST64(1078056000000);
 	strncpy(expected, "2004 02 Feb 29 00 %zzz = %zzz", J9STR_BUFFER_SIZE);
 	test_str_ftime(portLibrary, testName, buf, J9STR_BUFFER_SIZE, "%Y %m %b %d %S %zzz = %%zzz", timeMillis, OMRSTR_FTIME_FLAG_LOCAL, expected);
-		
+
 	/* Sixth Test: Pass in all time tokens.
 	 * Use the time February 29th, 2004, 12:00:00, UTC. */
 	timeMillis = J9CONST64(1078056000000);
 	strncpy(expected, "04,(2004) 02,(Feb) 29 XX:00:00 %", J9STR_BUFFER_SIZE);
 	test_str_ftime(portLibrary, testName, buf, J9STR_BUFFER_SIZE, "%y,(%Y) %m,(%b) %d XX:%M:%S %", timeMillis, OMRSTR_FTIME_FLAG_LOCAL, expected);
-			
+
 	return reportTestExit(portLibrary, testName);
 }
 
@@ -585,9 +585,9 @@ j9str_test3(struct J9PortLibrary *portLibrary)
  *
  * Exercise @ref j9str.c::j9str_subst_tokens "j9str_subst_tokens" with various tokens.
  * Tests include simple token tests, too short a dest buffer and token precedence
- * 
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
 int
@@ -602,82 +602,81 @@ j9str_test4(struct J9PortLibrary *portLibrary)
 	char buf[TEST_BUF_LEN];
 	char bufOverflow[TEST_OVERFLOW_LEN];
 
-	
 	reportTestEntry(portLibrary, testName);
-	
+
 	/* February 29th, 2004, 12:00:00, UTC */
 	timeMillis = J9CONST64(1078056000000);
-	
+
 	j9tty_printf(PORTLIB, "\t This test will fail if you abut the international dateline\n");
 	tokens = j9str_create_tokens(timeMillis);
-	j9str_set_token(portLibrary, tokens, "longtkn", "Long Token Value");
-	j9str_set_token(portLibrary, tokens, "yyy", "nope nope nope");
-	j9str_set_token(portLibrary, tokens, "yyy", "yup yup yup");
-	j9str_set_token(portLibrary, tokens, "empty", "");
+	j9str_set_token(tokens, "longtkn", "Long Token Value");
+	j9str_set_token(tokens, "yyy", "nope nope nope");
+	j9str_set_token(tokens, "yyy", "yup yup yup");
+	j9str_set_token(tokens, "empty", "");
 	if (NULL == tokens) {
 		outputErrorMessage(PORTTEST_ERROR_ARGS, "Failed to create tokens\n");
 	} else {
 		/* Test 1: No tokens */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "Teststring", tokens,
-		                  "Teststring", 10);
+						  "Teststring", tokens,
+						  "Teststring", 10);
 		/* Test 2: Single token */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "%Y", tokens,
-		                  "2004", 4);
+						  "%Y", tokens,
+						  "2004", 4);
 		/* Test 3: End with a token */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "Teststring %Y", tokens,
-		                  "Teststring 2004", 15);
+						  "Teststring %Y", tokens,
+						  "Teststring 2004", 15);
 		/* Test 4: Start with a token */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "%y Teststring", tokens,
-		                  "04 Teststring", 13);
+						  "%y Teststring", tokens,
+						  "04 Teststring", 13);
 		/* Test 5: Many tokens */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "%Y/%m/%d %S seconds %longtkn", tokens,
-		                  "2004/02/29 00 seconds Long Token Value", 38);
+						  "%Y/%m/%d %S seconds %longtkn", tokens,
+						  "2004/02/29 00 seconds Long Token Value", 38);
 		/* Test 6: Tokens and strings combined */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "Test1 %Y Test2-%m%d%y-%S %longtkn, %longtkn", tokens,
-		                  "Test1 2004 Test2-022904-00 Long Token Value, Long Token Value",
-		                  61);
+						  "Test1 %Y Test2-%m%d%y-%S %longtkn, %longtkn", tokens,
+						  "Test1 2004 Test2-022904-00 Long Token Value, Long Token Value",
+						  61);
 		/* Test 7: %% and end with % */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "99%% is the same as 99%", tokens,
-		                  "99% is the same as 99%", 22);
+						  "99%% is the same as 99%", tokens,
+						  "99% is the same as 99%", 22);
 		/* Test 8: Invalid tokens */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "%zzz = %%zzz", tokens,
-		                  "%zzz = %zzz", 11);
+						  "%zzz = %%zzz", tokens,
+						  "%zzz = %zzz", 11);
 		/* Test 9: Excessive % stuff */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "%Y%%%m%%%d %zzz% %%%%%%", tokens,
-		                  "2004%02%29 %zzz% %%%", 20);
+						  "%Y%%%m%%%d %zzz% %%%%%%", tokens,
+						  "2004%02%29 %zzz% %%%", 20);
 		/* Test 10: Simple string, buffer too short */
 		test_j9str_tokens(portLibrary, testName, buf, 7, "Teststring", tokens, "Testst", 11);
 		/* Test 11: Single token, buffer too short */
-		test_j9str_tokens(portLibrary, testName, buf, 3, "%Y", tokens, "20", 5);	
+		test_j9str_tokens(portLibrary, testName, buf, 3, "%Y", tokens, "20", 5);
 		/* Test 12: Test for overflow with an actual short buffer (simple string) */
 		test_j9str_tokens(portLibrary, testName, bufOverflow, TEST_OVERFLOW_LEN,
-		                  "Teststring", tokens,
-		                  "Teststr", 11);
+						  "Teststring", tokens,
+						  "Teststr", 11);
 		/* Test 13: Test for overflow with an actual short buffer (token) */
 		test_j9str_tokens(portLibrary, testName, bufOverflow, TEST_OVERFLOW_LEN,
-		                  "Test %Y", tokens,
-		                  "Test 20", 10);
+						  "Test %Y", tokens,
+						  "Test 20", 10);
 		/* Test 14: Test for token precedence based on length */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "%yyy is not %yy is not %y", tokens,
-		                  "yup yup yup is not 04y is not 04", 32);
+						  "%yyy is not %yy is not %y", tokens,
+						  "yup yup yup is not 04y is not 04", 32);
 		/* Test 15: Test the read only mode (should return the required buf len) */
 		test_j9str_tokens(portLibrary, testName, NULL, 0,
-		                  "%yyy is not %yy is not %y", tokens,
-		                  NULL, 33); /* 33 because must include \0 */
+						  "%yyy is not %yy is not %y", tokens,
+						  NULL, 33); /* 33 because must include \0 */
 		/* Test 16: Test an empty token */
 		test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
-		                  "x%emptyx == xx", tokens,
-		                  "xx == xx", 8);
+						  "x%emptyx == xx", tokens,
+						  "xx == xx", 8);
 
 		/* Test 17: All tokens that we get for free in j9str_create_tokens (and that the user may be relying on) */
 		{
@@ -692,19 +691,19 @@ j9str_test4(struct J9PortLibrary *portLibrary)
 
 			UDATA i = 0;
 			UDATA rc;
-			char *timePortionOfFormatString = "%y,(%Y) %m,(%b) %d XX:%M:%S %"; 
+			char *timePortionOfFormatString = "%y,(%Y) %m,(%b) %d XX:%M:%S %";
 			char *fullFormatString = NULL;
 			UDATA sizeOfFullFormatString = 0;
-		
+
 			strncpy(expected, "04,(2004) 02,(Feb) 29 XX:00:00 %", J9STR_BUFFER_SIZE);
-			
+
 			/* build the format string (tack on the default tokens) */
-			
+
 			/* how large does it need to be? */
 			sizeOfFullFormatString = strlen(timePortionOfFormatString);
 			for (i = 0 ; i < (sizeof(default_tokens)/sizeof(char *)) ; i++) {
 				sizeOfFullFormatString = sizeOfFullFormatString + strlen(default_tokens[i]);
-			}	
+			}
 			sizeOfFullFormatString = sizeOfFullFormatString + 1 /* null terminator */;
 
 			/* ok, now build the format string */
@@ -712,11 +711,11 @@ j9str_test4(struct J9PortLibrary *portLibrary)
 			strncpy(fullFormatString, timePortionOfFormatString, sizeOfFullFormatString);
 			for (i = 0 ; i < (sizeof(default_tokens)/sizeof(char *)) ; i++) {
 				strncat(fullFormatString, default_tokens[i], sizeOfFullFormatString - strlen(fullFormatString));
-			}		
-			
+			}
+
 			rc = j9str_subst_tokens(buf, TEST_BUF_LEN, fullFormatString, tokens);
-			
-			/* We don't know how long the returned string will be, 
+
+			/* We don't know how long the returned string will be,
 			 * but make sure that something has been substituted for each token and that the time is substituted properly .
 			 * Do this by making sure that %<token> is not present in the output buffer*/
 			if (rc > TEST_BUF_LEN) {
@@ -733,7 +732,7 @@ j9str_test4(struct J9PortLibrary *portLibrary)
 			j9mem_free_memory(fullFormatString);
 			fullFormatString = NULL;
 		}
-	
+
 		/* We're done, let's cleanup */
 		j9str_free_tokens(tokens);
 	}
@@ -746,11 +745,11 @@ j9str_test4(struct J9PortLibrary *portLibrary)
 /**
  * Verify port library token operations.
  *
- * j9str_test5 isn't really a test. Just want to do the normal use case of j9time_current_time_millis() followed 
+ * j9str_test5 isn't really a test. Just want to do the normal use case of j9time_current_time_millis() followed
  *  by j9str_create_tokens().
- * 
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
 int
@@ -763,27 +762,27 @@ j9str_test5(struct J9PortLibrary *portLibrary)
 	I_64 timeMillis;
 	struct J9StringTokens *tokens;
 	char buf[TEST_BUF_LEN];
-		
+
 	reportTestEntry(portLibrary, testName);
-	
+
 	j9tty_printf(PORTLIB, "\n\tThe results of j9str_test5 are not evaluated as time conversions are specific to a time zone.\n");
 	j9tty_printf(PORTLIB, "\tTherefore, this is for your viewing pleasure only.\n");
-	
+
 	timeMillis = j9time_current_time_millis();
 	j9tty_printf(PORTLIB, "\n\tj9time_current_time_millis returned: %lli\n", timeMillis);
 	j9tty_printf(PORTLIB, "\t...creating and substituting tokens...\n");
 	tokens = j9str_create_tokens(timeMillis);
 	(void)j9str_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
 	j9tty_printf(PORTLIB, "\tThe current time was converted to: %s\n",buf);
-	
- 	timeMillis = J9CONST64(1139952606740);
+
+	timeMillis = J9CONST64(1139952606740);
 	j9tty_printf(PORTLIB, "\n\t using UTC timeMillis = %lli. \n\t", timeMillis);
 	j9tty_printf(PORTLIB, "\t...creating and substituting tokens...\n");
 	tokens = j9str_create_tokens(timeMillis);
 	(void)j9str_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
 	j9tty_printf(PORTLIB, "\tExpecting local time (in Ottawa, Eastern Standard Time): 2006/02/14 16:30:06 \n", timeMillis);
 	j9tty_printf(PORTLIB, "\t                                       ... converted to: %s\n",buf);
-	
+
 	timeMillis = J9CONST64(1150320606740);
 	j9tty_printf(PORTLIB, "\n\t using UTC timeMillis = %lli. \n\t ", timeMillis);
 	j9tty_printf(PORTLIB, "\t...creating and substituting tokens...\n");
@@ -791,7 +790,7 @@ j9str_test5(struct J9PortLibrary *portLibrary)
 	(void)j9str_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
 	j9tty_printf(PORTLIB, "\tExpecting local time (in Ottawa, Eastern Daylight Time): 2006/06/14 17:30:06 \n", timeMillis);
 	j9tty_printf(PORTLIB, "\t                                       ... converted to: %s\n",buf);
-	
+
 	timeMillis = J9CONST64(1160688606740);
 	j9tty_printf(PORTLIB, "\n\t using UTC timeMillis = %lli. \n\t ", timeMillis);
 	j9tty_printf(PORTLIB, "\t...creating and substituting tokens...\n");
@@ -807,19 +806,19 @@ j9str_test5(struct J9PortLibrary *portLibrary)
 	(void)j9str_subst_tokens(buf, TEST_BUF_LEN, "%Y/%m/%d %H:%M:%S", tokens);
 	j9tty_printf(PORTLIB, "\tExpecting local time (in Ottawa, Eastern Standard Time): 2006/12/11 16:30:06 \n", timeMillis);
 	j9tty_printf(PORTLIB, "\t                                       ... converted to: %s\n",buf);
-	
+
 	j9tty_printf(PORTLIB, "\n");
 	return reportTestExit(portLibrary, testName);
-	
+
 }
 
 /**
  * Verify port library token operations.
  *
  * Test  (-)ive value of  0-12 hours and make sure we get UTC time in millis a
- * 
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return TEST_PASS on success, TEST_FAIL on error
  */
 int
@@ -832,15 +831,15 @@ j9str_test6(struct J9PortLibrary *portLibrary)
 	I_64 timeMillis;
 	struct J9StringTokens *tokens;
 	char buf[TEST_BUF_LEN];
-		
+
 	reportTestEntry(portLibrary, testName);
-	
+
 	/* anything less than 12 hours before Epoch should come back as Epoch */
 	timeMillis = 0 - 12*60*60*1000;
 	tokens = j9str_create_tokens(timeMillis);
 	test_j9str_tokens(portLibrary, testName, buf, TEST_BUF_LEN,
 			"%Y/%m/%d %H:%M:%S", tokens,
-	                  "1970/01/01 00:00:00", 19);	
+					  "1970/01/01 00:00:00", 19);
 	return reportTestExit(portLibrary, testName);
 }
 
@@ -1689,15 +1688,15 @@ j9str_test_atoe_vsnprintf(struct J9PortLibrary *portLibrary)
 
 /**
  * Verify port library string operations.
- * 
+ *
  * Exercise all API related to port library string operations found in
  * @ref j9str.c
- * 
+ *
  * @param[in] portLibrary The port library under test
- * 
+ *
  * @return 0 on success, -1 on failure
  */
-I_32 
+I_32
 j9str_runTests(struct J9PortLibrary *portLibrary)
 {
 	PORT_ACCESS_FROM_PORT(portLibrary);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1651,7 +1651,7 @@ initializeClassPath(J9JavaVM *vm, char *classPath, U_8 classPathSeparator, U_16 
 	}
 
 _end:
-        return classPathEntryCount;
+	return classPathEntryCount;
 }
 
 IDATA
@@ -7190,8 +7190,8 @@ xlogerr:
 				}
 				j9str_subst_tokens(timeBuf, sizeof(timeBuf), "%Y-%m-%d_%H-%M-%S", stringTokens);
 
-				if (j9str_set_token(PORTLIB, stringTokens, "p", "%lld", j9sysinfo_get_pid())
-					|| j9str_set_token(PORTLIB, stringTokens, "t", "%s", timeBuf)
+				if ((0 != j9str_set_token(stringTokens, "p", "%lld", j9sysinfo_get_pid()))
+				||  (0 != j9str_set_token(stringTokens, "t", "%s", timeBuf))
 				) {
 					j9str_free_tokens(stringTokens);
 					rc = JNI_ERR;


### PR DESCRIPTION
There's no need to expect users to provide a pointer to the port library (the macro already assumes access via `PORTLIB`); this avoids possible problems being used with a different, incompatible argument.

At least three parameters must be supplied (so the function in `omrstr.c` receives at least four).

Tidy up whitespace.