### PR TITLE
Replace isdigit with OMR_ISDIGIT

### DIFF
--- a/runtime/cfdumper/romdump.c
+++ b/runtime/cfdumper/romdump.c
@@ -698,14 +698,14 @@ parseROMQuery(J9Pool *allocator, const char *query)
 
 		if ('[' == *query) {
 			query++;
-			if (!isdigit(*query)) {
+			if (!OMR_ISDIGIT(*query)) {
 				return NULL;
 			}
 
 			component->arrayIndex = atoi(query);
 			do {
 				query++;
-			} while (isdigit(*query));
+			} while (OMR_ISDIGIT(*query));
 
 			if (']' != *query) {
 				return NULL;

--- a/runtime/compiler/il/J9DataTypes.cpp
+++ b/runtime/compiler/il/J9DataTypes.cpp
@@ -1057,7 +1057,7 @@ J9::DataType::getBCDPrecisionFromString(char *str, TR::DataType dt) // +123 prec
       }
    else
       {
-      TR_ASSERT(isdigit(str[0]),"expecting a minus/plus sign or a decimal digit and not 0x%x\n",str[0]);
+      TR_ASSERT(OMR_ISDIGIT(str[0]), "expecting a minus/plus sign or a decimal digit and not 0x%x\n", str[0]);
       }
    return precision;
    }
@@ -1073,7 +1073,7 @@ J9::DataType::getBCDStringFirstIndex(char *str, TR::DataType dt)
       }
    else
       {
-      TR_ASSERT(isdigit(firstChar),"expecting a minus/plus sign or a decimal digit and not 0x%x\n",firstChar);
+      TR_ASSERT(OMR_ISDIGIT(firstChar), "expecting a minus/plus sign or a decimal digit and not 0x%x\n", firstChar);
       firstIndex = 0;
       }
    return firstIndex;

--- a/runtime/jcl/common/jcltrace.c
+++ b/runtime/jcl/common/jcltrace.c
@@ -367,7 +367,7 @@ buildCallPattern(const char *const templateString, UDATA *const result)
 				/*Reparse this letter in the READING_MODIFIER state*/
 				state = READING_MODIFIER;
 				continue;
-			} else if (('.' != *p) && !isdigit(*p)) {
+			} else if (('.' != *p) && !OMR_ISDIGIT(*p)) {
 				state = READING_TYPE;
 				continue;
 			}

--- a/runtime/rastrace/trccomponent.c
+++ b/runtime/rastrace/trccomponent.c
@@ -734,7 +734,7 @@ parseAndSetTracePointsInRange(const char *componentName,
 
 		ret = 0;
 		temp = p;
-		while (isdigit((int)*temp)) {
+		while (OMR_ISDIGIT((int)*temp)) {
 			ret++;
 			temp++;
 		}
@@ -747,11 +747,11 @@ parseAndSetTracePointsInRange(const char *componentName,
 			p += ret + 1;
 			length++; /* plus one for the dash */
 			ret = 0;
-			if (!isdigit(*temp)) {
+			if (!OMR_ISDIGIT(*temp)) {
 				reportCommandLineError(suppressMessages, "Expecting tracepoint range specified as tpnid{componentName.offset1-offset2} e.g. tpnid{j9trc.2-6}");
 				return OMR_ERROR_ILLEGAL_ARGUMENT;
 			}
-			while (isdigit(*temp)) {
+			while (OMR_ISDIGIT(*temp)) {
 				ret++;
 				temp++;
 			}
@@ -913,7 +913,7 @@ setTracePointsToParsed(const char *componentName, UtComponentList *componentList
 
 		if (0 == j9_cmdla_strnicmp(tempstr, UT_LEVEL_KEYWORD, strlen(UT_LEVEL_KEYWORD)) ||
 			  *tempstr == 'l' || *tempstr == 'L') {
-			while (!isdigit(*tempstr)) {
+			while (!OMR_ISDIGIT(*tempstr)) {
 				if (*tempstr == ',' || *tempstr == '}' || *tempstr == '\0') {
 					reportCommandLineError(suppressMessages, "Trace level required without an integer level specifier");
 					return OMR_ERROR_ILLEGAL_ARGUMENT;

--- a/runtime/rastrace/trcoptions.c
+++ b/runtime/rastrace/trcoptions.c
@@ -149,7 +149,7 @@ parseBufferSize(const char * const str, const int argSize, BOOLEAN atRuntime)
 	const char * p = str;
 
 	for (; '\0' != *p; ++p) {
-		if (isdigit(*p)) {
+		if (OMR_ISDIGIT(*p)) {
 			if (-1 == firstDigit) {
 				firstDigit = p - str;
 			}

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -381,8 +381,7 @@ scan_u64(char **scan_start, U_64* result)
 	UDATA rc = 1;
 	char *c = *scan_start;
 
-	/* isdigit isn't properly supported everywhere */
-	while ( *c >= '0' && *c <= '9' ) {
+	while (OMR_ISDIGIT(*c)) {
 		UDATA digitValue = *c - '0';
 
 		if (total > ((U_64)-1) / 10 ) {

--- a/runtime/util_core/j9argscan.c
+++ b/runtime/util_core/j9argscan.c
@@ -20,6 +20,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
@@ -198,8 +199,7 @@ uintptr_t scan_udata(char **scan_start, uintptr_t* result)
 	uintptr_t total = 0, rc = 1;
 	char *c = *scan_start;
 
-	/* isdigit isn't properly supported everywhere */
-	while ( *c >= '0' && *c <= '9' ) {
+	while (OMR_ISDIGIT(*c)) {
 		uintptr_t digitValue = *c - '0';
 
 		if (total > ((uintptr_t)-1) / 10 ) {
@@ -236,8 +236,7 @@ scan_u64(char **scan_start, uint64_t* result)
 	uintptr_t rc = 1;
 	char *c = *scan_start;
 
-	/* isdigit isn't properly supported everywhere */
-	while ( *c >= '0' && *c <= '9' ) {
+	while (OMR_ISDIGIT(*c)) {
 		uintptr_t digitValue = *c - '0';
 
 		if (total > ((uint64_t)-1) / 10 ) {
@@ -274,8 +273,7 @@ scan_u32(char **scan_start, uint32_t* result)
 	uintptr_t rc = 1;
 	char *c = *scan_start;
 
-	/* isdigit isn't properly supported everywhere */
-	while ( *c >= '0' && *c <= '9' ) {
+	while (OMR_ISDIGIT(*c)) {
 		uint32_t digitValue = *c - '0';
 
 		if (total > ((uint32_t)-1) / 10 ) {


### PR DESCRIPTION
In order to support removal of a2e header redefinitions for
isdigit() method, the usage of isdigit() are replaced with
OMR_ISDIGIT() to properly recognize ascii digit literals.
This is done by conditionally using __isdigit_a() on z/OS
platforms.

Main PR driving this change, that needs to be merged beforehand: https://github.com/eclipse-omr/omr/pull/7761

(project tag: Open XL z/OS compiler support)