### PR TITLE
WIP: Add changes to support patching of BlockFrequencyInfo

### DIFF
--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -51,6 +51,7 @@ enum TR_RuntimeAssumptionKind {
     RuntimeAssumptionOnStaticFinalFieldModification,
     RuntimeAssumptionOnMutableCallSiteChange,
     RuntimeAssumptionOnMethodBreakPoint,
+    RuntimeAssumptionOnPatchJProfBlockFreqCounters,
     LastAssumptionKind,
     // If you add another kind, add its name to the runtimeAssumptionKindNames array
     RuntimeAssumptionSentinel // This is special as there is no hashtable associated with it and we only create one of

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -67,7 +67,9 @@
 #include "runtime/ExternalProfiler.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "runtime/J9ValueProfiler.hpp"
-
+#if defined(TR_TARGET_X86)
+#include "x/runtime/X86Runtime.hpp"
+#endif
 //*************************************************************************
 //
 // Optimization passes to insert recompilation counters, etc
@@ -2762,4 +2764,84 @@ TR_PersistentProfileInfo *TR_JProfilerThread::deleteProfileInfo(TR_PersistentPro
     }
 
     return next;
+}
+
+TR_JProfBlockFrequencyCounterSites *TR_JProfBlockFrequencyCounterSites::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
+    uintptr_t key, TR::JProfBFPatchSites *sites, OMR::RuntimeAssumption **sentinel)
+{
+    TR_JProfBlockFrequencyCounterSites *res = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_JProfBlockFrequencyCounterSites));
+    if (mem) {
+        res = ::new (mem) TR_JProfBlockFrequencyCounterSites(pm, key, sites);
+        res->addToRAT(pm, RuntimeAssumptionOnPatchJProfBlockFreqCounters, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
+
+    return res;
+}
+
+void TR_JProfBlockFrequencyCounterSites::compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey)
+{
+    // Instead of patching flag, this routine will update the whole instruction
+    // (E.g, 6 Bytes on Z with NOP. PatchSites will hold two pointers, first one
+    // will have a location to update, second one is the original instruction
+    // which we would be caching. If modifying instruction to be NOP, the second
+    // entry would not be used, but in case if if we are enabling the profiling
+    // again, we will  update. NOP with the instruction to update counter which
+    // is already stored in the patch site second entry. _patchFlag zero means
+    // data collection is ON, in that case update all the increment code with
+    // NOP.
+    if (disableDataCollection && _patchFlag == 0) {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+            uint8_t instructionLength = *(uint8_t *)(_patchSites->getBumpInstructionPointer(i));
+#if defined(TR_TARGET_S390)
+            *(uint16_t *)cursor = 0xC004;
+#elif defined(TR_TARGET_X86)
+            if (instructionLength == 2) {
+                *(uint16_t *)cursor = 0x9066;
+            } else if (instructionLength == 3) {
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                // byte 2
+                cursor[2] = 0x00;
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = 0x1F0F
+            } else if (instructionLength == 4) {
+                *(uint32_t *)cursor = 0x00401F0F;
+            } else {
+                TR_ASSERT_FATAL(0, "Unexpected instruction lenght - Can not patch");
+            }
+#endif
+            _patchFlag = 1;
+        }
+    } else if (_patchFlag == 1) {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+            uint8_t *bumpInstruction = _patchSites->getBumpInstructionPointer(i);
+            uint8_t instructionLength = *bumpInstruction;
+            bumpInstruction += sizeof(uint8_t);
+#if defined(TR_TARGET_S390)
+            *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+#elif defined(TR_TARGET_X86)
+            if (instructionLength == 2) {
+                *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+            } else if (instructionLength == 3) {
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                cursor[2] = *(uint8_t *)(bumpInstruction + 2);
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+            } else if (instructionLength == 4) {
+                *(uint32_t *)cursor = *(uint32_t *)(bumpInstruction);
+            } else {
+                TR_ASSERT_FATAL(0, "Unexpected instruction lenght - Can not patch");
+            }
+#endif
+            _patchFlag = 0;
+        }
+    }
 }

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -39,6 +39,7 @@
 #include "env/VMJ9.h"
 #include "infra/TRlist.hpp"
 #include "runtime/J9ValueProfiler.hpp"
+#include "runtime/J9RuntimeAssumptions.hpp"
 
 #define PROFILING_INVOCATION_COUNT (2)
 
@@ -714,6 +715,20 @@ public:
         _counterDerivationInfo = counterDerivationInfo;
     }
 
+    void addJProfBlockFrequencyCounterPatchSites(TR_JProfBlockFrequencyCounterSites *patchSites)
+    {
+        _jProfilingBlockFrequencyCounterPatchSites = patchSites;
+    }
+
+    TR_JProfBlockFrequencyCounterSites *getJProfBlockFrequencyCounterPatchSites()
+    {
+        return _jProfilingBlockFrequencyCounterPatchSites;
+    }
+
+    void setTimestampDataCollectionStarted(uint64_t timeStamp) { _timeStampWhenDataCollectionStarted = timeStamp; }
+
+    uint64_t getTimestampDataCollectionStarted() { return _timeStampWhenDataCollectionStarted; }
+
     void setEntryBlockNumber(int32_t number) { _entryBlockNumber = number; }
 
     bool isJProfilingData() { return _counterDerivationInfo != NULL; }
@@ -820,6 +835,9 @@ private:
     // Following flag is checked at runtime to know if we have queued this method for recompilation and skip the
     // profiling code
     int32_t _isQueuedForRecompilation;
