### PR TITLE
(0.56) Support for ThreadSnapshot part 1

### DIFF
--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -38,6 +38,10 @@
 #if JAVA_SPEC_VERSION >= 24
 #include "j9protos.h"
 #endif /* JAVA_SPEC_VERSION >= 24 */
+#if JAVA_SPEC_VERSION >= 25
+#include "jvmtiInternal.h"
+#include "objhelp.h"
+#endif /* JAVA_SPEC_VERSION >= 25 */
 
 extern "C" {
 
@@ -684,8 +688,77 @@ JVM_TakeVirtualThreadListToUnblock(JNIEnv *env, jclass ignored)
 JNIEXPORT jobject JNICALL
 JVM_CreateThreadSnapshot(JNIEnv *env, jobject thread)
 {
-	Assert_SC_true(!"JVM_CreateThreadSnapshot unimplemented");
-	return NULL;
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions const * const vmfns = vm->internalVMFunctions;
+	j9object_t resultObject = NULL;
+	jobject result = NULL;
+	J9Class* clazz = J9VMJDKINTERNALVMTHREADSNAPSHOT_OR_NULL(vm);
+	vmfns->internalEnterVMFromJNI(currentThread);
+
+	if ((NULL == thread)
+		|| (NULL == clazz)
+	) {
+		vmfns->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+	} else {
+		j9object_t threadObject = NULL;
+		BOOLEAN isVirtual = JNI_FALSE;
+		BOOLEAN isAlive = JNI_FALSE;
+		J9VMThread *targetThread = NULL;
+		if (JVMTI_ERROR_NONE != vmfns->getTargetVMThreadHelper(
+				currentThread, thread, JVMTI_ERROR_NONE, 0,
+				&targetThread, &isVirtual, &isAlive)
+		) {
+			goto done;
+		}
+
+		if (!isAlive) {
+			goto done;
+		}
+
+		resultObject = vm->memoryManagerFunctions->J9AllocateObject(currentThread, clazz, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+		if (NULL == resultObject) {
+			vmfns->setHeapOutOfMemoryError(currentThread);
+			goto done;
+		}
+		if (NULL != targetThread) {
+			PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, resultObject);
+			vmfns->haltThreadForInspection(currentThread, targetThread);
+			resultObject = PEEK_OBJECT_IN_SPECIAL_FRAME(currentThread, 0);
+		}
+		threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
+		J9VMJDKINTERNALVMTHREADSNAPSHOT_SET_NAME(currentThread, resultObject, J9VMJAVALANGTHREAD_NAME(currentThread, threadObject));
+		if (isVirtual) {
+			j9object_t continuationObject = J9VMJAVALANGVIRTUALTHREAD_CONT(currentThread, threadObject);
+			J9VMJDKINTERNALVMTHREADSNAPSHOT_SET_CARRIERTHREAD(
+					currentThread, resultObject, J9VMJAVALANGVIRTUALTHREAD_CARRIERTHREAD(currentThread, threadObject));
+			J9VMJDKINTERNALVMTHREADSNAPSHOT_SET_BLOCKEROBJECT(
+					currentThread, resultObject, J9VMJDKINTERNALVMCONTINUATION_BLOCKER(currentThread, continuationObject));
+			/* blockerTypeOrdinal to be filled */
+			/* status to be filled */
+			/* stacktrace to be filled */
+			/* locks to be filled */
+		} else {
+			J9VMJDKINTERNALVMTHREADSNAPSHOT_SET_BLOCKEROBJECT(
+					currentThread, resultObject, vmfns->j9jni_createLocalRef(env, targetThread->blockingEnterObject));
+			/* blockerTypeOrdinal to be filled */
+			/* status to be filled */
+			/* stacktrace to be filled */
+			/* locks to be filled */
+		}
+		if (NULL != targetThread) {
+			vmfns->resumeThreadForInspection(currentThread, targetThread);
+			resultObject = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+		}
+		vmfns->releaseTargetVMThreadHelper(currentThread, targetThread, thread);
+	}
+
+done:
+	if (NULL != resultObject) {
+		result = vmfns->j9jni_createLocalRef(env, resultObject);
+	}
+	vmfns->internalExitVMToJNI(currentThread);
+	return result;
 }
 
 JNIEXPORT jboolean JNICALL

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -693,7 +693,7 @@ JVM_CreateThreadSnapshot(JNIEnv *env, jobject thread)
 	J9InternalVMFunctions const * const vmfns = vm->internalVMFunctions;
 	j9object_t resultObject = NULL;
 	jobject result = NULL;
-	J9Class* clazz = J9VMJDKINTERNALVMTHREADSNAPSHOT_OR_NULL(vm);
+	J9Class *clazz = J9VMJDKINTERNALVMTHREADSNAPSHOT_OR_NULL(vm);
 	vmfns->internalEnterVMFromJNI(currentThread);
 
 	if ((NULL == thread)
@@ -702,8 +702,8 @@ JVM_CreateThreadSnapshot(JNIEnv *env, jobject thread)
 		vmfns->setCurrentExceptionUTF(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 	} else {
 		j9object_t threadObject = NULL;
-		BOOLEAN isVirtual = JNI_FALSE;
-		BOOLEAN isAlive = JNI_FALSE;
+		BOOLEAN isVirtual = FALSE;
+		BOOLEAN isAlive = FALSE;
 		J9VMThread *targetThread = NULL;
 		if (JVMTI_ERROR_NONE != vmfns->getTargetVMThreadHelper(
 				currentThread, thread, JVMTI_ERROR_NONE, 0,

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5467,6 +5467,8 @@ typedef struct J9InternalVMFunctions {
 #endif /* JAVA_SPEC_VERSION >= 24 */
 	jobjectArray (*getSystemPropertyList)(JNIEnv *env);
 	void (*freeMapCaches)(struct J9ClassLoader *classLoader);
+	jvmtiError (*getTargetVMThreadHelper)(struct J9VMThread *currentThread, jthread thread, jvmtiError vThreadError, UDATA flags, struct J9VMThread **vmThreadPtr, BOOLEAN* isVirtualThread, BOOLEAN *isThreadAlive);
+	void (*releaseTargetVMThreadHelper)(struct J9VMThread *currentThread, struct J9VMThread *targetThread, jthread thread);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5272,6 +5272,33 @@ void
 freeTLS(J9VMThread *currentThread, j9object_t threadObj);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 
+/**
+ * Get the target J9VMThread given a j.l.Thread
+ *
+ * @param[in] currentThread the current thread
+ * @param[in] thread the j.l.Thread
+ * @paarm[in] vThreadError the error code to return if a virtual thread is not allowed to get the J9VMThread
+ * @param[in] flags J9JVMTI_GETVMTHREAD_XX flags
+ * @param[out] J9VMThread the J9VMThread corresponding to the j.l.Thread
+ * @param[out] isVirtualThread Whether it is a virtual thread
+ * @param[out] isThreadAlive Whether the thread is alive
+ *
+ * @return jvmtiError
+ */
+jvmtiError
+getTargetVMThreadHelper(J9VMThread *currentThread, jthread thread, jvmtiError vThreadError, UDATA flags, J9VMThread **vmThreadPtr, BOOLEAN* isVirtualThread, BOOLEAN *isThreadAlive);
+
+/**
+ * Release the target J9VMThread retuned from getTargetVMThreadHelper()
+ *
+ * @param[in] currentThread the current thread
+ * @param[in] targetThread the J9VMThread retuned from getTargetVMThreadHelper()
+ * @param[in] thread the j.l.Thread corresponding to the targetThread
+ */
+void
+releaseTargetVMThreadHelper(J9VMThread *currentThread, J9VMThread *targetThread, jthread thread);
+
+
 /* -------------------- J9OMRHelpers.cpp ------------ */
 
 /**

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -150,6 +150,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<classref name="java/lang/invoke/MethodHandleNatives" flags="opt_openjdkMethodhandle" versions="18-"/>
 
 	<classref name="jdk/internal/vm/Continuation" versions="19-"/>
+	<classref name="jdk/internal/vm/ThreadSnapshot" versions="25-"/>
 
 	<classref name="openj9/internal/criu/JVMCheckpointException" flags="opt_criuSupport"/>
 	<classref name="openj9/internal/criu/JVMRestoreException" flags="opt_criuSupport"/>
@@ -435,6 +436,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<!-- Field references for Synchronize Virtual Threads without Pinning (JEP491). -->
 	<fieldref class="jdk/internal/vm/Continuation" name="blocker" signature="Ljava/lang/Object;" versions="24-"/>
+
+	<!-- Field references for ThreadSnapshot -->
+	<fieldref class="jdk/internal/vm/ThreadSnapshot" name="name" signature="Ljava/lang/String;" versions="25-"/>
+	<fieldref class="jdk/internal/vm/ThreadSnapshot" name="threadStatus" signature="I" versions="25-"/>
+	<fieldref class="jdk/internal/vm/ThreadSnapshot" name="carrierThread" signature="Ljava/lang/Thread;" versions="25-"/>
+	<fieldref class="jdk/internal/vm/ThreadSnapshot" name="stackTrace" signature="[Ljava/lang/StackTraceElement;" versions="25-"/>
+	<fieldref class="jdk/internal/vm/ThreadSnapshot" name="locks" signature="[Ljdk/internal/vm/ThreadSnapshot$ThreadLock;" versions="25-"/>
+	<fieldref class="jdk/internal/vm/ThreadSnapshot" name="blockerTypeOrdinal" signature="I" versions="25-"/>
+	<fieldref class="jdk/internal/vm/ThreadSnapshot" name="blockerObject" signature="Ljava/lang/Object;" versions="25-"/>
 
 	<!-- Field references needed to support Foreign Linker API. -->
 	<fieldref class="java/lang/invoke/NativeMethodHandle" name="invokeCache" signature="[Ljava/lang/Object;" flags="opt_openjdkFfi" versions="22-"/>

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -493,4 +493,6 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* JAVA_SPEC_VERSION >= 24 */
 	getSystemPropertyList,
 	freeMapCaches,
+	getTargetVMThreadHelper,
+	releaseTargetVMThreadHelper,
 };


### PR DESCRIPTION
Refactor getVMThread/releaseVMThread into internalVMFunctions
Add ThreadSnapshot constant pool entries
Set thread name, carrier and blocker object on the snapshot

Port of https://github.com/eclipse-openj9/openj9/pull/22476 and https://github.com/eclipse-openj9/openj9/pull/22517