### PR TITLE
JDK25 removes JavaLangAccess.virtualThreadDelayedTaskSchedulers()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -869,10 +869,12 @@ final class Access implements JavaLangAccess {
 		return VirtualThread.defaultScheduler();
 	}
 
+	/*[IF (JAVA_SPEC_VERSION < 25) | INLINE-TYPES]*/
 	@Override
 	public Stream<ScheduledExecutorService> virtualThreadDelayedTaskSchedulers() {
 		return VirtualThread.delayedTaskSchedulers();
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION < 25) | INLINE-TYPES */
 /*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */


### PR DESCRIPTION
JDK25 removes `JavaLangAccess.virtualThreadDelayedTaskSchedulers()`

This fixes https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/773/consoleFull
```
00:06:32  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:610: error: method does not override or implement a method from a supertype
00:06:32  	@Override
00:06:32  	^
00:06:32  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:612: error: cannot find symbol
00:06:32  		return VirtualThread.delayedTaskSchedulers();
00:06:32  		                    ^
00:06:32    symbol:   method delayedTaskSchedulers()
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>