### PR TITLE
Do not add Own.Sync. object to the list if scan wasn't successful

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -322,8 +322,9 @@ private:
 	 * @param reservingContext[in] The context to which we would prefer to copy any objects discovered in this method
 	 * @param objectPtr current object being scanned.
 	 * @param reason to scan (dirty card, packet, scan cache, overflow)
+	 * @return true if all slots have been copied successfully
 	 */
-	void scanMixedObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
+	bool scanMixedObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
 	/**
 	 * Scan the slots of a reference mixed object.
 	 * Copy and forward all relevant slots values found in the object.


### PR DESCRIPTION
If Ownable Synchronizer object scan (regardless if for PACKET or COPY reason) has not been successful (caused Copy Forward Abort, when a child object fails to copy) it should not be added to the list right away. This object is remembered in the work packet and is going to be rescanned for the second time.

The existing logic is incorrect for the case when the original scan reason was PACKET (object still a part of Collection Set) and failed to scan - the object would be added twice (both on the first and the second scan isObjectInEvacuateMemoryNoCheck condition would be true).

This is a more correct variant of the first similar attempt to fix https://github.com/eclipse-openj9/openj9/pull/20589/, which would miss to add the object if originally scanned with COPY reason and failed during the scan - the object would neither be added on the first scan due to failed scanning nor be added on the second scan due to not being a part of CS (it's copied, in survivor memory).

It is also a more correct variant of the second attempt https://github.com/eclipse-openj9/openj9/pull/21857, which would incorrectly add the object if originally scanned with DIRTY_CARD (as Remembered Set, which is Root, not part of Collection Set) and failed during the scan, but would be (incorrectly) added on the rescan as being with PACKET
reason (lost info that original scan was DIRTY_CARD).