### PR TITLE
(0.51) Add JFR GCHeapConfiguration Event

### DIFF
--- a/runtime/vm/JFRChunkWriter.cpp
+++ b/runtime/vm/JFRChunkWriter.cpp
@@ -810,6 +810,70 @@ VM_JFRChunkWriter::writeOSInformationEvent()
 }
 
 void
+VM_JFRChunkWriter::writeNarrowOOPModeTypesEvent()
+{
+	U_8 *dataStart = writeCheckpointEventHeader(Generic, 1);
+
+	/* class ID */
+	_bufferWriter->writeLEB128(NarrowOopModesID);
+
+	/* number of states */
+	_bufferWriter->writeLEB128(OOPModeTypeCount);
+
+	for (int i = 0; i < OOPModeTypeCount; i++) {
+		/* constant index */
+		_bufferWriter->writeLEB128(i);
+
+		/* write string */
+		writeStringLiteral(oopModeTypeNames[i]);
+	}
+
+	/* write size */
+	writeEventSize(dataStart);
+
+}
+
+void
+VM_JFRChunkWriter::writeGCHeapConfigurationEvent()
+{
+	GCHeapConfigurationEntry *gcConfig = &(VM_JFRConstantPoolTypes::getJFRConstantEvents(_vm)->GCHeapConfigEntry);
+
+	/* reserve size field */
+	U_8 *dataStart = reserveEventSize();
+
+	/* write event type */
+	_bufferWriter->writeLEB128(GCHeapConfigID);
+
+	/* write event start time */
+	_bufferWriter->writeLEB128(j9time_nano_time());
+
+	/* write heap min size */
+	_bufferWriter->writeLEB128(gcConfig->minSize);
+
+	/* write heap max size */
+	_bufferWriter->writeLEB128(gcConfig->maxSize);
+
+	/* write heap initial size */
+	_bufferWriter->writeLEB128(gcConfig->initialSize);
+
+	/* write whether oops are used or not */
+	_bufferWriter->writeBoolean(gcConfig->usesCompressedOops);
+
+	/* write oops type being used */
+	_bufferWriter->writeLEB128(gcConfig->compressedOopsMode);
+
+	/* write how object alignment is on the heap */
+	_bufferWriter->writeLEB128(gcConfig->objectAlignment);
+
+	/* write how many bits head addresses are */
+	_bufferWriter->writeLEB128(gcConfig->heapAddressBits);
+
+	/* write event size */
+	writeEventSize(dataStart);
+
+}
+
+void
 VM_JFRChunkWriter::writeInitialSystemPropertyEvents(J9JavaVM *vm)
 {
 	pool_state walkState;

--- a/runtime/vm/JFRChunkWriter.hpp
+++ b/runtime/vm/JFRChunkWriter.hpp
@@ -52,6 +52,10 @@ static constexpr const char * const threadStateNames[] = {
 	"STATE_BLOCKED_ON_MONITOR_ENTER"
 };
 
+static constexpr const char * const oopModeTypeNames[] = {
+	"Zero based"
+};
+
 enum StringEnconding {
 	NullString = 0,
 	EmptyString,
@@ -82,6 +86,7 @@ enum MetadataTypeID {
 	PhysicalMemoryID = 108,
 	ExecutionSampleID = 109,
 	ThreadDumpID = 111,
+	GCHeapConfigID = 133,
 	ThreadID = 164,
 	ThreadGroupID = 165,
 	ClassID = 166,
@@ -89,6 +94,7 @@ enum MetadataTypeID {
 	MethodID = 168,
 	SymbolID = 169,
 	ThreadStateID = 170,
+	NarrowOopModesID = 180,
 	ModuleID = 186,
 	PackageID = 187,
 	StackTraceID = 188,
@@ -148,6 +154,7 @@ private:
 	static constexpr int CHECKPOINT_EVENT_HEADER_AND_FOOTER = 68;
 	static constexpr int STRING_CONSTANT_SIZE = 128;
 	static constexpr int THREADSTATE_ENTRY_LENGTH = CHECKPOINT_EVENT_HEADER_AND_FOOTER + sizeof(threadStateNames) + (THREADSTATE_COUNT * STRING_HEADER_LENGTH);
+	static constexpr int OOP_MODES_ENTRY_SIZE = CHECKPOINT_EVENT_HEADER_AND_FOOTER + sizeof(oopModeTypeNames) + (OOPModeTypeCount * STRING_HEADER_LENGTH);
 	static constexpr int CLASS_ENTRY_ENTRY_SIZE = (5 * sizeof(U_64)) + sizeof(U_8);
 	static constexpr int CLASSLOADER_ENTRY_SIZE = 3 * sizeof(U_64);
 	static constexpr int PACKAGE_ENTRY_SIZE = (3 * sizeof(U_64)) + sizeof(U_8);
@@ -344,6 +351,10 @@ done:
 
 			writeFrameTypeCheckpointEvent();
 
+			if (0 == _vm->jfrState.jfrChunkCount) {
+				writeNarrowOOPModeTypesEvent();
+			}
+
 			writeThreadCheckpointEvent();
 
 			writeThreadGroupCheckpointEvent();
@@ -399,6 +410,8 @@ done:
 				writeInitialSystemPropertyEvents(_vm);
 
 				writeInitialEnvironmentVariableEvents();
+
+				writeGCHeapConfigurationEvent();
 			}
 
 			writePhysicalMemoryEvent();
@@ -799,6 +812,10 @@ done:
 	U_8 *writeOSInformationEvent();
 
 	U_8 *writeThreadDumpEvent();
+
+	void writeNarrowOOPModeTypesEvent();
+
+	void writeGCHeapConfigurationEvent();
 
 	void writeInitialSystemPropertyEvents(J9JavaVM *vm);
 

--- a/test/functional/cmdLineTests/jfr/jfrevents.xml
+++ b/test/functional/cmdLineTests/jfr/jfrevents.xml
@@ -75,4 +75,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="success" caseSensitive="yes" regex="no">stackTrace</output>
 		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
 	</test>
+	<test id="test jfr gc heap configuration - approx 30seconds">
+		<command>$JFR_EXE$ print --xml --events "GCHeapConfiguration" defaultJ9recording.jfr</command>
+		<output type="required" caseSensitive="yes" regex="no">http://www.w3.org/2001/XMLSchema-instance</output>
+		<output type="success" caseSensitive="yes" regex="no">jdk.GCHeapConfiguration</output>
+		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
+	</test>
 </suite>


### PR DESCRIPTION
This change adds support for the JFR GC Heap Configuration Event.

Backport of https://github.com/eclipse-openj9/openj9/pull/21382