### PR TITLE
Fill SystemProcess and NativeLibrary pools only on explicit dump

### DIFF
--- a/runtime/vm/JFRChunkWriter.hpp
+++ b/runtime/vm/JFRChunkWriter.hpp
@@ -258,9 +258,9 @@ public:
 	}
 
 	void
-	loadEvents()
+	loadEvents(bool dumpCalled)
 	{
-		_constantPoolTypes.loadEvents();
+		_constantPoolTypes.loadEvents(dumpCalled);
 		_buildResult = _constantPoolTypes.getBuildResult();
 	}
 
@@ -422,6 +422,7 @@ done:
 
 			if (dumpCalled) {
 				writeThreadDumpEvent();
+				_constantPoolTypes.loadNativeLibraries(_currentThread);
 				pool_do(_constantPoolTypes.getSystemProcessTable(), &writeSystemProcessEvent, this);
 				pool_do(_constantPoolTypes.getNativeLibraryTable(), &writeNativeLibraryEvent, this);
 			}

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -946,7 +946,7 @@ public:
 
 	BuildResult getBuildResult() { return _buildResult; };
 
-	void loadEvents()
+	void loadEvents(bool dumpCalled)
 	{
 		J9JFRBufferWalkState walkstate = {0};
 		J9Pool *shallowEntries = NULL;
@@ -999,6 +999,11 @@ public:
 
 		if (isResultNotOKay()) {
 			goto done;
+		}
+
+		if (dumpCalled) {
+			loadSystemProcesses(_currentThread);
+			loadNativeLibraries(_currentThread);
 		}
 
 		shallowEntries = pool_new(sizeof(ClassEntry**), 0, sizeof(U_64), 0, J9_GET_CALLSITE(), OMRMEM_CATEGORY_VM, POOL_FOR_PORT(privatePortLibrary));
@@ -1598,9 +1603,6 @@ done:
 			_buildResult = OutOfMemory;
 			goto done;
 		}
-
-		loadSystemProcesses(_currentThread);
-		loadNativeLibraries(_currentThread);
 
 		/* Add reserved index for default entries. For strings zero is the empty or NUll string.
 		 * For package zero is the deafult package, for Module zero is the unnamed module. ThreadGroup

--- a/runtime/vm/JFRWriter.hpp
+++ b/runtime/vm/JFRWriter.hpp
@@ -185,7 +185,7 @@ done:
 			goto fail;
 		}
 
-		chunkWriter.loadEvents();
+		chunkWriter.loadEvents(dumpCalled);
 		if (!chunkWriter.isOkay()) {
 			result = false;
 			goto fail;


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/21823 Follow-up of https://github.com/eclipse-openj9/openj9/pull/21818