### PR TITLE
Refetch module object reference after GC point

### DIFF
--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -256,6 +256,9 @@ createPackage(J9VMThread *currentThread, J9Module *fromModule, J9UTF8 *packageNa
 }
 
 /** @note It assumes moduleObject is guaranteed not to be NULL
+ *
+ * This method has potential GC point.
+ *
  *  @return Pointer to module's classloader
  */
 static J9ClassLoader *
@@ -931,9 +934,12 @@ JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version,
 	} else {
 		j9object_t modObj = J9_JNI_UNWRAP_REFERENCE(module);
 		J9ClassLoader *systemClassLoader = vm->systemClassLoader;
-
 		J9ClassLoader * const classLoader = getModuleObjectClassLoader(currentThread, modObj);
-		j9object_t moduleNameObject = J9VMJAVALANGMODULE_NAME(currentThread, modObj);
+		j9object_t moduleNameObject = NULL;
+
+		/* refetch module object reference after GC point */
+		modObj = J9_JNI_UNWRAP_REFERENCE(module);
+		moduleNameObject = J9VMJAVALANGMODULE_NAME(currentThread, modObj);
 
 		/* extensionClassLoader holds the platform class loader in Java 11+ */
 		if ((classLoader != systemClassLoader) && (classLoader != vm->extensionClassLoader)) {

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -287,6 +287,9 @@ resolveNativeAddress(J9VMThread *currentThread, J9Method *nativeMethod, UDATA ru
 
 /**
 * @brief
+*
+* This method has potential GC point.
+*
 * @param *javaVM
 * @param *classLoaderObject
 * @return J9ClassLoader
@@ -378,6 +381,8 @@ internalCreateArrayClassWithOptions(J9VMThread *vmThread, J9ROMArrayClass *romCl
 /**
  * Load the class with the specified name in a given module
  *
+ * This method has potential GC point.
+ *
  * @param currentThread Current VM thread
  * @param moduleName j.l.String object representing module name; can be null
  * @param className String object representing name of the class to load
@@ -395,6 +400,8 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 /**
  * Load the class with the specified name in the given module.
  *
+ * This method has potential GC point.
+ *
  * @param currentThread Current VM thread
  * @param moduleName Pointer to J9Module representing the module containing the class
  * @param className Name of class to load
@@ -408,6 +415,35 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 J9Class*
 internalFindClassInModule(J9VMThread* vmThread, J9Module* j9module, U_8* className, UDATA classNameLength, J9ClassLoader* classLoader, UDATA options);
 
+/**
+ * It is a wrapper method of internalFindClassInModule().
+ *
+ * This method has potential GC point.
+ *
+ * @param vmThread Current VM thread
+ * @param className Name of class to load
+ * @param classNameLength Length of the class name
+ * @param classLoader J9ClassLoader to use
+ * @param options load options such as J9_FINDCLASS_FLAG_EXISTING_ONLY
+ *
+ * @return pointer to J9Class if success, NULL if fail
+ */
+J9Class*
+internalFindClassUTF8(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9ClassLoader* classLoader, UDATA options);
+
+/**
+ * Get the class for the index, loading and initializing the class if necessary.
+ *
+ * This method has potential GC point.
+ *
+ * @param vmThread Current VM thread
+ * @param index The class index
+ * @param flags The J9_FINDKNOWNCLASS_FLAG
+ *
+ * @return pointer to J9Class if success, NULL if fail
+ */
+J9Class*
+internalFindKnownClass(J9VMThread *vmThread, UDATA index, UDATA flags);
 
 /**
 * @brief

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -74,7 +74,7 @@ totalStaticSlotsForClass( J9ROMClass *romClass ) {
 /**
  * @internal
  *
- * This function should only be called by internalFindClassUTF8()!
+ * This method has potential GC point.
  *
  * Load the array class with the specified name.
  * If nameData does not refer to a valid array, return NULL.


### PR DESCRIPTION
Refetch module object reference after GC point

Added comment for methods with potential GC points;
Added `internalFindClassUTF8()` & `internalFindKnownClass()` defines into `vm_api.h`.

Related to
* https://github.com/eclipse-openj9/openj9/issues/18970

Signed-off-by: Jason Feng <fengj@ca.ibm.com>