### PR TITLE
Update CRC32C acceleration for off-heap

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3734,7 +3734,7 @@ J9::Z::CodeGenerator::suppressInliningOfRecognizedMethod(TR::RecognizedMethod me
       }
 
    static bool disableCRC32CAcceleration = (feGetEnv("TR_DisableCRC32CAcceleration") != NULL);
-   if (!disableCRC32CAcceleration && self()->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
+   if (!disableCRC32CAcceleration && self()->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets())
       {
       if (method == TR::java_util_zip_CRC32C_updateBytes ||
          method == TR::java_util_zip_CRC32C_updateDirectByteBuffer)


### PR DESCRIPTION
The acceleration was initially disabled because it added array header size to the array object, which was required to reach the elements. However, this is unnecessary for off-heap mode. As a result, the evaluator has been updated to add the array header size exclusively for non-off-heap mode, while in off-heap mode, it now retrieves the data element address directly from the array header, enabling acceleration in off-heap mode.