### PR TITLE
Eliminate VM_compiledAsDLTBefore message for JITServer

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -40,6 +40,7 @@
 #include "control/rossa.h"
 #include "runtime/RelocationRuntime.hpp"
 #if defined(J9VM_OPT_JITSERVER)
+#include <vector>
 #include "control/JITServerHelpers.hpp"
 #include "env/PersistentCollections.hpp"
 #include "net/ServerStream.hpp"
@@ -788,6 +789,9 @@ public:
    void  cleanDLTRecordOnUnload();
    DLTTracking *getDLT_HT() const { return _dltHT; }
    void setDLT_HT(DLTTracking *dltHT) { _dltHT = dltHT; }
+#if defined(J9VM_OPT_JITSERVER)
+   std::vector<J9Method*> collectDLTedMethods();
+#endif /* defined(J9VM_OPT_JITSERVER) */
 #else
    DLTTracking *getDLT_HT() const { return NULL; }
 #endif // J9VM_JIT_DYNAMIC_LOOP_TRANSFER
@@ -1229,6 +1233,7 @@ private:
    TR::Monitor *_dltMonitor;
    struct DLT_record     *_freeDLTRecord;
    struct DLT_record     *_dltHash[DLT_HASHSIZE];
+   int32_t _numDLTRecords;
 #endif
    DLTTracking           *_dltHT;
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 83; // ID: yInQ3zszluYaDVc6hSwi
+   static const uint16_t MINOR_NUMBER = 84; // ID: gIq88QhwCmuOoBAlidaE
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -106,7 +106,6 @@ const char *messageNames[] =
    "VM_getClassFromSignature",
    "VM_jitFieldsOrStaticsAreSame",
    "VM_classHasBeenExtended",
-   "VM_compiledAsDLTBefore",
    "VM_isThunkArchetype",
    "VM_printTruncatedSignature",
    "VM_getStaticHookAddress",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -115,7 +115,6 @@ enum MessageType : uint16_t
    VM_getClassFromSignature,
    VM_jitFieldsOrStaticsAreSame,
    VM_classHasBeenExtended,
-   VM_compiledAsDLTBefore,
    VM_isThunkArchetype,
    VM_printTruncatedSignature,
    VM_getStaticHookAddress,


### PR DESCRIPTION
Recent changes in Inliner have added a check of whether a method has been DLTed before (DLT stands for Dynamic Loop Transfer). As a consequence, the number of `VM_compiledAsDLTBefore` messages sent by the server has increased a lot adding to compilation overhead.

This commit eliminates all `VM_compiledAsDLTBefore` messages. The idea is for the server to keep track of all DLT compilations that it performs on behalf of a client. When the client connects for the first time to a new server, it will send the set of DLTed methods to the server, so that the server can initialize its own set. This action takes care of two possible situations: (1) The client connects to a server at a later point in time (because a server was not available from the very begining). (2) The client is connected to a server at the begining of its run, but later on, the connection is broken and the client is forced to connect to a different server.