### PR TITLE
Delete unused methods related to class `ramStatics` addresses

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -1666,39 +1666,6 @@ J9::SymbolReferenceTable::findOrCreateMethodHandleSymbol(TR::ResolvedMethodSymbo
 
 
 TR::SymbolReference *
-J9::SymbolReferenceTable::findOrCreateClassStaticsSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex)
-   {
-   TR_ResolvedMethod * owningMethod = owningMethodSymbol->getResolvedMethod();
-
-   TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
-   void * classStatics = fej9->addressOfFirstClassStatic(owningMethod->classOfStatic(cpIndex, true));
-
-   ListIterator<TR::SymbolReference> i(&_classStaticsSymbolRefs);
-   TR::SymbolReference * symRef;
-   for (symRef = i.getFirst(); symRef; symRef = i.getNext())
-      if (symRef->getSymbol()->getStaticSymbol()->getStaticAddress() == classStatics)
-         return symRef;
-
-   TR::StaticSymbol * sym = TR::StaticSymbol::create(trHeapMemory(),TR::Address);
-   sym->setStaticAddress(classStatics);
-   if (!TR::Compiler->cls.classObjectsMayBeCollected())
-      sym->setNotCollected();
-   // cpIndex for resolved Class statics symbol is unused. Furthermore having a cpIndex here might create illusion for cases where we
-   // care about cpIndex and also as Two or more (resolved) static field references belonging to same class will
-   // share the same information (inlined call site index, cpIndex) , using a cpIndex for these cases will
-   // need further changes to prevent any sharing hence it is set to -1 for static resolved fields.
-   // For more detailed information take a look at PR#4322 in eclipse-openj9/openj9 repo
-   symRef = new (trHeapMemory()) TR::SymbolReference(self(), sym, owningMethodSymbol->getResolvedMethodIndex(), -1);
-
-   aliasBuilder.addressStaticSymRefs().set(symRef->getReferenceNumber()); // add the symRef to the statics list to get correct aliasing info
-
-   _classStaticsSymbolRefs.add(symRef);
-
-   return symRef;
-   }
-
-
-TR::SymbolReference *
 J9::SymbolReferenceTable::findOrCreateClassFromJavaLangClassAsPrimitiveSymbolRef()
    {
    if (!element(classFromJavaLangClassAsPrimitiveSymbol))

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -299,7 +299,6 @@ class SymbolReferenceTable : public OMR::SymbolReferenceTableConnector
    TR::SymbolReference * findOrCreateCompiledMethodSymbolRef();
    TR::SymbolReference * findOrCreateMethodTypeSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * findOrCreateMethodHandleSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
-   TR::SymbolReference * findOrCreateClassStaticsSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex);
    TR::SymbolReference * findOrCreateStaticSymbol(TR::ResolvedMethodSymbol * owningMethodSymbol, int32_t cpIndex, bool isStore);
 
    TR::SymbolReference * findOrCreateClassIsArraySymbolRef();

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -968,12 +968,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, fe->getMethodSize(method));
          }
          break;
-      case MessageType::VM_addressOfFirstClassStatic:
-         {
-         TR_OpaqueClassBlock *clazz = std::get<0>(client->getRecvData<TR_OpaqueClassBlock *>());
-         client->write(response, fe->addressOfFirstClassStatic(clazz));
-         }
-         break;
       case MessageType::VM_getStaticFieldAddress:
          {
          auto recv = client->getRecvData<TR_OpaqueClassBlock *, std::string, std::string>();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6016,12 +6016,6 @@ TR_J9VMBase:: virtualCallOffsetToVTableSlot(U_32 offset)
    return TR::Compiler->vm.getInterpreterVTableOffset() - offset;
    }
 
-void *
-TR_J9VMBase:: addressOfFirstClassStatic(TR_OpaqueClassBlock * j9Class)
-   {
-   return (void *)(TR::Compiler->cls.convertClassOffsetToClassPtr(j9Class)->ramStatics);
-   }
-
 U_32
 TR_J9VMBase::offsetOfIsOverriddenBit()
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -838,7 +838,6 @@ public:
    virtual bool               isBeingCompiled(TR_OpaqueMethodBlock *methodInfo, void *startPC);
    virtual uint32_t           virtualCallOffsetToVTableSlot(uint32_t offset);
    virtual int32_t            vTableSlotToVirtualCallOffset(uint32_t vTableSlot);
-   virtual void *             addressOfFirstClassStatic(TR_OpaqueClassBlock *);
 
    virtual TR_ResolvedMethod * getDefaultConstructor(TR_Memory *, TR_OpaqueClassBlock *);
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1706,14 +1706,6 @@ TR_J9ServerVM::getMethodSize(TR_OpaqueMethodBlock *method)
    }
 
 void *
-TR_J9ServerVM::addressOfFirstClassStatic(TR_OpaqueClassBlock *clazz)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_addressOfFirstClassStatic, clazz);
-   return std::get<0>(stream->read<void *>());
-   }
-
-void *
 TR_J9ServerVM::getStaticFieldAddress(TR_OpaqueClassBlock *clazz, unsigned char *fieldName, uint32_t fieldLen, unsigned char *sig, uint32_t sigLen)
    {
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -183,7 +183,6 @@ public:
    virtual void reportHotField(int32_t reducedCpuUtil, J9Class* clazz, uint8_t fieldOffset,  uint32_t reducedFrequency) override;
    virtual int32_t * getReferenceSlotsInClass(TR::Compilation *comp, TR_OpaqueClassBlock *clazz) override;
    virtual uint32_t getMethodSize(TR_OpaqueMethodBlock *method) override;
-   virtual void * addressOfFirstClassStatic(TR_OpaqueClassBlock *clazz) override;
    virtual void * getStaticFieldAddress(TR_OpaqueClassBlock *clazz, unsigned char *fieldName, uint32_t fieldLen, unsigned char *sig, uint32_t sigLen) override;
    virtual int32_t getInterpreterVTableSlot(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz) override;
    virtual void revertToInterpreted(TR_OpaqueMethodBlock *method) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 84; // ID: gIq88QhwCmuOoBAlidaE
+   static const uint16_t MINOR_NUMBER = 85; // ID: VpWQDRXvGwj4itEK28/M
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -148,7 +148,6 @@ const char *messageNames[] =
    "VM_reportHotField",
    "VM_getReferenceSlotsInClass",
    "VM_getMethodSize",
-   "VM_addressOfFirstClassStatic",
    "VM_getStaticFieldAddress",
    "VM_getInterpreterVTableSlot",
    "VM_revertToInterpreted",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -157,7 +157,6 @@ enum MessageType : uint16_t
    VM_reportHotField,
    VM_getReferenceSlotsInClass,
    VM_getMethodSize,
-   VM_addressOfFirstClassStatic,
    VM_getStaticFieldAddress,
    VM_getInterpreterVTableSlot,
    VM_revertToInterpreted,


### PR DESCRIPTION
- Delete `J9::SymbolReferenceTable::findOrCreateClassStaticsSymbol()`
- Delete unused method `TR_J9VMBase::addressOfFirstClassStatic()`