### PR TITLE
JDK25+ ManagementPermission adds @Deprecated annotation

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
@@ -34,6 +34,9 @@ import java.security.BasicPermission;
  *
  * @since 1.5
  */
+/*[IF JAVA_SPEC_VERSION >= 25]*/
+@Deprecated(forRemoval=true, since="25")
+/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
 public final class ManagementPermission extends BasicPermission {
 
 	/**


### PR DESCRIPTION
JDK25+ `ManagementPermission` adds `@Deprecated` annotation

Resolved an [internal workitem](https://jazz103.hursley.ibm.com:9443/jazz/resource/itemName/com.ibm.team.workitem.WorkItem/152976)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>