### PR TITLE
Restore 32-bit Coded Restrictions to CodeCache Page Sizes on P

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -308,7 +308,14 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
    if (config.largeCodePageSize() > pageSizes[0])
       largeCodePageSize = config.largeCodePageSize();
 
+#if defined(TR_TARGET_POWER) && defined(TR_HOST_POWER) && !defined(TR_HOST_64BIT)
+   /* Use largeCodePageSize on PPC only if its 16M.
+    If we pass in any pagesize other than the default page size, the port library picks the shared memory api to allocate which wastes memory */
+   size_t sixteenMegs = 16 * 1024 * 1024;
+   if (largeCodePageSize == sixteenMegs)
+#else
    if (largeCodePageSize > 0)
+#endif
       {
       vmemParams.pageSize = largeCodePageSize;
       vmemParams.pageFlags = config.largeCodePageFlags();


### PR DESCRIPTION
Reverts https://github.ibm.com/Peter-Shipton/openj9/commit/6faf673 for 32-bit.

Fixes a 4K page allocation on 32-bit, when running utilities such as javah or javac. Otherwise `JVMJ9VM013W Initialization error in function VMInitStages(13): JVMJ9VM009E J9VMDllMain failed` occurs when a 4K page cannot be allocated at
https://github.com/eclipse-openj9/openj9/blob/master/runtime/vm/FlushProcessWriteBuffers.cpp#L72

Internal RTC 153064