### PR TITLE
Add spill registers in walkTransitionFrame()

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/JITStackWalker.java
@@ -911,6 +911,9 @@ public class JITStackWalker
 
 						if ((walkState.flags & J9_STACKWALK_MAINTAIN_REGISTER_MAP) != 0) {
 							CLEAR_LOCAL_REGISTER_MAP_ENTRIES(walkState);
+							if (!inMethodPrologue) {
+								jitAddSpilledRegisters(walkState, VoidPointer.NULL);
+							}
 						}
 
 						UNWIND_TO_NEXT_FRAME(walkState);

--- a/runtime/codert_vm/jswalk.c
+++ b/runtime/codert_vm/jswalk.c
@@ -417,6 +417,9 @@ static UDATA walkTransitionFrame(J9StackWalkState *walkState)
 
 				if (walkState->flags & J9_STACKWALK_MAINTAIN_REGISTER_MAP) {
 					CLEAR_LOCAL_REGISTER_MAP_ENTRIES(walkState);
+					if (!inMethodPrologue) {
+						jitAddSpilledRegisters(walkState, walkState->stackMap);
+					}
 				}
 
 				UNWIND_TO_NEXT_FRAME(walkState);


### PR DESCRIPTION
There are cases that the stack walker walk jit frames in transition frame e.g. when a virtual thread fails to enter a synchronized method. We still walk the register map in transition frame if there are object slots in registers but we don't update the register table with spilled registers which is causing failure.
This PR add procedure to update register table with spilled register when it is in method prologue for synchronized method cases.

Closes: [#22079](https://github.com/eclipse-openj9/openj9/issues/22079)