### PR TITLE
AArch64: Inline StringUTF16.indexOf([BI[BII)I

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -6602,12 +6602,12 @@ static TR::Register* inlineIntrinsicIndexOf(TR::Node* node, TR::CodeGenerator* c
  *
  * Note that this version does not support discontiguous arrays
  */
-static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::CodeGenerator *cg)
+static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::CodeGenerator *cg, bool isLatin1)
    {
    static bool verboseInlineStrIdxOfStr = (feGetEnv("TR_verboseInlineStrIdxOfStr") != NULL);
    if (verboseInlineStrIdxOfStr)
       {
-      fprintf(stderr, "*Latin1.indexOfString(): %s @%s\n", cg->comp()->signature(), cg->comp()->getHotnessName());
+      fprintf(stderr, "*%s.indexOfString(): %s @%s\n", isLatin1 ? "Latin1" : "UTF16", cg->comp()->signature(), cg->comp()->getHotnessName());
       }
 
    TR_ASSERT_FATAL(!TR::Compiler->om.canGenerateArraylets(), "Discontiguous array is not supported");
@@ -6647,11 +6647,11 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
       }
 
    TR::Register *s1addrReg = cg->allocateRegister(TR_GPR);
-   TR::Register *s1idxReg = cg->allocateRegister(TR_GPR);
    TR::Register *s2addrReg = cg->allocateRegister(TR_GPR);
    TR::Register *s2idxReg = cg->allocateRegister(TR_GPR);
    TR::Register *tmp1Reg = cg->allocateRegister(TR_GPR);
    TR::Register *tmp2Reg = cg->allocateRegister(TR_GPR);
+   TR::Register *tmp3Reg = cg->allocateRegister(TR_GPR);
    TR::Register *s2firstCharReg = cg->allocateRegister(TR_VRF);
    TR::Register *vtmp1Reg = cg->allocateRegister(TR_VRF);
    TR::Register *vtmp2Reg = cg->allocateRegister(TR_VRF);
@@ -6663,11 +6663,11 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
    dependencies->addPreCondition(maxReg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(resultReg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(s1addrReg, TR::RealRegister::NoReg);
-   dependencies->addPreCondition(s1idxReg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(s2addrReg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(s2idxReg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(tmp1Reg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(tmp2Reg, TR::RealRegister::NoReg);
+   dependencies->addPreCondition(tmp3Reg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(s2firstCharReg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(vtmp1Reg, TR::RealRegister::NoReg);
    dependencies->addPreCondition(vtmp2Reg, TR::RealRegister::NoReg);
@@ -6678,11 +6678,11 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
    dependencies->addPostCondition(maxReg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(resultReg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(s1addrReg, TR::RealRegister::NoReg);
-   dependencies->addPostCondition(s1idxReg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(s2addrReg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(s2idxReg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(tmp1Reg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(tmp2Reg, TR::RealRegister::NoReg);
+   dependencies->addPostCondition(tmp3Reg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(s2firstCharReg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(vtmp1Reg, TR::RealRegister::NoReg);
    dependencies->addPostCondition(vtmp2Reg, TR::RealRegister::NoReg);
@@ -6703,6 +6703,7 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
    generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel);
 
    const int32_t vecWidth = 16;
+   const int32_t shift = isLatin1 ? 0 : 1;
 
    // Addresses of array elements
 #ifdef J9VM_GC_SPARSE_HEAP_ALLOCATION
@@ -6721,8 +6722,10 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
       }
 
    // First character of s2
-   generateTrg1MemInstruction(cg, TR::InstOpCode::ldrbimm, node, tmp1Reg, TR::MemoryReference::createWithDisplacement(cg, s2addrReg, 0));
-   generateTrg1Src1Instruction(cg, TR::InstOpCode::vdup16b, node, s2firstCharReg, tmp1Reg);
+   generateTrg1MemInstruction(cg, isLatin1 ? TR::InstOpCode::ldrbimm : TR::InstOpCode::ldrhimm, node,
+                              tmp1Reg, TR::MemoryReference::createWithDisplacement(cg, s2addrReg, 0));
+   generateTrg1Src1Instruction(cg, isLatin1 ? TR::InstOpCode::vdup16b : TR::InstOpCode::vdup8h, node,
+                               s2firstCharReg, tmp1Reg);
 
    // Calculate max
    generateTrg1Src2Instruction(cg, TR::InstOpCode::subw, node, maxReg, s1lenReg, s2lenReg);
@@ -6733,33 +6736,68 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, notFoundLabel, TR::CC_GT);
 
    // Search for the first character
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, tmp1Reg, s1addrReg, resultReg);
+   if (isLatin1)
+      {
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, tmp1Reg, s1addrReg, resultReg);
+      }
+   else
+      {
+      generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, node, tmp1Reg, s1addrReg, resultReg, TR::SH_LSL, 1);
+      }
    generateLogicalImmInstruction(cg, TR::InstOpCode::andimmx, node, tmp2Reg, tmp1Reg, true, 3); // N = true, immr:imms = 3 for immediate value 0xf
-   generateCompareBranchInstruction(cg, TR::InstOpCode::cbzw, node, tmp2Reg, firstCharLoopLabel);
+   generateCompareBranchInstruction(cg, TR::InstOpCode::cbzx, node, tmp2Reg, firstCharLoopLabel);
 
    generateTrg1Src2Instruction(cg, TR::InstOpCode::subx, node, tmp1Reg, tmp1Reg, tmp2Reg); // tmp1Reg is 16-byte aligned
    generateTrg1MemInstruction(cg, TR::InstOpCode::vldrimmq, node, vtmp1Reg, TR::MemoryReference::createWithDisplacement(cg, tmp1Reg, 0));
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmeq16b, node, vtmp1Reg, vtmp1Reg, s2firstCharReg);
-   generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, vtmp1Reg, vtmp1Reg, 4); // 8 bits x 16 -> 4 bits x 16
+   generateTrg1Src2Instruction(cg, isLatin1 ? TR::InstOpCode::vcmeq16b : TR::InstOpCode::vcmeq8h, node,
+                               vtmp1Reg, vtmp1Reg, s2firstCharReg);
+   if (isLatin1)
+      {
+      generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, vtmp1Reg, vtmp1Reg, 4); // 8 bits x 16 -> 4 bits x 16
+      }
+   else
+      {
+      generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_4h, node, vtmp1Reg, vtmp1Reg, 8); // 16 bits x 8 -> 8 bits x 8
+      }
    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, tmp1Reg, vtmp1Reg, 0);
-   generateLogicalShiftLeftImmInstruction(cg, node, s1idxReg, tmp2Reg, 2, /* is64bit */ false); // s1idxReg is used for other purpose here
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::lsrvx, node, tmp1Reg, tmp1Reg, s1idxReg);
+   generateLogicalShiftLeftImmInstruction(cg, node, tmp3Reg, tmp2Reg, 2, /* is64bit */ false);
+   generateTrg1Src2Instruction(cg, TR::InstOpCode::lsrvx, node, tmp1Reg, tmp1Reg, tmp3Reg);
    generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, tmp1Reg, firstCharMatchedLabel);
 
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, resultReg, resultReg, vecWidth);
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, resultReg, resultReg, vecWidth >> shift);
+   if (!isLatin1)
+      {
+      generateLogicalShiftRightImmInstruction(cg, node, tmp2Reg, tmp2Reg, 1, /* is64bit */ false);
+      }
    generateTrg1Src2Instruction(cg, TR::InstOpCode::subw, node, resultReg, resultReg, tmp2Reg);
 
    generateCompareInstruction(cg, node, resultReg, maxReg, /* is64bit */ false);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, notFoundLabel, TR::CC_GT);
 
-   // (s1addrReg + resultReg) is 16-byte aligned here
+   // (s1addrReg + resultReg << shift) is 16-byte aligned here
    generateLabelInstruction(cg, TR::InstOpCode::label, node, firstCharLoopLabel);
-   generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp1Reg, TR::MemoryReference::createWithIndexReg(cg, s1addrReg, resultReg));
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmeq16b, node, vtmp1Reg, vtmp1Reg, s2firstCharReg);
-   generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, vtmp1Reg, vtmp1Reg, 4); // 8 bits x 16 -> 4 bits x 16
+   if (isLatin1)
+      {
+      generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp1Reg, TR::MemoryReference::createWithIndexReg(cg, s1addrReg, resultReg));
+      }
+   else
+      {
+      generateLogicalShiftLeftImmInstruction(cg, node, tmp3Reg, resultReg, 1, /* is64bit */ false);
+      generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp1Reg, TR::MemoryReference::createWithIndexReg(cg, s1addrReg, tmp3Reg));
+      }
+   generateTrg1Src2Instruction(cg, isLatin1 ? TR::InstOpCode::vcmeq16b : TR::InstOpCode::vcmeq8h, node,
+                               vtmp1Reg, vtmp1Reg, s2firstCharReg);
+   if (isLatin1)
+      {
+      generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, vtmp1Reg, vtmp1Reg, 4); // 8 bits x 16 -> 4 bits x 16
+      }
+   else
+      {
+      generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_4h, node, vtmp1Reg, vtmp1Reg, 8); // 16 bits x 8 -> 8 bits x 8
+      }
    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, tmp1Reg, vtmp1Reg, 0);
    generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzx, node, tmp1Reg, firstCharMatchedLabel);
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, resultReg, resultReg, vecWidth);
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, resultReg, resultReg, vecWidth >> shift);
    generateCompareInstruction(cg, node, resultReg, maxReg, /* is64bit */ false);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, firstCharLoopLabel, TR::CC_LE);
    generateLabelInstruction(cg, TR::InstOpCode::b, node, notFoundLabel);
