### PR TITLE
Fix synchronization issues of notifying yielding vthreads

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5256,6 +5256,10 @@ done:
 				}
 				/* Reset the virtual thread's notified field before releasing Object monitor. */
 				J9VMJAVALANGVIRTUALTHREAD_SET_NOTIFIED(_currentThread, _currentThread->threadObject, JNI_FALSE);
+				/* Prevent Object.notify() calls between prepareVirtualThreadForUnmount() and
+				 * yieldPinnedContinuation() from being ignored by the unblocker.
+				 */
+				J9VMJAVALANGVIRTUALTHREAD_SET_STATE(_currentThread, _currentThread->threadObject, newState);
 				/* Try to yield the virtual thread if it will be blocked. */
 				UDATA result = preparePinnedVirtualThreadForUnmount(_currentThread, object, true);
 				VMStructHasBeenUpdated(REGISTER_ARGS);

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -1113,13 +1113,14 @@ restart:
 			syncObjectMonitor->ownerContinuation = NULL;
 
 			/* Add Continuation struct to the monitor's waiting list. */
-			omrthread_monitor_exit(monitor);
 			currentThread->ownedMonitorCount -= continuation->waitingMonitorEnterCount;
 
 			omrthread_monitor_enter(vm->blockedVirtualThreadsMutex);
 			continuation->nextWaitingContinuation = syncObjectMonitor->waitingContinuations;
 			syncObjectMonitor->waitingContinuations = continuation;
 			omrthread_monitor_exit(vm->blockedVirtualThreadsMutex);
+
+			omrthread_monitor_exit(monitor);
 		} else {
 			if (NULL != monitor) {
 				/* If we are blocking to wait on a contended monitor then we can't be the owner. */


### PR DESCRIPTION
- Prevent vthreads from being notified before being added to the wait list
- Prevent Object.notify occuring between prepareVirtualThreadForUnmount
and yieldPinnedContinuation to be ignored by unblocker