### PR TITLE
(0.54) Add notify to carrier thread wait path 

### DIFF
--- a/runtime/oti/monhelp.h
+++ b/runtime/oti/monhelp.h
@@ -44,10 +44,10 @@
 
 #define J9_LOCK_IS_INFLATED(lockWord) ((lockWord) & OBJECT_HEADER_LOCK_INFLATED)
 #define J9_INFLLOCK_OBJECT_MONITOR(lockWord) ((J9ObjectMonitor *)((UDATA)(lockWord) & (~(UDATA)OBJECT_HEADER_LOCK_INFLATED)))
-#define J9_INFLLOCK_MONITOR(lockWord) (J9_INFLLOCK_OBJECT_MONITOR(lockWord)->monitor)
+#define J9_INFLLOCK_MONITOR(lockWord) (J9_INFLLOCK_OBJECT_MONITOR((lockWord))->monitor)
 
-#define J9_INFLLOCK_ABSTRACT_MONITOR(lockWord) ((J9ThreadAbstractMonitor*)J9_INFLLOCK_MONITOR(lockWord))
+#define J9_INFLLOCK_ABSTRACT_MONITOR(lockWord) ((J9ThreadAbstractMonitor*)J9_INFLLOCK_MONITOR((lockWord)))
 
-#define J9_LOCK_IS_FLATLOCKED(lockWord) (!J9_LOCK_IS_INFLATED(lockWord) && (J9_FLATLOCK_OWNER(lockWord) != NULL))
+#define J9_LOCK_IS_FLATLOCKED(lockWord) (!J9_LOCK_IS_INFLATED((lockWord)) && (J9_FLATLOCK_OWNER((lockWord)) != NULL && (J9_FLATLOCK_COUNT((lockWord)) > 0)))
 
 #endif /*J9_MONHELP_H_*/

--- a/runtime/oti/monhelp.h
+++ b/runtime/oti/monhelp.h
@@ -44,10 +44,13 @@
 
 #define J9_LOCK_IS_INFLATED(lockWord) ((lockWord) & OBJECT_HEADER_LOCK_INFLATED)
 #define J9_INFLLOCK_OBJECT_MONITOR(lockWord) ((J9ObjectMonitor *)((UDATA)(lockWord) & (~(UDATA)OBJECT_HEADER_LOCK_INFLATED)))
-#define J9_INFLLOCK_MONITOR(lockWord) (J9_INFLLOCK_OBJECT_MONITOR((lockWord))->monitor)
+#define J9_INFLLOCK_MONITOR(lockWord) (J9_INFLLOCK_OBJECT_MONITOR(lockWord)->monitor)
 
-#define J9_INFLLOCK_ABSTRACT_MONITOR(lockWord) ((J9ThreadAbstractMonitor*)J9_INFLLOCK_MONITOR((lockWord)))
+#define J9_INFLLOCK_ABSTRACT_MONITOR(lockWord) ((J9ThreadAbstractMonitor*)J9_INFLLOCK_MONITOR(lockWord))
 
-#define J9_LOCK_IS_FLATLOCKED(lockWord) (!J9_LOCK_IS_INFLATED((lockWord)) && (J9_FLATLOCK_OWNER((lockWord)) != NULL && (J9_FLATLOCK_COUNT((lockWord)) > 0)))
+#define J9_LOCK_IS_FLATLOCKED(lockWord) \
+		(!J9_LOCK_IS_INFLATED(lockWord) \
+				&& (NULL != J9_FLATLOCK_OWNER(lockWord)) \
+				&& (J9_FLATLOCK_COUNT(lockWord) > 0))
 
 #endif /*J9_MONHELP_H_*/

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1581,6 +1581,8 @@ obj:
 				VM_ContinuationHelpers::sendUnblockerThreadSignal(_vm);
 			}
 			omrthread_monitor_exit(_vm->blockedVirtualThreadsMutex);
+		} else if ((JAVA_LANG_VIRTUALTHREAD_WAITING == newThreadState) || (JAVA_LANG_VIRTUALTHREAD_TIMED_WAITING == newThreadState)) {
+			VM_ContinuationHelpers::sendUnblockerThreadSignal(_vm);
 		}
 
 		/* Enter critical transition after the prepare stage is complete and hooks dispatched. */

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -1009,7 +1009,7 @@ restart:
 #if defined(J9VM_THR_LOCK_RESERVATION)
 						if (J9_ARE_ANY_BITS_SET(lock, OBJECT_HEADER_LOCK_RESERVED)) {
 							/* Lock is now reserved, exit the inflated monitor and restart to cancel lock reservation. */
-							omrthread_monitor_exit(monitor);
+							Assert_VM_true(0 == omrthread_monitor_exit(monitor));
 							goto restart;
 						}
 #endif /* J9VM_THR_LOCK_RESERVATION */
