### PR TITLE
Enable MethodHandleTransformer opt for peeking ILGen methods

### DIFF
--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -78,15 +78,21 @@ static bool isKnownObject(TR::KnownObjectTable::Index objectInfo)
 
 int32_t TR_MethodHandleTransformer::perform()
    {
-   // Only do the opt for MethodHandle methods
+   // Only do the opt for LambdaForm generated methods, and for for peeking ILGen, since currently
+   // peeking ILGen is only triggered for MethodHandle/VarHandle-related cases to propagate object info
    TR_ResolvedMethod* currentMethod = comp()->getCurrentMethod();
-   if (!comp()->fej9()->isLambdaFormGeneratedMethod(currentMethod))
+   if (!comp()->fej9()->isLambdaFormGeneratedMethod(currentMethod) && !comp()->isPeekingMethod())
       return 0;
 
    TR::StackMemoryRegion stackMemoryRegion(*trMemory());
 
    if (trace())
-      traceMsg(comp(), "Start transforming LambdaForm generated method %s\n", currentMethod->signature(trMemory()));
+      {
+      if (comp()->isPeekingMethod())
+         traceMsg(comp(), "Start transforming peeking method %s\n", currentMethod->signature(trMemory()));
+      else
+         traceMsg(comp(), "Start transforming LambdaForm generated method %s\n", currentMethod->signature(trMemory()));
+      }
 
    // Assign local index to parms, autos and temps (including pending push temps)
    assignLocalIndices();


### PR DESCRIPTION
Peeking ILGen is currently mainly performed for MethodHandle or VarHandle scenarios to propagate object info along call graphs. However, in cases where, for example, a call node corresponding to an invokehandle/invokedynamic bytecode within a non-root method loads from an auto slot containing a MethodHandle/VarHandle object, the object info would not be available even with peeking ILGen. This would result in failure to inline along the
invokehandle/invokedynamic operation. MethodHandleTransformer is part of ilgenStrategyOpts that would only be triggered for LambdaForm generated methods, and this change will expand the role of this opt to also be triggered for peeking ILGen.