### PR TITLE
Generate vblend for Vector API blend intrinsic

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -3117,7 +3117,7 @@ TR::ILOpCodes TR_VectorAPIExpansion::ILOpcodeFromVectorAPIOpcode(TR::Compilation
       if (scalar)
          return TR::BadILOp;
       else
-         return TR::ILOpCode::createVectorOpCode(TR::vbitselect, vectorType);
+         return TR::ILOpCode::createVectorOpCode(TR::vblend, vectorType);
       }
    else if ((opCodeType == Test) && withMask)
       {


### PR DESCRIPTION
- The blend() intrinsic requires lane-wise value selection, while TR::vbitselect is bitwise
- Vector API blend() intrinsic should generate TR::vblend and not TR::vbitselect