### PR TITLE
Fix bug with DAA enablement conditions for off-heap memory

### DIFF
--- a/runtime/compiler/optimizer/DataAccessAccelerator.cpp
+++ b/runtime/compiler/optimizer/DataAccessAccelerator.cpp
@@ -102,7 +102,7 @@ int32_t TR_DataAccessAccelerator::perform()
 
        // We cannot handle arraylets because hardware intrinsics act on contiguous memory
        !comp()->generateArraylets() && !TR::Compiler->om.useHybridArraylets() &&
-       (!TR::Compiler->om.isOffHeapAllocationEnabled() || comp()->getOption(TR_DisableVectorBCD)))
+       !(TR::Compiler->om.isOffHeapAllocationEnabled() && comp()->getOption(TR_DisableVectorBCD)))
      {
 
      // A vector to keep track of variable packed decimal calls


### PR DESCRIPTION
Previously, the non-vectorized DAA path was mistakenly enabled along with the vectorized DAA path for off-heap. Now, only the vectorized DAA path is enabled as intended.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>