### PR TITLE
JDK25 adds JVM_CreateThreadSnapshot, removes isCarrierThreadLocalPresent

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -802,9 +802,11 @@ final class Access implements JavaLangAccess {
 		return local;
 	}
 
+	/*[IF (JAVA_SPEC_VERSION < 25) | INLINE-TYPES]*/
 	public boolean isCarrierThreadLocalPresent(CarrierThreadLocal<?> carrierThreadlocal) {
 		return asThreadLocal(carrierThreadlocal).isCarrierThreadLocalPresent();
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION < 25) | INLINE-TYPES */
 
 	public <T> T getCarrierThreadLocal(CarrierThreadLocal<T> carrierThreadlocal) {
 		return asThreadLocal(carrierThreadlocal).getCarrierThreadLocal();

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -479,6 +479,7 @@ if(JAVA_SPEC_VERSION LESS 25)
 	)
 else()
 	jvm_add_exports(jvm
+		JVM_CreateThreadSnapshot
 		JVM_NeedsClassInitBarrierForCDS
 	)
 endif()

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -679,6 +679,13 @@ JVM_TakeVirtualThreadListToUnblock(JNIEnv *env, jclass ignored)
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
 #if JAVA_SPEC_VERSION >= 25
+JNIEXPORT jobject JNICALL
+JVM_CreateThreadSnapshot(JNIEnv *env, jobject thread)
+{
+	Assert_SC_true(!"JVM_CreateThreadSnapshot unimplemented");
+	return NULL;
+}
+
 JNIEXPORT jboolean JNICALL
 JVM_NeedsClassInitBarrierForCDS(JNIEnv *env, jclass cls)
 {

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -457,4 +457,6 @@ _IF([JAVA_SPEC_VERSION >= 24],
 _IF([JAVA_SPEC_VERSION >= 24],
 	[_X(JVM_TakeVirtualThreadListToUnblock, JNICALL, false, jobject, JNIEnv* env, jclass ignored)])
 _IF([JAVA_SPEC_VERSION >= 25],
+	[_X(JVM_CreateThreadSnapshot, JNICALL, false, jobject, JNIEnv *env, jobject thread)])
+_IF([JAVA_SPEC_VERSION >= 25],
 	[_X(JVM_NeedsClassInitBarrierForCDS, JNICALL, false, jboolean, JNIEnv *env, jclass clazz)])


### PR DESCRIPTION
JDK25 adds `JVM_CreateThreadSnapshot`, removes `isCarrierThreadLocalPresent`

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1032

Signed-off-by: Jason Feng <fengj@ca.ibm.com>