### PR TITLE
Remove z/OS compile options from AIX

### DIFF
--- a/runtime/cmake/platform/toolcfg/xlc.cmake
+++ b/runtime/cmake/platform/toolcfg/xlc.cmake
@@ -22,13 +22,17 @@
 
 list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
 	-O3
-	"\"-Wc,inline(auto,noreport,600,5000)\""
-	"\"-Wc,list(),offset,gonumber\""
+	-qstackprotect
 )
 
-list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -qnortti)
+if(OMR_OS_ZOS)
+	list(APPEND OMR_PLATFORM_COMPILE_OPTIONS
+		"\"-Wc,inline(auto,noreport,600,5000)\""
+		"\"-Wc,list(),offset,gonumber\""
+	)
+endif()
 
-list(APPEND OMR_PLATFORM_COMPILE_OPTIONS -qstackprotect)
+list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -qnortti)
 
 if(NOT OMR_OS_ZOS)
 	list(APPEND OMR_PLATFORM_CXX_COMPILE_OPTIONS -qsuppress=1540-1087:1540-1088:1540-1090)


### PR DESCRIPTION
Avoid warnings on AIX

/opt/IBM/xlC/13.1.3/bin/.orig/xlC_r: 1501-210 (W) command option Wc,inline(auto contains an incorrect subargument
/opt/IBM/xlC/13.1.3/bin/.orig/xlC_r: 1501-210 (W) command option Wc,list() contains an incorrect subargument
/opt/IBM/xlC/13.1.3/bin/.orig/xlC_r: 1501-210 (W) command option Wc,offset contains an incorrect subargument
/opt/IBM/xlC/13.1.3/bin/.orig/xlC_r: 1501-210 (W) command option Wc,gonumber contains an incorrect subargument

Related to https://github.com/eclipse-openj9/openj9/pull/19657