### PR TITLE
Fix TR_ResolvedJ9Method::isSameMethod() for native methods

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5263,9 +5263,6 @@ TR_ResolvedJ9Method::setInvocationCount(intptr_t oldCount, intptr_t newCount)
 bool
 TR_ResolvedJ9Method::isSameMethod(TR_ResolvedMethod * m2)
    {
-   if (isNative())
-      return false; // A jitted JNI method doesn't call itself
-
    TR_ResolvedJ9Method *other = (TR_ResolvedJ9Method *)m2; // TODO: Use something safer in the presence of multiple inheritance
 
    bool sameRamMethod = ramMethod() == other->ramMethod();

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1260,9 +1260,6 @@ TR_ResolvedJ9JITServerMethod::shouldFailSetRecognizedMethodInfoBecauseOfHCR()
 bool
 TR_ResolvedJ9JITServerMethod::isSameMethod(TR_ResolvedMethod * m2)
    {
-   if (isNative())
-      return false; // A jitted JNI method doesn't call itself
-
    auto other = static_cast<TR_ResolvedJ9JITServerMethod*>(m2);
 
    bool sameRamMethod = ramMethod() == other->ramMethod();


### PR DESCRIPTION
The prior logic here would refuse to acknowledge that two instances of `TR_ResolvedJ9Method` represent the same method if that method was native. A single instance wouldn't even be treated as the same method as itself. For most purposes, that negative result is incorrect and surprising.

The reason for excluding native methods was that when compiling a linkage adapter for a JNI method, the call would otherwise appear to be recursive according to `isRecursiveMethodTarget()`, which could cause code generators to encode the call instruction as a call to the JIT body instead of the native function that implements the method. This is now handled in `isRecursiveMethodTarget()` so that `isSameMethod()` can return the obviously correct result.

This depends on https://github.com/eclipse-omr/omr/pull/7730