### PR TITLE
Refactor wasDeserialized flag

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -1169,7 +1169,6 @@ TR::CompilationInfoPerThread::CompilationInfoPerThread(TR::CompilationInfo &comp
       {
       _classesThatShouldNotBeNewlyExtended = NULL;
       }
-   _deserializerWasReset = false;
 #endif /* defined(J9VM_OPT_JITSERVER) */
    }
 
@@ -13374,7 +13373,10 @@ TR::CompilationInfo::notifyCompilationThreadsOfDeserializerReset()
       {
       TR::CompilationInfoPerThread *curCompThreadInfoPT = _arrayOfCompilationInfoPerThread[i];
       TR_ASSERT(curCompThreadInfoPT, "a thread's compinfo is missing\n");
-      curCompThreadInfoPT->setDeserializerWasReset();
+
+      // The curCompThreadInfoPT->_vm may not be set yet
+      auto vm = TR_J9VMBase::get(_jitConfig, curCompThreadInfoPT->getCompilationThread());
+      vm->setDeserializerWasReset();
       }
    }
 #endif /* defined(J9VM_OPT_JITSERVER) */

--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -145,8 +145,10 @@ class CompilationInfoPerThreadBase
    public:
    CompilationInfoPerThreadBase(TR::CompilationInfo &compInfo, J9JITConfig *jitConfig, int32_t id, bool onSeparateThread);
 
-   TR::CompilationInfo    *getCompilationInfo() { return &_compInfo; }
+   TR::CompilationInfo   *getCompilationInfo() { return &_compInfo; }
    J9JITConfig           *getJitConfig() { return _jitConfig; }
+   TR_J9VMBase           *getJ9VM() { return _vm; }
+
    TR_MethodToBeCompiled *getMethodBeingCompiled() { return _methodBeingCompiled; }
    void                   setMethodBeingCompiled(TR_MethodToBeCompiled *m) { _methodBeingCompiled = m; }
 
@@ -516,11 +518,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    J9ROMClass               *getAndCacheRemoteROMClass(J9Class *clazz);
    J9ROMClass               *getRemoteROMClassIfCached(J9Class *clazz);
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *getClassesThatShouldNotBeNewlyExtended() const { return _classesThatShouldNotBeNewlyExtended; }
-   bool                      getDeserializerWasReset() const { return _deserializerWasReset; }
-   // Called externally by a compilation thread that is resetting the JITServer AOT deserializer
-   void                      setDeserializerWasReset() { _deserializerWasReset = true; }
-   // Called by the current compilation thread at the beginning of a remote compilation to clear the _deserializerWasReset flag
-   void                      clearDeserializerWasReset() { _deserializerWasReset = false; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    protected:
@@ -545,8 +542,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
    // The following hastable caches <classLoader,classname> --> <J9Class> mappings
    // The cache only lives during a compilation due to class unloading concerns
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *_classesThatShouldNotBeNewlyExtended;
-   // A flag notifying this thread that the JITServer AOT deserializer was reset.
-   bool _deserializerWasReset;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    }; // CompilationInfoPerThread

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3451,7 +3451,7 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
    // 1. Requests an AOT cache store or load from the server, or
    // 2. Accesses the JITServer AOT deserializer in any way.
    // That moment is currently right here, when we get the new known IDs that are cached in the deserializer.
-   ((TR::CompilationInfoPerThread *)compInfoPT)->clearDeserializerWasReset();
+   compInfoPT->getJ9VM()->clearDeserializerWasReset();
    std::vector<uintptr_t> newKnownIds = deserializer ? deserializer->getNewKnownIds(compiler) : std::vector<uintptr_t>();
 
    // TODO: make this a synchronized region to avoid bad_alloc exceptions

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -798,6 +798,7 @@ TR_J9VMBase::TR_J9VMBase(
      _shouldSleep(false)
 #if defined(J9VM_OPT_JITSERVER)
      ,_deserializerSharedCache(NULL)
+     ,_deserializerWasReset(false)
 #endif /* defined(J9VM_OPT_JITSERVER) */
    {
    for (int32_t i = 0; i < UT_MODULE_INFO.count; ++i)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1454,6 +1454,12 @@ public:
 
 #if defined(J9VM_OPT_JITSERVER)
    TR_J9DeserializerSharedCache *deserializerSharedCache() const { return _deserializerSharedCache; }
+
+   bool                      getDeserializerWasReset() const { return _deserializerWasReset; }
+   // Called externally by a compilation thread that is resetting the JITServer AOT deserializer
+   void                      setDeserializerWasReset() { _deserializerWasReset = true; }
+   // Called by the current compilation thread at the beginning of a remote compilation to clear the _deserializerWasReset flag
+   void                      clearDeserializerWasReset() { _deserializerWasReset = false; }
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
    const char *getByteCodeName(uint8_t opcode);
@@ -1557,6 +1563,10 @@ protected:
 
    flags32_t _flags;
 
+#if defined(J9VM_OPT_JITSERVER)
+   // A flag notifying this thread that the JITServer AOT deserializer was reset.
+   bool _deserializerWasReset;
+#endif // defined(J9VM_OPT_JITSERVER)
    };
 
 class TR_J9VM : public TR_J9VMBase


### PR DESCRIPTION
The wasDeserialized flag is used to inform other threads that the deserializer was reset. This used to be a member of the TR_CompilationInfoPerThread class. However, this class is only guaranteed to exist for compilation threads. In preparation to support AOT Method Dependencies for JITServer, a non-compilation thread may need to invoke the deserializer. As such, there needs to be a way to inform non-compilation threads that the deserializer was reset.

This commit refactors out the flag and places it in the TR_J9VMBase class. It also adds an API to allow non-compilation threads to register with the Deserializer to be notified about when the deserializer gets reset.

See https://github.com/eclipse-openj9/openj9/issues/22014