### PR TITLE
Remove Continuation.Pinned.MONITOR for jdk26+

### DIFF
--- a/runtime/oti/ContinuationHelpers.hpp
+++ b/runtime/oti/ContinuationHelpers.hpp
@@ -37,9 +37,11 @@
 #endif /* JAVA_SPEC_VERSION >= 24 */
 #include "VMHelpers.hpp"
 
-/* These should match the error code values in enum Pinned within class Continuation. */
+/* These should match the error code values in enum Continuation.Pinned. */
 #define J9VM_CONTINUATION_PINNED_REASON_NATIVE 1
+#if JAVA_SPEC_VERSION < 26
 #define J9VM_CONTINUATION_PINNED_REASON_MONITOR 2
+#endif /* JAVA_SPEC_VERSION < 26 */
 #define J9VM_CONTINUATION_PINNED_REASON_CRITICAL_SECTION 3
 #if JAVA_SPEC_VERSION >= 24
 #define J9VM_CONTINUATION_PINNED_REASON_EXCEPTION 4

--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -469,16 +469,15 @@ isPinnedContinuation(J9VMThread *currentThread)
 	if (currentThread->continuationPinCount > 0) {
 		result = J9VM_CONTINUATION_PINNED_REASON_CRITICAL_SECTION;
 	} else if (currentThread->callOutCount > 0) {
-		/* TODO: This check should be changed from > 1 to > 0 once the call-ins are no
-		 * longer used and the new design for single cInterpreter is implemented.
-		 */
 		result = J9VM_CONTINUATION_PINNED_REASON_NATIVE;
+#if JAVA_SPEC_VERSION < 26
 	} else if ((currentThread->ownedMonitorCount > 0)
 #if JAVA_SPEC_VERSION >= 24
 	&& J9_ARE_NO_BITS_SET(currentThread->javaVM->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)
 #endif /* JAVA_SPEC_VERSION >= 24 */
 	) {
 		result = J9VM_CONTINUATION_PINNED_REASON_MONITOR;
+#endif /* JAVA_SPEC_VERSION < 26 */
 	} else {
 		/* Do nothing. */
 	}


### PR DESCRIPTION
It was removed upstream:
* [8367601: Remove held_monitor_count](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/bdf969829e46d9eca42679825b0aae97ec447452)