### PR TITLE
JITServer profiling infra for CallGraph entries

### DIFF
--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 79; // ID: Su+UK1Q5oJlgUkWIBA6f
+   static const uint16_t MINOR_NUMBER = 80; // ID: snCDuoE2+InCmAiOg6YU
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -265,6 +265,7 @@ const char *messageNames[] =
    "KnownObjectTable_addFieldAddressFromBaseIndex",
    "KnownObjectTable_getFieldAddressData",
    "AOTCache_getROMClassBatch",
+   "AOTCache_getRAMClassFromClassRecordBatch",
    "AOTCacheMap_request",
    "AOTCacheMap_reply"
    };

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -294,6 +294,7 @@ enum MessageType : uint16_t
    KnownObjectTable_getFieldAddressData,
 
    AOTCache_getROMClassBatch,
+   AOTCache_getRAMClassFromClassRecordBatch,
 
    AOTCacheMap_request,
    AOTCacheMap_reply,

--- a/runtime/compiler/runtime/JITServerAOTCache.hpp
+++ b/runtime/compiler/runtime/JITServerAOTCache.hpp
@@ -480,6 +480,9 @@ public:
    Vector<const AOTSerializationRecord *>
    getSerializationRecords(const CachedAOTMethod *method, const KnownIdSet &knownIds, TR_Memory &trMemory) const;
 
+   // Pack a vector of serialization records into a linear buffer
+   static void packSerializationRecords(const Vector<const AOTSerializationRecord *> &records, uint8_t *buffer, size_t bufferSize);
+
    void incNumCacheBypasses() { ++_numCacheBypasses; }
    void incNumCacheMisses() { ++_numCacheMisses; }
    size_t getNumDeserializedMethods() const { return _numDeserializedMethods; }

--- a/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
+++ b/runtime/compiler/runtime/JITServerAOTSerializationRecords.hpp
@@ -417,7 +417,18 @@ private:
    //         uint8_t             data[_dataSize]
    //         char*               signature[_signatureSize]
    uint8_t _varSizedData[];
-   };
+   }; // struct SerializedAOTMethod
 
+// Helper macros to make the code for printing class and method names to vlog more concise
+#define RECORD_NAME(record) (int)(record)->nameLength(), (const char *)(record)->name()
+#define LENGTH_AND_DATA(str) J9UTF8_LENGTH(str), (const char *)J9UTF8_DATA(str)
+#define ROMCLASS_NAME(romClass) LENGTH_AND_DATA(J9ROMCLASS_CLASSNAME(romClass))
+#define ROMMETHOD_NAS(romMethod) LENGTH_AND_DATA(J9ROMMETHOD_NAME(romMethod)), LENGTH_AND_DATA(J9ROMMETHOD_SIGNATURE(romMethod))
+#define RAMCLASS_NAME(ramClass) ROMCLASS_NAME((ramClass)->romClass)
+#define FULL_RAMCLASS_NAME(ramClass, region) LENGTH_AND_DATA(JITServerHelpers::getFullClassName(ramClass, region))
+#define RAMMETHOD_SIGNATURE(ramMethod) \
+   RAMCLASS_NAME(J9_CLASS_FROM_METHOD(ramMethod)), ROMMETHOD_NAS(J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod))
+#define OPTLEVEL_NAME(comp) (comp)->compileRelocatableCode() ? "AOT " : "", (comp)->getHotnessName()
+#define SIGNATURE_AND_OPTLEVEL(comp) (comp)->signature(), OPTLEVEL_NAME(comp)
 
 #endif /* defined(JITSERVER_AOT_SERIALIZATION_RECORDS_H) */

--- a/runtime/compiler/runtime/JITServerProfileCache.cpp
+++ b/runtime/compiler/runtime/JITServerProfileCache.cpp
@@ -210,7 +210,7 @@ ProfiledMethodEntry::cloneBytecodeData(TR_Memory &trMemory, bool stable,
          }
       newEntries.push_back(newEntry);
       // Remember the callGraph entries so that we can adjust the slots
-      TR_IPBCDataCallGraph *cgEntry = entry->asIPBCDataCallGraph();
+      TR_IPBCDataCallGraph *cgEntry = newEntry->asIPBCDataCallGraph();
       if (cgEntry)
          cgEntries.push_back(cgEntry);
       } // end for
