### PR TITLE
0.51 Release notes update

### DIFF
--- a/doc/release-notes/0.51/0.51.md
+++ b/doc/release-notes/0.51/0.51.md
@@ -67,6 +67,14 @@ The following table covers notable changes in v0.51.0. Further information about
 <td valign="top">All versions</td>
 <td valign="top">When you use the method tracing options, such as <tt>-Xtrace:methods={java/lang/String.concat'()'}</tt>, the argument is passed to the function as a string and the value is returned as a string. Earlier, you could not capture the contents of the string arguments and return values, only the address of the string object was printed. Now, both the actual strings as well as the addresses can be printed and with the new parameter, you can specify the length of the strings that are printed.</td>
 </tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/920">#920</a></td>
+<td valign="top">Support for JDK Flight Recorder (JFR) in the VM is provided as a technical preview for OpenJDK 11 and later running on all platforms.</td>
+<td valign="top">OpenJDK 11 and later (All platforms)</td>
+<td valign="top">Earlier, support was provided for JFR that was available for OpenJDK 11 and later running on Linux&reg; x86 and Linux on AArch64 only.</td>
+
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
0.51.0 release note updated with the available content specific to 0.51.0 release. Added JFR related content.

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com