### PR TITLE
Add NULL check for moduleObject in GC

### DIFF
--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -88,8 +88,9 @@ MM_RootScanner::scanModularityObjects(J9ClassLoader * classLoader)
 		J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
 		while (NULL != modulePtr) {
 			J9Module * const module = *modulePtr;
-
-			doSlot(&module->moduleObject);
+			if (NULL != module->moduleObject) {
+				doSlot(&module->moduleObject);
+			}
 			if (NULL != module->version) {
 				doSlot(&module->version);
 			}
@@ -97,7 +98,9 @@ MM_RootScanner::scanModularityObjects(J9ClassLoader * classLoader)
 		}
 
 		if (classLoader == _javaVM->systemClassLoader) {
-			doSlot(&_javaVM->unnamedModuleForSystemLoader->moduleObject);
+			if (NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject) {
+				doSlot(&_javaVM->unnamedModuleForSystemLoader->moduleObject);
+			}
 		}
 	}
 }

--- a/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
+++ b/runtime/gc_glue_java/ConcurrentMarkingDelegate.cpp
@@ -397,8 +397,9 @@ MM_ConcurrentMarkingDelegate::concurrentClassMark(MM_EnvironmentBase *env, bool 
 					J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
 					while (NULL != modulePtr) {
 						J9Module * const module = *modulePtr;
-
-						_markingScheme->markObject(env, (j9object_t)module->moduleObject);
+						if (NULL != module->moduleObject) {
+							_markingScheme->markObject(env, (j9object_t)module->moduleObject);
+						}
 						if (NULL != module->version) {
 							_markingScheme->markObject(env, (j9object_t)module->version);
 						}
@@ -409,7 +410,9 @@ MM_ConcurrentMarkingDelegate::concurrentClassMark(MM_EnvironmentBase *env, bool 
 					}
 
 					if (classLoader == _javaVM->systemClassLoader) {
-						_markingScheme->markObject(env, _javaVM->unnamedModuleForSystemLoader->moduleObject);
+						if (NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject) {
+							_markingScheme->markObject(env, _javaVM->unnamedModuleForSystemLoader->moduleObject);
+						}
 					}
 				}
 

--- a/runtime/gc_glue_java/MarkingDelegate.cpp
+++ b/runtime/gc_glue_java/MarkingDelegate.cpp
@@ -454,8 +454,9 @@ MM_MarkingDelegate::completeMarking(MM_EnvironmentBase *env)
 									J9Module **modulePtr = (J9Module**)hashTableStartDo(classLoader->moduleHashTable, &moduleWalkState);
 									while (NULL != modulePtr) {
 										J9Module * const module = *modulePtr;
-
-										_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->moduleObject);
+										if (NULL != module->moduleObject) {
+											_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->moduleObject);
+										}
 										if (NULL != module->version) {
 											_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )module->version);
 										}
@@ -463,7 +464,9 @@ MM_MarkingDelegate::completeMarking(MM_EnvironmentBase *env)
 									}
 
 									if (classLoader == javaVM->systemClassLoader) {
-										_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )javaVM->unnamedModuleForSystemLoader->moduleObject);
+										if (NULL != javaVM->unnamedModuleForSystemLoader->moduleObject) {
+											_markingScheme->markObjectNoCheck(env, (omrobjectptr_t )javaVM->unnamedModuleForSystemLoader->moduleObject);
+										}
 									}
 								}
 							}

