### PR TITLE
Adjust max heap size if -Xms is set higher explicitly

### DIFF
--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -240,8 +240,8 @@ MM_GCExtensions::updateIdentityHashDataForSaltIndex(uintptr_t index)
 }
 
 /*
- * computeDefaultMaxHeapForJava is for Java only, it will be called during gcParseCommandLineAndInitializeWithValues(),
- * computeDefaultMaxHeap() will still be called during MM_GCExtensionsBase::initialize(), computeDefaultMaxHeapForJava() can overwrite value of memoryMax.
+ * computeDefaultMaxHeapForJava() is used for Java only.
+ * computeDefaultMaxHeap() will still be called during MM_GCExtensionsBase::initialize().
  */
 uintptr_t
 MM_GCExtensions::computeDefaultMaxHeapForJava(bool enableOriginalJDK8HeapSizeCompatibilityOption)

--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -248,6 +248,7 @@ public:
 	TimingAddContinuationInList timingAddContinuationInList;
 	bool testContainerMemLimit; /**< if set simulates a container with memory limit set - for GC testing only*/
 	double testRAMSizePercentage; /**< a percentage to increase/decrease usablePhysicalMemory - for GC testing only, only applies to CRIU restore VM */
+	bool enableOriginalJDK8HeapSizeCompatibilityOption; /**< if set use JDK8 heap size default */
 protected:
 private:
 protected:
@@ -449,6 +450,7 @@ public:
 		, timingAddContinuationInList(onCreated)
 		, testContainerMemLimit(false)
 		, testRAMSizePercentage(-1.0)
+		, enableOriginalJDK8HeapSizeCompatibilityOption(false)
 	{
 		_typeId = __FUNCTION__;
 	}

--- a/runtime/gc_modron_startup/mminit.cpp
+++ b/runtime/gc_modron_startup/mminit.cpp
@@ -3011,6 +3011,20 @@ gcInitializeDefaults(J9JavaVM* vm)
 		memoryParameterTable[opt_Xmx] = memoryParameterTable[opt_maxRAMPercent];
 	}
 
+	if (-1 == memoryParameterTable[opt_Xmx]) {
+		/* set default max heap for Java */
+		extensions->memoryMax = extensions->computeDefaultMaxHeapForJava(extensions->enableOriginalJDK8HeapSizeCompatibilityOption);
+		/* if max heap size smaller than specified initial size adjust it */
+		if ((-1 != memoryParameterTable[opt_Xms]) && (extensions->initialMemorySize > extensions->memoryMax)) {
+			extensions->memoryMax = extensions->initialMemorySize;
+		}
+	}
+
+	/* Since the user is not specifying a value, ensure that -Xmdx is set to the same value
+	 * as -Xmx.  It does not matter whether -Xmx was specified or not.
+	 */
+	extensions->maxSizeDefaultMemorySpace = extensions->memoryMax;
+
 	if (gc_policy_metronome == extensions->configurationOptions._gcPolicy) {
 		/* Heap is segregated; take into account segregatedAllocationCache. */
 		vm->segregatedAllocationCacheSize = (J9VMGC_SIZECLASSES_NUM_SMALL + 1)*sizeof(J9VMGCSegregatedAllocationCacheEntry);


### PR DESCRIPTION
In the case if maximum heap size is not specified and taken by default and initial heap size is specified and initial value is larger than default maximum increase maximum heap size to match initial size.

Related https://github.com/eclipse-openj9/openj9/issues/14386