### PR TITLE
JFR: Fix Windows build failure

### DIFF
--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -293,7 +293,6 @@ omr_add_exports(jclse
 	Java_com_ibm_oti_vm_ORBVMHelpers_is32Bit
 	Java_com_ibm_oti_vm_VM_allInstances
 	Java_com_ibm_oti_vm_VM_dumpString
-	Java_com_ibm_oti_vm_VM_getjfrCMDLineOption
 	Java_com_ibm_oti_vm_VM_getClassNameImpl
 	Java_com_ibm_oti_vm_VM_getClassPathCount
 	Java_com_ibm_oti_vm_VM_getNonBootstrapClassLoader
@@ -695,6 +694,7 @@ endif()
 
 if(J9VM_OPT_JFR)
 	omr_add_exports(jclse
+		Java_com_ibm_oti_vm_VM_getjfrCMDLineOption
 		Java_com_ibm_oti_vm_VM_isJFREnabled
 		Java_com_ibm_oti_vm_VM_isJFRRecordingStarted
 		Java_com_ibm_oti_vm_VM_jfrDump

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -726,7 +726,9 @@ Java_com_ibm_oti_vm_VM_setCommonData (JNIEnv * env, jclass unused, jobject strin
 jboolean JNICALL
 Java_com_ibm_oti_vm_VM_setDaemonThreadImpl (JNIEnv *env, jobject recv, jobject aThread);
 void JNICALL Java_com_ibm_oti_vm_VM_dumpString(JNIEnv * env, jclass clazz, jstring str);
+#if defined(J9VM_OPT_JFR)
 jstring JNICALL Java_com_ibm_oti_vm_VM_getjfrCMDLineOption(JNIEnv *env, jclass clazz);
+#endif /* defined(J9VM_OPT_JFR) */
 jboolean JNICALL Java_com_ibm_oti_vm_VM_appendToCPNativeImpl(JNIEnv * env, jclass clazz, jstring classPathAdditions, jstring newClassPath);
 jboolean JNICALL Java_com_ibm_oti_vm_VM_isApplicationClassLoaderPresent(JNIEnv * env, jclass clazz);
 jstring JNICALL Java_openj9_internal_tools_attach_target_DiagnosticUtils_getHeapClassStatisticsImpl(JNIEnv * env, jclass unused);


### PR DESCRIPTION
The native method should only be declared and exported if configured with JFR support.

Fixes: https://github.com/eclipse-openj9/openj9/issues/22422.