### PR TITLE
[0.54] Detect any monitorenter before point of dynamic loop transfers

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9703,6 +9703,18 @@ TR_J9VMBase::isJ9VMThreadCurrentThreadImmutable()
 #endif /* JAVA_SPEC_VERSION >= 19 */
    }
 
+bool
+TR_J9VMBase::isLiveMonitorMapCorrectnessRequired()
+   {
+#if JAVA_SPEC_VERSION >= 24
+   J9JavaVM *javaVM = getJ9JITConfig()->javaVM;
+   return J9_ARE_ANY_BITS_SET(javaVM->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION);
+#else
+   return false;
+#endif /* JAVA_SPEC_VERSION >= 24 */
+   }
+
+
 // Native method bodies
 //
 #if defined(TR_HOST_X86)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -1555,6 +1555,23 @@ public:
     */
    virtual bool isJ9VMThreadCurrentThreadImmutable();
 
+   /**
+    * \brief Answers whether live monitor map correctness is required.
+    *
+    * In the context of Dynamic Loop Transfer, the JIT compiler might not
+    * have complete information about which monitorenter bytecode operations
+    * have been executed.  With some versions of Java, that could result in
+    * an object being kept live longer than necessary, but does not cause
+    * problems for correctness.  For other versions of Java, the JVM consults
+    * the live monitor map to detect any monitor that needs to be detached from
+    * or attached to a carrier thread when a virtual thread is unmounted from
+    * or mounted on, respectively, the carrier thread.
+    *
+    * \returns True if live monitor map correctness is required; false,
+    *          otherwise.
+    */
+   virtual bool isLiveMonitorMapCorrectnessRequired();
+
 protected:
    bool isSignatureForPrimitiveType(const char * sig, int32_t sigLength)
       {

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -410,6 +410,21 @@ private:
    void markRequiredKnownObjectIndex(TR::Node *node, TR::KnownObjectTable::Index koi);
    void assertFoldedAllRequiredConsts();
 
+   /**
+    * Answers whether some path through predecessors of a block contains a \ref TR::monent
+    * operation.
+    *
+    * \param[in] currBlock The block whose predecessor paths are being examined
+    * \param[in] hasMonent A \ref TR_BitVector of the blocks that contained
+    *                      \ref TR::monent operations
+    * \param[in] visited   A \ref TR_BitVector of blocks that have already been
+    *                      or are in the process of being visited
+    *
+    * \returns true if some path through predecessors contains a \ref TR::monent;
+    *          false, otherwise.
+    */
+   bool hasMonentOnPredecessorPath(TR::CFGNode *currBlock, TR_BitVector &hasMonent, TR_BitVector &visited);
+
    // data
    //
    TR::SymbolReferenceTable *         _symRefTab;


### PR DESCRIPTION
Dynamic loop transfer can transfer control from the interpreter into a JIT-compiled method after the point at which `monitorenter` bytecode instructions have been executed.  With Java 24 and later, the JVM uses the JIT's live monitor metadata to locate monitors that might need to be detached from carrier threads when the owning virtual thread is unmounted.

If the JIT is unable to determine that no `monitorenter`s will be executed prior to the entry point for dynamic loop transfer, it must fail the compilation.

Fixes: #22266

Port of pull request #22291 to v0.54.0-release branch