### PR TITLE
Enable bigCallee size adjustment during ECS for JDK8 and 11

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -1838,13 +1838,7 @@ TR_J9EstimateCodeSize::realEstimateCodeSize(TR_CallTarget *calltarget, TR_CallSt
                         }
                      }
 
-#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
                   int32_t bigCalleesSizeBelowMe = _bigCalleesSize - origBigCalleesSize;
-#else
-                  // Temporarily disable bigCalleeSize adjustment for OpenJ9 MethodHandle implementation as it exposes a functional issue
-                  // with the change in inlining behaviour resulting from this big callee adjustment.
-                  int32_t bigCalleesSizeBelowMe = 0;
-#endif /* J9VM_OPT_OPENJDK_METHODHANDLE */
                   if ((_analyzedSize - origAnalyzedSize - bigCalleesSizeBelowMe) > bigCalleeThreshold)
                      {
                      ///printf("set warmcallgraphtoobig for method %s at index %d\n", calleeName, newBCInfo._byteCodeIndex);fflush(stdout);


### PR DESCRIPTION
During EstimateCodeSize, if we came across a callee method that was deemed too big, and therefore, set to be discarded as an inlining candidate, a size adjustment for other methods above such methods is necessary to ensure the entire call graph does not get marked as too big. For JDK8 and 11, this adjustment was disabled due to a functional issue that was exposed due to the different inlining outcome from this adjustment. This change removes the restriction that was in place as a workaround, and fixes performance issues resulting from early ECS termination in JDK8 and 11.

The restriction placed to avoid any functional issues until JDK8 and 11 builds switch to using OpenJDK MethodHandle implementation is to terminate recursive ECS once we reach a MethodHandle thunk archetype.

With the initial attempt to have this be in effect across all Java versions, we ran into test failures across several platforms with JDK8 and 11, detailed in #21397. Test failures reported in #21397 are no longer reproducible with the current set of inliner changes that have been contributed over the past few months. Attempting to reproduce those test failures with the change in this PR has been unsuccessful in [60X Grinder on Aarch64 Linux (JDK11)](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/50992/). Furthermore, no failures were seen in a [100X Grinder job on X86_64 Linux (JDK11)](https://hyc-runtimes-jenkins.swg-devops.com/job/Grinder/50995/), in which over half of the test iterations have completed as of now.

Recently, the WAS perf team observed a regression using IBM Java 8 caused by the ECS issue that this PR is going to address. In addition to fixing the perf regression, an additional 2.8% performance gain was observed compared to the pre-regression baseline build. Given the significant perf impact this change has, I would like to propose that this change is double-delivered for the 0.53 release branch. @vijaysun-omr @vij-singh @pshipton Please let me know your thoughts on whether we have enough justification to double deliver this.

@vijaysun-omr Also, requesting your review of this change.