### PR TITLE
x86: Introduce getMaxPreferredVectorLength()

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -353,6 +353,27 @@ J9::X86::CodeGenerator::endInstructionSelection()
       }
    }
 
+TR::VectorLength
+J9::X86::CodeGenerator::getMaxPreferredVectorLength()
+   {
+   TR::CPU *cpu = &self()->comp()->target().cpu;
+
+   // Regressive CPU frequency scaling when using 256 or 512-bit vectorization is
+   // a known issue on Intel x86 hardware. Some microarchitectures are known to be
+   // more affected than others.
+   if (cpu->supportsFeature(OMR_FEATURE_X86_AVX2))
+      {
+      // We set a minimum microarchitecture target of Broadwell for 256-bit
+      // vectorization on Intel. This decision is empirically driven.
+      if (cpu->isAuthenticAMD() || cpu->isAtLeast(OMR_PROCESSOR_X86_INTEL_SKYLAKE))
+         {
+         return TR::VectorLength256;
+         }
+      }
+
+   return TR::VectorLength128;
+   }
+
 TR::Instruction *
 J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
       TR::Instruction *prev,

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -52,6 +52,24 @@ public:
 
    void endInstructionSelection();
 
+   /**
+    * @brief Determines the maximum preferred vector length for compiler intrinsics based on the target microarchitecture.
+    *
+    * This function queries the underlying hardware capabilities and internal knowledge about
+    * CPU microarchitectures to recommend the optimal vector length (e.g., 128-bit, 256-bit, 512-bit)
+    * that is likely to yield the best performance without incurring significant frequency scaling
+    * penalties. This function does not take into account profiling data or any other runtime
+    * information in the decision making process.
+    *
+    * @note All new vectorized intrinsics that support 256 or 512-bit vectorization should query this
+    * function instead of relying strictly on whether the CPU supports vectorization at a given vector
+    * length.
+    *
+    * @return The maximum preferred vector length in bits (e.g., 128, 256, 512).
+    * This function will return a minimum of TR::VectorLength128 on all target hardware.
+    */
+   TR::VectorLength getMaxPreferredVectorLength();
+
    TR::Instruction *generateSwitchToInterpreterPrePrologue(
          TR::Instruction *prev,
          uint8_t alignment,

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -9900,13 +9900,7 @@ J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, TR::DataType dt
    TR_ASSERT_FATAL(shift >= 0 && shift <= 2, "Unsupported datatype for vectorized hashcode");
 
    TR::Compilation *comp = cg->comp();
-   TR::VectorLength vl = TR::VectorLength128;
-
-   if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX512F))
-      vl = TR::VectorLength512;
-   else if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_AVX2))
-      vl = TR::VectorLength256;
-
+   TR::VectorLength vl = cg->getMaxPreferredVectorLength();
    TR::Node *addressNode = node->getChild(0);
 
    bool nonZeroOffset = node->getChild(1)->getOpCodeValue() != TR::iconst || node->getChild(1)->getInt() != 0;


### PR DESCRIPTION
This commit introduces `getMaxPreferredVectorLength()` for detecting the optimal vector length for compiler intrinsics. New intrinsics that support 256-bit and 512-bit vectorization should consult this function. Wider vectors can cause CPU frequency throttling on some microarchitectures. An ~8% freq regression was observed on Haswell with 256-bit vectorization. This function should avoid penalties by preferring smaller lengths on some microarchitectures.