### PR TITLE
Guard pragmas to avoid warnings from MSVC

### DIFF
--- a/runtime/tests/port/j9vmemTest.c
+++ b/runtime/tests/port/j9vmemTest.c
@@ -1618,7 +1618,9 @@ j9vmem_test_commitOutsideOfReservedRange(struct J9PortLibrary *portLibrary)
 }
 
 #if defined(AIXPPC) || defined(LINUX) || defined(WIN32) || defined(WIN64) || defined(J9ZOS390)
+#if defined(__clang__)
 #pragma clang optimize off
+#endif /* defined(__clang__) */
 /**
  * Verify port library memory management.
  * 
@@ -1734,7 +1736,9 @@ j9vmem_test_reserveExecutableMemory(struct J9PortLibrary *portLibrary)
 
 	return reportTestExit(portLibrary, testName);
 }
+#if defined(__clang__)
 #pragma clang optimize on
+#endif /* defined(__clang__) */
 #endif /* defined(AIXPPC) || defined(LINUX) || defined(WIN32) || defined(WIN64) */
 
 #if defined(J9VM_GC_VLHGC)


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/22695.