### PR TITLE
Update J9SP register on interp exit

### DIFF
--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -449,6 +449,7 @@ END_PROC(cInterpreterFromJIT)
 
 ifelse(eval(ASM_JAVA_SPEC_VERSION >= 24), 1, {
 BEGIN_RETURN_POINT(jitExitInterpreter0RestoreAll)
+	UPDATE_SP_IN_GPR_SAVE_SLOT
 	RESTORE_ALL_REGS
 END_RETURN_POINT(jitExitInterpreter0RestoreAll)
 }) dnl jitExitInterpreter0RestoreAll is only supported on JAVA 24+

--- a/runtime/oti/arm64helpers.m4
+++ b/runtime/oti/arm64helpers.m4
@@ -235,3 +235,7 @@ define({BRANCH_VIA_VMTHREAD},{
 
 define({SWITCH_TO_JAVA_STACK},{ldr J9SP,[J9VMTHREAD,{#}J9TR_VMThread_sp]})
 define({SWITCH_TO_C_STACK},{str J9SP,[J9VMTHREAD,{#}J9TR_VMThread_sp]})
+define({UPDATE_SP_IN_GPR_SAVE_SLOT},{
+	ldr J9SP,[J9VMTHREAD,{#}J9TR_VMThread_sp]
+	str J9SP,JIT_GPR_SAVE_SLOT(20)
+})


### PR DESCRIPTION
Upon exit from the interpreter on aarch64, the SP (x20) register is
re-loaded from the ELS. This would be the SP upon calling the
jitMonitor* helper. If there is a decompiation the vthread will resume
with the jitResolveFrame on the stack. This means the SP is incorrect.
This PR reloads the latest SP upon exiting the interpreter, this will
account for any frames pushed between the point the JIT calls the helper
and when the vthread returns after blocking.

Fixes https://github.com/eclipse-openj9/openj9/issues/22206