### PR TITLE
Reduce compilation overhead when JVM is CPU starved

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1064,7 +1064,7 @@ public:
    void setAppSleepNano(int32_t t) { _appSleepNano = t; }
    int32_t computeAppSleepNano() const;
    TR_YesNoMaybe detectCompThreadStarvation();
-   bool getStarvationDetected() const { return _starvationDetected; }
+   bool getStarvationDetected() const { return _starvationDetected; } // This refers to compilation threads starvation
    void setStarvationDetected(bool b) { _starvationDetected = b; }
    int32_t getTotalCompThreadCpuUtilWhenStarvationComputed() const { return _totalCompThreadCpuUtilWhenStarvationComputed; }
    int32_t getNumActiveCompThreadsWhenStarvationComputed() const { return _numActiveCompThreadsWhenStarvationComputed; }
@@ -1343,7 +1343,7 @@ private:
    //----------------
    int32_t                _appSleepNano; // make app threads sleep when sampling
 
-   bool                   _starvationDetected;
+   bool                   _starvationDetected; // This refers to compilation threads starvation
    int32_t                _totalCompThreadCpuUtilWhenStarvationComputed;   // for RAS purposes
    int32_t                _numActiveCompThreadsWhenStarvationComputed; // for RAS purposes
    //--------------

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5137,7 +5137,7 @@ static void jitStateLogic(J9JITConfig * jitConfig, TR::CompilationInfo * compInf
       }
 
    // Control how much application threads will be sleeping to give
-   // application threads more time on the CPU
+   // compilation threads more time on the CPU
    TR_YesNoMaybe starvation = compInfo->detectCompThreadStarvation();
    bool newStarvationStatus = (starvation == TR_yes);
    if (newStarvationStatus != compInfo->getStarvationDetected()) // did the status change?


### PR DESCRIPTION
This commit implements heuristics that reduce the compilation overhead when the JVM is starved of CPU resources. Specifically, the following changes are performed under CPU starvation conditions:
- Warm compilations will be downgraded to cold. If allowed, (SCC is enabled, enough space in SCC, etc) these compilations will use AOT.
- For AOT compilations some of the expensive optimizations will be disabled.
- Inlining will be subdued (similar to the -Xtune:virtualized case)

All these changes can be disabled by preventing the JVM to enter the starvation mode with -Xjit:jvmStarvationThreshold=-1