### PR TITLE
Instance strict field support

### DIFF
--- a/runtime/oti/bcverify.h
+++ b/runtime/oti/bcverify.h
@@ -53,6 +53,13 @@ typedef struct J9BranchTargetStack {
 	UDATA stackElements[1];
 } J9BranchTargetStack;
 
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+typedef struct J9StrictFieldEntry {
+	J9UTF8* nameutf8;
+	BOOLEAN isSet; /* isSet is not used for a query. */
+} J9StrictFieldEntry;
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+
 #define	BCV_TARGET_STACK_HEADER_UDATA_SIZE			4
 #define	BCV_STACK_OVERFLOW_BUFFER_UDATA_SIZE		2
 

--- a/runtime/oti/bcverify_api.h
+++ b/runtime/oti/bcverify_api.h
@@ -414,10 +414,26 @@ isClassCompatibleByName(J9BytecodeVerificationData *verifyData, UDATA sourceClas
 * @param receiver
 * @param reasonCode
 * 	output parameter denoting error conditions
+* @param isInitMethod
+* 	true if the current method is <init>
+* @param anotherInstanceInitCalled
+* 	true if the current method is <init> and another
+* 	instance <init> has been called in this method
 * @return IDATA
 */
 IDATA
-isFieldAccessCompatible(J9BytecodeVerificationData * verifyData, J9ROMFieldRef * fieldRef, UDATA bytecode, UDATA receiver, IDATA *reasonCode);
+isFieldAccessCompatible(
+	J9BytecodeVerificationData *verifyData,
+	J9ROMFieldRef *fieldRef,
+	UDATA bytecode,
+	UDATA receiver,
+	IDATA *reasonCode
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+	,
+	BOOLEAN isInitMethod,
+	BOOLEAN anotherInstanceInitCalled
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+);
 
 /**
 * @brief
@@ -493,6 +509,20 @@ pushLdcType(J9BytecodeVerificationData *verifyData, J9ROMClass * romClass, UDATA
 */
 UDATA*
 pushReturnType(J9BytecodeVerificationData *verifyData, J9UTF8 * utf8string, UDATA * stackTop);
+
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+/**
+ * Create or reset the list of strict instance fields for the class being
+ * verified. This list is used to track which strict fields have been
+ * set during the early larval state.
+ *
+ * @param verifyData information about the class being verified.
+ * @param addToStrictFieldTable true if this is the first <init> found in the class, false otherwise.
+ * @return void
+ */
+void
+createOrResetStrictFieldsList(J9BytecodeVerificationData *verifyData, BOOLEAN *addToStrictFieldTable);
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 
 /**
  * Classification of Unicode characters for use in Java identifiers.

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -373,10 +373,7 @@ static const struct { \
 #define IS_CLASS_SIGNATURE(firstChar) ('L' == (firstChar))
 
 #if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
-/* TODO Update the class version check if strict fields is released before value types. */
-#define J9ROMFIELD_IS_STRICT_FINAL(romClassOrClassfile, fieldModifiers) \
-	(J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClassOrClassfile) \
-		&& J9_ARE_ALL_BITS_SET(fieldModifiers, J9AccStrictInit | J9AccFinal))
+#define J9ROMFIELD_IS_STRICT(fieldModifiers) J9_ARE_ALL_BITS_SET(fieldModifiers, J9AccStrictInit)
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -600,6 +600,9 @@ extern "C" {
 #define BCV_ERR_BYTECODE_ERROR							-34
 #define BCV_ERR_NEW_OJBECT_MISMATCH						-35
 #define BCV_ERR_INIT_FLAGS_MISMATCH						-36
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+#define BCV_ERR_STRICT_FIELDS_UNASSIGNED                -37
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 
 #define J9_GC_OBJ_HEAP_HOLE 0x1
 #define J9_GC_MULTI_SLOT_HOLE 0x1
@@ -984,6 +987,7 @@ extern "C" {
 #define VALUE_TYPES_MAJOR_VERSION (44 + 26)
 #define PREVIEW_MINOR_VERSION 65535
 #define J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(classfileOrRomClass) (((classfileOrRomClass)->majorVersion >= VALUE_TYPES_MAJOR_VERSION) && (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion))
+#define J9_CLASSFILE_OR_ROMCLASS_SUPPORTS_STRICT_FIELDS(classfileOrRomClass) J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(classfileOrRomClass)
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 /* Constants for java.lang.reflect.Field flags */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2189,6 +2189,10 @@ typedef struct J9BytecodeVerificationData {
 	struct J9PortLibrary * portLib;
 	struct J9JavaVM* javaVM;
 	BOOLEAN createdStackMap;
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+	J9HashTable *strictFields;
+	UDATA strictFieldsUnsetCount;
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 } J9BytecodeVerificationData;
 
 typedef struct J9BytecodeOffset {

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -947,6 +947,11 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 	case BCV_ERR_NEW_OJBECT_MISMATCH:
 		printMessage(&msgBuf, "The arity (0x%x) of the new object is greater than zero", verifyData->errorTempData);
 		break;
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+	case BCV_ERR_STRICT_FIELDS_UNASSIGNED:
+		printMessage(&msgBuf, "All strict final fields must be initialized before super().");
+		break;
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 	default:
 		Assert_VRB_ShouldNeverHappen();
 		break;

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3697,8 +3697,7 @@ fail:
 	}
 
 #if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
-	/* TODO Update the class version check if strict fields is released before value types. */
-	if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass)) {
+	if (J9_CLASSFILE_OR_ROMCLASS_SUPPORTS_STRICT_FIELDS(romClass)) {
 		J9ROMFieldWalkState fieldWalkState = {0};
 		J9ROMFieldShape *field = romFieldsStartDo(romClass, &fieldWalkState);
 		while (NULL != field) {

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
@@ -100,4 +100,43 @@ public class StrictFieldTests {
 			throw e.getException();
 		}
 	}
+
+	/* A strict instance field must be assigned by putfield before invoking an
+	 * instance initialization method of the direct superclass.
+	 */
+	@Test
+	static public void testInstanceStrictFieldSetBeforeSuperclassInit() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestInstanceStrictFieldSetBeforeSuperclassInit();
+		c.newInstance();
+	}
+
+	@Test(expectedExceptions = VerifyError.class, expectedExceptionsMessageRegExp = ".*<init>.*JBinvokespecial.*")
+	static public void testInstanceStrictFieldNotSetBeforeSuperclassInit() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestInstanceStrictFieldNotSetBeforeSuperclassInit();
+		c.newInstance();
+	}
+
+	@Test(expectedExceptions = VerifyError.class, expectedExceptionsMessageRegExp = ".*<init>.*JBinvokespecial.*")
+	static public void testInstanceStrictFieldNotSetBeforeSuperclassInitMulti() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestInstanceStrictFieldNotSetBeforeSuperclassInitMulti();
+		c.newInstance();
+	}
+
+	/* A strict final instance field may not be assigned after invoking
+	 * another instance initialization method of this.
+	 */
+	@Test(expectedExceptions = VerifyError.class, expectedExceptionsMessageRegExp = ".*<init>.*JBputfield.*")
+	static public void testInstanceStrictFinalFieldSetAfterThisInit() throws Throwable {
+		Class<?> c = StrictFieldGenerator.testInstanceStrictFinalFieldSetAfterThisInit();
+		c.newInstance();
+	}
+
+	/* A non-final strict instance field may be assigned after invoking
+	 * another instance initialization method of this.
+	 */
+	@Test
+	static public void testInstanceStrictNonFinalFieldSetAfterThisInit() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestInstanceStrictNonFinalFieldSetAfterThisInit();
+		c.newInstance();
+	}
 }


### PR DESCRIPTION
This change includes support for strict instance fields except for the required stack map frame changes.

A hash map is used to track that all strict instance fields
 are set prior to an <init> method's transition out of the
early larval phase.

Related: https://github.com/eclipse-openj9/openj9/issues/21884