### PR TITLE
Retry AOT compilations on J2I thunk store failure

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -2288,6 +2288,7 @@ bool TR::CompilationInfo::shouldRetryCompilation(J9VMThread *vmThread, TR_Method
             case compilationAOTNoSupportForAOTFailure:
             case compilationAOTRelocationRecordGenerationFailure:
             case compilationRelocationFailure:
+            case compilationAOTThunkPersistenceFailure:
                // switch to JIT for these cases (we don't want to relocate again)
                entry->_doNotAOTCompile = true;
                tryCompilingAgain = true;
@@ -11450,6 +11451,10 @@ TR::CompilationInfoPerThreadBase::processException(
    catch (const J9::AOTRelocationRecordGenerationFailure &e)
       {
       _methodBeingCompiled->_compErrCode = compilationAOTRelocationRecordGenerationFailure;
+      }
+   catch (const J9::AOTThunkPersistenceFailure &e)
+      {
+      _methodBeingCompiled->_compErrCode = compilationAOTThunkPersistenceFailure;
       }
    catch (const J9::ClassChainPersistenceFailure &e)
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -213,15 +213,16 @@ const char *compilationErrorNames[]={
    "compilationAotPatchedCPConstant",                      // 45
    "compilationAotHasInvokeSpecialInterface",              // 46
    "compilationRelocationFailure",                         // 47
+   "compilationAOTThunkPersistenceFailure",                // 48
 #if defined(J9VM_OPT_JITSERVER)
-   "compilationStreamFailure",                             // compilationFirstJITServerFailure     = 48
-   "compilationStreamLostMessage",                         // compilationFirstJITServerFailure + 1 = 49
-   "compilationStreamMessageTypeMismatch",                 // compilationFirstJITServerFailure + 2 = 50
-   "compilationStreamVersionIncompatible",                 // compilationFirstJITServerFailure + 3 = 51
-   "compilationStreamInterrupted",                         // compilationFirstJITServerFailure + 4 = 52
-   "aotCacheDeserializationFailure",                       // compilationFirstJITServerFailure + 5 = 53
-   "aotDeserializerReset",                                 // compilationFirstJITServerFailure + 6 = 54
-   "compilationAOTCachePersistenceFailure",                // compilationFirstJITServerFailure + 7 = 55
+   "compilationStreamFailure",                             // compilationFirstJITServerFailure     = 49
+   "compilationStreamLostMessage",                         // compilationFirstJITServerFailure + 1 = 50
+   "compilationStreamMessageTypeMismatch",                 // compilationFirstJITServerFailure + 2 = 51
+   "compilationStreamVersionIncompatible",                 // compilationFirstJITServerFailure + 3 = 52
+   "compilationStreamInterrupted",                         // compilationFirstJITServerFailure + 4 = 53
+   "aotCacheDeserializationFailure",                       // compilationFirstJITServerFailure + 5 = 54
+   "aotDeserializerReset",                                 // compilationFirstJITServerFailure + 6 = 55
+   "compilationAOTCachePersistenceFailure",                // compilationFirstJITServerFailure + 7 = 56
 #endif /* defined(J9VM_OPT_JITSERVER) */
    "compilationMaxError"
 };

--- a/runtime/compiler/control/rossa.h
+++ b/runtime/compiler/control/rossa.h
@@ -74,16 +74,17 @@ typedef enum {
    compilationAotPatchedCPConstant                      = 45,
    compilationAotHasInvokeSpecialInterface              = 46,
    compilationRelocationFailure                         = 47,
+   compilationAOTThunkPersistenceFailure                = 48,
 #if defined(J9VM_OPT_JITSERVER)
    compilationFirstJITServerFailure,
-   compilationStreamFailure                             = compilationFirstJITServerFailure,     // 48
-   compilationStreamLostMessage                         = compilationFirstJITServerFailure + 1, // 49
-   compilationStreamMessageTypeMismatch                 = compilationFirstJITServerFailure + 2, // 50
-   compilationStreamVersionIncompatible                 = compilationFirstJITServerFailure + 3, // 51
-   compilationStreamInterrupted                         = compilationFirstJITServerFailure + 4, // 52
-   aotCacheDeserializationFailure                       = compilationFirstJITServerFailure + 5, // 53
-   aotDeserializerReset                                 = compilationFirstJITServerFailure + 6, // 54
-   compilationAOTCachePersistenceFailure                = compilationFirstJITServerFailure + 7, // 55
+   compilationStreamFailure                             = compilationFirstJITServerFailure,     // 49
+   compilationStreamLostMessage                         = compilationFirstJITServerFailure + 1, // 50
+   compilationStreamMessageTypeMismatch                 = compilationFirstJITServerFailure + 2, // 51
+   compilationStreamVersionIncompatible                 = compilationFirstJITServerFailure + 3, // 52
+   compilationStreamInterrupted                         = compilationFirstJITServerFailure + 4, // 53
+   aotCacheDeserializationFailure                       = compilationFirstJITServerFailure + 5, // 54
+   aotDeserializerReset                                 = compilationFirstJITServerFailure + 6, // 55
+   compilationAOTCachePersistenceFailure                = compilationFirstJITServerFailure + 7, // 56
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    /* must be the last one */

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9572,7 +9572,7 @@ TR_J9SharedCacheVM::setJ2IThunk(char *signatureChars, uint32_t signatureLength, 
       {
       TR::Compilation* comp = _compInfoPT->getCompilation();
       if (comp)
-         comp->failCompilation<TR::CompilationException>("Failed to persist thunk");
+         comp->failCompilation<J9::AOTThunkPersistenceFailure>("Failed to persist thunk");
       else
          throw TR::CompilationException();
       }
@@ -9612,7 +9612,7 @@ TR_J9SharedCacheVM::persistMHJ2IThunk(void *thunk)
       {
       TR::Compilation* comp = _compInfoPT->getCompilation();
       if (comp)
-         comp->failCompilation<TR::CompilationException>("Failed to persist thunk");
+         comp->failCompilation<J9::AOTThunkPersistenceFailure>("Failed to persist MH thunk");
       else
          throw TR::CompilationException();
       }

--- a/runtime/compiler/exceptions/AOTFailure.hpp
+++ b/runtime/compiler/exceptions/AOTFailure.hpp
@@ -138,6 +138,11 @@ class AOTRelocationRecordGenerationFailure: public virtual TR::CompilationExcept
    virtual const char* what() const throw() { return "AOT Relocation Record Generation Failed"; }
    };
 
+class AOTThunkPersistenceFailure: public virtual TR::CompilationException
+   {
+   virtual const char* what() const throw() { return "Thunk persistence to SCC failed"; }
+   };
+
 #if defined(J9VM_OPT_JITSERVER)
 /**
  * AOT Cache Deserialization Failure exception type.


### PR DESCRIPTION
During an AOT compilation, if the compiler needs to store a J2I thunk in the shared class cache (SCC) but fails, the JIT throws a CompilationException exception and the method under compilation will continue as interpreted.

This commit introduces a new exception, AOTThunkPersistenceFailure, which will be thrown when a J2I thunk cannot be stored in SCC. When this type of exception is caught, the JIT will retry the compilation of the method, but refrain from using AOT.