### PR TITLE
Remove dead IL generator path for `invokehandle` method types

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4811,12 +4811,6 @@ TR_J9VMBase::MethodOfHandle TR_J9VMBase::methodOfDirectOrVirtualHandle(
    return result;
    }
 
-bool
-TR_J9VMBase::hasMethodTypesSideTable()
-   {
-   return true;
-   }
-
 void *
 TR_J9VMBase::methodHandle_jitInvokeExactThunk(uintptr_t methodHandle)
    {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -910,8 +910,6 @@ public:
 
    virtual MethodOfHandle methodOfDirectOrVirtualHandle(uintptr_t *mh, bool isVirtual);
 
-   bool hasMethodTypesSideTable();
-
    // Openjdk implementation
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
    /*

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -2951,26 +2951,6 @@ TR_J9ByteCodeIlGenerator::loadFromMethodTypeTable(TR::Node* methodHandleInvokeCa
    return methodType;
    }
 
-
-TR::Node*
-TR_J9ByteCodeIlGenerator::loadCallSiteMethodTypeFromCP(TR::Node* methodHandleInvokeCall)
-   {
-   int32_t cpIndex = next2Bytes();
-   TR_ASSERT(method()->isMethodTypeConstant(cpIndex), "Address-type CP entry %d must be methodType", cpIndex);
-   TR::SymbolReference *symRef = symRefTab()->findOrCreateMethodTypeSymbol(_methodSymbol, cpIndex);
-   TR::Node* methodType = TR::Node::createWithSymRef(methodHandleInvokeCall, TR::aload, 0, symRef);
-   return methodType;
-   }
-
-TR::Node*
-TR_J9ByteCodeIlGenerator::loadCallSiteMethodType(TR::Node* methodHandleInvokeCall)
-   {
-   if (fej9()->hasMethodTypesSideTable())
-      return loadFromMethodTypeTable(methodHandleInvokeCall);
-   else
-      return loadCallSiteMethodTypeFromCP(methodHandleInvokeCall);
-   }
-
 void TR_J9ByteCodeIlGenerator::insertCustomizationLogicTreeIfEnabled(TR::TreeTop* tree, TR::Node* methodHandle)
    {
    if (comp()->getOption(TR_EnableMHCustomizationLogicCalls))
@@ -3040,7 +3020,7 @@ void TR_J9ByteCodeIlGenerator::expandInvokeHandle(TR::TreeTop *tree)
    TR::Node * receiverHandle = callNode->getArgument(0);
    callNode->getByteCodeInfo().setDoNotProfile(true);
 
-   TR::Node* callSiteMethodType = loadCallSiteMethodType(callNode);
+   TR::Node* callSiteMethodType = loadFromMethodTypeTable(callNode);
 
    if (callSiteMethodType->getSymbolReference()->isUnresolved())
       {
@@ -3164,7 +3144,7 @@ void TR_J9ByteCodeIlGenerator::expandInvokeHandleGeneric(TR::TreeTop *tree)
    TR::Node * receiverHandle = callNode->getArgument(0);
    callNode->getByteCodeInfo().setDoNotProfile(true);
 
-   TR::Node* callSiteMethodType = loadCallSiteMethodType(callNode);
+   TR::Node* callSiteMethodType = loadFromMethodTypeTable(callNode);
    if (callSiteMethodType->getSymbolReference()->isUnresolved())
       {
       TR::Node *resolveChkOnMethodType = TR::Node::createWithSymRef(callNode, TR::ResolveCHK, 1, callSiteMethodType, comp()->getSymRefTab()->findOrCreateResolveCheckSymbolRef(_methodSymbol));

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -349,9 +349,7 @@ private:
    void expandInvokeHandleGeneric(TR::TreeTop *tree);
    void expandMethodHandleInvokeCall(TR::TreeTop *tree);
    void insertCustomizationLogicTreeIfEnabled(TR::TreeTop *tree, TR::Node* methodHandle);
-   TR::Node* loadCallSiteMethodTypeFromCP(TR::Node* methodHandleInvokeCall);
    TR::Node* loadFromMethodTypeTable(TR::Node* methodHandleInvokeCall);
-   TR::Node* loadCallSiteMethodType(TR::Node* methodHandleInvokeCall);
 
    // inline functions
    //


### PR DESCRIPTION
...in J9 `java/lang/invoke`. `TR_J9VMBase::hasMethodTypesSideTable()` has been true for many years.