### PR TITLE
Remove obsolete comment regarding OMR_MIXED_REFERENCES_MODE

### DIFF
--- a/runtime/cmake/caches/mxdptrs.cmake
+++ b/runtime/cmake/caches/mxdptrs.cmake
@@ -21,8 +21,6 @@
 ################################################################################
 
 set(OMR_GC_POINTER_MODE "mixed" CACHE STRING "")
-
-# OMR_MIXED_REFERENCES_MODE is set to 'static' or 'dynamic' in the extensions CMAKE_ARGS, but a default value is provided here just in case
 set(OMR_MIXED_REFERENCES_MODE "static" CACHE STRING "")
 
 include("${CMAKE_CURRENT_LIST_DIR}/cmprssptrs.cmake")


### PR DESCRIPTION
It is no longer explicitly specified by the extension repositories; see https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1112 and backports.