### PR TITLE
Remove JVM_GetClassAccessFlags() no longer used by Java 26+

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -75,7 +75,6 @@ jvm_add_exports(jvm
 	_JVM_GC@0
 	_JVM_GCNoCompact@0
 	_JVM_GetAllThreads@8
-	_JVM_GetClassAccessFlags@8
 	_JVM_GetClassAnnotations@8
 	_JVM_GetClassConstantPool@8
 	_JVM_GetClassLoader@8
@@ -481,6 +480,12 @@ else()
 	jvm_add_exports(jvm
 		JVM_CreateThreadSnapshot
 		JVM_NeedsClassInitBarrierForCDS
+	)
+endif()
+
+if(JAVA_SPEC_VERSION LESS 26)
+	jvm_add_exports(jvm
+		_JVM_GetClassAccessFlags@8
 	)
 endif()
 

--- a/runtime/j9vm/vmi.c
+++ b/runtime/j9vm/vmi.c
@@ -37,23 +37,22 @@
 #include "ut_j9scar.h"
 
 extern J9JavaVM *BFUjavaVM;
-SunVMI* g_VMI;
+SunVMI *g_VMI;
 
 /**
  * Initializes the VM-interface from the supplied JNIEnv.
- * 
  */
-void 
+void
 initializeVMI(void)
 {
 	PORT_ACCESS_FROM_JAVAVM(BFUjavaVM);
-	jint result;
-	
-	/* Register this module with trace */
+	jint result = 0;
+
+	/* Register this module with trace. */
 	UT_MODULE_LOADED(J9_UTINTERFACE_FROM_VM(BFUjavaVM));
 	Trc_SC_VMInitStages_Event1(BFUjavaVM->mainThread);
-	result = (BFUjavaVM)->internalVMFunctions->GetEnv((JavaVM*)BFUjavaVM, (void**)&g_VMI, SUNVMI_VERSION_1_1);
-	if (result != JNI_OK) {
+	result = (BFUjavaVM)->internalVMFunctions->GetEnv((JavaVM *)BFUjavaVM, (void **)&g_VMI, SUNVMI_VERSION_1_1);
+	if (JNI_OK != result) {
 		j9tty_printf(PORTLIB, "FATAL ERROR: Could not obtain SUNVMI from VM.\n");
 		exit(-1);
 	}
@@ -65,7 +64,6 @@ JVM_LatestUserDefinedLoader(JNIEnv *env)
 	ENSURE_VMI();
 	return g_VMI->JVM_LatestUserDefinedLoader(env);
 }
-
 
 jobject JNICALL
 #if JAVA_SPEC_VERSION >= 11
@@ -82,29 +80,28 @@ JVM_GetCallerClass(JNIEnv *env, jint depth)
 #endif /* JAVA_SPEC_VERSION >= 11 */
 }
 
-
 jobject JNICALL
-JVM_NewInstanceFromConstructor(JNIEnv * env, jobject c, jobjectArray args)
+JVM_NewInstanceFromConstructor(JNIEnv *env, jobject c, jobjectArray args)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_NewInstanceFromConstructor(env, c, args);
 }
 
-
 jobject JNICALL
-JVM_InvokeMethod(JNIEnv * env, jobject method, jobject obj, jobjectArray args)
+JVM_InvokeMethod(JNIEnv *env, jobject method, jobject obj, jobjectArray args)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_InvokeMethod(env, method, obj, args);
 }
 
-
+#if JAVA_SPEC_VERSION < 26
 jint JNICALL
-JVM_GetClassAccessFlags(JNIEnv * env, jclass clazzRef)
+JVM_GetClassAccessFlags(JNIEnv *env, jclass clazzRef)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetClassAccessFlags(env, clazzRef);
 }
+#endif /* JAVA_SPEC_VERSION < 26 */
 
 #if JAVA_SPEC_VERSION < 24
 jobject JNICALL
@@ -122,7 +119,6 @@ JVM_Halt(jint exitCode)
 	g_VMI->JVM_Halt(exitCode);
 }
 
