### PR TITLE
Update references to -Xdump NLS tags

### DIFF
--- a/.github/ISSUE_TEMPLATE/user-problem.md
+++ b/.github/ISSUE_TEMPLATE/user-problem.md
@@ -37,7 +37,7 @@ JVMDUMP032I JVM requested Snap dump using '/home/jenkins/cmdLineTest_gpTest_0/Sn
 JVMDUMP010I Snap dump written to /home/jenkins/cmdLineTest_gpTest_0/Snap.20190304.015802.21708.0003.trc
 JVMDUMP007I JVM Requesting JIT dump using '/home/jenkins/cmdLineTest_gpTest_0/jitdump.20190304.015802.21708.0004.dmp'
 JVMDUMP010I JIT dump written to /home/jenkins/cmdLineTest_gpTest_0/jitdump.20190304.015802.21708.0004.dmp
-JVMDUMP013I Processed dump event "abort", detail "".
+JVMDUMP056I Processed dump event "abort", detail "" at 2019/03/04 01:58:03 (1.374 seconds).
 ```
 
 OutOfMemoryError: Java Heap Space

--- a/doc/diagnostics/AddingTracepoints.md
+++ b/doc/diagnostics/AddingTracepoints.md
@@ -385,14 +385,14 @@ Example of an assert tracepoint firing, in this case GC assert j9mm.107:
 ```
 09:41:07.450 0x40600700 j9mm.107 ** ASSERTION FAILED ** at ../gc_modron_base/HeapRegionManager.hpp:233:
                  ((false && (heapAddress < (void *)((UDATA)(this)->_highTableEdge))))
-JVMDUMP006I Processing dump event "traceassert", detail "" - please wait.
-JVMDUMP032I JVM requested System dump using 'core.20110329.054107.4797.0001.dmp' in response to an event
-JVMDUMP010I System dump written to core.20110329.054107.4797.0001.dmp
+JVMDUMP039I Processing dump event "traceassert", detail "" at 2025/06/27 10:43:24 - please wait.
+JVMDUMP032I JVM requested System dump using 'core.20250627.104324.612361.0001.dmp' in response to an event
+JVMDUMP010I System dump written to core.20250627.104324.612361.0001.dmp
 JVMDUMP032I JVM requested Java dump using ...
 JVMDUMP010I Java dump written to ...
 JVMDUMP032I JVM requested Snap dump using ...
 JVMDUMP010I Snap dump written to ...
-JVMDUMP013I Processed dump event "traceassert", detail "".
+JVMDUMP056I Processed dump event "traceassert", detail "" at 2025/06/27 10:43:25 (0.271 seconds).
 ```
 
 ## Parameters to Assertions/Tracepoints and Side-effects (A warning)

--- a/test/functional/cmdLineTests/gcsuballoctests/gcsuballoctests.xml
+++ b/test/functional/cmdLineTests/gcsuballoctests/gcsuballoctests.xml
@@ -36,7 +36,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -46,7 +46,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -56,7 +56,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -66,7 +66,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -76,7 +76,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -89,7 +89,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -102,7 +102,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -115,7 +115,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -128,7 +128,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -141,7 +141,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -151,7 +151,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -161,7 +161,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -171,7 +171,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -183,7 +183,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -193,7 +193,7 @@
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="required">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
   <output regex="no" type="failure">Exception</output>
   <output regex="no" type="failure">Error</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -205,7 +205,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 
@@ -215,7 +215,7 @@
   <output regex="no" caseSensitive="no" type="required">Could not create the Java Virtual Machine.</output>
   <output regex="no" type="failure">version</output>
   <output regex="yes" caseSensitive="yes" javaUtilPattern="yes" type="failure">(Semeru|OpenJDK|Java\(TM\) SE) Runtime</output>
-  <output regex="no" type="failure">JVMDUMP006I</output>
+  <output regex="no" type="failure">JVMDUMP039I</output>
   <output regex="no" type="failure">Processing dump event</output>
  </test>
 

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLOpenJ9.xml
@@ -43,7 +43,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 	<exec command="$JAVA_EXE$ -Xshareclasses:destroy" quiet="false"/>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -80,7 +80,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-2.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-2.xml
@@ -71,7 +71,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-3.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-3.xml
@@ -69,7 +69,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		
@@ -1676,8 +1676,8 @@
 		<command>$JAVA_EXE$ -Xdump:java:events=vmstop,file=testjavacore.txt $currentMode$,layer=2 $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
 		<output type="required" caseSensitive="yes" regex="no">JVMDUMP010I Java dump written to</output>
-		<output type="required" caseSensitive="yes" regex="no">JVMDUMP013I Processed dump event "vmstop"</output>
-		
+		<output type="required" caseSensitive="yes" regex="no">JVMDUMP056I Processed dump event "vmstop"</output>
+
 		<output type="failure" caseSensitive="yes" regex="no">JVMDUMP030W Cannot write dump to file</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception:</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-4.xml
@@ -83,7 +83,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-5.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-5.xml
@@ -81,7 +81,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-6.xml
@@ -71,7 +71,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/SharedClassesModularityTests.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/SharedClassesModularityTests.xml
@@ -50,7 +50,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLAotMethodOperation.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLAotMethodOperation.xml
@@ -48,7 +48,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
@@ -49,7 +49,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSoftmx.xml
@@ -49,7 +49,7 @@
 	
 	The string 'corrupt' is checked because it can appear several messages like below.
 		JVMSHRC443E Cache CRC is incorrect indicating a corrupt cache. Incorrect cache CRC: 0x0.
-		JVMDUMP013I Processed dump event "corruptcache", detail "".
+		JVMDUMP056I Processed dump event "corruptcache", detail "" at yyyy/mm/dd HH:MM:SS.
 		JVMSHRC442E Shared cache "jim" is corrupt. Corruption code is -1. Corrupt value is 0x0. No new JVMs will be allowed to connect to the cache.
 	-->
 		


### PR DESCRIPTION
* `JVMDUMP006I` -> `JVMDUMP039I`
* `JVMDUMP013I` -> `JVMDUMP056I`

Fixes #22158.