### PR TITLE
Fix spelling of "supress"

### DIFF
--- a/runtime/compiler/optimizer/EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/EstimateCodeSize.cpp
@@ -137,9 +137,9 @@ TR_EstimateCodeSize::isInlineable(TR_CallStack * prevCallStack, TR_CallSite *cal
    heuristicTrace(tracer(),"Depth %d: Created Call Site %p for call found at bc index %d. Signature %s  Looking for call targets.",
                              _recursionDepth, callsite, callsite->_byteCodeIndex, tracer()->traceSignature(callsite));
 
-   if (_inliner->getPolicy()->supressInliningRecognizedInitialCallee(callsite, _inliner->comp()))
+   if (_inliner->getPolicy()->suppressInliningRecognizedInitialCallee(callsite, _inliner->comp()))
       {
-      heuristicTrace(tracer(),"Skip looking for call targets because supressInliningRecognizedInitialCallee is true for this call site %p\n", callsite);
+      heuristicTrace(tracer(), "Skip looking for call targets because suppressInliningRecognizedInitialCallee is true for this call site %p\n", callsite);
       return false;
       }
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5428,7 +5428,7 @@ TR_J9InlinerPolicy::validateArguments(TR_CallTarget *calltarget, TR_LinkHead<TR_
    }
 
 bool
-TR_J9InlinerPolicy::supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp)
+TR_J9InlinerPolicy::suppressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp)
    {
    TR::ResolvedMethodSymbol *initialCalleeSymbol = callsite->_initialCalleeSymbol;
    if (initialCalleeSymbol != NULL && initialCalleeSymbol->canReplaceWithHWInstr())

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -356,7 +356,7 @@ class TR_J9InlinerPolicy : public OMR_InlinerPolicy
       bool _tryToGenerateILForMethod (TR::ResolvedMethodSymbol* calleeSymbol, TR::ResolvedMethodSymbol* callerSymbol, TR_CallTarget* calltarget);
       bool doCorrectnessAndSizeChecksForInlineCallTarget(TR_CallStack *callStack, TR_CallTarget *calltarget, bool inlinefromgraph, TR_PrexArgInfo *argInfo);
       bool validateArguments(TR_CallTarget *calltarget, TR_LinkHead<TR_ParameterMapping> &map);
-      virtual bool supressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
+      virtual bool suppressInliningRecognizedInitialCallee(TR_CallSite* callsite, TR::Compilation* comp);
       virtual TR_InlinerFailureReason checkIfTargetInlineable(TR_CallTarget* target, TR_CallSite* callsite, TR::Compilation* comp);
       /** \brief
        *     This query decides whether the given method is JSR292 related


### PR DESCRIPTION
This commit fixes the misspelled function name
supressInliningRecognizedInitialCallee().