### PR TITLE
Use the full (canonical) MXBean object name in GC notifications

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/MemoryNotificationThread.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/MemoryNotificationThread.java
@@ -101,7 +101,7 @@ final class MemoryNotificationThread implements Runnable {
 			if (bean instanceof GarbageCollectorMXBeanImpl && bean.getName().equals(gcName)) {
 				Notification notification = new Notification(
 						GarbageCollectionNotificationInfo.GARBAGE_COLLECTION_NOTIFICATION,
-						"java.lang:type=GarbageCollector", //$NON-NLS-1$
+						bean.getObjectName().getCanonicalName(),
 						sequenceNumber);
 				notification.setUserData(GarbageCollectionNotificationInfoUtil.toCompositeData(info));
 				((GarbageCollectorMXBeanImpl) bean).sendNotification(notification);


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/22120.