### PR TITLE
Update assertion to account for state change in afterYield

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -1207,8 +1207,8 @@ restart:
 					continue;
 				case JAVA_LANG_VIRTUALTHREAD_WAIT:
 				case JAVA_LANG_VIRTUALTHREAD_TIMED_WAIT:
-					/* WAIT/TIMED_WAIT can only be added to blocked list if they have been notifed and threads updated. */
-					Assert_VM_unreachable();
+					/* WAIT/TIMED_WAIT can only be added to blocked list if they have been notified. */
+					Assert_VM_true(J9VMJAVALANGVIRTUALTHREAD_NOTIFIED(currentThread, current->vthread));
 					break;
 				case JAVA_LANG_VIRTUALTHREAD_BLOCKED:
 				{


### PR DESCRIPTION
In vthread.afterYield() where the state is first set to WAIT then BLOCKED if the notify occurred during the transition phase.

Related: https://github.com/eclipse-openj9/openj9/issues/21037#issuecomment-2860676990