### PR TITLE
SVM: Always specify the actual inlined method for inlined method relos

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -530,7 +530,8 @@ J9::AheadOfTimeCompile::initializeCommonAOTRelocationHeader(TR::IteratedExternal
          uint8_t flags = 0;
 
          TR_ResolvedMethod *resolvedMethod;
-         if (kind == TR_InlinedInterfaceMethodWithNopGuard ||
+         if (comp->getOption(TR_UseSymbolValidationManager) ||
+             kind == TR_InlinedInterfaceMethodWithNopGuard ||
              kind == TR_InlinedInterfaceMethod ||
              kind == TR_InlinedAbstractMethodWithNopGuard ||
              kind == TR_InlinedAbstractMethod)


### PR DESCRIPTION
...and ignore the call symref. For an inlined indirect call, the inlined method can differ from the method specified by the call symref, which could result in an incorrect inlining table at load time.