### PR TITLE
JDK26 migrates away from jdk.internal.ref.Cleaner

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -31,7 +31,11 @@ import java.util.Objects;
 /*[IF JAVA_SPEC_VERSION >= 12]*/
 import java.nio.ByteBuffer;
 import sun.nio.ch.DirectBuffer;
+/*[IF JAVA_SPEC_VERSION >= 26]*/
+import sun.nio.Cleaner;
+/*[ELSE] JAVA_SPEC_VERSION >= 26 */
 import jdk.internal.ref.Cleaner;
+/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
 /*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 public final class Unsafe {


### PR DESCRIPTION
JDK26 migrates away from `jdk.internal.ref.Cleaner`

Use `sun.nio.Cleaner` instead.

Required by 
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1044

Signed-off-by: Jason Feng <fengj@ca.ibm.com>