### PR TITLE
Raise allowance size threshold along alwaysWorthInlining calls

### DIFF
--- a/runtime/compiler/optimizer/EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.hpp
@@ -108,7 +108,7 @@ class TR_EstimateCodeSize
 
    protected:
 
-   virtual bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true) = 0;
+   virtual bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true, int32_t callerAnalyzedSizeThreshold = 0) = 0;
 
 
    /*

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
@@ -118,7 +118,7 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
                              TR::Compilation *comp);
 
    protected:
-      bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true);
+      bool estimateCodeSize(TR_CallTarget *, TR_CallStack * , bool recurseDown = true, int32_t callerAnalyzedSizeThreshold = 0);
 
      /** \brief
       *     Generates a CFG for the calltarget->_calleeMethod.
@@ -150,7 +150,7 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
       *     Reference to cfg
       */
       TR::CFG &processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, TR::Region &cfgRegion, TR_J9ByteCodeIterator &bci, NeedsPeekingHeuristic &nph, TR::Block** blocks, flags8_t * flags);
-      bool realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallStack *prevCallStack, bool recurseDown, TR::Region &cfgRegion);
+      bool realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallStack *prevCallStack, bool recurseDown, TR::Region &cfgRegion, int32_t callerAnalyzedSizeThreshold = 0);
 
       bool reduceDAAWrapperCodeSize(TR_CallTarget* target);
 


### PR DESCRIPTION
In Estimate Code Size, we would terminate estimation once _analyzedSize exceeded the analyzed size threshold, which was obtained using sizeThreshold * allowanceFactor. However, not increasing the analyzed size threshold for methods that are always worth inlining - a property set through inliner policy or through the use of @ForceInline annotation, meant that those methods were not being prioritized as necessary. To overcome that issue, this commit introduces a few changes to the ECS heuristics:
  * forceInlineMultiplier - to be used to multiply the analyzed size threshold for a method that is always worth inlining.
  * Change estimateCodeSize function signature to be able to recursively pass down caller method's analyzed size threshold to callees along an always worth inlining call graph.
  * Reset _analyzedSize to pre-analysis _analyzedSize for methods always worth inlining.