### PR TITLE
Add #if defined(J9VM_OPT_SNAPSHOTS) around Snapshot utility macros

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -1657,11 +1657,14 @@ JVM_SetBootLoaderUnnamedModule(JNIEnv *env, jobject module)
 					vmFuncs->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, "module is already set in the unnamedModuleForSystemLoader");
 				} else {
 					J9Module *j9mod = NULL;
+#if defined(J9VM_OPT_SNAPSHOTS)
 					if (IS_RESTORE_RUN(vm)) {
 						j9mod = unnamedModuleForSystemLoader;
 						/* Bind J9Module and module object via the hidden field. */
 						J9OBJECT_ADDRESS_STORE(currentThread, modObj, vm->modulePointerOffset, j9mod);
-					} else {
+					} else
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+					{
 						j9mod = createModule(currentThread, modObj, systemClassLoader, NULL /* NULL name field */);
 					}
 					unnamedModuleForSystemLoader->moduleObject = modObj;
@@ -1670,12 +1673,15 @@ JVM_SetBootLoaderUnnamedModule(JNIEnv *env, jobject module)
 #else /* JAVA_SPEC_VERSION >= 21 */
 				if (NULL == J9VMJAVALANGCLASSLOADER_UNNAMEDMODULE(currentThread, systemClassLoader->classLoaderObject)) {
 					J9Module *j9mod = NULL;
+#if defined(J9VM_OPT_SNAPSHOTS)
 					if (IS_RESTORE_RUN(vm)) {
 						j9mod = vm->unnamedModuleForSystemLoader;
 						vm->unnamedModuleForSystemLoader->moduleObject = modObj;
 						/* Bind J9Module and module object via the hidden field. */
 						J9OBJECT_ADDRESS_STORE(currentThread, modObj, vm->modulePointerOffset, j9mod);
-					} else {
+					} else
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+					{
 						j9mod = createModule(currentThread, modObj, systemClassLoader, NULL /* NULL name field */);
 					}
 					J9VMJAVALANGCLASSLOADER_SET_UNNAMEDMODULE(currentThread, systemClassLoader->classLoaderObject, modObj);

--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -630,10 +630,12 @@ initializeBootstrapClassPath(J9JavaVM *vm)
 	}
 	(*VMI)->GetSystemProperty(VMI, BOOT_PATH_SEPARATOR_SYS_PROP, &classpathSeparator);
 
+#if defined(J9VM_OPT_SNAPSHOTS)
 	if (IS_RESTORE_RUN(vm)) {
 		Assert_JCL_true(J9_ARE_ALL_BITS_SET(loader->flags, J9CLASSLOADER_CLASSPATH_SET));
 		return INIT_BOOTSTRAP_CLASS_PATH_RESTORED;
 	}
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
 
 	/* Fail if the classpath has already been set. */
 	if (J9_ARE_ALL_BITS_SET(loader->flags, J9CLASSLOADER_CLASSPATH_SET)) {

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2379,10 +2379,12 @@ nativeOOM:
 		}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
+#if defined(J9VM_OPT_SNAPSHOTS)
 		if (IS_RESTORE_RUN(javaVM)) {
 			/* This flag is needed to ensure class hooks are run only once. */
 			classFlags |= J9ClassIsLoadedFromSnapshot;
 		}
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
 
 		state->ramClass->classFlags = classFlags;
 

--- a/runtime/vm/initsendtarget.cpp
+++ b/runtime/vm/initsendtarget.cpp
@@ -334,15 +334,21 @@ initializeInitialMethods(J9JavaVM *vm)
 	J9Method *cInitialSpecialMethod = NULL;
 	J9Method *cInitialVirtualMethod = NULL;
 
+#if defined(J9VM_OPT_SNAPSHOTS)
 	if (IS_RESTORE_RUN(vm)) {
 		setInitialVMMethods(vm, &cInitialStaticMethod, &cInitialSpecialMethod, &cInitialVirtualMethod);
-	} else {
+	} else
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+	{
+#if defined(J9VM_OPT_SNAPSHOTS)
 		if (IS_SNAPSHOT_RUN(vm)) {
 			cInitialStaticMethod = (J9Method *)vmsnapshot_allocate_memory(sizeof(J9Method), J9MEM_CATEGORY_CLASSES);
 			cInitialSpecialMethod = (J9Method *)vmsnapshot_allocate_memory(sizeof(J9Method), J9MEM_CATEGORY_CLASSES);
 			cInitialVirtualMethod = (J9Method *)vmsnapshot_allocate_memory(sizeof(J9Method), J9MEM_CATEGORY_CLASSES);
 			storeInitialVMMethods(vm, cInitialStaticMethod, cInitialSpecialMethod, cInitialVirtualMethod);
-		} else {
+		} else
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
+		{
 			cInitialStaticMethod = (J9Method *)j9mem_allocate_memory(sizeof(J9Method), J9MEM_CATEGORY_CLASSES);
 			cInitialSpecialMethod = (J9Method *)j9mem_allocate_memory(sizeof(J9Method), J9MEM_CATEGORY_CLASSES);
 			cInitialVirtualMethod = (J9Method *)j9mem_allocate_memory(sizeof(J9Method), J9MEM_CATEGORY_CLASSES);


### PR DESCRIPTION
Add `#if defined(J9VM_OPT_SNAPSHOTS)` around Snapshot utility macros

As per https://github.com/eclipse-openj9/openj9/pull/21667#discussion_r2049086579, when the feature is disabled, `IS_RESTORE_RUN` is always `FALSE`. The previous assumption was that the compiler will optimize the code block
and evaluate it as dead code, removing it. However, we've observed perf issues on `zLinux` where the compiler fails to optimize correctly. Just to be safe, it should be `#ifdef'ed`.


Signed-off-by: Jason Feng <fengj@ca.ibm.com>