### PR TITLE
Guard peeking behaviour for invokedynamic/handle with an env option

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -982,8 +982,12 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
             break;
          case J9BCinvokedynamic:
          case J9BCinvokehandle:
-            nph.setNeedsPeekingToTrue();
-            heuristicTrace(tracer(), "Depth %d: Enabled peeking ILGen for method %s due to invokedynamic/invokehandle bytecode at bc index %d.", _recursionDepth, callerName, i);
+            const static bool enablePeekingForMHInvokes = feGetEnv("TR_enablePeekingForMHInvokes") ? true : false;
+            if (enablePeekingForMHInvokes)
+               {
+               nph.setNeedsPeekingToTrue();
+               heuristicTrace(tracer(), "Depth %d: Enabled peeking ILGen for method %s due to invokedynamic/invokehandle bytecode at bc index %d.", _recursionDepth, callerName, i);
+               }
             // intentional fallthrough
          case J9BCinvokehandlegeneric:
             // TODO:JSR292: Use getResolvedHandleMethod


### PR DESCRIPTION
This commit disables peeking ILGen due to presence of invokedynamic or invokehandle bytecodes. This is meant to be a temporary measure until DDR test failures caused with such peeking ILGen can be investigated and fixed. Peeking ILGen for non-root methods containing invokedynamic/invokehandle bytecodes would now have to be enabled using the option TR_enablePeekingForMHInvokes.

Issue: #22256