### PR TITLE
Align RAM Class Sub4G allocation increment with J9Class

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6083,6 +6083,7 @@ typedef struct J9JavaVM {
 	struct J9MemorySegmentList* classMemorySegments;
 	UDATA stackSize;
 	UDATA ramClassAllocationIncrement;
+	UDATA ramClassSub4GAllocationIncrement;
 	UDATA romClassAllocationIncrement;
 	UDATA memoryMax;
 	UDATA directByteBufferMemoryMax;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -4375,8 +4375,7 @@ allocateRemainingFragments(RAMClassAllocationRequest *requests, UDATA allocation
 			classAllocationIncrement = 0;
 		} else {
 			if (SK_SUB4G == segmentKind) {
-				const UDATA headersPerSegment = 32;
-				classAllocationIncrement = sizeof(J9Class) * headersPerSegment;
+				classAllocationIncrement = javaVM->ramClassSub4GAllocationIncrement;
 			}
 		}
 


### PR DESCRIPTION
Aligning the RAM Class Sub4G allocation increment with `J9Class`
improves both startup performance and memory footprint.

Recent performance measurements showed the best results when the
increment size was aligned with the default `-Xmca` value of `32 KB`.