### PR TITLE
X: implement general case multianewarrayEvaluator for 2D arrays

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1726,7 +1726,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
  *
  * NB Must only be used for arrays of at least two dimensions
 */
-static TR::Register * generateMultianewArrayWithInlineAllocators(TR::Node *node, TR::CodeGenerator *cg)
+static TR::Register * generate2DZeroLengthArrayWithInlineAllocators(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Compilation *comp = cg->comp();
 
@@ -2031,78 +2031,85 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    TR_ASSERT_FATAL(secondChild->getOpCodeValue() == TR::iconst, "dims of multianewarray must be iconst");
 
    TR::Node *classNode   = node->getThirdChild();      // class of the outermost dimension
-
-   // Get the size of the elements in the leaf components
-   int32_t leafArrayElementSize = -1;
-   TR::SymbolReference *classSymRef = NULL;
-   const TR::ILOpCodes opcode = classNode->getOpCodeValue();
-   bool isClassNodeLoadAddr = opcode == TR::loadaddr;
-   // getting the symref
-   if (isClassNodeLoadAddr)
+   uint32_t nDims = secondChild->get32bitIntegralValue();
+   if (nDims > 1)
       {
-      classSymRef = classNode->getSymbolReference();
-      }
-   else if (opcode == TR::aloadi)
-      {
-      // recognizedCallTransformer adds another layer of aloadi
-      while (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::aloadi)
+      // Get the size of the elements in the leaf components
+      int32_t leafArrayElementSize = -1;
+      TR::SymbolReference *classSymRef = NULL;
+      const TR::ILOpCodes opcode = classNode->getOpCodeValue();
+      bool isClassNodeLoadAddr = opcode == TR::loadaddr;
+      // getting the symref
+      if (isClassNodeLoadAddr)
          {
-         classNode = classNode->getFirstChild();
+         classSymRef = classNode->getSymbolReference();
          }
-
-      if (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::loadaddr)
+      else if (opcode == TR::aloadi)
          {
-         classSymRef = classNode->getFirstChild()->getSymbolReference();
-         }
-      }
-   // Infer the data type and length from the signature
-   if (classSymRef)
-      {
-      int32_t len;
-      const char *sig = classSymRef->getTypeSignature(len);
-      if (sig)
-         {
-         if (sig[0] == '[' && sig[1] == '[')
+         // recognizedCallTransformer adds another layer of aloadi
+         while (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::aloadi)
             {
-            switch (sig[2])
+            classNode = classNode->getFirstChild();
+            }
+
+         if (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::loadaddr)
+            {
+            classSymRef = classNode->getFirstChild()->getSymbolReference();
+            }
+         }
+      // Infer the data type and length from the signature
+      if (classSymRef)
+         {
+         int32_t len;
+         const char *sig = classSymRef->getTypeSignature(len);
+         if (sig)
+            {
+            if (sig[0] == '[' && sig[1] == '[')
                {
-               case 'B':
-                  leafArrayElementSize = 1;
-                  break;
-               case 'C':
-               case 'S':
-                  leafArrayElementSize = 2;
-                  break;
-               case 'I':
-               case 'F':
-                  leafArrayElementSize = 4;
-                  break;
-               case 'D':
-               case 'J':
-                  leafArrayElementSize = 8;
-                  break;
-               case 'Z':
-                  leafArrayElementSize =
-                     static_cast<int32_t>(TR::Compiler->om.elementSizeOfBooleanArray());
-                  break;
-               case 'L':
-               default :
-                  leafArrayElementSize = TR::Compiler->om.sizeofReferenceField();
-                  break;
+               switch (sig[2])
+                  {
+                  case 'B':
+                     leafArrayElementSize = 1;
+                     break;
+                  case 'C':
+                  case 'S':
+                     leafArrayElementSize = 2;
+                     break;
+                  case 'I':
+                  case 'F':
+                     leafArrayElementSize = 4;
+                     break;
+                  case 'D':
+                  case 'J':
+                     leafArrayElementSize = 8;
+                     break;
+                  case 'Z':
+                     leafArrayElementSize =
+                        static_cast<int32_t>(TR::Compiler->om.elementSizeOfBooleanArray());
+                     break;
+                  case 'L':
+                  default :
+                     leafArrayElementSize = TR::Compiler->om.sizeofReferenceField();
+                     break;
+                  }
                }
             }
          }
-      }
 
-   // Anything with more than 2 dimensions will be replaced by a direct call when lowering trees,
-   // so this is functionally equivalent of saying only inline if the dimension is exactly 2.
-   // We also need to make sure the TLH is properly zeroed.
-   // Finally, we need to be sure we know the elementSize
-   TR_J9VMBase *fej9 = comp->fej9();
-   uint32_t nDims = secondChild->get32bitIntegralValue();
-   if (nDims > 1 && leafArrayElementSize != -1 && (fej9->tlhHasBeenCleared() || node->canSkipZeroInitialization()) && !comp->getOptions()->realTimeGC())
-      {
-      return generate2DArrayWithInlineAllocators(node, cg, leafArrayElementSize);
+      // Anything with more than 2 dimensions will be replaced by a direct call when lowering trees,
+      // so this is functionally equivalent of saying only inline if the dimension is exactly 2.
+      // If we know the element size and we don't need to zero the TLH, we can use the general
+      // inline allocator. Otherwise only generate inline for the 0 length special cases.
+      TR_J9VMBase *fej9 = comp->fej9();
+      static const bool disable = feGetEnv("TR_Disable2DArrayWithInlineAllocators") != NULL;
+      if (!disable && leafArrayElementSize != -1 && (fej9->tlhHasBeenCleared() || node->canSkipZeroInitialization()) && !comp->getOptions()->realTimeGC())
+         {
+         return generate2DArrayWithInlineAllocators(node, cg, leafArrayElementSize);
+         }
+      else
+         {
+         return generate2DZeroLengthArrayWithInlineAllocators(node, cg);
+         }
       }
    else
       {

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1587,8 +1587,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    generateLabelInstruction(TR::InstOpCode::label, node, startControlFlow, cg);
    startControlFlow->setStartInternalControlFlow();
 
-   TR::LabelSymbol *oolJumpPoint = generateLabelSymbol(cg);
-   generateLabelInstruction(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
+   generateLabelInstruction(TR::InstOpCode::JA4, node, oolFailLabel, cg);
 
    // no heap overflow, advance heap alloc to end of allocation
    generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), allocEndReg, cg);
@@ -1640,11 +1639,11 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
          {
          generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, tempReg, shiftAmount, cg);
          }
