### PR TITLE
Use CpuUtilization info only if it has valid data

### DIFF
--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -58,6 +58,48 @@
  * } j9thread_process_time_t;
  */
 
+/**
+ * @brief Resets the CpuUtilization data after a CRIU restore operation
+ *
+ * @param jitConfig J9JITCoonfig for this JVM
+ */
+void CpuUtilization::reset(J9JITConfig *jitConfig)
+   {
+   _cpuUsage = 0;
+   _vmCpuUsage = 0;
+   _avgCpuUsage= 0;
+   _cpuIdle = 0;
+   _avgCpuIdle = 0;
+
+   _prevIntervalLength = 0;
+   _prevMachineUptime = 0;
+   _prevMachineCpuTime = 0;
+   _prevMachineUserTime = 0;
+   _prevMachineSystemTime = 0;
+   _prevMachineIdleTime = 0;
+   _prevVmSysTime = 0;
+   _prevVmUserTime = 0;
+
+   _isFunctional = true;
+   _validData = false;
+
+   if (_cpuUsageCircularBufferSize && _cpuUsageCircularBuffer)
+      {
+      _cpuUsageCircularBufferIndex = 0;
+      for (int32_t i = 0; i < _cpuUsageCircularBufferSize; i++)
+         {
+         _cpuUsageCircularBuffer[i]._timeStamp = 0;
+         }
+      _isCpuUsageCircularBufferFunctional = true;
+      }
+   else
+      {
+      _isCpuUsageCircularBufferFunctional= false;
+      }
+   // Get our first data point
+   updateCpuUtil(jitConfig);
+   }
+
 int32_t CpuUtilization::getCpuUtil(J9JITConfig *jitConfig, J9SysinfoCPUTime *machineCpuStats, j9thread_process_time_t *vmCpuStats)
    {
    IDATA portLibraryStatusSys; // port lib call return value for system cpu usage
@@ -242,7 +284,7 @@ CpuUtilization::CpuUtilization(J9JITConfig *jitConfig):
    // fields since we can just check if _timeStamp equals 0
    for (int32_t i = 0; i < _cpuUsageCircularBufferSize; i++)
       {
-      _cpuUsageCircularBuffer[_cpuUsageCircularBufferIndex]._timeStamp = 0;
+      _cpuUsageCircularBuffer[i]._timeStamp = 0;
       }
    } // CpuUtilization
 

