### PR TITLE
Barebones JITServer shared profile cache implementation

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -418,6 +418,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/runtime/JITServerAOTCache.cpp \
     compiler/runtime/JITServerAOTDeserializer.cpp \
     compiler/runtime/JITServerIProfiler.cpp \
+    compiler/runtime/JITServerProfileCache.cpp \
     compiler/runtime/JITServerROMClassHash.cpp \
     compiler/runtime/JITServerSharedROMClassCache.cpp \
     compiler/runtime/JITServerStatisticsThread.cpp \

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -422,8 +422,10 @@ J9::ExternalOptionsMetadata J9::Options::_externalOptionsMetadata[J9::ExternalOp
    { "-XX:-JITServerHealthProbes",                  EXACT_MATCH,         -1, true  }, // = 75
    { "-XX:JITServerHealthProbePort=",               STARTSWITH_MATCH,    -1, true  }, // = 76
    { "-XX:+TrackAOTDependencies",                   EXACT_MATCH,         -1, true  }, // = 77
-   { "-XX:-TrackAOTDependencies",                   EXACT_MATCH,         -1, true  }  // = 78
-   // TR_NumExternalOptions                                                              = 79
+   { "-XX:-TrackAOTDependencies",                   EXACT_MATCH,         -1, true  }, // = 78
+   { "-XX:+JITServerUseProfileCache",               EXACT_MATCH,         -1, true  }, // = 79
+   { "-XX:-JITServerUseProfileCache",               EXACT_MATCH,         -1, true  }  // = 80
+   // TR_NumExternalOptions                                                              = 81
    };
 
 //************************************************************************

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -132,7 +132,9 @@ enum ExternalOptions
    XXJITServerHealthProbePortOption              = 76,
    XXplusTrackAOTDependencies                    = 77,
    XXminusTrackAOTDependencies                   = 78,
-   TR_NumExternalOptions                         = 79
+   XXplusJITServerUseProfileCache                = 79,
+   XXminusJITServerUseProfileCache               = 80,
+   TR_NumExternalOptions                         = 81
    };
 
 /**

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -545,6 +545,11 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
                }
             }
          vmInfo._useServerOffsets = comp->getPersistentInfo()->getJITServerAOTCacheIgnoreLocalSCC();
+         int32_t enableProfileCacheArgIndex  = J9::Options::getExternalOptionIndex(J9::ExternalOptions::XXplusJITServerUseProfileCache);
+         int32_t disableProfileCacheArgIndex = J9::Options::getExternalOptionIndex(J9::ExternalOptions::XXminusJITServerUseProfileCache);
+         // The profile cache feature needs to be enabled explicitly by the client. The presence of the AOT cache is a pre-requisite.
+         vmInfo._useSharedProfileCache = compInfo->getPersistentInfo()->getJITServerUseAOTCache() &&
+                                         enableProfileCacheArgIndex > disableProfileCacheArgIndex;
          vmInfo._inSnapshotMode = fe->inSnapshotMode();
          vmInfo._isPortableRestoreMode = fe->isPortableRestoreModeEnabled();
          vmInfo._isSnapshotModeEnabled = fe->isSnapshotModeEnabled();

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -83,6 +83,8 @@ public:
    size_t getClientOptionsSize() { return _clientOptionsSize; }
 
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry);
+   bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, const Vector<TR_IPBytecodeHashTableEntry *> &entries);
+
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
 
    void cacheResolvedMethod(TR_ResolvedMethodKey key, TR_OpaqueMethodBlock *method, uint32_t vTableSlot, const TR_ResolvedJ9JITServerMethodInfo &methodInfo, bool isUnresolvedInCP, int32_t ttlForUnresolved = 2);

--- a/runtime/compiler/control/JITServerHelpers.cpp
+++ b/runtime/compiler/control/JITServerHelpers.cpp
@@ -946,6 +946,7 @@ JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Cl
    {
    ClientSessionData::ClassInfo classInfoStruct(clientSessionData->persistentMemory());
 
+   classInfoStruct._ramClass = clazz;
    classInfoStruct._romClass = romClass;
    J9Method *methods = std::get<1>(classInfoTuple);
    classInfoStruct._methodsOfClass = methods;
@@ -973,7 +974,7 @@ JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Cl
    classInfoStruct._constantPool = (J9ConstantPool *)std::get<18>(classInfoTuple);
    classInfoStruct._classFlags = std::get<19>(classInfoTuple);
    classInfoStruct._classChainOffsetIdentifyingLoader = std::get<20>(classInfoTuple);
-   auto &origROMMethods = std::get<21>(classInfoTuple);
+   auto &origROMMethods = std::get<21>(classInfoTuple); // vector of ROMMethod pointers valid at the client
    classInfoStruct._classNameIdentifyingLoader = std::get<22>(classInfoTuple);
    classInfoStruct._arrayElementSize = std::get<23>(classInfoTuple);
    classInfoStruct._defaultValueSlotAddress = std::get<24>(classInfoTuple);
@@ -986,7 +987,7 @@ JITServerHelpers::cacheRemoteROMClass(ClientSessionData *clientSessionData, J9Cl
    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
    for (uint32_t i = 0; i < numMethods; i++)
       {
-      ClientSessionData::J9MethodInfo m(romMethod, origROMMethods[i], (TR_OpaqueClassBlock *)clazz,
+      ClientSessionData::J9MethodInfo m(romMethod, origROMMethods[i], result.first->second, /* classInfoStruct */
                                         i, static_cast<bool>(methodTracingInfo[i]));
       methodMap.insert({ &methods[i], m });
       romMethod = nextROMMethod(romMethod);

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -184,6 +184,8 @@ J9::OptionsPostRestore::iterateOverExternalOptions()
          case J9::ExternalOptions::XXJITServerHealthProbePortOption:
          case J9::ExternalOptions::XXplusTrackAOTDependencies:
          case J9::ExternalOptions::XXminusTrackAOTDependencies:
