### PR TITLE
Add missing header include required by __atoe

### DIFF
--- a/runtime/tests/sharedclassapi/sharedClasses.c
+++ b/runtime/tests/sharedclassapi/sharedClasses.c
@@ -28,6 +28,9 @@
 #include <string.h>
 #include <time.h>
 #include <stdlib.h>
+#if defined(ZOS)
+#include <unistd.h>
+#endif /* defined(ZOS) */
 
 #include "jvmti.h"
 #include "ibmjvmti.h"


### PR DESCRIPTION
Whilst compiling with Open XL on z/OS, what usually would appears as a warning surfaces as an error:
error: call to undeclared function '__atoe'; ISO C99 and later do not support implicit function declarations
[-Wimplicit-function-declaration]

This change includes the header that declares this function.