### PR TITLE
Re-enable Java 24+ cmdline tests

### DIFF
--- a/test/functional/cmdLineTests/criu/playlist.xml
+++ b/test/functional/cmdLineTests/criu/playlist.xml
@@ -490,13 +490,6 @@
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_criu_nonPortableRestoreJDK20Up</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/21443</comment>
-				<platform>ppc64le.*</platform>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xjit -XX:+CRIURestoreNonPortableMode</variation>
 			<variation>-Xint -XX:+CRIURestoreNonPortableMode</variation>

--- a/test/functional/cmdLineTests/jvmtitests/playlist.xml
+++ b/test/functional/cmdLineTests/jvmtitests/playlist.xml
@@ -787,13 +787,6 @@
 	</test>
 	<test>
 		<testCaseName>cmdLineTester_jvmtitests_Java21andUp</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/21444</comment>
-				<platform>ppc64le.*</platform>
-				<version>24+</version>
-			</disable>
-		</disables>
 		<variations>
 			<variation>Mode101</variation>
 			<variation>Mode110</variation>


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/21443
Fixes: https://github.com/eclipse-openj9/openj9/issues/21444