+         case J9::ExternalOptions::XXplusJITServerUseProfileCache:
+         case J9::ExternalOptions::XXminusJITServerUseProfileCache:
             {
             // do nothing, consume them to prevent errors
             FIND_AND_CONSUME_RESTORE_ARG(OPTIONAL_LIST_MATCH, optString, 0);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1775,7 +1775,7 @@ TR_J9ServerVM::getClassFromMethodBlock(TR_OpaqueMethodBlock *method)
       auto it = _compInfoPT->getClientData()->getJ9MethodMap().find((J9Method*) method);
       if (it != _compInfoPT->getClientData()->getJ9MethodMap().end())
          {
-         return it->second._owningClass;
+         return (TR_OpaqueClassBlock *)it->second.definingClass();
          }
       }
 

--- a/runtime/compiler/runtime/CMakeLists.txt
+++ b/runtime/compiler/runtime/CMakeLists.txt
@@ -66,6 +66,7 @@ if(J9VM_OPT_JITSERVER)
 		runtime/JITServerAOTCache.cpp
 		runtime/JITServerAOTDeserializer.cpp
 		runtime/JITServerIProfiler.cpp
+		runtime/JITServerProfileCache.cpp
 		runtime/JITServerROMClassHash.cpp
 		runtime/JITServerSharedROMClassCache.cpp
 		runtime/JITServerStatisticsThread.cpp

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -333,6 +333,7 @@ public:
       // Should we use server offsets (idAndType of AOT cache serialization records) instead of
       // local SCC offsets during AOT cache compilations?
       bool _useServerOffsets;
+      bool _useSharedProfileCache; // Indicates client's intention to use the global profile cache
       TR_AOTHeader _aotHeader;
       TR_OpaqueClassBlock *_JavaLangObject;
       TR_OpaqueClassBlock *_JavaStringObject;

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -30,6 +30,8 @@
 #include "env/SystemSegmentProvider.hpp"
 #include "runtime/JITServerAOTSerializationRecords.hpp"
 
+class JITServerSharedProfileCache;
+
 static const uint32_t JITSERVER_AOTCACHE_VERSION = 1;
 static const char JITSERVER_AOTCACHE_EYECATCHER[] = "AOTCACHE";
 // the eye-catcher is not null-terminated in the snapshot files
@@ -424,10 +426,11 @@ class JITServerAOTCache
 public:
    TR_PERSISTENT_ALLOC(TR_Memory::JITServerAOTCache)
 
-   JITServerAOTCache(const std::string &name);
+   JITServerAOTCache(const std::string &name, J9JavaVM *javaVM);
    ~JITServerAOTCache();
 
    const std::string &name() const { return _name; }
+   JITServerSharedProfileCache *sharedProfileCache() const { return _sharedProfileCache; }
 
    // Each get{Type}Record() method except getThunkRecord returns the record for given parameters (which fully identify
    // the unique record), by either looking up the existing record or creating a new one if there is sufficient
@@ -607,6 +610,7 @@ private:
                            PersistentUnorderedMap<K, V *, H> &map, V *&traversalHead, V *&traversalTail, Vector<V *> &records);
 
    const std::string _name;
+   JITServerSharedProfileCache *const _sharedProfileCache;
 
    // Along with each map we also store pointers to the start and end points of a traversal of all the records.
    // The _nextRecord in each record points to the next record in this traversal.

--- a/runtime/compiler/runtime/JITServerIProfiler.hpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.hpp
@@ -29,7 +29,11 @@ namespace JITServer
 {
 class ClientStream;
 }
