### PR TITLE
Dynamic copy-cache allocation in Balanced

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -122,6 +122,7 @@ private:
 	uintptr_t _scanCacheListSize;	/**< The number of entries in _cacheScanLists */
 	volatile uintptr_t _scanCacheWaitCount;	/**< The number of threads currently sleeping on _scanCacheMonitor, awaiting scan cache work */
 	omrthread_monitor_t _scanCacheMonitor;	/**< Used when waiting on work on any of the _cacheScanLists */
+	omrthread_monitor_t _freeCacheMonitor; /**< Monitor to synchronize threads while resizing free list */
 
 	volatile uintptr_t *_workQueueWaitCountPtr;	/**< The number of threads currently sleeping on *_workQueueMonitorPtr, awaiting scan cache work or work from packets*/
 	omrthread_monitor_t *_workQueueMonitorPtr;	/**< Used when waiting on work on any of the _cacheScanLists or workPackets*/

--- a/runtime/gc_vlhgc/CopyScanCacheChunkVLHGC.hpp
+++ b/runtime/gc_vlhgc/CopyScanCacheChunkVLHGC.hpp
@@ -49,9 +49,9 @@ public:
 	MMINLINE MM_CopyScanCacheChunkVLHGC *getNext() const { return _nextChunk; }
 	MMINLINE void setNext(MM_CopyScanCacheChunkVLHGC *newNext) { _nextChunk = newNext; }
 	
-	static MM_CopyScanCacheChunkVLHGC *newInstance(MM_EnvironmentVLHGC *env, UDATA cacheEntryCount, MM_CopyScanCacheVLHGC **nextCacheAddr, MM_CopyScanCacheChunkVLHGC *nextChunk);
+	static MM_CopyScanCacheChunkVLHGC *newInstance(MM_EnvironmentVLHGC *env, uintptr_t cacheEntryCount, MM_CopyScanCacheVLHGC **tailCacheAddr, MM_CopyScanCacheChunkVLHGC *nextChunk);
 	virtual void kill(MM_EnvironmentVLHGC *env);
-	bool initialize(MM_EnvironmentVLHGC *env, UDATA cacheEntryCount, MM_CopyScanCacheVLHGC **nextCacheAddr, MM_CopyScanCacheChunkVLHGC *nextChunk);
+	bool initialize(MM_EnvironmentVLHGC *env, uintptr_t cacheEntryCount, MM_CopyScanCacheVLHGC **tailCacheAddr, MM_CopyScanCacheChunkVLHGC *nextChunk);
 	virtual void tearDown(MM_EnvironmentVLHGC *env);
 
 	/**


### PR DESCRIPTION
Currently we preallocate all copy-scan-caches upfront based on the maximum heap size. This unnecessarily slows down startup time and increases footprint during during ramp-up.

Now, we create only small set at startup and dynamically increase during GC as we need it.

The code is mostly borrowed from Scavenger, except we don't look at heap size, but only at GC thread count during both initial and incremental increase (the goal is just not to create contention during incremental increase).