### PR TITLE
Remove TR::Options::INLINE_failedToDevirtualize usage

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4450,8 +4450,6 @@ void JitShutdown(J9JITConfig * jitConfig)
    if (options && options->getOption(TR_VerboseInlineProfiling))
       {
       j9tty_printf(PORTLIB, "Inlining statistics:\n");
-      j9tty_printf(PORTLIB, "\tFailed to devirtualize virtual calls:    %10d\n", TR::Options::INLINE_failedToDevirtualize);
-      j9tty_printf(PORTLIB, "\tFailed to devirtualize interface calls:  %10d\n", TR::Options::INLINE_failedToDevirtualizeInterface);
       j9tty_printf(PORTLIB, "\tCallee method is too big:                %10d\n", TR::Options::INLINE_calleeToBig);
       j9tty_printf(PORTLIB, "\tCallee method is too deep:               %10d\n", TR::Options::INLINE_calleeToDeep);
       j9tty_printf(PORTLIB, "\tCallee method has too many nodes:        %10d\n", TR::Options::INLINE_calleeHasTooManyNodes);


### PR DESCRIPTION
`TR::Options::INLINE_failedToDevirtualize` and `TR::Options::INLINE_failedToDevirtualizeInterface` are not really options, but rather statistics. The code that updates them (present in omr project) is supposed to be removed and thus we must remove their references in OpenJ9 as well.