### PR TITLE
Ensure AOT-only relocations are not generated in a non-AOT compilation

### DIFF
--- a/runtime/compiler/z/codegen/S390AOTRelocation.cpp
+++ b/runtime/compiler/z/codegen/S390AOTRelocation.cpp
@@ -249,29 +249,35 @@ void TR::S390EncodingRelocation::addRelocation(TR::CodeGenerator *cg, uint8_t *c
       }
    else if (_reloType==TR_CallsiteTableEntryAddress)
       {
-      cg->addExternalRelocation(
-         TR::ExternalRelocation::create(
-            cursor,
-            (uint8_t *)_symbolReference,
-            NULL,
-            TR_CallsiteTableEntryAddress,
-            cg),
-         file,
-         line,
-         node);
+      if (comp->compileRelocatableCode())
+         {
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)_symbolReference,
+               NULL,
+               TR_CallsiteTableEntryAddress,
+               cg),
+            file,
+            line,
+            node);
+         }
       }
    else if (_reloType==TR_MethodTypeTableEntryAddress)
       {
-      cg->addExternalRelocation(
-         TR::ExternalRelocation::create(
-            cursor,
-            (uint8_t *)_symbolReference,
-            NULL,
-            TR_MethodTypeTableEntryAddress,
-            cg),
-         file,
-         line,
-         node);
+      if (comp->compileRelocatableCode())
+         {
+         cg->addExternalRelocation(
+            TR::ExternalRelocation::create(
+               cursor,
+               (uint8_t *)_symbolReference,
+               NULL,
+               TR_MethodTypeTableEntryAddress,
+               cg),
+            file,
+            line,
+            node);
+         }
       }
    else
       {


### PR DESCRIPTION
Related to but does not depend on https://github.com/eclipse-omr/omr/pull/7983

A recent change to how classes are laid out in memory resulted in some addresses no longer being in the sub-4G region. As a consequence, the code emitted by the compiler changed, causing some code paths to execute that rarely executed in a non-relocatable compilation. In a normal run, this did not change much because although the relocatable code paths created a relocation record, the compiler would not actually process them. However, when enabling JITServer, the compiler would process the relocation records.

The two relocation types that are guarded in this PR (`TR_CallsiteTableEntryAddress` and `TR_MethodTypeTableEntryAddress`) are normally only generated for a relocatable compilation when the SVM feature is enabled; however, under JITServer, it would also be generated for a JIT compilation. However, since these relocation records cannot be processed without the SVM, which is not used in a JIT compilation, it resulted in a compilation failure, ultimately impacting throughput performance.

This PR fixes this by ensuring that these relocation records are only generated under a relocatable compile.