### PR TITLE
 Sharing scanning continuation logic for Marking Delegates

### DIFF
--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.hpp
@@ -46,11 +46,9 @@
 #include "ScanClassesMode.hpp"
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
-#if JAVA_SPEC_VERSION >= 24
-class GC_ContinuationSlotIterator;
-#endif /* JAVA_SPEC_VERSION >= 24 */
 class GC_VMThreadIterator;
 class MM_ConcurrentGC;
+class MM_MarkingDelegate;
 class MM_MarkingScheme;
 
 /**
@@ -67,6 +65,7 @@ protected:
 	J9JavaVM *_javaVM;
 	GC_ObjectModel *_objectModel;
 	MM_ConcurrentGC *_collector;
+	MM_MarkingDelegate *_markingDelegate;
 	MM_MarkingScheme *_markingScheme;
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	MM_ScanClassesMode _scanClassesMode; /** Support for dynamic class unloading in concurrent mark */
@@ -88,11 +87,6 @@ public:
 		, CONCURRENT_ROOT_TRACING3 = CONCURRENT_ROOT_TRACING + 3
 		, CONCURRENT_ROOT_TRACING4 = CONCURRENT_ROOT_TRACING + 4
 	};
-
-	typedef struct markSchemeStackIteratorData {
-		MM_ConcurrentMarkingDelegate *concurrentMarkingDelegate;
-		MM_EnvironmentBase *env;
-	} markSchemeStackIteratorData;
 
 	/*
 	 * Function members
@@ -117,11 +111,6 @@ public:
 	 */
 	bool initialize(MM_EnvironmentBase *env, MM_ConcurrentGC *collector);
 
-	MMINLINE void doSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr);
-#if JAVA_SPEC_VERSION >= 24
-	void doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
-#endif /* JAVA_SPEC_VERSION >= 24 */
-	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, J9StackWalkState *walkState, const void *stackLocation);
 	/**
 	 * In the case of Weak Consistency platforms we require this method to bring mutator threads to a safe point. A safe
 	 * point is a point at which a GC may occur.
@@ -372,6 +361,7 @@ public:
 		: _javaVM(NULL)
 		, _objectModel(NULL)
 		, _collector(NULL)
+		, _markingDelegate(NULL)
 		, _markingScheme(NULL)
 	{ }
 };

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -242,7 +242,7 @@ MM_MarkingDelegate::startRootListProcessing(MM_EnvironmentBase *env)
 }
 
 void
-MM_MarkingDelegate::doSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr)
+MM_MarkingDelegate::doSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr)
 {
 	if (_extensions->isConcurrentScavengerEnabled() && _extensions->isScavengerBackOutFlagRaised()) {
 		_markingScheme->fixupForwardedSlot(slotPtr);
@@ -252,10 +252,10 @@ MM_MarkingDelegate::doSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, om
 
 #if JAVA_SPEC_VERSION >= 24
 void
-MM_MarkingDelegate::doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator)
+MM_MarkingDelegate::doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator)
 {
 	if (_markingScheme->isHeapObject(*slotPtr) && !_extensions->heap->objectIsInGap(*slotPtr)) {
-		doSlot(env, objectPtr, slotPtr);
+		doSlot(env, slotPtr);
 	} else if (NULL != *slotPtr) {
 		Assert_MM_true(GC_ContinuationSlotIterator::state_monitor_records == continuationSlotIterator->getState());
 	}
@@ -263,11 +263,11 @@ MM_MarkingDelegate::doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t o
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
 void
-MM_MarkingDelegate::doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr, void *walkState, const void* stackLocation)
+MM_MarkingDelegate::doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, void *walkState, const void* stackLocation)
 {
 	if (_markingScheme->isHeapObject(*slotPtr) && !_extensions->heap->objectIsInGap(*slotPtr)) {
 		Assert_MM_validStackSlot(MM_StackSlotValidator(0, *slotPtr, stackLocation, walkState).validate(env));
-		doSlot(env, objectPtr, slotPtr);
+		doSlot(env, slotPtr);
 	} else if (NULL != *slotPtr) {
 		/* stack object - just validate */
 		Assert_MM_validStackSlot(MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, *slotPtr, stackLocation, walkState).validate(env));