-
 void JNICALL
 JVM_GCNoCompact(void)
 {
@@ -130,14 +126,12 @@ JVM_GCNoCompact(void)
 	g_VMI->JVM_GCNoCompact();
 }
 
-
 void JNICALL
 JVM_GC(void)
 {
 	ENSURE_VMI();
 	g_VMI->JVM_GC();
 }
-
 
 /**
  * JVM_TotalMemory
@@ -149,7 +143,6 @@ JVM_TotalMemory(void)
 	return g_VMI->JVM_TotalMemory();
 }
 
-
 jlong JNICALL
 JVM_FreeMemory(void)
 {
@@ -157,45 +150,41 @@ JVM_FreeMemory(void)
 	return g_VMI->JVM_FreeMemory();
 }
 
-
 jobject JNICALL
-JVM_GetSystemPackages(JNIEnv* env)
+JVM_GetSystemPackages(JNIEnv *env)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetSystemPackages(env);
 }
-
 
 /**
  * Returns the package information for the specified package name.  Package information is the directory or
  * jar file name from where the package was loaded (separator is to be '/' and for a directory the return string is
  * to end with a '/' character). If the package is not loaded then null is to be returned.
  *
- * @arg[in] env          - JNI environment.
+ * @arg[in] env     - JNI environment.
  * @arg[in] pkgName -  A Java string for the name of a package. The package must be separated with '/' and optionally end with a '/' character.
  *
  * @return Package information as a string.
  *
- * @note In the current implementation, the separator is not guaranteed to be '/', not is a directory guaranteed to be
+ * @note In the current implementation, the separator is not guaranteed to be '/', nor is a directory guaranteed to be
  * terminated with a slash. It is also unclear what the expected implementation is for UNC paths.
  *
  * @note see CMVC defects 81175 and 92979
  */
 jstring JNICALL
-JVM_GetSystemPackage(JNIEnv* env, jstring pkgName)
+JVM_GetSystemPackage(JNIEnv *env, jstring pkgName)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetSystemPackage(env, pkgName);
 }
 
-
 jobject JNICALL
-JVM_AllocateNewObject(JNIEnv *env, jclass caller, jclass current, jclass init) 
+JVM_AllocateNewObject(JNIEnv *env, jclass caller, jclass current, jclass init)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_AllocateNewObject(env, caller, current, init);
 }
-
 
 jobject JNICALL
 JVM_AllocateNewArray(JNIEnv *env, jclass caller, jclass current, jint length)
@@ -204,7 +193,6 @@ JVM_AllocateNewArray(JNIEnv *env, jclass caller, jclass current, jint length)
 	return g_VMI->JVM_AllocateNewArray(env, caller, current, length);
 }
 
-
 jobject JNICALL
 JVM_GetClassLoader(JNIEnv *env, jobject obj)
 {
@@ -212,14 +200,12 @@ JVM_GetClassLoader(JNIEnv *env, jobject obj)
 	return g_VMI->JVM_GetClassLoader(env, obj);
 }
 
-
-void* JNICALL
+void * JNICALL
 JVM_GetThreadInterruptEvent(void)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetThreadInterruptEvent();
 }
-
 
 jlong JNICALL
 JVM_MaxObjectInspectionAge(void)

--- a/runtime/oti/sunvmi_api.h
+++ b/runtime/oti/sunvmi_api.h
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-
 #ifndef SUNVMI_API_H
 #define SUNVMI_API_H
 
