### PR TITLE
Improve IllegalAccessError with specific exception messages

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2448,3 +2448,55 @@ J9NLS_VM_JAVA_COMPILER_WARNING_XINT.explanation=The java.compiler system propert
 J9NLS_VM_JAVA_COMPILER_WARNING_XINT.system_action=Setting the java.compiler system property is ignored.
 J9NLS_VM_JAVA_COMPILER_WARNING_XINT.user_response=Use the -Xint option to disable the JIT.
 # END NON-TRANSLATABLE
+
+# Java 8 message for an IllegalAccessError when the class or interface can't access its super class or interface.
+# argument 1 is "class" or "interface"
+# arguments 2 and 3 are the class or interface name
+# arguments 4 and 5 are the classloader name of the class or interface
+# argument 6 is "superclass" or "superinterface"
+# arguments 7 and 8 are the super class or interface name
+# arguments 9 and 10 are the classloader name of the super class or interface
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8=%1$s %3$.*2$s (from loader %5$.*4$s) cannot access its %6$s %8$.*7$s (from loader %10$.*9$s)
+# START NON-TRANSLATABLE
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_1=class
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_2=59
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_3=org/openj9/test/illegalAccessError/ExtendsDefaultVisibility
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_4=23
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_5=java/net/URLClassLoader
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_6=superclass
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_7=52
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_8=org/openj9/test/illegalAccessError/DefaultVisibility
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_9=47
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.sample_input_10=jdk/internal/loader/ClassLoaders$AppClassLoader
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.explanation=The specified class or interface is not visible
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.system_action=The JVM will throw an IllegalAccessError.
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA8.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# Java 11+ message for an IllegalAccessError when the class or interface can't access its super class or interface.
+# argument 1 is "class" or "interface"
+# arguments 2 and 3 are the class or interface name
+# argument 4 is the module name of the class or interface
+# arguments 5 and 6 are the classloader name of the class or interface
+# argument 7 is "superclass" or "superinterface"
+# arguments 8 and 9 are the super class or interface name
+# argument 10 is the module name of the super class or interface
+# arguments 11 and 12 are the classloader name of the super class or interface
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS=%1$s %3$.*2$s (in %4$s from loader %6$.*5$s) cannot access its %7$s %9$.*8$s (in %10$s from loader %12$.*11$s)
+# START NON-TRANSLATABLE
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_1=class
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_2=59
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_3=org/openj9/test/illegalAccessError/ExtendsDefaultVisibility
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_4=unnamed module 0x0000000000000000
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_5=23
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_6=java/net/URLClassLoader
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_7=superclass
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_8=52
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_9=org/openj9/test/illegalAccessError/DefaultVisibility
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_10=unnamed module 0x0000000000000000
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_11=47
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.sample_input_12=jdk/internal/loader/ClassLoaders$AppClassLoader
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.explanation=The specified class or interface is not visible
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.system_action=The JVM will throw an IllegalAccessError.
+J9NLS_VM_CLASS_LOADING_ERROR_INVISIBLE_SUPERCLASS_OR_INTERFACE_JAVA11_PLUS.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -991,24 +991,9 @@ defaultMethodConflictExceptionMessage(J9VMThread *currentThread, J9Class *target
 }
 
 #if JAVA_SPEC_VERSION >= 11
