### PR TITLE
Rename JFR BuildResult to JfrBuildResult

### DIFF
--- a/runtime/vm/JFRChunkWriter.hpp
+++ b/runtime/vm/JFRChunkWriter.hpp
@@ -126,7 +126,7 @@ class VM_JFRChunkWriter {
 private:
 	J9VMThread *_currentThread;
 	J9JavaVM *_vm;
-	BuildResult _buildResult;
+	JfrBuildResult _buildResult;
 	bool _debug;
 	J9PortLibrary *privatePortLibrary; //PORT_ACCESS_FROM...
 	bool _finalWrite;
@@ -272,7 +272,7 @@ public:
 		return _buildResult == OK;
 	}
 
-	BuildResult buildResult()
+	JfrBuildResult buildResult()
 	{
 		return _buildResult;
 	}

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -352,7 +352,7 @@ class VM_JFRConstantPoolTypes {
 private:
 	J9VMThread *_currentThread;
 	J9JavaVM *_vm;
-	BuildResult _buildResult;
+	JfrBuildResult _buildResult;
 	bool _debug;
 	J9PortLibrary *privatePortLibrary;
 
@@ -967,7 +967,7 @@ public:
 
 	void printTables();
 
-	BuildResult getBuildResult()
+	JfrBuildResult getBuildResult()
 	{
 		return _buildResult;
 	}
@@ -1085,7 +1085,7 @@ done:
 	 *
 	 * @param vm[in] the J9JavaVM
 	 */
-	static void initializeJFRConstantEvents(J9JavaVM *vm, J9VMThread *currentThread, BuildResult *result)
+	static void initializeJFRConstantEvents(J9JavaVM *vm, J9VMThread *currentThread, JfrBuildResult *result)
 	{
 		initializeJVMInformationEvent(vm, currentThread, result);
 		initializeCPUInformationEvent(vm, currentThread, result);
@@ -1116,7 +1116,7 @@ done:
 	 *
 	 * @param vm[in] the J9JavaVM
 	 */
-	static void initializeJVMInformationEvent(J9JavaVM *vm, J9VMThread *currentThread, BuildResult *result)
+	static void initializeJVMInformationEvent(J9JavaVM *vm, J9VMThread *currentThread, JfrBuildResult *result)
 	{
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		/* Initialize JVM Information */
@@ -1183,7 +1183,7 @@ done:
 	 *
 	 * @param vm[in] the J9JavaVM
 	 */
-	static void initializeCPUInformationEvent(J9JavaVM *vm, J9VMThread *currentThread, BuildResult *result)
+	static void initializeCPUInformationEvent(J9JavaVM *vm, J9VMThread *currentThread, JfrBuildResult *result)
 	{
 		PORT_ACCESS_FROM_JAVAVM(vm);
 		OMRPORT_ACCESS_FROM_J9PORT(privatePortLibrary);
@@ -1265,7 +1265,7 @@ done:
 	 *
 	 * @param vm[in] the J9JavaVM
 	 */
-	static void initializeOSInformation(J9JavaVM *vm, BuildResult *result)
+	static void initializeOSInformation(J9JavaVM *vm, JfrBuildResult *result)
 	{
 		PORT_ACCESS_FROM_JAVAVM(vm);
 

--- a/runtime/vm/JFRUtils.hpp
+++ b/runtime/vm/JFRUtils.hpp
@@ -28,7 +28,7 @@
 
 #if defined(J9VM_OPT_JFR)
 
-enum BuildResult {
+enum JfrBuildResult {
 	OK,
 	OutOfMemory,
 	InternalVMError,
@@ -57,7 +57,7 @@ protected:
 
 public:
 
-	static U_64 getCurrentTimeNanos(J9PortLibrary *privatePortLibrary, BuildResult &buildResult)
+	static U_64 getCurrentTimeNanos(J9PortLibrary *privatePortLibrary, JfrBuildResult &buildResult)
 	{
 		UDATA success = 0;
 		U_64 result = (U_64) j9time_current_time_nanos(&success);


### PR DESCRIPTION
Avoid conflict with pre-existing type declared in `BuildResult.hpp`.

Discovered while investigating https://github.com/eclipse-openj9/openj9/issues/22056.