### PR TITLE
Return branch counters info only for branches

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -2160,7 +2160,18 @@ void
 TR_IProfiler::getBranchCounters(TR::Node *node, TR::TreeTop *fallThroughTree, int32_t *taken, int32_t *notTaken, TR::Compilation *comp)
    {
    static bool traceIProfiling = ((debug("traceIProfiling") != NULL));
-   uintptr_t data = getProfilingData (node, comp);
+
+   // Ensure that we call getProfilingData() only for branch bytecodes
+   uintptr_t pc = getSearchPC(getMethodFromNode(node, comp), node->getByteCodeInfo().getByteCodeIndex(), comp);
+   uint8_t bytecode = *((U_8*)pc);
+   if (!isCompact(bytecode))
+      {
+      *taken = 0;
+      *notTaken = 0;
+      return;
+      }
+
+   uintptr_t data = getProfilingData(node, comp);
 
    if (data)
       {


### PR DESCRIPTION
Sometimes the ILGenerator creates nodes/trees/blocks that are not directly connected to Java bytecodes. A case in point is the Guarded Counting Recompilation logic. In other cases one bytecode can be transformed into several nodes that represent branches like in the following `instanceof` example:
```
n23n      BBStart <block_35>                                                                  [0x7f6596481b80] bci=[-1,311,1059] rc=0 vc=0 vn=- li=- udi=- nc=0
n442n     treetop                                                                             [0x7f65964f49e0] bci=[-1,313,1059] rc=0 vc=0 vn=- li=- udi=- nc=1
n229n       aload  f<auto slot 7>[#441  Auto] [flags 0x7 0x0 ]                                [0x7f65964f0750] bci=[-1,311,1059] rc=3 vc=0 vn=- li=- udi=- nc=0
n445n     astore  <temp slot 22>[#489  Auto] [flags 0x7 0x0 ]                                 [0x7f65964f4ad0] bci=[-1,0,1018] rc=0 vc=0 vn=- li=- udi=- nc=1
n229n       ==>aload
n452n     ifacmpeq --> block_60 BBStart at n449n ()                                           [0x7f65964f4d00] bci=[-1,313,1059] rc=0 vc=0 vn=- li=- udi=- nc=2 flg=0x20
n229n       ==>aload
n451n       aconst NULL (X==0 X>=0 X<=0 )                                                     [0x7f65964f4cb0] bci=[-1,313,1059] rc=1 vc=0 vn=- li=- udi=- nc=0 flg=0x302
n444n     BBEnd </block_35> =====                                                             [0x7f65964f4a80] bci=[-1,313,1059] rc=0 vc=0 vn=- li=- udi=- nc=0

n443n     BBStart <block_58>                                                                  [0x7f65964f4a30] bci=[-1,313,1059] rc=0 vc=0 vn=- li=- udi=- nc=0
n461n     ResolveCHK [#347]                                                                   [0x7f65964f4fd0] bci=[-1,313,1059] rc=0 vc=0 vn=- li=- udi=- nc=1
n459n       loadaddr  unknown class object[#474  unresolved Static] [flags 0x18307 0x0 ]      [0x7f65964f4f30] bci=[-1,313,1059] rc=2 vc=0 vn=- li=- udi=- nc=0
n456n     istore  <temp slot 23>[#490  Auto] [flags 0x3 0x0 ]                                 [0x7f65964f4e40] bci=[-1,313,1059] rc=0 vc=0 vn=- li=- udi=- nc=1
n457n       instanceof  jitInstanceOf[#88  helper Method] [flags 0x400 0x0 ]                  [0x7f65964f4e90] bci=[-1,313,1059] rc=1 vc=0 vn=- li=- udi=- nc=2
n458n         aload  <temp slot 22>[#489  Auto] [flags 0x7 0x0 ]                              [0x7f65964f4ee0] bci=[-1,0,1018] rc=1 vc=0 vn=- li=- udi=- nc=0
n459n         ==>loadaddr
n448n     BBEnd </block_58> =====                                                             [0x7f65964f4bc0] bci=[-1,313,1059] rc=0 vc=0 vn=- li=- udi=- nc=0
```
Given a branch node, the JIT may obtain the ByteCodeInfo associated with it, get the byteCodeIndex and ask the IProfiler for information about that bytecode. However, that bytecode could be a non-branch one. In the example above the JIT would like to get the branch counters for node n452n. The bytecode index is 313 and corresponds to a "instanceof" bytecode. The IProfiler finds the profiling information for that "instanceof" bytecode and returns the J9Class for the dominant target. This J9Class is wrongly interpreted as branch taken/not-taken information.

This commit adds a check in `TR_IProfiler::getBranchCounters()` so that it returns information only if the profiled bytecode is a branch.