-      generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(spineArrReg, firstDimLenReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), tempReg, cg);
+      generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(spineArrReg, firstDimLenReg, trailingZeroes(TR::Compiler->om.sizeofReferenceField()), TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), tempReg, cg);
       }
    else
       {
-      generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, generateX86MemoryReference(spineArrReg, firstDimLenReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), leafArrReg, cg);
+      generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, generateX86MemoryReference(spineArrReg, firstDimLenReg, trailingZeroes(TR::Compiler->om.sizeofReferenceField()), TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), leafArrReg, cg);
       }
 
    // increment leafArrReg and loop back

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1517,6 +1517,9 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    bool use64BitClasses = !TR::Compiler->om.generateCompressedObjectHeaders();
 
+   bool skipZeroInit = fej9->tlhHasBeenCleared() || node->canSkipZeroInitialization();
+   TR::Register *zeroReg = skipZeroInit ? NULL : cg->allocateRegister();
+
    uintptr_t classOffset = TR::Compiler->om.offsetOfObjectVftField();
    uintptr_t sizeOffset = fej9->getOffsetOfContiguousArraySizeField();
 
@@ -1592,6 +1595,18 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    // no heap overflow, advance heap alloc to end of allocation
    generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), allocEndReg, cg);
 
+   // zero out allocation
+   if (!skipZeroInit)
+      {
+      generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, eax, eax, cg);
+      // REPSTOSB fills rcx bytes at [rdi] with al
+      // rcx = allocEndReg - leafArrReg
+      // rdi = leafArrReg
+      generateRegRegInstruction(TR::InstOpCode::SUB8RegReg, node, allocEndReg, leafArrReg, cg);
+      generateInstruction(TR::InstOpCode::REPSTOSB, node, cg);
+      cg->stopUsingRegister(zeroReg);
+      }
+
    // initialise spine array header
    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node, generateX86MemoryReference(spineArrReg, classOffset, cg), classReg, cg);
    generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(spineArrReg, sizeOffset, cg), firstDimLenReg, cg);
@@ -1652,7 +1667,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    generateLabelInstruction(TR::InstOpCode::label, node, loopBottom, cg);
 
-   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 10, cg);
+   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, skipZeroInit ? 10 : 11, cg);
 
    deps->addPostCondition(dimsPtrReg, TR::RealRegister::NoReg, cg);
    deps->addPostCondition(firstDimLenReg, TR::RealRegister::NoReg, cg);
@@ -1661,9 +1676,21 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    deps->addPostCondition(spineSizeReg, TR::RealRegister::NoReg, cg);
    deps->addPostCondition(leafSizeReg, TR::RealRegister::NoReg, cg);
    deps->addPostCondition(leafArrReg, TR::RealRegister::NoReg, cg);
-   deps->addPostCondition(allocEndReg, TR::RealRegister::NoReg, cg);
 
-   deps->addPostCondition(spineArrReg, TR::RealRegister::eax, cg);
+   if (skipZeroInit)
+      {
+      deps->addPostCondition(spineArrReg, TR::RealRegister::eax, cg);
+      deps->addPostCondition(allocEndReg, TR::RealRegister::NoReg, cg);
+      deps->addPostCondition(leafArrReg, TR::RealRegister::NoReg, cg);
+      }
+   else
+      {
+      deps->addPostCondition(zeroReg, TR::RealRegister::eax, cg);
+      deps->addPostCondition(spineArrReg, TR::RealRegister::NoReg, cg);
+      deps->addPostCondition(allocEndReg, TR::RealRegister::ecx, cg);
+      deps->addPostCondition(leafArrReg, TR::RealRegister::edi, cg);
+      }
+
    deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
 
    TR::Node *callNode = outlinedHelperCall->getCallNode();
@@ -2031,6 +2058,11 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    TR_ASSERT_FATAL(secondChild->getOpCodeValue() == TR::iconst, "dims of multianewarray must be iconst");
 
    TR::Node *classNode   = node->getThirdChild();      // class of the outermost dimension
+
+   // Anything with more than 2 dimensions will be replaced by a direct call when lowering trees,
+   // so this is functionally equivalent of saying only inline if the dimension is exactly 2.
+   // If we know the element size and we don't need to zero the TLH, we can use the general
+   // inline allocator. Otherwise only generate inline for the 0 length special cases.
    uint32_t nDims = secondChild->get32bitIntegralValue();
    if (nDims > 1)
       {
@@ -2096,13 +2128,9 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
             }
          }
 
