### PR TITLE
Add pending notify to compensate for missed notify

### DIFF
--- a/runtime/oti/ContinuationHelpers.hpp
+++ b/runtime/oti/ContinuationHelpers.hpp
@@ -121,6 +121,12 @@ public:
 #endif /* JAVA_SPEC_VERSION >= 24 */
 	}
 
+	static VMINLINE void
+	sendUnblockerThreadSignal(J9JavaVM *vm)
+	{
+		J9VM_SEND_VIRTUAL_UNBLOCKER_THREAD_SIGNAL(vm);
+	}
+
 	static VMINLINE ContinuationState volatile *
 	getContinuationStateAddress(J9VMThread *vmThread , j9object_t object)
 	{
@@ -410,7 +416,7 @@ public:
 				current->nextWaitingContinuation = vm->blockedContinuations;
 				vm->blockedContinuations = current;
 			}
-			omrthread_monitor_notify(vm->blockedVirtualThreadsMutex);
+			VM_ContinuationHelpers::sendUnblockerThreadSignal(vm);
 		}
 
 		omrthread_monitor_exit(vm->blockedVirtualThreadsMutex);

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -438,6 +438,14 @@ static_assert((LITERAL_STRLEN(J9_UNMODIFIABLE_CLASS_ANNOTATION) < (size_t)'/'), 
 #define J9VM_SHOULD_CLEAR_JNIIDS_FOR_ASGCT(vm, classLoader) (J9_ARE_NO_BITS_SET((vm)->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_NEVER_KEEP_JNI_IDS) \
 		&& ((classLoader)->asyncGetCallTraceUsed || J9_ARE_ANY_BITS_SET((vm)->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ALWAYS_KEEP_JNI_IDS)))
 
+#define J9VM_SEND_VIRTUAL_UNBLOCKER_THREAD_SIGNAL(vm) \
+		do {															\
+			omrthread_monitor_enter((vm)->blockedVirtualThreadsMutex); 	\
+			omrthread_monitor_notify((vm)->blockedVirtualThreadsMutex);	\
+			(vm)->pendingBlockedVirtualThreadsNotify = TRUE; 			\
+			omrthread_monitor_exit((vm)->blockedVirtualThreadsMutex);	\
+		} while (0)
+
 #define DIR_LIB_STR "lib"
 
 #if defined(J9VM_OPT_JFR)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6476,6 +6476,7 @@ typedef struct J9JavaVM {
 #if JAVA_SPEC_VERSION >= 24
 	J9VMContinuation *blockedContinuations;
 	omrthread_monitor_t blockedVirtualThreadsMutex;
+	BOOLEAN pendingBlockedVirtualThreadsNotify;
 #endif /* JAVA_SPEC_VERSION >= 24 */
 } J9JavaVM;
 

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1578,7 +1578,7 @@ obj:
 				/* Notify unblocker if the blocking monitor is unlocked or
 				 * if a platform thread is currently waiting on the monitor.
 				 */
-				omrthread_monitor_notify(_vm->blockedVirtualThreadsMutex);
+				VM_ContinuationHelpers::sendUnblockerThreadSignal(_vm);
 			}
 			omrthread_monitor_exit(_vm->blockedVirtualThreadsMutex);
 		}

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -103,9 +103,7 @@ restart:
 				if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)
 				&& (0 != objectMonitor->virtualThreadWaitCount)
 				) {
-					omrthread_monitor_enter(vm->blockedVirtualThreadsMutex);
-					omrthread_monitor_notify(vm->blockedVirtualThreadsMutex);
-					omrthread_monitor_exit(vm->blockedVirtualThreadsMutex);
+					J9VM_SEND_VIRTUAL_UNBLOCKER_THREAD_SIGNAL(vm);
 				}
 			}
 		} else {
@@ -301,9 +299,7 @@ restart:
 		if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)
 		&& (0 != objectMonitor->virtualThreadWaitCount)
 		) {
-			omrthread_monitor_enter(vm->blockedVirtualThreadsMutex);
-			omrthread_monitor_notify(vm->blockedVirtualThreadsMutex);
-			omrthread_monitor_exit(vm->blockedVirtualThreadsMutex);
+			J9VM_SEND_VIRTUAL_UNBLOCKER_THREAD_SIGNAL(vm);
 		}
 #endif /* JAVA_SPEC_VERSION >= 24 */
 		Trc_VM_objectMonitorExit_Exit_InflatedLock(vmStruct, rc);


### PR DESCRIPTION
If a notify is sent before the unblocker thread has started to to wait,
the notify is missed and a virtual may remain in the blocked queue
indefinitely.

Related to https://github.com/eclipse-openj9/openj9/issues/21826