### PR TITLE
Defragment reserved regions for off heap Step1

### DIFF
--- a/runtime/gc_vlhgc/AllocationContextBalanced.cpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.cpp
@@ -355,30 +355,32 @@ MM_AllocationContextBalanced::lockedAllocateArrayletLeaf(MM_EnvironmentBase *env
 	/* look up the spine region since we need to add this region to its leaf list */
 	MM_HeapRegionDescriptorVLHGC *spineRegion = (MM_HeapRegionDescriptorVLHGC *)_heapRegionManager->tableDescriptorForAddress(spine);
 	/* the leaf requires a pointer back to the spine object so that it can verify its liveness elsewhere in the collector */
-	leafAllocateData->setSpine(spine);
+	if (!MM_GCExtensions::getExtensions(env)->isVirtualLargeObjectHeapEnabled) {
+		leafAllocateData->setSpine(spine);
+		/* add the leaf to the spine region's leaf list */
+		/* We own the lock on the spine region's context when this call is made so we can safely manipulate this list.
+		 * An exceptional scenario: A thread allocates a spine (and possibly a few arraylets), but does not complete the allocation. A global GC (or a series of regular PGCs) occurs
+		 * that age out regions to max age. The spine moves into a common context. Now, we successfully resume the leaf allocation, but the common lock that
+		 * we already hold is not sufficient any more. We need to additionally acquire common context' common lock, since multiple spines from different ACs could have come into this state,
+		 * and worse multiple spines originally allocated from different ACs may end up in a single common context region.
+		 */
+
+		MM_AllocationContextTarok *spineContext = spineRegion->_allocateData._owningContext;
+		if (this != spineContext) {
+			Assert_MM_true(env->getCommonAllocationContext() == spineContext);
+			/* The common allocation context is always an instance of AllocationContextBalanced */
+			((MM_AllocationContextBalanced *)spineContext)->lockCommon();
+		}
+
+		leafAllocateData->addToArrayletLeafList(spineRegion);
+
+		if (this != spineContext) {
+			/* The common allocation context is always an instance of AllocationContextBalanced */
+			((MM_AllocationContextBalanced *)spineContext)->unlockCommon();
+		}
+	}
+
 	freeRegionForArrayletLeaf->resetAge(env, (U_64)_subspace->getBytesRemainingBeforeTaxation());
-	/* add the leaf to the spine region's leaf list */
-	/* We own the lock on the spine region's context when this call is made so we can safely manipulate this list.
-	 * An exceptional scenario: A thread allocates a spine (and possibly a few arraylets), but does not complete the allocation. A global GC (or a series of regular PGCs) occurs
-	 * that age out regions to max age. The spine moves into a common context. Now, we successfully resume the leaf allocation, but the common lock that
-	 * we already hold is not sufficient any more. We need to additionally acquire common context' common lock, since multiple spines from different ACs could have come into this state,
-	 * and worse multiple spines originally allocated from different ACs may end up in a single common context region.
-	 */
-
-	MM_AllocationContextTarok *spineContext = spineRegion->_allocateData._owningContext;
-	if (this != spineContext) {
-		Assert_MM_true(env->getCommonAllocationContext() == spineContext);
-		/* The common allocation context is always an instance of AllocationContextBalanced */
-		((MM_AllocationContextBalanced *)spineContext)->lockCommon();
-	}
-
-	leafAllocateData->addToArrayletLeafList(spineRegion);
-	
-	if (this != spineContext) {
-		/* The common allocation context is always an instance of AllocationContextBalanced */
-		((MM_AllocationContextBalanced *)spineContext)->unlockCommon();
-	}
-
 	/* store the base address of the leaf for the memset and the return */
 	return freeRegionForArrayletLeaf->getLowAddress();
 }

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -97,6 +97,7 @@
 #include "SlotObject.hpp"
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 #include "SparseVirtualMemory.hpp"
+#include "SparseAddressOrderedFixedSizeDataPool.hpp"
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 #include "StackSlotValidator.hpp"
 #include "SublistFragment.hpp"
