### PR TITLE
Enable can_generate_sampled_object_alloc_events for Balanced

### DIFF
--- a/runtime/jvmti/jvmtiCapability.c
+++ b/runtime/jvmti/jvmtiCapability.c
@@ -182,7 +182,6 @@ jvmtiGetPotentialCapabilities(jvmtiEnv* env, jvmtiCapabilities* capabilities_ptr
 #if JAVA_SPEC_VERSION >= 11
 	if (isEventHookable(j9env, JVMTI_EVENT_SAMPLED_OBJECT_ALLOC)
 		&& (J9_GC_POLICY_METRONOME != vm->gcPolicy)
-		&& (J9_GC_POLICY_BALANCED != vm->gcPolicy)
 	) {
 		rv_capabilities.can_generate_sampled_object_alloc_events = 1;
 	}


### PR DESCRIPTION
There is no reason can_generate_sampled_object_alloc_events capability should be disabled for Balanced. This capability is supported. Enabling it for Balanced.