### PR TITLE
Add -XXgc options to enable/disable Size to Index in Ints

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -1139,6 +1139,16 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		if (try_scan(&scan_start, "enableSizeToIndexInt")) {
+			extensions->shouldUseIntegerSizeToIndex = true;
+			continue;
+		}
+
+		if (try_scan(&scan_start, "disableSizeToIndexInt")) {
+			extensions->shouldUseIntegerSizeToIndex = false;
+			continue;
+		}
+
 		if (try_scan(&scan_start, "enableEstimateFragmentationGlobalGCOnly")) {
 			extensions->estimateFragmentation = GLOBALGC_ESTIMATE_FRAGMENTATION;
 			extensions->processLargeAllocateStats = true;


### PR DESCRIPTION
Adding -XXgc:enableSizeToIndexInt and -XXgc:disableSizeToIndexInt to enable / disable using conversion in Ints for Size to Index and Index to Size. Default for this option is Enabled.

Required https://github.com/eclipse-omr/omr/pull/7986 to be merged first.