### PR TITLE
Add flags to the functions of class hash table

### DIFF
--- a/runtime/bcutil/ROMClassCreationContext.hpp
+++ b/runtime/bcutil/ROMClassCreationContext.hpp
@@ -455,7 +455,7 @@ public:
 				}
 			} else { /* classname is null */
 				/* If a name was not provided with the load data, now is our first chance to check for a duplicate definition */
-				if ((NULL != _javaVM) && (NULL != J9_VM_FUNCTION_VIA_JAVAVM(_javaVM, hashClassTableAt)(_classLoader, className, classNameLength))) {
+				if ((NULL != _javaVM) && (NULL != J9_VM_FUNCTION_VIA_JAVAVM(_javaVM, hashClassTableAt)(_classLoader, className, classNameLength, 0))) {
 					PORT_ACCESS_FROM_PORT(_portLibrary);
 					U_8 *errorUTF = (U_8 *) j9mem_allocate_memory(classNameLength + 1, J9MEM_CATEGORY_CLASSES);
 					if (NULL != errorUTF) {

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -272,7 +272,8 @@ checkForExistingClass(J9VMThread* vmThread, J9LoadROMClassData * loadData)
 	existingClass = J9_VM_FUNCTION(vmThread, hashClassTableAt)(
 		loadData->classLoader,
 		loadData->className,
-		loadData->classNameLength);
+		loadData->classNameLength,
+		0);
 
 	if (existingClass != NULL) {
 		/* error! a class with this name is already loaded in this class loader */

--- a/runtime/bcverify/classrelationships.c
+++ b/runtime/bcverify/classrelationships.c
@@ -192,7 +192,7 @@ j9bcv_validateClassRelationships(J9VMThread *vmThread, J9ClassLoader *classLoade
 
 	while (NULL != parentNode) {
 		/* Find the parent class in the loaded classes table */
-		parentClass = J9_VM_FUNCTION(vmThread, hashClassTableAt)(classLoader, parentNode->className, parentNode->classNameLength);
+		parentClass = J9_VM_FUNCTION(vmThread, hashClassTableAt)(classLoader, parentNode->className, parentNode->classNameLength, 0);
 
 		/* If the parent class has not been loaded, then it has to be an interface since the child is already loaded */
 		if (NULL == parentClass) {

--- a/runtime/bcverify/clconstraints.c
+++ b/runtime/bcverify/clconstraints.c
@@ -131,8 +131,8 @@ j9bcv_checkClassLoadingConstraintForName (J9VMThread *vmThread, J9ClassLoader *l
 	Assert_RTV_validateClassLoadingConstraints(vmThread, loader1, loader2, name1, name2, length);
 
 	/* peek at the class tables to see if the class has been loaded yet */
-	class1 = vmFuncs->hashClassTableAt (loader1, name1, length);
-	class2 = vmFuncs->hashClassTableAt (loader2, name2, length);
+	class1 = vmFuncs->hashClassTableAt (loader1, name1, length, 0);
+	class2 = vmFuncs->hashClassTableAt (loader2, name2, length, 0);
 
 	if (class1 && class2) {
 		if (class1 != class2) {

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -69,7 +69,7 @@ j9rtv_verifierGetRAMClass( J9BytecodeVerificationData *verifyData, J9ClassLoader
 
 	/* Sniff the class table to see if already loaded */
 	Trc_RTV_j9rtv_verifierGetRAMClass_Entry(verifyData->vmStruct, classLoader, nameLength, className);
-	found = vm->internalVMFunctions->hashClassTableAt (classLoader, className, nameLength);
+	found = vm->internalVMFunctions->hashClassTableAt (classLoader, className, nameLength, 0);
 
 #ifdef J9VM_THR_PREEMPTIVE
 	threadEnv->monitor_exit(vm->classTableMutex);

--- a/runtime/j9vm/j7vmi.c
+++ b/runtime/j9vm/j7vmi.c
@@ -2587,7 +2587,7 @@ retry:
 
 	threadEnv->monitor_enter(vm->classTableMutex);
 
-	if (vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length) != NULL) {
+	if (NULL != vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length, 0)) {
 		/* Bad, we have already defined this class - fail */
 		threadEnv->monitor_exit(vm->classTableMutex);
 		vmFuncs->setCurrentExceptionNLSWithArgs(currentThread, J9NLS_JCL_DUPLICATE_CLASS_DEFINITION, J9VMCONSTANTPOOL_JAVALANGLINKAGEERROR, utf8Length, utf8Name);

--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -156,7 +156,7 @@ retry:
 	omrthread_monitor_enter(vm->classTableMutex);
 	/* Hidden class is never added into the hash table */
 	if ((NULL != utf8Name) && J9_ARE_NO_BITS_SET(*options, J9_FINDCLASS_FLAG_HIDDEN)) {
-		if (NULL != vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length)) {
+		if (NULL != vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length, 0)) {
 			/* Bad, we have already defined this class - fail */
 			omrthread_monitor_exit(vm->classTableMutex);
 			if (J9_ARE_NO_BITS_SET(*options, J9_FINDCLASS_FLAG_NAME_IS_INVALID)) {
@@ -165,7 +165,7 @@ retry:
 				 */
 #if defined(J9VM_OPT_SNAPSHOTS)
 				if (IS_RESTORE_RUN(vm)) {
-					clazz = vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length);
+					clazz = vmFuncs->hashClassTableAt(classLoader, utf8Name, utf8Length, 0);
 
 					if (!vmFuncs->loadWarmClassFromSnapshot(currentThread, classLoader, clazz)) {
 						clazz = NULL;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5029,7 +5029,7 @@ typedef struct J9InternalVMFunctions {
 	struct J9Class*  ( *internalFindClassUTF8)(struct J9VMThread *currentThread, U_8 *className, UDATA classNameLength, struct J9ClassLoader *classLoader, UDATA options) ;
 	struct J9Class*  ( *internalFindClassInModule)(struct J9VMThread *currentThread, struct J9Module *j9module, U_8 *className, UDATA classNameLength, struct J9ClassLoader *classLoader, UDATA options) ;
 	struct J9Class*  ( *internalFindClassString)(struct J9VMThread* currentThread, j9object_t moduleName, j9object_t className, struct J9ClassLoader* classLoader, UDATA options, UDATA allowedBitsForClassName) ;
-	struct J9Class*  ( *hashClassTableAt)(struct J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength) ;
+	struct J9Class*  ( *hashClassTableAt)(struct J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength, UDATA flags) ;
 	UDATA  ( *hashClassTableAtPut)(struct J9VMThread *vmThread, struct J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength, struct J9Class *value) ;
 	UDATA  ( *hashClassTableDelete)(struct J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength) ;
 	void  ( *hashClassTableReplace)(struct J9VMThread* vmThread, struct J9ClassLoader *classLoader, struct J9Class *originalClass, struct J9Class *replacementClass) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -2171,20 +2171,22 @@ hashClassTableFree(J9ClassLoader* classLoader);
 * @param *classLoader
 * @param *className
 * @param classNameLength
+* @param flags
 * @return J9Class *
 */
 J9Class *
-hashClassTableAt(J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength);
+hashClassTableAt(J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength, UDATA flags);
 
 
 /**
 * @brief
 * @param *classLoader
 * @param stringObject
+* @param flags
 * @return J9Class *
 */
 J9Class *
-hashClassTableAtString(J9ClassLoader *classLoader, j9object_t stringObject);
+hashClassTableAtString(J9ClassLoader *classLoader, j9object_t stringObject, UDATA flags);
 
 
 /**

--- a/runtime/sunvmi/sunvmi.c
+++ b/runtime/sunvmi/sunvmi.c
@@ -868,7 +868,7 @@ JVM_GetSystemPackage_Impl(JNIEnv *env, jstring pkgName)
 	if (NULL != idEntry) {
 		J9ROMClass *resultROMClass = (J9ROMClass *)(idEntry->taggedROMClass & ~(UDATA)(J9PACKAGE_ID_TAG | J9PACKAGE_ID_GENERATED));
 		J9UTF8 *className = J9ROMCLASS_CLASSNAME(resultROMClass);
-		clazz = funcs->hashClassTableAt(vm->systemClassLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+		clazz = funcs->hashClassTableAt(vm->systemClassLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className), 0);
 	}
 	VM.monitorExit(vm->classTableMutex);
 

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2527,7 +2527,7 @@ fixNestMembers(J9VMThread * currentThread, J9HashTable * classPairs)
 
 			for (i = 0; i < nestMemberCount; i++) {
 				J9UTF8 *nestMemberName = NNSRP_GET(nestMembers[i], J9UTF8*);
-				J9Class *nestMember = vmFuncs->hashClassTableAt(classLoader, J9UTF8_DATA(nestMemberName), J9UTF8_LENGTH(nestMemberName));
+				J9Class *nestMember = vmFuncs->hashClassTableAt(classLoader, J9UTF8_DATA(nestMemberName), J9UTF8_LENGTH(nestMemberName), 0);
 				if (NULL != nestMember) {
 					if (nestMember->nestHost == originalRAMClass) {
 						nestMember->nestHost = replacementRAMClass;

--- a/runtime/util/resolvehelp.c
+++ b/runtime/util/resolvehelp.c
@@ -125,7 +125,7 @@ isDirectSuperInterface(J9VMThread *vmStruct, J9Class *resolvedClass, J9Class *cu
 			J9Class *interfaceClass = NULL;
 			J9UTF8 *interfaceName = NNSRP_GET(interfaceNames[i], J9UTF8*);
 			omrthread_monitor_enter(vm->classTableMutex);
-			interfaceClass = vm->internalVMFunctions->hashClassTableAt(resolvedClass->classLoader, J9UTF8_DATA(interfaceName), J9UTF8_LENGTH(interfaceName));
+			interfaceClass = vm->internalVMFunctions->hashClassTableAt(resolvedClass->classLoader, J9UTF8_DATA(interfaceName), J9UTF8_LENGTH(interfaceName), 0);
 			omrthread_monitor_exit(vm->classTableMutex);
 			if (interfaceClass == resolvedClass) {
 				/* Found resolvedClass in the currentClass ROMClass interface list */

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -333,7 +333,7 @@ hashClassTableNew(J9JavaVM *javaVM, U_32 initialSize)
 }
 
 J9Class *
-hashClassTableAt(J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength)
+hashClassTableAt(J9ClassLoader *classLoader, U_8 *className, UDATA classNameLength, UDATA flags)
 {
 	J9HashTable *table = classLoader->classHashTable;
 	KeyHashTableClassQueryEntry key;
@@ -733,7 +733,7 @@ hashPkgTableNextDo(J9HashTableState *walkState)
 }
 
 J9Class *
-hashClassTableAtString(J9ClassLoader *classLoader, j9object_t stringObject)
+hashClassTableAtString(J9ClassLoader *classLoader, j9object_t stringObject, UDATA flags)
 {
 	J9HashTable *table = classLoader->classHashTable;
 	KeyHashTableClassQueryEntry key;
@@ -818,7 +818,7 @@ addLocationGeneratedClass(J9VMThread *vmThread, J9ClassLoader *classLoader, KeyH
 	J9UTF8 *className = J9ROMCLASS_CLASSNAME(resultROMClass);
 	J9Class *clazz = NULL;
 
-	clazz = funcs->hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+	clazz = funcs->hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className), 0);
 	if (NULL != clazz) {
 		J9ClassLocation *classLocation = NULL;
 		J9ClassLocation newLocation = {0};

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -306,7 +306,7 @@ peekClassHashTable(J9VMThread* currentThread, J9ClassLoader* classLoader, U_8* c
 	if (!fastMode) {
 		omrthread_monitor_enter(vm->classTableMutex);
 	}
-	ramClass = hashClassTableAt(classLoader, className, classNameLength);
+	ramClass = hashClassTableAt(classLoader, className, classNameLength, 0);
 	if (!fastMode) {
 		omrthread_monitor_exit(vm->classTableMutex);
 	}
@@ -324,7 +324,7 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 	if (!fastMode) {
 		omrthread_monitor_enter(vm->classTableMutex);
 	}
-	result = hashClassTableAtString(classLoader, (j9object_t) className);
+	result = hashClassTableAtString(classLoader, (j9object_t) className, 0);
 #if defined(J9VM_OPT_SNAPSHOTS)
 	if ((NULL != result) && IS_RESTORE_RUN(vm)) {
 		if (!loadWarmClassFromSnapshot(currentThread, classLoader, result)) {
@@ -808,7 +808,7 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 			} else {
 				/* See if a class of this name is already in the table - if not, add it */
 
-				ramClass = hashClassTableAt(classLoader, className, classNameLength);
+				ramClass = hashClassTableAt(classLoader, className, classNameLength, 0);
 				if (NULL == ramClass) {
 					/* Ensure loading constraints have not been violated */
 
@@ -836,7 +836,7 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 
 						/* See if a class of this name is already in the table - if not, try the add again */
 
-						ramClass = hashClassTableAt(classLoader, className, classNameLength);
+						ramClass = hashClassTableAt(classLoader, className, classNameLength, 0);
 						if (NULL == ramClass) {
 							if (!hashClassTableAtPut(vmThread, classLoader, className, classNameLength, foundClass)) {
 								addedClassToInitiatingLoader = TRUE;
@@ -922,7 +922,7 @@ waitForContendedLoadClass(J9VMThread* vmThread, J9ContendedLoadTableEntry *table
 	} while ((status = tableEntry->status) == CLASSLOADING_LOAD_IN_PROGRESS);
 	/* still have classTableMutex here */
 	Trc_VM_waitForContendedLoadClass_waited(vmThread, vmThread, tableEntry->classLoader, classNameLength, className, status);
-	foundClass = hashClassTableAt(tableEntry->classLoader, className, classNameLength);
+	foundClass = hashClassTableAt(tableEntry->classLoader, className, classNameLength, 0);
 #if defined(J9VM_OPT_SNAPSHOTS)
 	if ((NULL != foundClass) && IS_RESTORE_RUN(vm)) {
 		if (!loadWarmClassFromSnapshot(vmThread, tableEntry->classLoader, foundClass)) {
@@ -1181,7 +1181,7 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 		omrthread_monitor_enter(vm->classTableMutex);
 	}
 
-	foundClass = hashClassTableAt(classLoader, className, classNameLength);
+	foundClass = hashClassTableAt(classLoader, className, classNameLength, 0);
 	if (NULL != foundClass) {
 #if defined(J9VM_OPT_SNAPSHOTS)
 		if (IS_RESTORE_RUN(vm)) {
@@ -1212,7 +1212,7 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 				omrthread_monitor_enter(vm->classTableMutex);
 
 				/* check again if somebody else already loaded the class */
-				foundClass = hashClassTableAt(classLoader, className, classNameLength);
+				foundClass = hashClassTableAt(classLoader, className, classNameLength, 0);
 				if (NULL != foundClass) {
 #if defined(J9VM_OPT_SNAPSHOTS)
 					if (IS_RESTORE_RUN(vm)

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -282,7 +282,7 @@ markInterfaces(J9ROMClass *romClass, J9Class *superclass, J9ClassLoader *classLo
 			J9ITable *iTable;
 			J9UTF8 *interfaceName = NNSRP_GET(interfaceNames[i], J9UTF8*);
 			/* peek the table, do not load */
-			J9Class *interfaceClass = hashClassTableAt(classLoader, J9UTF8_DATA(interfaceName), J9UTF8_LENGTH(interfaceName));
+			J9Class *interfaceClass = hashClassTableAt(classLoader, J9UTF8_DATA(interfaceName), J9UTF8_LENGTH(interfaceName), 0);
 			/* the interface classes are not NULL, as this was checked by the caller */
 			if ((foundCloneable != NULL) && (J9AccClassCloneable == (J9CLASS_FLAGS(interfaceClass) & J9AccClassCloneable))) {
 				*foundCloneable = TRUE;
@@ -2244,7 +2244,7 @@ internalCreateRAMClassDone(J9VMThread *vmThread, J9ClassLoader *classLoader, J9C
 
 			/* If the class was successfully loaded while we were GCing, use that one. */
 			if (elementClass == NULL) {
-				alreadyLoadedClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+				alreadyLoadedClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className), 0);
 			} else {
 				alreadyLoadedClass = getArrayClass(elementClass, options);
 			}
@@ -2451,7 +2451,7 @@ nativeOOM:
 				if (J9_ARE_NO_BITS_SET(options, J9_FINDCLASS_FLAG_HIDDEN)) {
 					/* If the class was successfully loaded while we were GCing, use that one */
 					if (elementClass == NULL) {
-						alreadyLoadedClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+						alreadyLoadedClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className), 0);
 					} else {
 						alreadyLoadedClass = getArrayClass(elementClass, options);
 					}
@@ -3038,7 +3038,7 @@ fail:
 
 	if (!hotswapping) {
 		if (elementClass == NULL) {
-			ramClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+			ramClass = hashClassTableAt(classLoader, J9UTF8_DATA(className), J9UTF8_LENGTH(className), 0);
 		} else {
 			ramClass = getArrayClass(elementClass, options);
 		}

--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -267,7 +267,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 		 * All ROMClasses from the SCC are owned by the bootstrap class loader. To minimize the chances to iterate all class loaders, probe
 		 * the booststrap loader, extensionClassLoader and application loader first to determine if they have the J9Class for the current class.
 		 */
-		ramClass = hashClassTableAt(*resultClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+		ramClass = hashClassTableAt(*resultClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName), 0);
 		if ((NULL != ramClass)
 			&& (romClass == ramClass->romClass)
 		) {
@@ -278,7 +278,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 			goto cacheresult;
 		}
 
-		ramClass = hashClassTableAt(vm->extensionClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+		ramClass = hashClassTableAt(vm->extensionClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName), 0);
 		if ((NULL != ramClass)
 			&& (romClass == ramClass->romClass)
 		) {
@@ -290,7 +290,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 			goto cacheresult;
 		}
 
-		ramClass = hashClassTableAt(vm->applicationClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+		ramClass = hashClassTableAt(vm->applicationClassLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName), 0);
 		if ((NULL != ramClass)
 			&& (romClass == ramClass->romClass)
 		) {
@@ -308,7 +308,7 @@ findJ9ClassForROMClass(J9VMThread *vmThread, J9ROMClass *romClass, J9ClassLoader
 				&& (classLoader != vm->extensionClassLoader)
 				&& (classLoader != vm->applicationClassLoader)
 			) {
-				ramClass = hashClassTableAt(classLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName));
+				ramClass = hashClassTableAt(classLoader, (U_8 *)J9UTF8_DATA(utfClassName), J9UTF8_LENGTH(utfClassName), 0);
 				if ((NULL != ramClass)
 					&& (romClass == ramClass->romClass)
 				) {

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -1304,7 +1304,7 @@ getTypeIdUTF8(J9VMThread *currentThread, const J9UTF8 *className)
 	Trc_VM_getTypeIdUTF8_Entry(currentThread, J9UTF8_LENGTH(className), J9UTF8_DATA(className));
 
 	omrthread_monitor_enter(vm->classTableMutex);
-	J9Class *clazz = hashClassTableAt(vm->systemClassLoader, (U_8 *)J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+	J9Class *clazz = hashClassTableAt(vm->systemClassLoader, (U_8 *)J9UTF8_DATA(className), J9UTF8_LENGTH(className), 0);
 	omrthread_monitor_exit(vm->classTableMutex);
 
 	if (NULL != clazz) {

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -625,7 +625,7 @@ addHiddenInstanceField(J9JavaVM *vm, const char *className, const char *fieldNam
 
 	/* Verify that the class hasn't yet been loaded. */
 	if ((NULL != vm->systemClassLoader)
-		&& (NULL != hashClassTableAt(vm->systemClassLoader, (U_8*)className, classNameLength))
+		&& (NULL != hashClassTableAt(vm->systemClassLoader, (U_8*)className, classNameLength, 0))
 	) {
 #if defined(J9VM_OPT_SNAPSHOTS)
 		/* By this point during a restore run, the hidden field is already added. Just fill in the offset. */


### PR DESCRIPTION
To simplify the changes when the result from the class hash table
is conditional on flags of J9Class, a flag is added to the
functions hashClassTableAt() and hashClassTableAtString() to filter
the result from hash class table. The changes will save a number
of changes all over of the source codes affected and can be reused
by other purpose similar to this case. It also makes the update of
source codes easy if the conditions are changed in the future.
The PR is required by PR https://github.com/eclipse-openj9/openj9/pull/22537

Co-authored-by: Tobi Ajila tobi_ajila@ca.ibm.com