@@ -6768,45 +6806,69 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
    generateLabelInstruction(cg, TR::InstOpCode::label, node, firstCharMatchedLabel);
    generateTrg1Src1Instruction(cg, TR::InstOpCode::rbitx, node, tmp1Reg, tmp1Reg);
    generateTrg1Src1Instruction(cg, TR::InstOpCode::clzx, node, tmp1Reg, tmp1Reg);
-   generateLogicalShiftRightImmInstruction(cg, node, tmp1Reg, tmp1Reg, 2, /* is64bit */ true); // div by 4
+   generateLogicalShiftRightImmInstruction(cg, node, tmp1Reg, tmp1Reg, 2 + shift, /* is64bit */ true); // div by 4 (Latin1) or 8 (UTF16)
    generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, resultReg, resultReg, tmp1Reg);
 
    generateCompareInstruction(cg, node, resultReg, maxReg, /* is64bit */ false);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, notFoundLabel, TR::CC_GT);
 
    // Compare the rest of s2
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, s1idxReg, resultReg, 1); // s1idx = offset + 1
+   if (isLatin1)
+      {
+      generateTrg1Src2Instruction(cg, TR::InstOpCode::addx, node, tmp3Reg, s1addrReg, resultReg); // tmp3 = &(s1addr[offset])
+      }
+   else
+      {
+      generateTrg1Src2ShiftedInstruction(cg, TR::InstOpCode::addx, node, tmp3Reg, s1addrReg, resultReg, TR::SH_LSL, 1); // tmp3 = &(s1addr[offset << 1])
+      }
    loadConstant32(cg, node, 1, s2idxReg); // s2idx = 1
 
    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subimmw, node, tmp2Reg, s2lenReg, 1);
