### PR TITLE
(0.54) Use r11 instead of r0 for non-local return

### DIFF
--- a/runtime/oti/phelpers.m4
+++ b/runtime/oti/phelpers.m4
@@ -863,8 +863,8 @@ define({RESTORE_PRESERVED_REGS},{
 })
 
 define({BRANCH_VIA_VMTHREAD},{
-	laddr r0,$1(J9VMTHREAD)
-	mtctr r0
+	laddr r11,$1(J9VMTHREAD)
+	mtctr r11
 	bctr
 })
 


### PR DESCRIPTION
r11 is volatile for all linkages

Backport https://github.com/eclipse-openj9/openj9/pull/22345