### PR TITLE
Add table of invokeBasic() call sites to J9JITExceptionTable

### DIFF
--- a/doc/compiler/runtime/J9JITExceptionTable.md
+++ b/doc/compiler/runtime/J9JITExceptionTable.md
@@ -56,6 +56,8 @@ The following diagram provides the high level overview. The
 (7) | GPU Info                                            | // If GPU
     |-----------------------------------------------------|
 (8) | Bytecode PC to Instruction Address Map              | // If Hardware Profiling
+    |-----------------------------------------------------|
+(9) | invokeBasic() Call Site Info                        | // If Applicable Call Sites Exist
     +-----------------------------------------------------+
 ```
 
@@ -435,3 +437,10 @@ via the `bodyInfo` field of the `J9JITExceptionTable` struct. This
 structure contains data such as flags used to describe the body,
 as well as data used to implement features such as
 Guarded Counting Recompilation (GCR).
+
+## (9) `invokeBasic()` Call Info
+The `invokeBasic()` Call Info section can be accessed via the
+`invokeBasicCallInfo` field of the `J9JITExceptionTable` struct. This section
+consists of a single instance of the variable-size `J9JITInvokeBasicCallInfo`
+struct, which contains a table of call sites that are capable of calling the
+interpreter's implementation of `MethodHandle.invokeBasic()`.

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -3397,12 +3397,26 @@ old_slow_icallVMprJavaSendPatchupVirtual(J9VMThread *currentThread)
 	J9Class *clazz = J9OBJECT_CLAZZ(currentThread, receiver);
 	UDATA interpVTableOffset = sizeof(J9Class) - jitVTableOffset;
 	J9Method *method = *(J9Method**)((UDATA)clazz + interpVTableOffset);
-	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	J9ROMNameAndSignature *nas = &romMethod->nameAndSignature;
-	UDATA const thunk = (UDATA)jitConfig->thunkLookUpNameAndSig(jitConfig, nas);
-	UDATA const patchup = (UDATA)jitConfig->patchupVirtual;
-	UDATA *jitVTableSlot = (UDATA*)((UDATA)clazz + jitVTableOffset);
-	VM_AtomicSupport::lockCompareExchange(jitVTableSlot, patchup, thunk);
+	UDATA thunk = 0;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	if (J9_BCLOOP_SEND_TARGET_METHODHANDLE_INVOKEBASIC == J9_BCLOOP_DECODE_SEND_TARGET(method->methodRunAddress)) {
+		/* Because invokeBasic() is signature-polymorphic, the signature from the ROM method is irrelevant.
+		 * We need the J2I thunk that corresponds to the signature that the JIT was using at the call site.
+		 * Since this varies depending on the call site, we can't replace the VFT entry with the J2I thunk.
+		 */
+		J9JITInvokeBasicCallSite *site = jitGetInvokeBasicCallSiteFromPC(currentThread, (UDATA)jitReturnAddress);
+		thunk = (UDATA)site->j2iThunk;
+	}
+	else
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+	{
+		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+		J9ROMNameAndSignature *nas = &romMethod->nameAndSignature;
+		thunk = (UDATA)jitConfig->thunkLookUpNameAndSig(jitConfig, nas);
+		UDATA const patchup = (UDATA)jitConfig->patchupVirtual;
+		UDATA *jitVTableSlot = (UDATA*)((UDATA)clazz + jitVTableOffset);
+		VM_AtomicSupport::lockCompareExchange(jitVTableSlot, patchup, thunk);
+	}
 	currentThread->tempSlot = thunk;
 }
 

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -81,6 +81,9 @@ J9::CodeGenerator::CodeGenerator(TR::Compilation *comp) :
    _jniCallSites(getTypedAllocator<TR_Pair<TR_ResolvedMethod,TR::Instruction> *>(comp->allocator())),
    _monitorMapping(std::less<ncount_t>(), MonitorMapAllocator(comp->trMemory()->heapMemoryRegion())),
    _dummyTempStorageRefNode(NULL)
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   , _invokeBasicCallSites(comp->region())
+#endif
    {
    /**
     * Do not add CodeGenerator initialization logic here.
@@ -797,15 +800,16 @@ J9::CodeGenerator::lowerTreeIfNeeded(
       {
       TR::RecognizedMethod rm = node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod();
 
-      if(rm == TR::java_lang_invoke_MethodHandle_invokeBasic ||
-        rm == TR::java_lang_invoke_MethodHandle_linkToStatic ||
+      // There's no need to set tempSlot for invokeBasic(). The number of stack
+      // slots for the arguments will be available from the JIT body metadata.
+
+      if(rm == TR::java_lang_invoke_MethodHandle_linkToStatic ||
         rm == TR::java_lang_invoke_MethodHandle_linkToSpecial ||
         rm == TR::java_lang_invoke_MethodHandle_linkToVirtual ||
         rm == TR::java_lang_invoke_MethodHandle_linkToInterface)
          {
-         // invokeBasic and linkTo* are signature-polymorphic, so the VM needs to know the number of argument slots
-         // for the INL call in order to locate the start of the arguments on the stack. The arg slot count is stored
-         // in vmThread.tempSlot.
+         // linkTo* is signature-polymorphic, so the VM needs to know the number of argument slots for the INL call in order to
+         // locate the start of the arguments on the stack. The arg slot count is stored in vmThread.tempSlot.
          //
          // Furthermore, for unresolved invokedynamic and invokehandle bytecodes, we create a dummy TR_ResolvedMethod call to
          // linkToStatic. The appendix object in the invoke cache array entry could be NULL, which we cannot determine at compile
@@ -5278,3 +5282,111 @@ J9::CodeGenerator::stressJitDispatchJ9MethodJ2I()
    static const bool stress = feGetEnv("TR_stressJitDispatchJ9MethodJ2I") != NULL;
    return stress;
    }
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+void
+J9::CodeGenerator::addInvokeBasicCallSiteImpl(
+   TR::Node *callNode, TR::Instruction *instr, uint8_t *retAddr)
+   {
+   TR_ASSERT_FATAL_WITH_NODE(
+      callNode,
+      (instr != NULL) != (retAddr != NULL),
+      "expected exactly one of TR::Instruction or return address");
+
+   if (comp()->getOption(TR_TraceCG))
+      {
+      traceMsg(comp(), "Call instruction ");
+      if (instr != NULL)
+         {
+         traceMsg(comp(), "%p", instr);
+         }
+      else
+         {
+         traceMsg(comp(), "with return address %p", retAddr);
+         }
+
+      traceMsg(
+         comp(),
+         " for n%un [%p] may target VM MethodHandle.invokeBasic\n",
+         callNode->getGlobalIndex(),
+         callNode);
+      }
+
+   TR_J9VMBase *fej9 = comp()->fej9();
+   TR::Node *j2iCallNode = callNode;
+   TR::MethodSymbol *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
+   TR::RecognizedMethod rm = methodSymbol->getMandatoryRecognizedMethod();
+   switch (rm)
+      {
+      case TR::java_lang_invoke_MethodHandle_invokeBasic:
+         break; // ok
+
+      case TR::com_ibm_jit_JITHelpers_dispatchVirtual:
+         j2iCallNode =
+            fej9->getEquivalentVirtualCallNodeForDispatchVirtual(callNode, comp());
+         break;
+
+      default:
+         TR_ASSERT_FATAL_WITH_NODE(
+            callNode,
+            false,
+            "expected MethodHandle.invokeBasic or JITHelpers.dispatchVirtual");
+         break;
+      }
+
+   int32_t numChildren = j2iCallNode->getNumChildren();
+   int32_t firstArgIndex = j2iCallNode->getFirstArgumentIndex();
+   uint32_t numArgSlots32 = 0;
+   for (int32_t i = firstArgIndex; i < numChildren; i++)
+      {
+      TR::Node *child = j2iCallNode->getChild(i);
+
+      // PassThrough nodes will appear to have type TR::NoType. The actual type
+      // of the resulting value is the same as the type of the child.
+      while (child->getOpCodeValue() == TR::PassThrough)
+         {
+         child = child->getChild(0);
+         }
+
+      TR::DataTypes dt = child->getDataType().getDataType();
+      numArgSlots32 += 1 + (uint32_t)(dt == TR::Int64 || dt == TR::Double);
+      }
+
+   if (comp()->getOption(TR_TraceCG))
+      {
+      traceMsg(comp(), "  arg slots: %u\n", numArgSlots32);
+      }
+
+   TR_ASSERT_FATAL_WITH_NODE(
+      callNode,
+      numArgSlots32 <= UINT8_MAX,
+      "too many argument slots (%u)",
+      numArgSlots32);
+
+   uint8_t numArgSlots = (uint8_t)numArgSlots32;
+
+   void *j2iThunk = NULL;
+   if (rm == TR::com_ibm_jit_JITHelpers_dispatchVirtual)
+      {
+      TR::Method *m = methodSymbol->getMethod();
+      char *sig = fej9->getJ2IThunkSignatureForDispatchVirtual(
+         m->signatureChars(), m->signatureLength(), comp());
+
+      int32_t sigLen = strlen(sig);
+      j2iThunk = fej9->getJ2IThunk(sig, sigLen, comp());
+      TR_ASSERT_FATAL_WITH_NODE(callNode, j2iThunk != NULL, "missing J2I thunk");
+
+      if (comp()->getOption(TR_TraceCG))
+         {
+         traceMsg(comp(), "  J2I thunk: %p\n", j2iThunk);
+         }
+      }
+
+   InvokeBasicCallSite site = {};
+   site._instr = instr;
+   site._retAddr = retAddr;
+   site._numArgSlots = numArgSlots;
+   site._j2iThunk = j2iThunk;
+   _invokeBasicCallSites.push_back(site);
+   }
+#endif // defined(J9VM_OPT_OPENJDK_METHODHANDLE)

--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -373,6 +373,14 @@ uint8_t *TR::PPCCallSnippet::emitSnippetBody()
 
    cursor += PPC_INSTRUCTION_LENGTH;
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   auto rm = methodSymbol->getMandatoryRecognizedMethod();
+   if (rm == TR::java_lang_invoke_MethodHandle_invokeBasic)
+      {
+      cg()->addInvokeBasicCallSite(callNode, cursor);
+      }
+#endif
+
    if (isNativeStatic)
       {
       // Rather than placing the return address as data after the 'bl', place a 'b' back to main line code

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -2320,6 +2320,15 @@ void J9::Power::PrivateLinkage::buildVirtualDispatch(TR::Node                   
       TR::Instruction *gcPoint = generateInstruction(cg(), TR::InstOpCode::bctrl, callNode);
       generateDepLabelInstruction(cg(), TR::InstOpCode::label, callNode, doneLabel, dependencies);
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+      // JITHelpers.dispatchVirtual() can target MethodHandle.invokeBasic().
+      auto rm = methodSymbol->getMandatoryRecognizedMethod();
+      if (rm == TR::com_ibm_jit_JITHelpers_dispatchVirtual)
+         {
+         cg()->addInvokeBasicCallSite(callNode, gcPoint);
+         }
+#endif
+
       gcPoint->PPCNeedsGCMap(regMapForGC);
       return;
       }

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1471,15 +1471,21 @@ createMethodMetaData(
 
    /* Legend of the info stored at "data". From top to bottom, the address increases
 
-      Exception Info
+      Exception info
       --------------
-      Inline Info
+      Inline info
       --------------
-      Stack Atlas
+      Stack atlas
       --------------
-      Stack alloc map (if exists)
+      Stack alloc map (if there are local objects)
       --------------
-      internal pointer map
+      Internal pointer map
+      --------------
+      OSR info (if OSR)
+      --------------
+      GPU info (if GPU)
+      --------------
+      Bytecode PC to instruction address map (if enabled for RI)
 
    */
 

--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -2506,6 +2506,29 @@ UDATA osrScratchBufferSize(J9VMThread* currentThread, J9JITExceptionTable *metaD
    return (UDATA) maxScratchBufferSize;
    }
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+J9JITInvokeBasicCallSite *
+jitGetInvokeBasicCallSiteFromPC(J9VMThread *vmThread, UDATA jitPC)
+   {
+   J9JITExceptionTable *metadata =
+      vmThread->javaVM->jitConfig->jitGetExceptionTableFromPC(vmThread, jitPC);
+
+   uintptr_t queryOffset = jitPC - metadata->startPC;
+   J9JITInvokeBasicCallInfo *info = metadata->invokeBasicCallInfo;
+   uint32_t i;
+   for (i = 0; i < info->numSites; i++)
+      {
+      J9JITInvokeBasicCallSite *site = &info->sites[i];
+      if (site->jitReturnAddressOffset == queryOffset)
+         {
+         return site;
+         }
+      }
+
+   assert(0); // unreachable - the site must exist
+   return NULL;
+   }
+#endif // defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 
 /* New hook for getting a JIT exception table.  This will be used as a pivot to help assimilate the implementation into the JIT. */
 J9JITExceptionTable *

--- a/runtime/compiler/runtime/MethodMetaData.h
+++ b/runtime/compiler/runtime/MethodMetaData.h
@@ -345,6 +345,10 @@ UDATA usesOSR (J9VMThread* currentThread, J9JITExceptionTable *metaData);
 /* returns the size required for the scratch buffer */
 UDATA osrScratchBufferSize(J9VMThread* currentThread, J9JITExceptionTable *metaData, void *pc);
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+J9JITInvokeBasicCallSite *jitGetInvokeBasicCallSiteFromPC(struct J9VMThread *vmThread, UDATA jitPC);
+#endif
+
 #if (defined(TR_HOST_ARM))
 #define alignStackMaps 1
 #else

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -857,6 +857,15 @@ TR_RelocationRuntime::relocateMethodMetaData(UDATA codeRelocationAmount, UDATA d
       _exceptionTable->osrInfo = (void *) (((U_8 *)_exceptionTable->osrInfo) + dataRelocationAmount);
       }
 
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   if (_exceptionTable->invokeBasicCallInfo != NULL)
+      {
+      uint8_t *infoAddr = (uint8_t*)_exceptionTable->invokeBasicCallInfo;
+      infoAddr += dataRelocationAmount;
+      _exceptionTable->invokeBasicCallInfo = (J9JITInvokeBasicCallInfo*)infoAddr;
+      }
+#endif
+
    // Reset the uninitialized bit
    _exceptionTable->flags &= ~JIT_METADATA_NOT_INITIALIZED;
    }

--- a/runtime/compiler/runtime/codertinit.cpp
+++ b/runtime/compiler/runtime/codertinit.cpp
@@ -478,6 +478,9 @@ void codert_init_helpers_and_targets(J9JITConfig * jitConfig, char isSMP)
    jitConfig->getByteCodeIndex = getByteCodeIndex;
    jitConfig->getByteCodeIndexFromStackMap = getByteCodeIndexFromStackMap;
    jitConfig->getCurrentByteCodeIndexAndIsSameReceiver = getCurrentByteCodeIndexAndIsSameReceiver;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+   jitConfig->jitGetInvokeBasicCallSiteFromPC = jitGetInvokeBasicCallSiteFromPC;
+#endif
    jitConfig->getJitRegisterMap = getJitRegisterMap;
    jitConfig->jitReportDynamicCodeLoadEvents = jitReportDynamicCodeLoadEvents;
 #if (defined(TR_HOST_X86) || defined(TR_HOST_POWER) || defined(TR_HOST_S390) || defined(TR_HOST_ARM) || defined(TR_HOST_ARM64))

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1987,6 +1987,15 @@ void J9::X86::PrivateLinkage::buildDirectCall(
          }
 
       callInstr = generateHelperCallInstruction(callNode, TR_j2iTransition, NULL, cg());
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+      auto rm = methodSymbol->getMandatoryRecognizedMethod();
+      if (rm == TR::java_lang_invoke_MethodHandle_invokeBasic)
+         {
+         cg()->addInvokeBasicCallSite(callNode, callInstr);
+         }
+#endif
+
       cg()->stopUsingRegister(ramMethodReg);
       }
    else if (comp()->target().is64Bit() && methodSymbol->isJITInternalNative())
@@ -2294,6 +2303,15 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
          //
          TR::LabelSymbol *jmpLabel   = TR::LabelSymbol::create(cg()->trHeapMemory(),cg());
          callInstr = generateLabelInstruction(TR::InstOpCode::CALLImm4, callNode, jmpLabel, cg());
+
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+         // JITHelpers.dispatchVirtual() can target MethodHandle.invokeBasic().
+         auto rm = resolvedMethodSymbol->getMandatoryRecognizedMethod();
+         if (rm == TR::com_ibm_jit_JITHelpers_dispatchVirtual)
+            {
+            cg()->addInvokeBasicCallSite(callNode, callInstr);
+            }
+#endif
 
          // Jump outlined
          //

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -699,6 +699,34 @@ typedef struct J9VTuneInterface {
 
 #define J9VTUNE_TRACE_LINE_NUMBERS  1
 
+/* A description of a call instruction within a JIT body that may land directly
+ * in the interpreter's invokeBasic() INL. From the JIT's perspective, the call
+ * is either a direct call to invokeBasic() (for which the actual call instruction
+ * goes via j2iTransition), or it's a call to JITHelpers.dispatchVirtual().
+ */
+typedef struct J9JITInvokeBasicCallSite {
+	U_32 jitReturnAddressOffset; /* from startPC */
+	U_8 numArgSlots;
+	void *j2iThunk; /* for JITHelpers.dispatchVirtual() */
+} J9JITInvokeBasicCallSite;
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4200)
+#endif /* defined(_MSC_VER) */
+
+/* Metadata describing the calls within a JIT body that may land directly in
+ * the interpreter's invokeBasic() INL.
+ */
+typedef struct J9JITInvokeBasicCallInfo {
+	U_32 numSites;
+	struct J9JITInvokeBasicCallSite sites[];
+} J9JITInvokeBasicCallInfo;
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif /* defined(_MSC_VER) */
+
 /* @ddr_namespace: map_to_type=J9JITExceptionTable */
 
 /* This structure is exposed by the compile_info field of CompiledMethodLoad() / JVMTI_EVENT_COMPILED_METHOD_LOAD.
@@ -737,6 +765,11 @@ typedef struct J9JITExceptionTable {
 	UDATA codeCacheAlloc;
 	void* gpuCode;
 	void* riData;
+	/* This is only needed for J9VM_OPT_OPENJDK_METHODHANDLE, but include this
+	 * field unconditionally so that the size and layout of J9JITExceptionTable
+	 * won't depend on configure options.
+	 */
+	struct J9JITInvokeBasicCallInfo* invokeBasicCallInfo;
 } J9JITExceptionTable;
 
 #define JIT_METADATA_FLAGS_USED_FOR_SIZE 0x1
@@ -4260,6 +4293,9 @@ typedef struct J9JITConfig {
 	UDATA  ( *getByteCodeIndexFromStackMap)(struct J9JITExceptionTable *metaData, void *stackMap) ;
 	U_32  ( *getJitRegisterMap)(struct J9JITExceptionTable *metadata, void * stackMap) ;
 	UDATA  ( *getCurrentByteCodeIndexAndIsSameReceiver)(struct J9JITExceptionTable * methodMetaData, void * stackMap, void * currentInlinedCallSite, UDATA * isSameReceiver) ;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+	struct J9JITInvokeBasicCallSite* ( *jitGetInvokeBasicCallSiteFromPC)(struct J9VMThread *vmThread, UDATA jitPC);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	void  ( *jitCodeBreakpointAdded)(struct J9VMThread * currentThread, J9Method * method) ;
 	void  ( *jitCodeBreakpointRemoved)(struct J9VMThread * currentThread, J9Method * method) ;
 	void  ( *jitDataBreakpointAdded)(struct J9VMThread * currentThread) ;

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -9530,10 +9530,11 @@ done:
 		UDATA mhReceiverIndex = 0;
 
 		if (fromJIT) {
-			/* tempSlot contains the number of stack slots for the arguments, and the MH
+			/* JIT body metadata specifies the number of stack slots for the arguments, and the MH
 			 * receiver is the first argument.
 			 */
-			mhReceiverIndex = _currentThread->tempSlot - 1;
+			J9JITInvokeBasicCallSite *site = _vm->jitConfig->jitGetInvokeBasicCallSiteFromPC(_currentThread, (UDATA)_literals);
+			mhReceiverIndex = site->numArgSlots - 1;
 		} else {
 			U_16 index = *(U_16 *)(_pc + 1);
 			J9ConstantPool *ramConstantPool = J9_CP_FROM_METHOD(_literals);


### PR DESCRIPTION
It is possible for `MethodHandle.linkToVirtual()` to be called with a `MemberName` that specifies `MethodHandle.invokeBasic()` as the virtual method. For performance, any `linkToVirtual()` call that goes unrefined in a JIT compilation will be transformed into a computed call through the vtable using `JITHelpers.dispatchVirtual()`. When the target happens at runtime to be `invokeBasic()`, this will result in a call through the vtable entry for `invokeBasic()`, which has been the cause of multiple problems that are fixed by this commit.

1. `old_slow_icallVMprJavaSendPatchupVirtual()` would try to find the J2I thunk based on the signature from the ROM method, which doesn't necessarily (or even probably) match the signature at the call site because `invokeBasic()` is signature-polymorphic. The J2I thunk might not exist, in which case the lookup would return null, and execution would jump to address 0. Even if it did exist, the arguments likely wouldn't be copied correctly to the stack. There needs to be some way for the correct J2I thunk to be determined.

2. `old_slow_icallVMprJavaSendPatchupVirtual()` would update the vtable entry to point to the J2I thunk. Even if it had the correct J2I thunk for the particular call that was underway at the time, later calls from different call sites might require a different J2I thunk (again due to signature-polymorphism). For `invokeBasic()`, the vtable entry must be left as-is so that the thunk can be determined separately for each call.

3. For J2I `invokeBasic()`, the VM expected `J9VMThread.tempSlot` to specify the number of stack slots for the arguments. This was not set by the JIT prior to `dispatchVirtual()` calls, but even if it were, the count would be wrong when calling `invokeBasic()` that way because `tempSlot` would be clobbered before reaching the interpreter. Specifically, `old_slow_icallVMprJavaSendPatchupVirtual()` receives the JIT vtable offset (for cases where it isn't immediate) in `tempSlot`, and then it uses `tempSlot` again to specify the thunk to which control should be transferred.

Now, for any JIT body containing a call to either `invokeBasic()` or `dispatchVirtual()`, the `J9JITExceptionTable` has a table of all such call sites, identified by the offset from `startPC` to the JIT return address. Each entry specifies the number of stack slots for the arguments, and in the case of `dispatchVirtual()`, the J2I thunk. This allows the necessary information to be looked up based solely on the JIT return address both in `old_slow_icallVMprJavaSendPatchupVirtual()` and in the interpreter's `invokeBasic()`.

Issue: #19081