### PR TITLE
(Rework) Print string contents for "this" references

### DIFF
--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -172,44 +172,77 @@ traceMethodEnter(J9VMThread *thr, J9Method *method, void *receiverAddress, UDATA
 	J9UTF8* methodName = J9ROMMETHOD_NAME(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 	J9UTF8* methodSignature = J9ROMMETHOD_SIGNATURE(J9_ROM_METHOD_FROM_RAM_METHOD(method));
 	UDATA modifiers = J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers;
+	j9object_t receiver = J9_ARE_ANY_BITS_SET(modifiers, J9AccStatic) ? NULL : *(j9object_t *)receiverAddress;
 
-	if (isCompiled) {
-		if (modifiers & J9AccStatic) {
+	if (0 != isCompiled) {
+		if (J9_ARE_ANY_BITS_SET(modifiers, J9AccStatic)) {
 			Trc_MethodEntryCS(thr, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSignature), J9UTF8_DATA(methodSignature));
 		} else {
-			j9object_t receiver = *(j9object_t*)receiverAddress;
 			Trc_MethodEntryC(thr, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSignature), J9UTF8_DATA(methodSignature), receiver);
 		}
 	} else {
 		char buf[1024];
 
-		if (modifiers & J9AccStatic) {
-			if (modifiers & J9AccNative) {
+		if (J9_ARE_ANY_BITS_SET(modifiers, J9AccStatic)) {
+			if (J9_ARE_ANY_BITS_SET(modifiers, J9AccNative)) {
 				Trc_MethodEntryNS(thr, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSignature), J9UTF8_DATA(methodSignature));
 			} else {
 				Trc_MethodEntryS(thr, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSignature), J9UTF8_DATA(methodSignature));
 			}
-			if (doParameters) {
-				Trc_MethodArgumentsS(thr, traceMethodArguments(thr, methodSignature, (UDATA*)receiverAddress, buf, buf + sizeof(buf)));
+			if (0 != doParameters) {
+				Trc_MethodArgumentsS(thr, traceMethodArguments(thr, methodSignature, (UDATA *)receiverAddress, buf, buf + sizeof(buf)));
 			}
 		} else {
-			j9object_t receiver = *(j9object_t*)receiverAddress;
-			J9Class* receiverClazz = J9OBJECT_CLAZZ(thr, receiver);
-			J9UTF8* receiverClassName = J9ROMCLASS_CLASSNAME(receiverClazz->romClass);
-
-			if (modifiers & J9AccNative) {
+			if (J9_ARE_ANY_BITS_SET(modifiers, J9AccNative)) {
 				Trc_MethodEntryN(thr, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSignature), J9UTF8_DATA(methodSignature), receiver);
 			} else {
 				Trc_MethodEntry(thr, J9UTF8_LENGTH(className), J9UTF8_DATA(className), J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodSignature), J9UTF8_DATA(methodSignature), receiver);
 			}
-
-			if (doParameters) {
-				Trc_MethodArguments(
-						thr, 
-						(U_32)J9UTF8_LENGTH(receiverClassName),
-						J9UTF8_DATA(receiverClassName),
-						receiver,
-						traceMethodArguments(thr, methodSignature, (UDATA*)receiverAddress - 1, buf, buf + sizeof(buf)));
+			if (0 != doParameters) {
+				J9Class *receiverClazz = J9OBJECT_CLAZZ(thr, receiver);
+				J9JavaVM *vm = thr->javaVM;
+				const unsigned int maxStringLength = RAS_GLOBAL_FROM_JAVAVM(maxStringLength, vm);
+				if ((receiverClazz == J9VMJAVALANGSTRING_OR_NULL(vm))
+						&& (0 != maxStringLength)
+						&& !J9UTF8_LITERAL_EQUALS(J9UTF8_DATA(methodName), J9UTF8_LENGTH(methodName), "<init>")
+				) {
+					PORT_ACCESS_FROM_JAVAVM(vm);
+					char utf8Buffer[RAS_MAX_STRING_LENGTH_LIMIT + 1];
+					char outputString[RAS_MAX_STRING_LENGTH_LIMIT + 1];
+					UDATA utf8Length = 0;
+					char *utf8String = vm->internalVMFunctions->copyStringToUTF8WithMemAlloc(
+							thr,
+							receiver,
+							0,
+							"",
+							0,
+							utf8Buffer,
+							sizeof(utf8Buffer),
+							&utf8Length);
+					if (NULL == utf8String) {
+						j9str_printf(outputString, sizeof(outputString), "<Memory allocation error>");
+					} else if (utf8Length > maxStringLength) {
+						j9str_printf(outputString, sizeof(outputString), "\"%.*s\"...", (U_32)maxStringLength, utf8String);
+					} else {
+						j9str_printf(outputString, sizeof(outputString), "\"%.*s\"", (U_32)utf8Length, utf8String);
+					}
+					if (utf8Buffer != utf8String) {
+						j9mem_free_memory(utf8String);
+					}
+					Trc_MethodArgumentsStr(
+							thr,
+							receiver,
+							outputString,
+							traceMethodArguments(thr, methodSignature, (UDATA *)receiverAddress - 1, buf, buf + sizeof(buf)));
+				} else {
+					J9UTF8 *receiverClassName = J9ROMCLASS_CLASSNAME(receiverClazz->romClass);
+					Trc_MethodArguments(
+							thr,
+							(U_32)J9UTF8_LENGTH(receiverClassName),
+							J9UTF8_DATA(receiverClassName),
+							receiver,
+							traceMethodArguments(thr, methodSignature, (UDATA *)receiverAddress - 1, buf, buf + sizeof(buf)));
+				}
 			}
 		}
 	}
@@ -496,11 +529,11 @@ traceMethodArgObject(J9VMThread *thr, UDATA* arg0EA, char* cursor, UDATA length)
 					&utf8Length);
 
 			if (NULL == utf8String) {
-				j9str_printf(cursor, length, "(String)<Memory allocation error>");
+				j9str_printf(cursor, length, "(String)@%p - <Memory allocation error>", object);
 			} else if (utf8Length > maxStringLength) {
-				j9str_printf(cursor, length, "(String)\"%.*s\"...", (U_32)maxStringLength, utf8String);
+				j9str_printf(cursor, length, "(String)@%p - \"%.*s\"...", object, (U_32)maxStringLength, utf8String);
 			} else {
-				j9str_printf(cursor, length, "(String)\"%.*s\"", (U_32)utf8Length, utf8String);
+				j9str_printf(cursor, length, "(String)@%p - \"%.*s\"", object, (U_32)utf8Length, utf8String);
 			}
 
 			if (utf8Buffer != utf8String) {

--- a/runtime/rastrace/mt.tdf
+++ b/runtime/rastrace/mt.tdf
@@ -59,3 +59,5 @@ TraceExit-Exception=Trc_MethodExitNXS Overhead=1 Level=5 Group=throw,nativeMetho
 
 TraceEvent=Trc_MethodReturn Overhead=1 Level=5 Group=methodArguments Template="return value: %s"
 TraceEvent=Trc_MethodException Overhead=1 Level=5 Group=methodArguments Template="exception: %s"
+
+TraceEvent=Trc_MethodArgumentsStr Overhead=1 Level=5 Group=methodArguments Template="this: (String)@%p - %s method arguments: (%s)"


### PR DESCRIPTION
Address the review comments on: https://github.com/eclipse-openj9/openj9/pull/20933

The changes reflect the feature request https://github.com/eclipse-openj9/openj9/issues/20878.
Print string contents for this references.
Also, print address for string arguments and returns.