@@ -433,32 +434,56 @@ MM_CopyForwardScheme::updateLeafRegions(MM_EnvironmentVLHGC *env)
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 
-	while (NULL != (region = regionIterator.nextRegion())) {
-		if (region->isArrayletLeaf()) {
-			J9Object *spineObject = (J9Object *)region->_allocateData.getSpine();
-			Assert_MM_true(NULL != spineObject);
+	if (MM_GCExtensions::getExtensions(env)->isVirtualLargeObjectHeapEnabled) {
+		const uintptr_t arrayletLeafSize = env->getOmrVM()->_arrayletLeafSize;
+		MM_SparseVirtualMemory *largeObjectVirtualMemory = MM_GCExtensions::getExtensions(env)->largeObjectVirtualMemory;
+		uintptr_t arrayletLeafCount = 0;
+		J9HashTableState walkState;
 
-			J9Object *updatedSpineObject = updateForwardedPointer(spineObject);
-			if (updatedSpineObject != spineObject) {
-				MM_HeapRegionDescriptorVLHGC *spineRegion = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(spineObject);
-				MM_HeapRegionDescriptorVLHGC *updatedSpineRegion = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(updatedSpineObject);
-
-				Assert_MM_true(spineRegion->_markData._shouldMark);
-				Assert_MM_true(spineRegion != updatedSpineRegion);
-				Assert_MM_true(updatedSpineRegion->containsObjects());
-
-				/* we need to move the leaf to another region's leaf list since its spine has moved */
-				region->_allocateData.removeFromArrayletLeafList(env);
-				region->_allocateData.addToArrayletLeafList(updatedSpineRegion);
-				region->_allocateData.setSpine((J9IndexableObject *)updatedSpineObject);
-			} else if (!isLiveObject(spineObject)) {
-				Assert_MM_true(isObjectInEvacuateMemory(spineObject));
-				/* the spine is in evacuate space so the arraylet is dead => recycle the leaf */
-				/* remove arraylet leaf from list */
-				region->_allocateData.removeFromArrayletLeafList(env);
-				/* recycle */
-				region->_allocateData.setSpine(NULL);
+		MM_SparseDataTableEntry *sparseDataEntry = (MM_SparseDataTableEntry *)hashTableStartDo(largeObjectVirtualMemory->getSparseDataPool()->getObjectToSparseDataTable(), &walkState);
+		while (NULL != sparseDataEntry) {
+			J9Object *spineObject = (J9Object *)sparseDataEntry->_proxyObjPtr;
+			if (!isLiveObject(spineObject)) {
+				uintptr_t dataSize = sparseDataEntry->_size;
+				arrayletLeafCount += MM_Math::roundToCeiling(arrayletLeafSize, dataSize) / arrayletLeafSize;
+			}
+			sparseDataEntry = (MM_SparseDataTableEntry *)hashTableNextDo(&walkState);
+		}
+		while ((arrayletLeafCount > 0) && (NULL != (region = regionIterator.nextRegion()))) {
+			if (region->isArrayletLeaf()) {
 				region->getSubSpace()->recycleRegion(env, region);
+				arrayletLeafCount -= 1;
+			}
+		}
+		Assert_MM_true(0 == arrayletLeafCount);
+	} else {
+		while (NULL != (region = regionIterator.nextRegion())) {
+			if (region->isArrayletLeaf()) {
+				J9Object *spineObject = (J9Object *)region->_allocateData.getSpine();
+				Assert_MM_true(NULL != spineObject);
+
+				J9Object *updatedSpineObject = updateForwardedPointer(spineObject);
+				if (updatedSpineObject != spineObject) {
+					MM_HeapRegionDescriptorVLHGC *spineRegion = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(spineObject);
+					MM_HeapRegionDescriptorVLHGC *updatedSpineRegion = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(updatedSpineObject);
+
+					Assert_MM_true(spineRegion->_markData._shouldMark);
+					Assert_MM_true(spineRegion != updatedSpineRegion);
+					Assert_MM_true(updatedSpineRegion->containsObjects());
+
+					/* we need to move the leaf to another region's leaf list since its spine has moved */
+					region->_allocateData.removeFromArrayletLeafList(env);
+					region->_allocateData.addToArrayletLeafList(updatedSpineRegion);
+					region->_allocateData.setSpine((J9IndexableObject *)updatedSpineObject);
+				} else if (!isLiveObject(spineObject)) {
+					Assert_MM_true(isObjectInEvacuateMemory(spineObject));
+					/* the spine is in evacuate space so the arraylet is dead => recycle the leaf */
+					/* remove arraylet leaf from list */
+					region->_allocateData.removeFromArrayletLeafList(env);
+					/* recycle */
+					region->_allocateData.setSpine(NULL);
+					region->getSubSpace()->recycleRegion(env, region);
+				}
 			}
 		}
 	}

--- a/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.cpp
+++ b/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.cpp
@@ -56,6 +56,8 @@
 #include "ParallelDispatcher.hpp"
 #include "ParallelSweepChunk.hpp"
 #include "ParallelTask.hpp"
+#include "SparseVirtualMemory.hpp"
+#include "SparseAddressOrderedFixedSizeDataPool.hpp"
 #include "SweepHeapSectioningVLHGC.hpp"
 #include "SweepPoolManagerVLHGC.hpp"
 #include "SweepPoolManagerAddressOrderedList.hpp"
@@ -1006,37 +1008,65 @@ MM_ParallelSweepSchemeVLHGC::recycleFreeRegions(MM_EnvironmentVLHGC *env)
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	
-	while(NULL != (region = regionIterator.nextRegion())) {
-		/* Region must be marked for sweep */
-		if (!region->_sweepData._alreadySwept && region->hasValidMarkMap()) {
-			MM_MemoryPool *regionPool = region->getMemoryPool();
-			Assert_MM_true(NULL != regionPool);
-			MM_HeapRegionDescriptorVLHGC *walkRegion = region;
-			MM_HeapRegionDescriptorVLHGC *next = walkRegion->_allocateData.getNextArrayletLeafRegion();
-			/* Try to walk list from this head */
-			while (NULL != (walkRegion = next)) {
-				Assert_MM_true(walkRegion->isArrayletLeaf());
-				J9Object *spineObject = (J9Object *)walkRegion->_allocateData.getSpine();
-				next = walkRegion->_allocateData.getNextArrayletLeafRegion();
-				Assert_MM_true( region->isAddressInRegion(spineObject) );
-				if (!_cycleState._markMap->isBitSet(spineObject)) {
-					/* Arraylet is dead */
+	if (MM_GCExtensions::getExtensions(env)->isVirtualLargeObjectHeapEnabled) {
+		const uintptr_t arrayletLeafSize = env->getOmrVM()->_arrayletLeafSize;
+		MM_SparseVirtualMemory *largeObjectVirtualMemory = MM_GCExtensions::getExtensions(env)->largeObjectVirtualMemory;
+		uintptr_t arrayletLeafCount = 0;
+		J9HashTableState walkState;
 
-					/* remove arraylet leaf from list */
-					walkRegion->_allocateData.removeFromArrayletLeafList(env);
+		MM_SparseDataTableEntry *sparseDataEntry = (MM_SparseDataTableEntry *)hashTableStartDo(largeObjectVirtualMemory->getSparseDataPool()->getObjectToSparseDataTable(), &walkState);
+		while (NULL != sparseDataEntry) {
+			J9Object *spineObject = (J9Object *)sparseDataEntry->_proxyObjPtr;
 
-					/* recycle */
-					walkRegion->_allocateData.setSpine(NULL);
-
-					walkRegion->getSubSpace()->recycleRegion(env, walkRegion);
-				}
+			if (!_cycleState._markMap->isBitSet(spineObject)) {
+				/* Arraylet is dead */
+				uintptr_t dataSize = sparseDataEntry->_size;
+				arrayletLeafCount += MM_Math::roundToCeiling(arrayletLeafSize, dataSize) / arrayletLeafSize;
 			}
+			sparseDataEntry = (MM_SparseDataTableEntry *)hashTableNextDo(&walkState);
+		}
 
-			/* recycle if empty */
-			if (region->getSize() == regionPool->getActualFreeMemorySize()) {
-				Assert_MM_true(NULL == region->_allocateData.getSpine());
-				Assert_MM_true(NULL == region->_allocateData.getNextArrayletLeafRegion());
+		while ((arrayletLeafCount > 0) && (NULL != (region = regionIterator.nextRegion()))) {
+			if (region->isArrayletLeaf()) {
 				region->getSubSpace()->recycleRegion(env, region);
+				arrayletLeafCount -= 1;
+			}
+		}
+		Assert_MM_true(0 == arrayletLeafCount);
+
+	} else {
+		while(NULL != (region = regionIterator.nextRegion())) {
+			/* Region must be marked for sweep */
+			if (!region->_sweepData._alreadySwept && region->hasValidMarkMap()) {
+				MM_MemoryPool *regionPool = region->getMemoryPool();
+				Assert_MM_true(NULL != regionPool);
+				MM_HeapRegionDescriptorVLHGC *walkRegion = region;
+				MM_HeapRegionDescriptorVLHGC *next = walkRegion->_allocateData.getNextArrayletLeafRegion();
+				/* Try to walk list from this head */
+				while (NULL != (walkRegion = next)) {
+					Assert_MM_true(walkRegion->isArrayletLeaf());
+					J9Object *spineObject = (J9Object *)walkRegion->_allocateData.getSpine();
+					next = walkRegion->_allocateData.getNextArrayletLeafRegion();
+					Assert_MM_true( region->isAddressInRegion(spineObject) );
+					if (!_cycleState._markMap->isBitSet(spineObject)) {
+						/* Arraylet is dead */
+
+						/* remove arraylet leaf from list */
+						walkRegion->_allocateData.removeFromArrayletLeafList(env);
+
+						/* recycle */
+						walkRegion->_allocateData.setSpine(NULL);
+
+						walkRegion->getSubSpace()->recycleRegion(env, walkRegion);
+					}
+				}
+
+				/* recycle if empty */
+				if (region->getSize() == regionPool->getActualFreeMemorySize()) {
+					Assert_MM_true(NULL == region->_allocateData.getSpine());
+					Assert_MM_true(NULL == region->_allocateData.getNextArrayletLeafRegion());
+					region->getSubSpace()->recycleRegion(env, region);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
For off-heap enabled case, the Large size Array(larger than region size) will be allocated on sparse heap, but we still reserve leaf regions for preventing over usage on heap. Currently we have to allocate/reserve whole region for the remaining bytes(remainder of array size from region size), it potentially generate fragmentation on heap.

first step:
1, Decouple spineObject with leaf regions for off-heap eanbled case.
2, find spineObjects via SparseDataTable in recycling leaf regions.

#depends on https://github.com/eclipse-omr/omr/pull/7748