### PR TITLE
Suppress "this-escape" warning for StructureHeader

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureHeader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/StructureHeader.java
@@ -72,15 +72,16 @@ public class StructureHeader {
 	private String packageID = DEFAULT_J9_PACKAGE_PREFIX;	// set the default Java package name
 	private final long headerSize;							// size of the header based on the number of bytes being read from the stream -1 = unknown
 
+	@SuppressWarnings("this-escape")
 	public StructureHeader(ImageInputStream ddrStream) throws IOException {
 		long start = ddrStream.getStreamPosition();
 		readCommonData(ddrStream);
 		switch (coreVersion) {
-			case 2:
-				readBlobVersion(ddrStream);
-				break;
-			default:
-				break;
+		case 2:
+			readBlobVersion(ddrStream);
+			break;
+		default:
+			break;
 		}
 		headerSize = ddrStream.getStreamPosition() - start;
 	}


### PR DESCRIPTION
To avoid warnings building DDR tools in newer Java versions.