### PR TITLE
(0.52) Fix synchronized method enter vthread transition

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1759,7 +1759,8 @@ obj:
 			VM_YesNoMaybe isObjectConstructor,
 			VM_YesNoMaybe zeroing,
 			bool j2i = false,
-			bool decompileOccurred = false
+			bool decompileOccurred = false,
+			bool skipStackOverflowCheck = false
 	) {
 		VM_BytecodeAction rc = EXECUTE_BYTECODE;
 		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(_sendMethod);
@@ -1806,7 +1807,7 @@ obj:
 		_literals = _sendMethod;
 		_pc = _sendMethod->bytecodes;
 		UDATA volatile stackOverflowMark = (UDATA)_currentThread->stackOverflowMark;
-		if ((UDATA)_sp >= stackOverflowMark) {
+		if (skipStackOverflowCheck || ((UDATA)_sp >= stackOverflowMark)) {
 			if (methodIsSynchronized) {
 				UDATA monitorRC = enterObjectMonitor(REGISTER_ARGS, syncObject);
 				/* Monitor enter can only fail in the nonblocking case, which does not
@@ -5816,9 +5817,16 @@ ffi_OOM:
 			break;
 		}
 		case J9VM_CONTINUATION_RETURN_FROM_SYNC_METHOD: {
-			UDATA *bp = ((UDATA *)(((J9SFMethodFrame *)_sp) + 1)) - 1;
-			restoreSpecialStackFrameLeavingArgs(REGISTER_ARGS, bp);
-			rc = inlineSendTarget(REGISTER_ARGS, VM_MAYBE, VM_MAYBE, VM_MAYBE, VM_MAYBE);
+			/* Reset interpreter state to what it would have been upon entry to inline send target. */
+			J9SFStackFrame *bytecodeFrame = (J9SFStackFrame *)_sp;
+			J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(_literals);
+			_sp = (UDATA *)((J9SFStackFrame *)_sp + 1) + (romMethod->tempCount + 1);
+			_sendMethod = _literals;
+			_literals = bytecodeFrame->savedCP;
+			_pc = bytecodeFrame->savedPC;
+			bytecodeFrame->savedA0 = (UDATA *)((UDATA)bytecodeFrame->savedA0 & ~((UDATA)J9SF_A0_INVISIBLE_TAG));
+			_arg0EA = bytecodeFrame->savedA0;
+			rc = inlineSendTarget(REGISTER_ARGS, VM_MAYBE, VM_MAYBE, VM_MAYBE, VM_MAYBE, false, false, true);
 			break;
 		}
 		case J9VM_CONTINUATION_RETURN_FROM_JIT_MONITOR_ENTER: {


### PR DESCRIPTION
- Correctly unwind the thread stack frame when re-mounting from J9VM_CONTINUATION_RETURN_FROM_SYNC_METHOD
- Ensure that all access to blockedVirtualThreadsMutex is done consistently
- Address infinite loop in takeVirtualThreadListToUnblock if vm->blockedContinuations is NULL
- Also skip SO check when returning from J9VM_CONTINUATION_RETURN_FROM_SYNC_METHOD to remain consistent with how it would behave in the pinning case.

https://github.com/eclipse-openj9/openj9/issues/21560 https://github.com/eclipse-openj9/openj9/issues/21649 https://github.com/eclipse-openj9/openj9/issues/21648 are now passing

https://github.com/eclipse-openj9/openj9/issues/21446 https://github.com/eclipse-openj9/openj9/issues/21422 no longer crashing