-   generateLogicalShiftRightImmInstruction(cg, node, tmp2Reg, tmp2Reg, 4, /* is64bit */ false); // div by 16
+   generateLogicalShiftRightImmInstruction(cg, node, tmp2Reg, tmp2Reg, 4 - shift, /* is64bit */ false); // div by 16 (Latin1) or 8 (UTF16)
    generateCompareBranchInstruction(cg, TR::InstOpCode::cbzw, node, tmp2Reg, arrayCmpByteLoopLabel);
 
    // Vector comparison
    generateLabelInstruction(cg, TR::InstOpCode::label, node, arrayCmpVectorLoopLabel);
-   generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp1Reg, TR::MemoryReference::createWithIndexReg(cg, s1addrReg, s1idxReg));
-   generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp2Reg, TR::MemoryReference::createWithIndexReg(cg, s2addrReg, s2idxReg));
-   generateTrg1Src2Instruction(cg, TR::InstOpCode::vcmeq16b, node, vtmp1Reg, vtmp1Reg, vtmp2Reg);
+   if (isLatin1)
+      {
+      generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp1Reg, TR::MemoryReference::createWithIndexReg(cg, tmp3Reg, s2idxReg));
+      generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp2Reg, TR::MemoryReference::createWithIndexReg(cg, s2addrReg, s2idxReg));
+      }
+   else
+      {
+      generateLogicalShiftLeftImmInstruction(cg, node, tmp1Reg, s2idxReg, 1, /* is64bit */ false);
+      generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp1Reg, TR::MemoryReference::createWithIndexReg(cg, tmp3Reg, tmp1Reg));
+      generateTrg1MemInstruction(cg, TR::InstOpCode::vldroffq, node, vtmp2Reg, TR::MemoryReference::createWithIndexReg(cg, s2addrReg, tmp1Reg));
+      }
+   generateTrg1Src2Instruction(cg, isLatin1 ? TR::InstOpCode::vcmeq16b : TR::InstOpCode::vcmeq8h, node,
+                               vtmp1Reg, vtmp1Reg, vtmp2Reg);
    generateVectorShiftImmediateInstruction(cg, TR::InstOpCode::vshrn_8b, node, vtmp1Reg, vtmp1Reg, 4); // 8 bits x 16 -> 4 bits x 16
    generateMovVectorElementToGPRInstruction(cg, TR::InstOpCode::umovxd, node, tmp1Reg, vtmp1Reg, 0);
    generateCompareImmInstruction(cg, node, tmp1Reg, -1, /* is64bit */ true);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, unmatchedLabel, TR::CC_NE);
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, s1idxReg, s1idxReg, vecWidth);
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, s2idxReg, s2idxReg, vecWidth);
+   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, s2idxReg, s2idxReg, vecWidth >> shift);
    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::subsimmw, node, tmp2Reg, tmp2Reg, 1);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, arrayCmpVectorLoopLabel, TR::CC_NE);
 
