### PR TITLE
Enable jitDispatchJ9Method for MethodHandles on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -4015,3 +4015,12 @@ bool J9::Z::CodeGenerator::supportsInliningOfIsAssignableFrom()
     static const bool disableInliningOfIsAssignableFrom = feGetEnv("TR_disableInlineIsAssignableFrom") != NULL;
     return !disableInliningOfIsAssignableFrom;
 }
+
+bool J9::Z::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
+{
+    if (symbol == TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol) {
+        return true;
+    }
+
+    return J9::CodeGenerator::supportsNonHelper(symbol);
+}

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -328,6 +328,9 @@ public:
     // See J9::CodeGenerator::guaranteesResolvedDirectDispatchForSVM
     bool guaranteesResolvedDirectDispatchForSVM() { return true; }
 
+    // See OMR::CodeGenerator::supportsNonHelper
+    bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
+
 private:
     /** \brief
      *     Determines whether decimal overflow or fixed point overflow checks should be generated for instructions which

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.cpp
@@ -88,7 +88,7 @@ uint8_t *TR::S390J9CallSnippet::generateVIThunk(TR::Node *callNode, int32_t argS
                 comp->getDebug()->getName(callNode->getDataType()));
     }
 
-    cursor = S390flushArgumentsToStack(cursor, callNode, argSize, cg);
+    cursor = S390FlushArgumentsToStack(cursor, callNode, argSize, cg);
 
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     //  if you change the following code,
@@ -172,7 +172,7 @@ TR_MHJ2IThunk *TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node *call
                 comp->getDebug()->getName(callNode->getDataType()));
     }
 
-    cursor = S390flushArgumentsToStack(cursor, callNode, argSize, cg);
+    cursor = S390FlushArgumentsToStack(cursor, callNode, argSize, cg);
 
     // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
     //  if you change the following code,
@@ -242,6 +242,24 @@ TR_MHJ2IThunk *TR::S390J9CallSnippet::generateInvokeExactJ2IThunk(TR::Node *call
     return thunk;
 }
 
+uint8_t *TR::S390J9CallSnippet::S390FlushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+    TR::CodeGenerator *cg)
+{
+    TR::Linkage *linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
+
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(cg->comp());
+    int32_t argStart = callNode->getFirstArgumentIndex();
+    // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
+    bool rightToLeft = linkage->getRightToLeft() && !callNode->getSymbolReference()->isOSRInductionHelper()
+        && !isJitDispatchJ9Method;
+
+    if (isJitDispatchJ9Method) {
+        argStart++;
+    }
+
+    return S390FlushArgumentsToStackHelper(buffer, callNode, argSize, cg, argStart, rightToLeft, linkage);
+}
+
 uint8_t *TR::S390J9CallSnippet::emitSnippetBody()
 {
     TR::Compilation *comp = cg()->comp();
@@ -259,7 +277,7 @@ uint8_t *TR::S390J9CallSnippet::emitSnippetBody()
     getSnippetLabel()->setCodeLocation(cursor);
 
     // Flush in-register arguments back to the stack for interpreter
-    cursor = S390flushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
+    cursor = S390FlushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
 
     TR_RuntimeHelper runtimeHelper = getInterpretedDispatchHelper(methodSymRef, callNode->getDataType());
     TR::SymbolReference *glueRef = cg()->symRefTab()->findOrCreateRuntimeHelper(runtimeHelper);
@@ -505,7 +523,8 @@ void TR::S390J9CallSnippet::print(OMR::Logger *log, TR_Debug *debug)
     debug->printSnippetLabel(log, getSnippetLabel(), bufferPos,
         methodSymRef->isUnresolved() ? "Unresolved Call Snippet" : "Call Snippet");
 
-    bufferPos = debug->printS390ArgumentsFlush(log, callNode, bufferPos, getSizeOfArguments());
+    bufferPos = TR::S390CallSnippet::printS390ArgumentsFlush(log, callNode, bufferPos, getSizeOfArguments(), debug,
+        getNode()->getFirstArgumentIndex(), cg()->machine(), cg()->getLinkage(methodSymbol->getLinkageConvention()));
 
     if (methodSymRef->isUnresolved()
         || (cg()->comp()->compileRelocatableCode() && !cg()->comp()->getOption(TR_UseSymbolValidationManager))) {
@@ -1635,4 +1654,84 @@ void TR::S390JNICallDataSnippet::print(OMR::Logger *log, TR_Debug *debug)
     debug->printPrefix(log, NULL, bufferPos, sizeof(intptr_t));
     log->printf("DC   \t%p \t\t# targetAddress", *((intptr_t *)bufferPos));
     bufferPos += sizeof(intptr_t);
+}
+
+uint8_t *TR::S390J9HelperCallSnippet::emitSnippetBody()
+{
+    uint8_t *cursor = cg()->getBinaryBufferCursor();
+    getSnippetLabel()->setCodeLocation(cursor);
+
+    TR::Node *callNode = getNode();
+    TR::SymbolReference *helperSymRef = getHelperSymRef();
+    bool jitInduceOSR = helperSymRef->isOSRInductionHelper();
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(cg()->comp());
+
+    if (_needsArgFlush)
+        cursor = TR::S390J9CallSnippet::S390FlushArgumentsToStack(cursor, callNode, getSizeOfArguments(), cg());
+
+    /* The J9Method pointer to be passed to be interpreter is in the entry point register, but the interpreter expects
+     * it to be in R1. Since the first integer argument register is also R1, we only load it after we have flushed the
+     * args to the stack.
+     */
+    uint32_t rEP = (uint32_t)cg()->getEntryPointRegister() - 1;
+    if (getNode()->isJitDispatchJ9MethodCall(comp())) {
+        bool is64Bit = comp()->target().is64Bit();
+
+        if (comp()->target().is64Bit()) {
+            *(int32_t *)cursor = 0xB9040010 + rEP; // LGR R1, R4/15
+            cursor += sizeof(int32_t);
+        } else {
+            *(int16_t *)cursor = (int16_t)(0x1810 + rEP); // LR R1, R4/15
+            cursor += sizeof(int16_t);
+        }
+    }
+
+    return TR::S390HelperCallSnippet::emitSnippetBodyInner(cursor, helperSymRef);
+}
+
+void TR::S390J9HelperCallSnippet::print(OMR::Logger *log, TR_Debug *debug)
+{
+    if (log == NULL) {
+        return;
+    }
+
+    TR::SymbolReference *helperSymRef = getHelperSymRef();
+
+    uint8_t *bufferPos = getSnippetLabel()->getCodeLocation();
+    debug->printSnippetLabel(log, getSnippetLabel(), bufferPos, "Helper Call Snippet", debug->getName(helperSymRef));
+
+    TR::Node *callNode = getNode();
+    TR::MethodSymbol *methodSymbol = callNode->getSymbol()->castToMethodSymbol();
+    TR::Linkage *privateLinkage = cg()->getLinkage(methodSymbol->getLinkageConvention());
+    TR::Machine *machine = cg()->machine();
+    int32_t argStart = callNode->getFirstArgumentIndex() + (callNode->isJitDispatchJ9MethodCall(comp()) ? 1 : 0);
+
+    if (_needsArgFlush)
+        bufferPos = TR::S390CallSnippet::printS390ArgumentsFlush(log, getNode(), bufferPos, getSizeOfArguments(), debug,
+            argStart, cg()->machine(), privateLinkage);
+
+    if (getNode()->isJitDispatchJ9MethodCall(comp())) {
+        debug->printPrefix(log, NULL, bufferPos, comp()->target().is64Bit() ? 4 : 2);
+        log->printf("%s  \t%s,%s \t %s", comp()->target().is64Bit() ? "LGR" : "LR", "R1",
+            comp()->target().isLinux() ? "R4" : "R15", "move j9method pointer to R1 for interpreter");
+        bufferPos += comp()->target().is64Bit() ? 4 : 2;
+    }
+    printInner(log, debug, bufferPos);
+}
+
+uint32_t TR::S390J9HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
+{
+    uint32_t length = _needsArgFlush ? TR::S390J9CallSnippet::instructionCountForArguments(getNode(), cg()) : 0;
+    if (getNode()->isJitDispatchJ9MethodCall(comp())) {
+        length += comp()->target().is64Bit() ? 4 : 2; // register move
+    }
+    return length + TR::S390HelperCallSnippet::getLength(length + estimatedSnippetStart);
+}
+
+int32_t TR::S390J9CallSnippet::instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg)
+{
+    int32_t argStart = callNode->getFirstArgumentIndex();
+    if (callNode->isJitDispatchJ9MethodCall(comp()))
+        argStart += 1;
+    return TR::S390CallSnippet::instructionCountForArgumentsInner(callNode, cg, argStart);
 }

