### PR TITLE
Edit file tag of various generated files for z/OS

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -135,10 +135,19 @@ add_custom_target(j9vm_hookgen
 
 # Generate NLS headers
 file(GLOB_RECURSE nls_files "${CMAKE_CURRENT_SOURCE_DIR}/nls/*.nls")
+
+# On z/OS, nls generated files must be tagged as ASCII to allow for accurate EBCDIC conversion.
+if(OMR_OS_ZOS)
+	set(tag_nls_headers find ${CMAKE_CURRENT_BINARY_DIR}/nls -name "*.h" | xargs chtag -t -c ISO8859-1)
+else()
+	set(tag_nls_headers "true")
+endif()
+
 add_custom_command(
 	OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/nls.stamp"
 	DEPENDS j9nls ${nls_files}
 	COMMAND "${Java_JAVA_EXECUTABLE}" -cp "$<TARGET_PROPERTY:j9nls,JAR_FILE>" com.ibm.oti.NLSTool.J9NLS -source "${CMAKE_CURRENT_SOURCE_DIR}"
+	COMMAND ${tag_nls_headers}
 	COMMAND "${CMAKE_COMMAND}" -E touch "${CMAKE_CURRENT_BINARY_DIR}/nls.stamp"
 	COMMENT "Generating NLS files"
 	VERBATIM


### PR DESCRIPTION
The IBM Semeru Runtime Certified Edition for z/OS, Version 21 (JDK21) features JEP400 support, which expects files to be tagged appropriately in order for correct encoding on z/OS platforms when running without `COMPAT` option. The following changes were made in OpenJ9 in order to address these needs:
- Tag NLS header files as ISO8859-1
- Tag j9jvmconstantpool.c/.h as ISO8859-1
- Tag generated j9jcl files as IBM-1047

Currently opening the PR in draft as other internal edits must be merged before the following changes in OpenJ9 for z/OS. 

Signed-off-by: Danja Papajani <danja.papajani@ibm.com>