### PR TITLE
Delete duplicated code in `J9::SymbolReference` constructor

### DIFF
--- a/runtime/compiler/il/J9SymbolReference.cpp
+++ b/runtime/compiler/il/J9SymbolReference.cpp
@@ -47,20 +47,9 @@ SymbolReference::SymbolReference(
       int32_t cpIndex,
       int32_t unresolvedIndex,
       TR::KnownObjectTable::Index knownObjectIndex)
+   : OMR::SymbolReferenceConnector(
+      symRefTab, sym, owningMethodIndex, cpIndex, unresolvedIndex, knownObjectIndex)
    {
-   self()->init(symRefTab,
-        symRefTab->assignSymRefNumber(self()),
-        sym,
-        0,  // Offset 0
-        owningMethodIndex,
-        cpIndex,
-        unresolvedIndex);
-
-   _knownObjectIndex = knownObjectIndex;
-
-   if (sym->isResolvedMethod())
-      symRefTab->comp()->registerResolvedMethodSymbolReference(self());
-
    //Check for init method
    if (sym->isMethod() &&
        sym->castToMethodSymbol()->getMethod()->isConstructor())


### PR DESCRIPTION
The code deleted here is a verbatim copy of the body of the corresponding `OMR::SymbolReference` constructor, which is now called from the initializer list. Previously, the initializer list was empty, resulting in an implicit call to the `OMR::SymbolReference` default constructor, which is empty.