### PR TITLE
(0.56) Modify memory option rounding to avoid overflow

### DIFF
--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -577,9 +577,17 @@ optionValueOperations(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA
 				} else {
 					switch (*cursor) {
 						case '\0':
-							oldValue = value;
-							value = (value +  sizeof(UDATA) - 1) & ~(sizeof(UDATA) - 1);		/* round to nearest pointer value */
-							if (value < oldValue) return OPTION_OVERFLOW;
+#if defined(J9VM_ENV_DATA64)
+#define MEM_MAX_LIMIT I_64_MAX
+#else /* defined(J9VM_ENV_DATA64) */
+#define MEM_MAX_LIMIT U_32_MAX
+#endif /* defined(J9VM_ENV_DATA64) */
+							/* Round (up if possible) to a multiple of the pointer width. */
+							if (value < ((UDATA)MEM_MAX_LIMIT & ~(sizeof(UDATA) - 1))) {
+								value += sizeof(UDATA) - 1;
+							}
+							value &= ~(sizeof(UDATA) - 1);
+#undef MEM_MAX_LIMIT
 							break;
 						case 'k':
 						case 'K':

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -341,7 +341,8 @@ optionValueOperations(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA
 	char *values, *scanStart;
 	char *cursor;
 	IDATA sepCount = 0;
-	UDATA value, oldValue, done;
+	UDATA value = 0;
+	UDATA done = 0;
 	IDATA errorFound = 0;
 	UDATA mapType;
 	double dvalue = 0.0;

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -5397,7 +5397,7 @@ testFindArgs(J9JavaVM* vm)
 #define FAIL (failed = "Failed ")
 #define PASS ("Passed ")
 #define SET_TO(element, string) vm->vmArgsArray->actualVMArgs->options[element].optionString = string; printf("\nTesting: %s \t\t", string)
-#define TEST_INT(value, expected) printf( (value==expected) ? PASS : FAIL )
+#define TEST_INT(value, expected) printf("%s", (value==expected) ? PASS : FAIL )
 
 #ifdef J9VM_OPT_SIDECAR
 #define SET_MAP_TO(element, j9opt, sovopt, mapflags) registerCmdLineMapping(vm, sovopt, j9opt, mapflags)
@@ -5825,13 +5825,13 @@ testOptionValueOps(J9JavaVM* vm)
 
 #define FAIL (failed = "Failed ")
 #define PASS ("Passed ")
-#define COMPARE(result, expected) printf((result==NULL) ? FAIL : ((strcmp(result, expected)==0) ? PASS : FAIL ))
-#define IS_NULL(result) printf((result==NULL) ? PASS : FAIL)
-#define IS_EMPTY_STRING(result) printf((result!=NULL && strlen(result)==0) ? PASS : FAIL)
-#define IS_0(result) printf((result=='\0') ? PASS : FAIL)
+#define COMPARE(result, expected) printf("%s", (result==NULL) ? FAIL : ((strcmp(result, expected)==0) ? PASS : FAIL ))
+#define IS_NULL(result) printf("%s", (result==NULL) ? PASS : FAIL)
+#define IS_EMPTY_STRING(result) printf("%s", (result!=NULL && strlen(result)==0) ? PASS : FAIL)
+#define IS_0(result) printf("%s", (result=='\0') ? PASS : FAIL)
 #define SET_TO(element, string) vm->vmArgsArray->actualVMArgs->options[element].optionString = string; printf("\nTesting: %s \t\t", string)
 #define NEXT_ELEMENT(array) (array += strlen(array) + 1)
-#define TEST_INT(value, expected) printf( (value==expected) ? PASS : FAIL )
+#define TEST_INT(value, expected) printf("%s", (value==expected) ? PASS : FAIL )
 
 #ifdef J9VM_OPT_SIDECAR
 #define SET_MAP_TO(element, j9opt, sovopt, mapflags) registerCmdLineMapping(vm, sovopt, j9opt, mapflags)
@@ -6622,7 +6622,7 @@ testOptionValueOps(J9JavaVM* vm)
 	vm->vmArgsArray->actualVMArgs->options[5].optionString = origOption5;
 	vm->vmArgsArray->actualVMArgs->options[6].optionString = origOption6;
 
-	printf((failed==NULL) ? "\n\nTESTS PASSED\n" : "\n\nTESTS FAILED\n");
+	printf("%s", (failed==NULL) ? "\n\nTESTS PASSED\n" : "\n\nTESTS FAILED\n");
 }
 
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -6387,8 +6387,13 @@ testOptionValueOps(J9JavaVM* vm)
 	SET_TO(1, "-Xfok5347534875438758474");
 	optName = "-Xfok";
 	intResult = GET_INTEGER_VALUE(1, optName, uResult);
+#if defined(J9VM_ENV_DATA64)
+	TEST_INT(uResult, 5347534875438758474);
+	TEST_INT(intResult, OPTION_OK);
+#else /* defined(J9VM_ENV_DATA64) */
 	TEST_INT(uResult, 0);
 	TEST_INT(intResult, OPTION_MALFORMED);
+#endif /* defined(J9VM_ENV_DATA64) */
 
 	SET_TO(1, "-Xfoo31");
 	optName = "-Xfoo";
@@ -6405,8 +6410,35 @@ testOptionValueOps(J9JavaVM* vm)
 	SET_TO(1, "-Xfob4294967295");			/* (2^32 - 1) */
 	optName = "-Xfob";
 	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+#if defined(J9VM_ENV_DATA64)
+	TEST_INT(uResult, 4294967296);
+	TEST_INT(intResult, OPTION_OK);
+#else /* defined(J9VM_ENV_DATA64) */
+	TEST_INT(uResult, 4294967292);
+	TEST_INT(intResult, OPTION_OK);
+#endif /* defined(J9VM_ENV_DATA64) */
+
+	SET_TO(1, "-Xfob9223372036854775807");			/* (2^63 - 1) */
+	optName = "-Xfob";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+#if defined(J9VM_ENV_DATA64)
+	TEST_INT(uResult, 9223372036854775800);
+	TEST_INT(intResult, OPTION_OK);
+#else /* defined(J9VM_ENV_DATA64) */
 	TEST_INT(uResult, 0);
-	TEST_INT(intResult, OPTION_OVERFLOW);
+	TEST_INT(intResult, OPTION_MALFORMED);
+#endif /* defined(J9VM_ENV_DATA64) */
+
+	SET_TO(1, "-Xfob9223372036854775809");			/* (2^63 + 1) */
+	optName = "-Xfob";
+	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+#if defined(J9VM_ENV_DATA64)
+	TEST_INT(uResult, 9223372036854775808U);
+	TEST_INT(intResult, OPTION_OK);
+#else /* defined(J9VM_ENV_DATA64) */
+	TEST_INT(uResult, 0);
+	TEST_INT(intResult, OPTION_MALFORMED);
+#endif /* defined(J9VM_ENV_DATA64) */
 
 	SET_TO(1, "-Xfoc4294967280");			/* 0xfffffff0 */
 	optName = "-Xfoc";
@@ -6587,14 +6619,24 @@ testOptionValueOps(J9JavaVM* vm)
 	SET_TO(1, "-Xfou99999999999M");
 	optName = "-Xfou";
 	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+#if defined(J9VM_ENV_DATA64)
+	TEST_INT(uResult, 104857599998951424);
+	TEST_INT(intResult, OPTION_OK);
+#else /* defined(J9VM_ENV_DATA64) */
 	TEST_INT(uResult, 0);
 	TEST_INT(intResult, OPTION_MALFORMED);
+#endif /* defined(J9VM_ENV_DATA64) */
 
 	SET_TO(1, "-Xfow99999M");
 	optName = "-Xfow";
 	intResult = GET_MEMORY_VALUE(1, optName, uResult);
+#if defined(J9VM_ENV_DATA64)
+	TEST_INT(uResult, 104856551424);
+	TEST_INT(intResult, OPTION_OK);
+#else /* defined(J9VM_ENV_DATA64) */
 	TEST_INT(uResult, 0);
 	TEST_INT(intResult, OPTION_OVERFLOW);
+#endif /* defined(J9VM_ENV_DATA64) */
 
 #ifdef J9VM_OPT_SIDECAR
 

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2556,6 +2556,15 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 				parseErrorOption = VMOPT_XXMAXDIRECTMEMORYSIZEEQUALS;
 				goto _memParseError;
 			}
+#if defined(J9VM_ENV_DATA64)
+			if ((~(UDATA)0 != vm->directByteBufferMemoryMax)
+				&& (vm->directByteBufferMemoryMax > (((UDATA)I_64_MAX) & ~(sizeof(UDATA) - 1)))
+			) {
+				parseErrorOption = VMOPT_XXMAXDIRECTMEMORYSIZEEQUALS;
+				parseError = OPTION_OUTOFRANGE;
+				goto _memParseError;
+			}
+#endif /* defined(J9VM_ENV_DATA64) */
 
 			/* workaround option in case if OMRPORT_VMEM_ALLOC_QUICK Smart Address feature still be not reliable  */
 			argIndex = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXNOFORCE_FULL_HEAP_ADDRESS_RANGE_SEARCH, NULL);

