### PR TITLE
Z: Remove bitwise compress/expand recognition

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3788,20 +3788,6 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
       return true;
       }
 
-   static bool disableZ17CompressExpand = feGetEnv("TR_DisableZ17CompressExpand") != NULL;
-   if (!disableZ17CompressExpand &&
-       (self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4) ||
-        TR::InstOpCode(TR::InstOpCode::BEXTG).canEmulate() && TR::InstOpCode(TR::InstOpCode::BDEPG).canEmulate()))
-      {
-      if (method == TR::java_lang_Integer_compress ||
-          method == TR::java_lang_Integer_expand ||
-          method == TR::java_lang_Long_compress ||
-          method == TR::java_lang_Long_expand)
-         {
-         return true;
-         }
-      }
-
    if (method == TR::java_util_concurrent_atomic_AtomicBoolean_getAndSet ||
        method == TR::java_util_concurrent_atomic_AtomicInteger_getAndAdd ||
        method == TR::java_util_concurrent_atomic_AtomicInteger_getAndIncrement ||
@@ -4182,30 +4168,6 @@ J9::Z::CodeGenerator::inlineDirectCall(
          return true;
       default:
          break;
-      }
-
-   static bool disableZ17CompressExpand = feGetEnv("TR_DisableZ17CompressExpand") != NULL;
-   if (!disableZ17CompressExpand &&
-       (self()->comp()->target().cpu.supportsFeature(OMR_FEATURE_S390_MISCELLANEOUS_INSTRUCTION_EXTENSION_4) ||
-        TR::InstOpCode(TR::InstOpCode::BEXTG).canEmulate() && TR::InstOpCode(TR::InstOpCode::BDEPG).canEmulate()))
-      {
-      switch (methodSymbol->getRecognizedMethod())
-         {
-         case TR::java_lang_Integer_compress:
-            resultReg = TR::TreeEvaluator::inlineBitCompress(node, cg, false);
-            return true;
-         case TR::java_lang_Integer_expand:
-            resultReg = TR::TreeEvaluator::inlineBitExpand(node, cg, false);
-            return true;
-         case TR::java_lang_Long_compress:
-            resultReg = TR::TreeEvaluator::inlineBitCompress(node, cg, true);
-            return true;
-         case TR::java_lang_Long_expand:
-            resultReg = TR::TreeEvaluator::inlineBitExpand(node, cg, true);
-            return true;
-         default:
-            break;
-         }
       }
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION


### PR DESCRIPTION
With bitwise compress/expand IL opcodes implemented for Z recognition of Long and Integer compress and expand methods will happen in platform generic code, rendering the Z specific recognition redundant.

Relies on https://github.com/eclipse-omr/omr/pull/7721 for these methods to continue to be accelerated.