### PR TITLE
RAM Class Persistence: Remove redundant call to initializeSnapshotClassObject

### DIFF
--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -169,9 +169,9 @@ retry:
 
 					if (!vmFuncs->loadWarmClassFromSnapshot(currentThread, classLoader, clazz)) {
 						clazz = NULL;
+						goto done;
 					}
 
-					clazz = vmFuncs->initializeSnapshotClassObject(vm, classLoader, clazz);
 					if (NULL != protectionDomain) {
 						J9VMJAVALANGCLASS_SET_PROTECTIONDOMAIN(
 							currentThread,


### PR DESCRIPTION
The initialization of classObject of J9Class is done by
loadWarmClassFromSnapshot() and make initializeSnapshotClassObject()
redundant. Other modification includes if the call is failed, go to
exit or error processing.

Fixes: #22201