### PR TITLE
Add flag for JVM CPU starvation

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1074,6 +1074,9 @@ public:
 
    void initCPUEntitlement();
 
+   bool isJVMStarved() const { return _jvmIsStarved; }
+   void setIsJVMStarved(bool val) { _jvmIsStarved = val; }
+
    bool getLowCompDensityMode() const { return _lowCompDensityMode; }
    void enterLowCompDensityMode() { _lowCompDensityMode = true; _hasEnteredLowCompDensityModeInThePast = true;}
    void exitLowCompDensityMode() { _lowCompDensityMode = false; }
@@ -1367,6 +1370,7 @@ private:
    bool _lowCompDensityMode; // set to true when compilations occur infrequently and are unlikely to contribute to JVM performance
    bool _hasEnteredLowCompDensityModeInThePast; // set to true when _lowCompDensityMode is set to true at least once
    bool _compileFromLPQRegardlessOfCPU;
+   bool _jvmIsStarved; // set to true if the JVM uses very little CPU because of external factors
 
 #if defined(J9VM_OPT_JITSERVER)
    ClientSessionHT               *_clientSessionHT; // JITServer hashtable that holds session information about JITClients

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -316,6 +316,8 @@ bool J9::Options::_aggressiveLockReservation = false;
 
 bool J9::Options::_xrsSync = false;
 
+int32_t J9::Options::_jvmStarvationThreshold = 40; // 40% CPU utilization. Use 10 (or lower) to disable the feature
+
 void
 J9::Options::findExternalOptions(J9JavaVM *vm, bool consume)
    {
@@ -1117,6 +1119,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
 #endif /* defined(J9VM_OPT_JITSERVER) */
    {"jProfilingEnablementSampleThreshold=", "M<nnn>\tNumber of global samples to allow generation of JProfiling bodies",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_jProfilingEnablementSampleThreshold, 0, "F%d", NOT_IN_SUBSET },
+   {"jvmStarvationThreshold=", "M<nnn>\tCPU utilization of the JVM that determines whether the JVM is starved",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_jvmStarvationThreshold , 0, "F%d", NOT_IN_SUBSET},
    {"kcaoffsets",         "I\tGenerate a header file with offset data for use with KCA", TR::Options::kcaOffsets, 0, 0, "F" },
    {"largeTranslationTime=", "D<nnn>\tprint IL trees for methods that take more than this value (usec)"
                              "to compile. Need to have a log file defined on command line",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -495,6 +495,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static bool _xrsSync;
 
+   static int32_t _jvmStarvationThreshold;
+
    static ExternalOptionsMetadata _externalOptionsMetadata[ExternalOptions::TR_NumExternalOptions];
 
    /**


### PR DESCRIPTION
`CompilationInfo` will a add a boolean flag that indicates whether or not the JVM is starved of CPU resources. The flag is supposed to be used by future commits. The flag is set/reset by the sampling thread based on the CPU utilization of the JVM and the machine it is running on. 
The feature is controlable through a new option, `-Xjit:jvmStarvationThreshold=<NNN>`, whose default value is 40. If the CPU utilization of the JVM is lower than jvmStarvationThreshold-10 either because of low JVM CPU entitlement or because of other processes running on the machine, the starvation flag is set. When the CPU utilization of the JVM goes above jvmStarvationThreshold+10, the flag is reset. The flag is also reset if the JVM does not use its entire CPU entitlement and there are idle CPUs on the system.