### PR TITLE
Remove unused var to fix compilation error on Windows

### DIFF
--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -339,7 +339,8 @@ optionValueOperations(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA
 	char *values, *scanStart;
 	char *cursor;
 	IDATA sepCount = 0;
-	UDATA value, oldValue, done;
+	UDATA value = 0;
+	UDATA done = 0;
 	IDATA errorFound = 0;
 	UDATA mapType;
 	double dvalue = 0.0;


### PR DESCRIPTION
vmargs.c(342): error C2220: the following warning is treated as an error
vmargs.c(342): warning C4101: 'oldValue': unreferenced local variable

Related to https://github.com/eclipse-openj9/openj9/pull/22481