### PR TITLE
Improve Java preprocessor

### DIFF
--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
@@ -99,12 +99,15 @@ public class JavaPreprocessor {
 		 */
 		static final int ELSE_INACTIVE = 4;
 
+		final int ifLineNumber;
+
 		final boolean outerActive;
 
 		int state;
 
-		IfState(boolean active, Stack<IfState> stack) {
+		IfState(int ifLineNumber, boolean active, Stack<IfState> stack) {
 			super();
+			this.ifLineNumber = ifLineNumber;
 			this.outerActive = stack.isEmpty() || stack.peek().isActive();
 			this.state = active ? IF_ACTIVE : IF_INACTIVE;
 		}
@@ -552,7 +555,7 @@ public class JavaPreprocessor {
 			}
 		}
 
-		IfState top = new IfState(satisfied, ifResults);
+		IfState top = new IfState(lineCount, satisfied, ifResults);
 
 		ifResults.push(top);
 		echo = top.isActive();
@@ -1969,6 +1972,10 @@ public class JavaPreprocessor {
 			}
 		} else if (shouldInclude && !foundCopyright) {
 			warning("No copyright");
+		}
+
+		if (!ifResults.empty()) {
+			error("Missing ENDIF for IF on line " + ifResults.peek().ifLineNumber);
 		}
 
 		if (shouldInclude) {


### PR DESCRIPTION
Detect missing `[ENDIF]` directives, referring to the unmatched `[IF]` line.

With this change, situations like https://github.com/eclipse-openj9/openj9/pull/22564#discussion_r2331176372 will be discovered automatically.