### PR TITLE
Transient class caching class loader

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -817,6 +817,16 @@ public:
    void acquireLogMonitor();
    void releaseLogMonitor();
 
+#if !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
+   // Synchronize transient class caching
+   bool isClassLoaderMarkedTransient(J9ClassLoader *classLoader);
+   void markClassLoaderTransient(J9ClassLoader *classLoader);
+   void setTransientClassLoadersSet(PersistentUnorderedSet<J9ClassLoader*> *transientClassLoaders) { _transientClassLoaders = transientClassLoaders; }
+   PersistentUnorderedSet<J9ClassLoader*> *getTransientClassLoadersSet() { return _transientClassLoaders; }
+   TR::Monitor *getTransientClassLoaderMonitor() { return _transientClassLoaderMonitor; }
+   void setTransientClassLoadersMonitor(TR::Monitor *monitor) { _transientClassLoaderMonitor = monitor; }
+#endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
+
    int32_t getQueueWeight() const { return _queueWeight; }
    void increaseQueueWeightBy(uint8_t w) { _queueWeight += (int32_t)w; }
    int32_t decreaseQueueWeightBy(uint8_t w) { TR_ASSERT((int32_t)w <= _queueWeight, "assertion failure"); return _queueWeight -= (int32_t)w; }
@@ -1321,6 +1331,10 @@ private:
       S390SupportsVectorFacility       = 0x00040000,
       DummyLastFlag
       };
+#if !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
+   TR::Monitor            *_transientClassLoaderMonitor;
+   PersistentUnorderedSet<J9ClassLoader*> *_transientClassLoaders;
+#endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
 
 #ifdef DEBUG
    bool                   _traceCompiling;

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -2401,6 +2401,15 @@ static void jitHookClassLoaderUnload(J9HookInterface * * hookInterface, UDATA ev
 
    TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
 
+#if !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
+   // Lock acquistion is not required, since compilation threads are stopped
+   // while class unloading happens.
+   if (compInfo->getTransientClassLoadersSet())
+      {
+      compInfo->getTransientClassLoadersSet()->erase(classLoader);
+      }
+#endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
+
    bool p = TR::Options::getVerboseOption(TR_VerboseHookDetailsClassUnloading);
    if (p)
       {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1923,6 +1923,28 @@ onLoadInternal(
 
    jitConfig->jitAddNewLowToHighRSSRegion = jitAddNewLowToHighRSSRegion;
 
+#if !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
+   if (TR::Options::getCmdLineOptions()->getTransientClassRegex()
+#if defined(J9VM_OPT_JITSERVER)
+       && compInfo->getPersistentInfo()->getRemoteCompilationMode() != JITServer::SERVER
+#endif /* defined(J9VM_OPT_JITSERVER) */
+   )
+      {
+      compInfo->setTransientClassLoadersSet(new (PERSISTENT_NEW) PersistentUnorderedSet<J9ClassLoader*>(PersistentUnorderedSet<J9ClassLoader*>::allocator_type(TR::Compiler->persistentAllocator())));
+      if (!compInfo->getTransientClassLoadersSet())
+         {
+         fprintf(stderr, "Cannot create transient class loaders unordered set\n");
+         return -1;
+         }
+      compInfo->setTransientClassLoadersMonitor(TR::Monitor::create("JIT-TransientClassLoadersMonitor"));
+      if (!compInfo->getTransientClassLoaderMonitor())
+         {
+         fprintf(stderr, "Cannot create transient class loaders monitor\n");
+         return -1;
+         }
+      }
+#endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
+
    return 0;
    }
 


### PR DESCRIPTION
Modify existing support for making classes as transient using a regex for their name
- if a class is identified as transient, its class loader is marked as transient
- in the future, all methods which are being loaded by a transient class loader are also considered transient for code cache purposes.