### PR TITLE
Recognize StringUTF16.indexOfUnsafe([BI[BII)I

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -243,6 +243,7 @@
    java_lang_StringUTF16_getChar,
    java_lang_StringUTF16_indexOf,
    java_lang_StringUTF16_indexOfCharUnsafe,
+   java_lang_StringUTF16_indexOfUnsafe,
    java_lang_StringUTF16_length,
    java_lang_StringUTF16_newBytesFor,
    java_lang_StringUTF16_putChar,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3300,6 +3300,7 @@ void TR_ResolvedJ9Method::construct()
       { x(TR::java_lang_StringUTF16_getChar,                                  "getChar",            "([BI)C")},
       { x(TR::java_lang_StringUTF16_indexOf,                                  "indexOf",            "([BI[BII)I")},
       { x(TR::java_lang_StringUTF16_indexOfCharUnsafe,                        "indexOfCharUnsafe",  "([BIII)I")},
+      { x(TR::java_lang_StringUTF16_indexOfUnsafe,                            "indexOfUnsafe",      "([BI[BII)I")},
       { x(TR::java_lang_StringUTF16_length,                                   "length",             "([B)I")},
       { x(TR::java_lang_StringUTF16_newBytesFor,                              "newBytesFor",        "(I)[B")},
       { x(TR::java_lang_StringUTF16_putChar,                                  "putChar",            "([BII)V")},

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5634,6 +5634,7 @@ TR_J9InlinerPolicy::suppressInliningRecognizedInitialCallee(TR_CallSite* callsit
          break;
       case TR::java_lang_StringLatin1_indexOf:
       case TR::java_lang_StringUTF16_indexOf:
+      case TR::java_lang_StringUTF16_indexOfUnsafe:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
          if (cg->getSupportsInlineStringIndexOfString())

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12985,6 +12985,7 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
          break;
 
       case TR::java_lang_StringUTF16_indexOf:
+      case TR::java_lang_StringUTF16_indexOfUnsafe:
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
          if (cg->getSupportsInlineStringIndexOfString())
             returnRegister = inlineIntrinsicStringIndexOfString(node, cg, false);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4227,6 +4227,7 @@ J9::Z::CodeGenerator::inlineDirectCall(
                resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, false);
                return resultReg != NULL;
          case TR::java_lang_StringUTF16_indexOf:
+         case TR::java_lang_StringUTF16_indexOfUnsafe:
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
                resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, true);
                return resultReg != NULL;


### PR DESCRIPTION
This commit changes the JIT compiler to recognize the method StringUTF16.indexOfUnsafe([BI[BII)I in addition to StringUTF16.indexOf([BI[BII)I.

It improves the performance of String.indexOf(String) on Z and X with Java 17+.