### PR TITLE
JDK24+ add com.ibm.oti.vm.VM.isYieldBlockedVirtualThreadsEnabled()

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
@@ -682,4 +682,14 @@ public static native void stopJFR();
  */
 public static native void triggerExecutionSample();
 /*[ENDIF] JFR_SUPPORT */
+
+/*[IF JAVA_SPEC_VERSION >= 24]*/
+/**
+ * Queries whether -XX:+YieldPinnedVirtualThreads is enabled.
+ * By default, this method returns true, i.e., not in legacy locking mode.
+ *
+ * @return true if -XX:+YieldPinnedVirtualThreads is enabled, false otherwise
+ */
+public static native boolean isYieldBlockedVirtualThreadsEnabled();
+/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 }

--- a/runtime/jcl/common/com_ibm_oti_vm_VM.cpp
+++ b/runtime/jcl/common/com_ibm_oti_vm_VM.cpp
@@ -300,4 +300,21 @@ Java_com_ibm_oti_vm_VM_triggerExecutionSample(JNIEnv *env, jclass unused)
 }
 #endif /* defined(J9VM_OPT_JFR) */
 
+#if JAVA_SPEC_VERSION >= 24
+/**
+ * Queries whether -XX:+YieldPinnedVirtualThreads is enabled.
+ * By default, this method returns true, i.e., not in legacy locking mode.
+ *
+ * @return JNI_TRUE if -XX:+YieldPinnedVirtualThreads is enabled, JNI_FALSE otherwise
+ */
+jboolean JNICALL
+Java_com_ibm_oti_vm_VM_isYieldBlockedVirtualThreadsEnabled(JNIEnv *env, jclass unused)
+{
+	jboolean result = JNI_FALSE;
+	if (J9_ARE_ANY_BITS_SET(((J9VMThread *)env)->javaVM->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)) {
+		result = JNI_TRUE;
+	}
+	return result;
+}
+#endif /* JAVA_SPEC_VERSION >= 24 */
 } /* extern "C" */

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -856,3 +856,10 @@ if(NOT JAVA_SPEC_VERSION LESS 20)
 		Java_java_lang_Thread_setScopedValueCache
 	)
 endif()
+
+# Java 24+
+if(NOT JAVA_SPEC_VERSION LESS 24)
+	omr_add_exports(jclse
+		Java_com_ibm_oti_vm_VM_isYieldBlockedVirtualThreadsEnabled
+	)
+endif()

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1362,6 +1362,11 @@ void JNICALL
 Java_jdk_internal_vm_Continuation_unpin(JNIEnv *env, jclass unused);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
+#if JAVA_SPEC_VERSION >= 24
+jboolean JNICALL
+Java_com_ibm_oti_vm_VM_isYieldBlockedVirtualThreadsEnabled(JNIEnv *env, jclass unused);
+#endif /* JAVA_SPEC_VERSION >= 24 */
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif


### PR DESCRIPTION
JDK24+ add `com.ibm.oti.vm.VM.isYieldBlockedVirtualThreadsEnabled()`

By default, this method returns `true`, i.e., not in legacy locking mode.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>