### PR TITLE
(0.52)Add validStackSlot for all of doStackSlots

### DIFF
--- a/runtime/gc_base/StackSlotValidator.hpp
+++ b/runtime/gc_base/StackSlotValidator.hpp
@@ -41,8 +41,8 @@ class MM_StackSlotValidator : public MM_Validator {
 /* data members */
 private:
 	const UDATA _flags; /**< Flags for this validator: COULD_BE_FORWARDED / NOT_ON_HEAP */
-	J9Object *const _slotValue; /**< The object in the stack slot being validated */
-	const void* const _stackLocation; /**< The actual stack slot pointer */
+	J9Object * const _slotValue; /**< The object in the stack slot being validated */
+	const void * const _stackLocation; /**< The actual stack slot pointer */
 	J9StackWalkState * const _walkState; /**< The current stack walk state */
 protected:
 public:
@@ -59,11 +59,14 @@ private:
 	 * @param env[in] the current thread (not necessarily the thread whose stack is being inspected)
 	 * @param message[in] a message to include with the report
 	 */
-	void reportStackSlot(MM_EnvironmentBase* env, const char* message);
-	
+	void reportStackSlot(MM_EnvironmentBase *env, const char *message);
+#if JAVA_SPEC_VERSION >= 19
+	char *getContinuationThreadName(MM_EnvironmentBase *env, J9VMContinuation *continuation);
+	void releaseContinuationThreadName(MM_EnvironmentBase *env, char *threadName);
+#endif /* JAVA_SPEC_VERSION >= 19 */
 protected:
 public:
-	virtual void threadCrash(MM_EnvironmentBase* env);
+	virtual void threadCrash(MM_EnvironmentBase *env);
 
 	/**
 	 * Construct a new StackSlotValidator
@@ -72,7 +75,7 @@ public:
 	 * @param stackLocation[in] The actual stack slot pointer
 	 * @param walkState[in] The current stack walk state 
 	 */
-	MM_StackSlotValidator(UDATA flags, J9Object *slotValue, const void* stackLocation, void *walkState)
+	MM_StackSlotValidator(UDATA flags, J9Object *slotValue, const void *stackLocation, void *walkState)
 		: MM_Validator()
 		, _flags(flags)
 		, _slotValue(slotValue)
@@ -113,7 +116,7 @@ public:
 		} else if (shouldCheckRegionValidity && onHeap && ( (NULL == region) || !region->containsObjects())) {
 			reportStackSlot(env, "Object not in valid region");
 			result = false;
-		} else if ( !onHeap && (((U_8*)_slotValue >= (U_8*)stack->end) || ((U_8*)_slotValue < (U_8*)(stack + 1)))) {
+		} else if ( !onHeap && (((U_8*)_slotValue >= (U_8 *)stack->end) || ((U_8 *)_slotValue < (U_8 *)(stack + 1)))) {
 			reportStackSlot(env, "Object neither in heap nor stack-allocated");
 			result = false;
 		} else if ( !onHeap && (0 != ((UDATA)_slotValue & (sizeof(UDATA) - 1)))) {

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -61,7 +61,12 @@ MM_ConcurrentMarkingDelegate::doStackSlot(MM_EnvironmentBase *env, omrobjectptr_
 {
 	omrobjectptr_t object = *slotPtr;
 	if (_markingScheme->isHeapObject(object) && !env->getExtensions()->heap->objectIsInGap(object)) {
+		/* heap object - validate and mark */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(0, object, stackLocation, walkState).validate(env));
 		doSlot(env, slotPtr);
+	} else if (NULL != object) {
+		/* stack object - just validate */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, object, stackLocation, walkState).validate(env));
 	}
 }
 /**

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -266,7 +266,11 @@ void
 MM_MarkingDelegate::doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr, void *walkState, const void* stackLocation)
 {
 	if (_markingScheme->isHeapObject(*slotPtr) && !_extensions->heap->objectIsInGap(*slotPtr)) {
+		Assert_MM_validStackSlot(MM_StackSlotValidator(0, *slotPtr, stackLocation, walkState).validate(env));
 		doSlot(env, objectPtr, slotPtr);
+	} else if (NULL != *slotPtr) {
+		/* stack object - just validate */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, *slotPtr, stackLocation, walkState).validate(env));
 	}
 }
 

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -1664,8 +1664,14 @@ MM_MetronomeDelegate::doContinuationSlot(MM_EnvironmentRealtime *env, J9Object *
 void
 MM_MetronomeDelegate::doStackSlot(MM_EnvironmentRealtime *env, J9Object **slotPtr, J9StackWalkState *walkState, const void *stackLocation)
 {
-	if (_markingScheme->isHeapObject(*slotPtr)) {
+	J9Object *object = *slotPtr;
+	if (_markingScheme->isHeapObject(object)) {
+		/* heap object - validate and mark */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(0, object, stackLocation, walkState).validate(env));
 		doSlot(env, slotPtr);
+	} else if (NULL != object) {
+		/* stack object - just validate */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, object, stackLocation, walkState).validate(env));
 	}
 }
 