--- a/runtime/gc_glue_java/MetronomeDelegate.cpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.cpp
@@ -1040,14 +1040,19 @@ MM_MetronomeDelegate::doClassTracing(MM_EnvironmentRealtime *env)
 						J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
 						while (NULL != modulePtr) {
 							J9Module * const module = *modulePtr;
-
-							didWork |= _markingScheme->markObject(env, module->moduleObject);
-							didWork |= _markingScheme->markObject(env, module->version);
+							if (NULL != module->moduleObject) {
+								didWork |= _markingScheme->markObject(env, module->moduleObject);
+							}
+							if (NULL != module->version) {
+								didWork |= _markingScheme->markObject(env, module->version);
+							}
 							modulePtr = (J9Module**)hashTableNextDo(&walkState);
 						}
 
 						if (classLoader == _javaVM->systemClassLoader) {
-							didWork |= _markingScheme->markObject(env, _javaVM->unnamedModuleForSystemLoader->moduleObject);
+							if (NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject) {
+								didWork |= _markingScheme->markObject(env, _javaVM->unnamedModuleForSystemLoader->moduleObject);
+							}
 						}
 					}
 				}

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2734,7 +2734,9 @@ MM_CopyForwardScheme::scanClassLoaderObjectSlots(MM_EnvironmentVLHGC *env, MM_Al
 				J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
 				while (success && (NULL != modulePtr)) {
 					J9Module * const module = *modulePtr;
-					success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->moduleObject));
+					if (NULL != module->moduleObject) {
+						success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->moduleObject));
+					}
 					if (success) {
 						if (NULL != module->version) {
 							success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(module->version));
@@ -2744,7 +2746,9 @@ MM_CopyForwardScheme::scanClassLoaderObjectSlots(MM_EnvironmentVLHGC *env, MM_Al
 				}
 
 				if (success && (classLoader == _javaVM->systemClassLoader)) {
-					success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(_javaVM->unnamedModuleForSystemLoader->moduleObject));
+					if (NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject) {
+						success = copyAndForward(env, reservingContext, classLoaderObject, (J9Object **)&(_javaVM->unnamedModuleForSystemLoader->moduleObject));
+					}
 				}
 			}
 		}
@@ -4526,7 +4530,9 @@ MM_CopyForwardScheme::scanRoots(MM_EnvironmentVLHGC *env)
 									J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
 									while (success && (NULL != modulePtr)) {
 										J9Module * const module = *modulePtr;
-										success = copyAndForward(env, getContextForHeapAddress(module->moduleObject), (J9Object **)&(module->moduleObject));
+										if (NULL != module->moduleObject) {
+											success = copyAndForward(env, getContextForHeapAddress(module->moduleObject), (J9Object **)&(module->moduleObject));
+										}
 										if (success) {
 											if (NULL != module->version) {
 												success = copyAndForward(env, getContextForHeapAddress(module->version), (J9Object **)&(module->version));
@@ -4536,7 +4542,11 @@ MM_CopyForwardScheme::scanRoots(MM_EnvironmentVLHGC *env)
 									}
 
 									if (success && (classLoader == _javaVM->systemClassLoader)) {
-										success = copyAndForward(env, getContextForHeapAddress(_javaVM->unnamedModuleForSystemLoader->moduleObject), (J9Object **)&(_javaVM->unnamedModuleForSystemLoader->moduleObject));
+										if (NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject) {
+											success = copyAndForward(
+													env, getContextForHeapAddress(_javaVM->unnamedModuleForSystemLoader->moduleObject),
+													(J9Object **)&(_javaVM->unnamedModuleForSystemLoader->moduleObject));
+										}
 									}
 								}
 							}

