### PR TITLE
Decrease Arraylet Allocate test heap size

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/arraylets/ArrayletAllocateTestRunner.java
+++ b/test/functional/VM_Test/src/j9vm/test/arraylets/ArrayletAllocateTestRunner.java
@@ -25,7 +25,7 @@ import j9vm.runner.Runner;
 
 public class ArrayletAllocateTestRunner extends Runner {
 
-	private final String customizedHeapOptions = "-Xms71m -Xmx71m";
+	private final String customizedHeapOptions = "-Xms63m -Xmx63m";
 	
 	public ArrayletAllocateTestRunner(String className, String exeName, String bootClassPath, String userClassPath, String javaVersion) {
 		super(className, exeName, bootClassPath, userClassPath, javaVersion);


### PR DESCRIPTION
Decreasing the heap size of ArrayletAllocateTest to 63MB to reduce the maximum array size to 2 million elements, what will minimize the ratio of the live set size vs the heap size.