### PR TITLE
Pop extra args on BootstrapMethodError for invokedynamic

### DIFF
--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -149,14 +149,15 @@ private:
 
    bool         runMacro(TR::SymbolReference *);
    bool         runFEMacro(TR::SymbolReference *);
-   TR::Node *    genInvoke(TR::SymbolReference *, TR::Node *indirectCallFirstChild, TR::Node *invokedynamicReceiver = NULL);
+   TR::Node *    genInvoke(TR::SymbolReference *, TR::Node *indirectCallFirstChild, TR::Node *invokedynamicReceiver = NULL, int32_t numExpectedArgs = -1);
    TR::Node *    genInvokeInner(
       TR::SymbolReference *,
       TR::Node *indirectCallFirstChild,
       TR::Node *invokedynamicReceiver,
-      TR::KnownObjectTable::Index *requiredKoi);
+      TR::KnownObjectTable::Index *requiredKoi,
+      int32_t numExpectedArgs = -1);
 
-   TR::Node *    genInvokeDirect(TR::SymbolReference *symRef){ return genInvoke(symRef, NULL); }
+   TR::Node *    genInvokeDirect(TR::SymbolReference *symRef, int32_t numExpectedArgs = -1){ return genInvoke(symRef, NULL, NULL, numExpectedArgs); }
    TR::Node *    genInvokeWithVFTChild(TR::SymbolReference *);
    TR::Node *    getReceiverFor(TR::SymbolReference *);
    void          stashArgumentsForOSR(TR_J9ByteCode byteCode);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3200,6 +3200,29 @@ static char *suffixedName(char *baseName, char typeSuffix, char *buf, int32_t bu
    return methodName;
    }
 
+static int32_t countParams(unsigned char *sig)
+   {
+   sig++; // skip opening brace
+   int32_t count = 0;
+   while (*sig != ')')
+      {
+      while (*sig == '[')
+         {
+         sig++;
+         }
+      if (*sig == 'L')
+         {
+         while (*sig != ';')
+            {
+            sig++;
+            }
+         }
+      count++;
+      sig++;
+      }
+   return count;
+   }
+
 void
 TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
    {
@@ -3210,7 +3233,7 @@ TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
       {
       comp()->failCompilation<J9::AOTHasInvokeHandle>("COMPILATION_AOT_HAS_INVOKEHANDLE 0");
       }
-   // Call generated when call site table entry is resolved:
+   // Call generated when call site table entry is resolved and appendix object is non-null:
    // -----------------------------------------------------
    // call <target method obtained from memberName object>
    //    arg0
@@ -3261,7 +3284,33 @@ TR_J9ByteCodeIlGenerator::genInvokeDynamic(int32_t callSiteIndex)
    if (comp()->getOption(TR_TraceILGen))
       printStack(comp(), _stack, "(Stack after load from callsite table)");
 
-   TR::Node* callNode = genInvokeDirect(targetMethodSymRef);
+   /* We need to get the expected number of parameters from the signature. There is a case where findOrCreateDynamicMethodSymbol()
+    * returns an error-throwing MethodHandle that takes 0 arguments (occurs when an error is caught during resolveInvokeDynamic()). We cannot use
+    * TR::Method::numberOfExplicitParameters() since that fetches the number of parameters of targetMethodSymRefs (the MH actually returned)
+    * instead of whats expected the invokedynamic call. This can be a problem since the expcected of args are already on the stack and won't be
+    * properly popped.
+    */
+   int32_t paramCount = 0;
+   if (isUnresolved)
+      {
+      // we need both appendix and membername objects ==> we have at least 2 args
+      paramCount = 2;
+      }
+   else
+      {
+      // we only need to account for the appendix object if it is non-null
+      paramCount = (isInvokeCacheAppendixNull ? 0 : 1);
+      }
+
+   TR_ResolvedJ9Method* ownerMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
+   J9ROMClass *ownerROMMethod = ownerMethod->romClassPtr();
+   J9SRP *callSiteData = (J9SRP *) J9ROMCLASS_CALLSITEDATA(ownerROMMethod);
+   J9ROMNameAndSignature *nameAndSig = SRP_PTR_GET(callSiteData + callSiteIndex, J9ROMNameAndSignature*);
+   J9UTF8* sig = J9ROMNAMEANDSIGNATURE_SIGNATURE(nameAndSig);
+   // count params gets the number of explicit parameters and does not include the appendix and/or membername objects
+   paramCount += countParams(J9UTF8_DATA(sig));
+
+   TR::Node* callNode = genInvokeDirect(targetMethodSymRef, paramCount);
 
 #else
    if (comp()->compileRelocatableCode())
@@ -3659,11 +3708,11 @@ static TR::SymbolReference * getPrimitiveValueFieldSymbolReference(TR_J9ByteCode
    }
 
 TR::Node*
-TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indirectCallFirstChild, TR::Node *invokedynamicReceiver)
+TR_J9ByteCodeIlGenerator::genInvoke(TR::SymbolReference * symRef, TR::Node *indirectCallFirstChild, TR::Node *invokedynamicReceiver, int32_t numExpectedArgs)
    {
    TR::KnownObjectTable::Index requiredKoi;
    TR::Node *callNode = genInvokeInner(
-      symRef, indirectCallFirstChild, invokedynamicReceiver, &requiredKoi);
+      symRef, indirectCallFirstChild, invokedynamicReceiver, &requiredKoi, numExpectedArgs);
 
    if (requiredKoi == TR::KnownObjectTable::UNKNOWN)
       return callNode;