--- a/runtime/gc_glue_java/ScavengerDelegate.cpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.cpp
@@ -352,10 +352,14 @@ MM_ScavengerDelegate::doContinuationSlot(MM_EnvironmentStandard *env, omrobjectp
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
 void
-MM_ScavengerDelegate::doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember, void *walkState, const void* stackLocation)
+MM_ScavengerDelegate::doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember, void *walkState, const void *stackLocation)
 {
 	if (_extensions->scavenger->isHeapObject(*slotPtr) && !_extensions->heap->objectIsInGap(*slotPtr)) {
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::COULD_BE_FORWARDED, *slotPtr, stackLocation, walkState).validate(env));
 		doSlot(env, slotPtr, reason, shouldRemember);
+	} else if (NULL != *slotPtr) {
+		/* stack object - just validate */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, *slotPtr, stackLocation, walkState).validate(env));
 	}
 }
 

--- a/runtime/gc_glue_java/ScavengerDelegate.hpp
+++ b/runtime/gc_glue_java/ScavengerDelegate.hpp
@@ -184,7 +184,7 @@ public:
 #if JAVA_SPEC_VERSION >= 24
 	void doContinuationSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember, GC_ContinuationSlotIterator *continuationSlotIterator);
 #endif /* JAVA_SPEC_VERSION >= 24 */
-	void doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember, void *walkState, const void* stackLocation);
+	void doStackSlot(MM_EnvironmentStandard *env, omrobjectptr_t *slotPtr, MM_ScavengeScanReason reason, bool *shouldRemember, void *walkState, const void *stackLocation);
 
 	bool initialize(MM_EnvironmentBase *env);
 	void tearDown(MM_EnvironmentBase *env);

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2336,7 +2336,12 @@ void
 MM_CopyForwardScheme::doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr, J9StackWalkState *walkState, const void *stackLocation)
 {
 	if (isHeapObject(*slotPtr)) {
+		/* heap object - validate and copyforward */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::COULD_BE_FORWARDED, *slotPtr, stackLocation, walkState).validate(env));
 		doSlot(env, fromObject, slotPtr);
+	} else if (NULL != *slotPtr) {
+		/* stack object - just validate */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, *slotPtr, stackLocation, walkState).validate(env));
 	}
 }
 

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -800,7 +800,12 @@ void
 MM_GlobalMarkingScheme::doStackSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object **slotPtr, J9StackWalkState *walkState, const void *stackLocation)
 {
 	if (isHeapObject(*slotPtr)) {
+		/* heap object - validate and mark */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(0, *slotPtr, stackLocation, walkState).validate(env));
 		doSlot(env, fromObject, slotPtr);
+	} else if (NULL != *slotPtr) {
+		/* stack object - just validate */
+		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, *slotPtr, stackLocation, walkState).validate(env));
 	}
 }
 

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -542,6 +542,8 @@ walkContinuationStackFrames(J9VMThread *currentThread, J9VMContinuation *continu
 
 		copyFieldsFromContinuation(currentThread, &stackThread, &els, continuation);
 		stackThread.threadObject = threadObject;
+		/* stackThread is "fake thread" there is no related omrThread and currentContinuation, so reuse stackThread.currentContinuation for recording relate walk continuation structure. */
+		stackThread.currentContinuation = continuation;
 		walkState->walkThread = &stackThread;
 		rc = currentThread->javaVM->walkStackFrames(currentThread, walkState);
 	}


### PR DESCRIPTION
 - validStackSlot for scanning/fixing java stack slots of continuations.
 - reuse stackThread.currentContinuation (stackThread is "fake Thread", which is created just for walkJavaStackSlots of the continuation)for recording related J9VMContinuation structure.
 - report related J9VMContinuation when validStackSlot fails during walkJavaStackSlots of the continuations.