### PR TITLE
Enable peeking ILGen for methods with invokedynamic/invokehandle

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -982,6 +982,9 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
             break;
          case J9BCinvokedynamic:
          case J9BCinvokehandle:
+            nph.setNeedsPeekingToTrue();
+            heuristicTrace(tracer(), "Depth %d: Enabled peeking ILGen for method %s due to invokedynamic/invokehandle bytecode at bc index %d.", _recursionDepth, callerName, i);
+            // intentional fallthrough
          case J9BCinvokehandlegeneric:
             // TODO:JSR292: Use getResolvedHandleMethod
          case J9BCmonitorenter:


### PR DESCRIPTION
Enabling peeking ILGen for non-root methods that contain invokedynamic or invokehandle bytecodes. This will ensure that final field folding necessary for obtaining the target method is possible, and paves the way for more inlining opportunities along MethodHandle operations.