-      // Anything with more than 2 dimensions will be replaced by a direct call when lowering trees,
-      // so this is functionally equivalent of saying only inline if the dimension is exactly 2.
-      // If we know the element size and we don't need to zero the TLH, we can use the general
-      // inline allocator. Otherwise only generate inline for the 0 length special cases.
       TR_J9VMBase *fej9 = comp->fej9();
       static const bool disable = feGetEnv("TR_Disable2DArrayWithInlineAllocators") != NULL;
-      if (!disable && leafArrayElementSize != -1 && (fej9->tlhHasBeenCleared() || node->canSkipZeroInitialization()) && !comp->getOptions()->realTimeGC())
+      if (!disable && leafArrayElementSize != -1 && !comp->getOptions()->realTimeGC())
          {
          return generate2DArrayWithInlineAllocators(node, cg, leafArrayElementSize);
          }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -2099,7 +2099,7 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    // Finally, we need to be sure we know the elementSize
    TR_J9VMBase *fej9 = comp->fej9();
    uint32_t nDims = secondChild->get32bitIntegralValue();
-   if (nDims > 1 && leafArrayElementSize != -1 && fej9->tlhHasBeenCleared() && !comp->getOptions()->realTimeGC())
+   if (nDims > 1 && leafArrayElementSize != -1 && (fej9->tlhHasBeenCleared() || node->canSkipZeroInitialization()) && !comp->getOptions()->realTimeGC())
       {
       return generate2DArrayWithInlineAllocators(node, cg, leafArrayElementSize);
       }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1455,6 +1455,272 @@ TR::Register *J9::X86::TreeEvaluator::newEvaluator(TR::Node *node, TR::CodeGener
    return targetRegister;
    }
 
