### PR TITLE
Add missing source folder for jdk.incubator.foreign

### DIFF
--- a/jcl/jpp_configuration.xml
+++ b/jcl/jpp_configuration.xml
@@ -183,6 +183,7 @@
 		<classpathentry kind="src" path="src/java.base/share/classes"/>
 		<classpathentry kind="src" path="src/java.management/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.attach/share/classes"/>
+		<classpathentry kind="src" path="src/jdk.incubator.foreign/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.jcmd/share/classes"/>
 		<classpathentry kind="src" path="src/jdk.management/share/classes"/>
 		<classpathentry kind="src" path="src/openj9.criu/share/classes"/>


### PR DESCRIPTION
Noticed while reviewing #22675.