@@ -335,6 +335,21 @@ JITServerSharedProfileCache::printStats(FILE *f) const
 int
 JITServerSharedProfileCache::compareBytecodeProfiles(const BytecodeProfileSummary &profile1, const BytecodeProfileSummary &profile2)
    {
+   // If one source has something and the other one has nothing, it's an easy choice
+   if (profile1._numSamples == 0)
+      {
+      if (profile2._numSamples > 0)
+         return -1;
+      else
+         return 0;
+      }
+   else
+      {
+      if (profile2._numSamples == 0)
+         return 1;
+      }
+
+
    if (profile1._numSamples > profile2._numSamples + 10 && profile1._numSamples * 15 > profile2._numSamples * 16) // 6.7% more samples
       {
       if (profile1._numProfiledBytecodes >= profile2._numProfiledBytecodes)


### PR DESCRIPTION
For virtual invokes, interface invokes, checkcast and instanceof bytecodes the IProfiler profiles 3 different target RAMClasses in a data structure called `CallSiteProfileInfo`. We will refer to them as slots. The server cannot cache the RAMClasses because they are valid for just one client. Because the SharedProfileCache is supposed to work with many clients, we need to convert the RAMClasses into something else that is client agnostic. In this implementation we will use the ClassRecord from the JITServer AOT cache.

If the server determined that the profiling information received from the client is better than the one it currently has in the SharedProfileCache (JITServerSharedProfileCache::compareBytecodeProfiles(sharedProfileSummary, clientProfileSummary);) then it will proceed to store this info into the shared profile repository by calling `ClientSessionData::storeBytecodeProfileInSharedRepository()`. Conversely, if the server determines that the shared profile info is better than the client profile info, it's going to load this shared info into the per-client IProfiler cache by calling
`ClientSessionData::loadBytecodeDataFromSharedProfileCache()`.

High level sequence of actions:

1. `ClientSessionData::storeBytecodeProfileInSharedRepository()`. 
1.1 The server deserializes the profiling information received from the client and creates `TR_IPBytecodeHashTableEntry` entries using stack memory. The `TR_IPBCDataCallGraph` entries are put into a different vector (called cgEntries) because they need special treatment.
1.2 For cgEntries we collect all the unique RAMClasses that these entries refer to and memorize to which entry and slot they refer to.
1.3 We then convert the unique RAMClasses into AOT ClassRecords by using `getClassRecord(ramClass, ...)`. Some of these conversions may not succeed because the server may not have cached that specific RAMClass.
1.4 The server creates a vector with uncachedRAMClasses and sends an `AOTCache_getROMClassBatch` message to the client.
1.5 The client will `packRemoteROMClassInfo()` and respond with ClassInfos for all missing classes. Note that if arrays are involved, the client may also send (unsolicited) information about the base component classes of those arrays.
1.6 The server will cache the information related to the missing classes: ` JITServerHelpers::cacheRemoteROMClassBatch(...)`
1.7 The server converts the missing RAMClasses into AOT ClassRecords by using `getClassRecord(ramClass,...)` like before. We expect for all such conversions to succeed this time.
1.8 Now that it performed all the RAMClass-->ClassRecord conversions, the server will patch all the profiling entries that are going to be stored in the shared profile cache, replacing the RAMClasses with ClassRecords.
1.9 The cgEntries are added to the set of other profiling entries 
1.10 The server adds the profiling entries to the shared repository by calling `_sharedProfileCache->addBytecodeData(entries,...)`. They will be cloned using memory that persists throughout the lifetime of the server.

2. `ClientSessionData::loadBytecodeDataFromSharedProfileCache()` 
2.1 For the method of interest, the server clones all profiling entries using either client persistent memory (if the information is to be stored in the per-client profile cache) or heap-memory (if the information is to be stored in the per-complation profile cache). This cloning is done with `methodEntry->cloneBytecodeData(trMemory, stable, newEntries, cgEntries);` Pointers to CallGraph entries are also copied into a `cgEntries` vector because they need special processing.
2.2 For cgEntries the server attempts to convert the ClassRecords from the profiling slots, back into RAMClasses specific to the client that performs the compilation. To help with conversion, the clientSession keeps a hashmap called `_classRecordMap`
2.3 ClassRecords that could not be converted into RAMClass with the help of `_classRecordMap` are collected into a vector called `uniqueUncachedClassRecords` (we eliminate duplicates).
2.4 The server will send a message to the client to perform the desired conversions, but the client also needs to know some record information that should help with deserialization. Thus, the server collects all class serialization records and class loader serialization records that the client might need. When building this list, the server uses the `_aotCacheKnownIds` map, to avoid sending information that the client already has.
2.5 The server sends a `AOTCache_getRAMClassFromClassRecordBatch` message with all the class IDs that need to be converted to RAMClasses and all the supporting serialization records.
2.6 The client caches all the serialization records: `deserializer->cacheRecords((const uint8_t *)recordsStr.data(), recordsStr.size(), ...)`
2.7 For requested classIDs the client performs the conversion into a RAMClass: deserializer->getRAMClass(id, comp, wasReset);
2.8 The server receives the response and updates its view of records that the client knows about (_aotCacheKnownIds)
2.9 For each of the entries in `uniqueUncachedClassRecords` we cache the corresponding RAMClass (obtained from the client) into `_classRecordMap` for future use. We also patch-up our CallGraph profiling entries that could not be fixed-up before.
2.10 The server stores the fixed-up entries into the per-client or per-compilation profile cache. If there is any error before this step the server needs to free the persistent memory it might have used for profiling entries in step 2.1