### PR TITLE
Support using newer versions of cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,15 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ################################################################################
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+# CMAKE_VERSION is not defined before 2.6.3.
+if ((CMAKE_MAJOR_VERSION LESS 3) OR (CMAKE_VERSION VERSION_LESS "3.12"))
+	cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+else()
+	# Beginning with version 3.12, cmake supports a version range here
+	# as a declaration from this project that new policy behaviors
+	# (up to the second version) are acceptable.
+	cmake_minimum_required(VERSION 3.12...3.28 FATAL_ERROR)
+endif()
 
 project(openj9)
 

--- a/runtime/libffi/CMakeLists.txt
+++ b/runtime/libffi/CMakeLists.txt
@@ -29,6 +29,10 @@ if(OMR_TOOLCONFIG STREQUAL "msvc")
 	omr_append_flags(CMAKE_ASM_MASM_FLAGS /W2)
 endif()
 
+# Remove -qsourcetype=assembler which doesn't appear to work with OpenXL.
+if(CMAKE_C_COMPILER_IS_XLCLANG)
+	omr_remove_flags(CMAKE_ASM_FLAGS -qsourcetype=assembler)
+endif()
 
 j9vm_add_library(ffi STATIC
 	closures.c


### PR DESCRIPTION
Newer builds of `cmake` may not be compatible with version 3.5.

This is essentially a replay of #22161, but with a fix for AIX  to remove `-qsourcetype=assembler` which doesn't appear to work with OpenXL.