### PR TITLE
Invokeinterface error handling for abstract method resolution

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8310,6 +8310,14 @@ foundITableCache:
 						rc = GOTO_THROW_CURRENT_EXCEPTION;
 						goto done;
 					}
+					if (J9_ARE_ALL_BITS_SET(romMethod->modifiers, J9AccAbstract)) {
+						/* If resulting method is abstract an error will be
+						 * thrown in throwUnsatisfiedLinkOrAbstractMethodError.
+						 * Return the interface class's method so the correct
+						 * exception handling is used.
+						 */
+						_sendMethod = interfaceClass->ramMethods + methodIndex;
+					}
 					profileInvokeReceiver(REGISTER_ARGS, receiverClass, _literals, _sendMethod);
 					_pc += offset;
 					goto done;


### PR DESCRIPTION
If invokeinterface resolves an abstract method _sendMethod should be the interface's method. This ensures the correct error handling logic is used by
throwUnsatisfiedLinkOrAbstractMethodError.

Fixes: https://github.com/eclipse-openj9/openj9/issues/22157

With this change the output in the test from https://github.com/eclipse-openj9/openj9/issues/22157 is:
```
Exception in thread "main" java.lang.IllegalAccessError: P0/C2.m()Ljava/lang/Integer;
	at P0.I0.test(Unknown Source)
	at P0.I0.main(Unknown Source)
```

invokeinterface tests:
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/54641/
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/54640/