--- a/test/functional/cmdLineTests/xxargtest/XXArgumentTesting_j9.xml
+++ b/test/functional/cmdLineTests/xxargtest/XXArgumentTesting_j9.xml
@@ -127,4 +127,18 @@
 		<output type="failure" caseSensitive="yes" regex="no">Compressed References</output>
 		<output type="failure" caseSensitive="no" regex="no">Unhandled Exception</output>
 	</test>
+
+	<test id="Verify 64-bit platforms reject MaxDirectMemorySize greater than Long.MAX_VALUE">
+		<command>$EXE$ -XX:MaxDirectMemorySize=9223372036854775808 -version</command>
+		<platformRequirements>bits.64</platformRequirements>
+		<return type="failure" value="0"/>
+		<output type="success" caseSensitive="no" javaUtilPattern="no" regex="no">Parse error for -XX:MaxDirectMemorySize= - value out of range.</output>
+	</test>
+
+	<test id="Verify 64-bit platforms allow MaxDirectMemorySize equal to Long.MAX_VALUE">
+		<command>$EXE$ -XX:MaxDirectMemorySize=9223372036854775807 -XX:+PrintFlagsFinal -version</command>
+		<platformRequirements>bits.64</platformRequirements>
+		<return type="success" value="0"/>
+		<output type="required" caseSensitive="no" javaUtilPattern="yes" regex="yes">MaxDirectMemorySize\s*=\s*9223372036854775800</output>
+	</test>
 </suite>


### PR DESCRIPTION
Memory option values are rounded up to be pointer-width aligned unless this would lead to a value greater than U_32_MAX or I_64_MAX on 32 and 64 bit platforms respectively. In these cases we truncate (round down) to the next pointer-width aligned value.
    
At the same time we add a bounds check on the MaxDirectMemorySize value on 64 bit platforms to ensure it maps safely to a Java long before passing in to the JVM initialization.

Issue https://github.com/eclipse-openj9/openj9/issues/22480

Backport https://github.com/eclipse-openj9/openj9/pull/22481 and https://github.com/eclipse-openj9/openj9/pull/22557