-
+namespace TR
+{
+class CompilationInfoPerThreadRemote;
+}
+class ClientSessionData;
 struct TR_ContiguousIPMethodData
    {
    TR_OpaqueMethodBlock *_method;
@@ -110,6 +114,8 @@ protected:
 
 private:
    void validateCachedIPEntry(TR_IPBytecodeHashTableEntry *entry, TR_IPBCDataStorageHeader *clientData, uintptr_t methodStart, bool isMethodBeingCompiled, TR_OpaqueMethodBlock *method, bool fromPerCompilationCache, bool isCompiledWhenProfiling);
+   bool cacheProfilingDataForMethod(TR_OpaqueMethodBlock *method, const std::string &ipdata, bool usePersistentCache, ClientSessionData *clientSessionData,
+                                    TR::CompilationInfoPerThreadRemote *compInfoPT, bool isCompiled, TR::Compilation *comp);
    bool _useCaching;
    // Statistics
    uint32_t _statsIProfilerInfoFromCache;  // IP cache answered the query
@@ -145,7 +151,8 @@ public:
 private:
    uint32_t walkILTreeForIProfilingEntries(uintptr_t *pcEntries, uint32_t &numEntries, TR_J9ByteCodeIterator *bcIterator,
                                            TR_OpaqueMethodBlock *method, TR_BitVector *BCvisit, bool &abort, TR::Compilation *comp);
-   uintptr_t serializeIProfilerMethodEntries(uintptr_t *pcEntries, uint32_t numEntries, uintptr_t memChunk, uintptr_t methodStartAddress);
+   uintptr_t serializeIProfilerMethodEntries(const uintptr_t *pcEntries, uint32_t numEntries, uintptr_t memChunk,
+                                             uintptr_t methodStartAddress, uint64_t &totalSamples);
    };
 
 #endif

--- a/runtime/compiler/runtime/JITServerIProfiler.hpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.hpp
@@ -101,7 +101,7 @@ public:
 
    virtual void persistIprofileInfo(TR::ResolvedMethodSymbol *methodSymbol, TR_ResolvedMethod *method, TR::Compilation *comp) override;
 
-   TR_IPBytecodeHashTableEntry *ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptr_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
+   static TR_IPBytecodeHashTableEntry *ipBytecodeHashTableEntryFactory(TR_IPBCDataStorageHeader *storage, uintptr_t pc, TR_Memory* mem, TR_AllocationKind allocKind);
    TR_IPMethodHashTableEntry *deserializeMethodEntry(TR_ContiguousIPMethodHashTableEntry *serialEntry, TR_Memory *trMemory);
    void printStats();
 

