### PR TITLE
JIT: fix a couple compiler warnings

### DIFF
--- a/runtime/compiler/runtime/GPUHelpers.cpp
+++ b/runtime/compiler/runtime/GPUHelpers.cpp
@@ -1349,7 +1349,7 @@ generatePTX(int tracing, const char *programSource, int deviceId, TR::Persistent
    if (detailsTrace) TR_VerboseLog::writeLine(TR_Vlog_GPU, "\tAdded NVVM module size=%d", strlen(programSource));
 
 #define OPTIONLENGTH    6
-#define OPTIONMAXSIZE   24
+#define OPTIONMAXSIZE   28
 
    char optionStr[OPTIONLENGTH][OPTIONMAXSIZE] = {"-opt=0", "-ftz=1", "-prec-sqrt=1", "-prec-div=1", "-fma=0", "-arch=compute_MMMMmmmm"};
    char *options[OPTIONLENGTH];

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1430,7 +1430,7 @@ createMethodMetaData(
    int32_t sizeOfCUmodule = 0;
 
 #ifdef ENABLE_GPU
-   int getCUmoduleSize();
+   extern int getCUmoduleSize(void);
    sizeOfCUmodule = getCUmoduleSize(); //get size of the CUmodule object from the CUDA library. Only used when the GPU is used
 #endif
 


### PR DESCRIPTION
* GPUHelpers.cpp: snprintf() expects more room
```
In function ‘int snprintf(char*, size_t, const char*, ...)’,
    inlined from ‘char* generatePTX(int, const char*, int, TR::PersistentInfo*, TR_Memory*, bool)’ at compiler/runtime/GPUHelpers.cpp:1363:12:
/usr/include/x86_64-linux-gnu/bits/stdio2.h:54:35: note: ‘__builtin___snprintf_chk’ output between 17 and 27 bytes into a destination of size 24
```

* MetaData.cpp: ambiguous declaration
```
compiler/runtime/MetaData.cpp: In function ‘TR_MethodMetaData* createMethodMetaData(TR_J9VMBase&, TR_ResolvedMethod*, TR::Compilation*)’:
compiler/runtime/MetaData.cpp:1433:23: warning: empty parentheses were disambiguated as a function declaration [-Wvexing-parse]
compiler/runtime/MetaData.cpp:1433:23: note: remove parentheses to default-initialize a variable
 1433 |    int getCUmoduleSize();
```