### PR TITLE
Fix crash under -Xaot:

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -430,8 +430,6 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                      return rc;
                   }
 
-               codert_onload(vm);
-
                /* do initializations for -Xaot options */
                if (isAOT && argIndexXaot >= 0)
                   {
@@ -439,6 +437,8 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
                   if (rc)
                      return rc;
                   }
+
+               codert_onload(vm);
 
                jitConfig = vm->jitConfig;
 


### PR DESCRIPTION
When running with -Xjit: (i.e., not -Xjit but -Xjit: which has the colon followed by an empty string), the JVM prints out an error message and terminates. However, when running with -Xaot: the error message is printed out but then the JVM crashes. This happens because there is a call to codert_onload between initializing the compiler args for -Xjit and -Xaot.

This PR fixes this by invoking codert_onload after initializing both -Xjit and -Xaot. This is ok because the initization does not actually process the options. Rather, it sets the value of a pointer to point to the compiler args. Thus, calling codert_onload after initializing both is safe because the initialization does not depend on any initialization that codert_onload performs.

Fixes https://github.com/eclipse-openj9/openj9/issues/20601