### PR TITLE
Fix 'bad integer narrowing constraint' assertion fails occurring with OpenJDK MethodHandle implementation on X86_32

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -1682,7 +1682,7 @@ void J9::RecognizedCallTransformer::process_java_lang_invoke_MethodHandle_linkTo
       "java/lang/invoke/MemberName.vmindex J");
 
    TR::Node *vftOffset =
-      TR::Node::createWithSymRef(node, TR::aloadi, 1, memberNameNode, vmIndexSymRef);
+      TR::Node::createWithSymRef(node, TR::lloadi, 1, memberNameNode, vmIndexSymRef);
 
    if (!comp()->target().is64Bit())
       vftOffset = TR::Node::create(node, TR::l2i, 1, vftOffset);


### PR DESCRIPTION
When loading `MemberName.vmindex` for the call to `dispatchVirtual`, we were loading using `aloadi`. However, this field has type `long`, which creates problems on x86_32.

This commit changes the load to use `lloadi` instead to avoid the compiler assertion fail `bad integer narrowing constraint`


Issue: #18751