### PR TITLE
Call getDependentLibs in lockWordAlignment

### DIFF
--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -35,6 +35,7 @@
 	<property name="PROJECT_ROOT" location="." />
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
+	<property name="LIB" value="asm"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
 
 	<target name="init">
@@ -42,7 +43,7 @@
 		<mkdir dir="${build}" />
 	</target>
 
-	<target name="compile" depends="init" description="Using java ${JDK_VERSION} to compile the source ">
+	<target name="compile" depends="init,getDependentLibs" description="Using java ${JDK_VERSION} to compile the source ">
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===fork:                         yes</echo>


### PR DESCRIPTION
resolves: https://github.com/eclipse-openj9/openj9/issues/22232