### PR TITLE
Remove casts from J9UTF8 macros

### DIFF
--- a/runtime/bcutil/ClassFileWriter.hpp
+++ b/runtime/bcutil/ClassFileWriter.hpp
@@ -363,8 +363,8 @@ public:
 			 */
 			if (J9_ARE_ALL_BITS_SET(_romClass->extraModifiers, J9AccClassIsInjectedInvoker)) {
 				_isInjectedInvoker = TRUE;
-				originalNameLength = J9UTF8_LENGTH(&injectedInvokerClassname);
-				anonClassNameData = J9UTF8_DATA(&injectedInvokerClassname);
+				originalNameLength = J9UTF8_LENGTH((J9UTF8 *)&injectedInvokerClassname);
+				anonClassNameData = J9UTF8_DATA((J9UTF8 *)&injectedInvokerClassname);
 			}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 			/* nameLength field + nameBytes field + NULL terminator */
@@ -373,8 +373,8 @@ public:
 				_buildResult = OutOfMemory;
 			} else {
 				J9UTF8_SET_LENGTH(_originalClassName, originalNameLength);
-				memcpy(((U_8 *)J9UTF8_DATA(_originalClassName)), anonClassNameData, originalNameLength);
-				*(((U_8 *)J9UTF8_DATA(_originalClassName)) + originalNameLength) = '\0';
+				memcpy(J9UTF8_DATA(_originalClassName), anonClassNameData, originalNameLength);
+				J9UTF8_DATA(_originalClassName)[originalNameLength] = '\0';
 			}
 		}
 		if (isOK()) {

--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -681,15 +681,20 @@ copyStack (J9BranchTargetStack *source, J9BranchTargetStack *destination)
 static IDATA
 mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDATA * targetTypePointer)
 {
-	J9ROMClass * romClass = verifyData->romClass;
+	J9ROMClass *romClass = verifyData->romClass;
 	UDATA targetType = *targetTypePointer;
-	UDATA sourceIndex, targetIndex;
-	J9UTF8 *name;
-	UDATA classArity, targetArity, classIndex;
+	UDATA sourceIndex = 0;
+	UDATA targetIndex = 0;
+	J9UTF8 *name = NULL;
+	UDATA classArity = 0;
+	UDATA targetArity = 0;
+	UDATA classIndex = 0;
 	IDATA rc = BCV_SUCCESS;
-	U_8 *sourceName, *targetName;
-	UDATA sourceLength, targetLength;
-	U_32 *offset;
+	U_8 *sourceName = NULL;
+	U_8 *targetName = NULL;
+	UDATA sourceLength = 0;
+	UDATA targetLength = 0;
+	U_32 *offset = NULL;
 	IDATA reasonCode = 0;
 
 	/* assume that sourceType and targetType are not equal */
@@ -697,8 +702,8 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 	/* if target is more general than source, then its fine */
 	rc =  isClassCompatible( verifyData, sourceType, targetType, &reasonCode ) ;
 
-	if (TRUE == rc) {
-		return BCV_SUCCESS;	/* no merge required */
+	if (rc) {
+		return BCV_SUCCESS; /* no merge required */
 	} else { /* FALSE == rc */
 		/* VM error, no need to continue, return appropriate rc */
 		if (BCV_ERR_INTERNAL_ERROR == reasonCode) {
@@ -776,22 +781,20 @@ mergeObjectTypes (J9BytecodeVerificationData *verifyData, UDATA sourceType, UDAT
 		sourceIndex = (sourceType & BCV_CLASS_INDEX_MASK) >> BCV_CLASS_INDEX_SHIFT;
 		targetIndex = (targetType & BCV_CLASS_INDEX_MASK) >> BCV_CLASS_INDEX_SHIFT;
 
-		offset = (U_32 *) verifyData->classNameList[sourceIndex];
-		sourceLength = (UDATA) J9UTF8_LENGTH(offset + 1);
+		offset = (U_32 *)verifyData->classNameList[sourceIndex];
+		sourceLength = J9UTF8_LENGTH((J9UTF8 *)(offset + 1));
 
-		if (offset[0] == 0) {
-			sourceName = J9UTF8_DATA(offset + 1);
-
+		if (0 == offset[0]) {
+			sourceName = J9UTF8_DATA((J9UTF8 *)(offset + 1));
 		} else {
 			sourceName = (U_8 *) ((UDATA) offset[0] + (UDATA) romClass);
 		}
 
 		offset = (U_32 *) verifyData->classNameList[targetIndex];
-		targetLength = (UDATA) J9UTF8_LENGTH(offset + 1);
+		targetLength = J9UTF8_LENGTH((J9UTF8 *)(offset + 1));
 
-		if (offset[0] == 0) {
-			targetName = J9UTF8_DATA(offset + 1);
-
+		if (0 == offset[0]) {
+			targetName = J9UTF8_DATA((J9UTF8 *)(offset + 1));
 		} else {
 			targetName = (U_8 *) ((UDATA) offset[0] + (UDATA) romClass);
 		}

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -1095,15 +1095,13 @@ static UDATA compareTwoUTF8s(J9UTF8 * first, J9UTF8 * second)
 
 static void getNameAndLengthFromClassNameList (J9BytecodeVerificationData *verifyData, UDATA listIndex, U_8 ** name, UDATA * length)
 {
-	U_32 * offset;
-
-	offset = (U_32 *) verifyData->classNameList[listIndex];
-	*length = (U_32) J9UTF8_LENGTH(offset + 1);
-	if (offset[0] == 0) {
-		*name = J9UTF8_DATA(offset + 1);
+	U_32 *offset = (U_32 *)verifyData->classNameList[listIndex];
+	*length = J9UTF8_LENGTH((J9UTF8 *)(offset + 1));
+	if (0 == offset[0]) {
+		*name = J9UTF8_DATA((J9UTF8 *)(offset + 1));
 	} else {
-		J9ROMClass * romClass = verifyData->romClass;
-		*name = (U_8 *) ((UDATA) offset[0] + (UDATA) romClass);
+		J9ROMClass *romClass = verifyData->romClass;
+		*name = (U_8 *)((UDATA)offset[0] + (UDATA)romClass);
 	}
 }
 

--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -823,8 +823,8 @@ setCallSiteTargetImpl(J9VMThread *currentThread, jobject callsite, jobject targe
 		J9Class *mcsClass = vmFuncs->peekClassHashTable(
 			currentThread,
 			javaVM->systemClassLoader,
-			J9UTF8_DATA(&mutableCallSite),
-			J9UTF8_LENGTH(&mutableCallSite));
+			J9UTF8_DATA((J9UTF8 *)&mutableCallSite),
+			J9UTF8_LENGTH((J9UTF8 *)&mutableCallSite));
 
 		if (!isVolatile /* MutableCallSite uses setTargetNormal(). */
 		&& (NULL != jitConfig)

--- a/runtime/jcl/common/jclexception.cpp
+++ b/runtime/jcl/common/jclexception.cpp
@@ -124,7 +124,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecode
 
 		/* If there is a valid method at this frame, fill in the information for it in the StackTraceElement */
 		if (NULL != romMethod) {
-			J9UTF8 const * utfClassName = J9ROMCLASS_CLASSNAME(romClass);
+			J9UTF8 const *utfClassName = J9ROMCLASS_CLASSNAME(romClass);
 			j9object_t string = NULL;
 
 			PUSH_OBJECT_IN_SPECIAL_FRAME(vmThread, element);
@@ -135,7 +135,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecode
 			 */
 			if (NULL != classLoader) {
 				if (NULL == ramClass) {
-					ramClass = vmFuncs->peekClassHashTable(vmThread, classLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+					ramClass = vmFuncs->peekClassHashTable(vmThread, classLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
 				}
 				if (NULL != ramClass) {
 					/* ramClass can never be an array here as arrays can't define methods so we don't need to
@@ -181,7 +181,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecode
 				} else {
 					UDATA length = packageNameLength(romClass);
 					omrthread_monitor_enter(vm->classLoaderModuleAndLocationMutex);
-					module = vmFuncs->findModuleForPackage(vmThread, classLoader, J9UTF8_DATA(utfClassName), (U_32) length);
+					module = vmFuncs->findModuleForPackage(vmThread, classLoader, (U_8 *)J9UTF8_DATA(utfClassName), (U_32)length);
 					omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
 				}
 				if (NULL != module) {
@@ -209,7 +209,7 @@ getStackTraceIterator(J9VMThread * vmThread, void * voidUserData, UDATA bytecode
 				if (J9ROMCLASS_IS_ANON_OR_HIDDEN(romClass)) {
 					flags |= J9_STR_ANON_CLASS_NAME;
 				}
-				string = mmfns->j9gc_createJavaLangString(vmThread, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName), flags);
+				string = mmfns->j9gc_createJavaLangString(vmThread, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName), flags);
 			}
 			element = PEEK_OBJECT_IN_SPECIAL_FRAME(vmThread, 0);
 			J9VMJAVALANGSTACKTRACEELEMENT_SET_DECLARINGCLASS(vmThread, element, string);

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -180,23 +180,22 @@ typedef struct J9ClassLoaderWalkState {
 
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
-
-/* UTF8 access macros - all access to J9UTF8 fields should be done through these macros */
-
-#define J9UTF8_LENGTH(j9UTF8Address) (((struct J9UTF8 *)(j9UTF8Address))->length)
-#define J9UTF8_SET_LENGTH(j9UTF8Address, len) (((struct J9UTF8 *)(j9UTF8Address))->length = (len))
-#define J9UTF8_DATA(j9UTF8Address) (((struct J9UTF8 *)(j9UTF8Address))->data)
-#define J9UTF8_TOTAL_SIZE(j9UTF8Address) (sizeof(J9UTF8) + J9UTF8_LENGTH(j9UTF8Address))
-#define J9UTF8_DATA_EQUALS(data1, length1, data2, length2) ((((length1) == (length2)) && (memcmp((data1), (data2), (length1)) == 0)))
-#define J9UTF8_EQUALS(utf1, utf2) (((utf1) == (utf2)) || (J9UTF8_DATA_EQUALS(J9UTF8_DATA(utf1), J9UTF8_LENGTH(utf1), J9UTF8_DATA(utf2), J9UTF8_LENGTH(utf2))))
-#define J9UTF8_LITERAL_EQUALS(data1, length1, cString) (J9UTF8_DATA_EQUALS((data1), (length1), (cString), sizeof(cString) - 1))
-#define J9UTF8_LITERAL_EQUALS_UTF8(utf8, cString) (J9UTF8_LITERAL_EQUALS(J9UTF8_DATA((utf8)), J9UTF8_LENGTH((utf8)), cString))
-
 /*
  * Equivalent to ((int)strlen(string_literal)) when given a literal string.
  * E.g.: LITERAL_STRLEN("lib") == 3
  */
 #define LITERAL_STRLEN(string_literal) ((IDATA)(sizeof(string_literal) - 1))
+
+/* UTF8 access macros - all access to J9UTF8 fields should be done through these macros. */
+
+#define J9UTF8_LENGTH(j9UTF8Address) ((j9UTF8Address)->length)
+#define J9UTF8_SET_LENGTH(j9UTF8Address, len) ((j9UTF8Address)->length = (len))
+#define J9UTF8_DATA(j9UTF8Address) ((j9UTF8Address)->data)
+#define J9UTF8_TOTAL_SIZE(j9UTF8Address) (sizeof(J9UTF8) + J9UTF8_LENGTH(j9UTF8Address))
+#define J9UTF8_DATA_EQUALS(data1, length1, data2, length2) (((length1) == (length2)) && (0 == memcmp((data1), (data2), (length1))))
+#define J9UTF8_EQUALS(utf1, utf2) (((utf1) == (utf2)) || J9UTF8_DATA_EQUALS(J9UTF8_DATA(utf1), J9UTF8_LENGTH(utf1), J9UTF8_DATA(utf2), J9UTF8_LENGTH(utf2)))
+#define J9UTF8_LITERAL_EQUALS(data1, length1, cString) J9UTF8_DATA_EQUALS((data1), (length1), (cString), LITERAL_STRLEN(cString))
+#define J9UTF8_LITERAL_EQUALS_UTF8(utf8, cString) J9UTF8_LITERAL_EQUALS(J9UTF8_DATA((utf8)), J9UTF8_LENGTH((utf8)), cString)
 
 #define ROUND_UP_TO(granularity, number) ((((number) % (granularity)) ? ((number) + (granularity) - ((number) % (granularity))) : (number)))
 #define ROUND_DOWN_TO(granularity, number) ((number) - ((number) % (granularity)))

--- a/runtime/tests/shared/CompiledMethodTest.cpp
+++ b/runtime/tests/shared/CompiledMethodTest.cpp
@@ -249,13 +249,13 @@ IDATA storeAndFindTest(J9JavaVM* vm)
 
 	/* Set the method name and signature */
 	methodNameAndSigMem = (BlockPtr)((UDATA)romMethod1 + sizeof(J9ROMMethod));
-	J9UTF8_SET_LENGTH(methodNameAndSigMem, (U_16)strlen(TEST_METHOD_NAME));
-	j9str_printf((BlockPtr) (J9UTF8_DATA(methodNameAndSigMem)), sizeof(TEST_METHOD_NAME), "%s", TEST_METHOD_NAME);
-	NNSRP_SET(romMethod1->nameAndSignature.name, (J9UTF8*)methodNameAndSigMem);
+	J9UTF8_SET_LENGTH((J9UTF8 *)methodNameAndSigMem, (U_16)strlen(TEST_METHOD_NAME));
+	j9str_printf((BlockPtr)J9UTF8_DATA((J9UTF8 *)methodNameAndSigMem), sizeof(TEST_METHOD_NAME), "%s", TEST_METHOD_NAME);
+	NNSRP_SET(romMethod1->nameAndSignature.name, (J9UTF8 *)methodNameAndSigMem);
 
-	J9UTF8_SET_LENGTH((methodNameAndSigMem + METHOD_NAME_SIZE), (U_16)strlen(TEST_METHOD_SIG));
-	j9str_printf((BlockPtr) (J9UTF8_DATA(methodNameAndSigMem + METHOD_NAME_SIZE)), sizeof(TEST_METHOD_SIG), "%s",TEST_METHOD_SIG);
-	NNSRP_SET(romMethod1->nameAndSignature.signature, (J9UTF8*)(methodNameAndSigMem + METHOD_NAME_SIZE));
+	J9UTF8_SET_LENGTH((J9UTF8 *)(methodNameAndSigMem + METHOD_NAME_SIZE), (U_16)strlen(TEST_METHOD_SIG));
+	j9str_printf((BlockPtr)J9UTF8_DATA((J9UTF8 *)(methodNameAndSigMem + METHOD_NAME_SIZE)), sizeof(TEST_METHOD_SIG), "%s", TEST_METHOD_SIG);
+	NNSRP_SET(romMethod1->nameAndSignature.signature, (J9UTF8 *)(methodNameAndSigMem + METHOD_NAME_SIZE));
 
 	/* PHASE 1
   	 * Store the "compiled" methods in the cache

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -111,12 +111,12 @@ getJ9RtvUTF8StringfromCP(J9UTF8Ref* buf, void* constantPool, UDATA index)
  * @param classIndex - class index in the classNameList array
  */
 static void
-getJ9RtvStringfromClassNameList(J9UTF8Ref* buf, void* classNameListPtr, void* romClass, UDATA classIndex)
+getJ9RtvStringfromClassNameList(J9UTF8Ref *buf, void *classNameListPtr, void *romClass, UDATA classIndex)
 {
-	struct J9UTF8** classNameList = (struct J9UTF8**)classNameListPtr;
-	U_32* offset = (U_32*)classNameList[BCV_INDEX_FROM_TYPE(classIndex)];
+	J9UTF8 **classNameList = (J9UTF8 **)classNameListPtr;
+	U_32 *offset = (U_32 *)classNameList[BCV_INDEX_FROM_TYPE(classIndex)];
 
-	buf->length = J9UTF8_LENGTH(offset + 1);
+	buf->length = J9UTF8_LENGTH((J9UTF8 *)(offset + 1));
 
 	/* addClassName() in vrfyhelp.c:
 	 * Note: offset[0] is set up in addClassName() to determine where to obtain the class name (classNameSegment or romClass).
@@ -125,10 +125,10 @@ getJ9RtvStringfromClassNameList(J9UTF8Ref* buf, void* classNameListPtr, void* ro
 	 */
 	if (0 == offset[0]) {
 		/* class name exists in the classNameSegment */
-		buf->bytes = (U_8*)J9UTF8_DATA(offset + 1);
+		buf->bytes = J9UTF8_DATA((J9UTF8 *)(offset + 1));
 	} else {
 		/* class name exists in the ROM class */
-		buf->bytes = (U_8*)((UDATA) offset[0] + (UDATA) romClass);
+		buf->bytes = (U_8 *)((UDATA)offset[0] + (UDATA)romClass);
 	}
 
 	buf->arity = (U_8)BCV_ARITY_FROM_TYPE(classIndex);

--- a/runtime/verbose/verbose.c
+++ b/runtime/verbose/verbose.c
@@ -1600,17 +1600,17 @@ baseTypeToIndex(UDATA encodedType)
  * convert a BCV encoded data type to a human readable string based on specified format.
  */
 static UDATA
-printDataType(J9PortLibrary* portLibrary, VerboseVerificationBuffer* buf, J9BytecodeVerificationData* verifyData, UDATA encodedType, const char* fmt)
+printDataType(J9PortLibrary *portLibrary, VerboseVerificationBuffer *buf, J9BytecodeVerificationData *verifyData, UDATA encodedType, const char *fmt)
 {
-	J9ROMClass* romClass = verifyData->romClass;
-	struct J9UTF8* utf = NULL;
-	U_32* offset = 0;
+	J9ROMClass *romClass = verifyData->romClass;
+	J9UTF8 *utf = NULL;
+	U_32 *offset = NULL;
 	UDATA typeTag = encodedType & BCV_TAG_MASK;
 	UDATA msgLen = 0;
 	UDATA cpIndex = 0;
-	const char* typeString = NULL;
+	const char *typeString = NULL;
 	J9ROMConstantPoolItem *constantPool = NULL;
-	U_8* code = NULL;
+	U_8 *code = NULL;
 	PORT_ACCESS_FROM_PORT(portLibrary);
 
 	switch (typeTag) {
@@ -1646,12 +1646,12 @@ printDataType(J9PortLibrary* portLibrary, VerboseVerificationBuffer* buf, J9Byte
 	case BCV_OBJECT_OR_ARRAY: /* FALLTHROUGH */
 	case BCV_SPECIAL_INIT: /* FALLTHROUGH */
 	default:
-		offset = (U_32*) verifyData->classNameList[BCV_INDEX_FROM_TYPE(encodedType)];
-		msgLen = (U_32) J9UTF8_LENGTH(offset + 1);
-		if (offset[0] == 0) {
-			typeString = (const char*)J9UTF8_DATA(offset + 1);
+		offset = (U_32 *)verifyData->classNameList[BCV_INDEX_FROM_TYPE(encodedType)];
+		msgLen = J9UTF8_LENGTH((J9UTF8 *)(offset + 1));
+		if (0 == offset[0]) {
+			typeString = (const char *)J9UTF8_DATA((J9UTF8 *)(offset + 1));
 		} else {
-			typeString = (const char*)((UDATA) offset[0] + (UDATA) romClass);
+			typeString = (const char *)((UDATA)offset[0] + (UDATA)romClass);
 		}
 		printVerificationInfo(PORTLIB, buf, fmt, msgLen, typeString);
 		break;

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -95,7 +95,7 @@ jvmCheckpointHooks(J9VMThread *currentThread)
 	/* initialize before running checkpoint hooks */
 	initializeCriuHooks(currentThread);
 	/* make sure Java hooks are the first thing run when initiating checkpoint */
-	runStaticMethod(currentThread, J9UTF8_DATA(&j9InternalCheckpointHookAPI_name), &nas, 0, NULL);
+	runStaticMethod(currentThread, J9UTF8_DATA((J9UTF8 *)&j9InternalCheckpointHookAPI_name), &nas, 0, NULL);
 
 	if (VM_VMHelpers::exceptionPending(currentThread)) {
 		result = FALSE;
@@ -116,7 +116,7 @@ jvmRestoreHooks(J9VMThread *currentThread)
 	Assert_VM_true(isCRaCorCRIUSupportEnabled(vm));
 
 	/* make sure Java hooks are the last thing run before restore */
-	runStaticMethod(currentThread, J9UTF8_DATA(&j9InternalCheckpointHookAPI_name), &nas, 0, NULL);
+	runStaticMethod(currentThread, J9UTF8_DATA((J9UTF8 *)&j9InternalCheckpointHookAPI_name), &nas, 0, NULL);
 
 	if (VM_VMHelpers::exceptionPending(currentThread)) {
 		result = FALSE;

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -223,13 +223,13 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, UDATA bytecodeO
 *
 * @return The J9class, or NULL on failure.
 */
-static J9Class*
+static J9Class *
 findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader **resultClassLoader)
 {
 	J9UTF8 const *utfClassName = J9ROMCLASS_CLASSNAME(romClass);
 	J9JavaVM *vm = vmThread->javaVM;
 	J9SharedClassConfig *config = vm->sharedClassConfig;
-	J9Class* ret = NULL;
+	J9Class *ret = NULL;
 
 	if (_J9ROMCLASS_J9MODIFIER_IS_SET(romClass, J9AccClassAnonClass)) {
 		/* Anonymous classes are not allowed in any class loader hash table. */
@@ -240,10 +240,10 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 		&& (NULL != config->romToRamHashTable)
 	) {
 		J9ClassLoaderWalkState walkState;
-		J9ClassLoader* classLoader = NULL;
+		J9ClassLoader *classLoader = NULL;
 		BOOLEAN fastMode = J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags, J9_EXTENDED_RUNTIME_FAST_CLASS_HASH_TABLE);
-		J9Class* ramClass = NULL;
-		RomToRamEntry *resultEntry;
+		J9Class *ramClass = NULL;
+		RomToRamEntry *resultEntry = NULL;
 		RomToRamQueryEntry searchEntry;
 		searchEntry.romClass = (J9ROMClass *)((UDATA)romClass | ROM_TO_RAM_QUERY_TAG);
 
@@ -267,7 +267,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 		 * All ROMClasses from the SCC are owned by the bootstrap class loader. To minimize the chances to iterate all class loaders, probe
 		 * the booststrap loader, extensionClassLoader and application loader first to determine if they have the J9Class for the current class.
 		 */
-		ramClass = hashClassTableAt(*resultClassLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+		ramClass = hashClassTableAt(*resultClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
 		if ((NULL != ramClass)
 			&& (romClass == ramClass->romClass)
 		) {
@@ -278,7 +278,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 			goto cacheresult;
 		}
 
-		ramClass = hashClassTableAt(vm->extensionClassLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+		ramClass = hashClassTableAt(vm->extensionClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
 		if ((NULL != ramClass)
 			&& (romClass == ramClass->romClass)
 		) {
@@ -290,7 +290,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 			goto cacheresult;
 		}
 
-		ramClass = hashClassTableAt(vm->applicationClassLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+		ramClass = hashClassTableAt(vm->applicationClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
 		if ((NULL != ramClass)
 			&& (romClass == ramClass->romClass)
 		) {
@@ -308,7 +308,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 				&& (classLoader != vm->extensionClassLoader)
 				&& (classLoader != vm->applicationClassLoader)
 			) {
-				ramClass = hashClassTableAt(classLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+				ramClass = hashClassTableAt(classLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
 				if ((NULL != ramClass)
 					&& (romClass == ramClass->romClass)
 				) {
@@ -332,7 +332,7 @@ cacheresult:
 			omrthread_rwmutex_exit_write(config->romToRamHashTableMutex);
 		}
 	} else {
-		ret = peekClassHashTable(vmThread, *resultClassLoader, J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+		ret = peekClassHashTable(vmThread, *resultClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
 	}
 done:
 	return ret;

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -1286,7 +1286,7 @@ getTypeIdUTF8(J9VMThread *currentThread, const J9UTF8 *className)
 	Trc_VM_getTypeIdUTF8_Entry(currentThread, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 
 	omrthread_monitor_enter(vm->classTableMutex);
-	J9Class *clazz = hashClassTableAt(vm->systemClassLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+	J9Class *clazz = hashClassTableAt(vm->systemClassLoader, (U_8 *)J9UTF8_DATA(className), J9UTF8_LENGTH(className));
 	omrthread_monitor_exit(vm->classTableMutex);
 
 	if (NULL != clazz) {

--- a/runtime/vm/stringhelpers.cpp
+++ b/runtime/vm/stringhelpers.cpp
@@ -356,18 +356,18 @@ copyStringToUTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stri
 	return (char *)result;
 }
 
-J9UTF8*
+J9UTF8 *
 copyStringToJ9UTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA stringFlags, const char *prependStr, UDATA prependStrLength, char *buffer, UDATA bufferLength)
 {
 	Assert_VM_notNull(prependStr);
 	Assert_VM_notNull(string);
 
-	U_8 *result = NULL;
+	J9UTF8 *result = NULL;
 	UDATA stringLength = J9VMJAVALANGSTRING_LENGTH(vmThread, string);
 	U_64 length = sizeof(J9UTF8) + prependStrLength + ((U_64)stringLength * 3);
 
 	if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_NULL_TERMINATE_RESULT)) {
-		++length;
+		length += 1;
 	}
 
 #if UDATA_MAX < (3 * INT32_MAX)
@@ -387,27 +387,27 @@ copyStringToJ9UTF8WithMemAlloc(J9VMThread *vmThread, j9object_t string, UDATA st
 	if ((prependStrLength > J9UTF8_MAX_LENGTH) || (length > (J9UTF8_MAX_LENGTH - prependStrLength))) {
 		result = NULL;
 	} else if (length > bufferLength) {
-		result = (U_8 *)j9mem_allocate_memory((UDATA)length, OMRMEM_CATEGORY_VM);
+		result = (J9UTF8 *)j9mem_allocate_memory((UDATA)length, OMRMEM_CATEGORY_VM);
 	} else {
-		result = (U_8 *)buffer;
+		result = (J9UTF8 *)buffer;
 	}
 
 	if (NULL != result) {
 		UDATA computedUtf8Length = 0;
 
 		if (0 < prependStrLength) {
-			memcpy(result + sizeof(J9UTF8), prependStr, prependStrLength);
+			memcpy(J9UTF8_DATA(result), prependStr, prependStrLength);
 		}
 
 		computedUtf8Length = copyStringToUTF8Helper(
 				vmThread, string, stringFlags, 0, stringLength,
-				result + sizeof(J9UTF8) + prependStrLength,
+				J9UTF8_DATA(result) + prependStrLength,
 				(UDATA)(length - sizeof(J9UTF8) - prependStrLength));
 
 		J9UTF8_SET_LENGTH(result, (U_16)computedUtf8Length + (U_16)prependStrLength);
 	}
 
-	return (J9UTF8 *)result;
+	return result;
 }
 
 J9UTF8 *
@@ -416,12 +416,12 @@ copyStringToJ9UTF8WithPortLib(J9VMThread *vmThread, j9object_t string, UDATA str
 	Assert_VM_notNull(prependStr);
 	Assert_VM_notNull(string);
 
-	U_8 *result = NULL;
+	J9UTF8 *result = NULL;
 	UDATA stringLength = J9VMJAVALANGSTRING_LENGTH(vmThread, string);
 	U_64 length = sizeof(J9UTF8) + prependStrLength + ((U_64)stringLength * 3);
 
 	if (J9_ARE_ALL_BITS_SET(stringFlags, J9_STR_NULL_TERMINATE_RESULT)) {
-		++length;
+		length += 1;
 	}
 
 #if UDATA_MAX < (3 * INT32_MAX)
@@ -437,25 +437,25 @@ copyStringToJ9UTF8WithPortLib(J9VMThread *vmThread, j9object_t string, UDATA str
 #endif /* UDATA_MAX < (3 * INT32_MAX) */
 
 	if ((prependStrLength <= J9UTF8_MAX_LENGTH) && (length <= (J9UTF8_MAX_LENGTH - prependStrLength))) {
-		result = (U_8 *)portLib->mem_allocate_memory(portLib, (UDATA)length, J9_GET_CALLSITE(), OMRMEM_CATEGORY_VM);
+		result = (J9UTF8 *)portLib->mem_allocate_memory(portLib, (UDATA)length, J9_GET_CALLSITE(), OMRMEM_CATEGORY_VM);
 	}
 
 	if (NULL != result) {
 		UDATA computedUtf8Length = 0;
 
 		if (0 < prependStrLength) {
-			memcpy(result + sizeof(J9UTF8), prependStr, prependStrLength);
+			memcpy(J9UTF8_DATA(result), prependStr, prependStrLength);
 		}
 
 		computedUtf8Length = copyStringToUTF8Helper(
 				vmThread, string, stringFlags, 0, stringLength,
-				result + sizeof(J9UTF8) + prependStrLength,
+				J9UTF8_DATA(result) + prependStrLength,
 				(UDATA)(length - sizeof(J9UTF8) - prependStrLength));
 
 		J9UTF8_SET_LENGTH(result, (U_16)computedUtf8Length + (U_16)prependStrLength);
 	}
 
-	return (J9UTF8 *)result;
+	return result;
 }
 
 char *


### PR DESCRIPTION
Adjust uses of `J9UTF8*` macros to provide arguments of the right types where necessary.

See also https://github.com/eclipse-openj9/openj9/pull/21688/files#r2056064379.