### PR TITLE
Move fast fail into correct branch

### DIFF
--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -11925,8 +11925,8 @@ TR::Register *J9::Z::TreeEvaluator::inlineCheckAssignableFromEvaluator(TR::Node 
                {
                debugObj->addInstructionComment(cursor, "toclass depth > fromClass depth at compile time - fast fail");
                }
-            }
             fastFail = true;
+            }
          }
       }
 


### PR DESCRIPTION
Previously we were skipping test case generation for most cases when both the toClassSymRefs and fromClassSymRefs are resolved at compile time and both are not interfaces.

Now the we set the fastFail guard in the correct branch to only fast fast when we known the depths at compile time and toClassDepth > fromClassDepth

Fixes: #22276