### PR TITLE
Increase Arraylet Allocate test heap size

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/arraylets/ArrayletAllocateTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/arraylets/ArrayletAllocateTestRunner.java
@@ -25,7 +25,7 @@ import j9vm.runner.Runner;
 
 public class ArrayletAllocateTestRunner extends Runner {
 
-	private final String customizedHeapOptions = "-Xms65m -Xmx65m";
+	private final String customizedHeapOptions = "-Xms71m -Xmx71m";
 	
 	public ArrayletAllocateTestRunner(String className, String exeName, String bootClassPath, String userClassPath, String javaVersion) {
 		super(className, exeName, bootClassPath, userClassPath, javaVersion);


### PR DESCRIPTION
Increasing the heap size of ArrayletAllocateTest to 71M, as per calculation in this comment:

https://github.com/eclipse-openj9/openj9/issues/9969#issuecomment-2803359631