### PR TITLE
Delete `refineInvokeCacheElementSymRefWithKnownObjectIndex()`

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1200,15 +1200,6 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, targetMethod->getPersistentIdentifier(), methodInfo);
          }
          break;
-      case MessageType::VM_refineInvokeCacheElementSymRefWithKnownObjectIndex:
-         {
-         auto recv = client->getRecvData<uintptr_t *>();
-         uintptr_t *invokeCacheArray = std::get<0>(recv);
-         uintptr_t arrayElementRef = (uintptr_t) fe->getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayAppendixIndex);
-         TR::KnownObjectTable::Index arrayElementKnotIndex = knot->getOrCreateIndex(arrayElementRef);
-         client->write(response, arrayElementKnotIndex, knot->getPointerLocation(arrayElementKnotIndex));
-         }
-         break;
       case MessageType::VM_isLambdaFormGeneratedMethod:
          {
          auto recv = client->getRecvData<TR_OpaqueMethodBlock *>();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5016,19 +5016,6 @@ TR_J9VMBase::targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp
    return createResolvedMethod(comp->trMemory(), targetMethodObj, owningMethod);
    }
 
-TR::SymbolReference*
-TR_J9VMBase::refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray)
-   {
-   TR::VMAccessCriticalSection vmAccess(this);
-   uintptr_t arrayElementRef = (uintptr_t) getReferenceElement(*invokeCacheArray, JSR292_invokeCacheArrayAppendixIndex);
-   TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
-   if (!knot) return originalSymRef;
-   TR::KnownObjectTable::Index arrayElementKnotIndex = TR::KnownObjectTable::UNKNOWN;
-   arrayElementKnotIndex = knot->getOrCreateIndex(arrayElementRef);
-   TR::SymbolReference *newRef = comp->getSymRefTab()->findOrCreateSymRefWithKnownObject(originalSymRef, arrayElementKnotIndex);
-   return newRef;
-   }
-
 static char *
 getSignatureForLinkToStatic(
    const char * const extraParamsBefore,

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -978,17 +978,6 @@ public:
     */
    virtual TR::KnownObjectTable::Index getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray);
 
-   /**
-    * \brief
-    *    Refines invokeCache element symRef with known object index for invokehandle and invokedynamic bytecode
-    *
-    * \param comp the compilation object
-    * \param originalSymRef the original symref to refine
-    * \param invokeCacheArray the array containing the element we use to get known object index
-    * \return TR::SymbolReference* the refined symRef
-    */
-   virtual TR::SymbolReference* refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray);
-
    /*
     * \brief
     *    Get the signature For MethodHandle.linkToStatic call for unresolved invokehandle

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2415,23 +2415,6 @@ TR_J9ServerVM::targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *co
    return createResolvedMethod(comp->trMemory(), targetMethodObj, owningMethod, methodInfo);
    }
 
-TR::SymbolReference*
-TR_J9ServerVM::refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray)
-   {
-   TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
-   if (!knot) return originalSymRef;
-
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(
-      JITServer::MessageType::VM_refineInvokeCacheElementSymRefWithKnownObjectIndex,
-      invokeCacheArray
-      );
-   auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
-   TR::KnownObjectTable::Index idx = std::get<0>(recv);
-   knot->updateKnownObjectTableAtServer(idx, std::get<1>(recv));
-   return comp->getSymRefTab()->findOrCreateSymRefWithKnownObject(originalSymRef, idx);
-   }
-
 bool
 TR_J9ServerVM::getMemberNameMethodInfo(
    TR::Compilation* comp,

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -251,7 +251,6 @@ public:
    virtual TR_OpaqueMethodBlock* targetMethodFromMethodHandle(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex) override;
    virtual TR_ResolvedMethod *targetMethodFromInvokeCacheArrayMemberNameObj(TR::Compilation *comp, TR_ResolvedMethod *owningMethod, uintptr_t *invokeCacheArray) override;
    virtual TR::KnownObjectTable::Index getKnotIndexOfInvokeCacheArrayAppendixElement(TR::Compilation *comp, uintptr_t *invokeCacheArray) override;
-   virtual TR::SymbolReference* refineInvokeCacheElementSymRefWithKnownObjectIndex(TR::Compilation *comp, TR::SymbolReference *originalSymRef, uintptr_t *invokeCacheArray) override;
    virtual bool isInvokeCacheEntryAnArray(uintptr_t *invokeCacheArray) override;
 
    virtual bool getMemberNameMethodInfo(TR::Compilation* comp, TR::KnownObjectTable::Index objIndex, MemberNameMethodInfo *out) override;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3487,15 +3487,18 @@ TR_J9ByteCodeIlGenerator::loadInvokeCacheArrayElements(TR::SymbolReference *tabl
       // When the callSite table entry (for invokedynamic) or methodType table entry (for invokehandle)
       // is resolved, we can improve the appendix object symRef with known object index as we can get
       // the object reference of the appendix object from the invokeCacheArray entry
-      TR_ResolvedJ9Method* owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
-      TR::Node * appendixNode = _stack->top();
-      TR::SymbolReference * appendixSymRef =
-         fej9()->refineInvokeCacheElementSymRefWithKnownObjectIndex(
-                  comp(),
-                  appendixNode->getSymbolReference(),
-                  invokeCacheArray
-                  );
-      appendixNode->setSymbolReference(appendixSymRef);
+      TR::KnownObjectTable::Index koi =
+         fej9()->getKnotIndexOfInvokeCacheArrayAppendixElement(comp(), invokeCacheArray);
+
+      if (koi != TR::KnownObjectTable::UNKNOWN)
+         {
+         TR::Node *appendixNode = _stack->top();
+         TR::SymbolReference *appendixSymRef =
+            comp()->getSymRefTab()->findOrCreateSymRefWithKnownObject(
+               appendixNode->getSymbolReference(), koi);
+
+         appendixNode->setSymbolReference(appendixSymRef);
+         }
       }
    }
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 88; // ID: J8MYSx3aPHFVfmu+fM3E
+   static const uint16_t MINOR_NUMBER = 89; // ID: uPlv7luHIkFSocuivhZ9
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -180,7 +180,6 @@ const char *messageNames[] =
    "VM_targetMethodFromMethodHandle",
    "VM_getKnotIndexOfInvokeCacheArrayAppendixElement",
    "VM_targetMethodFromInvokeCacheArrayMemberNameObj",
-   "VM_refineInvokeCacheElementSymRefWithKnownObjectIndex",
    "VM_isLambdaFormGeneratedMethod",
    "VM_getMemberNameMethodInfo",
    "VM_isMethodHandleExpectedType",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -189,7 +189,6 @@ enum MessageType : uint16_t
    VM_targetMethodFromMethodHandle,
    VM_getKnotIndexOfInvokeCacheArrayAppendixElement,
    VM_targetMethodFromInvokeCacheArrayMemberNameObj,
-   VM_refineInvokeCacheElementSymRefWithKnownObjectIndex,
    VM_isLambdaFormGeneratedMethod,
    VM_getMemberNameMethodInfo,
    VM_getMemberNameFieldKnotIndexFromMethodHandleKnotIndex,


### PR DESCRIPTION
The only caller will now instead get the known object index from the existing query `getKnotIndexOfInvokeCacheArrayAppendixElement()`.

This leaves improving the symref to the caller, which will be helpful later for const refs. With const refs, we'll no longer generate the same kind of improved symref, but we'll still need the known object index.