--- a/runtime/compiler/runtime/JITServerProfileCache.cpp
+++ b/runtime/compiler/runtime/JITServerProfileCache.cpp
@@ -1,0 +1,381 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+#include "control/CompilationRuntime.hpp"
+#include "runtime/JITServerAOTCache.hpp"
+#include "runtime/JITServerProfileCache.hpp"
+#include "runtime/JITServerSharedROMClassCache.hpp"
+
+ProfiledMethodEntry::BytecodeProfile::BytecodeProfile() :
+   _numSamples(0),
+   _data(decltype(_data)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _stable(false)
+   {
+   }
+
+ProfiledMethodEntry::BytecodeProfile::~BytecodeProfile()
+   {
+   clear();
+   }
+
+/**
+ * @brief Return a summary of the bytecode profiling data for this method.
+ *        The summary includes the total number of profiling samples,
+ *        the number of bytecodes that have profiling information and
+ *        whether the profiling information is 'stable'.
+ *        This information will be used to estimate the quality of the profiling data.
+ * @return BytecodeProfileSummary
+ */
+BytecodeProfileSummary
+ProfiledMethodEntry::BytecodeProfile::getSummary() const
+   {
+   return BytecodeProfileSummary(getNumSamples(), numProfiledBytecodes(), _stable);
+   }
+
+
+/**
+ * @brief Discard the profiling data for this method
+ */
+void
+ProfiledMethodEntry::BytecodeProfile::clear()
+   {
+   for (auto entry : _data)
+      {
+      // delete entry
+      entry->~TR_IPBytecodeHashTableEntry();
+      TR::Compiler->persistentGlobalMemory()->freePersistentMemory(entry);
+      }
+   _data.clear();
+   _numSamples = 0;
+   _stable = false;
+   }
+
+/**
+ * @brief Add bytecode profiling data to the shared profile repository for a method
+ *
+ * @param entries Vector of profiling entries to be added to this method's bytecode profile
+ * @param numSamples Total number of profiling samples for this method
+ * @param isStable 'true' if the profiling data quality is not expected to grow in the future
+ */
+void
+ProfiledMethodEntry::BytecodeProfile::addBytecodeData(const Vector<TR_IPBytecodeHashTableEntry *> &entries, uint64_t numSamples, bool isStable)
+   {
+   _data.reserve(entries.size());
+   // entries passed in use stack memory; we need to allocate clones with global persistent memory
+   for (const auto &entry : entries)
+      {
+      TR_IPBytecodeHashTableEntry *newEntry = entry->clone(TR::Compiler->persistentGlobalMemory(), TR_Memory::JITServerProfileCache);
+      _data.push_back(newEntry);
+      }
+   _numSamples = numSamples;
+   _stable = isStable;
+   }
+
+ProfiledMethodEntry::ProfiledMethodEntry(const AOTCacheMethodRecord *methodRecord, const J9ROMMethod *romMethod, J9ROMClass *romClass) :
+   _methodRecord(methodRecord), _romMethod(romMethod), _romClass(romClass),
+   _bytecodeProfile(NULL), _faninProfile(NULL)
+   {
+   // Increase the reference count to prevent deletion of this romClass from the shared repository
+   TR::CompilationInfo::get()->getJITServerSharedROMClassCache()->acquire(_romClass);
+   }
+
+ProfiledMethodEntry::~ProfiledMethodEntry()
+   {
+   // Decrement the reference count to allow deletion of this romClass from the shared repository
+   TR::CompilationInfo::get()->getJITServerSharedROMClassCache()->release(_romClass);
+
+   deleteBytecodeData();
+
+   if (_faninProfile)
+      {
+      // TODO: free more stuff here once we add it
+      _faninProfile->~FanInProfile();
+      TR::Compiler->persistentGlobalMemory()->freePersistentMemory(_faninProfile);
+      _faninProfile = NULL;
+      }
+   }
+
+BytecodeProfileSummary
+ProfiledMethodEntry::getBytecodeProfileSummary() const
+   {
+   return _bytecodeProfile ? _bytecodeProfile->getSummary() : BytecodeProfileSummary();
+   }
+
+/**
+ * @brief Delete all bytecode profiling data for this method
+ * @note JITServerSharedProfileCache monitor must be held.
+ */
+void
+ProfiledMethodEntry::deleteBytecodeData()
+   {
+   if (_bytecodeProfile)
+      {
+      _bytecodeProfile->~BytecodeProfile();
+      TR::Compiler->persistentGlobalMemory()->freePersistentMemory(_bytecodeProfile);
+      _bytecodeProfile = NULL;
+      }
+   }
+
+/**
+ * @brief Add bytecode profiling data to the shared profile repository for a method.
+ *        If bytecode profiling data already exists, it will be deleted first.
+ * @param entries Vector of profiling entries to be added to this method's profile
+ * @param numSamples Total number of profiling samples for this method
+ * @param isStable 'true' if the profiling data quality is not expected to grow in the future
+ * @return 'true' if profiling added was added successfully
+ * @note JITServerSharedProfileCache monitor must be held held.
+ */
+bool
+ProfiledMethodEntry::addBytecodeData(const Vector<TR_IPBytecodeHashTableEntry *> &entries, uint64_t numSamples, bool isStable)
+   {
+   // Existing data will be deleted. However, there is a possibility of an allocation failure for
+   // the new data and therefore only partial new data will be stored (or none at all). To cope with
+   // this situation we allocate new data in a shadow vector and only if everything went all we
+   // replace the existing data with the shadow vector.
+   bool success = false;
+   try
+      {
+      // Create new profile in a temporary
+      BytecodeProfile *newBytecodeProfile = new (TR::Compiler->persistentGlobalAllocator()) BytecodeProfile();
+      newBytecodeProfile->addBytecodeData(entries, numSamples, isStable);
+      // Delete old profile
+      deleteBytecodeData();
+      // Attach the new profile
+      _bytecodeProfile = newBytecodeProfile;
+      success = true;
+      }
+   catch (const std::bad_alloc &allocationFailure)
+      {
+      if (TR::Options::getVerboseOption(TR_VerboseJITServerSharedProfile))
+         TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer, "WARNING: Allocation failure while adding profile data to shared repository: %s", allocationFailure.what());
+      }
+   return success;
+   }
+
+/**
+ * @brief Copy out the shared profiling data for this method into a vector of pointers
+ *        to newly allocated 'TR_IPBytecodeHashTableEntry' entries. The allocations will
+ *        use persistentMemory if the 'stable' parameter is 'true' or heapMemory specific
+ *        to the compilation in progress, if 'stable' is false.
+ * @param trMemory Reference to TR_Memory for current compilation
+ * @param stable Boolean indicating whether the profling info cannot grow in the future.
+ * @param newEntries OUT Vector of pointers to TR_IPBytecodeHashTableEntry entries. The
+ *                   entries are allocated either with "heap" memory or with persistent memory.
+ * @param cgEntries OUT Vector of pointers to TR_IPBCDataCallGraph entries that need to be adjusted.
+ *                  Note that these entries are also present in `newEntries`
+ * @note JITServerSharedProfileCache monitor must be held.
+ */
+void
+ProfiledMethodEntry::cloneBytecodeData(TR_Memory &trMemory, bool stable,
+                                       Vector<TR_IPBytecodeHashTableEntry *> &newEntries,
+                                       Vector<TR_IPBCDataCallGraph *> &cgEntries) const
+   {
+   TR_ASSERT_FATAL(_bytecodeProfile, "We must have _bytecodeProfile if the caller decided to take profiled information from the shared repository");
+
+   size_t numProfileEntries = _bytecodeProfile->getData().size();
+
+   newEntries.reserve(numProfileEntries);
+   cgEntries.reserve(numProfileEntries);
+
+   for (const auto& entry : _bytecodeProfile->getData())
+      {
+      // Clone the entries using the appropriate memory type
+      TR_IPBytecodeHashTableEntry *newEntry = NULL;
+      if (stable)
+         {
+         // Use persistent memory specific to this client
+         newEntry = entry->clone(trMemory.trPersistentMemory());
+         }
+      else // Non-stable data; use heap memory associated with this compilation
+         {
+         newEntry = entry->clone(trMemory.heapMemoryRegion());
+         }
+      newEntries.push_back(newEntry);
+      // Remember the callGraph entries so that we can adjust the slots
+      TR_IPBCDataCallGraph *cgEntry = entry->asIPBCDataCallGraph();
+      if (cgEntry)
+         cgEntries.push_back(cgEntry);
+      } // end for
+   }
+
+/**
+ * @brief Constructor for JITServerSharedProfileCache
+ * @todo Consider using a dedicated persistent allocator rather than the global one
+ */
+JITServerSharedProfileCache::JITServerSharedProfileCache(JITServerAOTCache *aotCache, J9JavaVM *javaVM) :
+   _aotCache(aotCache),
+   _methodProfileMap(decltype(_methodProfileMap)::allocator_type(TR::Compiler->persistentGlobalAllocator())),
+   _monitor(TR::Monitor::create("JIT-SharedProfileCacheMonitor")),
+   _numStores(0), _numOverwrites(0)
+   //,_rawAllocator(javaVM), _segmentAllocator(MEMORY_TYPE_JIT_SCRATCH_SPACE | MEMORY_TYPE_VIRTUAL, *javaVM),
+   //TODO: configurable scratch memory limit
+   //_segmentProvider(64 * 1024, 16 * 1024 * 1024, 16 * 1024 * 1024, _segmentAllocator, _rawAllocator),
+   //_region(_segmentProvider, _rawAllocator), _trMemory(*TR::Compiler->persistentGlobalMemory(), _region)
+   {
+   if (!_monitor)
+      throw std::bad_alloc();
+   }
+
+JITServerSharedProfileCache::~JITServerSharedProfileCache()
+   {
+   TR::Monitor::destroy(_monitor);
+   }
+
+/**
+ * @brief Find the profiling info specific to the method of interest and return a pointer to it
+ * @note Must hold the JITServerSharedProfileCache monitor
+ * @param methodRecord: the method for which we are looking for profiling data
+ * @return Pointer to the shared profiling data for the method of interest
+ */
+ProfiledMethodEntry *
+JITServerSharedProfileCache::getProfileForMethod(const AOTCacheMethodRecord *methodRecord)
+   {
+   TR_ASSERT(_monitor->owned_by_self(), "Must hold monitor");
+
+   auto it = _methodProfileMap.find(methodRecord);
+   if (it != _methodProfileMap.end())
+     return &it->second;
+
+   return NULL;
+   }
+
+/**
+ * @brief Adds bytecode profiling data to the shared profile repository
+ * @note Existing profiling data for the method in question (if available) will be overwritten
+ *       but we may refuse to add the new data if better data already exists
+ * @note Acquires the shared profile repository monitor.
+ * @param entries Vector of pointers to TR_IPBytecodeHashTableEntry entities to be added (stack allocated)
+ * @param methodRecord The method record for which we add the profiling data
+ * @param romMethod ROMMethod corresponding to the method for which we add the data
+ * @param romClass ROMClass of the romMethod for which we add the data
+ * @param numSamples Total number of profiling samples for the specified method
+ * @param isStable 'true' if the profiling data quality is not expected to grow in the future
+ * @return 'true' if the profiling data was successfully added to the shared repository, 'false' otherwise
+ */
+bool
+JITServerSharedProfileCache::addBytecodeData(const Vector<TR_IPBytecodeHashTableEntry *> &entries,
+                                             const AOTCacheMethodRecord *methodRecord,
+                                             const J9ROMMethod *romMethod,
+                                             J9ROMClass *romClass,
+                                             uint64_t numSamples,
+                                             bool isStable)
+   {
+   TR_ASSERT_FATAL(methodRecord, "methodRecord must exist");
+   OMR::CriticalSection cs(monitor());
+   auto it = _methodProfileMap.find(methodRecord);
+   if (it == _methodProfileMap.end())
+      {
+      // At the moment there is no data for the method in question. Create an empty map.
+      it = _methodProfileMap.emplace_hint(it, std::piecewise_construct, std::forward_as_tuple(methodRecord),
+                                              std::forward_as_tuple(methodRecord, romMethod, romClass));
+      }
+   else // Some data already exists and could be overwritten
+      {
+      ProfiledMethodEntry::BytecodeProfile *storedProfile = it->second.getBytecodeProfile();
+      // Two threads may want to store the same data one after another (I have seen this happening).
+      // Prevent unnecesary work if the quality of the new data is the same or lower.
+      if (storedProfile)
+         {
+         BytecodeProfileSummary clientProfileSummary(numSamples, entries.size(), isStable);
+         BytecodeProfileSummary sharedProfileSummary = storedProfile->getSummary();
+         int sharedProfileQuality = compareBytecodeProfiles(sharedProfileSummary, clientProfileSummary);
+         if (sharedProfileQuality >= 0) // EXisting data is at least as good as the new data
+            {
+            if (TR::Options::getVerboseOption(TR_VerboseJITServerSharedProfile))
+               TR_VerboseLog::writeLineLocked(TR_Vlog_JITServer,
+                  "WARNING: Avoiding overwriting existing shared bytecode profile data."
+                  "New profiled bytecodes=%zu old profile bytecodes=%zu; newSamples=%" OMR_PRIu64 " oldSamples=%" OMR_PRIu64,
+                  entries.size(), storedProfile->numProfiledBytecodes(), numSamples, storedProfile->getNumSamples());
+            return false;
+            }
+         else // Existing data will be overwitten
+            {
+            _numOverwrites++;
+            }
+         }
+      }
+   _numStores++; // failed or not
+   ProfiledMethodEntry &profiledMethodEntry = it->second;
+   return profiledMethodEntry.addBytecodeData(entries, numSamples, isStable);
+   // TODO: We may also fail due to reaching limit for AOT cache space
+   }
+
+void
+JITServerSharedProfileCache::printStats(FILE *f) const
+   {
+   fprintf(f, "Stats about JITServer shared profile cache:\n");
+   fprintf(f, "\tNum store operations: %zu\n", _numStores);
+   fprintf(f, "\tNum overwrite operations: %zu\n", _numOverwrites);
+   }
+
+/**
+ * @brief Compare two bytecode profiles based on heuristics.
+ * @return If the first profile has better "quality" than the second profile, return 1.
+ *         If the second profile has better "quality" than the first profile, return -1.
+ *         If the "quality" of the two sources is comparable, return 0.
+ */
+int
+JITServerSharedProfileCache::compareBytecodeProfiles(const BytecodeProfileSummary &profile1, const BytecodeProfileSummary &profile2)
+   {
+   if (profile1._numSamples > profile2._numSamples + 10 && profile1._numSamples * 15 > profile2._numSamples * 16) // 6.7% more samples
+      {
+      if (profile1._numProfiledBytecodes >= profile2._numProfiledBytecodes)
+         {
+         // More samples and more or the same number of profiled bytecode
+         return 1;
+         }
+      else
+         {
+         // More samples, but less profiled bytecodes. Profile1 can be considered better
+         // only if it has substantially more samples.
+         if (profile1._numSamples * 3 > profile2._numSamples * 4) // 33% more samples
+            return 1;
+         else
+            return 0; // 6.7% - 33% more samples, but lower number of profiled bytecodes
+         }
+      }
+   else if (profile2._numSamples > profile1._numSamples + 10 && profile2._numSamples * 15 > profile1._numSamples * 16) // 6.7% more samples
+      {
+      if (profile2._numProfiledBytecodes >= profile1._numProfiledBytecodes)
+         {
+         // More samples and more or the same number of profiled bytecode
+         return -1;
+         }
+      else
+         {
+         // More samples, but less profiled bytecodes. Profile2 can be considered better
+         // only if it has substantially more samples.
+         if (profile2._numSamples * 3 > profile1._numSamples * 4) // 33% more samples
+            return -1;
+         else
+            return 0; // 6.7% - 33% more samples, but lower number of profiled bytecodes
+         }
+      }
+   else // About the same number of samples. Let's look at bytecodes profiled
+      {
+      if (profile1._numProfiledBytecodes == profile2._numProfiledBytecodes)
+         return 0;
+      else if (profile1._numProfiledBytecodes > profile2._numProfiledBytecodes)
+         return 1;
+      else
+         return -1;
+      }
+   }

