### PR TITLE
(0.54) Z: disable iTable check in jit

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -290,6 +290,12 @@ J9::Z::CodeGenerator::initialize()
       }
 
    cg->setIgnoreDecimalOverflowException(false);
+
+   // Disable last iTable cache by default.
+   static bool enableLastITableCache = feGetEnv("TR_EnableLastITableCache") != NULL;
+   if (!enableLastITableCache)
+      comp->setOption(TR_DisableLastITableCache);
+
    }
 
 bool


### PR DESCRIPTION
We populate the IPIC slots on helper call. When checking iTable entries in jit, we don't use helper therefore IPIC slots never get populated. Since PIC slots are fastest method of finding the implementation, this is causing some regression.
Disabling iTable cache until we can populate PIC slots.

Port https://github.com/eclipse-openj9/openj9/pull/22330