### PR TITLE
JITServer IProfiler cache fix

### DIFF
--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -377,7 +377,7 @@ JITServerIProfiler::profilingSample(TR_OpaqueMethodBlock *method, uint32_t byteC
 
       // If the shared profile cache is enabled, we must compare the "quality" of the data in the
       // shared repository to the "quality" of the data sent by the client.
-      int sharedProfileQuality = -1; // pessimistic; -1 means bad quality
+      int sharedProfileQuality = 0;
       if (clientSession->useSharedProfileCache())
          {
          BytecodeProfileSummary clientProfileSummary(numClientSamples, numProfiledBytecodes, usePersistentCache);


### PR DESCRIPTION
The IProfiler code at JITServer used to cache empty information about methods that have no profiled bytecodes. Recent changes related to the shared profile cache have added a new code path where caching of empty information no longer happens, resulting in more messages being sent and an increase in the CompCPU at the client. This commit rectifies the situation dscribed above.