### PR TITLE
Print Dynatrace core_pattern location in java dumps

### DIFF
--- a/runtime/rasdump/rasdump_internal.h
+++ b/runtime/rasdump/rasdump_internal.h
@@ -117,7 +117,7 @@ void setAllocationThreshold(J9VMThread *vmThread, UDATA min, UDATA max);
 #define J9RAS_SCHED_COMPAT_YIELD_FILE "/proc/sys/kernel/sched_compat_yield"
 #define J9RAS_CORE_PATTERN_FILE       "/proc/sys/kernel/core_pattern"
 #define J9RAS_CORE_USES_PID_FILE      "/proc/sys/kernel/core_uses_pid"
-#define J9RAS_CORE_ORIGINAL_PATTERN   ".../oneagent/agent/conf/original_core_pattern"
+#define J9RAS_CORE_ORIGINAL_PATTERN   "original_core_pattern"
 
 #if defined(WIN32)
 #define ALT_DIR_SEPARATOR '/'


### PR DESCRIPTION
Installations of newer releases of Dynatrace capture the original `core_pattern` in a fixed location.

Generalize the tag in `2CISYSINFO` for `original_core_pattern` so it doesn't include a partial path that could be misleading.

Fixes: https://github.com/eclipse-openj9/openj9/issues/21554.