### PR TITLE
JDK25+ Class.getEnclosingObject() returns method descriptor if not found

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -62,6 +62,10 @@ import java.lang.constant.Constable;
 /*[ENDIF] JAVA_SPEC_VERSION >= 12 */
 
 import sun.reflect.generics.repository.ClassRepository;
+/*[IF JAVA_SPEC_VERSION >= 25]*/
+import sun.reflect.generics.repository.ConstructorRepository;
+import sun.reflect.generics.repository.MethodRepository;
+/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
 import sun.reflect.generics.factory.CoreReflectionFactory;
 import sun.reflect.generics.scope.ClassScope;
 import sun.reflect.annotation.AnnotationType;
@@ -4233,6 +4237,15 @@ public Constructor<?> getEnclosingConstructor()
 		}
 		/*[PR CMVC 201439] To remove CheckPackageAccess call from getEnclosingMethod of J9 */
 		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+	/*[IF JAVA_SPEC_VERSION >= 25]*/
+	} else if (enclosing instanceof String descriptor) {
+		// The enclosing constructor can't be found, returning string from getEnclosingObject()
+		// is the constructor descriptor, validate it for error handling.
+		ConstructorRepository typeInfo = ConstructorRepository.make(descriptor, getFactory());
+		typeInfo.getParameterTypes();
+		typeInfo.getExceptionTypes();
+		throw new InternalError("Enclosing constructor not found for " + this); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
 	}
 	return constructor;
 }
@@ -4269,6 +4282,16 @@ public Method getEnclosingMethod()
 		}
 		/*[PR CMVC 201439] To remove CheckPackageAccess call from getEnclosingMethod of J9 */
 		/*[ENDIF] JAVA_SPEC_VERSION < 24 */
+	/*[IF JAVA_SPEC_VERSION >= 25]*/
+	} else if (enclosing instanceof String descriptor) {
+		// The enclosing method can't be found, returning string from getEnclosingObject()
+		// is the method descriptor, validate it for error handling.
+		MethodRepository typeInfo = MethodRepository.make(descriptor, getFactory());
+		typeInfo.getReturnType();
+		typeInfo.getParameterTypes();
+		typeInfo.getExceptionTypes();
+		throw new InternalError("Enclosing method not found for " + this); //$NON-NLS-1$
+	/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
 	}
 	return method;
 }

--- a/runtime/bcverify/staticverify.c
+++ b/runtime/bcverify/staticverify.c
@@ -1686,7 +1686,10 @@ j9bcv_verifyClassStructure (J9PortLibrary * portLib, J9CfrClassFile * classfile,
 			break;
 
 		case CFR_CONSTANT_NameAndType:
-			if (0 != (flags & CFR_Xfuture)) {
+#if JAVA_SPEC_VERSION < 25
+			if (J9_ARE_ANY_BITS_SET(flags, CFR_Xfuture))
+#endif /* JAVA_SPEC_VERSION < 25 */
+			{
 				/* TODO: use the flags field to determine if this entry has been verified already */
 				utf8 = &classfile->constantPool[info->slot2]; /* get the descriptor */
 				if ((U_8) '(' == (utf8->bytes)[0]) { /* method descriptor */

--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -853,6 +853,14 @@ Java_java_lang_Class_getEnclosingObject(JNIEnv *env, jobject recv)
 						} else if (isConstructor(romMethod)) {
 							resultObject = vm->reflectFunctions.createDeclaredConstructorObject(method, resolvedClass, NULL, currentThread);
 						}
+#if JAVA_SPEC_VERSION >= 25
+					} else {
+						/* There is an enclosing constructor or method from getEnclosingMethodForROMClass(),
+						 * but it can't be found, return its descriptor string for error handling.
+						 */
+						resultObject = vm->memoryManagerFunctions->j9gc_createJavaLangString(
+								currentThread, J9UTF8_DATA(enclosingMethodSigUTF), J9UTF8_LENGTH(enclosingMethodSigUTF), 0);
+#endif /* JAVA_SPEC_VERSION >= 25 */
 					}
 				}
 			}


### PR DESCRIPTION
JDK25+ `Class.getEnclosingObject()` returns method descriptor if not found

If the enclosing constructor or method wasn't found, return its descriptor string for error handling;
Use `MethodRepository.getReturnType()/getParameterTypes()` to validate the constructor or method descriptor string;
Enabled `CFR_CONSTANT_NameAndType` verification by default for JDK25+.

close https://github.com/eclipse-openj9/openj9/issues/21732

Signed-off-by: Jason Feng <fengj@ca.ibm.com>