### PR TITLE
Missing null-restricted support to fix OpenJDK MethodHandleTest

### DIFF
--- a/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
+++ b/runtime/jcl/common/java_lang_invoke_MethodHandleNatives.cpp
@@ -1341,6 +1341,11 @@ Java_java_lang_invoke_MethodHandleNatives_resolve(
 					if (VM_VMHelpers::isTrustedFinalField(fieldID->field, fieldID->declaringClass->romClass)) {
 						new_flags |= MN_TRUSTED_FINAL;
 					}
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+					if (J9ROMFIELD_IS_NULL_RESTRICTED(romField)) {
+						new_flags |= MN_NULL_RESTRICTED;
+					}
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 					romField = fieldID->field;
 

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3672,7 +3672,11 @@ fail:
 						J9ARRAYCLASS_SET_STRIDE(ramClass, J9_VALUETYPE_FLATTENED_SIZE(elementClass));
 					}
 				} else {
-					if (J9_IS_J9CLASS_ALLOW_DEFAULT_VALUE(elementClass)) {
+					if (J9_IS_J9CLASS_ALLOW_DEFAULT_VALUE(elementClass)
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+							&& J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_CLASS_OPTION_NULL_RESTRICTED_ARRAY)
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+					   ) {
 						ramArrayClass->classFlags |= J9ClassContainsUnflattenedFlattenables;
 					}
 					J9ARRAYCLASS_SET_STRIDE(ramClass, (((UDATA) 1) << (((J9ROMArrayClass*)romClass)->arrayShape & 0x0000FFFF)));


### PR DESCRIPTION
Related #22648
Set the J9ClassContainsUnflattenedFlattenables flag only for null-restricted arrays. 
Arrays that are not null-restricted should be initialized to null by default. 
Set the MN_NULL_RESTRICTED flag to throw NPE when assigning null to null-restricted fields.

This fixes MethodHandleTest::testFieldSetter and MethodHandleTest::testArrayElementSetterAndGetter