### PR TITLE
Use cg flags to check compress/expand support

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -1706,13 +1706,13 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop* treetop)
          case TR::java_lang_Long_rotateRight:
             return comp()->target().cpu.getSupportsHardware64bitRotate();
          case TR::java_lang_Integer_compress:
-            return comp()->target().cpu.getSupportsHardware32bitCompress();
+            return cg()->getSupports32BitCompress();
          case TR::java_lang_Long_compress:
-            return comp()->target().cpu.getSupportsHardware64bitCompress();
+            return cg()->getSupports64BitCompress();
          case TR::java_lang_Integer_expand:
-            return comp()->target().cpu.getSupportsHardware32bitExpand();
+            return cg()->getSupports32BitExpand();
          case TR::java_lang_Long_expand:
-            return comp()->target().cpu.getSupportsHardware64bitExpand();
+            return cg()->getSupports64BitExpand();
          case TR::java_lang_Math_abs_I:
          case TR::java_lang_Math_abs_L:
             return cg()->supportsIntAbs();


### PR DESCRIPTION
Use the codegen flags instead of cpu flags to check support for bitwise compress and expand IL opcodes when inlining `(Integer|Long).(compress|expand)`.

Requires coordinated merge with https://github.com/eclipse-omr/omr/pull/7740.