### PR TITLE
Make `getObjectClassFromKnownObjectIndex()` always succeed

### DIFF
--- a/runtime/compiler/env/J9KnownObjectTable.cpp
+++ b/runtime/compiler/env/J9KnownObjectTable.cpp
@@ -534,10 +534,8 @@ J9::KnownObjectTable::addStableArray(Index index, int32_t stableArrayRank)
    TR_OpaqueClassBlock *clazz =
       fej9->getObjectClassFromKnownObjectIndex(comp(), index);
 
-   // Null is only possible on failure to get VM access. Most of the time we
-   // should find the class successfully anyway, so check only in that case.
    TR_ASSERT_FATAL(
-      clazz == NULL || fej9->isClassArray(clazz),
+      fej9->isClassArray(clazz),
       "addStableArray can only be called for arrays");
 
    if (_stableArrayRanks[index] < stableArrayRank)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5157,14 +5157,7 @@ TR_J9VMBase::delegatingMethodHandleTarget(
    TR_OpaqueClassBlock *dmhType =
       getObjectClassFromKnownObjectIndex(comp, dmhIndex);
 
-   if (dmhType == NULL)
-      {
-      if (trace)
-         traceMsg(comp, "failed to determine concrete DelegatingMethodHandle type\n");
-
-      return TR::KnownObjectTable::UNKNOWN;
-      }
-   else if (isInstanceOf(dmhType, cwClass, true) != TR_yes)
+   if (isInstanceOf(dmhType, cwClass, true) != TR_yes)
       {
       if (trace)
          traceMsg(comp, "object is not a CountingWrapper\n");
@@ -5238,7 +5231,6 @@ TR_J9VMBase::getLayoutVarHandle(TR::Compilation *comp, TR::KnownObjectTable::Ind
       getObjectClassFromKnownObjectIndex(comp, layoutIndex);
 
    if (layoutClass == NULL ||
-       layoutObjClass == NULL ||
        isInstanceOf(layoutObjClass, layoutClass, true, true) != TR_yes)
       {
       if (comp->getOption(TR_TraceOptDetails))
@@ -5271,7 +5263,6 @@ TR_J9VMBase::getVarHandleAccessDescriptorMode(TR::Compilation *comp, TR::KnownOb
       getObjectClassFromKnownObjectIndex(comp, adIndex);
 
    if (adClass == NULL ||
-       adObjClass == NULL ||
        isInstanceOf(adObjClass, adClass, true, true) != TR_yes)
       {
       if (comp->getOption(TR_TraceOptDetails))

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1208,10 +1208,10 @@ TR_J9VMBase::getObjectClassAt(uintptr_t objectAddress)
 TR_OpaqueClassBlock *
 TR_J9VMBase::getObjectClassFromKnownObjectIndex(TR::Compilation *comp, TR::KnownObjectTable::Index idx)
    {
-   TR::VMAccessCriticalSection getObjectClassFromKnownObjectIndex(comp, TR::VMAccessCriticalSection::tryToAcquireVMAccess);
-   TR_OpaqueClassBlock *clazz = NULL;
-   if (getObjectClassFromKnownObjectIndex.hasVMAccess())
-      clazz = getObjectClass(comp->getKnownObjectTable()->getPointer(idx));
+   TR::VMAccessCriticalSection getObjectClassFromKnownObjectIndex(comp);
+   TR_OpaqueClassBlock *clazz =
+      getObjectClass(comp->getKnownObjectTable()->getPointer(idx));
+
    return clazz;
    }
 

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -1026,12 +1026,8 @@ InterpreterEmulator::getReturnValue(TR_ResolvedMethod *callee)
                {
                TR_OpaqueClassBlock *callSiteType =
                   fe()->getObjectClassFromKnownObjectIndex(comp(), callSiteIndex);
-               if (callSiteType == NULL)
-                  {
-                  debugTrace(tracer(), "failed to determine concrete CallSite type");
-                  return NULL;
-                  }
-               else if (fe()->isInstanceOf(callSiteType, mutableCallsiteClass, true) != TR_yes)
+
+               if (fe()->isInstanceOf(callSiteType, mutableCallsiteClass, true) != TR_yes)
                   {
                   debugTrace(tracer(), "not a MutableCallSite");
                   return NULL;


### PR DESCRIPTION
The possibility of failure makes this method inapplicable at some call sites, and unwieldy at others. There doesn't seem to be any good reason why this method needs to be fallible though. By simply blocking until it gets VM access, it can always succeed.