### PR TITLE
Fix inconsistencies related to checkJCL()

### DIFF
--- a/runtime/jcl/common/vm_scar.c
+++ b/runtime/jcl/common/vm_scar.c
@@ -83,7 +83,7 @@ char *iniBootpath = NULL;
 
 #endif
 
-const U_64 jclConfig = J9CONST64(0x7363617237306200);		/* 'scar70b' */
+const U_64 jclConfig = J9CONST64(0x7363617237306200); /* 'scar70b' */
 
 #if defined(WIN32)
 #define J9_AWTPRINTERJOB_VALUE	"sun.awt.windows.WPrinterJob"

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -767,7 +767,7 @@ jint JCL_OnUnload (J9JavaVM* vm, void* reserved);
 jint standardPreconfigure ( JavaVM *jvm);
 void
 internalInitializeJavaLangClassLoader (JNIEnv * env);
-IDATA checkJCL (J9VMThread * vmThread, U_8* dllValue, U_8* jclConfig, UDATA j9Version, UDATA jclVersion);
+IDATA checkJCL(J9VMThread *vmThread, const U_8 *dllValue, const U_8 *jclConfig, U_32 j9Version, U_32 jclVersion);
 jint
 completeInitialization (J9JavaVM * vm);
 jint standardInit ( J9JavaVM *vm, char* dllName);


### PR DESCRIPTION
Declare `jclConfig` consistent with its definition.

Shrink JCL and VM versions from `UDATA` to `U_32`.