### PR TITLE
RAM Class Persistence: Fix Open liberty server hangs

### DIFF
--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -349,6 +349,12 @@ hashClassTableAt(J9ClassLoader *classLoader, U_8 *className, UDATA classNameLeng
 		if (J9ROMCLASS_IS_HIDDEN(clazz->romClass)) {
 			return NULL;
 		}
+		/* Frozen classes are not loaded, so they should not be returned with J9_FINDCLASS_FLAG_EXISTING_ONLY. */
+		if (J9_ARE_ANY_BITS_SET(flags, J9_FINDCLASS_FLAG_EXISTING_ONLY)
+			&& J9_ARE_ANY_BITS_SET(clazz->classFlags, J9ClassIsFrozen)
+		) {
+			return NULL;
+		}
 		if (J9_ARE_NO_BITS_SET(flags, J9_FINDCLASS_FLAG_DONT_SKIP_FROZEN_JCL_DEFINE_CLASS)
 			&& J9_ARE_ALL_BITS_SET(clazz->classFlags, J9ClassIsJCLDefineClass | J9ClassIsFrozen)
 		) {
@@ -751,6 +757,12 @@ hashClassTableAtString(J9ClassLoader *classLoader, j9object_t stringObject, UDAT
 		J9Class *clazz = result->ramClass;
 		checkClassAlignment(clazz, "hashClassTableAtString");
 		if (J9ROMCLASS_IS_HIDDEN(clazz->romClass)) {
+			return NULL;
+		}
+		/* Frozen classes are not loaded, so they should not be returned with J9_FINDCLASS_FLAG_EXISTING_ONLY. */
+		if (J9_ARE_ANY_BITS_SET(flags, J9_FINDCLASS_FLAG_EXISTING_ONLY)
+			&& J9_ARE_ANY_BITS_SET(clazz->classFlags, J9ClassIsFrozen)
+		) {
 			return NULL;
 		}
 		if (J9_ARE_NO_BITS_SET(flags, J9_FINDCLASS_FLAG_DONT_SKIP_FROZEN_JCL_DEFINE_CLASS)

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -324,7 +324,7 @@ internalFindClassString(J9VMThread* currentThread, j9object_t moduleName, j9obje
 	if (!fastMode) {
 		omrthread_monitor_enter(vm->classTableMutex);
 	}
-	result = hashClassTableAtString(classLoader, (j9object_t) className, 0);
+	result = hashClassTableAtString(classLoader, (j9object_t) className, options);
 #if defined(J9VM_OPT_SNAPSHOTS)
 	if ((NULL != result) && IS_RESTORE_RUN(vm)) {
 		if (!loadWarmClassFromSnapshot(currentThread, classLoader, result)) {
@@ -1181,7 +1181,7 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 		omrthread_monitor_enter(vm->classTableMutex);
 	}
 
-	foundClass = hashClassTableAt(classLoader, className, classNameLength, 0);
+	foundClass = hashClassTableAt(classLoader, className, classNameLength, options);
 	if (NULL != foundClass) {
 #if defined(J9VM_OPT_SNAPSHOTS)
 		if (IS_RESTORE_RUN(vm)) {
@@ -1212,7 +1212,7 @@ loadNonArrayClass(J9VMThread* vmThread, J9Module *j9module, U_8* className, UDAT
 				omrthread_monitor_enter(vm->classTableMutex);
 
 				/* check again if somebody else already loaded the class */
-				foundClass = hashClassTableAt(classLoader, className, classNameLength, 0);
+				foundClass = hashClassTableAt(classLoader, className, classNameLength, options);
 				if (NULL != foundClass) {
 #if defined(J9VM_OPT_SNAPSHOTS)
 					if (IS_RESTORE_RUN(vm)


### PR DESCRIPTION
The Open liberty server hangs on startup when loading classes from RCP cache and initializes the frozen classes. It is caused
by deadlock. Two threads wait for each other on RCP cache mutex and class table mutex in classes loading from RCP cache in loadNonArrayClass(). The changes are to pass the flag J9_FINDCLASS_FLAG_EXISTING_ONLY to class table lookup functions. If it's set for a frozen class, then it won't be loaded from RCP cache. The real problem is that a thread requested a class with J9_FINDCLASS_FLAG_EXISTING_ONLY is attempting to perform a RCP classload (loadWarmClass) which should never happen.  We would have similar deadlock issues in a non-RCP scenario if a thread requesting a class with J9_FINDCLASS_FLAG_EXISTING_ONLY attempted to do a full classload. This is why the only threads that are allowed to load classes are VM threads and the JIT threads always call with J9_FINDCLASS_FLAG_EXISTING_ONLY.

Fixes: #22753

Co-authored-by: Tobi Ajila tobi_ajila@ca.ibm.com