### PR TITLE
Refine and inline MethodHandle.linkTo* methods in ValuePropagation

### DIFF
--- a/runtime/compiler/optimizer/J9ValuePropagation.hpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.hpp
@@ -283,6 +283,19 @@ class ValuePropagation : public OMR::ValuePropagation
    void transformVTObjectEqNeCompare(TR_OpaqueClassBlock *containingClass, TR::Node *callNode);
 
    /**
+    * \brief
+    *    Handles refined MethodHandle.invokeBasic and MethodHandle.linkTo* VM INL calls so that
+    *    they can be inlined during delayed VP transformations. This helper does the following:
+    *       1. Creates and populates TR_PrexArgInfo for the callee
+    *       2. Adds the corresponding OMR::ValuePropagation::CallInfo to
+    *          _refinedMethodHandleINLMethodsToInline
+    *
+    * \param node
+    *    The refined call node
+    */
+   void processRefinedMethodHandleINLCall(TR::Node *node);
+
+   /**
     * Determine the bounds and element size for an array constraint
     *
     * \param[in] arrayConstraint A \ref TR::VPConstraint for an array reference


### PR DESCRIPTION
When ValuePropagation is able to obtain the known object info of the MemberName child of a linkToSpecial, linkToVirtual and linkToStatic call, it is possible to refine the INL call and avoid a more expensive dispatch mechanism. The refined linkTo* INL call then gets inlined during delayed VP transformations.

This change also adds a new static helper to deal with populating prex arg info.