### PR TITLE
x86: Allow up to 512-bit vectorization in intrinsics

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -361,6 +361,11 @@ J9::X86::CodeGenerator::getMaxPreferredVectorLength()
    // Regressive CPU frequency scaling when using 256 or 512-bit vectorization is
    // a known issue on Intel x86 hardware. Some microarchitectures are known to be
    // more affected than others.
+   if (cpu->supportsFeature(OMR_FEATURE_X86_AVX512F) && cpu->supportsFeature(OMR_FEATURE_X86_AVX_VNNI))
+      {
+      return TR::VectorLength512;
+      }
+
    if (cpu->supportsFeature(OMR_FEATURE_X86_AVX2))
       {
       // We set a minimum microarchitecture target of Broadwell for 256-bit

--- a/runtime/compiler/x/env/J9CPU.cpp
+++ b/runtime/compiler/x/env/J9CPU.cpp
@@ -88,7 +88,8 @@ J9::X86::CPU::enableFeatureMasks()
                                         OMR_FEATURE_X86_FMA, OMR_FEATURE_X86_HLE, OMR_FEATURE_X86_RTM,
                                         OMR_FEATURE_X86_SSE3, OMR_FEATURE_X86_AVX2, OMR_FEATURE_X86_AVX512F,
                                         OMR_FEATURE_X86_AVX512VL, OMR_FEATURE_X86_AVX512BW, OMR_FEATURE_X86_AVX512DQ,
-                                        OMR_FEATURE_X86_AVX512CD, OMR_FEATURE_X86_SSE4_2, OMR_FEATURE_X86_BMI2};
+                                        OMR_FEATURE_X86_AVX512CD, OMR_FEATURE_X86_SSE4_2, OMR_FEATURE_X86_BMI2,
+                                        OMR_FEATURE_X86_AVX_VNNI };
 
    memset(_supportedFeatureMasks.features, 0, OMRPORT_SYSINFO_FEATURES_SIZE*sizeof(uint32_t));
    OMRPORT_ACCESS_FROM_OMRPORT(TR::Compiler->omrPortLib);
@@ -353,6 +354,7 @@ J9::X86::CPU::supports_feature_test(uint32_t feature)
       case OMR_FEATURE_X86_BMI2:
          return TR::CodeGenerator::getX86ProcessorInfo().supportsBMI2() == ans;
       case OMR_FEATURE_X86_AVX:
+      case OMR_FEATURE_X86_AVX_VNNI:
       case OMR_FEATURE_X86_AVX2:
       case OMR_FEATURE_X86_AVX512F:
       case OMR_FEATURE_X86_AVX512VL:


### PR DESCRIPTION
AVX-512 use is known to cause a CPU frequency regression on many x86 CPUs. CPUs with AVX-512 and AVX_VNNI have an insignificant frequency penalty. This change indicates to compiler intrinsics that 512-bit vectorization may be used on such CPUs.