+static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::CodeGenerator *cg,  int32_t leafArrayElementSize)
+   {
+   TR::Compilation *comp = cg->comp();
+
+   TR::Node *sizeArrNode = node->getFirstChild();      // ptr to array of sizes, one for each dimension. Array construction stops at the outermost zero size
+   TR::Node *nDimsNode   = node->getSecondChild();     // number of dimensions - this is fixed in the bytecode, so compile time constant 2
+   TR::Node *classNode   = node->getThirdChild();      // class of the outermost dimension
+   TR_ASSERT_FATAL_WITH_NODE(node, nDimsNode->getOpCodeValue() == TR::iconst && nDimsNode->getConstValue() == 2, "Dimension child of multianewarray must be iconst 2");
+
+   TR_J9VMBase *fej9 = comp->fej9();
+
+   TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
+
+   /*
+    * For a new m*n array of X we allocate the first dimension array spine immediately followed
+    * by the second dimension array leaves, inserting padding to align the arrays. This looks like the following:
+    *
+    *    |-------------------------|
+    *    | n empty X aray slots    | \
+    *    |-------------------------|  |
+    *    | mth leaf array header   |  |
+    *    |-------------------------|  |
+    *    | padding for alignment   |  |
+    *    |-------------------------|  |
+    *                ...              |
+    *    |-------------------------|  | m * (header bytes + n * X bytes + leaf padding bytes) - leaf padding bytes
+    *    | n empty X array slots   |  |
+    *    |-------------------------|  |
+    *    | 2nd leaf array header   |  |
+    *    |-------------------------|  |
+    *    | padding for alignment   |  |
+    *    |-------------------------|  |
+    *    | n empty X array slots   |  |
+    *    |-------------------------|  |
+    *    | 1st leaf array header   | /
+    *    |-------------------------|
+    *    | padding for alignment   | \
+    *    |-------------------------|  |
+    *    | m reference array slots |  | spine padding bytes + header bytes + m * reference bytes
+    *    |-------------------------|  |
+    *    | spine array header      | /
+    *    |-------------------------|
+    *    | padding for alignment   | vmThread->heapAlloc padding bytes
+    *    |-------------------------|
+    *
+    * If the whole allocation won't fit between vmThread->heapAlloc and vmThread->heapTop,
+    * call the snippet instead which will handle the heap overflow.
+    *
+    * After allocating, initialise
+    *   - Spine array header with class and size
+    *   - Spine array slots with references to leaf arrays
+    *   - Leaf array headers
+    */
+
+   // alignment requirement
+   int32_t alignmentInBytes = TR::Compiler->om.getObjectAlignmentInBytes();
+   // a length>0 array object would *not* require alignment if both a single element
+   // and the header are already the exact multiple of alignment; otherwise alignment is needed
+   bool needsAlignLeaf = (OMR::align(leafArrayElementSize, alignmentInBytes) != leafArrayElementSize);
+   bool needsAlignHeader = (TR::Compiler->om.contiguousArrayHeaderSizeInBytes()
+      != OMR::align(TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), alignmentInBytes));
+
+   bool use64BitClasses = !TR::Compiler->om.generateCompressedObjectHeaders();
+
+   uintptr_t classOffset = TR::Compiler->om.offsetOfObjectVftField();
+   uintptr_t sizeOffset = fej9->getOffsetOfContiguousArraySizeField();
+
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
+   bool isOffHeapAllocationEnabled = TR::Compiler->om.isOffHeapAllocationEnabled();
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
+
+   // load dimensions and class
+   TR::Register *dimsPtrReg = cg->longClobberEvaluate(firstChild);
+   TR::Register *secondDimLenReg = cg->allocateRegister();
+   TR::Register *classReg = cg->longClobberEvaluate(classNode);
+   TR::Register *firstDimLenReg = dimsPtrReg;
+
+   generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, secondDimLenReg, generateX86MemoryReference(dimsPtrReg, 0, cg), cg);
+   generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg, generateX86MemoryReference(dimsPtrReg, 4, cg), cg);
+
+   // calculate spine array size = header bytes + first dim * reference bytes
+   TR::Register *spineSizeReg = cg->allocateRegister();
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
+                             generateX86MemoryReference(NULL, firstDimLenReg, trailingZeroes(TR::Compiler->om.sizeofReferenceField()), TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+
+   // calculate leaf array size = header bytes + second dim * X bytes
+   TR::Register *leafSizeReg = cg->allocateRegister();
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafSizeReg,
+                             generateX86MemoryReference(NULL, secondDimLenReg, trailingZeroes(leafArrayElementSize), TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+
+
+   // pad array sizes so following leaf array is aligned
+   if (needsAlignLeaf)
+      {
+      generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineSizeReg, generateX86MemoryReference(spineSizeReg, alignmentInBytes-1), cg);
+      generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, spineSizeReg, -alignmentInBytes cg);
+
+      generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafSizeReg, generateX86MemoryReference(leafSizeReg, alignmentInBytes-1), cg);
+      generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, leafSizeReg, -alignmentInBytes cg);
+      }
+
+   // load heap alloc and pad so spine array is aligned
+   TR::Register *vmThreadReg = cg->getVMThreadRegister();
+   TR::Register *spineArrReg = cg->allocateRegister();
+   generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, spineArrReg, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+   if (needsAlignHeader)
+      {
+      generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineArrReg, generateX86MemoryReference(spineArrReg, alignmentInBytes-1), cg);
+      generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, tempReg, -alignmentInBytes cg);
+      }
+
+   // calculate start of first leaf array
+   TR::Register *leafArrReg = cg->allocateRegister();
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafArrReg, generateX86MemoryReference(spineArrReg, spineSizeReg), cg);
+
+   // calculate end of allocation = first leaf array address + (first dimension * size of leaf array) - leaf padding bytes
+   TR::Register *allocEndReg = cg->allocateRegister();
+   generateRegRegInstruction(TR::InstOpCode::MOVSXReg8Reg4, node, allocEndReg, leafSizeReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::IMUL8RegReg, node, allocEndReg, firstDimLenReg, cg);
+   generateRegMemInstruction(TR::InstOpCode::ADD8RegReg, node, allocEndReg, leafArrReg, cg);
+   // ignore removing extra leaf padding, a few extra bytes won't hurt, right?
+
+   // if end of allocation > heap top jump to snippet to handle heap overflow
+   TR::LabelSymbol *oolFailLabel
+   TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::acall, spineArrReg, oolFailLabel, doneLabel, cg);
+   cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
+
+   generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, allocEndReg, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+
+   TR::LabelSymbol *startControlFlow = generateLabelSymbol(cg);
+   generateLabelInstruction(TR::InstOpCode::label, node, startControlFlow, cg);
+   startControlFlow->setStartInternalControlFlow(cg);
+
+   TR::LabelSymbol *oolJumpPoint = generateLabelSymbol(cg);
+   generateLabelInstruction(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
+
+   // no heap overflow, advance heap alloc to end of allocation
+   generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), allocEndReg, cg);
+
+   // initialise spine array header
+   generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node, generateX86MemoryReference(spineArrReg, classOffset, cg), classReg, cg);
+   generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(spineArrReg, sizeOffset, cg), firstDimLenReg, cg);
+
+   // load class of leaf array
+   generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, classReg,
+            generateX86MemoryReference(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
+
+   // if the class and size fields fit in a contiguous 8 bytes, we can set them in a single store
+   bool arrayHeaderFitsInGPR = !use64BitClasses && ((sizeOffset - classOffset) == 4);
+   if (arrayHeaderFitsInGPR)
+      {
+      generateRegImmInstruction(TR::InstOpCode::SHL8RegImm1, node, secondDimLenReg, 32, cg);
+      generateRegRegInstruction(TR::InstOpCode::OR8RegReg, node, classReg, secondDimLenReg, cg);
+      }
+
+   // set up loop to initialise spine array elements and leaf array headers
+   TR::LabelSymbol *loopTop = generateLabelSymbol(cg);
+   TR::LabelSymbol *loopBottom = generateLabelSymbol(cg);
+   generateLabelInstruction(TR::InstOpCode::label, node, loopTop, cg);
+
+   generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, firstDimLenReg, firstDimLenReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JE4, node, loopBottom, cg);
+
+   generateRegInstruction(TR::InstOpCode::DECReg(), node, firstDimLenReg, cg);
+
+   // populate leaf array header
+   if (arrayHeaderFitsInGPR)
+      {
+      generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, generateX86MemoryReference(leafArrReg, classOffset, cg), classReg, cg);
+      }
+   else
+      {
+      generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node, generateX86MemoryReference(leafArrReg, classOffset, cg), classReg, cg);
+      generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(leafArrReg, sizeOffset, cg), secondDimLenReg, cg);
+      }
+
+   // populate spine array slot
+   if (comp->useCompressedPointers())
+      {
+      int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
+      TR::Register *tempReg = spineSizeReg; // we no longer need to know the size of the spine
+      generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg, leafArrReg, cg);
+      if (shiftAmount != 0)
+         {
+         generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, tempReg, shiftAmount, cg);
+         }
+      generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(spineArrReg, firstDimLenReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), tempReg, cg);
+      }
+   else
+      {
+      generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, generateX86MemoryReference(spineArrReg, firstDimLenReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), leafArrReg, cg);
+      }
+
+   // increment leafArrReg and loop back
+   generateRegMemInstruction(TR::InstOpCode::ADD8RegReg, node, leafArrReg, leafSizeReg, cg);
+   generateLabelInstruction(TR::InstOpCode::JMP4, node, loopTop, cg);
+
+   generateLabelInstruction(TR::InstOpCode::label, node, loopBottom, cg);
+
+   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 9, cg);
+
+   deps->addPostCondition(firstDimLenReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(secondDimLenReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(classReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(spineSizeReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(leafSizeReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(leafArrReg, TR::RealRegister::NoReg, cg);
+   deps->addPostCondition(allocEndReg, TR::RealRegister::NoReg, cg);
+
+   deps->addPostCondition(spineArrReg, TR::RealRegister::eax, cg);
+   deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
+
+   TR::Node *callNode = outlinedHelperCall->getCallNode();
+   TR::Register *reg;
+
+   if (callNode->getFirstChild() == node->getFirstChild())
+      {
+      reg = callNode->getFirstChild()->getRegister();
+      if (reg)
+         deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
+
+   if (callNode->getSecondChild() == node->getSecondChild())
+      {
+      reg = callNode->getSecondChild()->getRegister();
+      if (reg)
+         deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
+
+   if (callNode->getThirdChild() == node->getThirdChild())
+      {
+      reg = callNode->getThirdChild()->getRegister();
+      if (reg)
+         deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+      }
+
+   deps->stopAddingConditions();
+
+   generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+   doneLabel->setEndInternalControlFlow();
+
+   // Copy the newly allocated object into a collected reference register now that it is a valid object.
+   TR::Register *targetReg = cg->allocateCollectedReferenceRegister();
+   TR::RegisterDependencyConditions  *deps2 = generateRegisterDependencyConditions(0, 1, cg);
+   deps2->addPostCondition(targetReg, TR::RealRegister::eax, cg);
+   generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, targetReg, spineArrReg, deps2, cg);
+   cg->stopUsingRegister(spineArrReg);
+
+   cg->stopUsingRegister(firstDimLenReg);
+   cg->stopUsingRegister(secondDimLenReg);
+   cg->stopUsingRegister(classReg);
+   cg->stopUsingRegister(spineSizeReg);
+   cg->stopUsingRegister(leafSizeReg);
+   cg->stopUsingRegister(leafArrReg);
+   cg->stopUsingRegister(allocEndReg);
+
+   cg->decReferenceCount(sizeArrNode);
+   cg->decReferenceCount(classNode);
+   cg->recursivelyDecReferenceCount(nDimsNode);
+
+   node->setRegister(targetReg);
+   return targetReg;
+   }
+
 /**
  * Generate code for multianewarray
  *
@@ -1766,11 +2032,78 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    // The number of dimensions should always be an iconst
    TR_ASSERT_FATAL(secondChild->getOpCodeValue() == TR::iconst, "dims of multianewarray must be iconst");
 
-   // Only generate inline code if nDims > 1
-   uint32_t nDims = secondChild->get32bitIntegralValue();
-   if (nDims > 1)
+   TR::Node *classNode   = node->getThirdChild();      // class of the outermost dimension
+
+   // Get the size of the elements in the leaf components
+   int32_t leafArrayElementSize = -1;
+   TR::SymbolReference *classSymRef = NULL;
+   const TR::ILOpCodes opcode = classNode->getOpCodeValue();
+   bool isClassNodeLoadAddr = opcode == TR::loadaddr;
+   // getting the symref
+   if (isClassNodeLoadAddr)
       {
-      return generateMultianewArrayWithInlineAllocators(node, cg);
+      classSymRef = classNode->getSymbolReference();
+      }
+   else if (opcode == TR::aloadi)
+      {
+      // recognizedCallTransformer adds another layer of aloadi
+      while (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::aloadi)
+         {
+         classNode = classNode->getFirstChild();
+         }
+
+      if (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::loadaddr)
+         {
+         classSymRef = classNode->getFirstChild()->getSymbolReference();
+         }
+      }
+   // Infer the data type and length from the signature
+   if (classSymRef)
+      {
+      int32_t len;
+      const char *sig = classSymRef->getTypeSignature(len);
+      if (sig)
+         {
+         if (sig[0] == '[' && sig[1] == '[')
+            {
+            switch (sig[2])
+               {
+               case 'B':
+                  leafArrayElementSize = 1;
+                  break;
+               case 'C':
+               case 'S':
+                  leafArrayElementSize = 2;
+                  break;
+               case 'I':
+               case 'F':
+                  leafArrayElementSize = 4;
+                  break;
+               case 'D':
+               case 'J':
+                  leafArrayElementSize = 8;
+                  break;
+               case 'Z':
+                  leafArrayElementSize =
+                     static_cast<int32_t>(TR::Compiler->om.elementSizeOfBooleanArray());
+                  break;
+               case 'L':
+               default :
+                  leafArrayElementSize = TR::Compiler->om.sizeofReferenceField();
+                  break;
+               }
+            }
+         }
+      }
+
+   // Anything with more than 2 dimensions will be replaced by a direct call when lowering trees,
+   // so this is functionally equivalent of saying only inline if the dimension is exactly 2.
+   // We also need to make sure the TLH is properly zeroed.
+   // Finally, we need to be sure we know the elementSize
+   uint32_t nDims = secondChild->get32bitIntegralValue();
+   if (nDims > 1 && leafArrayElementSize != -1 && fej9->tlhHasBeenCleared() && !comp->getOptions()->realTimeGC())
+      {
+      return generate2DArrayWithInlineAllocators(node, cg, leafArrayElementSize);
       }
    else
       {

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1507,10 +1507,6 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
     *   - Leaf array headers
     */
 
-   static const bool breakOnInlineGenerate2DArray = feGetEnv("TR_BreakOnInlineGenerate2DArray") != NULL;
-   if (breakOnInlineGenerate2DArray)
-      generateInstruction(TR::InstOpCode::INT3, node, cg);
-
    // alignment requirement
    int32_t alignmentInBytes = TR::Compiler->om.getObjectAlignmentInBytes();
    // a length>0 array object would *not* require alignment if both a single element
@@ -1536,6 +1532,10 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    TR::Register *secondDimLenReg = cg->allocateRegister();
    TR::Register *classReg = cg->longClobberEvaluate(classNode);
    TR::Register *firstDimLenReg = cg->allocateRegister();
+
+   static const bool breakOnInlineGenerate2DArray = feGetEnv("TR_BreakOnInlineGenerate2DArray") != NULL;
+   if (breakOnInlineGenerate2DArray)
+      generateInstruction(TR::InstOpCode::INT3, node, cg);
 
    generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, secondDimLenReg, generateX86MemoryReference(dimsPtrReg, 0, cg), cg);
    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg, generateX86MemoryReference(dimsPtrReg, 4, cg), cg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -2073,70 +2073,8 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    uint32_t nDims = secondChild->get32bitIntegralValue();
    if (nDims > 1)
       {
-      // Get the size of the elements in the leaf components
-      int32_t leafArrayElementSize = -1;
-      TR::SymbolReference *classSymRef = NULL;
-      const TR::ILOpCodes opcode = classNode->getOpCodeValue();
-      bool isClassNodeLoadAddr = opcode == TR::loadaddr;
-      // getting the symref
-      if (isClassNodeLoadAddr)
-         {
-         classSymRef = classNode->getSymbolReference();
-         }
-      else if (opcode == TR::aloadi)
-         {
-         // recognizedCallTransformer adds another layer of aloadi
-         while (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::aloadi)
-            {
-            classNode = classNode->getFirstChild();
-            }
-
-         if (classNode->getOpCodeValue() == TR::aloadi && classNode->getFirstChild()->getOpCodeValue() == TR::loadaddr)
-            {
-            classSymRef = classNode->getFirstChild()->getSymbolReference();
-            }
-         }
-      // Infer the data type and length from the signature
-      if (classSymRef)
-         {
-         int32_t len;
-         const char *sig = classSymRef->getTypeSignature(len);
-         if (sig)
-            {
-            if (sig[0] == '[' && sig[1] == '[')
-               {
-               switch (sig[2])
-                  {
-                  case 'B':
-                     leafArrayElementSize = 1;
-                     break;
-                  case 'C':
-                  case 'S':
-                     leafArrayElementSize = 2;
-                     break;
-                  case 'I':
-                  case 'F':
-                     leafArrayElementSize = 4;
-                     break;
-                  case 'D':
-                  case 'J':
-                     leafArrayElementSize = 8;
-                     break;
-                  case 'Z':
-                     leafArrayElementSize =
-                        static_cast<int32_t>(TR::Compiler->om.elementSizeOfBooleanArray());
-                     break;
-                  case 'L':
-                  default :
-                     leafArrayElementSize = TR::Compiler->om.sizeofReferenceField();
-                     break;
-                  }
-               }
-            }
-         }
-
-      TR_J9VMBase *fej9 = comp->fej9();
       static const bool disable = feGetEnv("TR_Disable2DArrayWithInlineAllocators") != NULL;
+      int32_t leafArrayElementSize = TR::Compiler->om.getTwoDimensionalArrayComponentSize(classNode);
       if (!disable && leafArrayElementSize != -1 && !comp->getOptions()->realTimeGC())
          {
          return generate2DArrayWithInlineAllocators(node, cg, leafArrayElementSize);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1529,7 +1529,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
    // load dimensions and class
-   TR::Register *dimsPtrReg = cg->longClobberEvaluate(firstChild);
+   TR::Register *dimsPtrReg = cg->longClobberEvaluate(sizeArrNode);
    TR::Register *secondDimLenReg = cg->allocateRegister();
    TR::Register *classReg = cg->longClobberEvaluate(classNode);
    TR::Register *firstDimLenReg = dimsPtrReg;
@@ -1551,11 +1551,11 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    // pad array sizes so following leaf array is aligned
    if (needsAlignLeaf)
       {
-      generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineSizeReg, generateX86MemoryReference(spineSizeReg, alignmentInBytes-1), cg);
-      generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, spineSizeReg, -alignmentInBytes cg);
+      generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, spineSizeReg, alignmentInBytes-1, cg);
+      generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, spineSizeReg, -alignmentInBytes, cg);
 
-      generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafSizeReg, generateX86MemoryReference(leafSizeReg, alignmentInBytes-1), cg);
-      generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, leafSizeReg, -alignmentInBytes cg);
+      generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, leafSizeReg, alignmentInBytes-1, cg);
+      generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, leafSizeReg, -alignmentInBytes, cg);
       }
 
    // load heap alloc and pad so spine array is aligned