--- a/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
+++ b/runtime/compiler/z/codegen/S390J9CallSnippet.hpp
@@ -25,6 +25,7 @@
 
 #include "z/codegen/CallSnippet.hpp"
 #include "z/codegen/ConstantDataSnippet.hpp"
+#include "z/codegen/S390HelperCallSnippet.hpp"
 #include "z/codegen/S390Instruction.hpp"
 
 class TR_MHJ2IThunk;
@@ -64,6 +65,10 @@ public:
     virtual void print(OMR::Logger *log, TR_Debug *debug);
 
     virtual uint8_t *emitSnippetBody();
+
+    static uint8_t *S390FlushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+        TR::CodeGenerator *cg);
+    static int32_t instructionCountForArguments(TR::Node *, TR::CodeGenerator *);
 };
 
 class S390UnresolvedCallSnippet : public TR::S390J9CallSnippet {
@@ -275,6 +280,31 @@ public:
     virtual uint32_t getLength(int32_t estimatedSnippetStart);
     virtual uint8_t *emitSnippetBody();
 };
+
+/**
+ * @brief A helper-call snippet that has access to J9-specific methods
+ *
+ * Calls the given helper, optionally flushes the given node's arguments to the stack.
+ *
+ * For the case of jitDispatchJ9Method, moves the J9Method pointer in GPR4/GPR15 to GPR1 after flushing the args to the
+ * stack so it is where the interpreter expects it to be.
+ */
+class S390J9HelperCallSnippet : public TR::S390HelperCallSnippet {
+public:
+    S390J9HelperCallSnippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *snippetlab,
+        TR::SymbolReference *helper, TR::LabelSymbol *restartlab = NULL, int32_t s = 0, bool needsArgFlush = false)
+        : TR::S390HelperCallSnippet(cg, node, snippetlab, helper, restartlab, s)
+        , _needsArgFlush(needsArgFlush)
+    {}
+
+    virtual uint8_t *emitSnippetBody();
+    virtual void print(OMR::Logger *log, TR_Debug *);
+    virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+private:
+    bool _needsArgFlush;
+};
+
 } // namespace TR
 
 #endif

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -118,7 +118,7 @@ J9::Z::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *codeGen, TR_LinkageConv
     setReturnAddressRegister(TR::RealRegister::GPR14);
 
     setVTableIndexArgumentRegister(TR::RealRegister::GPR0);
