### PR TITLE
Override numInterfacesImplemented() fe query at the JITServer

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1323,6 +1323,12 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
          client->write(response, result, resultRefLocation);
          }
          break;
+      case MessageType::VM_numInterfacesImplemented:
+         {
+         auto clazz = std::get<0>(client->getRecvData<J9Class *>());
+         client->write(response, fe->numInterfacesImplemented(clazz));
+         }
+         break;
       case MessageType::mirrorResolvedJ9Method:
          {
          // allocate a new TR_ResolvedJ9Method on the heap, to be used as a mirror for performing actions which are only

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -402,7 +402,7 @@ public:
 
    // Get the length needed to contain the class chain associated with this class
    uintptr_t necessaryClassChainLength(J9Class *clazz) { return 2 + numInterfacesImplemented(clazz) + numSuperclasses(clazz); }
-   uint32_t numInterfacesImplemented(J9Class *clazz);
+   virtual uint32_t numInterfacesImplemented(J9Class *clazz);
    uintptr_t numSuperclasses(J9Class *clazz) { return TR::Compiler->cls.classDepthOf(convertClassPtrToClassOffset(clazz)); }
 
 protected:

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2813,8 +2813,15 @@ TR_J9ServerVM::getArrayClassFromDataType(TR::DataType type, bool booleanClass)
          }
       }
 
-
    return convertClassPtrToClassOffset(j9class);
+   }
+
+uint32_t
+TR_J9ServerVM::numInterfacesImplemented(J9Class *clazz)
+   {
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_numInterfacesImplemented, clazz);
+   return std::get<0>(stream->read<uint32_t>());
    }
 
 bool

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -269,9 +269,10 @@ public:
    virtual bool isIndexableDataAddrPresent() override;
    virtual bool isOffHeapAllocationEnabled() override;
 
-   virtual TR_arrayTypeCode       getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz) override;
-   virtual TR::DataType           getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz) override;
+   virtual TR_arrayTypeCode     getPrimitiveArrayTypeCode(TR_OpaqueClassBlock* clazz) override;
+   virtual TR::DataType         getClassPrimitiveDataType(TR_OpaqueClassBlock* clazz) override;
    virtual TR_OpaqueClassBlock *getArrayClassFromDataType(TR::DataType type, bool booleanClass) override;
+   virtual uint32_t numInterfacesImplemented(J9Class *clazz) override;
 
 private:
    bool instanceOfOrCheckCastHelper(J9Class *instanceClass, J9Class* castClass, bool cacheUpdate);
@@ -282,7 +283,7 @@ private:
 protected:
    void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer, List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods, uint32_t *numMethods);
    bool jitFieldsOrStaticsAreIdentical(TR_ResolvedMethod * method1, I_32 cpIndex1, TR_ResolvedMethod * method2, I_32 cpIndex2, int32_t isStatic);
-   };
+   }; // class TR_J9ServerVM
 
 /**
  * @class TR_J9SharedCacheServerVM

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 91; // ID: NaofZxmhextOnGlvYFI+
+   static const uint16_t MINOR_NUMBER = 92; // ID: OUona7sxVyMDiRQ1HpDm
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -195,6 +195,7 @@ const char *messageNames[] =
    "VM_getMethodHandleTableEntryIndex",
    "VM_getLayoutVarHandle",
    "VM_mutableCallSiteEpoch",
+   "VM_numInterfacesImplemented",
    "CompInfo_isCompiled",
    "CompInfo_getPCIfCompiled",
    "CompInfo_getInvocationCount",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -206,6 +206,7 @@ enum MessageType : uint16_t
    VM_getMethodHandleTableEntryIndex,
    VM_getLayoutVarHandle,
    VM_mutableCallSiteEpoch,
+   VM_numInterfacesImplemented,
 
    // For static TR::CompilationInfo methods
    CompInfo_isCompiled,


### PR DESCRIPTION
`TR_J9VMBase::numInterfacesImplemented(J9Class *clazz)` is a frontend query that returns the number of interfaces implemented by a j9class. The implementation retrives the iTable of the class and iterates through the interfaces in the iTable. Each such iteration means a message sent by the server to the client.
To reduce the number of messages exchanged by the client and server, this commit overrides the implementation of `numInterfacesImplemented()` at the server. The new implementation will have the server send a single message with the desired j9class. The client computes the number of interfaces implemented by that j9class and returns the answer to the server.

Issue: #22780