+    void *_startPCOfBodyCollectingProfilingData;
+    uint64_t _timeStampWhenDataCollectionStarted;
+    TR_JProfBlockFrequencyCounterSites *_jProfilingBlockFrequencyCounterPatchSites;
 };
 
 TR_BlockFrequencyInfo *TR_BlockFrequencyInfo::get(TR_PersistentProfileInfo *profileInfo)

--- a/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
@@ -101,4 +101,127 @@ public:
     virtual uintptr_t hashCode() { return TR_RuntimeAssumptionTable::hashCode((uintptr_t)getPicLocation()); }
 };
 
+/**
+ * @brief
+ *    A runtime assumption for patching the block frequency counter increment
+ *    instructions in the compiled body that is collecting JProfiling data.
+ *    It provides means to patch the instruction to turn off / turn on profiling
+ *    data collection.
+ */
+class TR_JProfBlockFrequencyCounterSites : public OMR::ValueModifyRuntimeAssumption {
+protected:
+    /**
+     * @brief Construct a new tr TR_JProfBlockFrequencyCounterSites object
+     *
+     * @param pm TR_PersistentMemory object for allocating the runtime assumption
+     * @param key key against which this runtime assumption is stored in table
+     * @param sites TR::JProfBFPatchSites object that contains the information to
+     *              accommodate patching instructons in the compiled method with JProfiling
+     *              to turn-on / turn off data collection.
+     */
+    TR_JProfBlockFrequencyCounterSites(TR_PersistentMemory *pm, uintptr_t key, TR::JProfBFPatchSites *sites)
+        : OMR::ValueModifyRuntimeAssumption(pm, key)
+        , _patchSites(sites)
+        , _patchFlag(Enabled)
+    {}
+
+    enum State {
+        Enabled,
+        Disabled
+    };
+
+public:
+    /**
+     * @brief Get the first instruction in the _patchSites for patching
+     *
+     * @return uint8_t* first instruction pointer in the _patchSites
+     */
+    virtual uint8_t *getFirstAssumingPC() { return _patchSites->getFirstLocation(); }
+
+    /**
+     * @brief Get the last instruction in the _patchSites for patching
+     *
+     * @return uint8_t* last instruction pointer in the _patchSites
+     */
+    virtual uint8_t *getLastAssumingPC() { return _patchSites->getLastLocation(); }
+
+    /**
+     * @brief
+     *    Goes through the instruction list for the compiled method which
+     *    increments static counters in JProfiling Data for block frequencies,
+     *    and patches them to diasble / enable Profiling Data Collection.
+     *
+     * @param vm TR_FrontEnd vm object
+     * @param disableDataCollection boolean flag to disable / enable data collection
+     * @param newKey
+     */
+    virtual void compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey);
+
+    virtual void dumpInfo() { return; }
+
+    /**
+     * @brief Get the Runtime Assumption Kind
+     *
+     * @return TR_RuntimeAssumptionKind
+     */
+    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnPatchJProfBlockFreqCounters; }
+
+    /**
+     * @brief Construct a new TR_JProfBlockFrequencyCounterSites runtime assumption for the method
+     *
+     * @param fe TR_FrontEnd object to facilitate adding constructed runtime assumption to RAT
+     * @param pm TR_PersistentMemory Persistent Memory object to allocate the persistent object
+     * @param key key using which the runtime assumption will be added in the RAT
+     * @param sites TR::JProfBFPatchSites object containing information about
+     *                instructions to be patched in method
+     * @param sentinel Setinnel node for the RAT
+     * @return TR_JProfBlockFrequencyCounterSites* returns constructed TR_JProfBlockFrequencyCounterSites object for
+     * this method.
+     */
+    static TR_JProfBlockFrequencyCounterSites *make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
+        TR::JProfBFPatchSites *sites, OMR::RuntimeAssumption **sentinel);
+
+    /**
+     * @brief Cleans up data structure associated with this runtime assumption.
+     *
+     */
+    void reclaim() { TR::JProfBFPatchSites::reclaim(_patchSites); }
+
+    /**
+     * @brief Get TR::JProfBFPatchSites object containing information about instructions to be patched in method.
+     *
+     * @return TR::JProfBFPatchSites*
+     */
+    TR::JProfBFPatchSites *getPatchSites() { return _patchSites; }
+
+    /**
+     * @brief Compares this runtime assumption with another one.
+     *
+     * @param other Other Runtime Assumption agains which this one will be compared.alignas
+     * @return true if equal
+     * @return false if not equal
+     */
+    virtual bool equals(OMR::RuntimeAssumption &other)
+    {
+        if (other.getAssumptionKind() != RuntimeAssumptionOnPatchJProfBlockFreqCounters)
+            return false;
+
+        TR_JProfBlockFrequencyCounterSites *otherSite = reinterpret_cast<TR_JProfBlockFrequencyCounterSites *>(&other);
+        return _patchSites->equals(otherSite->getPatchSites());
+    }
+
+private:
+    /**
+     * @brief TR::JProfBFPatchSites object containing list of instruction addresses in this compiled code and the
+     * instruciton itself that updates static counters to facilitate patching of the sites to turn on / off profiling
+     * data collection.
+     */
+    TR::JProfBFPatchSites *_patchSites;
+
+    /**
+     * @brief A flag to indicate the current status of body associated with this runtime assumption.
+     *
+     */
+    uint8_t _patchFlag;
+};
 #endif


### PR DESCRIPTION
Counters emitted for the block frequency info in low opt compilations through JProfiling would need to be patched to turn-off data collection and potentially turn-on. For the patching, adding TR_JProfBlockFrequencyCounterSites to facilitate back and forth patching.