### PR TITLE
Switch to interpreter on recomp failure if the JIT body is invalidated

### DIFF
--- a/runtime/compiler/aarch64/runtime/Recomp.cpp
+++ b/runtime/compiler/aarch64/runtime/Recomp.cpp
@@ -217,10 +217,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(oldStartPC);
    TR_PersistentMethodInfo *methodInfo = bodyInfo->getMethodInfo();
 
-   if (bodyInfo->getUsesPreexistence()
-       || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && !fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
-       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
+   if ((linkageInfo->isSamplingMethodBody() && !fej9->isAsyncCompilation()) // failed recomps in sync mode
+       || bodyInfo->getIsInvalidated())
       {
       // Patch the first instruction regardless of counting or sampling
       patchAddr = (int32_t *)((uint8_t *)oldStartPC + getJitEntryOffset(linkageInfo));

--- a/runtime/compiler/arm/runtime/Recomp.cpp
+++ b/runtime/compiler/arm/runtime/Recomp.cpp
@@ -259,10 +259,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(oldStartPC);
    TR_PersistentMethodInfo   *methodInfo = bodyInfo->getMethodInfo();
 
-   if (bodyInfo->getUsesPreexistence()  // TODO: reconsider whether this is a race cond for info
-       || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
-       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
+   if ((linkageInfo->isSamplingMethodBody() && !fej9->isAsyncCompilation()) // failed recomps in sync mode
+       || bodyInfo->getIsInvalidated()) // TODO: reconsider whether this is a race cond for info
       {
       // Patch the first instruction regardless of counting or sampling
       // TODO: We may need to cross-check with Invalidation to avoid racing cond

--- a/runtime/compiler/p/runtime/Recomp.cpp
+++ b/runtime/compiler/p/runtime/Recomp.cpp
@@ -204,10 +204,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(oldStartPC);
    TR_PersistentMethodInfo   *methodInfo = bodyInfo->getMethodInfo();
 
-   if (bodyInfo->getUsesPreexistence()  // TODO: reconsider whether this is a race cond for info
-       || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
-       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
+   if ((linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation()) // failed recomps in sync mode
+       || bodyInfo->getIsInvalidated()) // TODO: reconsider whether this is a race cond for info
       {
       // Patch the first instruction regardless of counting or sampling
       // TODO: We may need to cross-check with Invalidation to avoid racing cond

--- a/runtime/compiler/x/runtime/Recomp.cpp
+++ b/runtime/compiler/x/runtime/Recomp.cpp
@@ -293,10 +293,8 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
    TR_PersistentJittedBodyInfo *bodyInfo = getJittedBodyInfoFromPC(oldStartPC);
    TR_PersistentMethodInfo   *methodInfo = bodyInfo->getMethodInfo();
 
-   if (bodyInfo->getUsesPreexistence()
-       || methodInfo->hasBeenReplaced()
-       || (usesSampling && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
-       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
+   if ((usesSampling && !fej9->isAsyncCompilation()) // failed recomps in sync mode
+       || bodyInfo->getIsInvalidated())
       {
       // We need to switch the method to interpreted.  Change the first instruction of the
       // method to jump back to the call to the interpreter dispatch

--- a/runtime/compiler/z/runtime/Recomp.cpp
+++ b/runtime/compiler/z/runtime/Recomp.cpp
@@ -312,10 +312,8 @@ J9::Recompilation::methodCannotBeRecompiled(void * oldStartPC, TR_FrontEnd * fe)
 
    patchAddr = (int32_t *) ((uint8_t *) oldStartPC + getJitEntryOffset(linkageInfo));
 
-   if (bodyInfo->getUsesPreexistence()
-       || methodInfo->hasBeenReplaced()
-       || (linkageInfo->isSamplingMethodBody() && ! fej9->isAsyncCompilation()) // go interpreted for failed recomps in sync mode
-       || methodInfo->isExcludedPostRestore()) // go interpreted if method is excluded post restore
+   if ((linkageInfo->isSamplingMethodBody() && !fej9->isAsyncCompilation()) // failed recomps in sync mode
+       || bodyInfo->getIsInvalidated())
       {
       bool usesSampling = linkageInfo->isSamplingMethodBody();
       // We need to switch the method to interpreted.  Change the first instruction of the


### PR DESCRIPTION
...for any reason whatsoever.

In particular, don't check all possible invalidation reasons separately in the condition that decides whether or not to switch to interpreter in `methodCannotBeRecompiled()`. Listing them out this way duplicates more logic than necessary, and it makes it easy to miss one, e.g. when a new reason is added.

In fact, one new use of JIT body invalidation was not accounted for in these conditions: the body could have been invalidated because an inlined method was unloaded.

As a result, it was possible for `methodCannotBeRecompiled()` to take note that recompilation had failed (via `setHasFailedRecompilation()`) without further patching the prologue, which could cause execution to enter an infinite loop where:
1. the invalidated body's prologue tries to recompile synchronously, but
2. the JIT sees that recompilation has already finished (failed), so
3. it returns the existing start PC (for the invalidated body), and
4. execution jumps to the invalidated prologue again, returning to (1).

Some additional potential consequences of the old conditions (from inspection, unverified):

- `methodCannotBeRecompiled()` might sometimes have restored the original prologue, allowing the JIT body to be re-entered even though it was invalidated (after which is it never supposed to be entered again).

- Execution could have been unnecessarily sent to the interpreter if a recompilation failed for which the original JIT body used preexistence but had not been invalidated.

Fixes #22669 