### PR TITLE
x86: Inline StringLatin1.indexOf([BI[BII)I

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -109,6 +109,11 @@ J9::X86::CodeGenerator::initialize()
        !TR::Compiler->om.canGenerateArraylets() && !TR::Compiler->om.isOffHeapAllocationEnabled())
       {
       cg->setSupportsInlineStringIndexOf();
+      if (comp->target().is64Bit())
+         {
+         // Not supported on 32-bit platform
+         cg->setSupportsInlineStringIndexOfString();
+         }
       }
 
    if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_1) &&

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -10108,6 +10108,252 @@ static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, TR::CodeGenerator* c
 
 /**
  * \brief
+ *   Generate inlined instructions equivalent to java/lang/StringLatin1.indexOf([BI[BII)I
+ *
+ * \param node
+ *   The tree node
+ *
+ * \param cg
+ *   The Code Generator
+ *
+ * Note that this version does not support discontiguous arrays
+ */
+static TR::Register* inlineIntrinsicStringIndexOfString(TR::Node* node, TR::CodeGenerator* cg)
+   {
+   static bool disableStrIdxOfStr = (feGetEnv("TR_disableStrIdxOfStr") != NULL);
+   if (disableStrIdxOfStr) return NULL;
+
+   static bool verboseStrIdxOfStr = (feGetEnv("TR_verboseStrIdxOfStr") != NULL);
+   if (verboseStrIdxOfStr)
+      {
+      fprintf(stderr, "*Latin1.indexOfString(): %s @%s\n", cg->comp()->signature(), cg->comp()->getHotnessName());
+      }
+
+   TR_ASSERT_FATAL(cg->comp()->target().is64Bit(), "Not supported on 32-bit platform");
+
+   // This evaluator function handles different indexOf() intrinsics, some of which are static calls without a
+   // receiver. Hence, the need for static call check.
+   const bool isStaticCall = node->getSymbolReference()->getSymbol()->castToMethodSymbol()->isStatic();
+   const uint8_t firstCallArgIdx = isStaticCall ? 0 : 1;
+   TR::Register *s1Reg = cg->evaluate(node->getChild(firstCallArgIdx));
+   TR::Node *s1lenNode = node->getChild(firstCallArgIdx+1);
+   TR::Register *s1lenReg = cg->evaluate(s1lenNode);
+   TR::Register *s2Reg = cg->evaluate(node->getChild(firstCallArgIdx+2));
+   TR::Register *s2lenReg = cg->evaluate(node->getChild(firstCallArgIdx+3));
+   TR::Node *offsetNode = node->getChild(firstCallArgIdx+4);
+   TR::Register *offsetReg = cg->evaluate(offsetNode);
+
+   TR::Register *maxReg;
+   if (s1lenNode->getReferenceCount() == 1)
+      {
+      maxReg = s1lenReg;
+      }
+   else
+      {
+      maxReg = cg->allocateRegister(TR_GPR);
+      generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, maxReg, s1lenReg, cg);
+      }
+
+   TR::Register *resultReg;
+   if (offsetNode->getReferenceCount() == 1)
+      {
+      resultReg = offsetReg;
+      }
+   else
+      {
+      resultReg = cg->allocateRegister(TR_GPR);
+      generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, resultReg, offsetReg, cg);
+      }
+
+   static uint8_t MASKOFSIZEONE[] =
+      {
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      0x00, 0x00, 0x00, 0x00,
+      };
+
+   const uint8_t width = 16;
+
+   TR::Register *ECX = cg->allocateRegister(TR_GPR);
+   TR::Register *tmpReg = cg->allocateRegister(TR_GPR);
+   TR::Register *xmmReg1 = cg->allocateRegister(TR_VRF);
+   TR::Register *xmmReg2 = cg->allocateRegister(TR_VRF);
+   TR::Register *xmmReg3 = cg->allocateRegister(TR_VRF);
+   TR::Register *s1idxReg = cg->allocateRegister(TR_GPR);
+   TR::Register *s2idxReg = cg->allocateRegister(TR_GPR);
+
+   TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions((uint8_t)12, (uint8_t)12, cg);
+   dependencies->addPreCondition(s1Reg, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(s2Reg, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(s2lenReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(maxReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(resultReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(ECX, TR::RealRegister::ecx, cg);
+   dependencies->addPreCondition(tmpReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(xmmReg1, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(xmmReg2, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(xmmReg3, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(s1idxReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPreCondition(s2idxReg, TR::RealRegister::NoReg, cg);
+
+   dependencies->addPostCondition(s1Reg, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(s2Reg, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(s2lenReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(maxReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(resultReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(ECX, TR::RealRegister::ecx, cg);
+   dependencies->addPostCondition(tmpReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(xmmReg1, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(xmmReg2, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(xmmReg3, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(s1idxReg, TR::RealRegister::NoReg, cg);
+   dependencies->addPostCondition(s2idxReg, TR::RealRegister::NoReg, cg);
+
+   TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *outerLoopLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *firstCharLoopLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *firstCharMatchedLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *qwordLoopLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *byteLoopLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *unmatchedLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *notFoundLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *foundLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
+
+   startLabel->setStartInternalControlFlow();
+   doneLabel->setEndInternalControlFlow();
+
+   generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+
+   int32_t hdrSize = static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
+
+   // load first char of s2
+   generateRegMemInstruction(TR::InstOpCode::MOVZXReg4Mem1, node, tmpReg, generateX86MemoryReference(s2Reg, hdrSize, cg), cg);
+   generateRegRegInstruction(TR::InstOpCode::MOVDRegReg4, node, xmmReg2, tmpReg, cg);
+   generateRegMemInstruction(TR::InstOpCode::PSHUFBRegMem, node, xmmReg2, generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, MASKOFSIZEONE), cg), cg);
+
+   // calculate max
+   generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, maxReg, s2lenReg, cg); // s1len - s2len
+
+   // outer loop
+   generateLabelInstruction(TR::InstOpCode::label, node, outerLoopLabel, cg);
+   generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmpReg, generateX86MemoryReference(s1Reg, resultReg, 0, hdrSize, cg), cg);
+   generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, ECX, tmpReg, cg);
+   generateRegImmInstruction(TR::InstOpCode::AND4RegImms, node, ECX, width - 1, cg);
+   generateLabelInstruction(TR::InstOpCode::JE1, node, firstCharLoopLabel, cg);
+
+   generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, tmpReg, ~(width - 1), cg);
+   generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, generateX86MemoryReference(tmpReg, 0, cg), cg);
+   generateRegRegInstruction(TR::InstOpCode::PCMPEQBRegReg, node, xmmReg1, xmmReg2, cg);
+   generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+   generateRegInstruction(TR::InstOpCode::SHR4RegCL, node, tmpReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
+   generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, resultReg, width, cg);
+   generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, resultReg, ECX, cg);
+   generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+
+   // loop for finding the first char
+   generateLabelInstruction(TR::InstOpCode::label, node, firstCharLoopLabel, cg);
+   generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, generateX86MemoryReference(s1Reg, resultReg, 0, hdrSize, cg), cg);
+   generateRegRegInstruction(TR::InstOpCode::PCMPEQBRegReg, node, xmmReg1, xmmReg2, cg);
+   generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+   generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
+   generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, resultReg, width, cg);
+   generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JLE1, node, firstCharLoopLabel, cg);
+   generateLabelInstruction(TR::InstOpCode::JMP4, node, notFoundLabel, cg);
+
+   // first char matched
+   generateLabelInstruction(TR::InstOpCode::label, node, firstCharMatchedLabel, cg);
+
+   generateRegRegInstruction(TR::InstOpCode::BSF4RegReg, node, tmpReg, tmpReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, resultReg, tmpReg, cg);
+
+   generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, s1idxReg, generateX86MemoryReference(resultReg, 1, cg), cg); // s1idx = offset + 1
+   generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, s2idxReg, 1, cg); // s2idx = 1
+
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, ECX, generateX86MemoryReference(s2lenReg, -1, cg), cg); // ECX = s2len - 1: 1st char has already matched
+   generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, ECX, 4, cg);
+   generateLabelInstruction(TR::InstOpCode::JE1, node, byteLoopLabel, cg);
+
+   // Compare by 16 bytes
+   generateLabelInstruction(TR::InstOpCode::label, node, qwordLoopLabel, cg);
+   generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, generateX86MemoryReference(s1Reg, s1idxReg, 0, hdrSize, cg), cg);
+   generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg3, generateX86MemoryReference(s2Reg, s2idxReg, 0, hdrSize, cg), cg);
+   generateRegRegInstruction(TR::InstOpCode::PCMPEQBRegReg, node, xmmReg1, xmmReg3, cg);
+   generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+   generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, tmpReg, 0xffff, cg);
+   generateLabelInstruction(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
+
+   generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, s1idxReg, width, cg);
+   generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, s2idxReg, width, cg);
+   generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, node, ECX, 1, cg);
+   generateLabelInstruction(TR::InstOpCode::JG1, node, qwordLoopLabel, cg);
+
+   // Compare each byte
+   generateLabelInstruction(TR::InstOpCode::label, node, byteLoopLabel, cg);
+   generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, s2lenReg, s2idxReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JLE1, node, doneLabel, cg); // resultReg has the result
+
+   generateRegMemInstruction(TR::InstOpCode::L1RegMem, node, tmpReg, generateX86MemoryReference(s2Reg, s2idxReg, 0, hdrSize, cg), cg);
+   generateMemRegInstruction(TR::InstOpCode::CMP1MemReg, node, generateX86MemoryReference(s1Reg, s1idxReg, 0, hdrSize, cg), tmpReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
+
+   generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, s1idxReg, 1, cg);
+   generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, s2idxReg, 1, cg);
+   generateLabelInstruction(TR::InstOpCode::JMP1, node, byteLoopLabel, cg);
+
+   // substring did not match
+   generateLabelInstruction(TR::InstOpCode::label, node, unmatchedLabel, cg);
+   generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, resultReg, 1, cg);
+   generateLabelInstruction(TR::InstOpCode::JMP4, node, outerLoopLabel, cg);
+
+   // not found
+   generateLabelInstruction(TR::InstOpCode::label, node, notFoundLabel, cg);
+   generateRegImmInstruction(TR::InstOpCode::OR4RegImms, node, resultReg, -1, cg);
+   // fall through to doneLabel
+
+   generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, dependencies, cg);
+
+   cg->stopUsingRegister(ECX);
+   cg->stopUsingRegister(tmpReg);
+   cg->stopUsingRegister(xmmReg1);
+   cg->stopUsingRegister(xmmReg2);
+   cg->stopUsingRegister(xmmReg3);
+   cg->stopUsingRegister(s1idxReg);
+   cg->stopUsingRegister(s2idxReg);
+
+   if (maxReg != s1lenReg)
+      {
+      cg->stopUsingRegister(maxReg);
+      }
+
+   node->setRegister(resultReg);
+
+   if (!isStaticCall)
+      {
+      cg->recursivelyDecReferenceCount(node->getChild(0));
+      }
+   for (int32_t i = firstCallArgIdx; i < node->getNumChildren(); i++)
+      {
+      cg->decReferenceCount(node->getChild(i));
+      }
+
+   return resultReg;
+   }
+
+/**
+ * \brief
  *   Generate inlined instructions equivalent to sun/misc/Unsafe.compareAndSwapObject or jdk/internal/misc/Unsafe.compareAndSwapObject
  *
  * \param node
@@ -12596,6 +12842,14 @@ J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *c
       case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfUTF16:
          if (cg->getSupportsInlineStringIndexOf())
             return inlineIntrinsicIndexOf(node, cg, false);
+         break;
+
+      case TR::java_lang_StringLatin1_indexOf:
+      case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
+         if (cg->getSupportsInlineStringIndexOfString())
+            returnRegister = inlineIntrinsicStringIndexOfString(node, cg);
+
+         callInlined = (returnRegister != NULL);
          break;
 
       case TR::com_ibm_jit_JITHelpers_transformedEncodeUTF16Big:


### PR DESCRIPTION
This commit generates vectorized inlined code for methods StringLatin1.indexOf([BI[BII)I and
JITHelpers.intrinsicIndexOfStringLatin1().