### PR TITLE
Prevent DDR failed during reading garbage

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
@@ -1029,7 +1029,7 @@ class CheckEngine
 		}
 
 		// Short circuit if we've recently checked this class.
-		int cacheIndex = new UDATA(clazz.longValue()).mod(CLASS_CACHE_SIZE).intValue();
+		int cacheIndex = UDATA.cast(clazz).mod(CLASS_CACHE_SIZE).intValue();
 		if (allowUndead && clazz.eq(_checkedClassCacheAllowUndead[cacheIndex])) {
 			return J9MODRON_GCCHK_RC_OK;
 		} else if (clazz.eq(_checkedClassCache[cacheIndex])) {


### PR DESCRIPTION
DDR intends to read class slot from the object in the heap. However this slot can contain unexpected value (garbage). Use UDATA class to prevent failure.