@@ -278,12 +278,28 @@ MM_MarkingDelegate::doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPt
  * @todo Provide function documentation
  */
 void
-stackSlotIteratorForMarkingDelegate(J9JavaVM *javaVM, J9Object **slotPtr, void *localData, J9StackWalkState *walkState, const void *stackLocation)
+MM_MarkingDelegate::stackSlotIterator(J9JavaVM *javaVM, J9Object **slotPtr, void *localData, J9StackWalkState *walkState, const void *stackLocation)
 {
-	StackIteratorData4MarkingDelegate *data = (StackIteratorData4MarkingDelegate *)localData;
-	data->markingDelegate->doStackSlot(data->env, data->fromObject, slotPtr, walkState, stackLocation);
+	StackIteratorData *data = (StackIteratorData *)localData;
+	data->markingDelegate->doStackSlot(data->env, slotPtr, walkState, stackLocation);
 }
 
+void
+MM_MarkingDelegate::scanContinuationNativeSlotsNoSync(MM_EnvironmentBase *env, J9VMThread *walkThread, J9VMContinuation *continuation, bool stackFrameClassWalkNeeded)
+{
+	J9VMThread *currentThread = (J9VMThread *)env->getLanguageVMThread();
+	StackIteratorData localData(env, this);
+
+	GC_VMThreadStackSlotIterator::scanSlots(currentThread, walkThread, continuation, (void *)&localData, (J9MODRON_OSLOTITERATOR *)stackSlotIterator, stackFrameClassWalkNeeded, false);
+
+#if JAVA_SPEC_VERSION >= 24
+	GC_ContinuationSlotIterator continuationSlotIterator(currentThread, continuation);
+
+	while (J9Object **slotPtr = continuationSlotIterator.nextSlot()) {
+		doContinuationSlot(env, slotPtr, &continuationSlotIterator);
+	}
+#endif /* JAVA_SPEC_VERSION >= 24 */
+}
 
 void
 MM_MarkingDelegate::scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr)
@@ -294,27 +310,14 @@ MM_MarkingDelegate::scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobje
 	const bool isGlobalGC = true;
 	const bool beingMounted = false;
 	if (MM_GCExtensions::needScanStacksForContinuationObject(currentThread, objectPtr, isConcurrentGC, isGlobalGC, beingMounted)) {
-		StackIteratorData4MarkingDelegate localData;
-		localData.markingDelegate = this;
-		localData.env = env;
-		localData.fromObject = objectPtr;
-
 		bool stackFrameClassWalkNeeded = false;
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 		stackFrameClassWalkNeeded = isDynamicClassUnloadingEnabled();
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
-		GC_VMThreadStackSlotIterator::scanContinuationSlots(currentThread, objectPtr, (void *)&localData, stackSlotIteratorForMarkingDelegate, stackFrameClassWalkNeeded, false);
-
-#if JAVA_SPEC_VERSION >= 24
 		J9VMContinuation *continuation = J9VMJDKINTERNALVMCONTINUATION_VMREF(currentThread, objectPtr);
-		GC_ContinuationSlotIterator continuationSlotIterator(currentThread, continuation);
-
-		while (J9Object **slotPtr = continuationSlotIterator.nextSlot()) {
-			doContinuationSlot(env, objectPtr, slotPtr, &continuationSlotIterator);
-		}
-#endif /* JAVA_SPEC_VERSION >= 24 */
-
+		J9VMThread * const walkThread = NULL;
+		scanContinuationNativeSlotsNoSync(env, walkThread, continuation, stackFrameClassWalkNeeded);
 		if (isConcurrentGC) {
 			MM_GCExtensions::exitContinuationConcurrentGCScan(currentThread, objectPtr, isGlobalGC);
 		}

--- a/runtime/gc_glue_java/MarkingDelegate.hpp
+++ b/runtime/gc_glue_java/MarkingDelegate.hpp
@@ -66,6 +66,14 @@ private:
 protected:
 
 public:
+	struct StackIteratorData {
+		MM_EnvironmentBase *env;
+		MM_MarkingDelegate *markingDelegate;
+		StackIteratorData(MM_EnvironmentBase *envBase, MM_MarkingDelegate *delegate)
+			: env(envBase)
+			, markingDelegate(delegate)
+		{}
+	};
 
 /* Methods */
 
@@ -131,13 +139,14 @@ public:
 		return 0;
 	}
 
