### PR TITLE
Ensure method symbol is a resolved method before requesting it

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1207,6 +1207,7 @@ J9::Compilation::getReloTypeForMethodToBeInlined(TR_VirtualGuardSelection *guard
             }
          else if (receiverClass
                   && TR::Compiler->cls.isAbstractClass(self(), receiverClass)
+                  && methodSymbol->isResolvedMethod()
                   && methodSymbol->getResolvedMethodSymbol()->getResolvedMethod()->isAbstract())
             {
             reloKind = TR_InlinedAbstractMethod;


### PR DESCRIPTION
In J9::Compilation::getReloTypeForMethodToBeInlined, for the Abstract Method scenario, the compiler needs the resolved method from the call node's method symbol to determine whether the called method is abstract. However, interface calls are treated as unresolved. This can cause a crash.

Fix this by first checking if the method symbol is a resolved method before acquiring it.

Fixes https://github.com/eclipse-openj9/openj9/issues/22085