### PR TITLE
Fold calls to Invokers.checkVarHandleGenericType into its result

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1272,6 +1272,13 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, mhIndex, mhObj);
          }
          break;
+      case MessageType::VM_getVarHandleAccessDescriptorMode:
+         {
+         auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
+         int32_t result = fe->getVarHandleAccessDescriptorMode(comp, std::get<0>(recv));
+         client->write(response, result);
+         }
+         break;
       case MessageType::VM_getLayoutVarHandle:
          {
          auto recv = client->getRecvData<TR::KnownObjectTable::Index>();

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -444,6 +444,16 @@ public:
       }
 
    /**
+    * @brief Get the int32 value in the VarHandle$AccessDescriptor's mode field. This value is used as the index of the MethodHandle for
+    * the access mode in the MethodHandle table.
+    *
+    * @param comp the compilation
+    * @param adIndex the AccessDescriptor known object index
+    * @return int32_t the value in the mode field. -1 if unsuccessful.
+    */
+   virtual int32_t getVarHandleAccessDescriptorMode(TR::Compilation *comp, TR::KnownObjectTable::Index adIndex);
+
+   /**
     * @brief Get the known object index of a MethodHandle cached in a VarHandle's MH table
     * corresponding to the access descriptor. When the VarHandle is known, we can evaluate
     * the result of java/lang/invoke/Invokers.checkVarHandleGenericType at compile time and

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2504,6 +2504,19 @@ TR_J9ServerVM::getVMIndexOffset()
    return vmInfo->_vmindexOffset;
    }
 
+int32_t
+TR_J9ServerVM::getVarHandleAccessDescriptorMode(TR::Compilation *comp, TR::KnownObjectTable::Index adIndex)
+   {
+   TR::KnownObjectTable *knot = comp->getKnownObjectTable();
+   if (!knot) return -1;
+
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_getVarHandleAccessDescriptorMode, adIndex);
+   auto recv = stream->read<int32_t>();
+
+   return std::get<0>(recv);
+   }
+
 TR::KnownObjectTable::Index
 TR_J9ServerVM::getMethodHandleTableEntryIndex(TR::Compilation *comp, TR::KnownObjectTable::Index vhIndex, TR::KnownObjectTable::Index adIndex)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -258,6 +258,7 @@ public:
    virtual TR::KnownObjectTable::Index delegatingMethodHandleTargetHelper( TR::Compilation *comp, TR::KnownObjectTable::Index dmhIndex, TR_OpaqueClassBlock *cwClass) override;
    virtual UDATA getVMTargetOffset() override;
    virtual UDATA getVMIndexOffset() override;
+   virtual int32_t getVarHandleAccessDescriptorMode(TR::Compilation *comp, TR::KnownObjectTable::Index adIndex) override;
    virtual TR::KnownObjectTable::Index getMethodHandleTableEntryIndex(TR::Compilation *comp, TR::KnownObjectTable::Index vhIndex, TR::KnownObjectTable::Index adIndex) override;
    virtual TR::KnownObjectTable::Index getLayoutVarHandle(TR::Compilation *comp, TR::KnownObjectTable::Index layoutIndex) override;
 #endif

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -149,6 +149,12 @@
        {r(TR::Symbol::Java_lang_invoke_PrimitiveHandle_rawModifiers,  "java/lang/invoke/PrimitiveHandle", "rawModifiers", "I")},
        {r(TR::Symbol::Java_lang_invoke_PrimitiveHandle_defc,          "java/lang/invoke/PrimitiveHandle", "defc", "Ljava/lang/Class;")},
        {r(TR::Symbol::Java_lang_invoke_ThunkTuple_invokeExactThunk,   "java/lang/invoke/ThunkTuple", "invokeExactThunk", "J")},
+       {r(TR::Symbol::Java_lang_invoke_VarHandle_typesAndInvokers,    "java/lang/invoke/VarHandle", "typesAndInvokers", "Ljava/lang/invoke/VarHandle$TypesAndInvokers;")},
+#if JAVA_SPEC_VERSION <= 17
+       {r(TR::Symbol::Java_lang_invoke_VarHandle_methodHandleTable,   "java/lang/invoke/VarHandle$TypesAndInvokers", "methodHandle_table", "[Ljava/lang/invoke/MethodHandle;")},
+#else
+       {r(TR::Symbol::Java_lang_invoke_VarHandle_methodHandleTable,   "java/lang/invoke/VarHandle", "methodHandleTable", "[Ljava/lang/invoke/MethodHandle;")},
+#endif /* JAVA_SPEC_VERSION <= 17 */
        {r(TR::Symbol::Java_util_Hashtable_elementCount,               "java/util/Hashtable", "count", "I")},
        {r(TR::Symbol::Java_math_BigInteger_ZERO,                      "java/math/BigInteger", "ZERO", "Ljava/math/BigInteger;")},
        {r(TR::Symbol::Java_math_BigInteger_useLongRepresentation,     "java/math/BigInteger", "useLongRepresentation", "Z")},

