### PR TITLE
JDK26 removed JavaLangAccess StringConcatHelper APIs

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -469,6 +469,7 @@ final class Access implements JavaLangAccess {
 		return StringConcatHelper.lookupStatic(arg0, type);
 	}
 
+	/*[IF (JAVA_SPEC_VERSION < 26) | INLINE-TYPES]*/
 	public long stringConcatInitialCoder() {
 		return StringConcatHelper.initialCoder();
 	}
@@ -476,6 +477,7 @@ final class Access implements JavaLangAccess {
 	public long stringConcatMix(long arg0, String string) {
 		return StringConcatHelper.mix(arg0, string);
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION < 26) | INLINE-TYPES */
 	/*[ENDIF] JAVA_SPEC_VERSION >= 15 */
 
 	/*[IF JAVA_SPEC_VERSION >= 16]*/
@@ -591,10 +593,12 @@ final class Access implements JavaLangAccess {
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION < 24 */
 
+	/*[IF (JAVA_SPEC_VERSION < 26) | INLINE-TYPES]*/
 	@Override
 	public long stringConcatMix(long lengthCoder, char value) {
 		return StringConcatHelper.mix(lengthCoder, value);
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION < 26) | INLINE-TYPES */
 
 	@Override
 	public PrintStream initialSystemErr() {


### PR DESCRIPTION
JDK26 removed JavaLangAccess StringConcatHelper APIs

JDK26 removed `JavaLangAccess.stringConcatInitialCoder()/stringConcatMix()` APIs.

Resolves JDK next abuild compilation failures:
```
00:10:12      T extends Object declared in class Reference
00:10:12  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:325: error: cannot find symbol
00:10:12  		return StringConcatHelper.initialCoder();
00:10:12  		                         ^
00:10:12    symbol:   method initialCoder()
00:10:12    location: class StringConcatHelper
00:10:12  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:329: error: cannot find symbol
00:10:12  		return StringConcatHelper.mix(arg0, string);
00:10:12  		                         ^
00:10:12    symbol:   method mix(long,String)
00:10:12    location: class StringConcatHelper
00:10:12  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:381: error: method does not override or implement a method from a supertype
00:10:12  	@Override
00:10:12  	^
00:10:12  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:383: error: cannot find symbol
00:10:12  		return StringConcatHelper.mix(lengthCoder, value);
00:10:12  		                         ^
00:10:12    symbol:   method mix(long,char)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>