### PR TITLE
Update putfield ACC_STRICT_INIT verification and tests

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -372,7 +372,7 @@ static const struct { \
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #define IS_CLASS_SIGNATURE(firstChar) ('L' == (firstChar))
 /* TODO Update the class version check if strict fields is released before value types. */
-#define J9ROMFIELD_IS_STRICT(romClassOrClassfile, fieldModifiers) (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClassOrClassfile) && J9_ARE_ALL_BITS_SET(fieldModifiers, J9AccStrictInit))
+#define J9ROMFIELD_IS_STRICT_FINAL(romClassOrClassfile, fieldModifiers) (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClassOrClassfile) && J9_ARE_ALL_BITS_SET(fieldModifiers, J9AccStrictInit | J9AccFinal))
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 #define J9_IS_CRIU_OR_CRAC_CHECKPOINT_ENABLED(vm) (J9_ARE_ANY_BITS_SET(vm->checkpointState.flags, J9VM_CRAC_IS_CHECKPOINT_ENABLED | J9VM_CRIU_IS_CHECKPOINT_ENABLED))

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -391,4 +391,27 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>StrictFieldTests</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		--enable-preview \
+		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames StrictFieldTests \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldGenerator.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test.lworld;
+
+import org.objectweb.asm.*;
+
+import static org.objectweb.asm.Opcodes.*;
+
+public class StrictFieldGenerator extends ClassLoader {
+    private static StrictFieldGenerator generator = new StrictFieldGenerator();
+
+    // ACC_STRICT_INIT is not yet supported by ASM
+    private static final int ACC_STRICT_INIT = ACC_STRICT;
+
+    public static Class<?> generateTestPutStrictFinalFieldLateLarval() {
+        String className = "TestPutStrictFinalFieldLateLarval";
+        return generateTestPutStrictFinalField(className, true, false);
+    }
+
+    public static Class<?> generateTestPutStrictFinalFieldUnrestricted() {
+        String className = "TestPutStrictFinalFieldUnrestricted";
+        return generateTestPutStrictFinalField(className, false, true);
+    }
+
+    private static Class<?> generateTestPutStrictFinalField(String className, boolean lateLarval, boolean unrestricted) {
+        String fieldName = "i";
+        String fieldDesc = "I";
+
+        ClassWriter cw = new ClassWriter(0);
+        cw.visit(ValhallaUtils.VALUE_TYPE_CLASS_FILE_VERSION,
+            ACC_PUBLIC + ValhallaUtils.ACC_IDENTITY,
+            className, null, "java/lang/Object", null);
+
+        cw.visitField(ACC_STRICT_INIT | ACC_FINAL, fieldName, fieldDesc, null, null);
+
+        MethodVisitor mv = cw.visitMethod(ACC_PUBLIC, "<init>", "()V", null, null);
+        mv.visitCode();
+        mv.visitVarInsn(ALOAD, 0);
+        mv.visitMethodInsn(INVOKESPECIAL, "java/lang/Object", "<init>", "()V", false);
+        if (lateLarval) {
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitInsn(ICONST_0);
+            mv.visitFieldInsn(PUTFIELD, className, fieldName, fieldDesc);
+        }
+        mv.visitInsn(RETURN);
+        mv.visitMaxs(1, 1);
+        mv.visitEnd();
+
+        if (unrestricted) {
+            mv = cw.visitMethod(ACC_PUBLIC, "putI", "(I)V", null, null);
+            mv.visitCode();
+            mv.visitVarInsn(ALOAD, 0);
+            mv.visitVarInsn(ILOAD, 1);
+            mv.visitFieldInsn(PUTFIELD, className, fieldName, fieldDesc);
+            mv.visitInsn(RETURN);
+            mv.visitMaxs(2, 2);
+            mv.visitEnd();
+        }
+
+        cw.visitEnd();
+        byte[] bytes = cw.toByteArray();
+        return generator.defineClass(className, cw.toByteArray(), 0, bytes.length);
+    }
+}

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test.lworld;
+
+import org.objectweb.asm.*;
+
+import static org.objectweb.asm.Opcodes.*;
+
+import org.testng.annotations.Test;
+
+@Test(groups = { "level.sanity" })
+public class StrictFieldTests {
+	/* A strict final field cannot be set outside earlyLarvel.
+	 * Test in <init> after invokespecial (lateLarval).
+	 */
+	@Test(expectedExceptions = VerifyError.class)
+	static public void testPutStrictFinalFieldLateLarval() throws Throwable{
+		Class<?> c = StrictFieldGenerator.generateTestPutStrictFinalFieldLateLarval();
+		c.newInstance();
+	}
+
+	/* A strict final field cannot be set outside earlyLarvel.
+	 * Test outside of <init> (initialization state unrestricted).
+	 */
+	@Test(expectedExceptions = VerifyError.class)
+	static public void testPutStrictFinalFieldUnrestricted() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestPutStrictFinalFieldUnrestricted();
+		c.newInstance();
+	}
+}

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -2891,20 +2891,6 @@ public class ValueTypeTests {
 		ValueTypeGenerator.generateNonInterfaceClassWithMissingFlags("testNonInterfaceClassMustHaveFinalIdentityAbstractSet");
 	}
 
-	/* putfield is not allowed outside <init> for ACC_STRICT fields */
-	@Test(expectedExceptions = VerifyError.class)
-	static public void testValueClassWithIllegalSetters() throws Throwable {
-		String[] fields = {"x:I"};
-		Class<?> valueClass = ValueTypeGenerator.generateValueClassWithIllegalSetters("TestValueClassWithIllegalSetters", fields);
-		valueClass.newInstance();
-	}
-
-	/* putfield not allowed in <init> after class initialization for ACC_STRICT fields */
-	@Test(expectedExceptions = VerifyError.class)
-	static public void testValueClassPutStrictFieldAfterInitialization() throws Throwable {
-		Class<?> valueClass = ValueTypeGenerator.generateTestValueClassPutStrictFieldAfterInitialization();
-		valueClass.newInstance();
-	}
 
 	static MethodHandle generateGetter(Class<?> clazz, String fieldName, Class<?> fieldType) {
 		try {

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -60,4 +60,9 @@
 			<class name="org.openj9.test.lworld.ValueTypeSystemArraycopyTests"/>
 		</classes>
 	</test>
+	<test name="StrictFieldTests">
+		<classes>
+			<class name="org.openj9.test.lworld.StrictFieldTests"/>
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
- update putfield verification checks for ACC_STRICT_INIT fields with latest spec draft
- separate strict field test from value type tests

Related https://github.com/eclipse-openj9/openj9/issues/21884