### PR TITLE
ShareTwoDimensionArrayComponentSizeCalculationCrossPlatforms

### DIFF
--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -158,6 +158,18 @@ public:
 
    int32_t getObjectAlignmentInBytes();
 
+   /**
+   * \brief
+   * Calculate the leaf component size of a two dimensional array.
+   *
+   * \param classNode
+   * The class child of multianewarray node.
+   *
+   * \return
+   * The component size, or -1 if can not calculate the size.
+   */
+   int32_t getTwoDimensionalArrayComponentSize(TR::Node *classNode);
+
 private:
 
    bool                  _compressObjectReferences;


### PR DESCRIPTION
The procedure to calculate the size of 2D array component was implemented as part of #21870. This part of code is usable on other platforms so I moved it to a cross platform area.