### PR TITLE
Update non-FLC flatlock exit to use CAS

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -994,7 +994,9 @@ restart:
 										| ((count - 1) << OBJECT_HEADER_LOCK_V2_RECURSION_OFFSET)
 										| OBJECT_HEADER_LOCK_FLC;
 						}
+						Assert_VM_true(newLockword != OBJECT_HEADER_LOCK_FLC);
 						j9objectmonitor_t const oldValue = lock;
+						VM_AtomicSupport::writeBarrier();
 						lock = VM_ObjectMonitor::compareAndSwapLockword(currentThread, lwEA, lock, (j9objectmonitor_t)newLockword);
 						if (lock == oldValue) {
 							/* CAS succeeded, we can proceed with using the inflated monitor. */


### PR DESCRIPTION
Use CompareAndSwap to ensure updates to lockword is not overwritten during exit.

Also ensure vthread blocked on monitor is notified properly.

Related: #21826 