-    setJ9MethodArgumentRegister(TR::RealRegister::GPR1);
+    setJ9MethodArgumentRegister(comp()->target().isLinux() ? TR::RealRegister::GPR4 : TR::RealRegister::GPR15);
 
     setLitPoolRegister(TR::RealRegister::GPR6);
     setMethodMetaDataRegister(TR::RealRegister::GPR13);
@@ -2368,6 +2368,7 @@ TR::Instruction *J9::Z::PrivateLinkage::buildDirectCall(TR::Node *callNode, TR::
     TR_ResolvedMethod *fem = (sym == NULL) ? NULL : sym->getResolvedMethod();
     bool myself;
     bool isJitInduceOSR = callSymRef->isOSRInductionHelper();
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp());
     myself = comp()->isRecursiveMethodTarget(fem);
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
@@ -2379,7 +2380,7 @@ TR::Instruction *J9::Z::PrivateLinkage::buildDirectCall(TR::Node *callNode, TR::
     if (comp()->getOption(TR_EnableRMODE64))
 #endif
     {
-        if (callSymRef->getReferenceNumber() >= TR_S390numRuntimeHelpers) {
+        if ((callSymRef->getReferenceNumber() >= TR_S390numRuntimeHelpers) && !isJitDispatchJ9Method) {
             fej9->reserveTrampolineIfNecessary(comp(), callSymRef, false);
         }
     }
@@ -2413,6 +2414,77 @@ TR::Instruction *J9::Z::PrivateLinkage::buildDirectCall(TR::Node *callNode, TR::
         gcPoint->setNeedsGCMap(getPreservedRegisterMapForGC());
 
         return gcPoint;
+    }
+
+    if (isJitDispatchJ9Method) {
+        TR::Register *j9MethodReg = dependencies->searchPreConditionRegister(getJ9MethodArgumentRegister());
+        TR::Register *scratchReg = dependencies->searchPostConditionRegister(getVTableIndexArgumentRegister());
+
+        TR::LabelSymbol *interpreterCallLabel = generateLabelSymbol(cg());
+        TR::LabelSymbol *OOLReturnLabel = generateLabelSymbol(cg());
+        TR::LabelSymbol *doneLabel = generateLabelSymbol(cg());
+        TR::LabelSymbol *startICFLabel = generateLabelSymbol(cg());
+        startICFLabel->setStartInternalControlFlow();
+        doneLabel->setEndInternalControlFlow();
+
+        TR::RegisterDependencyConditions *preDeps = new (trHeapMemory()) TR::RegisterDependencyConditions(
+            dependencies->getPreConditions(), NULL, dependencies->getAddCursorForPre(), 0, cg());
+
+        TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
+        TR::SymbolReference *helperRef
+            = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, true, true, false);
+        TR::Snippet *snippet = new (trHeapMemory())
+            TR::S390J9HelperCallSnippet(cg(), callNode, snippetLabel, helperRef, doneLabel, argSize, true);
+        snippet->gcMap().setGCRegisterMask(getPreservedRegisterMapForGC());
+        cg()->addSnippet(snippet);
+        TR::SymbolReference *labelSymRef
+            = new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), snippetLabel);
+
+        TR_S390OutOfLineCodeSection *snippetCall
+            = new (cg()->trHeapMemory()) TR_S390OutOfLineCodeSection(interpreterCallLabel, doneLabel, cg());
+        cg()->getS390OutOfLineCodeSectionList().push_front(snippetCall);
+        snippetCall->swapInstructionListsWithCompilation();
+        generateS390LabelInstruction(cg(), TR::InstOpCode::label, callNode, interpreterCallLabel);
+        gcPoint = generateS390BranchInstruction(cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, callNode,
+            snippetLabel);
+        gcPoint->setNeedsGCMap(getPreservedRegisterMapForGC());
+        gcPoint = new (trHeapMemory()) TR::S390NOPInstruction(TR::InstOpCode::NOP, 2, callNode, cg());
+        gcPoint
+            = generateS390BranchInstruction(cg(), TR::InstOpCode::BRC, TR::InstOpCode::COND_BRC, callNode, doneLabel);
+
+        gcPoint->setNeedsGCMap(getPreservedRegisterMapForGC());
+        snippetCall->swapInstructionListsWithCompilation();
+
+        generateS390LabelInstruction(cg(), TR::InstOpCode::label, callNode, startICFLabel, preDeps);
+        // fetch J9Method::extra field
+        generateRXInstruction(cg(), TR::InstOpCode::getLoadOpCode(), callNode, scratchReg,
+            generateS390MemoryReference(j9MethodReg, offsetof(J9Method, extra), cg()));
+        // test J9Method::extra - if 1 then target is not compiled yet
+        generateRIInstruction(cg(), TR::InstOpCode::TMLL, callNode, scratchReg, J9_STARTPC_NOT_TRANSLATED);
+
+        // always go through j2iTransition if stressJitDispatchJ9MethodJ2I is set
+        TR::InstOpCode::S390BranchCondition oolBranchOp
+            = cg()->stressJitDispatchJ9MethodJ2I() ? TR::InstOpCode::COND_BRC : TR::InstOpCode::COND_MASK1;
+
+        gcPoint = generateS390BranchInstruction(cg(), TR::InstOpCode::BRC, oolBranchOp, callNode, interpreterCallLabel);
+        gcPoint->setNeedsGCMap(getPreservedRegisterMapForGC());
+
+        // find target address
+        gcPoint = generateRXInstruction(cg(), TR::InstOpCode::LY, callNode, j9MethodReg,
+            generateS390MemoryReference(scratchReg, -4, cg()));
+        gcPoint = generateRSInstruction(cg(), TR::InstOpCode::SRA, callNode, j9MethodReg, 16);
+
+        if (comp()->target().is64Bit()) {
+            gcPoint = generateRREInstruction(cg(), TR::InstOpCode::LGFR, callNode, j9MethodReg, j9MethodReg);
+        }
+
+        generateRRInstruction(cg(), TR::InstOpCode::getAddRegOpCode(), callNode, scratchReg, j9MethodReg);
+        TR::Register *regRA = dependencies->searchPostConditionRegister(getReturnAddressRegister());
+        gcPoint = generateRRInstruction(cg(), TR::InstOpCode::BASR, callNode, regRA, scratchReg);
+
+        gcPoint->setNeedsGCMap(getPreservedRegisterMapForGC());
+
+        return generateS390LabelInstruction(cg(), TR::InstOpCode::label, callNode, doneLabel, dependencies);
     }
 
     if (!callSymRef->isUnresolved() && !callSymbol->isInterpreted()
@@ -3213,6 +3285,10 @@ void J9::Z::PrivateLinkage::addSpecialRegDepsForBuildArgs(TR::Node *callNode,
             break;
     }
 
+    if (callNode->isJitDispatchJ9MethodCall(comp())) {
+        specialArgReg = getJ9MethodArgumentRegister();
+    }
+
     if (specialArgReg != TR::RealRegister::NoReg) {
         child = callNode->getChild(from);
         TR::Register *specialArg = copyArgRegister(callNode, child,
@@ -3220,6 +3296,7 @@ void J9::Z::PrivateLinkage::addSpecialRegDepsForBuildArgs(TR::Node *callNode,
         if (specialArg->getRegisterPair())
             specialArg = specialArg->getLowOrder(); // on 31-bit, the top half doesn't matter, so discard it
         dependencies->addPreCondition(specialArg, specialArgReg);
+
         cg()->decReferenceCount(child);
 
         logprintf(comp()->getOption(TR_TraceCG), comp()->log(), "Special arg %s %s reg %s in %s\n",
@@ -3297,8 +3374,9 @@ TR::Register *J9::Z::PrivateLinkage::buildDirectDispatch(TR::Node *callNode)
         getNumberOfDependencyGPRegisters(), getNumberOfDependencyGPRegisters(), cg());
 
     // setup arguments
-    argSize = buildArgs(callNode, dependencies, false, -1, vftReg);
-
+    // force left to right for jitDispatchJ9Method
+    bool passArgsRightToLeft = callNode->isJitDispatchJ9MethodCall(comp()) ? false : true;
+    argSize = buildArgs(callNode, dependencies, false, -1, vftReg, true, passArgsRightToLeft);
     buildDirectCall(callNode, callSymRef, dependencies, argSize);
 
     // set dependency on return register


### PR DESCRIPTION
Add support for jitDispatchJ9Method for MethodHandles on Z

- adds new call snippet S390J9HelperCallSnippet which adds a load
  instruction to load the J9Method pointer into GPR1 before generating a
  normal S390HelperCallSnippet
- adds an override of S390flushArgumentsToStack to handle special case
  for jitDispatchJ9Method where the first child is ignored
- modifies addSpecialRegDepsForBuildArgs to check for the special method
  and set the register dependency

Only merge after https://github.com/eclipse-omr/omr/pull/7930