### PR TITLE
JITServer shared fanin cache bug fix

### DIFF
--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -96,7 +96,11 @@ JITServerIProfiler::cacheFaninDataForMethod(TR_OpaqueMethodBlock *method, const 
       // The quality of the shared fanin profile is better than the quality of the fanin info sent by client.
       // Load the fanin profile from the shared repository.
       TR_FaninSummaryInfo *result = clientSession->loadFaninDataFromSharedProfileCache(method, trMemory);
-      if (!result) // failed, so use client data if available
+      if (result)
+         {
+         return result;
+         }
+      else // Loading shared fanin data failed, so use client data if available.
          {
          return deserializeFaninMethodEntry(serialEntry, trMemory);
          }


### PR DESCRIPTION
This commit fixes a bug related to the JITServer shared fanin cache: if the server determines that the quality of the fanin data from the shared profile cache is better than the quality of the fanin data sent by the client, it calls `loadFaninDataFromSharedProfileCache()` If this fails for whatever reason, the server will use the fanin data from the client. Because of a bug, the data from the shared profile cache was never returned. This commit fixes this bug so that the server can effectively use the fanin data from shared profile cache.