### PR TITLE
[0.56.0] Ensure createUnsafeGetWithOffset considers all Unsafe.get methods

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -2070,28 +2070,32 @@ TR_J9InlinerPolicy::createUnsafeGetWithOffset(TR::ResolvedMethodSymbol *calleeSy
       switch (calleeSymbol->getRecognizedMethod()) {
       //boolean and char are unsigned so we need an unsigned conversion
       case TR::sun_misc_Unsafe_getBoolean_jlObjectJ_Z:
-      case TR::sun_misc_Unsafe_putBooleanVolatile_jlObjectJZ_V:
       case TR::sun_misc_Unsafe_getBooleanVolatile_jlObjectJ_Z:
+      case TR::jdk_internal_misc_Unsafe_getBooleanAcquire_jlObjectJ_Z:
+      case TR::jdk_internal_misc_Unsafe_getBooleanOpaque_jlObjectJ_Z:
 
       case TR::sun_misc_Unsafe_getChar_jlObjectJ_C:
       case TR::sun_misc_Unsafe_getCharVolatile_jlObjectJ_C:
-      case TR::sun_misc_Unsafe_getChar_J_C:
+      case TR::jdk_internal_misc_Unsafe_getCharAcquire_jlObjectJ_C:
+      case TR::jdk_internal_misc_Unsafe_getCharOpaque_jlObjectJ_C:
       case TR::jdk_internal_misc_Unsafe_getCharUnaligned:
          unsignedType = true;
          break;
       //byte and short are signed so we need a signed conversion
       case TR::sun_misc_Unsafe_getByte_jlObjectJ_B:
-      case TR::sun_misc_Unsafe_getByte_J_B:
       case TR::sun_misc_Unsafe_getByteVolatile_jlObjectJ_B:
+      case TR::jdk_internal_misc_Unsafe_getByteAcquire_jlObjectJ_B:
+      case TR::jdk_internal_misc_Unsafe_getByteOpaque_jlObjectJ_B:
 
       case TR::sun_misc_Unsafe_getShort_jlObjectJ_S:
       case TR::sun_misc_Unsafe_getShortVolatile_jlObjectJ_S:
-      case TR::sun_misc_Unsafe_getShort_J_S:
+      case TR::jdk_internal_misc_Unsafe_getShortAcquire_jlObjectJ_S:
+      case TR::jdk_internal_misc_Unsafe_getShortOpaque_jlObjectJ_S:
       case TR::jdk_internal_misc_Unsafe_getShortUnaligned:
          unsignedType = false;
          break;
       default:
-         TR_ASSERT(false, "all TR::sun_misc_Unsafe.get* methods must be handled.");
+         TR_ASSERT_FATAL(false, "all TR::sun_misc_Unsafe_get* and  TR::jdk_internal_misc_Unsafe_get* methods must be handled.");
       }
 
       TR::ILOpCodes conversionOpCode =


### PR DESCRIPTION
In the process of preparing to generate IL for an `Unsafe.get` method, `createUnsafeGetWithOffset` tries to determine whether sign extension or zero extension is needed for array elements of type boolean, byte, char or short.  However, it was only accounting for a subset of the `Unsafe.get` methods &mdash; for other methods, whether it performed sign or zero extension was based on an uninitialized boolean variable.

This change accounts for all known `Unsafe.get` methods that will have IL generated by `createUnsafeGetWithOffset`, and changes a `TR_ASSERT` into a `TR_ASSERT_FATAL` so we can detect if any additional `Unsafe.get` methods need to be accounted for in the future.

It also removes `sun_misc_Unsafe_putBooleanVolatile_jlObjectJZ_V` from consideration, as only `Unsafe.get` methods should be considered, as well as `sun_misc_Unsafe_get{Byte|Char|Short}_J_{B|C|S}`, as they don't have IL generated through `createUnsafeGetWithOffset`.

Fixes:  #21601

Port of pull request #22531 to v0.56.0-release branch