@@ -3682,7 +3731,8 @@ TR_J9ByteCodeIlGenerator::genInvokeInner(
    TR::SymbolReference * symRef,
    TR::Node *indirectCallFirstChild,
    TR::Node *invokedynamicReceiver,
-   TR::KnownObjectTable::Index *requiredKoi)
+   TR::KnownObjectTable::Index *requiredKoi,
+   int32_t numExpectedArgs)
    {
    TR::MethodSymbol * symbol = symRef->getSymbol()->castToMethodSymbol();
    bool isStatic     = symbol->isStatic();
@@ -3690,6 +3740,12 @@ TR_J9ByteCodeIlGenerator::genInvokeInner(
 
    TR::Method * calledMethod = symbol->getMethod();
    int32_t numArgs = calledMethod->numberOfExplicitParameters() + (isStatic ? 0 : 1);
+
+   // need to track stack size at beginning and end of ILGeneration for invokeDynamic for the case
+   // where we get the special error throwing MethodHandle
+   int32_t startingStackSize = _stack->size();
+   if (numExpectedArgs == -1)
+      numExpectedArgs = numArgs;
 
    if (pushRequiredConst(requiredKoi))
       {
@@ -4600,6 +4656,22 @@ break
       }
    else
       resultNode = callNode;
+
+   /* There is a case where findOrCreateDynamicMethodSymbol() returns an error-throwing MethodHandle that
+    * takes 0 arguments (occurs when an error is thrown during resolveInvokeDynamic()). In that case, we will not have
+    * popped all the arguments off the stack, so we need to pop the expected number.
+    */
+   int32_t numPopped = startingStackSize - _stack->size();
+   if (numPopped < numExpectedArgs)
+      {
+      if (comp()->getOption(TR_TraceILGen))
+         traceMsg(comp(), "InvokeDynamic recieved error throwing MethodHandle. Popping extra args.\n");
+      while (numPopped < numExpectedArgs)
+         {
+         pop();
+         numPopped++;
+         }
+      }
 
    TR::DataType returnType = calledMethod->returnType();
    if (returnType != TR::NoType)


### PR DESCRIPTION
When an error is caught during resolveInvokeDynamic (MethodHandleResolver.java), a MethodHandle that throws a BootstrapMethodError is returned, which has no arguments. This can cause an issue for OSR where we run out of pending push temp slots during OSR BookKeeping since we are not popping all the args off the operand stack.

This change recognizes when we have not popped all the arguments and pops them accordingly

Fixes: #21419