### PR TITLE
Cleanup AOTCacheMap_request code

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -190,6 +190,10 @@ private:
                                   bool& useAotCompilation, bool& isCriticalRequest, bool& hasIncNumActiveThreads,
                                   bool& aotCacheHit, bool& abortCompilation);
 
+   void processAOTCacheMapRequest(const std::string& aotCacheName,
+                                  TR::CompilationInfo *compInfo,
+                                  JITServer::ServerStream *stream);
+
    TR_PersistentMethodInfo *_recompilationMethodInfo;
    uint32_t _seqNo;
    uint32_t _expectedSeqNo; // this request is allowed to go if _expectedSeqNo is processed

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -24,6 +24,7 @@
 #define JITSERVER_COMPILATION_THREAD_H
 
 #include "control/CompilationThread.hpp"
+#include "control/JITServerHelpers.hpp"
 #include "env/j9methodServer.hpp"
 #include "runtime/JITClientSession.hpp"
 
@@ -34,6 +35,14 @@ using IPTableHeap_t = UnorderedMap<J9Method *, IPTableHeapEntry *>;
 using ResolvedMirrorMethodsPersistIP_t = Vector<TR_ResolvedJ9Method *>;
 using ClassOfStatic_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_OpaqueClassBlock *>;
 using FieldOrStaticAttrTable_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_J9MethodFieldAttributes>;
+
+using CompilationRequest = std::tuple<
+   uint64_t, uint32_t, uint32_t, J9Method *, J9Class *, TR_OptimizationPlan, std::string,
+   J9::IlGeneratorMethodDetailsType, std::vector<TR_OpaqueClassBlock *>, std::vector<TR_OpaqueClassBlock *>,
+   JITServerHelpers::ClassInfoTuple, std::string, std::string, std::string, std::string,
+   bool, bool, bool, bool, uint32_t, uintptr_t, std::vector<J9Class *>, std::vector<J9Class *>,
+   std::vector<JITServerHelpers::ClassInfoTuple>, std::vector<uintptr_t>
+>;
 
 void outOfProcessCompilationEnd(TR_MethodToBeCompiled *entry, TR::Compilation *comp);
 
@@ -172,6 +181,14 @@ private:
    bool serveCachedAOTMethod(TR_MethodToBeCompiled &entry, J9Method *method, J9Class *definingClass,
                              TR_OptimizationPlan *optPlan, ClientSessionData *clientData,
                              J9::J9SegmentProvider &scratchSegmentProvider);
+
+   void processCompilationRequest(CompilationRequest& req, JITServer::ServerStream *stream,
+                                  TR::CompilationInfo *compInfo, J9VMThread *compThread,
+                                  ClientSessionData *& clientSession, TR_MethodToBeCompiled &entry,
+                                  TR_OptimizationPlan *& optPlan, J9::J9SegmentProvider &scratchSegmentProvider,
+                                  uint64_t& clientId, uint32_t& seqNo, bool& hasUpdatedSeqNo,
+                                  bool& useAotCompilation, bool& isCriticalRequest, bool& hasIncNumActiveThreads,
+                                  bool& aotCacheHit, bool& abortCompilation);
 
    TR_PersistentMethodInfo *_recompilationMethodInfo;
    uint32_t _seqNo;

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -156,7 +156,7 @@ public:
       @return Returns a tuple with information sent by the client
    */
    template <typename... T>
-   std::tuple<T...> readCompileRequest()
+   MessageType readCompileRequest(std::tuple<T...> &req)
       {
       readMessage(_cMsg);
       if (_cMsg.fullVersion() != 0 && _cMsg.fullVersion() != getJITServerFullVersion())
@@ -177,8 +177,9 @@ public:
             }
          case MessageType::compilationRequest:
             {
-            return getArgsRaw<T...>(_cMsg);
+            req = getArgsRaw<T...>(_cMsg);
             }
+            break;
          case MessageType::AOTCacheMap_request:
             {
             std::string cacheName = std::get<0>(getArgsRaw<std::string>(_cMsg));
@@ -189,6 +190,8 @@ public:
             throw StreamMessageTypeMismatch(MessageType::compilationRequest, _cMsg.type());
             }
          }
+
+      return _cMsg.type();
       }
 
    /**

--- a/runtime/compiler/net/ServerStream.hpp
+++ b/runtime/compiler/net/ServerStream.hpp
@@ -156,7 +156,7 @@ public:
       @return Returns a tuple with information sent by the client
    */
    template <typename... T>
-   MessageType readCompileRequest(std::tuple<T...> &req)
+   MessageType readCompileRequest(std::tuple<T...> &req, std::string &cacheName)
       {
       readMessage(_cMsg);
       if (_cMsg.fullVersion() != 0 && _cMsg.fullVersion() != getJITServerFullVersion())
@@ -182,9 +182,9 @@ public:
             break;
          case MessageType::AOTCacheMap_request:
             {
-            std::string cacheName = std::get<0>(getArgsRaw<std::string>(_cMsg));
-            throw StreamAotCacheMapRequest(cacheName);
+            cacheName = std::get<0>(getArgsRaw<std::string>(_cMsg));
             }
+            break;
          default:
             {
             throw StreamMessageTypeMismatch(MessageType::compilationRequest, _cMsg.type());

--- a/runtime/compiler/net/StreamExceptions.hpp
+++ b/runtime/compiler/net/StreamExceptions.hpp
@@ -81,25 +81,6 @@ private:
    uint64_t _clientId;
    };
 
-
-class StreamAotCacheMapRequest: public virtual std::exception
-   {
-public:
-   StreamAotCacheMapRequest(std::string cacheName) : _cacheName(cacheName)
-      {
-      }
-   virtual const char* what() const throw()
-      {
-      return "Requesting AOT cache content";
-      }
-   const std::string& getCacheName() const
-      {
-      return _cacheName;
-      }
-private:
-   const std::string _cacheName;
-   };
-
 class StreamOOO : public virtual std::exception
    {
    public:


### PR DESCRIPTION
The `AOTCacheMap_request` is processed by throwing an exception. This isn't a good way of implementing this from a conceptual integrity point of view. This PR refactors the code to explicitly process both `compilationRequest` and `AOTCacheMap_request`.