### PR TITLE
(0.52) CRIU Jcmd CRIU.checkpoint takes key/value pairs as system properties

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/crac/Core.java
+++ b/jcl/src/java.base/share/classes/jdk/crac/Core.java
@@ -74,11 +74,7 @@ class CRIUSupportContext<R extends Resource> extends Context<R> {
 	// InternalCRIUSupport.getCRaCCheckpointToDir() is not null if
 	// InternalCRIUSupport.isCRaCSupportEnabled() returns true before creating CRIUSupportContext<>().
 	private final InternalCRIUSupport internalCRIUSupport = InternalCRIUSupport.getInternalCRIUSupport()
-			.setImageDir(Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir()))
-			.setLeaveRunning(false)
-			.setShellJob(true)
-			.setTCPEstablished(true)
-			.setFileLocks(true);
+			.setCheckpointDefaultParams().setImageDir(Paths.get(InternalCRIUSupport.getCRaCCheckpointToDir()));
 
 	@Override
 	public void register(R resource) throws Exception {

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -35,9 +35,12 @@ import java.util.function.Function;
 
 import com.ibm.oti.vm.VM;
 
-/*[IF CRAC_SUPPORT]*/
+/*[IF CRIU_SUPPORT]*/
+import java.util.Properties;
+/*[ENDIF] CRIU_SUPPORT */
+/*[IF CRAC_SUPPORT | CRIU_SUPPORT]*/
 import openj9.internal.criu.InternalCRIUSupport;
-/*[ENDIF] CRAC_SUPPORT */
+/*[ENDIF] CRAC_SUPPORT | CRIU_SUPPORT */
 import openj9.internal.management.ClassLoaderInfoBaseImpl;
 import openj9.management.internal.IDCacheInitializer;
 import openj9.management.internal.InvalidDumpOptionExceptionBase;
@@ -111,12 +114,26 @@ public class DiagnosticUtils {
 	 */
 	private static final String DIAGNOSTICS_THREAD_PRINT = "Thread.print";
 
+/*[IF CRIU_SUPPORT]*/
+	/**
+	 * The system property prefix for the key/value pairs specified via CRIU.checkpoint.
+	 */
+	private static final String CRIU_SYSTEM_PROPERTY_PREFIX = "openj9.internal.criu.";
+/*[ENDIF] CRIU_SUPPORT */
+
 /*[IF CRAC_SUPPORT]*/
 	/**
-	 * Generate a checkpoint via CRIUSupport using a compatability name.
+	 * Generate a checkpoint via CRIUSupport using a compatible name for CRaC enabled JVM.
 	 */
 	private static final String DIAGNOSTICS_JDK_CHECKPOINT = "JDK.checkpoint";
 /*[ENDIF] CRAC_SUPPORT */
+
+/*[IF CRIU_SUPPORT]*/
+	/**
+	 * Generate a checkpoint via CRIUSupport using a compatible name for CRIU enabled JVM.
+	 */
+	private static final String DIAGNOSTICS_CRIU_CHECKPOINT = "CRIU.checkpoint";
+/*[ENDIF] CRIU_SUPPORT */
 
 	/**
 	 * Run System.gc();
@@ -160,9 +177,10 @@ public class DiagnosticUtils {
 	public static final String COMMAND_STRING = "command_string";
 
 	/**
-	 * Use this to separate arguments in a diagnostic command string.
+	 * Use these to separate arguments in a diagnostic command string.
 	 */
 	public static final String DIAGNOSTICS_OPTION_SEPARATOR = ",";
+	public static final String DIAGNOSTICS_PROPERTY_SEPARATOR = "=";
 
 	/**
 	 * Report live or all heap objects.
@@ -579,20 +597,86 @@ public class DiagnosticUtils {
 
 	}
 
+/*[IF CRAC_SUPPORT | CRIU_SUPPORT]*/
+	private static DiagnosticProperties parseCheckpointCommands(String diagnosticCommand) {
+		DiagnosticProperties result = null;
+		String[] parts = diagnosticCommand.split(DIAGNOSTICS_OPTION_SEPARATOR);
+		if (parts.length > 1) {
 /*[IF CRAC_SUPPORT]*/
-	private static DiagnosticProperties doCheckpointJVM(String diagnosticCommand) {
-		Thread checkpointThread = new Thread(() -> {
-			try {
-				jdk.crac.Core.checkpointRestore();
-			} catch (Throwable t) {
-				t.printStackTrace();
+			if (DIAGNOSTICS_JDK_CHECKPOINT.equalsIgnoreCase(parts[0])) {
+				// parts[0] is DIAGNOSTICS_JDK_CHECKPOINT
+				result = DiagnosticProperties.makeStringResult(DIAGNOSTICS_JDK_CHECKPOINT + " doesn't take any parameters");
+			} else
+/*[ENDIF] CRAC_SUPPORT */
+			{
+/*[IF CRIU_SUPPORT]*/
+				// parts[0] is DIAGNOSTICS_CRIU_CHECKPOINT
+				// the command format: CRIU.checkpoint,imageDir=/path/to/cpData,logLevel=4
+				for (int index = 1; index < parts.length; index++) {
+					IPC.logMessage("parseCheckpointCommands: ", "parts[" + index + "] : " + parts[index]);
+					String[] sysPropValue = parts[index].split(DIAGNOSTICS_PROPERTY_SEPARATOR);
+					if (sysPropValue.length != 2) {
+						result = DiagnosticProperties.makeErrorProperties("Expected Jcmd format: " + parts[0]
+								+ ",imageDir=/path/to/cpData,logLevel=4"
+								+ " that creates system properties <openj9.internal.criu.imageDir> with the value </path/to/cpData>"
+								+ " and <openj9.internal.criu.logLevel> with the value <4>, but got: " + diagnosticCommand);
+						break;
+					}
+					Properties props = VM.internalGetProperties();
+					props.setProperty(CRIU_SYSTEM_PROPERTY_PREFIX + sysPropValue[0], sysPropValue[1]);
+				}
+/*[ENDIF] CRIU_SUPPORT */
 			}
-		});
-		checkpointThread.start();
+		}
+		return result;
+	}
+/*[ENDIF] CRAC_SUPPORT | CRIU_SUPPORT */
 
-		return DiagnosticProperties.makeStringResult("JVM checkpoint requested");
+/*[IF CRAC_SUPPORT]*/
+	private static DiagnosticProperties doCRaCCheckpointJVM(String diagnosticCommand) {
+		DiagnosticProperties result;
+		if (InternalCRIUSupport.isCRaCSupportEnabled()) {
+			result = parseCheckpointCommands(diagnosticCommand);
+			if (result == null) {
+				Thread checkpointThread = new Thread(() -> {
+					try {
+						jdk.crac.Core.checkpointRestore();
+					} catch (Throwable t) {
+						t.printStackTrace();
+					}
+				});
+				checkpointThread.start();
+				result = DiagnosticProperties.makeStringResult("JVM checkpoint requested");
+			}
+		} else {
+			result = DiagnosticProperties.makeStringResult("CRaC support is not enabled, JVM can't perform a checkpoint");
+		}
+		return result;
 	}
 /*[ENDIF] CRAC_SUPPORT */
+
+/*[IF CRIU_SUPPORT]*/
+	private static DiagnosticProperties doCRIUCheckpointJVM(String diagnosticCommand) {
+		DiagnosticProperties result;
+		if (InternalCRIUSupport.isCRIUSupportEnabled()) {
+			result = parseCheckpointCommands(diagnosticCommand);
+			if (result == null) {
+				Thread checkpointThread = new Thread(() -> {
+					try {
+						InternalCRIUSupport.getInternalCRIUSupport().setCheckpointDefaultParams().checkpointJVM();
+					} catch (Throwable t) {
+						t.printStackTrace();
+					}
+				});
+				checkpointThread.start();
+				result = DiagnosticProperties.makeStringResult("JVM checkpoint requested");
+			}
+		} else {
+			result = DiagnosticProperties.makeStringResult("CRIU support is not enabled, JVM can't perform a checkpoint");
+		}
+		return result;
+	}
+/*[ENDIF] CRIU_SUPPORT */
 
 	/* Help strings for the jcmd utilities */
 	private static final String DIAGNOSTICS_HELP_HELP = "Show help for a command%n"
@@ -641,6 +725,16 @@ public class DiagnosticUtils {
 			+ FORMAT_PREFIX + DIAGNOSTICS_JDK_CHECKPOINT + "%n"
 			+ "NOTE: this utility might significantly affect the performance of the target VM.%n";
 /*[ENDIF] CRAC_SUPPORT */
+
+/*[IF CRIU_SUPPORT]*/
+	private static final String DIAGNOSTICS_CRIU_CHECKPOINT_HELP = "Produce a JVM checkpoint via CRIUSupport, optionally set system properties.%n"
+			+ FORMAT_PREFIX + DIAGNOSTICS_CRIU_CHECKPOINT + "[,imageDir=/path/to/cpData][,logLevel=4]" + "%n"
+			+ "          A prefix <" + CRIU_SYSTEM_PROPERTY_PREFIX + "> is added to the each key specified.%n"
+			+ "          The sample options above create following system properties:%n"
+			+ "          - a system property <openj9.internal.criu.imageDir> with the value </path/to/cpData>%n"
+			+ "          - a system property <openj9.internal.criu.logLevel> with the value <4>%n"
+			+ "NOTE: this utility might significantly affect the performance of the target VM.%n";
+/*[ENDIF] CRIU_SUPPORT */
 
 /*[IF JFR_SUPPORT]*/
 	private static final String DIAGNOSTICS_JFR_START_HELP = "Start a new Recording%n%n"
@@ -694,10 +788,17 @@ public class DiagnosticUtils {
 
 /*[IF CRAC_SUPPORT]*/
 		if (InternalCRIUSupport.isCRaCSupportEnabled()) {
-			commandTable.put(DIAGNOSTICS_JDK_CHECKPOINT, DiagnosticUtils::doCheckpointJVM);
+			commandTable.put(DIAGNOSTICS_JDK_CHECKPOINT, DiagnosticUtils::doCRaCCheckpointJVM);
 			helpTable.put(DIAGNOSTICS_JDK_CHECKPOINT, DIAGNOSTICS_JDK_CHECKPOINT_HELP);
 		}
 /*[ENDIF] CRAC_SUPPORT */
+
+/*[IF CRIU_SUPPORT]*/
+		if (InternalCRIUSupport.isCRIUSupportEnabled()) {
+			commandTable.put(DIAGNOSTICS_CRIU_CHECKPOINT, DiagnosticUtils::doCRIUCheckpointJVM);
+			helpTable.put(DIAGNOSTICS_CRIU_CHECKPOINT, DIAGNOSTICS_CRIU_CHECKPOINT_HELP);
+		}
+/*[ENDIF] CRIU_SUPPORT */
 
 /*[IF JFR_SUPPORT]*/
 		if (VM.isJFREnabled()) {


### PR DESCRIPTION
CRIU Jcmd `CRIU.checkpoint` takes key/value pairs as system properties

`InternalCRIUSupport` singleton instance overrides checkpoint parameters with current system properties;
Added a Jcmd command `CRIU.checkpoint` for CRIU enabled JVM;
Added `InternalCRIUSupport.setCheckpointDefaultParams()` to allow Jcmd `CRIU.checkpoint` and `JDK.checkpoint` work without additional key/value pairs;
Jcmd commands `CRIU.checkpoint` takes key/value pairs as system properties, the keys are added prefix `"openj9.internal.criu."`;
`JDK.checkpoint` doesn't take any parameters.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/21351

Signed-off-by: Jason Feng <fengj@ca.ibm.com>