--- a/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkCardScrubber.cpp
@@ -307,8 +307,9 @@ MM_GlobalMarkCardScrubber::scrubClassLoaderObject(MM_EnvironmentVLHGC *env, J9Ob
 			J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
 			while (doScrub && (NULL != modulePtr)) {
 				J9Module * const module = *modulePtr;
-				Assert_MM_true(NULL != module->moduleObject);
-				doScrub = mayScrubReference(env, classLoaderObject, module->moduleObject);
+				if (NULL != module->moduleObject) {
+					doScrub = mayScrubReference(env, classLoaderObject, module->moduleObject);
+				}
 				if (doScrub) {
 					doScrub = mayScrubReference(env, classLoaderObject, module->version);
 				}
@@ -316,9 +317,10 @@ MM_GlobalMarkCardScrubber::scrubClassLoaderObject(MM_EnvironmentVLHGC *env, J9Ob
 			}
 
 			if (classLoader == javaVM->systemClassLoader) {
-				Assert_MM_true(NULL != javaVM->unnamedModuleForSystemLoader->moduleObject);
 				if (doScrub) {
-					doScrub = mayScrubReference(env, classLoaderObject, javaVM->unnamedModuleForSystemLoader->moduleObject);
+					if (NULL != javaVM->unnamedModuleForSystemLoader->moduleObject) {
+						doScrub = mayScrubReference(env, classLoaderObject, javaVM->unnamedModuleForSystemLoader->moduleObject);
+					}
 				}
 			}
 		}

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -926,9 +926,10 @@ MM_GlobalMarkingScheme::scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object
 			J9Module **modulePtr = (J9Module **)hashTableStartDo(classLoader->moduleHashTable, &walkState);
 			while (NULL != modulePtr) {
 				J9Module * const module = *modulePtr;
-				Assert_MM_true(NULL != module->moduleObject);
-				markObject(env, module->moduleObject);
-				rememberReferenceIfRequired(env, classLoaderObject, module->moduleObject);
+				if (NULL != module->moduleObject) {
+					markObject(env, module->moduleObject);
+					rememberReferenceIfRequired(env, classLoaderObject, module->moduleObject);
+				}
 				if (NULL != module->version) {
 					markObject(env, module->version);
 					rememberReferenceIfRequired(env, classLoaderObject, module->version);
@@ -937,9 +938,10 @@ MM_GlobalMarkingScheme::scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object
 			}
 
 			if (classLoader == _javaVM->systemClassLoader) {
-				Assert_MM_true(NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject);
-				markObject(env, _javaVM->unnamedModuleForSystemLoader->moduleObject);
-				rememberReferenceIfRequired(env, classLoaderObject, _javaVM->unnamedModuleForSystemLoader->moduleObject);
+				if (NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject) {
+					markObject(env, _javaVM->unnamedModuleForSystemLoader->moduleObject);
+					rememberReferenceIfRequired(env, classLoaderObject, _javaVM->unnamedModuleForSystemLoader->moduleObject);
+				}
 			}
 		}
 	}

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -1366,14 +1366,14 @@ MM_WriteOnceCompactor::fixupClassLoaderObject(MM_EnvironmentVLHGC* env, J9Object
 				J9Module * const module = *modulePtr;
 
 				slotPtr = &module->moduleObject;
-
 				originalObject = *slotPtr;
-				J9Object* forwardedObject = getForwardWrapper(env, originalObject, cache);
-				*slotPtr = forwardedObject;
-				_interRegionRememberedSet->rememberReferenceForCompact(env, classLoaderObject, forwardedObject);
+				if (NULL != originalObject) {
+					J9Object* forwardedObject = getForwardWrapper(env, originalObject, cache);
+					*slotPtr = forwardedObject;
+					_interRegionRememberedSet->rememberReferenceForCompact(env, classLoaderObject, forwardedObject);
+				}
 
 				slotPtr = &module->version;
-
 				originalObject = *slotPtr;
 				if (NULL != originalObject) {
 					J9Object* forwardedObject = getForwardWrapper(env, originalObject, cache);
@@ -1385,6 +1385,12 @@ MM_WriteOnceCompactor::fixupClassLoaderObject(MM_EnvironmentVLHGC* env, J9Object
 			}
 
 			if (classLoader == _javaVM->systemClassLoader) {
+
+				Assert_GC_true_with_message(
+						env, (NULL != _javaVM->unnamedModuleForSystemLoader->moduleObject),
+						"Unnamed Module For System Loader %p has moduleObject set to NULL\n",
+						_javaVM->unnamedModuleForSystemLoader);
+
 				slotPtr = &_javaVM->unnamedModuleForSystemLoader->moduleObject;
 
 				originalObject = *slotPtr;


### PR DESCRIPTION
Current behaviour j9module should have moduleObject set when GC
discovers it has been changed in Java 21 by adding Java API to set a few
special module objects. It introduces a case when GC can see NULL in
moduleObject slot. Resolving this problem for GC by simple unconditional
NULL check applicable for any module.