-	MMINLINE void doSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr);
+	MMINLINE void doSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr);
 #if JAVA_SPEC_VERSION >= 24
-	void doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
+	void doContinuationSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
 #endif /* JAVA_SPEC_VERSION >= 24 */
-	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, omrobjectptr_t *slotPtr, void *walkState, const void* stackLocation);
+	void doStackSlot(MM_EnvironmentBase *env, omrobjectptr_t *slotPtr, void *walkState, const void *stackLocation);
 	void scanContinuationNativeSlots(MM_EnvironmentBase *env, omrobjectptr_t objectPtr);
 
+	void scanContinuationNativeSlotsNoSync(MM_EnvironmentBase *env, J9VMThread *walkThread, J9VMContinuation *continuation, bool stackFrameClassWalkNeeded);
 	MMINLINE GC_ObjectScanner *
 	getObjectScanner(MM_EnvironmentBase *env, omrobjectptr_t objectPtr, void *scannerSpace, MM_MarkingSchemeScanReason reason, uintptr_t *sizeToDo)
 	{
@@ -271,12 +280,7 @@ public:
 	static void clearClassLoadersScannedFlag(MM_EnvironmentBase *env);
 	MMINLINE bool isDynamicClassUnloadingEnabled() { return NULL != _markMap; }
 #endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */
+	static void stackSlotIterator(J9JavaVM *javaVM, J9Object **slotPtr, void *localData, J9StackWalkState *walkState, const void *stackLocation);
 };
-
-typedef struct StackIteratorData4MarkingDelegate {
-	MM_MarkingDelegate *markingDelegate;
-	MM_EnvironmentBase *env;
-	omrobjectptr_t fromObject;
-} StackIteratorData4MarkingDelegate;
 
 #endif /* MARKINGDELEGATE_HPP_ */

--- a/runtime/gc_structs/VMThreadStackSlotIterator.cpp
+++ b/runtime/gc_structs/VMThreadStackSlotIterator.cpp
@@ -168,6 +168,10 @@ GC_VMThreadStackSlotIterator::scanSlots(
 	J9StackWalkState stackWalkState;
 	initializeStackWalkState(&stackWalkState, vmThread, userData, oSlotIterator, includeStackFrameClassReferences, trackVisibleFrameDepth);
 
-	vmThread->javaVM->internalVMFunctions->walkContinuationStackFrames(vmThread, continuation, walkThread->carrierThreadObject, &stackWalkState);
+	j9object_t threadObject = NULL;
+	if (NULL != walkThread) {
+		threadObject = walkThread->carrierThreadObject;
+	}
+	vmThread->javaVM->internalVMFunctions->walkContinuationStackFrames(vmThread, continuation, threadObject, &stackWalkState);
 }
 #endif /* JAVA_SPEC_VERSION >= 19 */


### PR DESCRIPTION
Sharing logic for scanning continuation slots and
continuation stack slots between MarkingDelegate and
ConcurrentMarkingDelegate.

 - update GC_VMThreadStackSlotIterator::scanSlots() can
 handle both mounted and unmounted continuation Object.
 - update C method stackSlotIteratorForMarkingDelegate()
  to static MM_MarkingDelegate::stackSlotIterator().
 - update struct StackIteratorData4MarkingDelegate to
 MM_MarkingDelegate::StackIteratorData.
 - new method MM_MarkingDelegate.scanContinuationNativeSlotsNoSync
  handle scanning both continuation slots and continuation
  stack slots.
 - call MM_MarkingDelegate.scanContinuationNativeSlotsNoSync() in
 MM_ConcurrentMarkingDelegate for scanning.

Signed-off-by: lhu <linhu@ca.ibm.com>