@@ -1564,8 +1564,8 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, spineArrReg, generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
    if (needsAlignHeader)
       {
-      generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineArrReg, generateX86MemoryReference(spineArrReg, alignmentInBytes-1), cg);
-      generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, tempReg, -alignmentInBytes cg);
+      generateRegImmInstruction(TR::InstOpCode::ADD8RegImms, node, spineArrReg, alignmentInBytes-1, cg);
+      generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, spineArrReg, -alignmentInBytes, cg);
       }
 
    // calculate start of first leaf array

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1507,6 +1507,10 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
     *   - Leaf array headers
     */
 
+   static const bool breakOnInlineGenerate2DArray = feGetEnv("TR_BreakOnInlineGenerate2DArray") != NULL;
+   if (breakOnInlineGenerate2DArray)
+      generateInstruction(TR::InstOpCode::INT3, node, cg);
+
    // alignment requirement
    int32_t alignmentInBytes = TR::Compiler->om.getObjectAlignmentInBytes();
    // a length>0 array object would *not* require alignment if both a single element

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1604,7 +1604,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    if (!skipZeroInit)
       {
       generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, zeroReg, zeroReg, cg);
-      generateRegRegInstruction(TR::InstOpCode::MOV8RegReg, node, tmpReg, leafArrReg);
+      generateRegRegInstruction(TR::InstOpCode::MOV8RegReg, node, tmpReg, leafArrReg, cg);
       // REPSTOSB fills rcx bytes at [rdi] with al
       // rcx = allocEndReg - leafArrReg
       // rdi = leafArrReg

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1570,17 +1570,17 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    // calculate start of first leaf array
    TR::Register *leafArrReg = cg->allocateRegister();
