### PR TITLE
Fix x86-32 private linkage for dispatchVirtual

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5366,7 +5366,8 @@ J9::CodeGenerator::addInvokeBasicCallSiteImpl(
    uint8_t numArgSlots = (uint8_t)numArgSlots32;
 
    void *j2iThunk = NULL;
-   if (rm == TR::com_ibm_jit_JITHelpers_dispatchVirtual)
+   if (rm == TR::com_ibm_jit_JITHelpers_dispatchVirtual &&
+       !(comp()->target().cpu.isX86() && self()->comp()->target().is32Bit()))
       {
       TR::Method *m = methodSymbol->getMethod();
       char *sig = fej9->getJ2IThunkSignatureForDispatchVirtual(

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -1779,6 +1779,12 @@ void J9::RecognizedCallTransformer::makeIntoDispatchVirtualCall(
    TR::Node *jittedMethodEntryPoint =
       TR::Node::createWithSymRef(vftEntryLoadOp, 1, 1, jitVftSlotPtr, genericIntShadow);
 
+   if (!comp()->target().is64Bit())
+      {
+      jittedMethodEntryPoint = TR::Node::create(node, TR::i2l, 1, jittedMethodEntryPoint);
+      jitVftOffset = TR::Node::create(node, TR::i2l, 1, jitVftOffset);
+      }
+
    node->setAndIncChild(0, jittedMethodEntryPoint);
    node->setAndIncChild(1, jitVftOffset);
 

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -228,7 +228,7 @@ int32_t J9::X86::I386::PrivateLinkage::buildArgs(
          case TR::java_lang_invoke_ComputedCalls_dispatchVirtual:
          case TR::com_ibm_jit_JITHelpers_dispatchVirtual:
             linkageRegChildIndex = firstArgumentChild;
-            receiverChildIndex = callNode->getOpCode().isIndirect()? firstArgumentChild+1 : -1;
+            receiverChildIndex = callNode->getOpCode().isIndirect()? firstArgumentChild + 1 : -1;
          }
 
    for (int i = firstArgumentChild; i < callNode->getNumChildren(); i++)


### PR DESCRIPTION
Previously, the VTable index argument register was not marked as such on x86-32 for 32-bit arguments, which caused issues when invoking MethodHandles through dispatchVirtual. 

This changes dispatchVirtual to always use `long` arg0 for the jit entry point and jit vft offset so the index register is marked properly in linkage.


Issue: #18751