### PR TITLE
(0.56) Add missing locks for module hashtable access

### DIFF
--- a/runtime/gc_glue_java/MarkingSchemeRootMarker.cpp
+++ b/runtime/gc_glue_java/MarkingSchemeRootMarker.cpp
@@ -91,6 +91,7 @@ MM_MarkingSchemeRootMarker::doClassLoader(J9ClassLoader *classLoader)
 	 */
 	if(J9_GC_CLASS_LOADER_DEAD != (classLoader->gcFlags & J9_GC_CLASS_LOADER_DEAD)) {
 		_markingScheme->inlineMarkObject(_env, classLoader->classLoaderObject);
+		scanModularityObjects(classLoader);
 	}
 }
 

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -385,7 +385,9 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 					vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 					goto done;
 				}
+				omrthread_monitor_enter(vm->classLoaderModuleAndLocationMutex);
 				findResult = hashTableFind(classLoader->moduleHashTable, &modulePtr);
+				omrthread_monitor_exit(vm->classLoaderModuleAndLocationMutex);
 				if (NULL != findResult) {
 					j9module = *findResult;
 				}


### PR DESCRIPTION
Add missing locks for module hashtable access. Also add missing check to scan modularity objects.

Fixes https://github.com/eclipse-openj9/openj9/issues/22264

Backport of https://github.com/eclipse-openj9/openj9/pull/22495