-   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafArrReg, generateX86MemoryReference(spineArrReg, spineSizeReg), cg);
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafArrReg, generateX86MemoryReference(spineArrReg, spineSizeReg, cg), cg);
 
    // calculate end of allocation = first leaf array address + (first dimension * size of leaf array) - leaf padding bytes
    TR::Register *allocEndReg = cg->allocateRegister();
    generateRegRegInstruction(TR::InstOpCode::MOVSXReg8Reg4, node, allocEndReg, leafSizeReg, cg);
    generateRegRegInstruction(TR::InstOpCode::IMUL8RegReg, node, allocEndReg, firstDimLenReg, cg);
-   generateRegMemInstruction(TR::InstOpCode::ADD8RegReg, node, allocEndReg, leafArrReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::ADD8RegReg, node, allocEndReg, leafArrReg, cg);
    // ignore removing extra leaf padding, a few extra bytes won't hurt, right?
 
    // if end of allocation > heap top jump to snippet to handle heap overflow
-   TR::LabelSymbol *oolFailLabel
+   TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
    TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::acall, spineArrReg, oolFailLabel, doneLabel, cg);
    cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
 
@@ -1651,7 +1651,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
       }
 
    // increment leafArrReg and loop back
-   generateRegMemInstruction(TR::InstOpCode::ADD8RegReg, node, leafArrReg, leafSizeReg, cg);
+   generateRegRegInstruction(TR::InstOpCode::ADD8RegReg, node, leafArrReg, leafSizeReg, cg);
    generateLabelInstruction(TR::InstOpCode::JMP4, node, loopTop, cg);
 
    generateLabelInstruction(TR::InstOpCode::label, node, loopBottom, cg);
