### PR TITLE
Add inlined isAssignableFrom test on X

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -103,6 +103,11 @@ static int32_t minRepstosdWords = 0;
 // Maximum number of words per loop iteration for loop zero-initialization.
 //
 #define MAX_ZERO_INIT_WORDS_PER_ITERATION 4
+
+#define iComment2(str, cursor) \
+    if (debugObj)              \
+        debugObj->addInstructionComment(cursor, (const_cast<char *>(str)));
+
 static int32_t maxZeroInitWordsPerIteration = 0;
 
 static bool getNodeIs64Bit(TR::Node *node, TR::CodeGenerator *cg);
@@ -4207,6 +4212,184 @@ TR::Register *J9::X86::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, 
     return resultReg;
 }
 
+inline void generateInlineInterfaceTest(TR::Node *node, TR::CodeGenerator *cg, TR::Register *toClassReg,
+    TR::Register *fromClassReg, TR_X86ScratchRegisterManager *srm, TR::LabelSymbol *successLabel,
+    TR::LabelSymbol *failLabel)
+{
+    TR_Debug *debugObj = cg->getDebug();
+    TR::Compilation *comp = cg->comp();
+    bool use64BitClasses = comp->target().is64Bit()
+        && (!TR::Compiler->om.generateCompressedObjectHeaders()
+            || (comp->compileRelocatableCode() && comp->getOption(TR_UseSymbolValidationManager)));
+
+    TR::Instruction *cursor = NULL;
+    TR::LabelSymbol *iTableLoopLabel = generateLabelSymbol(cg);
+    // Obtain I-Table
+    // iTableReg holds head of J9Class->iTable of fromClass
+    TR::Register *iTableReg = srm->findOrCreateScratchRegister();
+    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, iTableReg,
+        generateX86MemoryReference(fromClassReg, offsetof(J9Class, iTable), cg), cg);
+    // Loop through I-Table
+    // iTableReg holds iTable list element through the loop
+    cursor = generateLabelInstruction(TR::InstOpCode::label, node, iTableLoopLabel, cg);
+    iComment2("-->Start of ITable walk", cursor);
+    generateRegRegInstruction(TR::InstOpCode::TESTRegReg(use64BitClasses), node, iTableReg, iTableReg, cg);
+    generateLabelInstruction(TR::InstOpCode::JE4, node, failLabel, cg);
+    generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, toClassReg,
+        generateX86MemoryReference(iTableReg, offsetof(J9ITable, interfaceClass), cg), cg);
+    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, iTableReg,
+        generateX86MemoryReference(iTableReg, offsetof(J9ITable, next), cg), cg);
+    generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
+
+    srm->reclaimScratchRegister(iTableReg);
+    cursor = generateLabelInstruction(TR::InstOpCode::JMP4, node, successLabel, cg);
+    iComment2("-->ITable walk succeeded", cursor);
+}
+
+inline void generateInlineSuperclassTest(TR::Node *node, TR::CodeGenerator *cg, TR::Register *toClassReg,
+    TR::Register *fromClassReg, TR_ScratchRegisterManager *srm, TR::LabelSymbol *failLabel, bool use64BitClasses,
+    int32_t toClassDepth = -1)
+{
+    TR_Debug *debugObj = cg->getDebug();
+    // class depth mask must be low 16 bits to safely load without the mask.
+    static_assert(J9AccClassDepthMask == 0xffff, "J9_JAVA_CLASS_DEPTH_MASK must be 0xffff");
+    TR::Register *superclassArrayReg = srm->findOrCreateScratchRegister();
+    TR::Register *toClassDepthReg = NULL;
+    TR::Instruction *cursor = NULL;
+    if (toClassDepth == -1) {
+        toClassDepthReg = srm->findOrCreateScratchRegister();
+        cursor = generateRegMemInstruction(
+            cg->comp()->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Mem2 : TR::InstOpCode::MOVZXReg4Mem2, node,
+            toClassDepthReg, generateX86MemoryReference(toClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+        iComment2("-->Load toClass depth", cursor);
+        // cast class depth >= obj class depth, return false
+        generateRegMemInstruction(TR::InstOpCode::CMP2RegMem, node, toClassDepthReg,
+            generateX86MemoryReference(fromClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+        cursor = generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
+    } else {
+        TR::Register *fromClassDepthReg = srm->findOrCreateScratchRegister();
+        // cast class depth >= obj class depth, return false
+        cursor = generateRegMemInstruction(
+            cg->comp()->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Mem2 : TR::InstOpCode::MOVZXReg4Mem2, node,
+            fromClassDepthReg, generateX86MemoryReference(fromClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+        iComment2("-->Load fromClass depth", cursor);
+        generateRegImmInstruction(TR::InstOpCode::CMP2RegImm2, node, fromClassDepthReg, toClassDepth, cg);
+        cursor = generateLabelInstruction(TR::InstOpCode::JBE4, node, failLabel, cg);
+        srm->reclaimScratchRegister(fromClassDepthReg);
+    }
+    iComment2("-->toClass Depth >= fromClassDepth - fast fail", cursor);
+
+    cursor = generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, superclassArrayReg,
+        generateX86MemoryReference(fromClassReg, offsetof(J9Class, superclasses), cg), cg);
+    iComment2("Load superclass array", cursor);
+    if (toClassDepth == -1) {
+        generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, toClassReg,
+            generateX86MemoryReference(superclassArrayReg, toClassDepthReg,
+                (uint8_t)(cg->comp()->target().is64Bit() ? 3 : 2), cg),
+            cg);
+        srm->reclaimScratchRegister(toClassDepthReg);
+    } else {
+        int32_t superClassOffset = toClassDepth * TR::Compiler->om.sizeofReferenceAddress();
+        generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, toClassReg,
+            generateX86MemoryReference(superclassArrayReg, superClassOffset, cg), cg);
+    }
+    generateLabelInstruction(TR::InstOpCode::JNE4, node, failLabel, cg);
+    srm->reclaimScratchRegister(superclassArrayReg);
+}
+
+static void generateInlinedIsAssignableFrom(TR::Node *node, TR::CodeGenerator *cg)
+{
+    TR_Debug *debugObj = cg->getDebug();
+
+    TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
+    TR::LabelSymbol *endLabel = generateLabelSymbol(cg);
+    TR::LabelSymbol *falseLabel = generateLabelSymbol(cg);
+    TR::LabelSymbol *outlinedCallLabel = generateLabelSymbol(cg);
+    TR::LabelSymbol *notInterfaceOrArrayLabel = generateLabelSymbol(cg);
+    TR::Register *resultReg = cg->allocateRegister();
+    startLabel->setStartInternalControlFlow();
+    endLabel->setEndInternalControlFlow();
+    auto comp = cg->comp();
+
+    TR::Node *fromClass = node->getFirstChild();
+    TR::Node *toClass = node->getSecondChild();
+
+    TR::Register *fromClassReg = cg->evaluate(fromClass);
+    TR::Register *toClassReg = cg->evaluate(toClass);
+
+    auto use64BitClasses = comp->target().is64Bit()
+        && (!TR::Compiler->om.generateCompressedObjectHeaders()
+            || (comp->compileRelocatableCode() && comp->getOption(TR_UseSymbolValidationManager)));
+
+    TR_X86ScratchRegisterManager *srm = cg->generateScratchRegisterManager(2);
+    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    TR_OutlinedInstructions *outlinedHelperCall
+        = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::icall, resultReg, outlinedCallLabel, endLabel, cg);
+    cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
+
+    // load with initial result of true
+    generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, resultReg, 1, cg);
+    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(use64BitClasses), node, toClassReg, fromClassReg, cg);
+    generateLabelInstruction(TR::InstOpCode::JE4, node, endLabel, cg);
+
+    TR::Register *modifierReg = srm->findOrCreateScratchRegister();
+    // testing if toClass is an array class
+    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, modifierReg,
+        generateX86MemoryReference(toClassReg, offsetof(J9Class, romClass), cg), cg);
+    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, modifierReg,
+        generateX86MemoryReference(modifierReg, offsetof(J9ROMClass, modifiers), cg), cg);
+
+    generateRegImmInstruction(TR::InstOpCode::TEST4RegImm4, node, modifierReg, J9AccClassArray, cg);
+    generateLabelInstruction(TR::InstOpCode::JNE4, node, outlinedCallLabel, cg);
+
+    generateRegImmInstruction(TR::InstOpCode::TEST4RegImm4, node, modifierReg, J9AccInterface, cg);
+    generateLabelInstruction(TR::InstOpCode::JE4, node, notInterfaceOrArrayLabel, cg);
+
+    srm->reclaimScratchRegister(modifierReg);
+
+    generateInlineInterfaceTest(node, cg, toClassReg, fromClassReg, srm, endLabel, falseLabel);
+
+    generateLabelInstruction(TR::InstOpCode::label, node, notInterfaceOrArrayLabel, cg);
+
+    generateInlineSuperclassTest(node, cg, toClassReg, fromClassReg, srm, falseLabel, use64BitClasses, -1);
+    generateLabelInstruction(TR::InstOpCode::JE4, node, endLabel, cg);
+
+    generateLabelInstruction(TR::InstOpCode::label, node, falseLabel, cg);
+    generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, resultReg, 0, cg);
+
+    TR::RegisterDependencyConditions *deps
+        = generateRegisterDependencyConditions((uint8_t)0, 3 + srm->numAvailableRegisters(), cg);
+    srm->addScratchRegistersToDependencyList(deps);
+    srm->stopUsingRegisters();
+    deps->addPostCondition(resultReg, TR::RealRegister::NoReg, cg);
+    deps->addPostCondition(fromClassReg, TR::RealRegister::NoReg, cg);
+    if (fromClassReg != toClassReg) {
+        deps->addPostCondition(toClassReg, TR::RealRegister::NoReg, cg);
+    }
+
+    TR::Node *callNode = outlinedHelperCall->getCallNode();
+    TR::Register *reg;
+
+    if (callNode->getFirstChild() == node->getFirstChild()) {
+        reg = callNode->getFirstChild()->getRegister();
+        if (reg)
+            deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+    }
+
+    if (callNode->getSecondChild() == node->getSecondChild()) {
+        reg = callNode->getSecondChild()->getRegister();
+        if (reg)
+            deps->unionPostCondition(reg, TR::RealRegister::NoReg, cg);
+    }
+
+    deps->stopAddingConditions();
+    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+
+    node->setRegister(resultReg);
+    cg->decReferenceCount(toClass);
+    cg->decReferenceCount(fromClass);
+}
+
 inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
