### PR TITLE
Add _AE_BIMODAL to support OMR_ISDIGIT macro

### DIFF
--- a/runtime/compiler/build/toolcfg/zos-xlc/common.mk
+++ b/runtime/compiler/build/toolcfg/zos-xlc/common.mk
@@ -110,6 +110,7 @@ CX_FLAGS+=\
     -qnosearch \
     $(patsubst %,-I%,$(PRODUCT_INCLUDES)) \
     -DIBM_ATOE \
+    -D_AE_BIMODAL \
     -Wc,"convlit(ISO8859-1)" \
     -qsearch=$(J9SRC)/a2e/headers \
     -qsearch=$(J9SRC)/zos_zlib/hzc/include \

--- a/runtime/makelib/targets.mk.zos.inc.ftl
+++ b/runtime/makelib/targets.mk.zos.inc.ftl
@@ -70,7 +70,7 @@ endif
 
 # _ISOC99_SOURCE Exposes c99 standard library changes which dont require c99 compiler support. (Also needed for c++, see below)
 # __STDC_LIMIT_MACROS Is needed to expose limit macros from <stdint.h> on c++ (also requires _ISOC99_SOURCE)
-UMA_ZOS_FLAGS += -DJ9ZOS390 -DLONGLONG -DJ9VM_TIERED_CODE_CACHE -D_ALL_SOURCE -D_XOPEN_SOURCE_EXTENDED -DIBM_ATOE -D_POSIX_SOURCE -D_ISOC99_SOURCE -D__STDC_LIMIT_MACROS
+UMA_ZOS_FLAGS += -DJ9ZOS390 -DLONGLONG -DJ9VM_TIERED_CODE_CACHE -D_ALL_SOURCE -D_XOPEN_SOURCE_EXTENDED -DIBM_ATOE -D_AE_BIMODAL -D_POSIX_SOURCE -D_ISOC99_SOURCE -D__STDC_LIMIT_MACROS
 UMA_ZOS_FLAGS += -I$(OMR_DIR)/util/a2e/headers $(UMA_OPTIMIZATION_FLAGS) $(UMA_OPTIMIZATION_LINKER_FLAGS) \
 	-Wc,"convlit(ISO8859-1),xplink,rostring,FLOAT(IEEE,FOLD,AFP),enum(4)" -Wa,goff -Wc,NOANSIALIAS -Wc,"inline(auto,noreport,600,5000)"
 UMA_ZOS_FLAGS += -Wc,"SERVICE(j${uma.buildinfo.build_date})"


### PR DESCRIPTION
OMR_ISDIGIT macro added to omrcomp.h requires _AE_BIMODAL to be defined in order to make isdigit_a() to be available. This defines it in the appropriate contexts for the z/OS builds.

This change is associated with https://github.com/eclipse-omr/omr/pull/7761

@keithc-ca @babsingh 

context tag: open xl 