### PR TITLE
(0.55) Implement JVMTI ClearAllFramePops and cleanup related decompilations

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -1815,6 +1815,28 @@ jitSingleStepRemoved(J9VMThread * currentThread)
 	Trc_Decomp_jitSingleStepRemoved_Exit(currentThread);
 }
 
+#if JAVA_SPEC_VERSION >= 25
+/**
+ * @brief Free JIT decompilation entries for a given thread.
+ *
+ * This function removes decompilation entries from a thread's decompilation stack
+ * based on the specified reason and method.
+ *
+ * @param[in] currentThread The current VM thread performing the cleanup.
+ * @param[in,out] previous Pointer to the head of the decompilation stack.
+ * @param[in] reason The reason for decompilation entries to remove (e.g., JITDECOMP_POP_FRAMES).
+ * @param[in] method Optional method filter; if NULL, all entries matching the reason are removed.
+ */
+void
+jitFreeDecompilations(J9VMThread *currentThread, J9JITDecompilationInfo **previous, UDATA reason, J9Method *method)
+{
+	Trc_Decomp_jitFreeDecompilations_Entry(currentThread);
+
+	freeDecompilations(currentThread, currentThread, previous, reason, method);
+
+	Trc_Decomp_jitFreeDecompilations_Exit(currentThread);
+}
+#endif /* JAVA_SPEC_VERSION >= 25 */
 
 UDATA
 initializeFSD(J9JavaVM * vm)
@@ -1839,7 +1861,9 @@ initializeFSD(J9JavaVM * vm)
 	jitConfig->jitStackLocalsModified = jitStackLocalsModified;
 	jitConfig->jitLocalSlotAddress = jitLocalSlotAddress;
 	jitConfig->jitAddDecompilationForFramePop = jitAddDecompilationForFramePop;
-
+#if JAVA_SPEC_VERSION >= 25
+	jitConfig->jitFreeDecompilations = jitFreeDecompilations;
+#endif /* JAVA_SPEC_VERSION >= 25 */
 	jitConfig->fsdEnabled = TRUE;
 
 	return 0;

--- a/runtime/codert_vm/j9codertvm.tdf
+++ b/runtime/codert_vm/j9codertvm.tdf
@@ -184,3 +184,6 @@ TraceEntry=Trc_Decomp_DecompileAfterMonitorEnter_Entry Overhead=1 Level=2 Templa
 TraceExit=Trc_Decomp_DecompileAfterMonitorEnter_Exit Overhead=1 Level=2 Template="DecompileAfterMonitorEnter exit: exitPC = %p, method = %p"
 TraceEntry=Trc_Decomp_DecompileOnReturn_Entry Overhead=1 Level=2 Template="DecompileOnReturn entry: pc = %p, sp = %p"
 TraceExit=Trc_Decomp_DecompileOnReturn_Exit Overhead=1 Level=2 Template="DecompileOnReturn exit: pc = %p, sp = %p, returnVal = %p"
+
+TraceEntry=Trc_Decomp_jitFreeDecompilations_Entry Overhead=1 Level=1 Template="jitFreeDecompilations"
+TraceExit=Trc_Decomp_jitFreeDecompilations_Exit Overhead=1 Level=1 Template="jitFreeDecompilations"

--- a/runtime/jvmti/jvmti_internal.h
+++ b/runtime/jvmti/jvmti_internal.h
@@ -2175,12 +2175,22 @@ jvmtiNotifyFramePop(jvmtiEnv* env,
 
 #if JAVA_SPEC_VERSION >= 25
 /**
- * @brief Clear all frame pop request to prevent generation of
- * FramePop events for any frames.
+ * @brief Clear all pending frame pop requests for a specified thread.
  *
- * @param env The JVMTI environment pointer
- * @param thread The thread whose FramePop events will be cleared
- * @return jvmtiError Error code returned by JVMTI function
+ * This function clears all frame pop requests so that no JVMTI FramePop events
+ * will be generated for any frames of the specified thread. It also resets any
+ * early return information and deletes corresponding JIT decompilation entries.
+ *
+ * The target thread must either be suspended or the current thread.
+ *
+ * @param[in] env The JVMTI environment.
+ * @param[in] thread The thread for which all frame pop events should be cleared.
+ *                   If NULL, the current thread is used.
+ *
+ * @return JVMTI_ERROR_NONE on success.
+ * @return JVMTI_ERROR_THREAD_NOT_SUSPENDED if the target thread is neither suspended
+ *         nor the current thread.
+ * @return Other JVMTI error codes in case of failure.
  */
 jvmtiError JNICALL
 jvmtiClearAllFramePops(jvmtiEnv *env, jthread thread);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4383,6 +4383,9 @@ typedef struct J9JITConfig {
 	void  ( *jitDecompileMethodForFramePop)(struct J9VMThread * currentThread, UDATA skipCount) ;
 	void  ( *jitExceptionCaught)(struct J9VMThread * currentThread) ;
 	void  ( *jitAddPermanentLoader)(struct J9VMThread *currentThread, struct J9ClassLoader *loader);
+#if JAVA_SPEC_VERSION >= 25
+	void  ( *jitFreeDecompilations)(struct J9VMThread *currentThread, struct J9JITDecompilationInfo **previous, UDATA reason, J9Method *method) ;
+#endif /* JAVA_SPEC_VERSION >= 25 */
 	void  ( *j9jit_printf)(void *voidConfig, const char *format, ...) ;
 	void* tracingHook;
 	void  ( *jitCheckScavengeOnResolve)(struct J9VMThread *currentThread) ;

--- a/runtime/oti/jitprotos.h
+++ b/runtime/oti/jitprotos.h
@@ -73,6 +73,10 @@ extern J9_CFUNC void   jitDecompileMethod (J9VMThread * currentThread, J9JITDeco
 extern J9_CFUNC void   jitCodeBreakpointRemoved (J9VMThread * currentThread, J9Method * method);
 extern J9_CFUNC UDATA  jitIsMethodBreakpointed(J9VMThread *currentThread, J9Method *method);
 
+#if JAVA_SPEC_VERSION >= 25
+extern J9_CFUNC void   jitFreeDecompilations(J9VMThread *currentThread, J9JITDecompilationInfo **previous, UDATA reason, J9Method *method);
+#endif /* JAVA_SPEC_VERSION >= 25 */
+
 extern J9_CFUNC void   c_jitDecompileAfterAllocation(J9VMThread * currentThread);
 extern J9_CFUNC void   c_jitDecompileAfterMonitorEnter(J9VMThread * currentThread);
 extern J9_CFUNC void   c_jitDecompileAtCurrentPC(J9VMThread * currentThread);


### PR DESCRIPTION
Introduce the `ClearAllFramePops` function to clear all pending frame pop
requests for a thread, preventing `FramePop` events. Clears the
`J9SF_A0_REPORT_FRAME_POP_TAG` during a stack walk, resets early return
info, clears the `POP_FRAMES_INTERRUPT` halt flag, and deletes JIT
decompilation entries with reason `JITDECOMP_POP_FRAMES`.

Related: https://github.com/eclipse-openj9/openj9/issues/21735

Backport of https://github.com/eclipse-openj9/openj9/pull/22479