### PR TITLE
Tag compilations using pre-existence in the vlog

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11157,6 +11157,10 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(
                 compiler->getRecompilationInfo()->getJittedBodyInfo()->getHasEdoSnippet())
                TR_VerboseLog::write(" EDO");
 
+            if (compiler->getRecompilationInfo() &&
+                compiler->getRecompilationInfo()->getJittedBodyInfo()->getUsesPreexistence())
+               TR_VerboseLog::write(" PREX");
+
 #if defined(J9VM_OPT_JITSERVER)
             if (_methodBeingCompiled->isRemoteCompReq())
                {


### PR DESCRIPTION
`Pre-existence` is an optimization that causes compiled body invalidations when assumptions that pre-existence is based upon are violated.
The current commit writes the tag "PREX" in the verbose log for any successful compilation that uses pre-extence and could be subject to invalidations in the future.