-/**
- * Get Module Name
- *
- * ***The caller must free the memory from this pointer if the return value is NOT the buffer argument ***
- *
- * @param[in] currentThread the current J9VMThread
- * @param[in] module the module
- * @param[in] buffer the buffer for the module name
- * @param[in] bufferLength the buffer length
- *
- * @return a char pointer to the module name
- */
-static char *
-getModuleNameUTF(J9VMThread *currentThread, j9object_t moduleObject, char *buffer, UDATA bufferLength)
+char *
+getModuleNameUTF(J9VMThread *currentThread, J9Module *module, char *buffer, UDATA bufferLength)
 {
-	J9JavaVM const *const vm = currentThread->javaVM;
-	J9InternalVMFunctions const *const vmFuncs = vm->internalVMFunctions;
-	J9Module *module = J9OBJECT_ADDRESS_LOAD(currentThread, moduleObject, vm->modulePointerOffset);
 	char *nameBuffer = NULL;
 
 	if ((NULL == module) || (NULL == module->moduleName)) {
@@ -1016,11 +1001,11 @@ getModuleNameUTF(J9VMThread *currentThread, j9object_t moduleObject, char *buffe
 		/* ensure bufferLength is not less than 128 which is enough for unnamed module */
 		PORT_ACCESS_FROM_VMC(currentThread);
 		Assert_VM_true(bufferLength >= 128);
-		j9str_printf(buffer, bufferLength, "%s0x%p", UNNAMED_MODULE, moduleObject);
+		j9str_printf(buffer, bufferLength, "%s0x%p", UNNAMED_MODULE, (NULL == module) ? NULL : module->moduleObject);
 		nameBuffer = buffer;
 #undef UNNAMED_MODULE
 	} else {
-		nameBuffer = vmFuncs->copyJ9UTF8ToUTF8WithMemAlloc(
+		nameBuffer = copyJ9UTF8ToUTF8WithMemAlloc(
 				currentThread, module->moduleName, J9_STR_NULL_TERMINATE_RESULT, "", 0, buffer, bufferLength);
 	}
 
@@ -1135,15 +1120,18 @@ illegalAccessMessage(J9VMThread *currentThread, IDATA badMemberModifier, J9Class
 		}
 	} else if (J9_VISIBILITY_NON_MODULE_ACCESS_ERROR != errorType) {
 		/* illegal module access */
+		UDATA modulePointerOffset = currentThread->javaVM->modulePointerOffset;
 		j9object_t srcModuleObject = J9VMJAVALANGCLASS_MODULE(currentThread, senderClass->classObject);
 		j9object_t destModuleObject = J9VMJAVALANGCLASS_MODULE(currentThread, targetClass->classObject);
 		/* caller of illegalAccessMessage already performed Assert_VM_true((NULL != srcClassObject) && (NULL != destClassObject)); */
 
-		srcModuleMsg = getModuleNameUTF(currentThread, srcModuleObject, srcModuleBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		srcModuleMsg = getModuleNameUTF(currentThread, J9OBJECT_ADDRESS_LOAD(currentThread, srcModuleObject, modulePointerOffset),
+				srcModuleBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
 		if (NULL == srcModuleMsg) {
 			goto allocationFailure;
 		}
-		destModuleMsg = getModuleNameUTF(currentThread, destModuleObject, destModuleBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
+		destModuleMsg = getModuleNameUTF(currentThread, J9OBJECT_ADDRESS_LOAD(currentThread, destModuleObject, modulePointerOffset),
+				destModuleBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH);
 		if (NULL == destModuleMsg) {
 			goto allocationFailure;
 		}

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -724,6 +724,23 @@ cleanupEnsureHashedConfig(J9JavaVM *jvm);
 UDATA
 parseEnsureHashedConfig(J9JavaVM *jvm, char *options, BOOLEAN isAdd);
 
+#if JAVA_SPEC_VERSION >= 11
+/**
+ * Get Module Name.
+ *
+ * *** The caller must free the memory from this pointer if the return value is NOT the buffer argument. ***
+ *
+ * @param[in] currentThread the current J9VMThread
+ * @param[in] module the module
+ * @param[in] buffer the buffer for the module name
+ * @param[in] bufferLength the buffer length
+ *
+ * @return a char pointer to the module name
+ */
+char *
+getModuleNameUTF(J9VMThread *currentThread, J9Module *module, char *buffer, UDATA bufferLength);
+#endif /* JAVA_SPEC_VERSION >= 11 */
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/test/functional/cmdLineTests/classLoaderTest/build.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/build.xml
@@ -28,13 +28,14 @@
 		Build cmdLineTests_EnableAssertionStatusTest
 	</description>
 
-	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml"/>
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml" />
 
 	<!-- set properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/classLoaderTest" />
 	<property name="PROJECT_ROOT" location="." />
-	<property name="src" location="./src"/>
-	<property name="build" location="./bin"/>
+	<property name="src" location="./src" />
+	<property name="TestUtilities" location="../../TestUtilities/src" />
+	<property name="build" location="./bin" />
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -49,12 +50,17 @@
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+			<src path="${TestUtilities}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar" />
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
 		<jar jarfile="${DEST}/classloadertest.jar" filesonly="true">
-			<fileset dir="${build}"/>
+			<fileset dir="${build}" />
 		</jar>
 		<copy todir="${DEST}">
 			<fileset dir="${src}/../" includes="*.xml,*.mk" />

--- a/test/functional/cmdLineTests/classLoaderTest/illegalAccessErrorTest.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/illegalAccessErrorTest.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!--
+Copyright IBM Corp. and others 2025
+
+This program and the accompanying materials are made available under
+the terms of the Eclipse Public License 2.0 which accompanies this
+distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+or the Apache License, Version 2.0 which accompanies this distribution and
+is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+This Source Code may also be made available under the following
+Secondary Licenses when the conditions for such availability set
+forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+General Public License, version 2 with the GNU Classpath
+Exception [1] and GNU General Public License, version 2 with the
+OpenJDK Assembly Exception [2].
+
+[1] https://www.gnu.org/software/classpath/license.html
+[2] https://openjdk.org/legal/assembly-exception.html
+
+SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+
+<suite id="IllegalAccessError Test in ClassLoder" timeout="300">
+
+	<variable name="CLASSPATH" value="-cp $Q$$TEST_RESROOT$$Q$classloadertest.jar" />
+
+	<test id="test IllegalAccessError with specific exception message">
+		<command>$EXE$ $CLASSPATH$ org.openj9.test.illegalAccessError.IllegalAccessErrorTest</command>
+		<output regex="no" type="success" caseSensitive="no">IllegalAccessErrorTest PASSED</output>
+		<output regex="no" type="failure" caseSensitive="no">IllegalAccessErrorTest FAILED</output>
+		<output regex="no" type="failure" caseSensitive="no">java.lang.Exception</output>
+		<output regex="no" type="failure" caseSensitive="no">java.lang.Throwable</output>
+	</test>
+</suite>

--- a/test/functional/cmdLineTests/classLoaderTest/playlist.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/playlist.xml
@@ -68,4 +68,54 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_IllegalAccessErrorTest_SE80</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)illegalAccessErrorTest.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>8</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
+
+	<test>
+		<testCaseName>cmdLineTester_IllegalAccessErrorTest</testCaseName>
+		<variations>
+			<variation>NoOptions</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
+		-DTEST_RESROOT=$(Q)$(TEST_RESROOT)$(D)$(Q) -DRESJAR=$(CMDLINETESTER_RESJAR) \
+		-DEXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS) --add-opens=java.base/java.lang=ALL-UNNAMED$(SQ) -jar $(CMDLINETESTER_JAR) -config $(Q)$(TEST_RESROOT)$(D)illegalAccessErrorTest.xml$(Q) \
+		-explainExcludes -nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>11+</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/DefaultVisibility.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/DefaultVisibility.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+
+package org.openj9.test.illegalAccessError;
+
+class DefaultVisibility {
+}

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/DefaultVisibilityInterface.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/DefaultVisibilityInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+
+package org.openj9.test.illegalAccessError;
+
+interface DefaultVisibilityInterface {
+}

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/ExtendsDefaultVisibility.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/ExtendsDefaultVisibility.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+
+package org.openj9.test.illegalAccessError;
+
+public class ExtendsDefaultVisibility extends DefaultVisibility {
+}

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/ExtendsDefaultVisibilityInterface.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/ExtendsDefaultVisibilityInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+
+package org.openj9.test.illegalAccessError;
+
+public interface ExtendsDefaultVisibilityInterface extends DefaultVisibilityInterface {
+}

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/IllegalAccessErrorTest.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/IllegalAccessErrorTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+
+package org.openj9.test.illegalAccessError;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.io.InputStream;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.openj9.test.util.VersionCheck;
+
+public class IllegalAccessErrorTest {
+
+	public static void main(String[] args) throws Exception {
+		boolean result;
+		URLClassLoader ucl = new URLClassLoader(new URL[] {});
+		Method method = ClassLoader.class.getDeclaredMethod("defineClass", String.class, byte[].class, int.class, int.class);
+		method.setAccessible(true);
+		try (InputStream in = ucl.getResourceAsStream("org/openj9/test/illegalAccessError/ExtendsDefaultVisibility.class")) {
+			byte[] bytes = new byte[in.available()];
+			in.read(bytes);
+			method.invoke(ucl, "org.openj9.test.illegalAccessError.ExtendsDefaultVisibility", bytes, 0, bytes.length);
+			System.out.println("defineClass for ExtendsDefaultVisibility should throw IllegalAccessError but didn't, test failed");
+			result = false;
+		} catch (InvocationTargetException e) {
+			String causeString = e.getCause().toString();
+			Pattern pattern = Pattern.compile(
+					"java.lang.IllegalAccessError:"
+						+ " class org/openj9/test/illegalAccessError/ExtendsDefaultVisibility"
+						+ " \\(in unnamed module 0x0{1,16} from loader java/net/URLClassLoader\\)"
+						+ " cannot access its superclass"
+						+ " org/openj9/test/illegalAccessError/DefaultVisibility"
+						+ " \\(in unnamed module 0x0{1,16} from loader jdk/internal/loader/ClassLoaders\\$AppClassLoader\\)");
+			Matcher matcher = pattern.matcher(causeString);
+			System.out.println("causeString = " + causeString);
+			if (((VersionCheck.major() == 8) && causeString.contains(
+					"java.lang.IllegalAccessError:"
+						+ " class org/openj9/test/illegalAccessError/ExtendsDefaultVisibility"
+						+ " (from loader java/net/URLClassLoader) cannot access its superclass"
+						+ " org/openj9/test/illegalAccessError/DefaultVisibility"
+						+ " (from loader sun/misc/Launcher$AppClassLoader)"))
+				|| ((VersionCheck.major() >= 11) && matcher.find())
+			) {
+				result = true;
+				System.out.println("defineClass for ExtendsDefaultVisibility threw IllegalAccessError with the expected exception message");
+			} else {
+				e.printStackTrace();
+				result = false;
+				System.out.println("defineClass for ExtendsDefaultVisibility threw an InvocationTargetException with unexpected exception cause, test failed");
+			}
+		} catch (SecurityException | IllegalAccessException | IOException e) {
+			e.printStackTrace();
+			result = false;
+			System.out.println("defineClass for ExtendsDefaultVisibility threw an unexpected exception, test failed");
+		}
+
+		try (InputStream in = ucl.getResourceAsStream("org/openj9/test/illegalAccessError/ImplementDefaultVisibilityInterface.class")) {
+			byte[] bytes = new byte[in.available()];
+			in.read(bytes);
+			method.invoke(ucl, "org.openj9.test.illegalAccessError.ImplementDefaultVisibilityInterface", bytes, 0, bytes.length);
+			System.out.println("defineClass for ImplementDefaultVisibilityInterface should throw IllegalAccessError but didn't, test failed");
+			result = false;
+		} catch (InvocationTargetException e) {
+			String causeString = e.getCause().toString();
+			Pattern pattern = Pattern.compile(
+					"java.lang.IllegalAccessError:"
+						+ " class org/openj9/test/illegalAccessError/ImplementDefaultVisibilityInterface"
+						+ " \\(in unnamed module 0x0{1,16} from loader java/net/URLClassLoader\\)"
+						+ " cannot access its superinterface org/openj9/test/illegalAccessError/DefaultVisibilityInterface"
+						+ " \\(in unnamed module 0x0{1,16} from loader jdk/internal/loader/ClassLoaders\\$AppClassLoader\\)");
+			Matcher matcher = pattern.matcher(causeString);
+			System.out.println("causeString = " + causeString);
+			if (((VersionCheck.major() == 8) && causeString.contains(
+					"java.lang.IllegalAccessError:"
+						+ " class org/openj9/test/illegalAccessError/ImplementDefaultVisibilityInterface"
+						+ " (from loader java/net/URLClassLoader) cannot access its superinterface"
+						+ " org/openj9/test/illegalAccessError/DefaultVisibilityInterface"
+						+ " (from loader sun/misc/Launcher$AppClassLoader)"))
+				|| ((VersionCheck.major() >= 11) && matcher.find())
+			) {
+				result = true;
+				System.out.println("defineClass for ImplementDefaultVisibilityInterface threw IllegalAccessError with the expected exception message");
+			} else {
+				e.printStackTrace();
+				result = false;
+				System.out.println("defineClass for ImplementDefaultVisibilityInterface threw an InvocationTargetException with unexpected exception cause, test failed");
+			}
+		} catch (SecurityException | IllegalAccessException | IOException e) {
+			e.printStackTrace();
+			result = false;
+			System.out.println("defineClass for ImplementDefaultVisibilityInterface threw an unexpected exception, test failed");
+		}
+
+		try (InputStream in = ucl.getResourceAsStream("org/openj9/test/illegalAccessError/ExtendsDefaultVisibilityInterface.class")) {
+			byte[] bytes = new byte[in.available()];
+			in.read(bytes);
+			method.invoke(ucl, "org.openj9.test.illegalAccessError.ExtendsDefaultVisibilityInterface", bytes, 0, bytes.length);
+			System.out.println("defineClass for ExtendsDefaultVisibilityInterface should throw IllegalAccessError but didn't, test failed");
+			result = false;
+		} catch (InvocationTargetException e) {
+			String causeString = e.getCause().toString();
+			Pattern pattern = Pattern.compile(
+					"java.lang.IllegalAccessError:"
+						+ " interface org/openj9/test/illegalAccessError/ExtendsDefaultVisibilityInterface"
+						+ " \\(in unnamed module 0x0{1,16} from loader java/net/URLClassLoader\\)"
+						+ " cannot access its superinterface org/openj9/test/illegalAccessError/DefaultVisibilityInterface"
+						+ " \\(in unnamed module 0x0{1,16} from loader jdk/internal/loader/ClassLoaders\\$AppClassLoader\\)");
+			Matcher matcher = pattern.matcher(causeString);
+			System.out.println("causeString = " + causeString);
+			if (((VersionCheck.major() == 8) && causeString.contains(
+					"java.lang.IllegalAccessError:"
+						+ " interface org/openj9/test/illegalAccessError/ExtendsDefaultVisibilityInterface"
+						+ " (from loader java/net/URLClassLoader) cannot access its superinterface"
+						+ " org/openj9/test/illegalAccessError/DefaultVisibilityInterface"
+						+ " (from loader sun/misc/Launcher$AppClassLoader)"))
+				|| ((VersionCheck.major() >= 11) && matcher.find())
+			) {
+				result = true;
+				System.out.println("defineClass for ExtendsDefaultVisibilityInterface threw IllegalAccessError with the expected exception message");
+			} else {
+				e.printStackTrace();
+				result = false;
+				System.out.println("defineClass for ExtendsDefaultVisibilityInterface threw an InvocationTargetException with unexpected exception cause, test failed");
+			}
+		} catch (SecurityException | IllegalAccessException | IOException e) {
+			e.printStackTrace();
+			result = false;
+			System.out.println("defineClass for ExtendsDefaultVisibilityInterface threw an unexpected exception, test failed");
+		}
+
+		if (result) {
+			System.out.println("IllegalAccessErrorTest PASSED");
+		} else {
+			System.out.println("IllegalAccessErrorTest FAILED");
+		}
+	}
+}

--- a/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/ImplementDefaultVisibilityInterface.java
+++ b/test/functional/cmdLineTests/classLoaderTest/src/org/openj9/test/illegalAccessError/ImplementDefaultVisibilityInterface.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+
+package org.openj9.test.illegalAccessError;
+
+public class ImplementDefaultVisibilityInterface implements DefaultVisibilityInterface {
+}


### PR DESCRIPTION
Improve `IllegalAccessError` with specific exception messages

The improved exception message looks like:
```
java.lang.IllegalAccessError: class org/openj9/test/illegalAccessError/ExtendsDefaultVisibility (in unnamed module 0x0000000000000000 from loader java/net/URLClassLoader) cannot access its superclass org/openj9/test/illegalAccessError/DefaultVisibility (in unnamed module 0x0000000000000000 from loader jdk/internal/loader/ClassLoaders$AppClassLoader)
```
Added a test.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>