### PR TITLE
(0.56) Set register dep to exclude GPR0 for temp2Reg in inlineCompareAndSet

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -8530,6 +8530,7 @@ static TR::Register *VMinlineCompareAndSetOrExchangeReference(TR::Node *node, TR
 
       TR::addDependency(conditions, temp1Reg, TR::RealRegister::gr11, TR_GPR, cg);
       TR::addDependency(conditions, temp2Reg, TR::RealRegister::NoReg, TR_GPR, cg);
+      conditions->getPostConditions()->getRegisterDependency(conditions->getAddCursorForPost() - 1)->setExcludeGPR0();
       TR::addDependency(conditions, offsetReg, TR::RealRegister::NoReg, TR_GPR, cg);
       TR::addDependency(conditions, temp4Reg, TR::RealRegister::NoReg, TR_GPR, cg);
 


### PR DESCRIPTION
The temp2Reg is used by VMnonNullSrcWrtBarCardCheckEvaluator in some cases in a stbx instruction, which can't have GPR0 as the RA argument or it will act upon it as a null value.
This can cause an unexpected register spill in the middle of an internal control-flow sequence that might not be fully executed.

Backport https://github.com/eclipse-openj9/openj9/pull/22633