@@ -2100,6 +2100,7 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
    // so this is functionally equivalent of saying only inline if the dimension is exactly 2.
    // We also need to make sure the TLH is properly zeroed.
    // Finally, we need to be sure we know the elementSize
+   TR_J9VMBase *fej9 = comp->fej9();
    uint32_t nDims = secondChild->get32bitIntegralValue();
    if (nDims > 1 && leafArrayElementSize != -1 && fej9->tlhHasBeenCleared() && !comp->getOptions()->realTimeGC())
       {

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1519,6 +1519,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    bool skipZeroInit = fej9->tlhHasBeenCleared() || node->canSkipZeroInitialization();
    TR::Register *zeroReg = skipZeroInit ? NULL : cg->allocateRegister();
+   TR::Register *tmpReg = skipZeroInit ? NULL : cg->allocateRegister();
 
    uintptr_t classOffset = TR::Compiler->om.offsetOfObjectVftField();
    uintptr_t sizeOffset = fej9->getOffsetOfContiguousArraySizeField();
@@ -1603,6 +1604,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    if (!skipZeroInit)
       {
       generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, zeroReg, zeroReg, cg);
+      generateRegRegInstruction(TR::InstOpCode::MOV8RegReg, node, tmpReg, leafArrReg);
       // REPSTOSB fills rcx bytes at [rdi] with al
       // rcx = allocEndReg - leafArrReg
       // rdi = leafArrReg
@@ -1610,6 +1612,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
       generateRegRegInstruction(TR::InstOpCode::SUB8RegReg, node, allocEndReg, leafArrReg, cg);
       generateInstruction(TR::InstOpCode::REPSTOSB, node, cg);
       cg->stopUsingRegister(zeroReg);
+      cg->stopUsingRegister(tmpReg);
       }
 
    // initialise spine array header
