### PR TITLE
JITServer: Recognize cross-loader superclasses in isSameOrSuperClass()

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -92,13 +92,6 @@ TR_J9ServerVM::isSameOrSuperClass(J9Class *superClass, J9Class *subClass)
    if (superClass == subClass) // same class
       return true;
 
-   void *superClassLoader, *subClassLoader;
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   JITServerHelpers::getAndCacheRAMClassInfo(superClass, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_LOADER, &superClassLoader);
-   JITServerHelpers::getAndCacheRAMClassInfo(subClass, _compInfoPT->getClientData(), stream, JITServerHelpers::CLASSINFO_CLASS_LOADER, &subClassLoader);
-   if (superClassLoader != subClassLoader)
-      return false;
-
    TR_OpaqueClassBlock *candidateSuperClassPtr = reinterpret_cast<TR_OpaqueClassBlock *>(superClass);
    TR_OpaqueClassBlock *classPtr = reinterpret_cast<TR_OpaqueClassBlock *>(subClass);
    // walk the hierarchy, trying to find a matching super class


### PR DESCRIPTION
It's possible for a class to be defined by a different loader than its superclass, in which case this method would incorrectly return false on JITServer. Now it will ignore class loaders like the base implementation does.

So far the incorrect result would only have caused the SVM to fail to notice that a class is a subclass of `Throwable` if the class was not defined by the bootstrap loader. Then it would remember such a class even though it's supposed to be considered not to be worth remembering.