### PR TITLE
Copy the excludes into latest_exclude_8 in openj9

### DIFF
--- a/test/TestConfig/resources/excludes/latest_exclude_8.txt
+++ b/test/TestConfig/resources/excludes/latest_exclude_8.txt
@@ -22,5 +22,30 @@
 
 # Exclude tests temporarily
 
-j9vm.test.softmx.SoftmxRemoteTest 480 generic-all
-org.openj9.test.vmArguments.VmArgumentTests:testCrNocr 244 generic-all
+j9vm.test.softmx.SoftmxRemoteTest                                                                                       480 generic-all
+org.openj9.test.vmArguments.VmArgumentTests:testCrNocr                                                                  244 generic-all
+#org.openj9.test.jsr335.interfacePrivateMethod.Test_ITestRunner															123456 generic-all
+#org.openj9.test.jsr335.interfacePrivateMethod.Test_ReflectionAndMethodHandles:testFindMethodsUsingGetMethods 			456789 linux_x86-64
+org.openj9.test.vm.Test_MsgHelp:test_loadMessages_EN																	124199 generic-all
+org.openj9.test.runlast.Test_JavaNetWithSideEffectsShouldRunLast:test_getResource										124199 generic-all
+#org.openj9.test.java.lang.Test_Class:testDefaultMethodInheritance														DaveW-58 generic-all
+#org.openj9.test.java.lang.Test_Class:testInterfaceMethodInheritance													DaveW-58 generic-all
+org.openj9.test.java.lang.Test_Class:test_getModifiers_classTypes														JTC-JAT-133182 generic-all
+org.openj9.test.java.lang.Test_Class:test_hideUnsafe																	124199 generic-all
+#org.openj9.test.java.lang.Test_Class:test_reflectConstructor															124199 generic-all
+#org.openj9.test.java.lang.Test_Class:test_reflectField																	124199 generic-all
+#org.openj9.test.java.lang.Test_Class:test_reflectMethod																124199 generic-all
+#org.openj9.test.java.lang.Test_String:test_toLowerCase																	124199 generic-all
+#org.openj9.test.java.lang.Test_Thread:test_stop3																		124199 generic-all
+#org.openj9.test.java.lang.Test_Thread:test_stop4																		124199 generic-all
+#org.openj9.test.java.lang.Test_Thread:test_stop5																		124199 generic-all
+org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher1															124199 generic-all
+org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher2															124199 generic-all
+org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_Cipher3															124199 generic-all
+org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_ECC1																124199 generic-all
+org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_ECC2																124199 generic-all
+org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_NIST_AES															124199 generic-all
+org.openj9.test.com.ibm.jit.Test_FunctionalCrypt:test_NIST_SHA															124199 generic-all
+jit.test.vich.CurrentTimeMillis:testCurrentTimeMillis																	158622 generic-all
+org.openj9.test.java.lang.Test_Thread:test_getContextClassLoader														125908 generic-all
+org.openj9.test.java.lang.Test_ClassLoader																				134754 generic-all


### PR DESCRIPTION
- Copy the excludes into latest_exclude_8 in openj9

related:https://github.ibm.com/runtimes/backlog/issues/1671