### PR TITLE
Fix type of jfrCMDLineOption

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5931,7 +5931,7 @@ typedef struct J9VMThread {
 
 typedef struct JFRState {
 	char *jfrFileName;
-	char *jfrCMDLineOption;
+	const char *jfrCMDLineOption;
 	U_8 *metaDataBlobFile;
 	UDATA metaDataBlobFileSize;
 	IDATA blobFileDescriptor;

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4367,14 +4367,14 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 	{
 		IDATA jfrOptionIndex = FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_XXSTARTOPENJ9EXPERIMENTALFLIGHTRECORDING, NULL);
 		if (0 <= jfrOptionIndex) {
-			char* jfrOptionBuffer = NULL;
+			char *jfrOptionBuffer = NULL;
 			if (0 <= FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, VMOPT_XXSTARTOPENJ9EXPERIMENTALFLIGHTRECORDING_EQUALS, NULL)) {
 				GET_OPTION_VALUE(jfrOptionIndex, '=', &jfrOptionBuffer);
 			} else if (0 <= FIND_ARG_IN_VMARGS(STARTSWITH_MATCH, VMOPT_XXSTARTOPENJ9EXPERIMENTALFLIGHTRECORDING_COLON, NULL)) {
 				GET_OPTION_OPTION(jfrOptionIndex, ':', ':', &jfrOptionBuffer);
 			}
 			if (NULL == jfrOptionBuffer) {
-				vm->jfrState.jfrCMDLineOption = (char*)"dumponexit=false";
+				vm->jfrState.jfrCMDLineOption = "dumponexit=false";
 			} else {
 				vm->jfrState.jfrCMDLineOption = jfrOptionBuffer;
 			}


### PR DESCRIPTION
Write access is not needed; avoid an improper cast.