### PR TITLE
Enable JFR NativeLibrary event test for MacOS and Windows

### DIFF
--- a/test/functional/cmdLineTests/jfr/jfrevents.xml
+++ b/test/functional/cmdLineTests/jfr/jfrevents.xml
@@ -95,7 +95,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="required" caseSensitive="yes" regex="no">commandLine</output>
 		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
 	</test>
-	<test id="test jfr native library - approx 30 seconds" platforms="aix.*,linux.*">
+	<test id="test jfr native library - approx 30 seconds" platforms="aix.*,linux.*,osx.*,win.*">
 		<command>$JFR_EXE$ print --xml --events "NativeLibrary" defaultJ9recording.jfr</command>
 		<output type="required" caseSensitive="yes" regex="no">http://www.w3.org/2001/XMLSchema-instance</output>
 		<output type="success" caseSensitive="yes" regex="no">jdk.NativeLibrary</output>


### PR DESCRIPTION
Enable JFR NativeLibrary test on MacOS and Windows. 
Update the platform tag.