### PR TITLE
Remove MemberName Object Ref from Stack in OpenJDK MethodHandle linkTo* INL Methods

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -9696,9 +9696,17 @@ done:
 				stackOffset = 2;
 			}
 
+			/* On x86-32 we do not want to preserve the MemberName object since this would cause it to
+			 * end up in the EIP register when the caller of the MH's target returns, since the target will only
+			 * pop off its own arguments in the call cleanup.
+			 */
+#if (defined(J9VM_ARCH_X86) && !defined(J9VM_ENV_DATA64))
+			_sp += stackOffset;
+#else /* (defined(J9VM_ARCH_X86) && !defined(J9VM_ENV_DATA64)) */
 			/* Shift arguments by stackOffset and place memberNameObject before the first argument. */
 			memmove(_sp, _sp + stackOffset, methodArgCount * sizeof(UDATA));
 			_sp[methodArgCount] = (UDATA)memberNameObject;
+#endif /* (defined(J9VM_ARCH_X86) && !defined(J9VM_ENV_DATA64)) */
 
 			VM_JITInterface::restoreJITReturnAddress(_currentThread, _sp, (void *)_literals);
 			rc = j2iTransition(REGISTER_ARGS, true);
@@ -9785,12 +9793,18 @@ throw_npe:
 		}
 
 		if (fromJIT) {
+			/* On x86-32 we do not want to preserve the MemberName object since this would cause it to
+			 * end up in the EIP register when the caller of the MH's target returns, since the target will only
+			 * pop off its own arguments in the call cleanup.
+			 */
+#if (!defined(J9VM_ARCH_X86) || defined(J9VM_ENV_DATA64))
 			/* Restore SP to before popping memberNameObject. */
 			_sp -= 1;
 
 			/* Shift arguments by 1 and place memberNameObject before the first argument. */
 			memmove(_sp, _sp + 1, methodArgCount * sizeof(UDATA));
 			_sp[methodArgCount] = (UDATA)memberNameObject;
+#endif /* (!defined(J9VM_ARCH_X86) || defined(J9VM_ENV_DATA64)) */
 
 			VM_JITInterface::restoreJITReturnAddress(_currentThread, _sp, (void *)_literals);
 			rc = j2iTransition(REGISTER_ARGS, true);
@@ -9894,12 +9908,18 @@ foundITable:
 		}
 
 		if (fromJIT) {
+			/* On x86-32 we do not want to preserve the MemberName object since this would cause it to
+			 * end up in the EIP register when the caller of the MH's target returns, since the target will only
+			 * pop off its own arguments in the call cleanup.
+			 */
+#if (!defined(J9VM_ARCH_X86) || defined(J9VM_ENV_DATA64))
 			/* Restore SP to before popping memberNameObject. */
 			_sp -= 1;
 
 			/* Shift arguments by 1 and place memberNameObject before the first argument. */
 			memmove(_sp, _sp + 1, methodArgCount * sizeof(UDATA));
 			_sp[methodArgCount] = (UDATA)memberNameObject;
+#endif /* (!defined(J9VM_ARCH_X86) || defined(J9VM_ENV_DATA64)) */
 
 			VM_JITInterface::restoreJITReturnAddress(_currentThread, _sp, (void *)_literals);
 			rc = j2iTransition(REGISTER_ARGS, true);


### PR DESCRIPTION
When calling the various linkTo methods (namely `linkToStatic()`, `linkToSpecial()`, `linkToVirtual()`, `linkToInterface()`), the JIT must pass in a `MemberName` object which` linkTo*()` expects to be at `_sp[0]`. The `linkTo*()` methods use the MN to find the target method, after which it is not needed. So, before running the target, we move the MN to `_sp[methodArgCount]`, where `methodArgCount` is the argument count of the target method.

This creates problems on x86 32 bit, where we pass arguments on the stack. When calling a MH from JITed code where we transition into the interpreter, only the target method's arguments will be popped of the stack upon return which causes the MN address to end up in the EIP when the caller returns.

This PR changes the `linkTo*()` methods to pop the MN from the stack since it is not used by the target.

Issue: https://github.com/eclipse-openj9/openj9/issues/18751