### PR TITLE
(0.56) Revert "RAM Class: Per-kind segment allocation and sizing"

### DIFF
--- a/runtime/jcl/common/mgmtmemory.c
+++ b/runtime/jcl/common/mgmtmemory.c
@@ -32,7 +32,7 @@ static UDATA getIndexFromGCID(J9JavaLangManagementData *mgmt, UDATA id);
 jobject JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getHeapMemoryUsageImpl(JNIEnv *env, jobject beanInstance, jclass memoryUsage, jobject memUsageConstructor)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	jlong used = 0;
 	jlong committed = 0;
 	jmethodID ctor = NULL;
@@ -48,59 +48,10 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getHeapMemoryUsageIm
 	return (*env)->NewObject(env, memoryUsage, ctor, (jlong)javaVM->managementData->initialHeapSize, used, committed, (jlong)javaVM->managementData->maximumHeapSize);
 }
 
-/**
- * @brief Subtracts sizes of all free list blocks from the accumulator.
- *
- * Iterates through tiny, small, and large block lists in
- * j9RAMClassFreeListsPtr and subtracts each block's size from used.
- *
- * @param j9RAMClassFreeListsPtr Pointer to RAM class free-lists (may be NULL).
- * @param used Pointer to a jlong accumulator decremented by block sizes.
- */
-void
-subtractFreeListBlocks(J9RAMClassFreeLists* j9RAMClassFreeListsPtr, jlong *used)
-{
-	if (NULL != j9RAMClassFreeListsPtr) {
-		J9RAMClassFreeListBlock *ramClassTinyBlockFreeListPtr = j9RAMClassFreeListsPtr->ramClassTinyBlockFreeList;
-		J9RAMClassFreeListBlock *ramClassSmallBlockFreeListPtr = j9RAMClassFreeListsPtr->ramClassSmallBlockFreeList;
-		J9RAMClassFreeListBlock *ramClassLargeBlockFreeListPtr = j9RAMClassFreeListsPtr->ramClassLargeBlockFreeList;
-		while (NULL != ramClassTinyBlockFreeListPtr) {
-			*used -= ramClassTinyBlockFreeListPtr->size;
-			ramClassTinyBlockFreeListPtr = ramClassTinyBlockFreeListPtr->nextFreeListBlock;
-		}
-		while (NULL != ramClassSmallBlockFreeListPtr) {
-			*used -= ramClassSmallBlockFreeListPtr->size;
-			ramClassSmallBlockFreeListPtr = ramClassSmallBlockFreeListPtr->nextFreeListBlock;
-		}
-		while (NULL != ramClassLargeBlockFreeListPtr) {
-			*used -= ramClassLargeBlockFreeListPtr->size;
-			ramClassLargeBlockFreeListPtr = ramClassLargeBlockFreeListPtr->nextFreeListBlock;
-		}
-	}
-}
-
-/**
- * @brief Subtracts the size of each UDATA block in a chain from the accumulator.
- *
- * Walks a chain of UDATA blocks starting at ramClassUDATABlockFreeListPtr
- * and subtracts sizeof(UDATA) for each from used.
- *
- * @param ramClassUDATABlockFreeListPtr Head of UDATA block chain (may be NULL).
- * @param used Pointer to a jlong accumulator decremented by block count * sizeof(UDATA).
- */
-void
-subtractUDATABlockChain(UDATA *ramClassUDATABlockFreeListPtr, jlong *used)
-{
-	while (NULL != ramClassUDATABlockFreeListPtr) {
-		*used -= sizeof(UDATA);
-		ramClassUDATABlockFreeListPtr = *(UDATA **)ramClassUDATABlockFreeListPtr;
-	}
-}
-
 jobject JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getNonHeapMemoryUsageImpl(JNIEnv *env, jobject beanInstance, jclass memoryUsage, jobject memUsageConstructor)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	jlong used = 0; 
 	jlong committed = 0;
