### PR TITLE
Refine MethodHandle invokeBasic INL calls during ValuePropagation

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -390,6 +390,7 @@ class ValuePropagation : public OMR::ValuePropagation
    TR::VP_BCDSign **_bcdSignConstraints;
    List<TreeNodeResultPair> _callsToBeFoldedToNode;
    List<TR_TreeTopNodePair> _offHeapCopyMemory;
+   TR_LinkHead<CallInfo> _refinedMethodHandleINLMethodsToInline;
 
    struct ValueTypesHelperCallTransform;
    struct ObjectComparisonHelperCallTransform;


### PR DESCRIPTION
When ValuePropagation is able to obtain the object info of the receiver MethodHandle object, we can refine the invokeBasic call, and possibly inline the refined method and its callees. The refined invokeBasic calls get stored in a new VP field _refinedMethodHandleINLMethodsToInline, and handled during delayed VP transformations.