### PR TITLE
Report optimization analysis phase with -Xjit:vmState option

### DIFF
--- a/doc/diagnostics/VMState.md
+++ b/doc/diagnostics/VMState.md
@@ -63,12 +63,7 @@ vmState [0x501ff]: {J9VMSTATE_JIT} {inlining}
 ### JIT compiler
 
 If the current active component is the JIT compiler, the low-order
-half is divided into two bytes, one of which is 0xFF.
-
-In the low-order half, if the lower byte is 0xFF, the current active
-component is the optimizer, and the higher byte is the numeric
-identifier of the current optimization (defined in an [enum][2]),
-e.g. 0x000501FF means that the inliner is active.
+half is divided into two bytes.
 
 If the higher byte is 0xFF, the current active component is the code
 generator, and the lower byte is the numeric identifier of the current
@@ -79,8 +74,17 @@ If the entire low-order half of the VM state is 0xFFFF, then the
 active component is likely to be in the compiler initialization or
 the IL generator.
 
+Otherwise, the current active component is the optimizer, and the higher
+byte is the numeric identifier of the current optimization (defined in an [enum][2]),
+while the lower byte is the numeric identifier of the current phase of
+the optimization (defined in an [enum][3]).
+e.g. 0x000501FF means that the inliner is active, while 0x000514a1 means that
+the Building value numbers analysis phase of Global Value Numbering is active.
+
+
 [2]: https://github.com/eclipse-omr/omr/blob/master/compiler/optimizer/Optimizations.hpp
 [3]: https://github.com/eclipse-openj9/openj9/blob/master/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
+[4]: https://github.com/eclipse-omr/omr/blob/master/compiler/optimizer/OMROptimizerAnalysisPhases.enum
 
 ## Finding the VM state examples
 

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -689,16 +689,6 @@ Options::vmStateOption(const char *option, void *base, TR::OptionTable *entry)
                   {
                   j9tty_printf(PORTLIB, "vmState [0x%x]: {%s} {ILGeneration}\n", state, vmStateArray[index]._xname);
                   }
-               else if ((state & J9VMSTATE_JIT_OPTIMIZER) == J9VMSTATE_JIT_OPTIMIZER)
-                  {
-                  OMR::Optimizations opts = static_cast<OMR::Optimizations>((state & 0xFF00) >> 8);
-                  if (opts < OMR::numOpts)
-                     {
-                      j9tty_printf(PORTLIB, "vmState [0x%x]: {%s} {%s}\n", state, vmStateArray[index]._xname, OMR::Optimizer::getOptimizationName(opts));
-                     }
-                  else
-                     j9tty_printf(PORTLIB, "vmState [0x%x]: {%s} {Illegal optimization number}\n", state, vmStateArray[index]._xname);
-                  }
                else if ((state & J9VMSTATE_JIT_CODEGEN) == J9VMSTATE_JIT_CODEGEN)
                   {
                   TR::CodeGenPhase::PhaseValue phase = static_cast<TR::CodeGenPhase::PhaseValue>(state & 0xFF);
@@ -708,7 +698,17 @@ Options::vmStateOption(const char *option, void *base, TR::OptionTable *entry)
                      j9tty_printf(PORTLIB, "vmState [0x%x]: {%s} {Illegal codegen phase number}\n", state, vmStateArray[index]._xname);
                   }
                else
-                  invalidState = true;
+                  {
+                  OMR::Optimizations opts = static_cast<OMR::Optimizations>((state & 0xFF00) >> 8);
+                  OMR::Optimizer::AnalysisPhases phase = static_cast<OMR::Optimizer::AnalysisPhases>(state & 0xFF);
+
+                  if (opts < OMR::numOpts)
+                     {
+                     j9tty_printf(PORTLIB, "vmState [0x%x]: {%s} {%s} {%s}\n", state, vmStateArray[index]._xname, OMR::Optimizer::getOptimizationName(opts), OMR::Optimizer::getAnalysisPhaseName(phase));
+                     }
+                  else
+                     j9tty_printf(PORTLIB, "vmState [0x%x]: {%s} {Illegal optimization number}\n", state, vmStateArray[index]._xname);
+                  }
                }
                break;
             default:


### PR DESCRIPTION
In the event of a compilation crash, a VM state might be reported that is not recognized by the `-Xjit:vmState` option.  This is most likely to happen if the crash occurs following an optimization while performing checks of the IL, CFG or structure, but could happen during other analysis phases associated with an optimization that are not directly a part of the optimization itself.  The `Options::vmStateOption` method was written assuming that the low byte of the VM State will always be 0xFF if the crash happened during the optimization phase, but that is only true if the crash happened in the midst of a particular optimization.

This change takes advantage of the new
`OMR::Optimizer::getAnalysisPhaseName` method to get the name of other optimization phases that might be encoded in the VMState.  It also updates documentation to reflect the fact that the low byte need not have the value 0xFF if a crash occurs during some analysis phase associated with optimization, rather than in the optimization itself.