--- a/runtime/compiler/runtime/JITServerProfileCache.hpp
+++ b/runtime/compiler/runtime/JITServerProfileCache.hpp
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+#ifndef JITSERVER_PROFILE_CACHE_H
+#define JITSERVER_PROFILE_CACHE_H
+#include <stdint.h>
+#include <stddef.h>
+#include "env/PersistentCollections.hpp"
+#include "env/TRMemory.hpp"
+
+class TR_IPBytecodeHashTableEntry;
+class TR_IPBCDataCallGraph;
+class AOTCacheMethodRecord;
+namespace TR { class Monitor; }
+
+
+struct BytecodeProfileSummary
+   {
+   BytecodeProfileSummary(uint64_t samples, size_t numBC, bool stable) :
+      _numSamples(samples), _numProfiledBytecodes(numBC), _stable(stable) {}
+   BytecodeProfileSummary() : _numSamples(0), _numProfiledBytecodes(0), _stable(false) {}
+   uint64_t _numSamples;
+   size_t _numProfiledBytecodes;
+   bool _stable;
+   };
+
+// Profiling information at the server is kept on a per-method basis.
+// Each ProfiledMethodEntry will keep profiling information related to
+// (1) various method bytecodes and related to (2) method fan-in.
+// The data should be easily serializable so that it can be saved to persistent storage.
+class ProfiledMethodEntry
+   {
+   public:
+   TR_PERSISTENT_ALLOC(TR_Memory::JITServerProfileCache)
+
+   class BytecodeProfile
+      {
+      public:
+      // Class that provides a summary of the profiling data
+      BytecodeProfile();
+      ~BytecodeProfile();
+      uint64_t getNumSamples() const { return _numSamples; }
+      void setNumSamples(uint64_t num) { _numSamples = num; }
+      size_t numProfiledBytecodes() const { return _data.size(); }
+      BytecodeProfileSummary getSummary() const;
+      const PersistentVector<TR_IPBytecodeHashTableEntry *> &getData() const { return _data; }
+      void addBytecodeData(const Vector<TR_IPBytecodeHashTableEntry *> &entries, uint64_t numSamples, bool isStable);
+      void clear();
+
+      private:
+      uint64_t _numSamples; // Total profiling samples across all bytecodes
+      // The actual data is a vector of profiling entries, one per bytecode of interest.
+      // The vector could be totally empty, if the method has no bytecodes that can be profiled.
+      // Storing empty profiles could be useful to avoid quering the client.
+      // TODO: consider allocating the entries inline, as a stream of data. This means
+      // that we will have a vector of bytes because the entries have different lengths.
+      PersistentVector<TR_IPBytecodeHashTableEntry *> _data; // Allocated with persistentMemory using the global allocator
+      bool _stable; // 'true' if method was compiled (or was under compilation) at the time when the profiling
+                    // info was stored. Thus, we don't expect the quality of this data to increase in the buture.
+      }; // BytecodeProfile
+   class FanInProfile
+      {
+      }; // FanInProfile
+
+   ProfiledMethodEntry(const AOTCacheMethodRecord *methodRecord, const J9ROMMethod *romMethod, J9ROMClass *romClass);
+   ~ProfiledMethodEntry();
+   uint64_t getNumSamples() const { return _bytecodeProfile ? _bytecodeProfile->getNumSamples() : 0; }
+   BytecodeProfile *getBytecodeProfile() const { return _bytecodeProfile; }
+   BytecodeProfileSummary getBytecodeProfileSummary() const;
+   bool addBytecodeData(const Vector<TR_IPBytecodeHashTableEntry *> &entries, uint64_t numSamples, bool isStable);
+   void cloneBytecodeData(TR_Memory &trMemory, bool stable,
+                          Vector<TR_IPBytecodeHashTableEntry *> &newEntries,
+                          Vector<TR_IPBCDataCallGraph *> &cgEntries) const;
+   private:
+   void deleteBytecodeData();
+
+   const AOTCacheMethodRecord *const _methodRecord; // Link back to the AOTCacheMethodRecord associated with this entry
+   const J9ROMMethod *const _romMethod;
+   J9ROMClass *const _romClass; // Counting references to shared ROMClass cache entry prevents deletion of profiling entries
+
+   // Created on demand; will stay NULL if we never attempted to store corresponding data for this method
+   BytecodeProfile *_bytecodeProfile;
+   FanInProfile *_faninProfile;
+   }; // class ProfiledMethodEntry
+
+class JITServerSharedProfileCache
+   {
+   public:
+   // NOTE: AOT cache memory limit applies to profile cache as well
+   TR_PERSISTENT_ALLOC(TR_Memory::JITServerProfileCache)
+
+   JITServerSharedProfileCache(JITServerAOTCache *aotCache, J9JavaVM *javaVM);
+   ~JITServerSharedProfileCache();
+
+   TR::Monitor *monitor() const { return _monitor; }
+   ProfiledMethodEntry *getProfileForMethod(const AOTCacheMethodRecord *);
+   bool addBytecodeData(const Vector<TR_IPBytecodeHashTableEntry *> &entries, const AOTCacheMethodRecord *methodRecord,
+                        const J9ROMMethod *romMethod, J9ROMClass *romClass, uint64_t numSamples, bool isStable);
+   // Returns NULL with 'present' set to true if data for method is cached but empty
+   TR_IPBytecodeHashTableEntry *getBytecodeData(const AOTCacheMethodRecord *methodRecord, uint32_t bci,
+                                                bool &present, TR_Memory &trMemory, TR::Region &cgEntryRegion);
+   size_t getNumStores() const { return _numStores; }
+   size_t getNumOverwrites() const { return _numOverwrites; }
+   void printStats(FILE *f) const;
+   static int compareBytecodeProfiles(const BytecodeProfileSummary &profile1, const BytecodeProfileSummary &profile2);
+   private:
+   PersistentUnorderedMap<const AOTCacheMethodRecord *, ProfiledMethodEntry> _methodProfileMap;
+   TR::Monitor *const _monitor;
+   // The aotCache that is associated with this sharedProfileCache
+   JITServerAOTCache *const _aotCache;
+   // Statistics
+   size_t _numStores;
+   size_t _numOverwrites; // part of the store operations
+
+   //TR::RawAllocator _rawAllocator;
+   //J9::SegmentAllocator _segmentAllocator;
+   //J9::SystemSegmentProvider _segmentProvider;
+   //TR::Region _region;
+   //TR_Memory _trMemory;
+   }; // SharedProfileCache
+
+
+#endif // JITSERVER_PROFILE_CACHE_H

