### PR TITLE
Include time and duration in dump completion messages

### DIFF
--- a/runtime/nls/dump/j9dmp.nls
+++ b/runtime/nls/dump/j9dmp.nls
@@ -100,18 +100,12 @@ J9NLS_DMP_MISSING_EXECUTABLE_STR.sample_input_1=bogus
 J9NLS_DMP_MISSING_EXECUTABLE_STR.link=dita:///diag/tools/dumpagents_exec.dita
 # END NON-TRANSLATABLE
 
-J9NLS_DMP_PROCESSING_EVENT_STR=Processing dump event \"%1$s\", detail \"%3$.*2$s\" - please wait.
+J9NLS_DMP_PROCESSING_EVENT_STR=
 # START NON-TRANSLATABLE
-J9NLS_DMP_PROCESSING_EVENT_STR.explanation=A dump event has occurred and is being handled.
-J9NLS_DMP_PROCESSING_EVENT_STR.system_action=The JVM attempts to process the event.
-J9NLS_DMP_PROCESSING_EVENT_STR.user_response=No response is required.
-# vmstop is not translatable
-J9NLS_DMP_PROCESSING_EVENT_STR.sample_input_1=vmstop
-J9NLS_DMP_PROCESSING_EVENT_STR.sample_input_2=9
-J9NLS_DMP_PROCESSING_EVENT_STR.sample_input_3=#00000000
-J9NLS_DMP_PROCESSING_EVENT_STR.link=dita:///diag/tools/dump_agents.dita
+J9NLS_DMP_PROCESSING_EVENT_STR.explanation=NOTAG
+J9NLS_DMP_PROCESSING_EVENT_STR.system_action=
+J9NLS_DMP_PROCESSING_EVENT_STR.user_response=
 # END NON-TRANSLATABLE
-
 
 J9NLS_DMP_REQUESTING_DUMP_STR=JVM Requesting %1$s dump using '%2$s'
 # START NON-TRANSLATABLE
@@ -179,16 +173,11 @@ J9NLS_DMP_ERROR_IN_DUMP_STR.link=
 
 # END NON-TRANSLATABLE
 
-J9NLS_DMP_PROCESSED_EVENT_STR=Processed dump event \"%1$s\", detail \"%3$.*2$s\".
+J9NLS_DMP_PROCESSED_EVENT_STR=
 # START NON-TRANSLATABLE
-J9NLS_DMP_PROCESSED_EVENT_STR.explanation=A dump event has occurred and has been handled.
-J9NLS_DMP_PROCESSED_EVENT_STR.system_action=The JVM continues.
-J9NLS_DMP_PROCESSED_EVENT_STR.user_response=Refer to other messages issued by the JVM for the location of the dump file, or for other actions required.
-J9NLS_DMP_PROCESSED_EVENT_STR.sample_input_1=vmstop
-J9NLS_DMP_PROCESSED_EVENT_STR.sample_input_2=9
-J9NLS_DMP_PROCESSED_EVENT_STR.sample_input_3=#00000000
-J9NLS_DMP_PROCESSED_EVENT_STR.link=
-
+J9NLS_DMP_PROCESSED_EVENT_STR.explanation=NOTAG
+J9NLS_DMP_PROCESSED_EVENT_STR.system_action=
+J9NLS_DMP_PROCESSED_EVENT_STR.user_response=
 # END NON-TRANSLATABLE
 
 J9NLS_DMP_UNRECOGNISED_REQUEST_STR=VM Action unrecognized: ...%s
@@ -457,7 +446,7 @@ J9NLS_DMP_PROCESSING_EVENT_TIME.user_response=No response is required.
 J9NLS_DMP_PROCESSING_EVENT_TIME.sample_input_1=vmstop
 J9NLS_DMP_PROCESSING_EVENT_TIME.sample_input_2=9
 J9NLS_DMP_PROCESSING_EVENT_TIME.sample_input_3=#00000000
-J9NLS_DMP_PROCESSING_EVENT_TIME.sample_input_4=20110901.134521
+J9NLS_DMP_PROCESSING_EVENT_TIME.sample_input_4=2011/09/01 13:45:21
 J9NLS_DMP_PROCESSING_EVENT_TIME.link=dita:///diag/tools/dump_agents.dita
 # END NON-TRANSLATABLE
 
@@ -617,4 +606,18 @@ J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_4=12
 J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_5=No such file
 J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.sample_input_6=20220919.114434
 J9NLS_DMP_PROCESSING_DETAILED_EVENT_TIME.link=dita:///diag/tools/dump_agents.dita
+# END NON-TRANSLATABLE
+
+J9NLS_DMP_PROCESSED_EVENT_TIME=Processed dump event \"%1$s\", detail \"%3$.*2$s\" at %4$s (%5$d.%6$03d seconds).
+# START NON-TRANSLATABLE
+J9NLS_DMP_PROCESSED_EVENT_TIME.explanation=A dump event has occurred and has been handled.
+J9NLS_DMP_PROCESSED_EVENT_TIME.system_action=The JVM continues.
+J9NLS_DMP_PROCESSED_EVENT_TIME.user_response=Refer to other messages issued by the JVM for the location of the dump file, or for other actions required.
+J9NLS_DMP_PROCESSED_EVENT_TIME.sample_input_1=vmstop
+J9NLS_DMP_PROCESSED_EVENT_TIME.sample_input_2=9
+J9NLS_DMP_PROCESSED_EVENT_TIME.sample_input_3=#00000000
+J9NLS_DMP_PROCESSED_EVENT_TIME.sample_input_4=2025/06/25 15:36:02
+J9NLS_DMP_PROCESSED_EVENT_TIME.sample_input_5=3
+J9NLS_DMP_PROCESSED_EVENT_TIME.sample_input_6=450
+J9NLS_DMP_PROCESSED_EVENT_TIME.link=dita:///diag/tools/dump_agents.dita
 # END NON-TRANSLATABLE

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -1059,8 +1059,29 @@ triggerDumpAgents(struct J9JavaVM *vm, struct J9VMThread *self, UDATA eventFlags
 		if (dumpTaken == 1) {
 			/* Release accumulated locks */
 			state = unwindAfterDump(vm, &context, state);
+
 			if (printed == 1) {
-				j9nls_printf(PORTLIB, J9NLS_INFO | J9NLS_STDERR, J9NLS_DMP_PROCESSED_EVENT_STR, mapDumpEvent(eventFlags), detailLength, detailData);
+				OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+				int64_t end = j9time_current_time_millis();
+				int64_t duration = end - now;
+				char dateStamp[64];
+
+				omrstr_ftime_ex(
+						dateStamp,
+						sizeof(dateStamp),
+						"%Y/%m/%d %H:%M:%S",
+						end,
+						OMRSTR_FTIME_FLAG_LOCAL);
+				j9nls_printf(
+						PORTLIB,
+						J9NLS_INFO | J9NLS_STDERR,
+						J9NLS_DMP_PROCESSED_EVENT_TIME,
+						mapDumpEvent(eventFlags),
+						detailLength,
+						detailData,
+						dateStamp,
+						duration / 1000,
+						duration % 1000);
 			}
 		}
 


### PR DESCRIPTION
* add `J9NLS_DMP_PROCESSED_EVENT_TIME`
* update the sample time for `J9NLS_DMP_PROCESSING_EVENT_TIME`
* mark `J9NLS_DMP_PROCESSING_EVENT_STR` as unused
* mark `J9NLS_DMP_PROCESSED_EVENT_STR` as unused