### PR TITLE
Re-enable IBM Java 8 compressedrefs native tests and disable thrstatetest

### DIFF
--- a/test/functional/DDR_Test/playlist.xml
+++ b/test/functional/DDR_Test/playlist.xml
@@ -241,13 +241,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>ibm_git/runtimes/backlog/issues/1654</comment>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-		</disables>
 		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \
@@ -275,13 +268,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode101</variation>
 			<variation>Mode601</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>ibm_git/runtimes/backlog/issues/1654</comment>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-		</disables>
 		<command>cp $(TEST_RESROOT)$(D)tck_ddrext.xml .; \
 	$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 	ant -DJAVA_COMMAND=$(JAVA_COMMAND) -DTEST_LIB_PATH=$(Q)-Djava.library.path=$(TEST_LIB_PATH_VALUE)$(Q) \

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -353,7 +353,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</variations>
 		<disables>
 			<disable>
-				<comment>ibm_git/runtimes/backlog/issues/1654</comment>
+				<comment>ibm_git/runtimes/backlog/issues/1659</comment>
 				<impl>ibm</impl>
 			</disable>
 		</disables>
@@ -490,6 +490,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
+		<disables>
+			<disable>
+				<comment>ibm_git/runtimes/backlog/issues/1659</comment>
+				<version>8</version>
+				<impl>ibm</impl>
+			</disable>
+		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 			$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest$(SQ) $(JVM_OPTIONS) -Djava.home=$(THRSTATETEST_JRE_HOME) -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \
 			$(TEST_STATUS)

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/playlist.xml
@@ -204,13 +204,6 @@
 			<variation>Mode110</variation>
 			<variation>Mode610</variation>
 		</variations>
-		<disables>
-			<disable>
-				<comment>ibm_git/runtimes/backlog/issues/1654</comment>
-				<version>8</version>
-				<impl>ibm</impl>
-			</disable>
-		</disables>
 		<command>cp $(Q)$(TEST_RESROOT)$(D)..$(D)URLHelperTests$(D)URLHelperTests.jar$(Q) .; \
 	true URLHelperTests.jar ;\
 	$(Q)$(TEST_JDK_HOME)$(D)bin$(D)jar$(EXECUTABLE_SUFFIX)$(Q) xf URLHelperTests.jar; \


### PR DESCRIPTION
Re-enable mixedrefs related tests since fixed, and exclude thrstatetest

Issue: Git_ibm/runtimes/backlog/issues/1659 and Git_ibm/runtimes/backlog/issues/1656