--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -71,7 +71,7 @@ int32_t CpuUtilization::getCpuUtil(J9JITConfig *jitConfig, J9SysinfoCPUTime *mac
    portLibraryStatusVm  = j9thread_get_process_times(vmCpuStats);
 
    // if either call failed, disable self
-   if (portLibraryStatusSys < 0 || portLibraryStatusVm < 0)
+   if (portLibraryStatusSys < 0 || portLibraryStatusVm < 0 || machineCpuStats->numberOfCpus <= 0)
       {
       disable();
       return (-1);
@@ -135,12 +135,8 @@ int CpuUtilization::updateCpuUtil(J9JITConfig *jitConfig)
 
    _avgCpuUsage = 100.0 * cpuLoad;
    _avgCpuIdle = 100.0 * cpuIdle;
-
-   if (machineCpuStats.numberOfCpus > 0)
-      {
-      _cpuUsage = 100.0 * machineCpuStats.numberOfCpus * cpuLoad;
-      _cpuIdle = 100.0 * machineCpuStats.numberOfCpus * cpuIdle;
-      }
+   _cpuUsage = 100.0 * machineCpuStats.numberOfCpus * cpuLoad;
+   _cpuIdle = 100.0 * machineCpuStats.numberOfCpus * cpuIdle;
    _vmCpuUsage = (100 * (newTotalTimeUsedByVm - prevTotalTimeUsedByVm)) / elapsedTime;
 
    // remember values for next time

--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -139,6 +139,11 @@ int CpuUtilization::updateCpuUtil(J9JITConfig *jitConfig)
    _cpuIdle = 100.0 * machineCpuStats.numberOfCpus * cpuIdle;
    _vmCpuUsage = (100 * (newTotalTimeUsedByVm - prevTotalTimeUsedByVm)) / elapsedTime;
 
+   // If _prevMachineUptime is different than 0 (initial value) it means that we already
+   // had a readout and we can effectively compute CPU values of a given time interval.
+   if (_prevMachineUptime > 0)
+      _validData = true;
+
    // remember values for next time
    _prevMachineUptime  = machineCpuStats.timestamp;
    _prevMachineCpuTime = machineCpuStats.cpuTime;
@@ -201,6 +206,7 @@ CpuUtilization::CpuUtilization(J9JITConfig *jitConfig):
    _prevVmUserTime (0),
 
    _isFunctional (true),
+   _validData(false),
 
    _cpuUsageCircularBufferIndex(0)
 

--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -90,6 +90,8 @@ public:
       _cpuUsage = _cpuIdle = _vmCpuUsage = _avgCpuUsage = _avgCpuIdle = -1;
       disableCpuUsageCircularBuffer();
       }
+   void reset(J9JITConfig *jitConfig); // To be used after a CRIU restore operation
+
 
    // Circular Buffer related functions
    CpuUsageCircularBuffer *getCpuUsageCircularBuffer() const { return _cpuUsageCircularBuffer; }

--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -81,7 +81,6 @@ public:
    int64_t getUptime() const { return _prevMachineUptime; } // in nanoseconds
    int64_t getLastMeasurementInterval() const { return _prevIntervalLength; } // in nanoseconds
    int64_t getVmTotalCpuTime() const { return _prevVmSysTime + _prevVmUserTime; }
-   int32_t getCpuUtil(J9JITConfig *jitConfig, J9SysinfoCPUTime *machineCpuStats, j9thread_process_time_t *vmCpuStats);
    int32_t updateCpuUtil(J9JITConfig *jitConfig);
    void    disable() { _isFunctional = false;
                        _cpuUsage = _cpuIdle = _vmCpuUsage = _avgCpuUsage = _avgCpuIdle = -1;
@@ -96,6 +95,7 @@ public:
    int32_t  updateCpuUsageCircularBuffer(J9JITConfig *jitConfig);
 
 private:
+   int32_t getCpuUtil(J9JITConfig *jitConfig, J9SysinfoCPUTime *machineCpuStats, j9thread_process_time_t *vmCpuStats);
 
    int32_t _cpuUsage;    // percentage of used CPU on the whole machine for the last update interval
    int32_t _cpuIdle;     // percentage of idle CPU on the whole machine for the last update interval

--- a/runtime/compiler/env/CpuUtilization.hpp
+++ b/runtime/compiler/env/CpuUtilization.hpp
@@ -73,6 +73,7 @@ public:
       } CpuUsageCircularBuffer;
 
    bool    isFunctional() const { return _isFunctional; }
+   bool    hasValidData() const { return _validData; }
    int32_t getCpuUsage() const { return _cpuUsage; }
    int32_t getCpuIdle() const { return _cpuIdle; }
    int32_t getVmCpuUsage() const { return _vmCpuUsage; }
@@ -82,9 +83,13 @@ public:
    int64_t getLastMeasurementInterval() const { return _prevIntervalLength; } // in nanoseconds
    int64_t getVmTotalCpuTime() const { return _prevVmSysTime + _prevVmUserTime; }
    int32_t updateCpuUtil(J9JITConfig *jitConfig);
-   void    disable() { _isFunctional = false;
-                       _cpuUsage = _cpuIdle = _vmCpuUsage = _avgCpuUsage = _avgCpuIdle = -1;
-                       disableCpuUsageCircularBuffer(); }
+   void    disable()
+      {
+      _isFunctional = false;
+      _validData = false;
+      _cpuUsage = _cpuIdle = _vmCpuUsage = _avgCpuUsage = _avgCpuIdle = -1;
+      disableCpuUsageCircularBuffer();
+      }
 
    // Circular Buffer related functions
    CpuUsageCircularBuffer *getCpuUsageCircularBuffer() const { return _cpuUsageCircularBuffer; }
@@ -121,6 +126,7 @@ private:
    int32_t                 _cpuUsageCircularBufferSize;  // Size of the circular buffer
 
    bool _isFunctional;
+   bool _validData; // Set to true if we have at least two measurements
    bool _isCpuUsageCircularBufferFunctional;
 
    }; // class CpuUtilization

--- a/runtime/compiler/runtime/CRRuntime.cpp
+++ b/runtime/compiler/runtime/CRRuntime.cpp
@@ -840,6 +840,9 @@ TR::CRRuntime::prepareForRestore()
    // Reset the start time.
    resetStartTime();
 
+   // Reset the CPU utilization values
+   getCompInfo()->getCpuUtil()->reset(getJITConfig());
+
    // Resume JIT threads.
    resumeJITThreadsForRestore(vmThread);
    }


### PR DESCRIPTION
Existing code uses CpuUtilization info after a test on CpuUtilization->isFunctional(). However, to report CPU utilization we need two data collections at different points in time (the JVM computes the difference of two absolute values). Until the two data collections are available, the data reported by CpuUtilization cannot be trusted (for instance the JVM CPU  utilization shows up as 0).
This PR introduces a new getter, `CpuUtilization->hasValidData()` that returns true if at least two CPU data collections have been performed. The existing code has been changed to replace isFunctional() with hasValidData() for most of the queries (isFunctional() is still used when updating the CpuUtilization information).
To minimize the window of time when the CpuUtilization is functional but does not have valid data, the sampling thread will attempt to collect the second CPU data point as soon as possible.

This PR also resets the CpuUtilization information during a CRIU restore operation.
