### PR TITLE
Correct stack size for StrictField test

### DIFF
--- a/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldGenerator.java
@@ -62,7 +62,7 @@ public class StrictFieldGenerator extends ClassLoader {
             mv.visitFieldInsn(PUTFIELD, className, fieldName, fieldDesc);
         }
         mv.visitInsn(RETURN);
-        mv.visitMaxs(1, 1);
+        mv.visitMaxs((lateLarval ? 2 : 1), 1);
         mv.visitEnd();
 
         if (unrestricted) {


### PR DESCRIPTION
This ensures that testPutStrictFinalFieldLateLarval throws VerifyError due to the strict fields spec and not a test error.

Related: https://github.com/eclipse-openj9/openj9/issues/21884