### PR TITLE
Mark final fields in value classes as Trusted Final fields

### DIFF
--- a/runtime/jcl/common/reflecthelp.c
+++ b/runtime/jcl/common/reflecthelp.c
@@ -834,11 +834,12 @@ createField(struct J9VMThread *vmThread, jfieldID fieldID)
 	J9VMJAVALANGREFLECTFIELD_SET_CLAZZ(vmThread, fieldObject, J9VM_J9CLASS_TO_HEAPCLASS(j9FieldID->declaringClass));
 	J9VMJAVALANGREFLECTFIELD_SET_MODIFIERS(vmThread, fieldObject, j9FieldID->field->modifiers & CFR_FIELD_ACCESS_MASK);
 #if JAVA_SPEC_VERSION >= 15
-	/* Trust that static final fields and final record or hidden class fields will not be modified. */
+	/* Trust that static final fields, and final fields of hidden, record or value classes will not be modified. */
 	if (J9_ARE_ALL_BITS_SET(j9FieldID->field->modifiers, J9AccFinal)) {
 		if (J9_ARE_ALL_BITS_SET(j9FieldID->field->modifiers, J9AccStatic)
-			|| J9ROMCLASS_IS_RECORD(j9FieldID->declaringClass->romClass)
-			|| J9ROMCLASS_IS_HIDDEN(j9FieldID->declaringClass->romClass)
+				|| J9ROMCLASS_IS_HIDDEN(j9FieldID->declaringClass->romClass)
+				|| J9ROMCLASS_IS_RECORD(j9FieldID->declaringClass->romClass)
+				|| J9ROMCLASS_IS_VALUE(j9FieldID->declaringClass->romClass)
 		) {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 			fieldFlags |= TRUST_FINAL;

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1960,8 +1960,8 @@ exit:
 	/**
 	 * Determine if the field is a trusted final field.
 	 *
-	 * A trusted final field must have be a static final field or
-	 * a final field defined in either a hidden class or Record class
+	 * A trusted final field must be a static final field or,
+	 * a final field defined in a hidden, record or value class.
 	 *
 	 * @param field the field to be checked
 	 * @param romClass the declaring class of the field
@@ -1972,7 +1972,11 @@ exit:
 	{
 		bool result = false;
 		if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccFinal)) {
-			if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccStatic) || J9ROMCLASS_IS_HIDDEN(romClass) || J9ROMCLASS_IS_RECORD(romClass)) {
+			if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccStatic)
+					|| J9ROMCLASS_IS_HIDDEN(romClass)
+					|| J9ROMCLASS_IS_RECORD(romClass)
+					|| J9ROMCLASS_IS_VALUE(romClass)
+			) {
 				result = true;
 			}
 		}


### PR DESCRIPTION
Fixes: #22648
Ensure IllegalAccessException is thrown when
a setter method handle is invoked on a final
field in a value class, to align with OpenJDK
Reference Implementation behaviour.
Fix for: MethodHandleTest:testFieldGetter