### PR TITLE
Adjust maxFrames in jvmtiInternalGetStackTrace for skipped frames

### DIFF
--- a/runtime/jvmti/jvmtiStackFrame.cpp
+++ b/runtime/jvmti/jvmtiStackFrame.cpp
@@ -868,7 +868,24 @@ jvmtiInternalGetStackTrace(
 		}
 		walkState.skipCount = framesWalked + start_depth;
 	}
-	walkState.maxFrames = max_frame_count;
+
+#if JAVA_SPEC_VERSION >= 20
+	/* Adjusts the second‑pass stack walk limit (maxFrames) to include the
+	 * number of frames skipped in the first pass (userData1).
+	 *
+	 * When the first pass walks more frames than the original max_frame_count,
+	 * the skipped frame count is added to the limit so that, after skipping,
+	 * up to max_frame_count frames can still be returned to the caller.
+	 */
+	if (walkState.framesWalked > max_frame_count) {
+		UDATA skippedFrames = (UDATA)walkState.userData1;
+		Assert_JVMTI_true(skippedFrames <= (UDATA_MAX - max_frame_count));
+		walkState.maxFrames = max_frame_count + skippedFrames;
+	} else {
+		walkState.maxFrames = max_frame_count;
+	}
+#endif /* JAVA_SPEC_VERSION >= 20 */
+
 	walkState.flags = J9_STACKWALK_INCLUDE_NATIVES | J9_STACKWALK_VISIBLE_ONLY
 		| J9_STACKWALK_RECORD_BYTECODE_PC_OFFSET | J9_STACKWALK_COUNT_SPECIFIED
 		| J9_STACKWALK_ITERATE_FRAMES;


### PR DESCRIPTION
The JDWP frames command sets max_frame_count for JVMTI GetStackTrace
based on the value returned by JVMTI GetFrameCount, and expects the
number of frames filled by GetStackTrace to match that frame count.

For JDK 20 and later, when debugging virtual threads, the first stack
walk in jvmtiInternalGetStackTrace may filter out frames annotated
with JvmtiMountTransition. These frames represent mount and unmount
transitions for virtual threads and are not reported to the debugger.
As a result, the frame count returned by GetStackTrace can be less than
expected, causing JDWP to report a
com.sun.jdi.InternalException: Unexpected JDWP Error: 113.

This change increases maxFrames in the second stack walk by the number
of frames skipped in the first pass. This ensures that after skipping
mount transition frames, GetStackTrace can still return up to the
original max_frame_count to JDWP, preserving consistency between
GetFrameCount and GetStackTrace results and avoiding the above
InternalException.

Related: https://github.com/eclipse-openj9/openj9/issues/22152