-   // Byte comparison
+   // Byte/char comparison
    generateLabelInstruction(cg, TR::InstOpCode::label, node, arrayCmpByteLoopLabel);
    generateCompareInstruction(cg, node, s2lenReg, s2idxReg);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, doneLabel, TR::CC_LE); // resultReg has the result
 
-   generateTrg1MemInstruction(cg, TR::InstOpCode::ldrbimm, node, tmp1Reg, TR::MemoryReference::createWithIndexReg(cg, s1addrReg, s1idxReg));
-   generateTrg1MemInstruction(cg, TR::InstOpCode::ldrbimm, node, tmp2Reg, TR::MemoryReference::createWithIndexReg(cg, s2addrReg, s2idxReg));
+   if (isLatin1)
+      {
+      generateTrg1MemInstruction(cg, TR::InstOpCode::ldrboff, node, tmp1Reg, TR::MemoryReference::createWithIndexReg(cg, tmp3Reg, s2idxReg));
+      generateTrg1MemInstruction(cg, TR::InstOpCode::ldrboff, node, tmp2Reg, TR::MemoryReference::createWithIndexReg(cg, s2addrReg, s2idxReg));
+      }
+   else
+      {
+      generateLogicalShiftLeftImmInstruction(cg, node, tmp2Reg, s2idxReg, 1, /* is64bit */ false);
+      generateTrg1MemInstruction(cg, TR::InstOpCode::ldrhoff, node, tmp1Reg, TR::MemoryReference::createWithIndexReg(cg, tmp3Reg, tmp2Reg));
+      generateTrg1MemInstruction(cg, TR::InstOpCode::ldrhoff, node, tmp2Reg, TR::MemoryReference::createWithIndexReg(cg, s2addrReg, tmp2Reg));
+      }
    generateCompareInstruction(cg, node, tmp1Reg, tmp2Reg, /* is64bit */ false);
    generateConditionalBranchInstruction(cg, TR::InstOpCode::b_cond, node, unmatchedLabel, TR::CC_NE);
 
-   generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, s1idxReg, s1idxReg, 1);
    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, s2idxReg, s2idxReg, 1);
    generateLabelInstruction(cg, TR::InstOpCode::b, node, arrayCmpByteLoopLabel);
 
@@ -6823,11 +6885,11 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, dependencies);
 
    cg->stopUsingRegister(s1addrReg);
-   cg->stopUsingRegister(s1idxReg);
    cg->stopUsingRegister(s2addrReg);
    cg->stopUsingRegister(s2idxReg);
    cg->stopUsingRegister(tmp1Reg);
    cg->stopUsingRegister(tmp2Reg);
+   cg->stopUsingRegister(tmp3Reg);
    cg->stopUsingRegister(s2firstCharReg);
    cg->stopUsingRegister(vtmp1Reg);
    cg->stopUsingRegister(vtmp2Reg);
@@ -7167,7 +7229,17 @@ J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&result
          case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
             if (cg->getSupportsInlineStringIndexOfString())
                {
-               resultReg = inlineIntrinsicStringIndexOfString(node, cg);
+               resultReg = inlineIntrinsicStringIndexOfString(node, cg, true);
+               return true;
+               }
+         break;
+
+         case TR::java_lang_StringUTF16_indexOf:
+         case TR::java_lang_StringUTF16_indexOfUnsafe:
+         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
+            if (cg->getSupportsInlineStringIndexOfString())
+               {
+               resultReg = inlineIntrinsicStringIndexOfString(node, cg, false);
                return true;
                }
             break;


### PR DESCRIPTION
This commit generates vectorized inlined code for AArch64 for methods StringUTF16.indexOf([BI[BII)I and
JITHelpers.intrinsicIndexOfStringUTF16().