### PR TITLE
Update IntegerToChars evaluators for off-heap

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -264,9 +264,19 @@ J9::Z::CodeGenerator::initialize()
       }
 
    static bool disableIntegerToChars = (feGetEnv("TR_DisableIntegerToChars") != NULL);
-   if (cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && !disableIntegerToChars && comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z16))
+   if (cg->getSupportsVectorRegisters()
+       && comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z16)
+       && !disableIntegerToChars
+       && !TR::Compiler->om.canGenerateArraylets())
       {
       cg->setSupportsIntegerToChars();
+      }
+
+   static bool disableIntegerStringSize = (feGetEnv("TR_DisableIntegerStringSize") != NULL);
+   if (cg->getSupportsVectorRegisters()
+       && comp->target().cpu.isAtLeast(OMR_PROCESSOR_S390_Z16)
+       && !disableIntegerStringSize)
+      {
       cg->setSupportsIntegerStringSize();
       }
 


### PR DESCRIPTION
The acceleration was initially disabled because it added array header size to the array object, which was required to reach the elements. However, this is unnecessary for off-heap mode. As a result, the evaluator has been updated to add the array header size exclusively for non-off-heap mode, while in off-heap mode, it now retrieves the data element address directly from the array header, enabling acceleration in off-heap mode.