### PR TITLE
AArch64: Accelerate StringCoding.hasNegatives()/countPositives()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -115,6 +115,19 @@ J9::ARM64::CodeGenerator::initialize()
       {
       cg->setSupportsInlineUnsafeCompareAndExchange();
       }
+
+   static bool disableInlineStringCodingHasNegatives = feGetEnv("TR_DisableInlineStringCodingHasNegatives") != NULL;
+   if (!TR::Compiler->om.canGenerateArraylets() && !disableInlineStringCodingHasNegatives)
+      {
+      cg->setSupportsInlineStringCodingHasNegatives();
+      }
+#if JAVA_SPEC_VERSION >= 19
+   static bool disableInlineStringCodingCountPositives = feGetEnv("TR_DisableInlineStringCodingCountPositives") != NULL;
+   if (!TR::Compiler->om.canGenerateArraylets() && !disableInlineStringCodingCountPositives)
+      {
+      cg->setSupportsInlineStringCodingCountPositives();
+      }
+#endif /* JAVA_SPEC_VERSION >= 19 */
    }
 
 TR::Linkage *


### PR DESCRIPTION
This commit generates vectorized inlined code for AArch64 for the following StringCoding methods.

- hasNegatives()
- countPositives()