### PR TITLE
Update 0.51 - Environment variable TMPDIR and the java.io.tmpdir

### DIFF
--- a/doc/release-notes/0.51/0.51.md
+++ b/doc/release-notes/0.51/0.51.md
@@ -54,13 +54,15 @@ The following table covers notable changes in v0.51.0. Further information about
 <a href="https://github.com/eclipse-openj9/openj9/pull/21452">#21452<br>
 <a href="https://github.com/eclipse-openj9/openj9/issues/21189">#21189<br>
 </td>
-<td valign="top">OpenJDK system properties are used to initialize default encodings and locales.</td>
+<td valign="top">OpenJDK system properties are used to initialize some system properties.</td>
 <td valign="top">All versions</td>
 <td valign="top">A number of OpenJDK system properties are set, some of which were not set before.
 Of note, on Windows the console encoding properties reflect the console charset.
 The default locale may be different from previous Semeru versions, and is now consistent with OpenJDK behavior.
 In particular on macOS the default locale reflects the control panel settings rather than environment variable settings.
-The locale script is set when available.</td>
+The locale script is set when available.
+Another example is that in all the JDK versions except for the IBM Java 8, OpenJDK is now used to initialize the <tt>java.io.tmpdir</tt> system property. Earlier, the <tt>TMPDIR=<directory></tt> environment variable set the value of the <tt>java.io.tmpdir</tt> property. Because of this change, even if the <tt>TMPDIR=<directory></tt> variable is specified, it is ignored when setting the <tt>java.io.tmpdir</tt> property value.
+</td>
 </tr>
 
 <tr>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1563

Updated the release note with the change in the impact of TMPDIR environment variable on the setting of the java.io.tmpdir system property.

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com