### PR TITLE
Add missed Write Barrier to adding new module to hash table

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -233,6 +233,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_set_allocation_threshold,
 	j9gc_objaccess_recentlyAllocatedObject,
 	j9gc_objaccess_postStoreClassToClassLoader,
+	j9gc_objaccess_postStoreModuleToClassLoader,
 	j9gc_objaccess_getObjectHashCode,
 	j9gc_createJavaLangString,
 	j9gc_createJavaLangStringWithUTFCache,

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -353,11 +353,26 @@ public:
 	 * @param[in] srcClass the referenced class
 	 */
 	virtual void 
-	postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass)
+	postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Class *srcClass)
 	{
 		/* Default behaviour is to do nothing. Only collectors which implement JAZZ 18309 require this barrier. */
 	}
 	
+	/**
+	 * Record that the specified module is stored in the specified ClassLoader.
+	 * There is one cases at the moment in which this must be called:
+	 * 1 - when a newly loaded module is stored in its defining loader's table
+	 *
+	 * @param[in] vmThread the current thread
+	 * @param[in] destClassLoader the referencing ClassLoader
+	 * @param[in] srcModule the referenced module
+	 */
+	virtual void
+	postStoreModuleToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Module *srcModule)
+	{
+		/* Default behaviour is to do nothing. Only collectors which implement JAZZ 18309 require this barrier. */
+	}
+
 	/**
 	 * Converts token (e.g. compressed pointer value) into real heap pointer.
 	 * @return the heap pointer value.

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -771,10 +771,17 @@ j9gc_objaccess_recentlyAllocatedObject(J9VMThread *vmThread, J9Object *dstObject
 }
 
 void
-j9gc_objaccess_postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass)
+j9gc_objaccess_postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Class *srcClass)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
 	return barrier->postStoreClassToClassLoader(vmThread, destClassLoader, srcClass);
+}
+
+void
+j9gc_objaccess_postStoreModuleToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Module *srcModule)
+{
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->postStoreModuleToClassLoader(vmThread, destClassLoader, srcModule);
 }
 
 I_32

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -254,7 +254,8 @@ extern J9_CFUNC void j9gc_allocation_threshold_changed(J9VMThread* currentThread
 extern J9_CFUNC void j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval);
 extern J9_CFUNC void j9gc_set_allocation_threshold(J9VMThread* vmThread, UDATA low, UDATA high);
 extern J9_CFUNC void j9gc_objaccess_recentlyAllocatedObject(J9VMThread *vmThread, J9Object *dstObject);
-extern J9_CFUNC void j9gc_objaccess_postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass);
+extern J9_CFUNC void j9gc_objaccess_postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Class *srcClass);
+extern J9_CFUNC void j9gc_objaccess_postStoreModuleToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Module *srcModule);
 extern J9_CFUNC I_32 j9gc_objaccess_getObjectHashCode(J9JavaVM *vm, J9Object* object);
 extern J9_CFUNC void* j9gc_objaccess_jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jarray array, jboolean *isCopy);
 extern J9_CFUNC void j9gc_objaccess_jniReleasePrimitiveArrayCritical(J9VMThread* vmThread, jarray array, void * elems, jint mode);

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.hpp
@@ -66,7 +66,8 @@ public:
 	virtual bool postBatchObjectStore(J9VMThread *vmThread, J9Object *destObject, bool isVolatile=false);
 	virtual bool postBatchObjectStore(J9VMThread *vmThread, J9Class *destClass, bool isVolatile=false);
 	virtual void recentlyAllocatedObject(J9VMThread *vmThread, J9Object *object); 
-	virtual void postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass);
+	virtual void postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Class *srcClass);
+	virtual void postStoreModuleToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Module *srcModule);
 	
 	virtual bool preWeakRootSlotRead(J9VMThread *vmThread, j9object_t *srcAddress);
 	virtual bool preWeakRootSlotRead(J9JavaVM *vm, j9object_t *srcAddress);

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -595,7 +595,11 @@ addModuleDefinition(J9VMThread * currentThread, J9Module * fromModule, const cha
 			if (NULL != version) {
 				fromModule->version = J9_JNI_UNWRAP_REFERENCE(version);
 			}
-			if (!success) {
+			if (success) {
+				J9JavaVM *vm = currentThread->javaVM;
+				/* Adding module to the classloader hash table should trigger Write Barrier */
+				vm->memoryManagerFunctions->j9gc_objaccess_postStoreModuleToClassLoader(currentThread, classLoader, fromModule);
+			} else {
 				/* If we failed to add the module to the hash table */
 				if (NULL != packages) {
 					removeMulPackageDefinitions(currentThread, fromModule, packages, numPackages);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4966,7 +4966,8 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9gc_set_allocation_sampling_interval)(struct J9JavaVM *vm, UDATA samplingInterval);
 	void  ( *j9gc_set_allocation_threshold)(struct J9VMThread *vmThread, UDATA low, UDATA high) ;
 	void  ( *j9gc_objaccess_recentlyAllocatedObject)(struct J9VMThread *vmThread, J9Object *dstObject) ;
-	void  ( *j9gc_objaccess_postStoreClassToClassLoader)(struct J9VMThread* vmThread, J9ClassLoader* destClassLoader, J9Class* srcClass) ;
+	void  ( *j9gc_objaccess_postStoreClassToClassLoader)(struct J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Class *srcClass) ;
+	void  ( *j9gc_objaccess_postStoreModuleToClassLoader)(struct J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Module *srcModule) ;
 	I_32  ( *j9gc_objaccess_getObjectHashCode)(struct J9JavaVM *vm, J9Object* object) ;
 	j9object_t  ( *j9gc_createJavaLangString)(struct J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags) ;
 	j9object_t  ( *j9gc_createJavaLangStringWithUTFCache)(struct J9VMThread *vmThread, struct J9UTF8 *utf) ;


### PR DESCRIPTION
Write Barrier should be triggered at the moment new module is added to the classloader's hash table. Introducing new external GC function j9gc_objaccess_postStoreModuleToClassLoader.