### PR TITLE
JITServer shared fanin cache

### DIFF
--- a/doc/compiler/jitserver/IProfiler.md
+++ b/doc/compiler/jitserver/IProfiler.md
@@ -28,7 +28,7 @@ There are two different kinds of entries that we handle: method entries and byte
 
 ## Method entries
 
-Holds profiling data relating to a method. This data is currently not cached. When the method `searchForMethodSample` is called on the server, it sends a message to the client. The client serializes the data using `TR_ContiguousIPMethodHashTableEntry::serialize` and the server deserializes it with `deserializeMethodEntry`.
+Holds profiling data relating to a method. This data is currently not cached. When the method `searchForMethodSample` is called on the server, it sends a message to the client. The client serializes the data using `TR_ContiguousIPMethodHashTableEntry::serialize` and the server deserializes it with `deserializeFaninMethodEntry`.
 
 ## Bytecode entries
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2721,7 +2721,7 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          auto recv = client->getRecvData<TR_OpaqueMethodBlock*>();
          auto method = std::get<0>(recv);
          JITClientIProfiler *iProfiler = (JITClientIProfiler *) fe->getIProfiler();
-         client->write(response, iProfiler->serializeIProfilerMethodEntry(method));
+         client->write(response, iProfiler->serializeFaninMethodEntry(method));
          }
          break;
       case MessageType::IProfiler_profilingSample:

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -260,7 +260,7 @@ private:
    bool _virtualMethodIsOverridden; // cached information coming from client
    TR_PersistentJittedBodyInfo *_bodyInfo; // cached info coming from the client; uses heap memory
                                            // If method is not yet compiled this is null
-   TR_IPMethodHashTableEntry *_iProfilerMethodEntry;
+   TR_FaninSummaryInfo *_faninSummaryInfo;
    bool _isLambdaFormGeneratedMethod;
    bool _isForceInline;
    bool _isDontInline;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 85; // ID: VpWQDRXvGwj4itEK28/M
