### PR TITLE
Remove breakOnDFSet functionality

### DIFF
--- a/runtime/compiler/runtime/SignalHandler.c
+++ b/runtime/compiler/runtime/SignalHandler.c
@@ -32,31 +32,6 @@
 
 #if defined(J9VM_PORT_SIGNAL_SUPPORT) && defined(J9VM_INTERP_NATIVE_SUPPORT)
 
-#if defined(TR_HOST_X86) && defined(TR_TARGET_X86)
-static UDATA isDfSet(J9VMThread* vmThread, void *sigInfo)
-{
-	PORT_ACCESS_FROM_VMC(vmThread);
-	const char* infoName;
-	void* infoValue;
-	U_32 infoType;
-	UDATA eflags;
-	const char* enableDFCheck = getenv("TR_enableBreakOnDFSet");
-
-	if (enableDFCheck) {
-		infoType = j9sig_info(sigInfo, J9PORT_SIG_CONTROL, J9PORT_SIG_CONTROL_X86_EFLAGS, &infoName, &infoValue);
-		if (infoType == J9PORT_SIG_VALUE_ADDRESS) {
-			eflags = *(UDATA*)infoValue;
-			if ((eflags & 0x400) != 0) {
-				j9tty_printf(PORTLIB, "EFlags %zx, EFlags & 0x400 = %zx, DF flag is set\n", eflags, eflags & 0x400);
-				return TRUE;
-			}
-		}
-	}
-
-	return FALSE;
-}
-#endif
-
 #if defined(TR_HOST_X86) && defined(TR_TARGET_X86) && !defined(TR_TARGET_64BIT)
 
 extern void * jitMathHelpersDivideBegin;
@@ -393,8 +368,6 @@ UDATA jitX86Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
 					break;
 
 				case J9PORT_SIG_FLAG_SIGSEGV:
-					if (isDfSet(vmThread, sigInfo) == TRUE)
-						break;
 				case J9PORT_SIG_FLAG_SIGBUS:
 
 					infoType = j9sig_info(sigInfo, J9PORT_SIG_SIGNAL, J9PORT_SIG_SIGNAL_INACCESSIBLE_ADDRESS, &infoName, &infoValue);
@@ -1879,8 +1852,6 @@ UDATA jitAMD64Handler(J9VMThread* vmThread, U_32 sigType, void *sigInfo)
 					break;
 #endif
 				case J9PORT_SIG_FLAG_SIGSEGV:
-					if (isDfSet(vmThread, sigInfo) == TRUE)
-						break;
 				case J9PORT_SIG_FLAG_SIGBUS:
 
 					vmThread->jitException = (J9Object *) ((UDATA) rip + 1);

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -518,13 +518,6 @@ J9::X86::CodeGenerator::supportsInliningOfIsAssignableFrom()
    return !disableInliningOfIsAssignableFrom;
    }
 
-bool
-J9::X86::CodeGenerator::canEmitBreakOnDFSet()
-   {
-   static const bool enableBreakOnDFSet = feGetEnv("TR_enableBreakOnDFSet") != NULL;
-   return enableBreakOnDFSet;
-   }
-
 void
 J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
    {

--- a/runtime/compiler/x/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.hpp
@@ -116,10 +116,6 @@ public:
     * \brief Determines whether the code generator supports stack allocations
     */
    bool supportsStackAllocations() { return true; }
-   /** \brief
-    *     Determines whether to insert instructions to check DF flag and break on DF set
-    */
-   bool canEmitBreakOnDFSet();
 
    // See OMR::CodeGenerator::supportsNonHelper
    bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -133,10 +133,6 @@ void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg
       espReal,
       generateX86MemoryReference(vmThreadReg, cg->fej9()->thisThreadGetJavaSPOffset(), cg),
       cg);
-
-   // Add DF check on return of JNI/System call
-   if (cg->canEmitBreakOnDFSet())
-      generateBreakOnDFSet(cg);
    }
 
 }

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1446,11 +1446,6 @@ TR::Register *J9::X86::TreeEvaluator::newEvaluator(TR::Node *node, TR::CodeGener
       bool spillFPRegs = (comp->canAllocateInlineOnStack(node, classInfo) <= 0);
       targetRegister = TR::TreeEvaluator::performHelperCall(node, NULL, TR::acall, spillFPRegs, cg);
       }
-   else if (cg->canEmitBreakOnDFSet())
-      {
-      // Check DF flag after inline new
-      generateBreakOnDFSet(cg);
-      }
 
    return targetRegister;
    }
@@ -1790,9 +1785,6 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
 
 TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
-   if (cg->canEmitBreakOnDFSet())
-      generateBreakOnDFSet(cg);
-
    TR::Compilation *comp = cg->comp();
 
    if (!node->isReferenceArrayCopy())

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -320,8 +320,5 @@ TR::Register* J9::X86::HelperCallSite::BuildCall()
       generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), _Node, ret, EAX, cg());
       }
 
-   if (cg()->canEmitBreakOnDFSet())
-      generateBreakOnDFSet(cg());
-
    return ret;
 }

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -819,9 +819,6 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
             }
          }
 
-      if (cg()->canEmitBreakOnDFSet())
-         cursor = generateBreakOnDFSet(cg(), cursor);
-
       if (atlas)
          {
          uint32_t  numberOfParmSlots = atlas->getNumberOfParmSlotsMapped();
@@ -1060,9 +1057,6 @@ TR::Instruction *J9::X86::PrivateLinkage::deallocateFrameIfNeeded(TR::Instructio
 
 void J9::X86::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
    {
-   if (cg()->canEmitBreakOnDFSet())
-      cursor = generateBreakOnDFSet(cg(), cursor);
-
    TR::RealRegister* espReal = machine()->getRealRegister(TR::RealRegister::esp);
 
    cursor = cg()->generateDebugCounter(cursor, "cg.epilogues", 1, TR::DebugCounter::Expensive);


### PR DESCRIPTION
There was logic inserted into JITed code and the JIT runtime many years ago to aid in investigating a peculiar bug. As I recall, the issue was that on x86 macOS, the CPU direction flag was being flipped on some calls to the C runtime which interfered with the operation of JIT inlined arraycopy. It was not possible to predict when or why this flag modification was occurring, so logic was introduced across certain entry points to the C runtime to detect a direction flag toggle when it occurred. We did not suspect a problem with the OpenJ9 Java VM, but either a C runtime or macOS issue.

This problem has not been seen in over five years despite exhaustive testing on x86 macOS in the meantime. The problem was repeatable every few days if I recall correctly, so I think it has either gone into deep remission or has been fixed.

Nevertheless, this diagnostic logic is just technical debt now and is removed by this PR.