@@ -1672,7 +1675,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    generateLabelInstruction(TR::InstOpCode::label, node, loopBottom, cg);
 
-   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, skipZeroInit ? 10 : 11, cg);
+   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, skipZeroInit ? 10 : 12, cg);
 
    deps->addPostCondition(dimsPtrReg, TR::RealRegister::NoReg, cg);
    deps->addPostCondition(firstDimLenReg, TR::RealRegister::NoReg, cg);
@@ -1686,14 +1689,13 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
       {
       deps->addPostCondition(spineArrReg, TR::RealRegister::eax, cg);
       deps->addPostCondition(allocEndReg, TR::RealRegister::NoReg, cg);
-      deps->addPostCondition(leafArrReg, TR::RealRegister::NoReg, cg);
       }
    else
       {
       deps->addPostCondition(zeroReg, TR::RealRegister::eax, cg);
       deps->addPostCondition(spineArrReg, TR::RealRegister::NoReg, cg);
       deps->addPostCondition(allocEndReg, TR::RealRegister::ecx, cg);
-      deps->addPostCondition(leafArrReg, TR::RealRegister::edi, cg);
+      deps->addPostCondition(tmpReg, TR::RealRegister::edi, cg);
       }
 
    deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1466,10 +1466,6 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    TR_J9VMBase *fej9 = comp->fej9();
 
-   TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
-   TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-   TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
-
    /*
     * For a new m*n array of X we allocate the first dimension array spine immediately followed
     * by the second dimension array leaves, inserting padding to align the arrays. This looks like the following:
@@ -1581,6 +1577,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    // if end of allocation > heap top jump to snippet to handle heap overflow
    TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
+   TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
    TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::acall, spineArrReg, oolFailLabel, doneLabel, cg);
    cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1598,10 +1598,11 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    // zero out allocation
    if (!skipZeroInit)
       {
-      generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, eax, eax, cg);
+      generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, zeroReg, zeroReg, cg);
       // REPSTOSB fills rcx bytes at [rdi] with al
       // rcx = allocEndReg - leafArrReg
       // rdi = leafArrReg
+      // eax = zeroReg
       generateRegRegInstruction(TR::InstOpCode::SUB8RegReg, node, allocEndReg, leafArrReg, cg);
       generateInstruction(TR::InstOpCode::REPSTOSB, node, cg);
       cg->stopUsingRegister(zeroReg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1525,10 +1525,10 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
    // load dimensions and class
-   TR::Register *dimsPtrReg = cg->longClobberEvaluate(sizeArrNode);
+   TR::Register *dimsPtrReg = cg->evaluate(sizeArrNode);
    TR::Register *secondDimLenReg = cg->allocateRegister();
    TR::Register *classReg = cg->longClobberEvaluate(classNode);
-   TR::Register *firstDimLenReg = dimsPtrReg;
+   TR::Register *firstDimLenReg = cg->allocateRegister();
 
    generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, secondDimLenReg, generateX86MemoryReference(dimsPtrReg, 0, cg), cg);
    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg, generateX86MemoryReference(dimsPtrReg, 4, cg), cg);
@@ -1652,8 +1652,9 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    generateLabelInstruction(TR::InstOpCode::label, node, loopBottom, cg);
 
-   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 9, cg);
+   TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 10, cg);
 
+   deps->addPostCondition(dimsPtrReg, TR::RealRegister::NoReg, cg);
    deps->addPostCondition(firstDimLenReg, TR::RealRegister::NoReg, cg);
    deps->addPostCondition(secondDimLenReg, TR::RealRegister::NoReg, cg);
    deps->addPostCondition(classReg, TR::RealRegister::NoReg, cg);
@@ -1701,6 +1702,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, targetReg, spineArrReg, deps2, cg);
    cg->stopUsingRegister(spineArrReg);
 
+   cg->stopUsingRegister(dimsPtrReg);
    cg->stopUsingRegister(firstDimLenReg);
    cg->stopUsingRegister(secondDimLenReg);
    cg->stopUsingRegister(classReg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1570,7 +1570,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    // calculate start of first leaf array
    TR::Register *leafArrReg = cg->allocateRegister();
-   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafArrReg, generateX86MemoryReference(spineArrReg, spineSizeReg, cg), cg);
+   generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, leafArrReg, generateX86MemoryReference(spineArrReg, spineSizeReg, 0, cg), cg);
 
    // calculate end of allocation = first leaf array address + (first dimension * size of leaf array) - leaf padding bytes
    TR::Register *allocEndReg = cg->allocateRegister();
@@ -1588,7 +1588,7 @@ static TR::Register * generate2DArrayWithInlineAllocators(TR::Node *node, TR::Co
 
    TR::LabelSymbol *startControlFlow = generateLabelSymbol(cg);
    generateLabelInstruction(TR::InstOpCode::label, node, startControlFlow, cg);
-   startControlFlow->setStartInternalControlFlow(cg);
+   startControlFlow->setStartInternalControlFlow();
 
    TR::LabelSymbol *oolJumpPoint = generateLabelSymbol(cg);
    generateLabelInstruction(TR::InstOpCode::JA4, node, oolJumpPoint, cg);


### PR DESCRIPTION
Currently `multianewarray` is only implemented on x86 for 2D arrays with zero first or second dimension, otherwise calling out to a VM helper. This PR adds logic to do allocation and initialisation inline for nonzero 2D arrays.