### PR TITLE
RCP: Invoke freeJavaVM() on VM shutdown

### DIFF
--- a/runtime/vm/vmprops.c
+++ b/runtime/vm/vmprops.c
@@ -1071,6 +1071,15 @@ initializeSystemProperties(J9JavaVM *vm)
 	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
+#if defined(J9VM_OPT_SNAPSHOTS)
+	if (IS_SNAPSHOT_RUN(vm)) {
+		rc = addSystemProperty(vm, "ibm.java9.forceCommonCleanerShutdown", "true", J9SYSPROP_FLAG_WRITEABLE);
+		if (J9SYSPROP_ERROR_NONE != rc) {
+			goto fail;
+		}
+	}
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+
 #if JAVA_SPEC_VERSION >= 23
 	{
 		/* JEP 471: Deprecate the Memory-Access Methods in sun.misc.Unsafe for Removal


### PR DESCRIPTION
Set the system property ibm.java9.forceCommonCleanerShutdown to true
to enable termination of the Common Cleaner thread, thus freeJavaVM()
is invoked to create snapshot file on VM shutdown.

Fixes: #20873

Co-authored-by: Babneet Singh sbabneet@ca.ibm.com
Co-authored-by: Tobi Ajila tobi_ajila@ca.ibm.com
Co-authored-by: Lige Zhou lige.zhou@ibm.com