### PR TITLE
Remove setting arrayShadow flag for unsafeShadow symbols

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2257,7 +2257,6 @@ J9::SymbolReferenceTable::findOrCreateUnsafeSymbolRef(TR::DataType type, bool ja
       {
       TR::Symbol * sym = TR::Symbol::createShadow(trHeapMemory(),type);
       sym->setUnsafeShadowSymbol();
-      sym->setArrayShadowSymbol();
       sym->setMemoryOrdering(ordering);
       (*unsafeSymRefs)[type] = symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, comp()->getMethodSymbol()->getResolvedMethodIndex(), -1);
       aliasBuilder.unsafeSymRefNumbers().set(symRef->getReferenceNumber());


### PR DESCRIPTION
When generating an unsafe-shadow symbol, the array-shadow flag is set.
This seems unnecessary and can trigger a wrong behaviour when checking for array-shadow symbols (eg with `sym->isArrayShadowSymbol()`) giving a false-positive for unsafe-shadow symbols.

Running vmfarm and jenkins tests and SPEC workload shows no functional issue with this change.

Don't have history to justify this line, any thoughts on doing this change?