### PR TITLE
Sharing code between ConcurrentMarkingDelegate and MarkingDelegate

### DIFF
--- a/runtime/gc_base/CMakeLists.txt
+++ b/runtime/gc_base/CMakeLists.txt
@@ -46,6 +46,7 @@ set(gc_base_sources
 	ReferenceObjectBuffer.cpp
 	ReferenceObjectList.cpp
 	RootScanner.cpp
+	ScanContinuationSlotsBase.cpp
 	StackSlotValidator.cpp
 	StringTable.cpp
 	UnfinalizedObjectBuffer.cpp

--- a/runtime/gc_base/ScanContinuationSlotsBase.cpp
+++ b/runtime/gc_base/ScanContinuationSlotsBase.cpp
@@ -20,7 +20,7 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
-#include "MarkingDelegateBase.hpp"
+#include "ScanContinuationSlotsBase.hpp"
 
 #if JAVA_SPEC_VERSION >= 24
 #include "ContinuationSlotIterator.hpp"
@@ -30,7 +30,7 @@
 #include "StackSlotValidator.hpp"
 
 bool
-MM_MarkingDelegateBase::initialize(MM_EnvironmentBase *env)
+MM_ScanContinuationSlotsBase::initialize(MM_EnvironmentBase *env)
 {
 	_heap = MM_GCExtensions::getExtensions(env)->heap;
 	return true;
@@ -38,7 +38,7 @@ MM_MarkingDelegateBase::initialize(MM_EnvironmentBase *env)
 
 #if JAVA_SPEC_VERSION >= 24
 void
-MM_MarkingDelegateBase::doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator)
+MM_ScanContinuationSlotsBase::doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator)
 {
 	if (isHeapObject(*slotPtr) && !_heap->objectIsInGap(*slotPtr)) {
 		doSlot(env, slotPtr);
@@ -49,7 +49,7 @@ MM_MarkingDelegateBase::doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
 void
-MM_MarkingDelegateBase::doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, J9StackWalkState *walkState, const void *stackLocation)
+MM_ScanContinuationSlotsBase::doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, J9StackWalkState *walkState, const void *stackLocation)
 {
 	omrobjectptr_t object = *slotPtr;
 	if (isHeapObject(object) && !_heap->objectIsInGap(object)) {

--- a/runtime/gc_base/ScanContinuationSlotsBase.hpp
+++ b/runtime/gc_base/ScanContinuationSlotsBase.hpp
@@ -20,9 +20,8 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
-#if !defined(MARKINGDELEGATEBASE_HPP_)
-
-#define MARKINGDELEGATEBASE_HPP_
+#if !defined(SCANCONTINUATIONSLOTSBASE_HPP_)
+#define SCANCONTINUATIONSLOTSBASE_HPP_
 
 #include "j9.h"
 #include "j9nonbuilder.h"
@@ -38,7 +37,7 @@ class MM_EnvironmentBase;
 
 //class MM_MarkingScheme;
 
-class MM_MarkingDelegateBase
+class MM_ScanContinuationSlotsBase
 {
 protected:
 	MM_Heap *_heap;
@@ -71,11 +70,11 @@ public:
 	/**
 	 * Constructor.
 	 */
-	MMINLINE MM_MarkingDelegateBase()
+	MMINLINE MM_ScanContinuationSlotsBase()
 		: _heap(NULL)
 	{}
 };
 
-#endif /* MARKINGDELEGATEBASE_HPP_ */
+#endif /* SCANCONTINUATIONSLOTSBASE_HPP_ */
 
 

--- a/runtime/gc_glue_java/CMakeLists.txt
+++ b/runtime/gc_glue_java/CMakeLists.txt
@@ -33,7 +33,6 @@ set(j9vm_gc_glue_sources
 	${CMAKE_CURRENT_SOURCE_DIR}/GlobalCollectorDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/HeapWalkerDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/JNICriticalRegion.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/MarkingDelegateBase.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/MarkingDelegate.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/MarkingSchemeRootClearer.cpp
 	${CMAKE_CURRENT_SOURCE_DIR}/MarkingSchemeRootMarker.cpp

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -63,7 +63,7 @@ concurrentStackSlotIterator(J9JavaVM *javaVM, omrobjectptr_t *objectIndirect, vo
 bool
 MM_ConcurrentMarkingDelegate::initialize(MM_EnvironmentBase *env, MM_ConcurrentGC *collector)
 {
-	MM_MarkingDelegateBase::initialize(env);
+	MM_ScanContinuationSlotsBase::initialize(env);
 	MM_GCExtensionsBase *extensions = env->getExtensions();
 	_javaVM = (J9JavaVM *)extensions->getOmrVM()->_language_vm;
 	_objectModel = &(extensions->objectModel);

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
@@ -40,7 +40,7 @@
 #include "ConcurrentSafepointCallbackJava.hpp"
 #include "EnvironmentBase.hpp"
 #include "GCExtensionsBase.hpp"
-#include "MarkingDelegateBase.hpp"
+#include "ScanContinuationSlotsBase.hpp"
 #include "MarkingScheme.hpp"
 #include "ReferenceObjectBuffer.hpp"
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
@@ -54,7 +54,7 @@ class MM_MarkingScheme;
 /**
  * Provides language-specific support for marking.
  */
-class MM_ConcurrentMarkingDelegate : public MM_MarkingDelegateBase
+class MM_ConcurrentMarkingDelegate : public MM_ScanContinuationSlotsBase
 {
 	/*
 	 * Data members
@@ -363,7 +363,7 @@ public:
 	/**
 	 * Constructor.
 	 */
-	MMINLINE MM_ConcurrentMarkingDelegate() : MM_MarkingDelegateBase()
+	MMINLINE MM_ConcurrentMarkingDelegate() : MM_ScanContinuationSlotsBase()
 		, _javaVM(NULL)
 		, _objectModel(NULL)
 		, _collector(NULL)

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -72,7 +72,7 @@
 bool
 MM_MarkingDelegate::initialize(MM_EnvironmentBase *env, MM_MarkingScheme *markingScheme)
 {
-	MM_MarkingDelegateBase::initialize(env);
+	MM_ScanContinuationSlotsBase::initialize(env);
 	_omrVM = env->getOmrVM();
 	_extensions = MM_GCExtensions::getExtensions(env);
 	_markingScheme = markingScheme;

--- a/runtime/gc_glue_java/MarkingDelegate.hpp
+++ b/runtime/gc_glue_java/MarkingDelegate.hpp
@@ -29,7 +29,7 @@
 #include "FlattenedArrayObjectScanner.hpp"
 #include "GCExtensions.hpp"
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-#include "MarkingDelegateBase.hpp"
+#include "ScanContinuationSlotsBase.hpp"
 #include "MarkMap.hpp"
 #endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */
 #include "MixedObjectScanner.hpp"
@@ -43,7 +43,7 @@ class MM_HeapRegionDescriptorStandard;
 class MM_MarkingScheme;
 class MM_ReferenceStats;
 
-class MM_MarkingDelegate : public MM_MarkingDelegateBase
+class MM_MarkingDelegate : public MM_ScanContinuationSlotsBase
 {
 /* Data members & types */
 private:
@@ -85,7 +85,7 @@ private:
 protected:
 
 public:
-	MM_MarkingDelegate() : MM_MarkingDelegateBase()
+	MM_MarkingDelegate() : MM_ScanContinuationSlotsBase()
 		, _omrVM(NULL)
 		, _extensions(NULL)
 		, _markingScheme(NULL)


### PR DESCRIPTION
sharing code for scanContinuationSlots

- new base class MM_MarkingDelegateBase
- virtual methods doContinuationSlot() and doStackSlot()
- pure virtual method doSlot()
- private method isHeapObject()

Signed-off-by: lhu <linhu@ca.ibm.com>