### PR TITLE
(0.54) Use AArch64 IPC register for indirect branches in JIT runtime

### DIFF
--- a/runtime/oti/arm64helpers.m4
+++ b/runtime/oti/arm64helpers.m4
@@ -229,8 +229,8 @@ define({RESTORE_PRESERVED_REGS},{
 })
 
 define({BRANCH_VIA_VMTHREAD},{
-	ldr x8,[J9VMTHREAD,{#}$1]
-	br x8
+	ldr x16,[J9VMTHREAD,{#}$1]
+	br x16
 })
 
 define({SWITCH_TO_JAVA_STACK},{ldr J9SP,[J9VMTHREAD,{#}J9TR_VMThread_sp]})


### PR DESCRIPTION
The macro `BRANCH_VIA_VMTHREAD` in the JIT runtime uses the `x8` register to perform an indirect branch to an arbitrary function. However, this macro may be used in contexts where it is not safe to clobber `x8`.

Use the conventional AArch64 ABI register `x16` for this purpose instead. The JIT does not register assign `x16` so there are no conflicts.

Fixes: #21824

Backport https://github.com/eclipse-openj9/openj9/pull/22339