### PR TITLE
Remove Hard-Coded Restrictions to CodeCache Page Sizes on P

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -308,14 +308,7 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    if (config.largeCodePageSize() > pageSizes[0])
       largeCodePageSize = config.largeCodePageSize();
 
-#if defined(TR_TARGET_POWER) && defined(TR_HOST_POWER)
-   /* Use largeCodePageSize on PPC only if its 16M.
-    If we pass in any pagesize other than the default page size, the port library picks the shared memory api to allocate which wastes memory */
-   size_t sixteenMegs = 16 * 1024 * 1024;
-   if (largeCodePageSize == sixteenMegs)
-#else
    if (largeCodePageSize > 0)
-#endif
       {
       vmemParams.pageSize = largeCodePageSize;
       vmemParams.pageFlags = config.largeCodePageFlags();


### PR DESCRIPTION
Remove the 16M restriction on large page size in the code cache manager for Power. The requested page size would have already been verified as valid when parsing the options, and any valid size request should be honoured.