### PR TITLE
Fix compilation error on z/OS due to initialization escaping case

### DIFF
--- a/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.cpp
@@ -982,12 +982,14 @@ TR_J9EstimateCodeSize::processBytecodeAndGenerateCFG(TR_CallTarget *calltarget, 
             break;
          case J9BCinvokedynamic:
          case J9BCinvokehandle:
+            {
             const static bool enablePeekingForMHInvokes = feGetEnv("TR_enablePeekingForMHInvokes") ? true : false;
             if (enablePeekingForMHInvokes)
                {
                nph.setNeedsPeekingToTrue();
                heuristicTrace(tracer(), "Depth %d: Enabled peeking ILGen for method %s due to invokedynamic/invokehandle bytecode at bc index %d.", _recursionDepth, callerName, i);
                }
+            }
             // intentional fallthrough
          case J9BCinvokehandlegeneric:
             // TODO:JSR292: Use getResolvedHandleMethod


### PR DESCRIPTION
Error was caused by initialization of enablePeekingForMHInvokes not enclosed within the scope of the case statement.