### PR TITLE
Restrict AIX compilation to build machines with the 16.1 C++ runtime

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -271,7 +271,7 @@ ppc64_aix:
     8: 'aix-ppc64-normal-server-release'
     11: 'aix-ppc64-normal-server-release'
   node_labels:
-    build: 'ci.role.build && hw.arch.ppc64 && sw.os.aix.7_2'
+    build: 'ci.role.build && hw.arch.ppc64 && sw.os.aix.7_2 && sw.tool.c++runtime.16_1'
   extra_configure_options:
     all: '--with-cups-include=/opt/freeware/include'
     8: ' --disable-ccache'


### PR DESCRIPTION
Restrict builds to https://openj9-jenkins.osuosl.org/label/ci.role.build%20&&%20hw.arch.ppc64%20&&%20sw.os.aix.7_2%20&&%20sw.tool.c++runtime.16_1/

This is required because some of the machines are modified to have the 17.1 C++ runtime. If any compilations hit these machines, the resulting JVM (assuming it even builds), won't be able to run on most of the machines.

See https://github.ibm.com/runtimes/infrastructure/issues/11302