### PR TITLE
Do not add Own.Sync. object to the list if scan wasn't successful

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -322,8 +322,9 @@ private:
 	 * @param reservingContext[in] The context to which we would prefer to copy any objects discovered in this method
 	 * @param objectPtr current object being scanned.
 	 * @param reason to scan (dirty card, packet, scan cache, overflow)
+	 * @return true if all slots have been copied successfully
 	 */
-	void scanMixedObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
+	bool scanMixedObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
 	/**
 	 * Scan the slots of a reference mixed object.
 	 * Copy and forward all relevant slots values found in the object.


### PR DESCRIPTION
If Ownable Synchronizer object scan has not been successful (caused Copy Forward Abort) it should not be aadded to the list right away. This object is remembered in the work packet and is going to be rescanned for the second time.