### PR TITLE
Fix compile warnings in native code on z/OS

### DIFF
--- a/runtime/jcl/common/system.c
+++ b/runtime/jcl/common/system.c
@@ -101,9 +101,9 @@ Java_java_lang_System_getSysPropBeforePropertiesInitialized(JNIEnv *env, jclass 
 #endif /* JAVA_SPEC_VERSION < 18 */
 		}
 #if defined(J9ZOS390)
-		if (__CSNameType(sysPropValue) == _CSTYPE_ASCII) {
+		if (__CSNameType((char *)sysPropValue) == _CSTYPE_ASCII) {
 			__ccsid_t ccsid;
-			ccsid = __toCcsid(sysPropValue);
+			ccsid = __toCcsid((char *)sysPropValue);
 			atoe_setFileTaggingCcsid(&ccsid);
 		}
 #endif /* defined(J9ZOS390) */

--- a/runtime/tests/zos/zosnatives.c
+++ b/runtime/tests/zos/zosnatives.c
@@ -35,32 +35,32 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest1(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	jboolean isCopy; /* dummy variable */
-	jbyteArray array_b;
-	jbyte * buffer_b;
+	jboolean isCopy = JNI_FALSE; /* dummy variable */
+	jbyteArray array_b = NULL;
+	jbyte *buffer_b = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest1 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest1 is starting\n");
 
 	array_b = (*env)->NewByteArray(env, LENGTH);
 	if (NULL == array_b) {
-		j9tty_printf( PORTLIB, "NewByteArray should not return NULL\n");
+		j9tty_printf(PORTLIB, "NewByteArray should not return NULL\n");
 		return 1;
 	}
 
 	buffer_b = (jbyte *)(*env)->GetByteArrayElements(env, array_b, &isCopy);
 	if (NULL == buffer_b) {
-		j9tty_printf( PORTLIB, "GetByteArrayElements should not return NULL\n");
+		j9tty_printf(PORTLIB, "GetByteArrayElements should not return NULL\n");
 		return 1;
 	}
 
 	/* Free the buffer */
 	(*env)->ReleaseByteArrayElements(env, array_b, buffer_b, 0);
 	if ((*env)->ExceptionCheck(env)) {
-		j9tty_printf( PORTLIB, "Exception occurred in ReleaseByteArrayElements\n");
+		j9tty_printf(PORTLIB, "Exception occurred in ReleaseByteArrayElements\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest1 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest1 has finished\n");
 
 	return 0;
 }
@@ -76,14 +76,14 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest2(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	char * buffer_str;
-	jstring testStr;
+	char *buffer_str = NULL;
+	jstring testStr = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest2 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest2 is starting\n");
 
-	buffer_str = (char *) j9mem_allocate_memory(LENGTH, OMRMEM_CATEGORY_VM);
+	buffer_str = (char *)j9mem_allocate_memory(LENGTH, OMRMEM_CATEGORY_VM);
 	if (NULL == buffer_str) {
-		j9tty_printf( PORTLIB, "j9mem_allocate_memory should not return NULL\n");
+		j9tty_printf(PORTLIB, "j9mem_allocate_memory should not return NULL\n");
 		return 1;
 	}
 
@@ -94,14 +94,13 @@ Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest2(JNIEnv *env, jclass clazz)
 	j9mem_free_memory((void *)buffer_str);
 
 	if (NULL == testStr) {
-		j9tty_printf( PORTLIB, "NewStringUTF should not return NULL\n");
+		j9tty_printf(PORTLIB, "NewStringUTF should not return NULL\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest2 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest2 has finished\n");
 	return 0;
 }
-
 
 /*
  * Class:     com.ibm.j9.zostest.TestZosNatives
@@ -114,36 +113,35 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest3(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	jbyteArray array_b;
-	jbyte *buffer_b;
+	jbyteArray array_b = NULL;
+	jbyte *buffer_b = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest3 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest3 is starting\n");
 
 	array_b = (*env)->NewByteArray(env, LENGTH);
 	if (NULL == array_b) {
-		j9tty_printf( PORTLIB,"NewByteArray should not return NULL\n");
+		j9tty_printf(PORTLIB, "NewByteArray should not return NULL\n");
 		return 1;
 	}
 
-	buffer_b = (jbyte*) j9mem_allocate_memory(LENGTH*sizeof(jbyte), OMRMEM_CATEGORY_VM);
+	buffer_b = (jbyte *)j9mem_allocate_memory(LENGTH * sizeof(jbyte), OMRMEM_CATEGORY_VM);
 	if (NULL == buffer_b) {
-		j9tty_printf( PORTLIB,"j9mem_allocate_memory should not return NULL\n");
+		j9tty_printf(PORTLIB, "j9mem_allocate_memory should not return NULL\n");
 		return 1;
 	}
 
 	(*env)->GetByteArrayRegion(env, array_b, 0, LENGTH, buffer_b);
-	j9mem_free_memory((void*)buffer_b);
+	j9mem_free_memory((void *)buffer_b);
 
 	if ((*env)->ExceptionCheck(env)) {
-		j9tty_printf( PORTLIB, "Exception occurred in GetByteArrayRegion\n");
+		j9tty_printf(PORTLIB, "Exception occurred in GetByteArrayRegion\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest3 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest3 has finished\n");
 
 	return 0;
 }
-
 
 /*
  * Class:     com.ibm.j9.zostest.TestZosNatives
@@ -156,22 +154,22 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest4(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	jint *buffer_i;
-	jintArray array_i;
+	jint *buffer_i = NULL;
+	jintArray array_i = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest4 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest4 is starting\n");
 
 	array_i = (*env)->NewIntArray(env, LENGTH);
 
 	if (NULL == array_i) {
-		j9tty_printf( PORTLIB,"NewIntArray should not return NULL\n");
+		j9tty_printf(PORTLIB, "NewIntArray should not return NULL\n");
 		return 1;
 	}
 
 	/* Allocate buffer */
-	buffer_i = (jint*) j9mem_allocate_memory(LENGTH*sizeof(jint), OMRMEM_CATEGORY_VM);
+	buffer_i = (jint *)j9mem_allocate_memory(LENGTH * sizeof(jint), OMRMEM_CATEGORY_VM);
 	if (NULL == buffer_i) {
-		j9tty_printf( PORTLIB,"j9mem_allocate_memory should not return NULL\n");
+		j9tty_printf(PORTLIB, "j9mem_allocate_memory should not return NULL\n");
 		return JNI_FALSE;
 	}
 
@@ -181,15 +179,14 @@ Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest4(JNIEnv *env, jclass clazz)
 	j9mem_free_memory(buffer_i);
 
 	if ((*env)->ExceptionCheck(env)) {
-		j9tty_printf( PORTLIB, "Exception occurred in SetIntArrayRegion\n");
+		j9tty_printf(PORTLIB, "Exception occurred in SetIntArrayRegion\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest4 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest4 has finished\n");
 
 	return 0;
 }
-
 
 /*
  * Class:     com.ibm.j9.zostest.TestZosNatives
@@ -202,23 +199,23 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest5(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	const jchar * buffer_str;
-	jstring testStr;
+	jchar *buffer_str = NULL;
+	jstring testStr = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest5 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest5 is starting\n");
 
-	buffer_str = (const jchar *) j9mem_allocate_memory(LENGTH*sizeof(jchar), OMRMEM_CATEGORY_VM);
+	buffer_str = (jchar *)j9mem_allocate_memory(LENGTH * sizeof(jchar), OMRMEM_CATEGORY_VM);
 	if (NULL == buffer_str) {
-		j9tty_printf( PORTLIB,"j9mem_allocate_memory should not return NULL\n");
+		j9tty_printf(PORTLIB, "j9mem_allocate_memory should not return NULL\n");
 		return 1;
 	}
 
-	memset((void *)buffer_str, 0, LENGTH*sizeof(jchar));
+	memset((void *)buffer_str, 0, LENGTH * sizeof(jchar));
 
 	testStr = (*env)->NewString(env, buffer_str, LENGTH);
 	if (NULL == testStr) {
-		j9tty_printf( PORTLIB, "NewString should not return NULL\n");
-		j9mem_free_memory((void*)buffer_str);
+		j9tty_printf(PORTLIB, "NewString should not return NULL\n");
+		j9mem_free_memory((void *)buffer_str);
 		return 1;
 	}
 
@@ -228,14 +225,13 @@ Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest5(JNIEnv *env, jclass clazz)
 	j9mem_free_memory((void *)buffer_str);
 
 	if ((*env)->ExceptionCheck(env)) {
-		j9tty_printf( PORTLIB, "Exception occurred in GetStringRegion\n");
+		j9tty_printf(PORTLIB, "Exception occurred in GetStringRegion\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest5 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest5 has finished\n");
 	return 0;
 }
-
 
 /*
  * Class:     com.ibm.j9.zostest.TestZosNatives
@@ -249,48 +245,47 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest6(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	jboolean isCopy; /* dummy variable */
+	jboolean isCopy = JNI_FALSE; /* dummy variable */
 	jthrowable ex = NULL;
-	const jchar * buffer_str;
-	const jchar * string_chars;
-	jstring testStr;
+	jchar *buffer_str = NULL;
+	const jchar *string_chars = NULL;
+	jstring testStr = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest6 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest6 is starting\n");
 
-	buffer_str = (const jchar *) j9mem_allocate_memory(LENGTH*sizeof(jchar), OMRMEM_CATEGORY_VM);
+	buffer_str = (jchar *)j9mem_allocate_memory(LENGTH * sizeof(jchar), OMRMEM_CATEGORY_VM);
 	if (NULL == buffer_str) {
-		j9tty_printf( PORTLIB,"j9mem_allocate_memory should not return NULL\n");
+		j9tty_printf(PORTLIB, "j9mem_allocate_memory should not return NULL\n");
 		return 1;
 	}
 
-	memset((void *)buffer_str, 0, LENGTH*sizeof(jchar));
+	memset((void *)buffer_str, 0, LENGTH * sizeof(jchar));
 
 	testStr = (*env)->NewString(env, buffer_str, LENGTH);
 	j9mem_free_memory((void *)buffer_str);
 
 	if (NULL == testStr) {
-		j9tty_printf( PORTLIB, "NewString should not return NULL\n");
+		j9tty_printf(PORTLIB, "NewString should not return NULL\n");
 		return 1;
 	}
 
 	string_chars = (*env)->GetStringChars(env, testStr, &isCopy);
 
 	if (NULL == string_chars) {
-		j9tty_printf( PORTLIB,"GetStringChars should not return NULL\n");
+		j9tty_printf(PORTLIB, "GetStringChars should not return NULL\n");
 		return 1;
 	}
 
 	(*env)->ReleaseStringChars(env, testStr, string_chars);
 	if ((*env)->ExceptionCheck(env)) {
-		j9tty_printf( PORTLIB, "Exception occurred in ReleaseStringChars\n");
+		j9tty_printf(PORTLIB, "Exception occurred in ReleaseStringChars\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest6 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest6 has finished\n");
 
 	return 0;
 }
-
 
 /*
  * Class:     com.ibm.j9.zostest.TestZosNatives
@@ -303,47 +298,46 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest7(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	jboolean isCopy; /* dummy variable */
+	jboolean isCopy = JNI_FALSE; /* dummy variable */
 	jthrowable ex = NULL;
-	const char * utfChars;
-	char * buffer_str;
-	jstring testStr;
+	const char * utfChars = NULL;
+	char * buffer_str = NULL;
+	jstring testStr = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest7 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest7 is starting\n");
 
-	buffer_str = (char *) j9mem_allocate_memory(LENGTH, OMRMEM_CATEGORY_VM);
+	buffer_str = (char *)j9mem_allocate_memory(LENGTH, OMRMEM_CATEGORY_VM);
 	if (NULL == buffer_str) {
-		j9tty_printf( PORTLIB,"j9mem_allocate_memory should not return NULL\n");
+		j9tty_printf(PORTLIB, "j9mem_allocate_memory should not return NULL\n");
 		return 1;
 	}
 	memset((void *)buffer_str, 's', LENGTH - 1);
-	buffer_str[LENGTH-1] = '\0';
+	buffer_str[LENGTH - 1] = '\0';
 
 	testStr = (*env)->NewStringUTF(env, buffer_str);
 	j9mem_free_memory((void *)buffer_str);
 	if (NULL == testStr) {
-		j9tty_printf( PORTLIB, "NewStringUTF should not return NULL\n");
+		j9tty_printf(PORTLIB, "NewStringUTF should not return NULL\n");
 		return 1;
 	}
 
 	utfChars = (*env)->GetStringUTFChars(env, testStr, &isCopy);
 
 	if (NULL == utfChars) {
-		j9tty_printf( PORTLIB,"GetStringUTFChars should not return NULL\n");
+		j9tty_printf(PORTLIB, "GetStringUTFChars should not return NULL\n");
 		return 1;
 	}
 
 	if ((*env)->ExceptionCheck(env)) {
-		j9tty_printf( PORTLIB, "Exception occurred in ReleaseStringUTFChars\n");
+		j9tty_printf(PORTLIB, "Exception occurred in ReleaseStringUTFChars\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest7 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest7 has finished\n");
 
 	return 0;
 
 }
-
 
 /*
  * Class:     com.ibm.j9.zostest.TestZosNatives
@@ -356,36 +350,36 @@ jint JNICALL
 Java_com_ibm_j9_zostest_ZosNativesTest_ifaSwitchTest8(JNIEnv *env, jclass clazz)
 {
 	PORT_ACCESS_FROM_ENV(env);
-	char * buffer_str;
-	jstring testStr;
+	char *buffer_str = NULL;
+	jstring testStr = NULL;
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest8 is starting\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest8 is starting\n");
 
-	buffer_str = (char *) j9mem_allocate_memory(LENGTH, OMRMEM_CATEGORY_VM);
+	buffer_str = (char *)j9mem_allocate_memory(LENGTH, OMRMEM_CATEGORY_VM);
 	if (NULL == buffer_str) {
-		j9tty_printf( PORTLIB,"j9mem_allocate_memory should not return NULL\n");
+		j9tty_printf(PORTLIB, "j9mem_allocate_memory should not return NULL\n");
 		return 1;
 	}
 
 	memset((void *)buffer_str, 's', LENGTH - 1);
-	buffer_str[LENGTH-1] = '\0';
+	buffer_str[LENGTH - 1] = '\0';
 
 	testStr = (*env)->NewStringUTF(env, buffer_str);
 
 	if (NULL == testStr) {
 		j9mem_free_memory((void *)buffer_str);
-		j9tty_printf( PORTLIB, "NewStringUTF should not return NULL\n");
+		j9tty_printf(PORTLIB, "NewStringUTF should not return NULL\n");
 		return 1;
 	}
 
 	(*env)->GetStringUTFRegion(env, testStr, 0, (*env)->GetStringUTFLength(env, testStr), buffer_str);
 	j9mem_free_memory((void *)buffer_str);
 	if ((*env)->ExceptionCheck(env)) {
-		j9tty_printf( PORTLIB, "Exception occurred in GetStringUTFRegion\n");
+		j9tty_printf(PORTLIB, "Exception occurred in GetStringUTFRegion\n");
 		return 1;
 	}
 
-	j9tty_printf( PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest8 has finished\n");
+	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_TestZosNatives_ifaSwitchTest8 has finished\n");
 
 	return 0;
 }
@@ -407,7 +401,7 @@ Java_com_ibm_j9_zostest_ZosNativesTest_registerNative(JNIEnv * env, jobject obj,
 {
 	PORT_ACCESS_FROM_ENV(env);
 	JNINativeMethod method;
-	int rc;
+	jint rc = 0;
 
 	j9tty_printf(PORTLIB, "Java_com_ibm_j9_zostest_ZosNativesTest_registerNative is starting\n");
 


### PR DESCRIPTION
WARNING CCN3280 system.c: lines 104, 106
* assignment between types "char*" and "const char*" is not allowed

WARNING CCN3068 zosnatives.c: line 275
* operation between types "unsigned short*" and "const unsigned short*" is not allowed

Also tidy up: formatting, initialize locals