### PR TITLE
Remove asyncCheck from enterContinuation

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5802,9 +5802,7 @@ ffi_OOM:
 
 		VMStructHasBeenUpdated(REGISTER_ARGS);
 
-		if (immediateAsyncPending()) {
-			rc = GOTO_ASYNC_CHECK;
-		} else if (VM_VMHelpers::exceptionPending(_currentThread)) {
+		if (VM_VMHelpers::exceptionPending(_currentThread)) {
 			rc = GOTO_THROW_CURRENT_EXCEPTION;
 		}
 #if JAVA_SPEC_VERSION >= 24


### PR DESCRIPTION
An immediate async event cannot occur in native INL

Signed-off-by: Jack Lu <Jack.S.Lu@ibm.com>