@@ -4215,8 +4398,8 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
             || (comp->compileRelocatableCode() && comp->getOption(TR_UseSymbolValidationManager)));
     TR::Register *ObjReg = cg->evaluate(node->getFirstChild());
     TR::Register *castClassReg = cg->evaluate(node->getSecondChild());
-    TR::Register *temp1Reg = cg->allocateRegister();
-    TR::Register *temp2Reg = cg->allocateRegister();
+
+    TR_X86ScratchRegisterManager *srm = cg->generateScratchRegisterManager(2);
     TR::Register *objClassReg = cg->allocateRegister();
 
     bool isCheckCastAndNullCheck = (node->getOpCodeValue() == TR::checkcastAndNULLCHK);
@@ -4226,7 +4409,6 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     TR::LabelSymbol *outlinedCallLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *throwLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *isClassLabel = generateLabelSymbol(cg);
-    TR::LabelSymbol *iTableLoopLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
     fallThruLabel->setEndInternalControlFlow();
 
@@ -4240,13 +4422,14 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     if (isCheckCastAndNullCheck)
         generateLoadJ9Class(node, objClassReg, ObjReg, cg);
 
-    // temp2Reg holds romClass of cast class, for testing array, interface class type
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp2Reg,
+    TR::Register *castClassRomClassReg = srm->findOrCreateScratchRegister();
+    // get romClass of cast class, for testing array, interface class type
+    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, castClassRomClassReg,
         generateX86MemoryReference(castClassReg, offsetof(J9Class, romClass), cg), cg);
 
     // If cast class is array, call out of line helper
     generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        generateX86MemoryReference(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
+        generateX86MemoryReference(castClassRomClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
     generateLabelInstruction(TR::InstOpCode::JNE4, node, outlinedCallLabel, cg);
 
     // objClassReg holds object class
@@ -4259,26 +4442,11 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     // Object not array, inline checks
     // Check cast class is interface
     generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        generateX86MemoryReference(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccInterface, cg);
+        generateX86MemoryReference(castClassRomClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccInterface, cg);
     generateLabelInstruction(TR::InstOpCode::JE4, node, isClassLabel, cg);
+    srm->reclaimScratchRegister(castClassRomClassReg);
 
-    // Obtain I-Table
-    // temp1Reg holds head of J9Class->iTable of obj class
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        generateX86MemoryReference(objClassReg, offsetof(J9Class, iTable), cg), cg);
-    // Loop through I-Table
-    // temp1Reg holds iTable list element through the loop
-    generateLabelInstruction(TR::InstOpCode::label, node, iTableLoopLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, temp1Reg, temp1Reg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, throwLabel, cg);
-    auto interfaceMR = generateX86MemoryReference(temp1Reg, offsetof(J9ITable, interfaceClass), cg);
-    generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), node, interfaceMR, castClassReg, cg);
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        generateX86MemoryReference(temp1Reg, offsetof(J9ITable, next), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
-
-    // Found from I-Table
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
+    generateInlineInterfaceTest(node, cg, castClassReg, objClassReg, srm, fallThruLabel, throwLabel);
 
     // cast class is non-interface class
     generateLabelInstruction(TR::InstOpCode::label, node, isClassLabel, cg);
@@ -4287,31 +4455,7 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     generateLabelInstruction(TR::InstOpCode::JE4, node, fallThruLabel, cg);
 
     // class not equal
-    // temp2 holds cast class depth
-    // class depth mask must be low 16 bits to safely load without the mask.
-    static_assert(J9AccClassDepthMask == 0xffff, "J9_JAVA_CLASS_DEPTH_MASK must be 0xffff");
-    generateRegMemInstruction(comp->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Mem2 : TR::InstOpCode::MOVZXReg4Mem2,
-        node, temp2Reg, generateX86MemoryReference(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-
-    // cast class depth >= obj class depth, throw
-    generateRegMemInstruction(TR::InstOpCode::CMP2RegMem, node, temp2Reg,
-        generateX86MemoryReference(objClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JAE4, node, throwLabel, cg);
-
-    // check obj class's super class array entry
-    // temp1Reg holds superClasses array of obj class
-    // An alternative sequences requiring one less register may be:
-    // SHL temp2Reg, 3 for 64-bit or 2 for 32-bit
-    // ADD temp2Reg, [temp3Reg, superclasses offset]
-    // CMP classClassReg, [temp2Reg]
-    // On 64 bit, the extra reg isn't likely to cause significant register pressure.
-    // On 32 bit, it could put more register pressure due to limited number of regs.
-    // Since 64-bit is more prevalent, we opt to optimize for 64bit in this case
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        generateX86MemoryReference(objClassReg, offsetof(J9Class, superclasses), cg), cg);
-    generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, castClassReg,
-        generateX86MemoryReference(temp1Reg, temp2Reg, comp->target().is64Bit() ? 3 : 2, cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, throwLabel, cg);
+    generateInlineSuperclassTest(node, cg, castClassReg, objClassReg, srm, throwLabel, use64BitClasses);
 
     // throw classCastException
     {
@@ -4328,8 +4472,8 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
 
     deps->addPostCondition(ObjReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(castClassReg, TR::RealRegister::NoReg, cg);
-    deps->addPostCondition(temp1Reg, TR::RealRegister::NoReg, cg);
-    deps->addPostCondition(temp2Reg, TR::RealRegister::NoReg, cg);
+    srm->addScratchRegistersToDependencyList(deps);
+    srm->stopUsingRegisters();
     deps->addPostCondition(objClassReg, TR::RealRegister::NoReg, cg);
 
     TR::Node *callNode = outlinedHelperCall->getCallNode();
@@ -4351,8 +4495,6 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
 
     generateLabelInstruction(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
 
-    cg->stopUsingRegister(temp1Reg);
-    cg->stopUsingRegister(temp2Reg);
     cg->stopUsingRegister(objClassReg);
 
     // Decrement use counts on the children
@@ -5718,20 +5860,26 @@ TR::Register *J9::X86::TreeEvaluator::checkcastinstanceofEvaluator(TR::Node *nod
     TR::Compilation *comp = cg->comp();
 
     bool isCheckCast = false;
+    bool isIsAssignableFrom = false;
     switch (node->getOpCodeValue()) {
         case TR::checkcast:
         case TR::checkcastAndNULLCHK:
             isCheckCast = true;
             break;
         case TR:: instanceof:
+            break;
         case TR::icall: // TR_checkAssignable
+            isIsAssignableFrom = true;
             break;
         default:
             TR_ASSERT(false, "Incorrect Op Code %d.", node->getOpCodeValue());
             break;
     }
     TR_OpaqueClassBlock *clazz = TR::TreeEvaluator::getCastClassAddress(node->getChild(1));
-    if (isCheckCast && !clazz && !comp->getOption(TR_DisableInlineCheckCast)
+
+    if (isIsAssignableFrom && !clazz) {
+        generateInlinedIsAssignableFrom(node, cg);
+    } else if (isCheckCast && !clazz && !comp->getOption(TR_DisableInlineCheckCast)
         && (!comp->compileRelocatableCode() || comp->getOption(TR_UseSymbolValidationManager))) {
         generateInlinedCheckCastForDynamicCastClass(node, cg);
     } else if (clazz && !TR::Compiler->cls.isClassArray(comp, clazz) && // not yet optimized


### PR DESCRIPTION
Adds inlined isAssignableFrom test, skipping the slow helper in most cases. This also adds logic to check if we know the type of the class (whether its an interface, array class, or other) at compile time and will only generate code for that specific case, skipping tests that will fail. For example, the superclass test will always fail for interfaces. So, if we know we have an interface at compile time, we only generate the itable test (an inline itable walk).

Commons out superclass test and itable walk from `generateInlinedCheckCastForDynamicCastClass` since isAssignableFrom uses the same tests