### PR TITLE
Revert "x86: Reduce AVX-SSE mixing penalties"

### DIFF
--- a/runtime/oti/xhelpers.m4
+++ b/runtime/oti/xhelpers.m4
@@ -20,19 +20,6 @@ dnl SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpat
 
 include(jilvalues.m4)
 
-define({INC_VZU_COUNT},{define({VZU_COUNT},incr(VZU_COUNT))})
-
-define({EMIT_VZEROUPPER_IF_AVX}, {
-	INC_VZU_COUNT()
-	mov r8, J9TR_VMThread_javaVM[J9VMTHREAD]
-	test dword ptr J9TR_JavaVM_extendedRuntimeFlags[r8], J9TR_J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS
-	jz LABEL(skip_vzu{}VZU_COUNT)
-
-	vzeroupper
-
-	LABEL(skip_vzu{}VZU_COUNT):
-})
-
 J9CONST({CINTERP_STACK_SIZE},J9TR_cframe_sizeof)
 
 ifdef({WIN32},{
@@ -322,7 +309,6 @@ define({SAVE_C_VOLATILE_REGS},{
 	mov qword ptr J9TR_cframe_r9[_rsp],r9
 	mov qword ptr J9TR_cframe_r10[_rsp],r10
 	mov qword ptr J9TR_cframe_r11[_rsp],r11
-	EMIT_VZEROUPPER_IF_AVX()
 ifdef({METHOD_INVOCATION},{
 	movq qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp],xmm0
 	movq qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp],xmm1
@@ -385,7 +371,6 @@ define({SAVE_C_NONVOLATILE_REGS},{
 ifdef({METHOD_INVOCATION},{
 dnl xmm6-7 are preserved as they are JIT FP arguments which may need
 dnl to be read in order to decompile.  They do not need to be restored.
-	EMIT_VZEROUPPER_IF_AVX()
 	movq qword ptr J9TR_cframe_jitFPRs+(6*8)[_rsp],xmm6
 	movq qword ptr J9TR_cframe_jitFPRs+(7*8)[_rsp],xmm7
 }) dnl METHOD_INVOCATION
@@ -413,7 +398,6 @@ define({SAVE_C_VOLATILE_REGS},{
 	mov qword ptr J9TR_cframe_r9[_rsp],r9
 	mov qword ptr J9TR_cframe_r10[_rsp],r10
 	mov qword ptr J9TR_cframe_r11[_rsp],r11
-	EMIT_VZEROUPPER_IF_AVX()
 ifdef({METHOD_INVOCATION},{
 	movq qword ptr J9TR_cframe_jitFPRs+(0*8)[_rsp],xmm0
 	movq qword ptr J9TR_cframe_jitFPRs+(1*8)[_rsp],xmm1
@@ -543,7 +527,6 @@ define({SAVE_C_VOLATILE_REGS},{
 ifdef({METHOD_INVOCATION},{
 dnl No FP parameter registers
 },{ dnl METHOD_INVOCATION
-	EMIT_VZEROUPPER_IF_AVX()
 	movdqa J9TR_cframe_jitFPRs+(0*16)[_rsp],xmm0
 	movdqa J9TR_cframe_jitFPRs+(1*16)[_rsp],xmm1
 	movdqa J9TR_cframe_jitFPRs+(2*16)[_rsp],xmm2

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1222,25 +1222,28 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	}
 #endif /* J9VM_OPT_JITSERVER */
 
-#if defined(J9HAMMER)
+/*
+ * Disable AVX+ vector register preservation on x86 due to a large performance regression.
+ * Issue: #15716
+ */
+#if defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17) && 0
 {
 	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 	OMRProcessorDesc desc;
 	omrsysinfo_get_processor_description(&desc);
 
-	/*
-	 * Set runtime flag J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS
-	 * if AVX is supported. This is used to determine if the vzeroupper
-	 * instruction is needed in JIT helper code to avoid performance
-	 * penalties when transitioning between AVX and legacy SSE code.
-	 */
-	if (omrsysinfo_processor_has_feature(&desc, OMR_FEATURE_X86_AVX)
-		&& omrsysinfo_processor_has_feature(&desc, OMR_FEATURE_X86_XSAVE_AVX)
+	if (omrsysinfo_processor_has_feature(&desc, OMR_FEATURE_X86_AVX512F)
+	&&  omrsysinfo_processor_has_feature(&desc, OMR_FEATURE_X86_AVX512BW)
 	) {
+		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
+		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS;
+	} else if (omrsysinfo_processor_has_feature(&desc, OMR_FEATURE_X86_AVX512F)) {
+		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_EXTENDED_VECTOR_REGISTERS;
+	} else if (omrsysinfo_processor_has_feature(&desc, OMR_FEATURE_X86_AVX)) {
 		vm->extendedRuntimeFlags |= J9_EXTENDED_RUNTIME_USE_VECTOR_REGISTERS;
 	}
 }
-#endif /* defined(J9HAMMER) */
+#endif /* defined(J9HAMMER) && (JAVA_SPEC_VERSION >= 17) && 0 */
 
 	initArgs.j2seVersion = createParams->j2seVersion;
 	initArgs.j2seRootDirectory = createParams->j2seRootDirectory;


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#21924

See https://github.com/eclipse-openj9/openj9/pull/21924#issuecomment-2914042755