### PR TITLE
JDK26 Access method updates

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -383,6 +383,7 @@ final class Access implements JavaLangAccess {
 /*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
 /*[IF JAVA_SPEC_VERSION >= 10]*/
+	/*[IF (JAVA_SPEC_VERSION < 26) | INLINE-TYPES]*/
 	public String newStringUTF8NoRepl(byte[] bytes, int offset, int length) {
 		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.newStringUTF8NoRepl(bytes, offset, length);
@@ -394,6 +395,8 @@ final class Access implements JavaLangAccess {
 		/*[ENDIF] JAVA_SPEC_VERSION < 21 */
 		/*[ENDIF] JAVA_SPEC_VERSION < 17 */
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION < 26) | INLINE-TYPES */
+
 	public byte[] getBytesUTF8NoRepl(String str) {
 		/*[IF JAVA_SPEC_VERSION < 17]*/
 		return StringCoding.getBytesUTF8NoRepl(str);
@@ -623,12 +626,16 @@ final class Access implements JavaLangAccess {
 	}
 	/*[ENDIF] (JAVA_SPEC_VERSION < 25) | INLINE-TYPES */
 
-	/*[IF (JAVA_SPEC_VERSION >= 25) & !INLINE-TYPES]*/
+	/*[IF (JAVA_SPEC_VERSION == 25) & !INLINE-TYPES]*/
 	public int uncheckedEncodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ELSE] (JAVA_SPEC_VERSION >= 25) & !INLINE-TYPES */
+	/*[ELSE] (JAVA_SPEC_VERSION == 25) & !INLINE-TYPES */
 	public int encodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ENDIF] (JAVA_SPEC_VERSION >= 25) & !INLINE-TYPES */
+	/*[ENDIF] (JAVA_SPEC_VERSION == 25) & !INLINE-TYPES */
+		/*[IF (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES]*/
+		return StringCoding.encodeAsciiArray(sa, sp, da, dp, len);
+		/*[ELSE] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);
+		/*[ENDIF] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 	}
 /*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
@@ -930,6 +937,11 @@ final class Access implements JavaLangAccess {
 	@Override
 	public int getClassFileAccessFlags(Class<?> clazz) {
 		return clazz.getClassFileAccessFlags();
+	}
+
+	@Override
+	public String uncheckedNewStringWithLatin1Bytes(byte[] src) {
+		return String.newStringWithLatin1Bytes(src);
 	}
 /*[ENDIF] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 }


### PR DESCRIPTION
JDK26 Access method updates

Removed `newStringUTF8NoRepl()` and `uncheckedEncodeASCII()` for JDK26;
JDK26 now uses encodeASCII() like pre-JDK25 levels;
Added `uncheckedNewStringWithLatin1Bytes()` for JDK26.

Resolves Java next compilation error - https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/861/consoleFull
```
23:51:33  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:72: error: Access is not abstract and does not override abstract method encodeASCII(char[],int,byte[],int,int) in JavaLangAccess
23:51:33  final class Access implements JavaLangAccess {
23:51:33        ^
23:51:33  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:288: error: method newStringUTF8NoRepl in class String cannot be applied to given types;
23:51:33  		return String.newStringUTF8NoRepl(bytes, offset, length, true);
23:51:33  		             ^
23:51:33    required: byte[],int,int
23:51:33    found:    byte[],int,int,boolean
23:51:33    reason: actual and formal argument lists differ in length
23:51:33  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:410: error: cannot find symbol
23:51:33  		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);
23:51:33  		                   ^
23:51:33    symbol:   method implEncodeAsciiArray(char[],int,byte[],int,int)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>