### PR TITLE
Introduce SupportsInlineStringIndexOfString flag

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -442,14 +442,24 @@ public:
    void setSupportsInlineStringCaseConversion() { _j9Flags.set(SupportsInlineStringCaseConversion);}
 
    /** \brief
-    *    Determines whether the code generator supports inlining of java/lang/String.indexOf()
+    *    Determines whether the code generator supports inlining of java/lang/String.indexOf(int)
     */
    bool getSupportsInlineStringIndexOf() { return _j9Flags.testAny(SupportsInlineStringIndexOf);}
 
    /** \brief
-    *    The code generator supports inlining of java/lang/String.indexOf()
+    *    The code generator supports inlining of java/lang/String.indexOf(int)
     */
    void setSupportsInlineStringIndexOf() { _j9Flags.set(SupportsInlineStringIndexOf);}
+
+   /** \brief
+    *    Determines whether the code generator supports inlining of java/lang/String.indexOf(String)
+    */
+   bool getSupportsInlineStringIndexOfString() { return _j9Flags.testAny(SupportsInlineStringIndexOfString);}
+
+   /** \brief
+    *    The code generator supports inlining of java/lang/String.indexOf(String)
+    */
+   void setSupportsInlineStringIndexOfString() { _j9Flags.set(SupportsInlineStringIndexOfString);}
 
    /** \brief
    *    Determines whether the code generator supports inlining of java/lang/String.hashCode()
@@ -764,6 +774,7 @@ private:
       SupportsInlineMath_MaxMin_FD                        = 0x00010000,
       SupportsInlineUnsafeCompareAndSet                   = 0x00020000,
       SupportsInlineUnsafeCompareAndExchange              = 0x00040000,
+      SupportsInlineStringIndexOfString                   = 0x00080000, /*! codegen inlining of Java string index of string */
       };
 
    flags32_t _j9Flags;

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5630,15 +5630,20 @@ TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite
             return true;
             }
          break;
-      case TR::java_lang_StringLatin1_indexOf:
       case TR::java_lang_StringLatin1_indexOfChar:
-      case TR::java_lang_StringUTF16_indexOf:
       case TR::java_lang_StringUTF16_indexOfCharUnsafe:
-      case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
-      case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
          if (comp->cg()->getSupportsInlineStringIndexOf())
+            {
+            return true;
+            }
+         break;
+      case TR::java_lang_StringLatin1_indexOf:
+      case TR::java_lang_StringUTF16_indexOf:
+      case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
+      case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
+         if (comp->cg()->getSupportsInlineStringIndexOfString())
             {
             return true;
             }

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -92,6 +92,7 @@ J9::Z::CodeGenerator::initialize()
          && !TR::Compiler->om.canGenerateArraylets())
       {
       cg->setSupportsInlineStringIndexOf();
+      cg->setSupportsInlineStringIndexOfString();
       }
 
    if (cg->getSupportsVectorRegisters() && !comp->getOption(TR_DisableSIMDStringHashCode) && !TR::Compiler->om.canGenerateArraylets())
@@ -4231,6 +4232,15 @@ J9::Z::CodeGenerator::inlineDirectCall(
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
             resultReg = TR::TreeEvaluator::inlineIntrinsicIndexOf(node, cg, false);
             return true;
+         default:
+            break;
+         }
+      }
+
+   if (cg->getSupportsInlineStringIndexOfString())
+      {
+      switch (methodSymbol->getRecognizedMethod())
+         {
          case TR::java_lang_StringLatin1_indexOf:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
                resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, false);


### PR DESCRIPTION
The existing SupportsInlineStringIndexOf flag controls inlining of both String.indexOf(int) and String.indexOf(String).
This commit introduces a new flag SupportsInlineStringIndexOfString for String.indexOf(String).

Only Z codegen supports String.indexOf(String) at the moment.