### PR TITLE
Modify objectMonitorExit to use OBJECT_HEADER_LOCK_FLC instead of 0x02

### DIFF
--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -84,7 +84,7 @@ restart:
 #endif /* if !(defined(AIXPPC) || defined(LINUXPPC)) */
 #endif /* ifndef J9VM_THR_LOCK_RESERVATION */
 #if JAVA_SPEC_VERSION >= 24
-		if (0x02 == count) {
+		if (OBJECT_HEADER_LOCK_FLC == count) {
 			/* FLC set, non-recursive. */
 			J9ObjectMonitor *objectMonitor = objectMonitorInflate(vmStruct, object, lock);
 


### PR DESCRIPTION
When debugging issues related to `OBJECT_HEADER_LOCK_FLC`, global search of `OBJECT_HEADER_LOCK_FLC` will miss this piece of code, which makes things harder. If the code is checking for a macro, use the macro rather than its value.