### PR TITLE
Keep 10 release builds instead of 3

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -108,7 +108,7 @@ slack_channel: '#jenkins'
 build_discarder:
   logs:
     Nightly: 30
-    Release: 3
+    Release: 10
     OMR: 3
     OpenJDK8: 3
     OpenJDK11: 3


### PR DESCRIPTION
We started running nightly jdk24 release builds. Keep more than the last 3, otherwise the build from the last weekend is quickly gone.