### PR TITLE
Improve build failure patterns

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -340,7 +340,7 @@ aarch64_linux:
   build_env:
     vars:
       all: 'CC=/usr/local/gcc10/bin/gcc-10.3 CXX=/usr/local/gcc10/bin/g++-10.3'
-  fail_pattern: 'IOException caught during compilation: Resource deadlock avoided'
+  fail_pattern: 'IOException caught during compilation:.*Resource deadlock avoided'
 #========================================#
 # Linux Aarch 64bits /w JITSERVER
 #========================================#
@@ -405,7 +405,7 @@ x86-64_mac:
     build: 'ci.role.build && hw.arch.x86 && sw.os.mac && sw.tool.xcode.15_2'
   build_env:
     vars: 'OPENJ9_JAVA_OPTIONS=-Xdump:system+java:events=systhrow,filter=java/lang/ClassCastException,request=exclusive+prepwalk+preempt'
-  fail_pattern: 'IOException caught during compilation: Resource deadlock avoided'
+  fail_pattern: 'IOException caught during compilation:.*Resource deadlock avoided'
 #========================================#
 # Mac Aarch64
 #========================================#
@@ -425,7 +425,7 @@ aarch64_mac:
   openjdk_reference_repo: '/Users/jenkins/openjdk_cache'
   node_labels:
     build: 'ci.role.build && hw.arch.aarch64 && sw.os.mac && sw.tool.xcode.15_2'
-  fail_pattern: 'IOException caught during compilation: Resource deadlock avoided'
+  fail_pattern: 'IOException caught during compilation:.*Resource deadlock avoided'
 #========================================#
 # Linux PPCLE 64bits /w OpenJDK JSR292
 #========================================#


### PR DESCRIPTION
Generalize the patterns to match occurrences like this
```
19:30:12  IOException caught during compilation: Server failed to initialize: Resource deadlock avoided
```
as seen in https://openj9-jenkins.osuosl.org/job/Build_JDK17_aarch64_mac_OMR/555/console.
