### PR TITLE
Add support for offheap allocation in multianewarray evaluator on IBM Z platform

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3472,11 +3472,11 @@ TR_J9VMBase::lowerMultiANewArray(TR::Compilation * comp, TR::Node * root, TR::Tr
    root->setNumChildren(3);
 
    static bool recreateRoot = feGetEnv("TR_LowerMultiANewArrayRecreateRoot") ? true : false;
-#if defined(TR_HOST_POWER)
+#if defined(TR_HOST_POWER) || defined(TR_HOST_S390)
    if (!comp->target().is64Bit() || recreateRoot || dims > 2)
 #else
    if (!comp->target().is64Bit() || recreateRoot || dims > 2 || secondDimConstNonZero)
-#endif /* defined(TR_HOST_POWER) */
+#endif /* defined(TR_HOST_POWER) || defined(TR_HOST_S390) */
       TR::Node::recreate(root, TR::acall);
 
    return treeTop;


### PR DESCRIPTION
@r30shah
This PR add support for offheap 2D array allocation. It is calling helper if the second dim is zero length and allocating offheap. I have a few possible solutions for that.