### PR TITLE
Remove unused getParentCallCount() method

### DIFF
--- a/runtime/compiler/infra/J9Cfg.cpp
+++ b/runtime/compiler/infra/J9Cfg.cpp
@@ -1370,37 +1370,6 @@ J9::CFG::computeInitialBlockFrequencyBasedOnExternalProfiler(TR::Compilation *co
    _initialBlockFrequency = startFrequency;
    }
 
-
-static int32_t
-getParentCallCount(TR::CFG *cfg, TR::Node *node)
-   {
-   if (node->getByteCodeInfo().getCallerIndex() >=-1)
-      {
-      int32_t parentSiteIndex = node->getInlinedSiteIndex();
-
-      if (parentSiteIndex >= 0)
-         {
-         TR_InlinedCallSite & site = cfg->comp()->getInlinedCallSite(parentSiteIndex);
-         int32_t callCount = cfg->comp()->fej9()->getIProfilerCallCount(site._byteCodeInfo, cfg->comp());
-
-         if (callCount != 0)
-            return callCount;
-         }
-      }
-   else
-      { // It's a dummy block in estimate code size
-        // The called frequency is set by estimate code size because at that time
-        // we don't have the final caller information.
-      int32_t callCount = cfg->_calledFrequency;
-
-      if (callCount != 0)
-         return callCount;
-      }
-
-   return 0;
-   }
-
-
 void
 J9::CFG::getInterpreterProfilerBranchCountersOnDoubleton(TR::CFGNode *cfgNode, int32_t *taken, int32_t *nottaken)
    {
@@ -1446,29 +1415,6 @@ J9::CFG::getInterpreterProfilerBranchCountersOnDoubleton(TR::CFGNode *cfgNode, i
       else
          *nottaken = LOW_FREQ;
 
-      /*int32_t sumFreq = summarizeFrequencyFromPredecessors(cfgNode, this);
-
-      if (sumFreq>0)
-         {
-         *nottaken = sumFreq>>1;
-         *taken = *nottaken;
-         }
-      else
-         {
-         if (node->getByteCodeIndex()==0)
-            {
-            int32_t callCount = getParentCallCount(this, node);
-
-            // we don't know what the call count is, assign some
-            // moderate frequency
-            if (callCount<=0)
-               callCount = AVG_FREQ;
-
-            *taken = 0;
-            *nottaken = callCount;
-            }
-         }
-      */
       if (comp()->getOption(TR_TraceBFGeneration))
          dumpOptDetails(comp(),"If with no profiling information on node %p has low branch counts: taken=%d, not taken=%d\n", node, *taken, *nottaken);
       }


### PR DESCRIPTION
getParentCallCount() is a method in J9CFG.cpp that is only used in some dead (commented out) code.
Remove its definition and the dead code where it is referenced.