--- a/runtime/compiler/il/J9Symbol.hpp
+++ b/runtime/compiler/il/J9Symbol.hpp
@@ -161,6 +161,8 @@ public:
       Java_lang_invoke_PrimitiveHandle_rawModifiers,
       Java_lang_invoke_PrimitiveHandle_defc,
       Java_lang_invoke_ThunkTuple_invokeExactThunk,
+      Java_lang_invoke_VarHandle_typesAndInvokers,
+      Java_lang_invoke_VarHandle_methodHandleTable,
       Java_util_Hashtable_elementCount,
       Java_math_BigInteger_ZERO,
       Java_math_BigInteger_useLongRepresentation,

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 87; // ID: yM39pYyKfv3R57cT/Oac
+   static const uint16_t MINOR_NUMBER = 88; // ID: J8MYSx3aPHFVfmu+fM3E
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -191,6 +191,7 @@ const char *messageNames[] =
    "VM_getVMIndexOffset",
    "VM_inSnapshotMode",
    "VM_isInvokeCacheEntryAnArray",
+   "VM_getVarHandleAccessDescriptorMode",
    "VM_getMethodHandleTableEntryIndex",
    "VM_getLayoutVarHandle",
    "VM_mutableCallSiteEpoch",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -200,6 +200,7 @@ enum MessageType : uint16_t
    VM_getVMIndexOffset,
    VM_inSnapshotMode,
    VM_isInvokeCacheEntryAnArray,
+   VM_getVarHandleAccessDescriptorMode,
    VM_getMethodHandleTableEntryIndex,
    VM_getLayoutVarHandle,
    VM_mutableCallSiteEpoch,

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5998,6 +5998,7 @@ TR_InlinerFailureReason
       case TR::java_lang_StringUTF16_putChar:
       case TR::java_lang_StringUTF16_toBytes:
       case TR::java_lang_invoke_MethodHandle_asType:
+      case TR::java_lang_invoke_Invokers_checkVarHandleGenericType:
             return DontInline_Callee;
       default:
          break;

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -374,6 +374,7 @@ static bool isArrayWithConstantElements(TR::SymbolReference *symRef, TR::Compila
          case TR::Symbol::Java_lang_invoke_VarHandle_handleTable:
          case TR::Symbol::Java_lang_invoke_MethodHandleImpl_LoopClauses_clauses:
          case TR::Symbol::Java_lang_String_value:
+         case TR::Symbol::Java_lang_invoke_VarHandle_methodHandleTable:
             return true;
          default:
             break;

--- a/runtime/compiler/optimizer/MethodHandleTransformer.hpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.hpp
@@ -147,6 +147,18 @@ class TR_MethodHandleTransformer : public TR::Optimization
     */
    void process_java_lang_invoke_Invokers_checkCustomized(TR::TreeTop* tt, TR::Node* node);
 
+   /**
+    * \brief
+    *    Eliminates calls to Invokers.checkVarHandleGenericType when its VarHandle and AccessDescriptor
+    *    args are known objects
+    *
+    * \param tt
+    *    The treetop of the call node
+    * \param node
+    *    The call node representing the call to java/lang/invoke/Invokers.checkVarHandleGenericType
+    */
+   void process_java_lang_invoke_Invokers_checkVarHandleGenericType(TR::TreeTop* tt, TR::Node* node);
+
    private:
    int32_t _numLocals; // Number of parms, autos and temps
    ObjectInfo * _currentObjectInfo;  // Object info for current block being processed


### PR DESCRIPTION
When the VarHandle object and the AccessDescriptor objects are known, we can perform a compile-time lookup of the corresponding entry in the VarHandle's MethodHandle table. This commit enables such a
transformation through the following:
* Add recognized fields from which the MethodHandle table gets loaded, accounting for the differences different JDK versions
* Add checkVarHandleGenericType to the list of non-inlinable methods
* Add new function in MethodHandleTransformer to be triggered when visiting checkVarHandleGenericType call node that generates the trees and transforms the call node.

Furthermore, visitStoreToLocalVariable can now be triggered for cases of direct stores of nodes anchored by PassThrough nodes, which would result from calls that have been transformed into PassThrough. PassThrough nodes do not have type info, and therefore this has to be accounted for. Once inside visitStoreToLocalVariable, it would have to recognize cases of stores of child nodes of PassThrough, and set the actual node to use as the RHS of the store.