### PR TITLE
Enable vectorizedHashCode intrinsic for OffHeap on POWER

### DIFF
--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -124,7 +124,6 @@ J9::Power::CodeGenerator::initialize()
       cg->setSupportsReadOnlyLocks();
 
    if (!TR::Compiler->om.canGenerateArraylets()
-         && !TR::Compiler->om.isOffHeapAllocationEnabled()
          && comp->target().cpu.isAtLeast(OMR_PROCESSOR_PPC_P8)
          && comp->target().cpu.supportsFeature(OMR_FEATURE_PPC_HAS_VSX)
          && !comp->compileRelocatableCode()


### PR DESCRIPTION
 Calculate the address for the array data in OffHeap mode correctly for vectorizedHashCode