### PR TITLE
Defer jfr init after GC structures are initialized

### DIFF
--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -7727,16 +7727,6 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 		goto error;
 	}
 
-#if defined(J9VM_OPT_JFR)
-	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_JFR_ENABLED)) {
-		if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_START_FLIGHT_RECORDING)) {
-			if (JNI_OK != initializeJFR(vm, FALSE)) {
-				goto error;
-			}
-		}
-	}
-#endif /* defined(J9VM_OPT_JFR) */
-
 	/* Use this stage to load libraries which need to set up hooks as early as possible */
 	if (JNI_OK != runLoadStage(vm, EARLY_LOAD)) {
 		goto error;
@@ -7784,6 +7774,16 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	if (JNI_OK != (stageRC = runInitializationStage(vm, HEAP_STRUCTURES_INITIALIZED))) {
 		goto error;
 	}
+
+#if defined(J9VM_OPT_JFR)
+	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_JFR_ENABLED)) {
+		if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_START_FLIGHT_RECORDING)) {
+			if (JNI_OK != initializeJFR(vm, FALSE)) {
+				goto error;
+			}
+		}
+	}
+#endif /* defined(J9VM_OPT_JFR) */
 
 	if (JNI_OK != (stageRC = runInitializationStage(vm, ALL_VM_ARGS_CONSUMED))) {
 		goto error;


### PR DESCRIPTION
Currently initialization of JFR hooks happens very early such that it is not possible to register GC hooks. This PR delays the initialization of JFR hooks until after other JVM compeonents have been initialized.