--- a/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
+++ b/runtime/compiler/runtime/JITServerSharedROMClassCache.hpp
@@ -48,9 +48,15 @@ public:
    // it will be the cached deterministic hash of packedROMClass received from the client.
    J9ROMClass *getOrCreate(const J9ROMClass *packedROMClass, const JITServerROMClassHash *packedROMClassHash);
    void release(J9ROMClass *romClass);
+   void acquire(J9ROMClass *romClass);
 
    // Get precomputed hash of a shared ROMClass
    static const JITServerROMClassHash &getHash(const J9ROMClass *romClass);
+
+   bool isInitialized() const { return _persistentMemory != NULL; }
+
+   // Print cache content for debugging purposes (ROMMethods pointers, names and hashes)
+   void printContent() const;
 
 private:
    struct Entry;
@@ -59,11 +65,6 @@ private:
    // To reduce lock contention, the cache is divided into a number of
    // partitions, each synchronized with a separate monitor
    Partition &getPartition(const JITServerROMClassHash &hash);
-
-   void createPartitions();
-   void destroyPartitions();
-
-   bool isInitialized() const { return _persistentMemory != NULL; }
 
    const size_t _numPartitions;
    TR_PersistentMemory *_persistentMemory;


### PR DESCRIPTION
This PR is a barebones implementation of a shared bytecode profile repository at JITServer.
At the moment only profiling related to branches is stored in the profile repository.

