### PR TITLE
TearDown Balanced Config on Offheap creation fail

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -185,15 +185,7 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 			/* reset vm->unsafeIndexableHeaderSize for off-heap case */
 			vm->unsafeIndexableHeaderSize = 0;
 		} else {
-#if defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD)
-			extensions->heapRegionStateTable->kill(env->getForge());
-			extensions->heapRegionStateTable = NULL;
-#endif /* defined(OMR_GC_VLHGC_CONCURRENT_COPY_FORWARD) */
-			extensions->compressedCardTable->kill(env);
-			extensions->compressedCardTable = NULL;
-			extensions->cardTable->kill(env);
-			extensions->cardTable = NULL;
-			heap->kill(env);
+			tearDown(env);
 			return NULL;
 		}
 	}


### PR DESCRIPTION
Currently, when creation of Offheap (for example due to virtual address space limit) fails, the inlined variant of the teardown does not properly check if components are really created before tearing them down.

We now call the full teardown instead (used at shutdown). It may be overkill (some components may be known to not be created yet), but it's still supposed to be completely safe and future proof.