### PR TITLE
(0.55) Avoid crash in fillInStackTrace when threadObject is null

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -3452,6 +3452,7 @@ done:
 				UDATA continuationWalkRC = J9_STACKWALK_RC_NONE;
 				J9StackWalkState continuationWalkState= {0};
 				if (J9_ARE_ALL_BITS_SET(_vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_SHOW_CARRIER_FRAMES)
+					&& (NULL != _currentThread->threadObject)
 					&& IS_JAVA_LANG_VIRTUALTHREAD(_currentThread, _currentThread->threadObject)
 				) {
 					continuationWalkState.flags = walkFlags;


### PR DESCRIPTION
Add a null check for `_currentThread->threadObject` in
`inlThrowableFillInStackTrace` to prevent a crash during early JVM
startup.

When `J9_EXTENDED_RUNTIME2_SHOW_CARRIER_FRAMES` is enabled,
continuation stack walking is triggered to collect carrier frames. This requires
a valid `threadObject`, which may be uninitialized during early exceptions
(e.g., during `Unsafe.registerNatives`). Without the check, a `null`
dereference can occur when calling `IS_JAVA_LANG_VIRTUALTHREAD`.

This fix ensures stack walking is only attempted when `threadObject` is
set, preventing segmentation faults during JVM initialization.

Related: https://github.com/eclipse-openj9/openj9/issues/21734

Backport of https://github.com/eclipse-openj9/openj9/pull/22382