### PR TITLE
Enable VectorAPI boxing by default

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -52,7 +52,7 @@ TR_VectorAPIExpansion::perform()
    {
    bool disableVectorAPIExpansion = comp()->getOption(TR_DisableVectorAPIExpansion);
    bool traceVectorAPIExpansion = comp()->getOption(TR_TraceVectorAPIExpansion);
-   _boxingAllowed = comp()->getOption(TR_EnableVectorAPIBoxing);
+   _boxingAllowed = !comp()->getOption(TR_DisableVectorAPIBoxing);
 
    _trace = traceVectorAPIExpansion;
 


### PR DESCRIPTION
- -Xjit:disableVectorAPIBoxing option can be used to disable