### PR TITLE
Fix thread address format in debug output

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/stackwalker/StackWalker.java
@@ -338,8 +338,8 @@ public class StackWalker
 			}
 
 			swPrintf(walkState, 1,
-					"*** BEGIN STACK WALK, flags = {0} walkThread = {1} ***",
-					String.format("%08X", walkState.flags), walkState.threadAddress);
+					"*** BEGIN STACK WALK, flags = {0} walkThread = 0x{1} ***",
+					String.format("%08X", walkState.flags), Long.toHexString(walkState.threadAddress));
 
 			if ((walkState.flags & J9_STACKWALK_START_AT_JIT_FRAME) != 0)
 				swPrintf(walkState, 2, "\tSTART_AT_JIT_FRAME");


### PR DESCRIPTION
The thread address is formatted as long integer in debug output that makes it difficult to read. Change the formatting to hexadecimal.