@@ -30,9 +29,9 @@ extern "C" {
 
 /**
  * This module exposes the vm-centric glue to attach J9 to the Sun
- * class library.  
- * 
- * The primary interface to this module is a table of function pointers 
+ * class library.
+ *
+ * The primary interface to this module is a table of function pointers
  * motivated by the fact that most consumers (classic/jvm.dll and proxy
  * services) are simply forwarders.
  */
@@ -40,7 +39,7 @@ extern "C" {
 #include "jni.h"
 #include "j9.h"
 
-/* 
+/*
  * Typedefs for all members of the SunVMI table.
  */
 typedef jobject (JNICALL *JVM_AllocateNewArray_Type)(JNIEnv *env, jclass caller, jclass current, jint length);
@@ -53,35 +52,36 @@ typedef jobject (JNICALL *JVM_GetCallerClass_Type)(JNIEnv *env);
 #else /* JAVA_SPEC_VERSION >= 11 */
 typedef jobject (JNICALL *JVM_GetCallerClass_Type)(JNIEnv *env, jint depth);
 #endif /* JAVA_SPEC_VERSION >= 11 */
-typedef jint (JNICALL *JVM_GetClassAccessFlags_Type)(JNIEnv * env, jclass clazzRef);
+#if JAVA_SPEC_VERSION < 26
+typedef jint (JNICALL *JVM_GetClassAccessFlags_Type)(JNIEnv *env, jclass clazzRef);
+#endif /* JAVA_SPEC_VERSION < 26 */
 #if JAVA_SPEC_VERSION < 24
 typedef jobject (JNICALL *JVM_GetClassContext_Type)(JNIEnv *env);
 #endif /* JAVA_SPEC_VERSION < 24 */
 typedef jobject (JNICALL *JVM_GetClassLoader_Type)(JNIEnv *env, jobject obj);
 
-
 /**
- * Returns an array of strings for the currently loaded system packages. 
- * The name returned for each package is to be '/' separated and end with 
+ * Returns an array of strings for the currently loaded system packages.
+ * The name returned for each package is to be '/' separated and end with
  * a '/' character.
  *
  * @param env
  * @param pkdName *
  * @return a jarray of jstrings
  */
-typedef jstring (JNICALL *JVM_GetSystemPackage_Type)(JNIEnv* env, jstring pkgName);
+typedef jstring (JNICALL *JVM_GetSystemPackage_Type)(JNIEnv *env, jstring pkgName);
 
-typedef jobject (JNICALL *JVM_GetSystemPackages_Type)(JNIEnv* env);
-typedef void* (JNICALL *JVM_GetThreadInterruptEvent_Type)(void);
+typedef jobject (JNICALL *JVM_GetSystemPackages_Type)(JNIEnv *env);
+typedef void * (JNICALL *JVM_GetThreadInterruptEvent_Type)(void);
 typedef void (JNICALL *JVM_Halt_Type)(jint exitCode);
-typedef jobject (JNICALL *JVM_InvokeMethod_Type)(JNIEnv * env, jobject method, jobject obj, jobjectArray args);
+typedef jobject (JNICALL *JVM_InvokeMethod_Type)(JNIEnv *env, jobject method, jobject obj, jobjectArray args);
 typedef jobject (JNICALL *JVM_LatestUserDefinedLoader_Type)(JNIEnv *env);
 typedef jlong (JNICALL *JVM_MaxObjectInspectionAge_Type)(void);
-typedef jobject (JNICALL *JVM_NewInstanceFromConstructor_Type)(JNIEnv * env, jobject c, jobjectArray args);
+typedef jobject (JNICALL *JVM_NewInstanceFromConstructor_Type)(JNIEnv *env, jobject c, jobjectArray args);
 typedef jlong (JNICALL *JVM_TotalMemory_Type)(void);
 typedef jlong (JNICALL *JVM_MaxMemory_Type)(void);
-typedef jobject (JNICALL *JVM_FindClassFromClassLoader_Type)(JNIEnv* env, char* className, jboolean init, jobject classLoader, jboolean throwError);
-typedef void (JNICALL *JVM_ExtendBootClassPath_Type)(JNIEnv* env, const char * pathSegment);
+typedef jobject (JNICALL *JVM_FindClassFromClassLoader_Type)(JNIEnv *env, char *className, jboolean init, jobject classLoader, jboolean throwError);
+typedef void (JNICALL *JVM_ExtendBootClassPath_Type)(JNIEnv *env, const char *pathSegment);
 typedef jbyteArray (JNICALL *JVM_GetClassTypeAnnotations_Type)(JNIEnv *env, jclass jlClass);
 typedef jbyteArray (JNICALL *JVM_GetFieldTypeAnnotations_Type)(JNIEnv *env, jobject jlrField);
 typedef jbyteArray (JNICALL *JVM_GetMethodTypeAnnotations_Type)(JNIEnv *env, jobject jlrMethod);
@@ -94,9 +94,11 @@ JNIEXPORT jobject JNICALL JVM_GetCallerClass_Impl(JNIEnv *env);
 #else /* JAVA_SPEC_VERSION >= 11 */
 JNIEXPORT jobject JNICALL JVM_GetCallerClass_Impl(JNIEnv *env, jint depth);
 #endif /* JAVA_SPEC_VERSION >= 11 */
-JNIEXPORT jobject JNICALL JVM_NewInstanceFromConstructor_Impl(JNIEnv * env, jobject c, jobjectArray args);
-JNIEXPORT jobject JNICALL JVM_InvokeMethod_Impl(JNIEnv * env, jobject method, jobject obj, jobjectArray args);
-JNIEXPORT jint JNICALL JVM_GetClassAccessFlags_Impl(JNIEnv * env, jclass clazzRef);
+JNIEXPORT jobject JNICALL JVM_NewInstanceFromConstructor_Impl(JNIEnv *env, jobject c, jobjectArray args);
+JNIEXPORT jobject JNICALL JVM_InvokeMethod_Impl(JNIEnv *env, jobject method, jobject obj, jobjectArray args);
+#if JAVA_SPEC_VERSION < 26
+JNIEXPORT jint JNICALL JVM_GetClassAccessFlags_Impl(JNIEnv *env, jclass clazzRef);
+#endif /* JAVA_SPEC_VERSION < 26 */
 #if JAVA_SPEC_VERSION < 24
 JNIEXPORT jobject JNICALL JVM_GetClassContext_Impl(JNIEnv *env);
 #endif /* JAVA_SPEC_VERSION < 24 */
@@ -105,22 +107,20 @@ JNIEXPORT void JNICALL JVM_GCNoCompact_Impl(void);
 JNIEXPORT void JNICALL JVM_GC_Impl(void);
 JNIEXPORT jlong JNICALL JVM_TotalMemory_Impl(void);
 JNIEXPORT jlong JNICALL JVM_FreeMemory_Impl(void);
-JNIEXPORT jobject JNICALL JVM_GetSystemPackages_Impl(JNIEnv* env);
-JNIEXPORT jstring JNICALL JVM_GetSystemPackage_Impl(JNIEnv* env, jstring pkgName);
+JNIEXPORT jobject JNICALL JVM_GetSystemPackages_Impl(JNIEnv *env);
+JNIEXPORT jstring JNICALL JVM_GetSystemPackage_Impl(JNIEnv *env, jstring pkgName);
 JNIEXPORT jobject JNICALL JVM_AllocateNewObject_Impl(JNIEnv *env, jclass caller, jclass current, jclass init);
 JNIEXPORT jobject JNICALL JVM_AllocateNewArray_Impl(JNIEnv *env, jclass caller, jclass current, jint length);
 JNIEXPORT jobject JNICALL JVM_GetClassLoader_Impl(JNIEnv *env, jobject obj);
-JNIEXPORT void* JNICALL JVM_GetThreadInterruptEvent_Impl(void);
+JNIEXPORT void * JNICALL JVM_GetThreadInterruptEvent_Impl(void);
 JNIEXPORT jlong JNICALL JVM_MaxObjectInspectionAge_Impl(void);
-JNIEXPORT jobject JNICALL JVM_FindClassFromClassLoader_Impl(JNIEnv* env, char* className, jboolean init, jobject classLoader, jboolean throwError);
+JNIEXPORT jobject JNICALL JVM_FindClassFromClassLoader_Impl(JNIEnv *env, char *className, jboolean init, jobject classLoader, jboolean throwError);
 JNIEXPORT jlong JNICALL JVM_MaxMemory_Impl(void);
-JNIEXPORT void JNICALL JVM_ExtendBootClassPath_Impl(JNIEnv* env, const char * pathSegment);
+JNIEXPORT void JNICALL JVM_ExtendBootClassPath_Impl(JNIEnv *env, const char *pathSegment);
 JNIEXPORT jbyteArray JNICALL JVM_GetClassTypeAnnotations_Impl(JNIEnv *env, jclass jlClass);
 JNIEXPORT jbyteArray JNICALL JVM_GetFieldTypeAnnotations_Impl(JNIEnv *env, jobject jlrField);
 JNIEXPORT jbyteArray JNICALL JVM_GetMethodTypeAnnotations_Impl(JNIEnv *env, jobject jlrMethod);
 JNIEXPORT jobjectArray JNICALL JVM_GetMethodParameters_Impl(JNIEnv *env, jobject jlrExecutable);
-
-
 
 /*
  * Structure which contains all of the VMI functions.
@@ -133,7 +133,9 @@ typedef struct SunVMI {
 	JVM_GC_Type JVM_GC;
 	JVM_GCNoCompact_Type JVM_GCNoCompact;
 	JVM_GetCallerClass_Type JVM_GetCallerClass;
+#if JAVA_SPEC_VERSION < 26
 	JVM_GetClassAccessFlags_Type JVM_GetClassAccessFlags;
+#endif /* JAVA_SPEC_VERSION < 26 */
 #if JAVA_SPEC_VERSION < 24
 	JVM_GetClassContext_Type JVM_GetClassContext;
 #endif /* JAVA_SPEC_VERSION < 24 */
@@ -156,19 +158,17 @@ typedef struct SunVMI {
 	JVM_GetMethodParameters_Type JVM_GetMethodParameters;
 } SunVMI;
 
-
-/* 
+/*
  * Lifecycle function used to push the SunVMI implementation through the
  * proper initialization stages.  This entrypoint should be called from
  * J9VMDllMain() as the JVM is bootstrapping.
- * 
  */
-IDATA SunVMI_LifecycleEvent(J9JavaVM* vm, IDATA stage, void* reserved);
+IDATA SunVMI_LifecycleEvent(J9JavaVM *vm, IDATA stage, void *reserved);
 
 /* Interface constants used with JNI GetEnv() call to obtain the VMI. */
 #define SUNVMI_VERSION_1_1 0x7D010001
 
-extern SunVMI* g_VMI;
+extern SunVMI *g_VMI;
 
 #define ENSURE_VMI() \
 	if (NULL == g_VMI) { \

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -61,7 +61,8 @@ _X(JVM_GetAllThreads,JNICALL,true,jobjectArray,JNIEnv *env, jclass aClass)
 _IF([JAVA_SPEC_VERSION < 11],
 	[_X(JVM_GetCallerClass,JNICALL,true,jobject,JNIEnv *env, jint depth)],
 	[_X(JVM_GetCallerClass,JNICALL,true,jobject,JNIEnv *env)])
-_X(JVM_GetClassAccessFlags,JNICALL,true,jint,JNIEnv *env, jclass clazzRef)
+_IF([JAVA_SPEC_VERSION < 26],
+	[_X(JVM_GetClassAccessFlags,JNICALL,true,jint,JNIEnv *env, jclass clazzRef)])
 _X(JVM_GetClassAnnotations,JNICALL,true,jbyteArray,JNIEnv *env, jclass target)
 _X(JVM_GetClassConstantPool,JNICALL,true,jobject,JNIEnv *env, jclass target)
 _IF([JAVA_SPEC_VERSION < 24],


### PR DESCRIPTION
Uses were removed earlier, but even the declaration has been removed from `jvm.h`:
* [8364750: Remove unused declaration in jvm.h](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/f64b51c0a6e3ac7997041165a0e03ee02b687573)