### PR TITLE
RCP: Reset object refs in unnamed module for system loader

### DIFF
--- a/runtime/vm/VMSnapshotImpl.cpp
+++ b/runtime/vm/VMSnapshotImpl.cpp
@@ -381,6 +381,9 @@ VMSnapshotImpl::saveModularityData()
 {
 	_snapshotHeader->savedJavaVMStructs.modularityPool = _vm->modularityPool;
 	_snapshotHeader->savedJavaVMStructs.javaBaseModule = _vm->javaBaseModule;
+
+	_vm->unnamedModuleForSystemLoader->moduleObject = NULL;
+	_vm->unnamedModuleForSystemLoader->version = NULL;
 	_snapshotHeader->savedJavaVMStructs.unnamedModuleForSystemLoader = _vm->unnamedModuleForSystemLoader;
 }
 


### PR DESCRIPTION
Currently, the object refs in the unnamed module for the system classloader are not reset before the snapshot is created. During the restore phase, this leads to an InternalError in RCP JDK21+ since the object refs point to stale objects which no longer exist.
To resolve the InternalError, the object refs in the unnamed module are reset before the snapshot is created.

Exception in thread "(unnamed thread)" java/lang/InternalError:
		module is already set in the unnamedModuleForSystemLoader
at jdk/internal/loader/BootLoader.setBootLoaderUnnamedModule0
at jdk/internal/loader/BootLoader. (java.base@21/BootLoader.java:68)
at java/lang/ClassLoader.initializeClassLoaders
		(java.base@21/ClassLoader.java:187)
at java/lang/Thread.initialize (java.base@21/Thread.java:3108)
at java/lang/Thread. (java.base@21/Thread.java:3190)

Co-authored-by: Babneet Singh <sbabneet@ca.ibm.com>
Co-authored-by: Tobi Ajila <tobi_ajila@ca.ibm.com>
Co-authored-by: Lige Zhou <lige_zhou@ibm.com>
