### PR TITLE
RAM Class Persistence: restore the application class loader

### DIFF
--- a/runtime/jcl/common/stdinit.c
+++ b/runtime/jcl/common/stdinit.c
@@ -465,12 +465,12 @@ internalInitializeJavaLangClassLoader(JNIEnv * env)
 
 	vmFuncs->internalEnterVMFromJNI(vmThread);
 
-#if defined(J9VM_OPT_SNAPSHOT)
+#if defined(J9VM_OPT_SNAPSHOTS)
 	/* Always use the persisted applicationClassLoader in restore runs. */
 	if (IS_RESTORE_RUN(vm)) {
 		vmFuncs->initializeSnapshotClassLoaderObject(vm, vm->applicationClassLoader, J9_JNI_UNWRAP_REFERENCE(appClassLoader));
 	} else
-#endif /* defined(J9VM_OPT_SNAPSHOT) */
+#endif /* defined(J9VM_OPT_SNAPSHOTS) */
 	{
 		vm->applicationClassLoader = J9VMJAVALANGCLASSLOADER_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(appClassLoader));
 


### PR DESCRIPTION
The MACRO J9VM_OPT_SNAPSHOTS is mispelled and the application class loader is overwritten.

Fixes: #22237