### PR TITLE
setWarmCallGraphTooBig() creates IProfiler entry if needed

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3447,7 +3447,23 @@ TR_IProfiler::setWarmCallGraphTooBig(TR_OpaqueMethodBlock *method, int32_t bcInd
    {
    TR_IPBytecodeHashTableEntry *entry = profilingSample(method, bcIndex, comp);
    if (entry)
+      {
       entry->setWarmCallGraphTooBig(set);
+      }
+   else
+      {
+      // This PC does not exist in the IProfiler hashtable.
+      // special/static invokes are not tracked by the IProfiler, yet we still want to set the warmCallGraphTooBig flag.
+      // Create an artificial entry for the sole purpose of setting the warmCallGraphTooBig flag.
+      uintptr_t pc = getSearchPC(method, bcIndex, comp);
+      uint8_t bytecode = *((U_8*)pc);
+      if (isSpecialOrStatic(bytecode))
+         {
+         TR_IPBytecodeHashTableEntry *entry = profilingSample(pc, /*data=*/1, /*addIt=*/true);
+         if (entry)
+            entry->setWarmCallGraphTooBig(set);
+         }
+      }
    }
 
 bool


### PR DESCRIPTION
setWarmCallGraphTooBig is an IProfiler routine used by the Inliner as a hint that the call at a particular callsite is expensive to be inlined.
Static and special invokes are not tracked by the IProfiler and therefore profiling entries for such calls are not created, yet we may want to set the warmCallTooBig hint for direct calls as well. We have empirical evidence that not doing so increases the compilation overhead by ~5%.
Having said that, the Inliner indirectly creates profiling entries for direct calls when using setCallCount(), so, most of the time the inliner can set the warmCallTooBig hint if it wants to. However, we plan to eliminate the setCallCount()/getCallCount() pair of routines and, to compensate, this PR creates IProfiler entries for static/special invokes in the setWarmCallGraphTooBig() routine.