### PR TITLE
(0.52) Fix disabling fast JNI wait for JEP491

### DIFF
--- a/runtime/vm/FastJNI.cpp
+++ b/runtime/vm/FastJNI.cpp
@@ -150,8 +150,8 @@ found:
 							 * native is the wait implememnation and reject it if so.
 							 */
 							if (J9_ARE_ANY_BITS_SET(currentThread->javaVM->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)
-							&& J9UTF8_LITERAL_EQUALS(methodName, methodNameLength, "waitImpl")
-							&& J9UTF8_LITERAL_EQUALS(methodSignature, methodSignatureLength, "(JI)V")
+							&& J9UTF8_LITERAL_EQUALS(methodNameData, methodNameLength, "waitImpl")
+							&& J9UTF8_LITERAL_EQUALS(methodSignatureData, methodSignatureLength, "(JI)V")
 							) {
 								goto done;
 							}


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/pull/21489