### PR TITLE
Add API for GC ID to use in JFR events

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -207,6 +207,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_get_object_size_in_bytes,
 	j9gc_get_object_total_footprint_in_bytes,
 	j9gc_get_explicit_GC_disabled,
+	j9gc_get_unique_GC_count,
 	j9gc_modron_global_collect,
 	j9gc_modron_global_collect_with_overrides,
 	j9gc_modron_local_collect,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -171,6 +171,7 @@ extern J9_CFUNC void j9gc_finalizer_shutdown(J9JavaVM * vm);
 extern J9_CFUNC UDATA j9gc_get_object_size_in_bytes(J9JavaVM* javaVM, j9object_t objectPtr);
 extern J9_CFUNC UDATA j9gc_get_object_total_footprint_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 extern J9_CFUNC BOOLEAN j9gc_get_explicit_GC_disabled(J9JavaVM *javaVM);
+extern J9_CFUNC UDATA j9gc_get_unique_GC_count(J9JavaVM *javaVM);
 extern J9_CFUNC UDATA j9gc_objaccess_compressedPointersShift(J9VMThread *vmThread);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreU64Split(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile);
 extern J9_CFUNC void cleanupMutatorModelJava(J9VMThread* vmThread);

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -991,6 +991,50 @@ j9gc_get_explicit_GC_disabled(J9JavaVM *javaVM)
 }
 
 /**
+ * API to return a unique GC ID based on all counts
+ *
+ * @parm[in] javaVM The J9JavaVM
+ * @return unique GC ID count
+ */
+UDATA
+j9gc_get_unique_GC_count(J9JavaVM *javaVM)
+{
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(javaVM);
+	OMR_VM *omrVm = javaVM->omrVM;
+	U_64 result = 0;
+
+	switch (omrVm->gcPolicy) {
+		case OMR_GC_POLICY_OPTTHRUPUT:
+		case OMR_GC_POLICY_OPTAVGPAUSE:
+		case OMR_GC_POLICY_METRONOME:
+			result = extensions->globalGCStats.gcCount;
+			break;
+
+		case OMR_GC_POLICY_GENCON:
+			result = extensions->globalGCStats.gcCount;
+#if defined(OMR_GC_MODRON_SCAVENGER)
+			result += extensions->scavengerStats._gcCount;
+#endif
+			break;
+
+		case OMR_GC_POLICY_BALANCED:
+#if defined(OMR_GC_VLHGC)
+			result = extensions->globalVLHGCStats.gcCount;
+#endif
+			break;
+
+		case OMR_GC_POLICY_NOGC:
+			break;
+
+		default :
+			/* Unknown GC policy */
+			Assert_MM_unreachable();
+			break;
+	}
+	return result;
+}
+
+/**
  * Called whenever the allocation threshold values or enablement state changes.
  * 
  * @parm[in] currentThread The current VM Thread

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -91,6 +91,7 @@ const char *j9gc_get_gcmodestring(J9JavaVM *javaVM);
 UDATA j9gc_get_object_size_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 UDATA j9gc_get_object_total_footprint_in_bytes(J9JavaVM *javaVM, j9object_t objectPtr);
 BOOLEAN j9gc_get_explicit_GC_disabled(J9JavaVM *javaVM);
+UDATA j9gc_get_unique_GC_count(J9JavaVM *javaVM);
 j9object_t j9gc_get_memoryController(J9VMThread *vmContext, j9object_t objectPtr);
 void j9gc_set_memoryController(J9VMThread *vmThread, j9object_t objectPtr, j9object_t memoryController);
 void j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4880,6 +4880,7 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA  ( *j9gc_get_object_size_in_bytes)(struct J9JavaVM* javaVM, j9object_t objectPtr) ;
 	UDATA  ( *j9gc_get_object_total_footprint_in_bytes)(struct J9JavaVM *javaVM, j9object_t objectPtr);
 	BOOLEAN ( *j9gc_get_explicit_GC_disabled)(struct J9JavaVM *javaVM) ;
+	UDATA  ( *j9gc_get_unique_GC_count)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_modron_global_collect)(struct J9VMThread *vmThread) ;
 	UDATA  ( *j9gc_modron_global_collect_with_overrides)(struct J9VMThread *vmThread, U_32 overrideFlags) ;
 	UDATA  ( *j9gc_modron_local_collect)(struct J9VMThread *vmThread) ;


### PR DESCRIPTION
This change adds an api call to get a unique ID for each GC for use in JFR events.