### PR TITLE
0.56: Update border frequencies under server inlining

### DIFF
--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -1157,8 +1157,14 @@ void TR_InlinerBase::getBorderFrequencies(int32_t &hotBorderFrequency, int32_t &
       {
       if (comp()->isServerInlining())
          {
-         hotBorderFrequency = 2000;
-         coldBorderFrequency = 50;
+         hotBorderFrequency = 500;
+         coldBorderFrequency = 500;
+
+         // Did the user specify specific values? If so, use those
+         if (comp()->getOptions()->getServerInlinerBorderFrequency() >= 0)
+            hotBorderFrequency = comp()->getOptions()->getServerInlinerBorderFrequency();
+         if (comp()->getOptions()->getServerInlinerVeryColdBorderFrequency() >= 0)
+            coldBorderFrequency = comp()->getOptions()->getServerInlinerVeryColdBorderFrequency();
          }
       else
          {


### PR DESCRIPTION
This change has been shown to help improve throughput without impacting rampup.

Cherry-pick of https://github.com/eclipse-openj9/openj9/pull/22561