### PR TITLE
Insert iTableWalk in _interfaceSlotsUnavailable

### DIFF
--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -2634,16 +2634,50 @@ _interfaceSlotsUnavailable:
 	staddr	r10, -8*ALen(J9SP)				! Replaced staddru r10, -8*ALen(J9SP) for P6 perf
 	staddr	r9, -7*ALen(J9SP)
 #ifndef NO_HELPER_LASTITABLE_CHECK
-        ! Before going to the VM helper, check if the receiver class lastITable matches the interface class
-        ! of the method being called and if so, use it to quickly look up the vtable offset and make the call
+        ! Before iTable walk or going to the VM helper, check if the receiver class lastITable matches the interface
+        ! class of the method being called and if so, use it to quickly look up the vtable offset and make the call
         LOAD_CLASS(r10,r3)										! Load the class
         maskVFT(r10)
         laddr   r12, 3*ALen(r11)                                ! Load the interface class of the method from the snippet
         laddr   r9, J9TR_J9Class_lastITable(r10)                ! Load the cached last ITable
         laddr   r0, J9TR_J9ITable_interfaceClass(r9)            ! Load the interface class whose ITable this is
         cmpl    cr0, CmpAddr, r12, r0
+#ifndef NO_ITABLEWALK_CHECK
+        beq     .L.hitITable
+        ! Before going to the VM helper do iTable walk N times
+        ! check iTable[0]
+        laddr   r9, J9TR_J9Class_iTable(r10)                    ! Load the iTable pointer
+        cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
+        beq     .L.callHelper
+        laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
+        cmpl    cr0, CmpAddr, r12, r0
+        beq     .L.hitITable
+        ! check iTable[1]
+        laddr   r9, J9TR_J9ITable_next(r9)                      ! Load the next iTable pointer
+        cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
+        beq     .L.callHelper
+        laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
+        cmpl    cr0, CmpAddr, r12, r0
+        beq     .L.hitITable
+        ! check iTable[2]
+        laddr   r9, J9TR_J9ITable_next(r9)                      ! Load the next iTable pointer
+        cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
+        beq     .L.callHelper
+        laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
+        cmpl    cr0, CmpAddr, r12, r0
+        beq     .L.hitITable
+        ! check iTable[3]
+        laddr   r9, J9TR_J9ITable_next(r9)                      ! Load the next iTable pointer
+        cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
+        beq     .L.callHelper
+        laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
+        cmpl    cr0, CmpAddr, r12, r0
         bne     .L.callHelper
+#else
+        bne     .L.callHelper
+#endif /* ~NO_ITABLEWALK_CHECK */
         ! lastITable is a match
+.L.hitITable:
         laddr   r12, 4*ALen(r11)                                ! Load the itable offset from the snippet
         andi.   r0, r12, J9TR_J9_ITABLE_OFFSET_TAG_BITS         ! Call the helper if the itable offset is tagged
         bne     .L.callHelper

--- a/runtime/jilgen/jilconsts.c
+++ b/runtime/jilgen/jilconsts.c
@@ -532,6 +532,7 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 
 			/* J9Class */
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9Class_classLoader", offsetof(J9Class, classLoader)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_J9Class_iTable", offsetof(J9Class, iTable)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9Class_lastITable", offsetof(J9Class, lastITable)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9Class_lockOffset", offsetof(J9Class, lockOffset)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_ArrayClass_componentType", offsetof(J9ArrayClass, componentType)) |
@@ -539,6 +540,7 @@ writeConstants(OMRPortLibrary *OMRPORTLIB, IDATA fd)
 			/* J9ITable */
 			writeConstant(OMRPORTLIB, fd, "J9TR_ITableOffset", sizeof(J9ITable)) |
 			writeConstant(OMRPORTLIB, fd, "J9TR_J9ITable_interfaceClass", offsetof(J9ITable, interfaceClass)) |
+			writeConstant(OMRPORTLIB, fd, "J9TR_J9ITable_next", offsetof(J9ITable, next)) |
 
 			/* J9Method */
 			writeConstant(OMRPORTLIB, fd, "J9TR_MethodFlagsOffset", offsetof(J9Method, constantPool)) |


### PR DESCRIPTION
This PR inserts iTableWalk for POWER in IPIC `_interfaceSlotsUnavailable` to be performed before calling the VM helper for better interface call performance when cache-miss.

The reason of choosing `_interfaceSlotsUnavailable` is because its the target called by the snippet after the 2 cache slots in the compilation snippet is populated and was a cache-miss. Hence interface calls use already existing paths to find and populate the caches (`_interfaceCallHelper` and `_interfaceCompeteSlot2`) and then the snippet call is patched to `_interfaceSlotsUnavailable` where the iTableWalk is performed.

New implementation path (after cache is populated):

1. Mainline cache check for the 2 snippet cache slots
2. IPIC lastITableCheck (checks the `J9Class.lastITable` cache)
3. IPIC iTableWalk (checks `J9Class.iTable[0..N-1]`) **NEW**
4. Call VM helper

`_interfaceSlotsUnavailable` layout:
```
<lastItable check
    b hitCall if hit>
<iTableWalk
    b vmhelperCall if all-miss>
<hitCall>

<vmhelperCall>
```

WIP:
* SPECjbb2015 runs passes, ~running CI tests~ and measuring performance. 
  * CI tests pass
  * Performance done
* Current implementation includes `N=4` iTableWalk iterations. Final value of N is TBD for best performance.
  * N=4 is better than N=6.
* ~~iTableWalk depends on lastITableCheck being enabled, determining if separating them (reordering code) to be able to have iTableWalk without lastITableCheck is worth it.~~