@@ -125,21 +76,26 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getNonHeapMemoryUsag
 	omrthread_monitor_enter(javaVM->classTableMutex);
 	classLoader = javaVM->internalVMFunctions->allClassLoadersStartDo(&walkState, javaVM, 0);
 	while (NULL != classLoader) {
-		J9RAMClassFreeLists *sub4gBlockPtr = &classLoader->sub4gBlock;
-		J9RAMClassFreeLists *frequentlyAccessedBlockPtr = &classLoader->frequentlyAccessedBlock;
-		J9RAMClassFreeLists *inFrequentlyAccessedBlockPtr = &classLoader->inFrequentlyAccessedBlock;
-		UDATA *ramClassSub4gUDATABlockFreeListPtr = sub4gBlockPtr->ramClassUDATABlockFreeList;
-		UDATA *ramClassFreqUDATABlockFreeListPtr = frequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
-		UDATA *ramClassInFreqUDATABlockFreeListPtr = inFrequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
-
-		subtractUDATABlockChain(ramClassSub4gUDATABlockFreeListPtr, &used);
-		subtractUDATABlockChain(ramClassFreqUDATABlockFreeListPtr, &used);
-		subtractUDATABlockChain(ramClassInFreqUDATABlockFreeListPtr, &used);
-
-		subtractFreeListBlocks(sub4gBlockPtr, &used);
-		subtractFreeListBlocks(frequentlyAccessedBlockPtr, &used);
-		subtractFreeListBlocks(inFrequentlyAccessedBlockPtr, &used);
-
+		UDATA *udataFreeListBlock = classLoader->ramClassUDATABlockFreeList;
+		J9RAMClassFreeListBlock *tinyFreeListBlock = classLoader->ramClassTinyBlockFreeList;
+		J9RAMClassFreeListBlock *smallFreeListBlock = classLoader->ramClassSmallBlockFreeList;
+		J9RAMClassFreeListBlock *largeFreeListBlock = classLoader->ramClassLargeBlockFreeList;
+		while (NULL != udataFreeListBlock) {
+			used -= sizeof(UDATA);
+			udataFreeListBlock = *(UDATA **) udataFreeListBlock;
+		}
+		while (NULL != tinyFreeListBlock) {
+			used -= tinyFreeListBlock->size;
+			tinyFreeListBlock = tinyFreeListBlock->nextFreeListBlock;
+		}
+		while (NULL != smallFreeListBlock) {
+			used -= smallFreeListBlock->size;
+			smallFreeListBlock = smallFreeListBlock->nextFreeListBlock;
+		}
+		while (NULL != largeFreeListBlock) {
+			used -= largeFreeListBlock->size;
+			largeFreeListBlock = largeFreeListBlock->nextFreeListBlock;
+		}
 		classLoader = javaVM->internalVMFunctions->allClassLoadersNextDo(&walkState);
 	}
 	javaVM->internalVMFunctions->allClassLoadersEndDo(&walkState);
@@ -210,7 +166,7 @@ jint JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getObjectPendingFinalizationCountImpl(JNIEnv *env, jobject beanInstance)
 {
 #if defined(J9VM_GC_FINALIZATION)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	return (jint)javaVM->memoryManagerFunctions->j9gc_get_objects_pending_finalization_count(javaVM);
 #else
 	return (jint)0;
@@ -220,7 +176,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getObjectPendingFina
 jboolean JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_isVerboseImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	return VERBOSE_GC == (VERBOSE_GC & javaVM->verboseLevel) ;
 }
