### PR TITLE
Correct arguments to virtual thread un/mount trace points

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -266,7 +266,7 @@ enterContinuation(J9VMThread *currentThread, j9object_t continuationObject)
 
 	currentThread->currentContinuation = continuation;
 #if JAVA_SPEC_VERSION >= 24
-	Trc_VM_enterContinuation_Mount(currentThread, continuation, continuation->returnState, continuation->ownedMonitorCount, continuation->enteredMonitors);
+	Trc_VM_enterContinuation_Mount(currentThread, continuation, continuation->returnState, currentThread->ownedMonitorCount, continuation->enteredMonitors);
 #endif /* JAVA_SPEC_VERSION >= 24 */
 	/* Reset counters which determine if the current continuation is pinned. */
 	currentThread->continuationPinCount = 0;

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -329,7 +329,7 @@ yieldContinuation(J9VMThread *currentThread, BOOLEAN isFinished, UDATA returnSta
 	currentThread->currentContinuation = NULL;
 	VM_ContinuationHelpers::swapFieldsWithContinuation(currentThread, continuation, continuationObject);
 #if JAVA_SPEC_VERSION >= 24
-	Trc_VM_yieldContinuation_Unmount(currentThread, continuation, continuation->returnState, continuation->ownedMonitorCount, continuation->enteredMonitors);
+	Trc_VM_yieldContinuation_Unmount(currentThread, continuation, returnState, continuation->ownedMonitorCount, continuation->enteredMonitors);
 #endif /* JAVA_SPEC_VERSION >= 24 */
 
 	/* We need a full fence here to preserve happens-before relationship on PPC and other weakly


### PR DESCRIPTION
- Trace the relevant `returnState` when unmounting a virtual thread
- Trace the relevant `ownedMonitorCount` when mounting a virtual thread