### PR TITLE
0.46.0 Release note update

### DIFF
--- a/doc/release-notes/0.46/0.46.md
+++ b/doc/release-notes/0.46/0.46.md
@@ -115,6 +115,14 @@ Now, you can enable class sharing from all class loaders, irrespective of whethe
 </td>
 </tr>
 
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/18272">#18272</a></td>
+<td valign="top">A new Data Access Accelerator (DAA) library API <tt>com/ibm/dataaccess/ExternalDecimal.checkExternalDecimal</tt> is added to verify the validity of the sign and digits of a given external decimal input before operating on the data.</td>
+<td valign="top">All versions</td>
+<td valign="top">The new DAA library API <tt>com/ibm/dataaccess/ExternalDecimal.checkExternalDecimal</tt> supports external decimals with all four sign configurations: sign embedded trailing, sign embedded leading, sign separate trailing, and sign separate leading. It also accommodates sign embedded trailing with spaces.
+</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
New DAA API related to external decimals added in 0.46.0 release documented.

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com