### PR TITLE
Use a "defaultMonitorSpinCount1" value of 1 when running on a single CPU

### DIFF
--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -710,6 +710,10 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #endif /* OMR_THR_ADAPTIVE_SPIN */
 
 #if defined(OMR_THR_THREE_TIER_LOCKING)
+	/* There is no advantage from spinning when running on a single processor. */
+	if (cpus <= 1) {
+		**(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount1") = 1;
+	}
 	omrthread_lib_clear_flags(J9THREAD_LIB_FLAG_SECONDARY_SPIN_OBJECT_MONITORS_ENABLED | J9THREAD_LIB_FLAG_FAST_NOTIFY);
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
 	{


### PR DESCRIPTION
When running on a single CPU, a tight spin loop may only waste CPU resources because there the thread that holds the lock cannot run on another CPU and release the lock. In such a case it's better to directly yield the CPU to another thread, hopefully the thread that holds the lock.