The profile cache code is enabled by the client which can signal its intention of using it by providing `-XX:+JITServerUseProfileCache` on the command line. Note that the client must also use the JITServer AOT cache which is a prerequisite for the profile cache: `-XX:+JITServerUseAOTCache`.

There is a strong association between an AOTCache and a sharedProfileCache. Each data structure points back to its counterpart. Once an AOT cache is created, a profile cache is also created even if the client has no intention of using it (if no client uses the profile cache, it will remain empty). Because a JITServer can have several named AOTCaches, it means that it can also have several profile caches. It is the responsibility of the user to connect clients to the appropriate AOT/profile cache (through names). 

**High level flow of information**
JITServer optimizer is interested in the profiling information for a particular j9method and bci using
 `JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR::Compilation *comp, uintptr_t data, bool addIt)`
The server checks its per-client IProfiler cache. If this has info, we use that info.
Next it checks the per-compilation IProfiler cache. If this has info, we use that info.
Next it sends a message to the client asking for all the IProfiler info for the method in question.
The client serializes the information (possibly looking in the SCC) and sends the information to the server(the client may send additional info about the classes that the server may be missing).
After receiving the method IP info, the server checks to see if there is something in the sharedProfileCache and if the quality of that cached profile is better than the quality of the profile received from the client.
	`JITServerSharedProfileCache::compareBytecodeProfiles(sharedProfileSummary, clientProfileSummary);`
