### PR TITLE
Enable EncodeASCII acceleration for off-heap

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -141,7 +141,7 @@ J9::Z::CodeGenerator::initialize()
       }
 
    static char *disableInlineEncodeASCII = feGetEnv("TR_disableInlineEncodeASCII");
-   if (comp->fej9()->isStringCompressionEnabledVM() && cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled() && !disableInlineEncodeASCII)
+   if (comp->fej9()->isStringCompressionEnabledVM() && cg->getSupportsVectorRegisters() && !TR::Compiler->om.canGenerateArraylets() && !disableInlineEncodeASCII)
       {
       cg->setSupportsInlineEncodeASCII();
       }


### PR DESCRIPTION
This already uses
`TR::TransformUtil::generateFirstArrayElementAddressTrees`  API to generate appropriate trees for off-heap and non off-heap modes so no change is needed to the evaluator.