### PR TITLE
(0.56) Free monitorEnterRecordPool in freecontinuation

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -380,6 +380,9 @@ freeContinuation(J9VMThread *currentThread, j9object_t continuationObject, BOOLE
 		/* Remove reverse link to vthread object. */
 		continuation->vthread = NULL;
 
+		pool_kill(continuation->monitorEnterRecordPool);
+		continuation->monitorEnterRecordPool = NULL;
+
 		if (NULL != continuation->objectWaitMonitor) {
 			bool errorNone = VM_ContinuationHelpers::removeBlockingContinuationFromLists(currentThread, continuation);
 			Assert_VM_true(errorNone);
@@ -451,11 +454,6 @@ T2:
 			vm->cacheFree += 1;
 			/* Caching failed, free the J9VMContinuation struct. */
 			freeJavaStack(vm, continuation->stackObject);
-#if JAVA_SPEC_VERSION >= 24
-			if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)) {
-				pool_kill(continuation->monitorEnterRecordPool);
-			}
-#endif /* JAVA_SPEC_VERSION >= 24 */
 			j9mem_free_memory(continuation);
 		}
 	}


### PR DESCRIPTION
Currently, the monitor enter record pool is only free'd when the continuation is removed from the continuation cache. This behaviour causes memory leaks as a continuation may never be removed from the cache.

Additionally, when allocate a new continuation each time enterContinuation is called.

This PR takes the conservative approach of free the monitor records as soon as the continuation is free'd. In future we should consider if the monitor records can be persisted run to run. Currently, this has not been tested yet.

Fixes: https://github.com/eclipse-openj9/openj9/issues/22776

Backport https://github.com/eclipse-openj9/openj9/pull/22792