### PR TITLE
Updated 0.55 release - XL C++ and java.vm.version

### DIFF
--- a/doc/release-notes/0.55/0.55.md
+++ b/doc/release-notes/0.55/0.55.md
@@ -48,6 +48,20 @@ The following table covers notable changes in v0.55.0. Further information about
 <tbody>
 
 <tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/19098">#19098</a></td>
+<td valign="top">XL C++ Runtime 17.1.3.0 or later required for AIX OpenJ9 builds.</td>
+<td valign="top">OpenJDK 25 and later (AIX)</td>
+<td valign="top">Earlier, XL C++ Runtime 16.1.0.10 or later was required for AIX OpenJ9 builds. Now, AIX OpenJ9 builds require version 17.1.3.0 or later of the IBM XL C++ Runtime.</td>
+</tr>
+
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/22626">#22626</a></td>
+<td valign="top">The format of the <tt>java.vm.version</tt> system property value is updated to be compatible with the Runtime.Version parser.</td>
+<td valign="top">All versions</td>
+<td valign="top">Earlier, the format of the <tt>java.vm.version</tt> system property value was not standardized and structured and was not parse-able by the <tt>java.lang.Runtime.Version</tt> class.<br>With the new structured format, the <tt>java.lang.Runtime.Version</tt> class parses the value and you can extract specific information such as the information related to the VM version. This modification also changes the <tt>-version</tt> output. For example, <tt>build openj9-0.55.0</tt> changes to <tt>build 25+36-openj9-0.55.0</tt>.</td>
+</tr>
+
+<tr>
 <td valign="top"><a href="https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1069">#1069</td>
 <td valign="top">A new system property, <tt>-Djava.security.propertiesList</tt> is added to support a list of java.security property files.
 </td>


### PR DESCRIPTION
Updated the release note for the 0.55.0 release with XL C++ Runtime version update and the new format of the java.vm.version

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com