### PR TITLE
Infrastructure to segregate code caches

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9229,6 +9229,9 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
             compiler->setStream(that->_methodBeingCompiled->_stream);
             auto compInfoPTRemote = static_cast<TR::CompilationInfoPerThreadRemote *>(that);
             compiler->setAOTCacheStore(compInfoPTRemote->isAOTCacheStore());
+
+            // Only use the default code cache on the server
+            compiler->getOptions()->setCodeCacheKind(TR::CodeCacheKind::DEFAULT_CC);
             }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -775,7 +775,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
             {
             // For non-AOT, copy thunk to code cache and relocate the vm helper address right away.
             // Also do this if we're ignoring the local SCC.
-            uint8_t *thunkStart = TR_JITServerRelocationRuntime::copyDataToCodeCache(serializedThunk.data(), serializedThunk.size(), fe);
+            uint8_t *thunkStart = TR_JITServerRelocationRuntime::copyDataToCodeCache(serializedThunk.data(), serializedThunk.size(), fe, comp->codeCacheKind());
             if (!thunkStart)
                compInfoPT->getCompilation()->failCompilation<TR::CodeCacheError>("Failed to allocate space in the code cache");
 
@@ -811,7 +811,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
 
          // Do not need relocation here, because helper address should have been originally
          // fetched from the client.
-         uint8_t *thunkStart = TR_JITServerRelocationRuntime::copyDataToCodeCache(serializedThunk.data(), serializedThunk.size(), fe);
+         uint8_t *thunkStart = TR_JITServerRelocationRuntime::copyDataToCodeCache(serializedThunk.data(), serializedThunk.size(), fe, comp->codeCacheKind());
          if (!thunkStart)
             compInfoPT->getCompilation()->failCompilation<TR::CodeCacheError>("Failed to allocate space in the code cache");
 

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5688,7 +5688,7 @@ TR_J9VMBase::getDesignatedCodeCache(TR::Compilation *comp) // MCT
    bool hadClassUnloadMonitor;
    bool hadVMAccess = releaseClassUnloadMonitorAndAcquireVMaccessIfNeeded(comp, &hadClassUnloadMonitor);
 
-   TR::CodeCache * result = TR::CodeCacheManager::instance()->reserveCodeCache(false, 0, compThreadID, &numReserved);
+   TR::CodeCache * result = TR::CodeCacheManager::instance()->reserveCodeCache(false, 0, compThreadID, &numReserved, comp->codeCacheKind());
 
    acquireClassUnloadMonitorAndReleaseVMAccessIfNeeded(comp, hadVMAccess, hadClassUnloadMonitor);
    if (!result)
@@ -5785,7 +5785,7 @@ TR_J9VMBase::reserveTrampolineIfNecessary(TR::Compilation * comp, TR::SymbolRefe
             if (retValue == OMR::CodeCacheErrorCode::ERRORCODE_INSUFFICIENTSPACE && !inBinaryEncoding) // code cache full, allocate a new one
                {
                // Allocate a new code cache and try again
-               newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID()); // class unloading may happen here
+               newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID(), curCache->_kind); // class unloading may happen here
                if (newCache)
                   {
                   // check for class unloading that can happen in getNewCodeCache
@@ -7277,7 +7277,7 @@ TR_J9VM::getResolvedTrampoline(TR::Compilation *comp, TR::CodeCache* curCache, J
          if (!isAOT_DEPRECATED_DO_NOT_USE())
             {
             // Allocate a new code cache and try again
-            newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID()); // class unloading may happen here
+            newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID(), curCache->_kind); // class unloading may happen here
             if (newCache)
                {
                // check for class unloading that can happen in getNewCodeCache
@@ -9498,7 +9498,7 @@ TR_J9SharedCacheVM::getDesignatedCodeCache(TR::Compilation *comp)
    int32_t compThreadID = comp ? comp->getCompThreadID() : -1;
    bool hadClassUnloadMonitor;
    bool hadVMAccess = releaseClassUnloadMonitorAndAcquireVMaccessIfNeeded(comp, &hadClassUnloadMonitor);
-   TR::CodeCache * codeCache = TR::CodeCacheManager::instance()->reserveCodeCache(true, 0, compThreadID, &numReserved);
+   TR::CodeCache * codeCache = TR::CodeCacheManager::instance()->reserveCodeCache(true, 0, compThreadID, &numReserved, comp->codeCacheKind());
    acquireClassUnloadMonitorAndReleaseVMAccessIfNeeded(comp, hadVMAccess, hadClassUnloadMonitor);
    // For AOT we need some alignment
    if (codeCache)

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -3381,7 +3381,7 @@ TR_J9SharedCacheServerVM::getDesignatedCodeCache(TR::Compilation *comp)
    int32_t compThreadID = comp ? comp->getCompThreadID() : -1;
    bool hadClassUnloadMonitor = false;
    bool hadVMAccess = releaseClassUnloadMonitorAndAcquireVMaccessIfNeeded(comp, &hadClassUnloadMonitor);
-   TR::CodeCache * codeCache = TR::CodeCacheManager::instance()->reserveCodeCache(true, 0, compThreadID, &numReserved);
+   TR::CodeCache * codeCache = TR::CodeCacheManager::instance()->reserveCodeCache(true, 0, compThreadID, &numReserved, comp->codeCacheKind());
    acquireClassUnloadMonitorAndReleaseVMAccessIfNeeded(comp, hadVMAccess, hadClassUnloadMonitor);
    // For AOT we need some alignment
    if (codeCache)

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -91,9 +91,9 @@ J9::CodeCache::j9segment()
 
 
 TR::CodeCache *
-J9::CodeCache::allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, int32_t reservingCompThreadID)
+J9::CodeCache::allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, int32_t reservingCompThreadID, TR::CodeCacheKind kind)
    {
-   TR::CodeCache *newCodeCache = OMR::CodeCache::allocate(cacheManager, segmentSize, reservingCompThreadID);
+   TR::CodeCache *newCodeCache = OMR::CodeCache::allocate(cacheManager, segmentSize, reservingCompThreadID, kind);
    if (newCodeCache != NULL)
       {
       // Generate a trace point into the Snap file
@@ -107,7 +107,8 @@ J9::CodeCache::allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, 
 bool
 J9::CodeCache::initialize(TR::CodeCacheManager *manager,
                           TR::CodeCacheMemorySegment *codeCacheSegment,
-                          size_t allocatedCodeCacheSizeInBytes)
+                          size_t allocatedCodeCacheSizeInBytes,
+                          TR::CodeCacheKind kind)
    {
    // make J9 memory segment look all used up
    //J9MemorySegment *j9segment = _segment->segment();
@@ -143,7 +144,7 @@ J9::CodeCache::initialize(TR::CodeCacheManager *manager,
       config._trampolineSpacePercentage = percentageToUse;
       }
 
-   if (!self()->OMR::CodeCache::initialize(manager, codeCacheSegment, allocatedCodeCacheSizeInBytes))
+   if (!self()->OMR::CodeCache::initialize(manager, codeCacheSegment, allocatedCodeCacheSizeInBytes, kind))
       return false;
 
 

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -59,14 +59,16 @@ public:
     * @param[in] manager : the TR::CodeCacheManager
     * @param[in] codeCacheSegment : the code cache memory segment that has been allocated
     * @param[in] allocatedCodeCacheSizeInBytes : the size (in bytes) of the allocated code cache
+    * @param[in] kind : the kind of this code cache
     *
     * @return true on a successful initialization; false otherwise.
     */
    bool                       initialize(TR::CodeCacheManager *manager,
                                          TR::CodeCacheMemorySegment *codeCacheSegment,
-                                         size_t allocatedCodeCacheSizeInBytes);
+                                         size_t allocatedCodeCacheSizeInBytes,
+                                         TR::CodeCacheKind kind);
 
-   static TR::CodeCache *     allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, int32_t reservingCompThreadID);
+   static TR::CodeCache *     allocate(TR::CodeCacheManager *cacheManager, size_t segmentSize, int32_t reservingCompThreadID, TR::CodeCacheKind kind);
 
    // Code Cache Reclamation
    void                       addFreeBlock(OMR::FaintCacheBlock *block);

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -257,12 +257,15 @@ TR::CodeCache*
 J9::CodeCacheManager::reserveCodeCache(bool compilationCodeAllocationsMustBeContiguous,
                                       size_t sizeEstimate,
                                       int32_t compThreadID,
-                                      int32_t *numReserved)
+                                      int32_t *numReserved,
+                                      TR::CodeCacheKind kind)
    {
    TR::CodeCache *codeCache = self()->OMR::CodeCacheManager::reserveCodeCache(compilationCodeAllocationsMustBeContiguous,
                                                                             sizeEstimate,
                                                                             compThreadID,
-                                                                            numReserved);
+                                                                            numReserved,
+                                                                            kind);
+
    if (codeCache == NULL)
       {
       J9JITConfig *jitConfig = self()->fej9()->getJ9JITConfig();

--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -90,7 +90,8 @@ public:
    TR::CodeCache * reserveCodeCache(bool compilationCodeAllocationsMustBeContiguous,
                                     size_t sizeEstimate,
                                     int32_t compThreadID,
-                                    int32_t *numReserved);
+                                    int32_t *numReserved,
+                                    TR::CodeCacheKind kind);
 
    TR::CodeCacheMemorySegment *setupMemorySegmentFromRepository(uint8_t *start,
                                                                 uint8_t *end,

--- a/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
+++ b/runtime/compiler/runtime/JITServerAOTDeserializer.cpp
@@ -1621,7 +1621,7 @@ JITServerNoSCCAOTDeserializer::cacheRecord(const ThunkSerializationRecord *recor
    isNew = true;
 
    TR::CompilationInfoPerThread *compInfoPT = fej9vm->_compInfoPT;
-   uint8_t *thunkStart = TR_JITServerRelocationRuntime::copyDataToCodeCache(record->thunkStart(), record->thunkSize(), fej9vm);
+   uint8_t *thunkStart = TR_JITServerRelocationRuntime::copyDataToCodeCache(record->thunkStart(), record->thunkSize(), fej9vm, comp->codeCacheKind());
    if (!thunkStart)
       compInfoPT->getCompilation()->failCompilation<TR::CodeCacheError>("Failed to allocate space in the code cache");
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1150,7 +1150,7 @@ TR_SharedCacheRelocationRuntime::allocateSpaceInCodeCache(UDATA codeSize)
       {
       int32_t numReserved;
 
-      _codeCache = manager->reserveCodeCache(false, codeSize, compThreadID, &numReserved);  // Acquire a cold/warm code cache.
+      _codeCache = manager->reserveCodeCache(false, codeSize, compThreadID, &numReserved, _comp->codeCacheKind());  // Acquire a cold/warm code cache.
       if (!codeCache())
          {
          // TODO: how do we pass back error codes to trigger retrial?
@@ -1561,7 +1561,7 @@ TR_JITServerRelocationRuntime::allocateSpaceInCodeCache(UDATA codeSize)
       {
       int32_t numReserved;
 
-      _codeCache = manager->reserveCodeCache(false, codeSize, compThreadID, &numReserved);  // Acquire a cold/warm code cache.
+      _codeCache = manager->reserveCodeCache(false, codeSize, compThreadID, &numReserved, _comp->codeCacheKind());  // Acquire a cold/warm code cache.
       if (!codeCache())
          {
          // TODO: How do we pass back error codes to trigger retrial?
@@ -1609,14 +1609,14 @@ TR_JITServerRelocationRuntime::allocateSpaceInDataCache(uintptr_t metaDataSize,
    }
 
 uint8_t *
-TR_JITServerRelocationRuntime::copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe)
+TR_JITServerRelocationRuntime::copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe, TR::CodeCacheKind kind)
    {
    TR::CompilationInfoPerThreadBase *compInfoPT = fe->_compInfoPT;
    int32_t numReserved;
    TR::CodeCache *codeCache = NULL;
    TR::CodeCacheManager *manager = TR::CodeCacheManager::instance();
    TR_ASSERT(!compInfoPT->getCompilation()->cg()->getCodeCache(), "No code caches should be reserved when copying a thunk");
-   codeCache = manager->reserveCodeCache(false, totalSize, compInfoPT->getCompThreadId(), &numReserved);
+   codeCache = manager->reserveCodeCache(false, totalSize, compInfoPT->getCompThreadId(), &numReserved, kind);
    if (!codeCache)
       return NULL;
 

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -521,7 +521,7 @@ public:
       virtual OMRProcessorDesc getProcessorDescriptionFromSCC(J9VMThread *curThread) override
          { TR_ASSERT_FATAL(false, "Should not be called in this RelocationRuntime!"); return OMRProcessorDesc(); }
 
-      static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe);
+      static uint8_t *copyDataToCodeCache(const void *startAddress, size_t totalSize, TR_J9VMBase *fe, TR::CodeCacheKind kind);
 
 private:
       virtual uint8_t * allocateSpaceInCodeCache(UDATA codeSize) override;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -498,7 +498,7 @@ J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
          newCache = 0;
          if (self()->getCodeGeneratorPhase() != TR::CodeGenPhase::BinaryEncodingPhase)
             {
-            newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID());
+            newCache = TR::CodeCacheManager::instance()->getNewCodeCache(comp->getCompThreadID(), curCache->_kind);
             if (newCache)
                {
                status = newCache->reserveSpaceForTrampoline_bridge(numTrampolines);


### PR DESCRIPTION
Add infrastructure to allow the compiler component to distinguish between different code caches. This infrastructure can be used to facilitate features such as file-backed code caches.

See https://github.com/eclipse-omr/omr/issues/7779

Depends on https://github.com/eclipse-omr/omr/pull/7780