### PR TITLE
Update to OpenSSL 3.5.1

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -138,7 +138,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-repo=https://github.com/ibmruntimes/openssl.git -openssl-branch=openssl-3.5+SemeruFixes'
+  extra_getsource_options: '-openssl-branch=openssl-3.5.1'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
Include fix for CVE-2025-4575 (see https://github.com/openssl/openssl/blob/openssl-3.5.1/NEWS.md).