### PR TITLE
Update hashCodeHelper for off-heap

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -93,8 +93,7 @@ J9::Z::CodeGenerator::initialize()
       cg->setSupportsInlineStringIndexOf();
       }
 
-   if (cg->getSupportsVectorRegisters() && !comp->getOption(TR_DisableSIMDStringHashCode) &&
-       !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
+   if (cg->getSupportsVectorRegisters() && !comp->getOption(TR_DisableSIMDStringHashCode) && !TR::Compiler->om.canGenerateArraylets())
       {
       cg->setSupportsInlineStringHashCode();
       cg->setSupportsInlineVectorizedHashCode();


### PR DESCRIPTION
The acceleration was initially disabled because it added array header size to the array object, which was required to reach the elements. However, this is unnecessary for off-heap mode. As a result, the evaluator has been updated to add the array header size exclusively for non-off-heap mode, while in off-heap mode, it now retrieves the data element address directly from the array header, enabling acceleration in off-heap mode.