### PR TITLE
AArch64: Add support for off-heap arrays in inlineIntrinsicIndexOf()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -87,7 +87,7 @@ J9::ARM64::CodeGenerator::initialize()
       {
       cg->setSupportsInlineStringHashCode();
       }
-   if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableFastStringIndexOf)) && !TR::Compiler->om.isOffHeapAllocationEnabled())
+   if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableFastStringIndexOf)))
       {
       cg->setSupportsInlineStringIndexOf();
       }


### PR DESCRIPTION
This commit adds support for off-heap arrays in inlineIntrinsicIndexOf() for AArch64.