### PR TITLE
Do not call getVMThreadFromOMRThread() if monitor owner is detached

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5523,6 +5523,13 @@ typedef struct J9VMContinuation {
 } J9VMContinuation;
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
+#if JAVA_SPEC_VERSION >= 24
+#define J9_OBJECT_MONITOR_OWNER_DETACHED 0x1
+#define IS_J9_OBJECT_MONITOR_OWNER_DETACHED(owner) (J9_OBJECT_MONITOR_OWNER_DETACHED == (UDATA)(owner))
+#else /* JAVA_SPEC_VERSION >= 24 */
+#define IS_J9_OBJECT_MONITOR_OWNER_DETACHED(owner) FALSE
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
 /* @ddr_namespace: map_to_type=J9VMThread */
 
 typedef struct J9VMThread {

--- a/runtime/util/moninfo.c
+++ b/runtime/util/moninfo.c
@@ -86,7 +86,9 @@ getObjectMonitorOwner(J9JavaVM *vm, j9object_t object, UDATA *pcount)
 		if (monitor) {
 			omrthread_t osOwner = monitor->owner;
 			if (osOwner) {
-				owner = getVMThreadFromOMRThread(vm, osOwner);
+				if (!IS_J9_OBJECT_MONITOR_OWNER_DETACHED(osOwner)) {
+					owner = getVMThreadFromOMRThread(vm, osOwner);
+				}
 				/* possible timing hole -- owner might exit monitor */
 				count = monitor->count;
 				if (count == 0) {

--- a/runtime/util/thrinfo.c
+++ b/runtime/util/thrinfo.c
@@ -264,7 +264,9 @@ getVMThreadStateHelper(J9VMThread *targetThread,
 							 * owned by a competing thread.
 							 */
 							vmstate = J9VMTHREAD_STATE_BLOCKED;
-							lockOwner = getVMThreadFromOMRThread(targetThread->javaVM, j9owner);
+							if (!IS_J9_OBJECT_MONITOR_OWNER_DETACHED(j9owner)) {
+								lockOwner = getVMThreadFromOMRThread(targetThread->javaVM, j9owner);
+							}
 							rawLock = (omrthread_monitor_t)objmon;
 						}
 					} else {
@@ -274,7 +276,9 @@ getVMThreadStateHelper(J9VMThread *targetThread,
 							} else {
 								vmstate = J9VMTHREAD_STATE_WAITING;
 							}
-							lockOwner = getVMThreadFromOMRThread(targetThread->javaVM, j9owner);
+							if (!IS_J9_OBJECT_MONITOR_OWNER_DETACHED(j9owner)) {
+								lockOwner = getVMThreadFromOMRThread(targetThread->javaVM, j9owner);
+							}
 							rawLock = (omrthread_monitor_t)objmon;
 							
 						} else if ((omrthread_monitor_t)objmon == j9state.blocker) {

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -797,7 +797,7 @@ detachMonitorInfo(J9VMThread *currentThread, j9object_t lockObject)
 	}
 
 	J9ThreadAbstractMonitor *monitor = (J9ThreadAbstractMonitor *)objectMonitor->monitor;
-	monitor->owner = (J9Thread*)1;
+	monitor->owner = (J9Thread *)J9_OBJECT_MONITOR_OWNER_DETACHED;
 	objectMonitor->ownerContinuation = currentThread->currentContinuation;
 
 	return objectMonitor;
@@ -981,7 +981,7 @@ restart:
 					&& J9_ARE_NO_BITS_SET(continuation->runtimeFlags, J9VM_CONTINUATION_RUNTIMEFLAG_JVMTI_CONTENDED_MONITOR_ENTER_RECORDED)
 				) {
 					/* Get owner here since it could be too late within yieldPinnedContinuation(). */
-					if ((void*)1 == monitor->owner) {
+					if (IS_J9_OBJECT_MONITOR_OWNER_DETACHED(monitor->owner)) {
 						continuation->previousOwner = NULL;
 					} else {
 						continuation->previousOwner = getVMThreadFromOMRThread(vm, ((J9ThreadMonitor *)monitor)->owner);

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -179,7 +179,7 @@ objectMonitorEnterBlocking(J9VMThread *currentThread)
 		 */
 		IDATA waitTime = 1;
 
-		if ((NULL != previousOMRThreadOwner) && (1 != (UDATA)previousOMRThreadOwner)) {
+		if ((NULL != previousOMRThreadOwner) && !IS_J9_OBJECT_MONITOR_OWNER_DETACHED(previousOMRThreadOwner)) {
 			previousOwner = getVMThreadFromOMRThread(vm, previousOMRThreadOwner);
 		}
 

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -163,7 +163,7 @@ restart:
 		objectMonitor = J9_INFLLOCK_OBJECT_MONITOR(lock);
 		monitor = (J9ThreadAbstractMonitor *)objectMonitor->monitor;
 		Assert_VM_notNull(monitor);
-		Assert_VM_false(monitor->owner == (void*)1);
+		Assert_VM_false(IS_J9_OBJECT_MONITOR_OWNER_DETACHED(monitor->owner));
 
 #ifdef OMR_THR_ADAPTIVE_SPIN
 		/* for now we don't allow deflation if spinning has been disabled for this monitor


### PR DESCRIPTION
Monitor owner is set to 1 if the virtual thread is detached. Add a new
macro for that. getVMThreadFromOMRThread() should only be called if the
owner is a valid omr thread.

Closes #21761