### PR TITLE
Fix JNI return types

### DIFF
--- a/runtime/jvmti/jvmtiModules.c
+++ b/runtime/jvmti/jvmtiModules.c
@@ -129,13 +129,13 @@ addModuleExportsOrOpens(jvmtiEnv* jvmtiEnv, jobject fromModule, const char* pkgN
 			if (NULL == pkg) {
 				rc = JVMTI_ERROR_OUT_OF_MEMORY;
 			} else {
-				(*env)->CallObjectMethod(env,
-										fromModule,
-										vm->addExports,
-										pkg,
-										toModule,
-										!exports,
-										JNI_TRUE);
+				(*env)->CallVoidMethod(env,
+						fromModule,
+						vm->addExports,
+						pkg,
+						toModule,
+						!exports,
+						JNI_TRUE);
 			}
 			if ((*env)->ExceptionCheck(env)) {
 				rc = JVMTI_ERROR_INTERNAL;
@@ -508,7 +508,7 @@ jvmtiAddModuleUses(jvmtiEnv* jvmtiEnv, jobject module, jclass service)
 
 				vm->addUses = addUses;
 			}
-			(*env)->CallObjectMethod(env, module, vm->addUses, service);
+			(*env)->CallVoidMethod(env, module, vm->addUses, service);
 			if ((*env)->ExceptionCheck(env)) {
 				rc = JVMTI_ERROR_INTERNAL;
 			}

--- a/runtime/jvmti/jvmtiThread.cpp
+++ b/runtime/jvmti/jvmtiThread.cpp
@@ -513,7 +513,7 @@ done:
 				vm->vThreadInterrupt = vThreadInterrupt;
 			}
 
-			jniEnv->CallObjectMethod(thread, vm->vThreadInterrupt);
+			jniEnv->CallVoidMethod(thread, vm->vThreadInterrupt);
 
 			if (jniEnv->ExceptionCheck()) {
 				rc = JVMTI_ERROR_INTERNAL;


### PR DESCRIPTION
Fix JNI return types

`CallVoidMethod()` replaced `CallObjectMethod()` for following JNI calls:
```
Module.implAddExportsOrOpens(Ljava/lang/String;Ljava/lang/Module;ZZ)V;
Module.implAddUses(Ljava/lang/Class;)V;
Thread.interrupt()V;
```

closes https://github.com/eclipse-openj9/openj9/issues/22000

Signed-off-by: Jason Feng <fengj@ca.ibm.com>