### PR TITLE
Use new lock word to check for lock owner

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -1035,7 +1035,7 @@ restart:
 							/* Either the lock is acquired or FLC bit set, safe to release the inflated monitor. */
 							omrthread_monitor_exit(monitor);
 
-							if (J9_FLATLOCK_OWNER(lock) == currentThread) {
+							if (J9_FLATLOCK_OWNER(newLockword) == currentThread) {
 								/* Lock is acquired. */
 								currentThread->ownedMonitorCount += 1;
 								result = (UDATA)syncObj;


### PR DESCRIPTION
The lock owner is in the new lock word rather than the old one

issue #22068