### PR TITLE
Move cmdLineTester_fips to extended.functional

### DIFF
--- a/test/functional/cmdLineTests/fips/playlist.xml
+++ b/test/functional/cmdLineTests/fips/playlist.xml
@@ -36,7 +36,7 @@
             <feature>FIPS140_2:required</feature>
         </features>
         <levels>
-            <level>sanity</level>
+            <level>extended</level>
         </levels>
         <groups>
             <group>functional</group>


### PR DESCRIPTION
Move cmdLineTester_fips from sanity to extended

Issue: git_ibm/runtimes/automation/issues/371