@@ -1020,6 +1020,8 @@ restart:
 							newLockword = (UDATA)J9_FLATLOCK_OWNER(lock)
 										| ((J9_FLATLOCK_COUNT(lock) - 1) << OBJECT_HEADER_LOCK_V2_RECURSION_OFFSET)
 										| OBJECT_HEADER_LOCK_FLC;
+
+							Assert_VM_true(J9_FLATLOCK_COUNT(lock) == J9_FLATLOCK_COUNT(newLockword));
 						} else {
 							/* Lock is unlocked, so try to directly acquire it as a flatlock. */
 							newLockword = (UDATA)currentThread;
@@ -1033,7 +1035,7 @@ restart:
 							/* CAS succeeded, we can proceed with using the inflated monitor. */
 							VM_ObjectMonitor::incrementCancelCounter(J9OBJECT_CLAZZ(currentThread, syncObj));
 							/* Either the lock is acquired or FLC bit set, safe to release the inflated monitor. */
-							omrthread_monitor_exit(monitor);
+							Assert_VM_true(0 == omrthread_monitor_exit(monitor));
 
 							if (J9_FLATLOCK_OWNER(newLockword) == currentThread) {
 								/* Lock is acquired. */
@@ -1132,7 +1134,7 @@ restart:
 			syncObjectMonitor->waitingContinuations = continuation;
 			omrthread_monitor_exit(vm->blockedVirtualThreadsMutex);
 
-			omrthread_monitor_exit(monitor);
+			Assert_VM_true(0 == omrthread_monitor_exit(monitor));
 		} else {
 			if (NULL != monitor) {
 				/* If we are blocking to wait on a contended monitor then we can't be the owner. */

--- a/runtime/vm/montable.c
+++ b/runtime/vm/montable.c
@@ -146,7 +146,7 @@ initializeMonitorTable(J9JavaVM* vm)
 		return -1;
 	}
 	memset(vm->monitorTables, 0, sizeof(J9HashTable *) * tableCount);
-	
+
 	vm->monitorTableList = NULL;
 
 	for (tableIndex = 0; tableIndex < tableCount; tableIndex++) {
@@ -170,7 +170,7 @@ initializeMonitorTable(J9JavaVM* vm)
 	}
 
 	vm->monitorTableCount = tableCount;
-	
+
 	return 0;
 }
 
@@ -299,20 +299,20 @@ monitorTableAt(J9VMThread* vmStruct, j9object_t object)
 					((J9ThreadAbstractMonitor *)monitor)->spinCount1 = j9threadOptions->customThreeTierSpinCount1;
 					((J9ThreadAbstractMonitor *)monitor)->spinCount2 = j9threadOptions->customThreeTierSpinCount2;
 					((J9ThreadAbstractMonitor *)monitor)->spinCount3 = j9threadOptions->customThreeTierSpinCount3;
-			
+
 					Trc_VM_MonitorTableAt_CustomSpinOption(option->className,
 														   object,
 													   	   ((J9ThreadAbstractMonitor *)monitor)->spinCount1,
 													   	   ((J9ThreadAbstractMonitor *)monitor)->spinCount2,
 													       ((J9ThreadAbstractMonitor *)monitor)->spinCount3);
 #endif /* OMR_THR_THREE_TIER_LOCKING */
-#if defined(OMR_THR_ADAPTIVE_SPIN)													  
+#if defined(OMR_THR_ADAPTIVE_SPIN)
 					Trc_VM_MonitorTableAt_CustomSpinOption2(option->className,
-														    object,													       
+														    object,
 														    j9threadOptions->customAdaptSpin);
-#endif /* OMR_THR_ADAPTIVE_SPIN */							
+#endif /* OMR_THR_ADAPTIVE_SPIN */
 				}
-#endif /* OMR_THR_CUSTOM_SPIN_OPTIONS */				
+#endif /* OMR_THR_CUSTOM_SPIN_OPTIONS */
 #endif /* J9VM_INTERP_CUSTOM_SPIN_OPTIONS */
 
 				key_objectMonitor.monitor = monitor;
@@ -324,6 +324,7 @@ monitorTableAt(J9VMThread* vmStruct, j9object_t object)
 
 #if JAVA_SPEC_VERSION >= 24
 				key_objectMonitor.virtualThreadWaitCount = 0;
+				key_objectMonitor.platformThreadWaitCount = 0;
 				key_objectMonitor.ownerContinuation = NULL;
 				key_objectMonitor.waitingContinuations = NULL;
 				key_objectMonitor.next = NULL;


### PR DESCRIPTION
Add a notify to unblocker in both vthread and platform thread wait
paths. Also, fix the lockword comparison to account for different
lockword modes (learning & reserved). Also, add some assertions to
catch invalid cases.

Fixes the MonitorWaitNotify test
Fixes: https://github.com/eclipse-openj9/openj9/issues/22332

Backport of https://github.com/eclipse-openj9/openj9/pull/22308 and https://github.com/eclipse-openj9/openj9/pull/22352