### PR TITLE
Disable System.nanoTime acceleration under AOT on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -228,8 +228,13 @@ J9::Z::CodeGenerator::initialize()
    // Enable high-resolution timer for System.nanoTime() unless we need to support checkpointing (i.e. snapshot mode), which requires
    // that we adjust nanoTime() after restoring checkpoints. This adjustment is currently not implemented for the high res timer, hence
    // we need to stick to the Java nanoTime() implementation.
-   if (!fej9->isSnapshotModeEnabled())
+   // In case of generating a portable code, even though we would not suffer the same issue of adjustment required, in case such code is
+   // used in application that will be checkpointed, it will suffer the same issue of unsupported nanoTime() adjustment for high res timer.
+   // As currently Snapshot mode is available on Linux on Z only, disabling the acceleration on Linux when we are generating portable code.
+   if (!(fej9->isSnapshotModeEnabled() || (comp->target().isLinux() && comp->compilePortableCode())))
+      {
       cg->setSupportsCurrentTimeMaxPrecision();
+      }
 
    // Support BigDecimal Long Lookaside versioning optimizations.
    if (!comp->getOption(TR_DisableBDLLVersioning))


### PR DESCRIPTION
A portable AOT code that accelerates the System.nanoTime can end up being loaded and executed in checkpointed images which could provide incorrect output and lead to unexpected behavior in checkpointed image. This change disables the acceleration when we are performing portable compiles.

Fixes: eclipse-openj9#21654