@@ -228,7 +184,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_isVerboseImpl(JNIEnv
 void JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setVerboseImpl(JNIEnv *env, jobject beanInstance, jboolean flag)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9VerboseSettings verboseOptions;
 
 	memset(&verboseOptions, 0, sizeof(J9VerboseSettings));
@@ -241,7 +197,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setVerboseImpl(JNIEn
 void JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_createMemoryManagers(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	jclass memBean = NULL;
 	jstring childName = NULL;
 	jmethodID helperID = NULL;
@@ -278,7 +234,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_createMemoryManagers
 	}
 
 	for (idx = 0; idx < mgmt->supportedCollectors; ++idx) {
-		id = (jint)mgmt->garbageCollectors[idx].id;
+		id = (jint) mgmt->garbageCollectors[idx].id;
 		childName = (*env)->NewStringUTF(env, mgmt->garbageCollectors[idx].name);
 		if (NULL == childName) {
 			return;
@@ -291,7 +247,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_createMemoryManagers
 void JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_createMemoryPools(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	jclass memBean = NULL;
 	jstring childName = NULL;
 	jmethodID helperID = NULL;
@@ -311,7 +267,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_createMemoryPools(JN
 
 	/* Heap Memory Pools */
 	for (idx = 0; idx < mgmt->supportedMemoryPools; ++idx) {
-		id = (jint)mgmt->memoryPools[idx].id;
+		id = (jint) mgmt->memoryPools[idx].id;
 		childName = (*env)->NewStringUTF(env, mgmt->memoryPools[idx].name);
 		if (NULL == childName) {
 			return;
@@ -325,7 +281,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_createMemoryPools(JN
 
 	/* NonHeap Memory Pools */
 	for (idx = 0; idx < mgmt->supportedNonHeapMemoryPools; ++idx) {
-		id = (jint)mgmt->nonHeapMemoryPools[idx].id;
+		id = (jint) mgmt->nonHeapMemoryPools[idx].id;
 		childName = (*env)->NewStringUTF(env, mgmt->nonHeapMemoryPools[idx].name);
 		if (NULL == childName) {
 			return;
@@ -341,7 +297,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_createMemoryPools(JN
 jlong JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMaxHeapSizeLimitImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	return javaVM->memoryManagerFunctions->j9gc_get_maximum_heap_size(javaVM);
 }
@@ -349,7 +305,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMaxHeapSizeLimitI
 jlong JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMaxHeapSizeImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	UDATA softmx = javaVM->memoryManagerFunctions->j9gc_get_softmx(javaVM);
 
 	/* if no softmx has been set, report -Xmx instead as it is the current max heap size */
@@ -362,7 +318,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMaxHeapSizeImpl(J
 jlong JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMinHeapSizeImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	return javaVM->memoryManagerFunctions->j9gc_get_initial_heap_size(javaVM);
 }
@@ -370,7 +326,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMinHeapSizeImpl(J
 void JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setMaxHeapSizeImpl(JNIEnv *env, jobject beanInstance, jlong newsoftmx)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	javaVM->memoryManagerFunctions->j9gc_set_softmx(javaVM, (UDATA)newsoftmx);
 }
@@ -381,7 +337,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setSharedClassCacheS
 	jboolean ret = JNI_FALSE;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		if (0 != javaVM->sharedClassConfig->setMinMaxBytes(javaVM, (U_32)value, -1, -1, -1, -1)) {
@@ -398,7 +354,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setSharedClassCacheM
 	jboolean ret = JNI_FALSE;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		if (0 != javaVM->sharedClassConfig->setMinMaxBytes(javaVM, (U_32)-1, (I_32)value, -1, -1, -1)) {
@@ -415,7 +371,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setSharedClassCacheM
 	jboolean ret = JNI_FALSE;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		if (0 != javaVM->sharedClassConfig->setMinMaxBytes(javaVM, (U_32)-1, -1, (I_32)value, -1, -1)) {
@@ -432,7 +388,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setSharedClassCacheM
 	jboolean ret = JNI_FALSE;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		if (0 != javaVM->sharedClassConfig->setMinMaxBytes(javaVM, (U_32)-1, -1, -1, (I_32)value, -1)) {
@@ -449,7 +405,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_setSharedClassCacheM
 	jboolean ret = JNI_FALSE;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		if (0 != javaVM->sharedClassConfig->setMinMaxBytes(javaVM, (U_32)-1, -1, -1, -1, (I_32)value)) {
@@ -466,7 +422,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getSharedClassCacheS
 	U_32 ret = 0;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		javaVM->sharedClassConfig->getUnstoredBytes(javaVM, &ret, NULL, NULL);
@@ -481,7 +437,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getSharedClassCacheM
 	U_32 ret = 0;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		javaVM->sharedClassConfig->getUnstoredBytes(javaVM, NULL, &ret, NULL);
@@ -496,7 +452,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getSharedClassCacheM
 	U_32 ret = 0;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 
 	if (javaVM->sharedClassConfig) {
 		javaVM->sharedClassConfig->getUnstoredBytes(javaVM, NULL, NULL, &ret);
@@ -514,7 +470,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_isSetMaxHeapSizeSupp
 jstring JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getGCModeImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	const char *gcMode = javaVM->memoryManagerFunctions->j9gc_get_gcmodestring(javaVM);
 
 	if (NULL != gcMode) {
@@ -527,7 +483,7 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getGCModeImpl(JNIEnv
 jlong JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getGCMainThreadCpuUsedImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	jlong result = 0;
 
@@ -541,12 +497,12 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getGCMainThreadCpuUs
 jlong JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getGCWorkerThreadsCpuUsedImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	jlong result = 0;
 
 	omrthread_rwmutex_enter_read(mgmt->managementDataLock);
-	result = (jlong)mgmt->gcWorkerCpuTime;
+	result = (jlong) mgmt->gcWorkerCpuTime;
 	omrthread_rwmutex_exit_read(mgmt->managementDataLock);
 
 	return result;
@@ -555,12 +511,12 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getGCWorkerThreadsCp
 jint JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMaximumGCThreadsImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	jint result = 0;
 
 	omrthread_rwmutex_enter_read(mgmt->managementDataLock);
-	result = (jint)mgmt->gcMaxThreads;
+	result = (jint) mgmt->gcMaxThreads;
 	omrthread_rwmutex_exit_read(mgmt->managementDataLock);
 
 	return result;
@@ -569,12 +525,12 @@ Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getMaximumGCThreadsI
 jint JNICALL
 Java_com_ibm_java_lang_management_internal_MemoryMXBeanImpl_getCurrentGCThreadsImpl(JNIEnv *env, jobject beanInstance)
 {
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	jint result = 0;
 
 	omrthread_rwmutex_enter_read(mgmt->managementDataLock);
-	result = (jint)mgmt->gcCurrentThreads;
+	result = (jint) mgmt->gcCurrentThreads;
 	omrthread_rwmutex_exit_read(mgmt->managementDataLock);
 
 	return result;
@@ -585,7 +541,7 @@ void JNICALL
 Java_com_ibm_lang_management_internal_MemoryNotificationThread_processNotificationLoop(JNIEnv *env, jobject threadInstance)
 {
 	/* currently, the only notification queue is for the heap */
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	jclass threadClass = NULL;
 	jclass stringClass = NULL;
@@ -770,7 +726,7 @@ Java_com_ibm_lang_management_internal_MemoryNotificationThread_processNotificati
 		} else {
 			/* dispatch  usage threshold Notification */
 			memoryPoolUsageThreshold *usageThreshold = notification->usageThreshold;
-			idx = (U_32)getIndexFromMemoryPoolID(mgmt, usageThreshold->poolID);
+			idx = (U_32) getIndexFromMemoryPoolID(mgmt, usageThreshold->poolID);
 			pool = &mgmt->memoryPools[idx];
 			poolName = poolNames[idx];
 			if (THRESHOLD_EXCEEDED == notification->type) {
@@ -832,7 +788,7 @@ void JNICALL
 Java_com_ibm_lang_management_internal_MemoryNotificationThreadShutdown_sendShutdownNotification(JNIEnv *env, jobject instance)
 {
 	/* currently, the only queue is the heap usage notification queue */
-	J9JavaVM *javaVM = ((J9VMThread *)env)->javaVM;
+	J9JavaVM *javaVM = ((J9VMThread *) env)->javaVM;
 	J9JavaLangManagementData *mgmt = javaVM->managementData;
 	J9MemoryNotification *notification = NULL;
 	J9MemoryNotification *next = NULL;

--- a/runtime/jvmti/jvmtiExtensionMechanism.c
+++ b/runtime/jvmti/jvmtiExtensionMechanism.c
@@ -2834,16 +2834,15 @@ done:
 static jvmtiError 
 jvmtiGetMethodAndClassNames_verifyRamMethod(J9JavaVM * vm, J9Method * ramMethod)
 {
-	J9Class *clazz = NULL;
-	J9MemorySegment *segment = NULL;
+	J9Class * clazz;
+	J9MemorySegment *segment;
 	J9ClassWalkState walkState;
+
 
 	omrthread_monitor_enter(vm->classTableMutex);
 
-	segment = (J9MemorySegment *)avl_search(&vm->classMemorySegments->avlTreeData, (UDATA)ramMethod);
-	if ((NULL == segment) || (NULL == segment->classLoader)
-		|| J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_UNDEAD_CLASS)
-	) {
+	segment = (J9MemorySegment *) avl_search(&vm->classMemorySegments->avlTreeData, (UDATA) ramMethod);
+	if ((segment == NULL) || (segment->type == MEMORY_TYPE_UNDEAD_CLASS) || (segment->classLoader == NULL)) {
 		/* Bail out if we happen to hit a segment with undead classes, those segments do not have a valid classloader
 		 * and would contain invalid methods in the first place. */
 		omrthread_monitor_exit(vm->classTableMutex);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -3677,14 +3677,8 @@ typedef struct J9HookedNative {
 	UDATA userdata;
 } J9HookedNative;
 
-typedef struct J9RAMClassFreeLists {
-	struct J9RAMClassFreeListBlock *ramClassTinyBlockFreeList;
-	struct J9RAMClassFreeListBlock *ramClassSmallBlockFreeList;
-	struct J9RAMClassFreeListBlock *ramClassLargeBlockFreeList;
-	UDATA *ramClassUDATABlockFreeList;
-} J9RAMClassFreeLists;
-
 /* @ddr_namespace: map_to_type=J9ClassLoader */
+
 typedef struct J9ClassLoader {
 	struct J9Pool* sharedLibraries;
 	struct J9HashTable* classHashTable;
@@ -3704,9 +3698,10 @@ typedef struct J9ClassLoader {
 #endif /* defined(J9VM_NEEDS_JNI_REDIRECTION) */
 	struct J9JITExceptionTable* jitMetaDataList;
 	struct J9MemorySegment* classSegments;
-	struct J9RAMClassFreeLists sub4gBlock;
-	struct J9RAMClassFreeLists frequentlyAccessedBlock;
-	struct J9RAMClassFreeLists inFrequentlyAccessedBlock;
+	struct J9RAMClassFreeListBlock* ramClassLargeBlockFreeList;
+	struct J9RAMClassFreeListBlock* ramClassSmallBlockFreeList;
+	struct J9RAMClassFreeListBlock* ramClassTinyBlockFreeList;
+	UDATA* ramClassUDATABlockFreeList;
 	struct J9HashTable* redefinedClasses;
 	struct J9NativeLibrary* librariesHead;
 	struct J9NativeLibrary* librariesTail;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -115,9 +115,9 @@ typedef struct J9RAMClassFreeListLargeBlock {
 } J9RAMClassFreeListLargeBlock;
 
 typedef enum SegmentKind {
-	SK_SUB4G,
-	SK_ABOVE4G_FREQUENTLY_ACCESSED,
-	SK_ABOVE4G_INFREQUENTLY_ACCESSED
+	SUB4G,
+	FREQUENTLY_ACCESSED,
+	INFREQUENTLY_ACCESSED
 } SegmentKind;
 
 typedef struct RAMClassAllocationRequest {
@@ -3063,14 +3063,14 @@ fail:
 			allocationRequests[RAM_CLASS_HEADER_FRAGMENT].alignment = J9_REQUIRED_CLASS_ALIGNMENT;
 			allocationRequests[RAM_CLASS_HEADER_FRAGMENT].alignedSize = sizeof(J9Class) + vTableSlots * sizeof(UDATA);
 			allocationRequests[RAM_CLASS_HEADER_FRAGMENT].address = NULL;
-			allocationRequests[RAM_CLASS_HEADER_FRAGMENT].segmentKind = SK_SUB4G;
+			allocationRequests[RAM_CLASS_HEADER_FRAGMENT].segmentKind = SUB4G;
 
 			/* RAM methods fragment */
 			allocationRequests[RAM_METHODS_FRAGMENT].prefixSize = extendedMethodBlockSize * sizeof(UDATA);
 			allocationRequests[RAM_METHODS_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_METHODS_FRAGMENT].alignedSize = (romClass->romMethodCount + defaultConflictCount) * sizeof(J9Method);
 			allocationRequests[RAM_METHODS_FRAGMENT].address = NULL;
-			allocationRequests[RAM_METHODS_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_METHODS_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 
 			/* superclasses fragment */
 			allocationRequests[RAM_SUPERCLASSES_FRAGMENT].prefixSize = 0;
@@ -3082,42 +3082,42 @@ fail:
 			}
 			allocationRequests[RAM_SUPERCLASSES_FRAGMENT].alignedSize = OMR_MAX(superclassSizeBytes, minimumSuperclassArraySizeBytes);
 			allocationRequests[RAM_SUPERCLASSES_FRAGMENT].address = NULL;
-			allocationRequests[RAM_SUPERCLASSES_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_SUPERCLASSES_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 
 			/* instance description fragment */
 			allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].alignedSize = instanceDescriptionSlotCount * sizeof(UDATA);
 			allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].address = NULL;
-			allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 
 			/* iTable fragment */
 			allocationRequests[RAM_ITABLE_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_ITABLE_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_ITABLE_FRAGMENT].alignedSize = iTableSlotCount * sizeof(UDATA);
 			allocationRequests[RAM_ITABLE_FRAGMENT].address = NULL;
-			allocationRequests[RAM_ITABLE_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_ITABLE_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 
 			/* static slots fragment */
 			allocationRequests[RAM_STATICS_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_STATICS_FRAGMENT].alignment = sizeof(U_64);
 			allocationRequests[RAM_STATICS_FRAGMENT].alignedSize = totalStaticSlots * sizeof(UDATA);
 			allocationRequests[RAM_STATICS_FRAGMENT].address = NULL;
-			allocationRequests[RAM_STATICS_FRAGMENT].segmentKind = SK_ABOVE4G_FREQUENTLY_ACCESSED;
+			allocationRequests[RAM_STATICS_FRAGMENT].segmentKind = FREQUENTLY_ACCESSED;
 
 			/* constant pool fragment */
 			allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].alignment = REQUIRED_CONSTANT_POOL_ALIGNMENT;
 			allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].alignedSize = romClass->ramConstantPoolCount * 2 * sizeof(UDATA);
 			allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].address = NULL;
-			allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].segmentKind = SK_SUB4G;
+			allocationRequests[RAM_CONSTANT_POOL_FRAGMENT].segmentKind = SUB4G;
 
 			/* call sites fragment */
 			allocationRequests[RAM_CALL_SITES_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_CALL_SITES_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_CALL_SITES_FRAGMENT].alignedSize = romClass->callSiteCount * sizeof(UDATA);
 			allocationRequests[RAM_CALL_SITES_FRAGMENT].address = NULL;
-			allocationRequests[RAM_CALL_SITES_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_CALL_SITES_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
 			/* invoke cache fragment */
@@ -3125,20 +3125,20 @@ fail:
 			allocationRequests[RAM_INVOKE_CACHE_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_INVOKE_CACHE_FRAGMENT].alignedSize = romClass->invokeCacheCount * sizeof(UDATA);
 			allocationRequests[RAM_INVOKE_CACHE_FRAGMENT].address = NULL;
-			allocationRequests[RAM_INVOKE_CACHE_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_INVOKE_CACHE_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 			/* method types fragment */
 			allocationRequests[RAM_METHOD_TYPES_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_METHOD_TYPES_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_METHOD_TYPES_FRAGMENT].alignedSize = romClass->methodTypeCount * sizeof(UDATA);
 			allocationRequests[RAM_METHOD_TYPES_FRAGMENT].address = NULL;
-			allocationRequests[RAM_METHOD_TYPES_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_METHOD_TYPES_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 			/* varhandle method types fragment */
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].alignedSize = romClass->varHandleMethodTypeCount * sizeof(UDATA);
 			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].address = NULL;
-			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_VARHANDLE_METHOD_TYPES_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 			/* static split table fragment */
@@ -3146,14 +3146,14 @@ fail:
 			allocationRequests[RAM_STATIC_SPLIT_TABLE_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_STATIC_SPLIT_TABLE_FRAGMENT].alignedSize = romClass->staticSplitMethodRefCount * sizeof(J9Method *);
 			allocationRequests[RAM_STATIC_SPLIT_TABLE_FRAGMENT].address = NULL;
-			allocationRequests[RAM_STATIC_SPLIT_TABLE_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_STATIC_SPLIT_TABLE_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 
 			/* special split table fragment */
 			allocationRequests[RAM_SPECIAL_SPLIT_TABLE_FRAGMENT].prefixSize = 0;
 			allocationRequests[RAM_SPECIAL_SPLIT_TABLE_FRAGMENT].alignment = sizeof(UDATA);
 			allocationRequests[RAM_SPECIAL_SPLIT_TABLE_FRAGMENT].alignedSize = romClass->specialSplitMethodRefCount * sizeof(J9Method *);
 			allocationRequests[RAM_SPECIAL_SPLIT_TABLE_FRAGMENT].address = NULL;
-			allocationRequests[RAM_SPECIAL_SPLIT_TABLE_FRAGMENT].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_SPECIAL_SPLIT_TABLE_FRAGMENT].segmentKind = INFREQUENTLY_ACCESSED;
 
 			/* flattened classes cache */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
@@ -3165,7 +3165,7 @@ fail:
 			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].alignment = OMR_MAX(sizeof(J9Class *), sizeof(UDATA));
 			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].alignedSize = flattenedClassCacheAllocSize;
 			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].address = NULL;
-			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].segmentKind = SK_ABOVE4G_INFREQUENTLY_ACCESSED;
+			allocationRequests[RAM_CLASS_FLATTENED_CLASS_CACHE].segmentKind = INFREQUENTLY_ACCESSED;
 #endif /* J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES */
 
 			if (fastHCR) {
@@ -4297,12 +4297,12 @@ coalesceAllFreeLists(J9RAMClassFreeLists *freeLists)
 /**
  * @brief Allocates pending RAM class fragments from a new segment.
  *
- * Computes the required segment size (incl. alignment and, for SK_SUB4G, space
- * for the lastAllocatedClass pointer). Skips allocation if no fragments are
- * pending. Uses a fixed increment for SK_SUB4G segments and the VM default
- * otherwise. Allocates a segment (tagged SK_SUB4G if needed), carves it into
- * aligned fragments, records each request->address, and returns gaps to the
- * free lists.
+ * Computes the required segment size (incl. alignment and, for SUB4G,
+ * space for the lastAllocatedClass pointer). Skips allocation if no
+ * fragments are pending. Uses a fixed increment for SUB4G segments and
+ * the VM default otherwise. Allocates a segment (tagged SUB4G if needed),
+ * carves it into aligned fragments, records each request->address,
+ * and returns gaps to the free lists.
  *
  * @param requests Head of the linked list of allocation requests.
  * @param allocationRequestCount Number of entries in allocationRequests.
@@ -4348,7 +4348,7 @@ allocateRemainingFragments(RAMClassAllocationRequest *requests, UDATA allocation
 		}
 
 		/* Add sizeof(UDATA) to hold the "lastAllocatedClass" pointer. */
-		if (SK_SUB4G == segmentKind) {
+		if (SUB4G == segmentKind) {
 			newSegmentSize += sizeof(UDATA);
 		}
 
@@ -4357,7 +4357,7 @@ allocateRemainingFragments(RAMClassAllocationRequest *requests, UDATA allocation
 		if (isLoadedByAnonClassLoader) {
 			classAllocationIncrement = 0;
 		} else {
-			if (SK_SUB4G == segmentKind) {
+			if (SUB4G == segmentKind) {
 				const UDATA headersPerSegment = 32;
 				classAllocationIncrement = sizeof(J9Class) * headersPerSegment;
 			}
@@ -4366,7 +4366,7 @@ allocateRemainingFragments(RAMClassAllocationRequest *requests, UDATA allocation
 		coalesceAllFreeLists(j9RamClassFreeList);
 
 		UDATA memoryType = MEMORY_TYPE_RAM_CLASS;
-		if (SK_SUB4G == segmentKind) {
+		if (SUB4G == segmentKind) {
 			memoryType |= MEMORY_TYPE_RAM_CLASS_SUB4G;
 		}
 		Trc_VM_internalAllocateRAMClass_AllocateClassMemorySegment(fragmentsLeftToAllocate, newSegmentSize, classAllocationIncrement);
@@ -4518,15 +4518,15 @@ internalAllocateRAMClass(J9JavaVM *javaVM, J9ClassLoader *classLoader, RAMClassA
 		dummyHead.next = requests;
 		prev = &dummyHead;
 		for (request = requests; NULL != request; request = request->next) {
-			if (SK_SUB4G == request->segmentKind) {
+			if (SUB4G == request->segmentKind) {
 				allocateFreeListBlock(
 						request, classLoader, prev, &classLoader->sub4gBlock,
 						classLoader->sub4gBlock.ramClassUDATABlockFreeList);
-			} else if (SK_ABOVE4G_FREQUENTLY_ACCESSED == request->segmentKind) {
+			} else if (FREQUENTLY_ACCESSED == request->segmentKind) {
 				allocateFreeListBlock(
 						request, classLoader, prev, &classLoader->frequentlyAccessedBlock,
 						classLoader->frequentlyAccessedBlock.ramClassUDATABlockFreeList);
-			} else if (SK_ABOVE4G_INFREQUENTLY_ACCESSED == request->segmentKind) {
+			} else if (INFREQUENTLY_ACCESSED == request->segmentKind) {
 				allocateFreeListBlock(
 						request, classLoader, prev, &classLoader->inFrequentlyAccessedBlock,
 						classLoader->inFrequentlyAccessedBlock.ramClassUDATABlockFreeList);
@@ -4544,7 +4544,7 @@ internalAllocateRAMClass(J9JavaVM *javaVM, J9ClassLoader *classLoader, RAMClassA
 	if (fragmentsLeftToAllocate) {
 		memoryAllocationSuccess = allocateRemainingFragments(
 				requests, allocationRequestCount, javaVM, classLoader, allocationRequests,
-				&classLoader->sub4gBlock, classLoader->sub4gBlock.ramClassUDATABlockFreeList, SK_SUB4G);
+				&classLoader->sub4gBlock, classLoader->sub4gBlock.ramClassUDATABlockFreeList, SUB4G);
 		if (!memoryAllocationSuccess) {
 			return NULL;
 		}
@@ -4552,14 +4552,14 @@ internalAllocateRAMClass(J9JavaVM *javaVM, J9ClassLoader *classLoader, RAMClassA
 		if (isNotLoadedByAnonClassLoader) {
 			memoryAllocationSuccess = allocateRemainingFragments(
 					requests, allocationRequestCount, javaVM, classLoader, allocationRequests, &classLoader->frequentlyAccessedBlock,
-					classLoader->frequentlyAccessedBlock.ramClassUDATABlockFreeList, SK_ABOVE4G_FREQUENTLY_ACCESSED);
+					classLoader->frequentlyAccessedBlock.ramClassUDATABlockFreeList, FREQUENTLY_ACCESSED);
 			if (!memoryAllocationSuccess) {
 				return NULL;
 			}
 
 			memoryAllocationSuccess = allocateRemainingFragments(
 					requests, allocationRequestCount, javaVM, classLoader, allocationRequests, &classLoader->inFrequentlyAccessedBlock,
-					classLoader->inFrequentlyAccessedBlock.ramClassUDATABlockFreeList, SK_ABOVE4G_INFREQUENTLY_ACCESSED);
+					classLoader->inFrequentlyAccessedBlock.ramClassUDATABlockFreeList, INFREQUENTLY_ACCESSED);
 
 			if (!memoryAllocationSuccess) {
 				return NULL;

--- a/runtime/vm/segment.c
+++ b/runtime/vm/segment.c
@@ -134,14 +134,12 @@ void freeMemorySegment(J9JavaVM *javaVM, J9MemorySegment *segment, BOOLEAN freeD
 		 */
 		if (J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_CODE | MEMORY_TYPE_FIXED_RAM_CLASS | MEMORY_TYPE_VIRTUAL)) {
 			j9vmem_free_memory(segment->baseAddress, segment->size, &segment->vmemIdentifier);
-		} else if (useAdvise && J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_JIT_SCRATCH_SPACE)) {
+		} else if ((useAdvise) && (MEMORY_TYPE_JIT_SCRATCH_SPACE & segment->type)) {
 			j9mem_advise_and_free_memory(segment->baseAddress);
-		} else if (J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS | MEMORY_TYPE_UNDEAD_CLASS)) {
+		} else if (segment->type & (MEMORY_TYPE_RAM_CLASS | MEMORY_TYPE_UNDEAD_CLASS)) {
 #if defined(J9VM_OPT_SNAPSHOTS)
 			if (IS_SNAPSHOTTING_ENABLED(javaVM)) {
-				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)
-					&& J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS_SUB4G)
-				) {
+				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)) {
 					vmsnapshot_free_memory32(segment->baseAddress);
 				} else {
 					vmsnapshot_free_memory(segment->baseAddress);
@@ -149,9 +147,7 @@ void freeMemorySegment(J9JavaVM *javaVM, J9MemorySegment *segment, BOOLEAN freeD
 			} else
 #endif /* defined(J9VM_OPT_SNAPSHOTS) */
 			{
-				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)
-					&& J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS_SUB4G)
-				) {
+				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)) {
 					j9mem_free_memory32(segment->baseAddress);
 				} else {
 					j9mem_free_memory(segment->baseAddress);
@@ -304,9 +300,7 @@ allocateMemoryForSegment(J9JavaVM *javaVM,J9MemorySegment *segment, J9PortVmemPa
 	} else if (J9_ARE_ALL_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS)) {
 #if defined(J9VM_OPT_SNAPSHOTS)
 		if (IS_SNAPSHOTTING_ENABLED(javaVM)) {
-			if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)
-				&& J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS_SUB4G)
-			) {
+			if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)) {
 				tmpAddr = vmsnapshot_allocate_memory32(segment->size, memoryCategory);
 			} else {
 				tmpAddr = vmsnapshot_allocate_memory(segment->size, memoryCategory);
@@ -314,9 +308,7 @@ allocateMemoryForSegment(J9JavaVM *javaVM,J9MemorySegment *segment, J9PortVmemPa
 		} else
 #endif /* defined(J9VM_OPT_SNAPSHOTS) */
 		{
-			if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)
-				&& J9_ARE_ANY_BITS_SET(segment->type, MEMORY_TYPE_RAM_CLASS_SUB4G)
-			) {
+			if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(javaVM)) {
 				tmpAddr = j9mem_allocate_memory32(segment->size, memoryCategory);
 			} else {
 				tmpAddr = j9mem_allocate_memory(segment->size, memoryCategory);
@@ -863,7 +855,6 @@ printSegments(J9MemorySegment *s, void* data)
 	if ((type & MEMORY_TYPE_VIRTUAL) == MEMORY_TYPE_VIRTUAL) printf("MEMORY_TYPE_VIRTUAL ");
 	if ((type & MEMORY_TYPE_FIXED_RAM_CLASS) == MEMORY_TYPE_FIXED_RAM_CLASS) printf("MEMORY_TYPE_FIXED_RAM_CLASS ");
 	if ((type & MEMORY_TYPE_RAM_CLASS) == MEMORY_TYPE_RAM_CLASS) printf("MEMORY_TYPE_RAM_CLASS ");
-	if ((type & MEMORY_TYPE_RAM_CLASS_SUB4G) == MEMORY_TYPE_RAM_CLASS_SUB4G) printf("MEMORY_TYPE_RAM_CLASS_SUB4G ");
 	if ((type & MEMORY_TYPE_IGC_SCAN_QUEUE) == MEMORY_TYPE_IGC_SCAN_QUEUE) printf("MEMORY_TYPE_IGC_SCAN_QUEUE ");
 	if ((type & MEMORY_TYPE_RAM) == MEMORY_TYPE_RAM) printf("MEMORY_TYPE_RAM ");
 	if ((type & MEMORY_TYPE_FIXED) == MEMORY_TYPE_FIXED) printf("MEMORY_TYPE_FIXED ");


### PR DESCRIPTION
This PR reverts the below PRs:
- https://github.com/eclipse-openj9/openj9/pull/22578
- https://github.com/eclipse-openj9/openj9/pull/22590

These changes are being reverted because of
- a perf issue (more details in https://github.com/eclipse-openj9/openj9/pull/22530#issuecomment-3304016781); and
- a functional issue (more details in https://github.com/eclipse-openj9/openj9/issues/22584#issuecomment-3309764285).