### PR TITLE
Add documentation about docker AOT issue on Linux on IBM Z®

### DIFF
--- a/doc/release-notes/0.51/0.51.md
+++ b/doc/release-notes/0.51/0.51.md
@@ -137,6 +137,27 @@ on x64 platforms, but builds with OpenJDK 17 and later also require more stack s
 <td valign="top">Avoid using the <tt>-XX:+ShowHiddenFrames</tt> option with OpenJDK 18 and later.</td>
 </tr>
 
+<tr>
+<td valign="top">N/A </td>
+<td valign="top">JVM fails to load AOT compiled code from portable shared class cache created on IBM z17.</td>
+<td valign="top">Linux on IBM Z®</td>
+<td valign="top">When a docker container image with Eclipse OpenJ9 is created
+on a system running on IBM z17 hardware and deployed on older IBM Z hardware,
+the JVM will fail to validate AOT-compiled code, which would cause the JVM to
+start JIT compiling methods. This issue can impact increased CPU usage driven
+by JIT compilation activities and/or slow application start-up. Outside of the
+Docker container, if portable shared class cache is enabled explicitly by using
+the <tt>-XX:+PortableSharedCache</tt> option, a similar issue can be seen when
+such shared class cache is populated with portable AOT code on IBM z17 hardware
+and used on older IBM Z hardware.</td>
+<td valign="top">If you are deploying application containers using Eclipse
+OpenJ9 on IBM Z platform, do not build your application container image on a
+system running on IBM z17 hardware. Similarly, in case of using Portable Shared
+Class Cache explicitly by supplying the JVM option
+<tt>-XX:+PortableSharedCache</tt>, do not prime the shared class cache on a
+system running on IBM z17 hardware and run on an older IBM Z platform.</td>
+</tr>
+
 </tbody>
 </table>
 


### PR DESCRIPTION
Documenting the issue seen when using docker container with IBM Semeru Runtime built on IBM Z17 hardware where AOT compiled code gets invalidated.