### PR TITLE
Remove unused isCallByteCode() method

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -738,21 +738,6 @@ TR_IProfiler::isSwitch (U_8 byteCode)
            (byteCode == JBtableswitch));
    }
 
-bool isCallByteCode(U_8 byteCode)
-   {
-   switch(byteCode)
-      {
-      case JBinvokestatic:
-      case JBinvokespecial:
-      case JBinvokeinterface:
-      case JBinvokeinterface2:
-      case JBinvokevirtual:
-        return true;
-      default:
-        return false;
-      }
-   }
-
 bool isInterfaceBytecode(U_8 byteCode)
    {
    return (byteCode == JBinvokeinterface);


### PR DESCRIPTION
`isCallByteCode(U_8 byteCode)` is a method defined in IProfiler.cpp but it is unused and incomplete: it misses two other call bytecodes (JBinvokestaticsplit and JBinvokestaticsplit).
Rather than fixing the code, it's better to just remove it.