### PR TITLE
Fix Invokeinterface error handling for abstract method

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8310,13 +8310,20 @@ foundITableCache:
 						rc = GOTO_THROW_CURRENT_EXCEPTION;
 						goto done;
 					}
-					if (J9_ARE_ALL_BITS_SET(romMethod->modifiers, J9AccAbstract)) {
+					if (J9_ARE_ALL_BITS_SET(romMethod->modifiers, J9AccAbstract)
+						&& !J9ROMCLASS_IS_INTERFACE(J9_CLASS_FROM_METHOD(_sendMethod)->romClass)
+					) {
 						/* If resulting method is abstract an error will be
 						 * thrown in throwUnsatisfiedLinkOrAbstractMethodError.
 						 * Return the interface class's method so the correct
 						 * exception handling is used.
 						 */
-						_sendMethod = interfaceClass->ramMethods + methodIndex;
+						_sendMethod = (J9Method*)javaLookupMethod(
+							_currentThread,
+							interfaceClass,
+							&romMethod->nameAndSignature,
+							NULL,
+							J9_LOOK_INTERFACE | J9_LOOK_NO_THROW | J9_LOOK_INVOKE_INTERFACE);
 					}
 					profileInvokeReceiver(REGISTER_ARGS, receiverClass, _literals, _sendMethod);
 					_pc += offset;

--- a/runtime/vm/lookupmethod.c
+++ b/runtime/vm/lookupmethod.c
@@ -575,6 +575,7 @@ doneItableSearch:
  * 
  * 		J9_LOOK_VIRTUAL							Search for a virtual (instance) method
  * 		J9_LOOK_STATIC							Search for a static method
+ * 		J9_LOOK_INVOKE_INTERFACE					Special handling for invokeinterface resolution.
  * 		J9_LOOK_INTERFACE						Search for an interface method - assumes given class is interface class and searches only it and its superinterfaces (i.e. does not search Object)
  * 		J9_LOOK_JNI								Use JNI behaviour (allow virtual lookup to succeed when it finds a method in an interface class, throw only NoSuchMethodError on failure, VERIFIED C strings for name and sig)
  * 		J9_LOOK_NO_CLIMB						Search only the given class, no superclasses or superinterfaces


### PR DESCRIPTION
Fix regression introduced in https://github.com/eclipse-openj9/openj9/pull/22582

The interface method may not exist in the interface class, it may be inherited. If the first abstract method found is in a class return the first available abstract method in an interface instead.

Tests:
Java 8 https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/55156/
Java 11 https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/55142/
Java 21 https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/55144/