### PR TITLE
Correct Mask unboxing in VectorAPIExpansion

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -1708,5 +1708,24 @@ class TR_VectorAPIExpansion : public TR::Optimization
 
       return TR::BadILOp;
       }
+
+
+  /** \brief
+   *    Returns opcode for converting a load from a byte array into a mask
+   *
+   *   \param numLanes
+   *      Nubmer of lanes
+   *
+   *   \param maskType
+   *      Mask type
+   *
+   *   \param loadOpCode
+   *      Opcode for loading a mask from a byte array
+   *
+   *   \return
+   *      conversion opcode
+   */
+   static TR::ILOpCodes getLoadToMaskConversion(int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &loadOpCode);
+
    };
 #endif /* VECTORAPIEXPANSION_INCL */


### PR DESCRIPTION
- use the same code as for loading a mask from an array

Depends on: https://github.com/eclipse-omr/omr/pull/7737