### PR TITLE
Fix is{Anonymous,Hidden}Class() for 64-bit big-endian JITServer

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2063,7 +2063,7 @@ TR_J9ServerVM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerC
 bool
 TR_J9ServerVM::isAnonymousClass(TR_OpaqueClassBlock *j9clazz)
    {
-   uintptr_t extraModifiers = 0;
+   uint32_t extraModifiers = 0;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)j9clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_ROMCLASS_EXTRAMODIFIERS, (void *)&extraModifiers);
 
@@ -2073,7 +2073,7 @@ TR_J9ServerVM::isAnonymousClass(TR_OpaqueClassBlock *j9clazz)
 bool
 TR_J9ServerVM::isHiddenClass(TR_OpaqueClassBlock *j9clazz)
    {
-   uintptr_t extraModifiers = 0;
+   uint32_t extraModifiers = 0;
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    JITServerHelpers::getAndCacheRAMClassInfo((J9Class *)j9clazz, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_ROMCLASS_EXTRAMODIFIERS, (void *)&extraModifiers);
 


### PR DESCRIPTION
For `CLASSINFO_ROMCLASS_EXTRAMODIFIERS` the result is `uint32_t`, but these call sites were passing a pointer to `uintptr_t`, which on 64-bit is twice as big as necessary. On a big-endian system, the result would be stored to the high half of the variable, leaving the low half zero, so these functions would return false for all classes.