### PR TITLE
Use user/system/idle times for CPU load calculation in CpuUtilization

### DIFF
--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -66,6 +66,9 @@ public:
       {
       int64_t _timeStamp;
       int64_t _sampleSystemCpu;
+      int64_t _sampleUserTime;
+      int64_t _sampleSystemTime;
+      int64_t _sampleIdleTime;
       int64_t _sampleJvmCpu;
       } CpuUsageCircularBuffer;
 
@@ -105,10 +108,13 @@ private:
    int64_t _prevIntervalLength; // the duration (in ns) of the last update interval
 
    // values recorded at start of this update interval
-   int64_t _prevMachineUptime;  // absolute value (in ns) of machine uptime
-   int64_t _prevMachineCpuTime; // absolute value (in ns) of used CPU time on the machine
-   int64_t _prevVmSysTime;      // absolute value (in ns) of time VM spent in kernel space
-   int64_t _prevVmUserTime;     // absolute value (in ns) of time VM spent in user space
+   int64_t _prevMachineUptime;      // absolute value (in ns) of machine uptime
+   int64_t _prevMachineCpuTime;     // absolute value (in ns) of used CPU time on the machine
+   int64_t _prevMachineIdleTime;    // absolute value (in CPU ticks) of total idle time on the machine
+   int64_t _prevVmSysTime;          // absolute value (in ns) of time VM spent in kernel space
+   int64_t _prevVmUserTime;         // absolute value (in ns) of time VM spent in user space
+   int64_t _prevMachineUserTime;    // absolute value (in CPU ticks) of total user time on the machine
+   int64_t _prevMachineSystemTime;  // absolute value (in CPU ticks) of total kernel time on the machine
 
    CpuUsageCircularBuffer *_cpuUsageCircularBuffer;      // Circular buffer containing timestamp, system cpu usage sample, and jvm cpu use sample
    int32_t                 _cpuUsageCircularBufferIndex; // Current index of the buffer; contains the oldest data. Subtract 1 to get the most recent data


### PR DESCRIPTION
Use the newly added userTime, systemTime, and idleTime fields in
J9SysinfoCPUTime to evaluate CPU load.

When all three fields are available for both current and previous
samples, CPU load is now calculated as:

```
  CPU load = (user + system) / (user + system + idle)
```

This replaces the previous calculation which relied on only cpuTime
and timestamps:

```
  CPU load = (cpuTime delta) /
             (number of CPUs * elapsed time)
```

If the new fields are unavailable, the implementation falls back to the
old method.

The average CPU usage and idle percentages are now computed using these
new ratios, and the values are stored in the CPU usage circular buffer
alongside user, system, and idle samples for better historical
tracking.

Depends on https://github.com/eclipse-omr/omr/pull/7853.