### PR TITLE
Try to create next subdirectory if current directory exists

### DIFF
--- a/runtime/port/common/j9prt.tdf
+++ b/runtime/port/common/j9prt.tdf
@@ -195,7 +195,7 @@ TraceExit=Trc_PRT_shared_createDirectory_Exit1 Group=j9shared Overhead=1 Level=1
 TraceExit=Trc_PRT_shared_createDirectory_Exit2 Group=j9shared Overhead=1 Level=1 NoEnv Template="j9sharedhelper createDirectory successfully created including parent dirs"
 TraceExit=Trc_PRT_shared_createDirectory_Exit3 Group=j9shared Overhead=1 Level=1 NoEnv Template="j9sharedhelper createDirectory unable to create %s"
 TraceEvent=Trc_PRT_shared_createDirectory_Event1 Group=j9shared Overhead=1 Level=1 NoEnv Template="j9sharedhelper createDirectory dir %s created"
-TraceEvent=Trc_PRT_shared_createDirectory_Event2 Group=j9shared Overhead=1 Level=1 NoEnv Template="j9sharedhelper createDirectory dir %s already exists"
+TraceEvent=Trc_PRT_shared_createDirectory_Event2 Obsolete Group=j9shared Overhead=1 Level=1 NoEnv Template="j9sharedhelper createDirectory dir %s already exists"
 
 TraceEntry=Trc_PRT_shsem_checkMarker_Entry Group=j9shared Overhead=1 Level=1 NoEnv Template="j9shsem checkMarker entering with handle=%p and semsetsize=%d"
 TraceExit=Trc_PRT_shsem_checkMarker_ExitNullHandle Group=j9shared Overhead=1 Level=1 NoEnv Template="j9shsem checkMarker exiting because handle is NULL"
@@ -2143,3 +2143,5 @@ TraceException=Trc_PRT_shared_cleanSharedMemorySegments_getEnvUserNameTooLong Gr
 TraceException=Trc_PRT_shared_cleanSharedMemorySegments_getEnvUserName_Failed Group=j9shmem Overhead=1 Level=1 NoEnv Template="cleanSharedMemorySegments: omrsysinfo_get_env failed"
 
 TraceException=Trc_PRT_j9shmem_getDir_tryHomeDirFailed_notFinalRestore Group=j9shmem Overhead=1 Level=1 NoEnv Template="j9shmem_getDir: not CRIU final restore, skip getpwuid(), and homeDir is NULL."
+
+TraceExit=Trc_PRT_shared_createDirectory_Exit4 Group=j9shared Overhead=1 Level=1 NoEnv Template="j9sharedhelper createDirectory unable to change permission of %s"

--- a/runtime/port/sysvipc/j9sharedhelper.h
+++ b/runtime/port/sysvipc/j9sharedhelper.h
@@ -30,7 +30,7 @@ intptr_t ControlFileOpenWithWriteLock(struct J9PortLibrary* portLibrary, intptr_
 intptr_t ControlFileCloseAndUnLock(struct J9PortLibrary* portLibrary, intptr_t fd);
 intptr_t changeDirectoryPermission(struct J9PortLibrary *portLibrary, const char* pathname, uintptr_t permission);
 void cleanSharedMemorySegments(struct J9PortLibrary* portLibrary);
-intptr_t createDirectory(struct J9PortLibrary *portLibrary, char *pathname, uintptr_t permission);
+intptr_t createDirectory(struct J9PortLibrary *portLibrary, const char *pathname, uintptr_t permission);
 BOOLEAN unlinkControlFile(struct J9PortLibrary* portLibrary, const char *controlFile, J9ControlFileStatus *status);
 
 #define J9SH_SUCCESS 0

--- a/runtime/port/sysvipc/j9shmem.c
+++ b/runtime/port/sysvipc/j9shmem.c
@@ -1376,7 +1376,7 @@ j9shmem_createDir(struct J9PortLibrary* portLibrary, char* cacheDirName, uintptr
 
 	Trc_PRT_j9shmem_createDir_Entry();
 	if (0 == j9shmem_getDir(portLibrary, NULL, J9SHMEM_GETDIR_APPEND_BASEDIR, pathBuffer, J9SH_MAXPATH)) {
-		if (0 == strcmp(cacheDirName, (const char*)pathBuffer)) {
+		if (0 == strcmp(cacheDirName, pathBuffer)) {
 			usingDefaultTmp = TRUE;
 		}
 	}
@@ -1415,8 +1415,7 @@ j9shmem_createDir(struct J9PortLibrary* portLibrary, char* cacheDirName, uintptr
 		if (cleanMemorySegments) {
 			cleanSharedMemorySegments(portLibrary);
 		}
-		/* Note that the createDirectory call may change pathBuffer */
-		rc = createDirectory(portLibrary, (char*)pathBuffer, cacheDirPerm);
+		rc = createDirectory(portLibrary, pathBuffer, cacheDirPerm);
 		if (J9SH_FAILED != rc) {
 			if (J9SH_DIRPERM_ABSENT == cacheDirPerm) {
 				if (usingDefaultTmp) {


### PR DESCRIPTION
Instead of relying on a specific error message confirm
whether the current subdirectory exists before continuing
to attempt creation of the next one.