+   static const uint16_t MINOR_NUMBER = 86; // ID: BCKfWO4CkQZavXQYQ4k2
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2967,9 +2967,6 @@ TR_J9InlinerPolicy::adjustFanInSizeInWeighCallSite(int32_t& weight,
 
       INLINE_fanInCallGraphFactor is an integer number divided by 100. This allows us to avoid using float numbers for specifying the factor.
       */
-
-
-
       if (comp()->getMethodHotness() > warm)
          return;
 

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3626,6 +3626,13 @@ TR_IProfiler::getFaninInfo(TR_OpaqueMethodBlock *calleeMethod, uint32_t *count, 
    return;
    }
 
+/**
+ * @brief Search for the calee-caller-bcIndex triplet in the method hashtable.
+ *        If the triplet is found, return 'true' and set '*weight' to the number of samples for that caller-bcIndex.
+ *        If there is cached info for the callee, but the desired caller-bcIndex is not found, return 'false'
+ *        and set '*weight' to the "other" bucket weight.
+ *        If there is no cached info for the callee, return 'false' and set '*weight' to ~0
+ */
 bool TR_IProfiler::getCallerWeight(TR_OpaqueMethodBlock *calleeMethod,TR_OpaqueMethodBlock *callerMethod, uint32_t *weight, uint32_t pcIndex, TR::Compilation *comp)
 {
    // First: hash the method

--- a/runtime/compiler/runtime/IProfiler.hpp
+++ b/runtime/compiler/runtime/IProfiler.hpp
@@ -300,12 +300,12 @@ class TR_IPMethodData
    {
    public:
    TR_IPMethodData() : _method(0),_pcIndex(0),_weight(0) {}
-   TR_OpaqueMethodBlock *getMethod() { return _method; }
+   TR_OpaqueMethodBlock *getMethod() const { return _method; }
    void setMethod (TR_OpaqueMethodBlock *meth) { _method = meth; }
-   uint32_t getWeight() { return _weight; }
+   uint32_t getWeight() const { return _weight; }
    void     incWeight() { ++_weight; }
    void     setWeight(uint32_t weight) { _weight = weight; }
-   uint32_t getPCIndex() { return _pcIndex; }
+   uint32_t getPCIndex() const { return _pcIndex; }
    void     setPCIndex(uint32_t i) { _pcIndex = i; }
 
    TR_IPMethodData* next;

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -39,6 +39,7 @@ class TR_OpaqueMethodBlock;
 class TR_PersistentClassInfo;
 class J9ConstantPool;
 class TR_IPBytecodeHashTableEntry;
+class TR_IPMethodHashTableEntry;
 class TR_MethodToBeCompiled;
 class TR_AddressRange;
 class TR_PersistentCHTable;
@@ -418,10 +419,12 @@ public:
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, TR_IPBytecodeHashTableEntry *entry, bool isCompiled);
    bool cacheIProfilerInfo(TR_OpaqueMethodBlock *method, const Vector<TR_IPBytecodeHashTableEntry *> &entries, bool isCompiled);
    void checkProfileDataMatching(J9Method *method, const std::string &ipdata);
-   uint64_t getNumSamplesForMethodInSharedProfileCache(J9Method* method);
+   ProfiledMethodEntry *getSharedProfileCacheForMethod(J9Method* method);
    BytecodeProfileSummary getSharedBytecodeProfileSummary(J9Method* method);
    bool loadBytecodeDataFromSharedProfileCache(J9Method *method, bool stable, TR::Compilation *comp, const std::string &ipdata);
    bool storeBytecodeProfileInSharedRepository(TR_OpaqueMethodBlock *method, const std::string &ipdata, uint64_t numSamples, bool isStable, TR::Compilation *);
+   TR_FaninSummaryInfo *loadFaninDataFromSharedProfileCache(TR_OpaqueMethodBlock *method, TR_Memory *trMemory);
+   bool storeFaninDataInSharedProfileCache(TR_OpaqueMethodBlock *method, const TR_ContiguousIPMethodHashTableEntry *serialEntry);
    VMInfo *getOrCacheVMInfo(JITServer::ServerStream *stream);
    void clearCaches(bool locked=false); // destroys _chTableClassMap, _romClassMap, _J9MethodMap, _unloadedClassAddresses and _DLTedMethodSet
    void clearCachesLocked(TR_J9VMBase *fe);
@@ -665,6 +668,11 @@ private:
    uint32_t _numSharedProfileCacheMethodLoadsFailed;
    uint32_t _numSharedProfileCacheMethodStores;
    uint32_t _numSharedProfileCacheMethodStoresFailed;
+
+   uint32_t _numSharedFaninCacheMethodLoads;
+   uint32_t _numSharedFaninCacheMethodLoadsFailed;
+   uint32_t _numSharedFaninCacheMethodStores;
+   uint32_t _numSharedFaninCacheMethodStoresFailed;
    }; // class ClientSessionData
 
 


### PR DESCRIPTION
Fanin data is used by the Inliner to determine from how many different places a callee is invoked. Fanin data is collected by the interpreter profiler and is kept per j9method caller. For each caller we have a linked list of up to 20 entries of <caller, pcIndex, numSamples>  (the searching key is <caller, pcIndex>). Currently, the fanin data is serialized and sent to server every time the server creates a j9ResolvedMethod (this happens very often).

This PR proposes to store fanin data at the server in a shared repository (JITServerSharedProfileCache hashtable) that can be accessed by different clients. The 'key' to search for the fanin data of a particular method is a `AOTCacheMethodRecord`. The 'value' is a `ProfiledMethodEntry` which includes a `FaninProfile`. For simplicity, the FaninProfile of a method will include only 3 fields:
```
class FaninProfile
   {
   uint64_t _numSamples; // Total number of fanin samples for this callee
   uint64_t _numSamplesOtherBucket; // Number of samples falling in the 'otherBucket'
   uint32_t _numCallers; // Number of different callers (max is MAX_IPMETHOD_CALLERS+1)
   };
```
This simplified view is enough for the Inliner to take appropriate inlining decisions. In a future PR we may eliminate the list of callers that are sent by the client to the server because their identity is not important for performance.

Flow if information:
1. The server creates a TR_ResolvedJ9JITServerMethod. As part of that process the server sends a message to the client to create a resolved method mirror and the client embeds the fanin info in the reply (serialized info).
2. The server stores fanin info into the resolved method (with "heap" memory) by using `TR_ResolvedJ9JITServerMethod::unpackMethodInfo()` which calls `iProfiler->cacheFaninDataForMethod()`
3. The server may have two different sources of fanin info: (1) the data sent by the client and (2) the data stored in the shared profile cache The server compares the quality of the data of both sources using `JITServerSharedProfileCache::compareFaninProfiles()` and picks the source of higher quality. At this point the quality is judged solely based on the total number of samples.
4. If the shared profile repository has better fanin quality, the server will load that using` clientSession->loadFaninDataFromSharedProfileCache();`
5. If the client has better fanin quality, the server deserializes the data from the client with `deserializeFaninMethodEntry()`, but also stores this information into the shared profile repository: `clientSession->storeFaninDataInSharedProfileCache()`
6. If the two fanin sources are about the same in tems of quality, then the server picks the data sent by the client because it is fresher.
7. At a later point, the Inliner reads the fanin info stored in the J9ResolvedMethod.

**Storing the fanin data into the shared profile repository:** `ClientSessionData::storeFaninDataInSharedProfileCache(TR_OpaqueMethodBlock *method, const TR_ContiguousIPMethodHashTableEntry *serialEntry)`
1. The server converts the incoming j9method into a `AOTCacheMethodRecord`. To do so, first the server uses the j9method as a key into the `_J9MethodMap` to find the corresponding `J9MethodInfo` and from there it returns `_aotCacheMethodRecord`. If the `aotCacheMethodRecord` does not yet exist, it will be created by using `getClassRecord()` and `getMethodRecord()`
2. The obtained methodRecord is used as a key into the `JITServerSharedProfileCache` hashtable to retrieve a `ProfiledMethodEntry`
3. If the desired `ProfiledMethodEntry` exists, the server writes (or overwrites) the fanin data.
4. If the desired `ProfiledMethodEntry`does not exist, the server creates a new one and writes the fanin data.

**Loading the fanin data from the shared profile repository:** `ClientSessionData::loadFaninDataFromSharedProfileCache(TR_OpaqueMethodBlock *method, TR_Memory *trMemory)`
1. The server converts the incoming j9method into a `AOTCacheMethodRecord` (see details in the storing procedure)
2. The obtained methodRecord is used as a key into the `JITServerSharedProfileCache` hashtable to retrieve a `ProfiledMethodEntry`
3. If the cached fanin exists, the server use "heap" memory to allocate a `TR_FaninSummaryInfo` structure which be returned to the caller to be stored in the J9ResolvedMethod. If the cached fanin does not exist, the server returns a NULL pointer.