### PR TITLE
Check memory segment ownership on downcall

### DIFF
--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/ConfinedMemorySegmentDowncallTest.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/ConfinedMemorySegmentDowncallTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test.jep442.downcall;
+
+import org.testng.annotations.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.testng.Assert.fail;
+
+/**
+ * Test case for JEP 442: Verify WrongThreadException when accessing a
+ * confined Arena from a different thread than the one it was created on.
+ */
+@Test(groups = { "level.sanity" })
+public class ConfinedMemorySegmentDowncallTest {
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+
+	private static final Linker linker = Linker.nativeLinker();
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test
+	public void test_confinedSegmentWrongThreadAccess() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(
+				JAVA_INT.withName("num1"),
+				JAVA_INT.withName("num2")
+		);
+		VarHandle vh1 = structLayout.varHandle(PathElement.groupElement("num1"));
+		VarHandle vh2 = structLayout.varHandle(PathElement.groupElement("num2"));
+
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment structSegment = arena.allocate(structLayout);
+			vh1.set(structSegment, 123);
+			vh2.set(structSegment, 456);
+			Object[] result = new Object[1];
+
+			Thread t1 = new Thread(() -> {
+				MemorySegment functionSymbol =
+						nativeLibLookup.find("addIntAndIntsFromStructPointer").get();
+				FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
+				MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+				try {
+					result[0] = (int) mh.invokeExact(42, structSegment);
+				} catch (Throwable t) {
+					result[0] = t;
+				}
+			});
+			t1.start();
+			t1.join();
+
+			if (result[0] instanceof WrongThreadException) {
+				// expected
+			} else if (result[0] instanceof Throwable) {
+				fail("Unexpected exception type: " + result[0]);
+			} else {
+				fail("Expected WrongThreadException was not thrown (result=" + result[0] + ")");
+			}
+		}
+	}
+}

--- a/test/functional/Java21Only/testng_210.xml
+++ b/test/functional/Java21Only/testng_210.xml
@@ -29,6 +29,7 @@
 	</listeners>
 	<test name="Jep442Tests_testLinkerFfi_DownCall">
 		<classes>
+			<class name="org.openj9.test.jep442.downcall.ConfinedMemorySegmentDowncallTest"/>
 			<class name="org.openj9.test.jep442.downcall.DuplicateMixedCallTests"/>
 			<class name="org.openj9.test.jep442.downcall.DuplicateStructTests"/>
 			<class name="org.openj9.test.jep442.downcall.InvalidDownCallTests"/>

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/ConfinedMemorySegmentDowncallTest.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/ConfinedMemorySegmentDowncallTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test.jep454.downcall;
+
+import org.testng.annotations.Test;
+
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.GroupLayout;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryLayout;
+import java.lang.foreign.MemoryLayout.PathElement;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.VarHandle;
+
+import static java.lang.foreign.ValueLayout.ADDRESS;
+import static java.lang.foreign.ValueLayout.JAVA_INT;
+import static org.testng.Assert.fail;
+
+/**
+ * Test case for JEP 454: Verify WrongThreadException when accessing a
+ * confined Arena from a different thread than the one it was created on.
+ */
+@Test(groups = { "level.sanity" })
+public class ConfinedMemorySegmentDowncallTest {
+
+	static {
+		System.loadLibrary("clinkerffitests");
+	}
+
+	private static final Linker linker = Linker.nativeLinker();
+	private static final SymbolLookup nativeLibLookup = SymbolLookup.loaderLookup();
+
+	@Test
+	public void test_confinedSegmentWrongThreadAccess() throws Throwable {
+		GroupLayout structLayout = MemoryLayout.structLayout(
+				JAVA_INT.withName("num1"),
+				JAVA_INT.withName("num2")
+		);
+		VarHandle vh1 = structLayout.varHandle(PathElement.groupElement("num1"));
+		VarHandle vh2 = structLayout.varHandle(PathElement.groupElement("num2"));
+
+		try (Arena arena = Arena.ofConfined()) {
+			MemorySegment structSegment = arena.allocate(structLayout);
+			vh1.set(structSegment, 0L, 123);
+			vh2.set(structSegment, 0L, 456);
+			Object[] result = new Object[1];
+
+			Thread t1 = new Thread(() -> {
+				MemorySegment functionSymbol =
+						nativeLibLookup.find("addIntAndIntsFromStructPointer").get();
+				FunctionDescriptor fd = FunctionDescriptor.of(JAVA_INT, JAVA_INT, ADDRESS);
+				MethodHandle mh = linker.downcallHandle(functionSymbol, fd);
+
+				try {
+					result[0] = (int) mh.invokeExact(42, structSegment);
+				} catch (Throwable t) {
+					result[0] = t;
+				}
+			});
+			t1.start();
+			t1.join();
+
+			if (result[0] instanceof WrongThreadException) {
+				// expected
+			} else if (result[0] instanceof Throwable) {
+				fail("Unexpected exception type: " + result[0]);
+			} else {
+				fail("Expected WrongThreadException was not thrown (result=" + result[0] + ")");
+			}
+		}
+	}
+}

--- a/test/functional/Java22andUp/testng_220.xml
+++ b/test/functional/Java22andUp/testng_220.xml
@@ -26,6 +26,7 @@
 <suite name="Java22+ test suite" parallel="none" verbose="2">
 	<test name="Jep454Tests_testLinkerFfi_DownCall">
 		<classes>
+			<class name="org.openj9.test.jep454.downcall.ConfinedMemorySegmentDowncallTest"/>
 			<class name="org.openj9.test.jep454.downcall.DuplicateMixedCallTests"/>
 			<class name="org.openj9.test.jep454.downcall.DuplicateStructTests"/>
 			<class name="org.openj9.test.jep454.downcall.InvalidDownCallTests"/>


### PR DESCRIPTION
Fixes: #22573
Ensure that checkValidState() is called for confined
memory segments which are passed as arguments to
the native call when argValue.address is invoked.
Make memArgScopeSet thread local.

With the following change, this is the error produced for the issue:
```
main result = 150
java.lang.WrongThreadException: Attempted access outside owning thread
	at java.base/jdk.internal.foreign.MemorySessionImpl.wrongThread(MemorySessionImpl.java:330)
	at java.base/jdk.internal.misc.ScopedMemoryAccess$ScopedAccessError.newRuntimeException(ScopedMemoryAccess.java:114)
	at java.base/jdk.internal.foreign.MemorySessionImpl.checkValidState(MemorySessionImpl.java:217)
	at java.base/openj9.internal.foreign.abi.InternalDowncallHandler.memSegmtOfPtrToLongArg(InternalDowncallHandler.java:295)
	at ConfinedMemorySegmentDowncallTest.makeDownCall(ConfinedMemorySegmentDowncallTest.java:26)
	at ConfinedMemorySegmentDowncallTest.lambda$main$0(ConfinedMemorySegmentDowncallTest.java:44)
	at java.base/java.lang.Thread.run(Thread.java:1485)


```