### PR TITLE
Allocate RS Control Blocks for Balanced as virtual memory

### DIFF
--- a/runtime/gc_vlhgc/InterRegionRememberedSet.hpp
+++ b/runtime/gc_vlhgc/InterRegionRememberedSet.hpp
@@ -57,6 +57,8 @@ private:
 public:
 	MM_HeapRegionManager *_heapRegionManager;				/**< cached pointer to heap region manager */
 
+	MM_MemoryHandle _rsclBufferControlBlockPoolMemoryHandle;	/**< memory handle for Control Blocks (but not Buffers) backing store */
+
 	MM_CardBufferControlBlock *_rsclBufferControlBlockPool; /**< starting address of the global pool of control blocks (kept around to be able to release memory at the end) */
 	MM_CardBufferControlBlock * volatile _rsclBufferControlBlockHead; /**< current head of BufferControlBlock global pool list */
 	volatile UDATA _freeBufferCount;							/**< current count of Buffers in the global free pool */
@@ -69,7 +71,7 @@ public:
 
 	UDATA _regionSize;  			/**< Cached region size */
 
-	bool _shouldFlushBuffersForDecommitedRegions;			/**< set to true at the end of a GC, if contraction occured. this is a signal for the next GC to perform flush buffers from regions contracted */
+	bool _shouldFlushBuffersForDecommitedRegions;			/**< set to true at the end of a GC, if contraction occurred. this is a signal for the next GC to perform flush buffers from regions contracted */
 
 	volatile UDATA _overflowedRegionCount;					/**< count of regions overflowed as full */
 	UDATA _stableRegionCount;								/**< count of regions overflowed as stable */


### PR DESCRIPTION
Currently, all Control Blocks (kind of a header structure) for Remembered Set Buffers, for all possible regions, are allocated upfront with one big malloc. This is suboptimal from footprint perspective. Also, in extreme cases with very large heaps the allocation may not even succeed.

We will now allocate that space as Virtual Memory which will be lazily committed as needed (as regions are first time used and their RSCL is first time initialized).

RS Buffers themselves are already allocated incrementally/gradually, as regions are first time used, although still malloced. In future, we may want to allocate them as virtual memory too, but currently that is less important (relative to Control Blocks) due to their incremental allocation.