This comparison is a heuristic and it looks at the number of samples and number of bytecodes profiled.

  1. If the sharedProfileInfo is better than the info from client, we pick this source and populate the per-client IProfiler cache which will be used from now on. 
	`clientSession->loadBytecodeDataFromSharedProfileCache((J9Method*)method, usePersistentCache, comp);`

  2. If the fresh profile info received from the client is better, we will cache locally (per client) and use that. 
	`cacheProfilingDataForMethod(method, ipdata, usePersistentCache, clientSession, compInfoPT, isCompiled, comp);`
     We will also store this information in the sharedProfileCache, possibly overwriting some lower quality data.
	`clientSession->storeBytecodeProfileInSharedRepository(method, ipdata, numClientSamples, usePersistentCache, comp);`
    
  3. If the two sources of profile info are of about same quality we prefer the data from the client because it should better reflect the client activity.
	`cacheProfilingDataForMethod(method, ipdata, usePersistentCache, clientSession, compInfoPT, isCompiled, comp);`
     We will not store this info into the sharedProfilerCache because it's just about the same what we had before.
    
The shared profile data is kept per method.
With a j9method in hand we find the corresponding J9MethodInfo (from clientSession), then we find
the `AOTCacheMethodRecord` corresponding to this method and then we access the 
`JITServerSharedProfileCache::_methodProfileMap` to find the `ProfiledMethodEntry` which holds the entire
profiling data for a method.
A `ProfiledMethodEntry` contains two dynamically allocated data structures:
  (1) a `BytecodeProfile` and (2) a `FanInProfile`. A `BytecodeProfile` is nothing more than a vector of pointers to IProfile entries.
(one entry for each bytecode that has profiling information).
The `BytecodeProfile` also remembers the total number of profiling samples across all bytecodes in the method. This is useful
when comparing the "quality" of two different profiles.
The entire shared profile infrastructure is protected by a single monitor: `JITServerSharedProfileCache:_monitor`.

An IProfiler CallGraph entry typically contains three j9class slots and their associated number of samples. Because
j9classes are specific to each client, we cannot store them in the JITServer shared profile cache. Instead, we need to replace
them with corresponding AOT Class Records. When loading from the shared profile repository we need to convert the class records back into j9classes. The AOT deserializer from the client can help with that conversion. This will be the subject of a follow up PR.  
