### PR TITLE
Implement JIT constant provenance graph

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -300,6 +300,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/env/J9ArithEnv.cpp \
     compiler/env/J9ClassEnv.cpp \
     compiler/env/J9CompilerEnv.cpp \
+    compiler/env/J9ConstProvenanceGraph.cpp \
     compiler/env/J9CPU.cpp \
     compiler/env/J9DebugEnv.cpp \
     compiler/env/J9IO.cpp \

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -42,6 +42,7 @@
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/ClassLoaderTable.hpp"
+#include "env/J9ConstProvenanceGraph.hpp"
 #include "env/j9method.h"
 #include "env/J9RetainedMethodSet.hpp"
 #include "env/TRMemory.hpp"
@@ -218,6 +219,7 @@ J9::Compilation::Compilation(int32_t id,
    _aotMethodDependencies(decltype(_aotMethodDependencies)::allocator_type(heapMemoryRegion)),
 #endif /* !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED) */
    _permanentLoaders(self()->region()),
+   _constProvenanceGraph(new (heapMemoryRegion) J9::ConstProvenanceGraph(self())),
    _osrProhibitedOverRangeOfTrees(false),
    _wasFearPointAnalysisDone(false),
    _permanentLoadersInitialized(false)

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -47,6 +47,7 @@ namespace J9 { typedef J9::Compilation CompilationConnector; }
 #include "env/PersistentCollections.hpp"
 
 namespace J9 { class RetainedMethodSet; }
+namespace J9 { class ConstProvenanceGraph; }
 class TR_AOTGuardSite;
 class TR_FrontEnd;
 class TR_ResolvedMethod;
@@ -448,6 +449,11 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
     */
    void addKeepaliveClass(TR_OpaqueClassBlock *c);
 
+   J9::ConstProvenanceGraph *constProvenanceGraph()
+      {
+      return _constProvenanceGraph;
+      }
+
    /**
     * \brief Determine whether it's currently expected to be possible to add
     * OSR assumptions and corresponding fear points somewhere in the method.
@@ -648,6 +654,7 @@ private:
 
    TR::SymbolValidationManager *_symbolValidationManager;
    TR::vector<J9ClassLoader*, TR::Region&> _permanentLoaders;
+   ConstProvenanceGraph *_constProvenanceGraph;
    bool _osrProhibitedOverRangeOfTrees;
    bool _wasFearPointAnalysisDone;
    bool _permanentLoadersInitialized;

--- a/runtime/compiler/env/CMakeLists.txt
+++ b/runtime/compiler/env/CMakeLists.txt
@@ -37,6 +37,7 @@ j9jit_files(
 	env/J9ArithEnv.cpp
 	env/J9ClassEnv.cpp
 	env/J9CompilerEnv.cpp
+	env/J9ConstProvenanceGraph.cpp
 	env/J9CPU.cpp
 	env/J9DebugEnv.cpp
 	env/j9fieldsInfo.cpp

--- a/runtime/compiler/env/J9ConstProvenanceGraph.cpp
+++ b/runtime/compiler/env/J9ConstProvenanceGraph.cpp
@@ -1,0 +1,423 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#include "env/J9ConstProvenanceGraph.hpp"
+#include "compile/Compilation.hpp"
+#include <algorithm>
+
+J9::ConstProvenanceGraph::ConstProvenanceGraph(TR::Compilation *comp)
+   : _comp(comp)
+   , _edges(comp->region())
+   , _emptyReferents(comp->region())
+   , _seenArgPairs(comp->region())
+   {
+   // empty
+   }
+
+const TR::set<J9::ConstProvenanceGraph::Place> &
+J9::ConstProvenanceGraph::referents(Place origin)
+   {
+   auto it = _edges.find(origin);
+   return it == _edges.end() ? _emptyReferents : it->second;
+   }
+
+bool
+J9::ConstProvenanceGraph::isConstProvenanceEnabled()
+   {
+   // Disable during AOT compilation. There is no known object table anyway.
+   // If/when the known object table is eventually supported in AOT, it will
+   // require SVM, and the relocations will specify how to find all of the
+   // known objects, so it will be possible to populate the graph from scratch
+   // as validations are carried out at load time.
+   //
+   // Also disable if class unloading is disabled (-Xnoclassgc). In that case
+   // all classes are permanent, and all const refs will be equally permanent,
+   // so it won't matter which classes own them.
+   //
+   return !_comp->compileRelocatableCode()
+      && !_comp->getOption(TR_NoClassGC)
+      && !_comp->getOption(TR_DisableConstProvenance);
+   }
+
+void
+J9::ConstProvenanceGraph::addEdgeImpl(Place origin, Place referent)
+   {
+   bool ignore = referent.kind() == PlaceKind_PermanentRoot || origin == referent;
+   if (trace())
+      {
+      const char *what = ignore ? "ignore redundant" : "accept";
+      traceMsg(_comp, "    %s edge: ", what);
+      trace(origin);
+      trace(" -> ");
+      trace(referent);
+      trace("\n");
+      }
+
+   assertValidPlace(origin);
+   assertValidPlace(referent);
+   if (ignore)
+      {
+      return;
+      }
+
+   TR::set<Place> emptyEdgeSet(_comp->region());
+   auto mapInsertResult = _edges.insert(std::make_pair(origin, emptyEdgeSet));
+   TR::set<Place> &edgeSet = mapInsertResult.first->second;
+   edgeSet.insert(referent);
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(J9ClassLoader *loader)
+   {
+   if (!isPermanentLoader(loader))
+      {
+      return Place::makeClassLoader(loader);
+      }
+
+   // Identify permanent loaders with the permanent root place. This eliminates
+   // edges that would otherwise uselessly target the permanent loaders.
+   if (trace())
+      {
+      trace("    ");
+      trace(loader);
+      trace(" is permanent\n");
+      }
+
+   return Place::makePermanentRoot();
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(TR_OpaqueClassBlock *clazz)
+   {
+   if (_comp->fej9()->isClassArray(clazz))
+      {
+      TR_OpaqueClassBlock *component =
+         _comp->fej9()->getLeafComponentClassFromArrayClass(clazz);
+
+      if (trace())
+         {
+         trace("    ");
+         trace(clazz);
+         trace(" is an array class with leaf component ");
+         trace(component);
+         trace("\n");
+         }
+
+      clazz = component;
+      }
+
+   if (_comp->fej9()->isAnonymousClass(clazz))
+      {
+      return Place::makeAnonymousClass((J9Class*)clazz);
+      }
+
+   // Identify the class with its loader, which has the same lifetime because
+   // the class is not anonymous.
+   auto loader = (J9ClassLoader*)_comp->fej9()->getClassLoader(clazz);
+
+   if (trace())
+      {
+      trace("    ");
+      trace(clazz);
+      trace(" is defined by ");
+      trace(loader);
+      trace("\n");
+      }
+
+   return place(loader);
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(J9Class *clazz)
+   {
+   return place((TR_OpaqueClassBlock*)clazz);
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(J9ConstantPool *cp)
+   {
+   // Identify the constant pool with the class it belongs to, which has the
+   // same lifetime.
+   TR_OpaqueClassBlock *clazz = _comp->fej9()->getClassFromCP(cp);
+
+   if (trace())
+      {
+      trace("    ");
+      trace(cp);
+      trace(" belongs to ");
+      trace(clazz);
+      trace("\n");
+      }
+
+   return place(clazz);
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(TR_ResolvedMethod *method)
+   {
+   // Identify the method with its class, which has the same lifetime.
+   TR_OpaqueClassBlock *clazz = method->classOfMethod();
+
+   if (trace())
+      {
+      trace("    ");
+      trace(method);
+      trace(" is defined by ");
+      trace(clazz);
+      trace("\n");
+      }
+
+   return place(clazz);
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(TR_OpaqueMethodBlock *method)
+   {
+   // Identify the method with its class, which has the same lifetime.
+   TR_OpaqueClassBlock *clazz = _comp->fej9()->getClassOfMethod(method);
+
+   if (trace())
+      {
+      trace("    ");
+      trace(method);
+      trace(" is defined by ");
+      trace(clazz);
+      trace("\n");
+      }
+
+   return place(clazz);
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(J9Method *method)
+   {
+   return place((TR_OpaqueMethodBlock*)method);
+   }
+
+J9::ConstProvenanceGraph::Place
+J9::ConstProvenanceGraph::place(KnownObject koi)
+   {
+   return Place::makeKnownObject(koi._i);
+   }
+
+bool
+J9::ConstProvenanceGraph::trace()
+   {
+   return _comp->getOption(TR_TraceConstProvenance);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(Place p)
+   {
+   switch (p.kind())
+      {
+      case PlaceKind_PermanentRoot:
+         traceMsg(_comp, "permanent root");
+         break;
+
+      case PlaceKind_ClassLoader:
+         traceMsg(_comp, "class loader %p", p.getClassLoader());
+         break;
+
+      case PlaceKind_AnonymousClass:
+         traceMsg(_comp, "anonymous class %p", p.getAnonymousClass());
+         break;
+
+      case PlaceKind_KnownObject:
+         traceMsg(_comp, "obj%d", p.getKnownObject());
+         break;
+      }
+   }
+
+void
+J9::ConstProvenanceGraph::trace(const char *s)
+   {
+   traceMsg(_comp, "%s", s);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(J9ClassLoader *loader)
+   {
+   traceMsg(_comp, "class loader %p", loader);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(TR_OpaqueClassBlock *clazz)
+   {
+   int32_t len = 0;
+   const char *name = TR::Compiler->cls.classNameChars(_comp, clazz, len);
+   traceMsg(_comp, "class %p %.*s", clazz, len, name);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(J9Class *clazz)
+   {
+   trace((TR_OpaqueClassBlock*)clazz);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(J9ConstantPool *cp)
+   {
+   traceMsg(_comp, "constant pool %p", cp);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(TR_ResolvedMethod *method)
+   {
+   traceMsg(
+      _comp,
+      "method %p %.*s.%.*s%.*s",
+      method->getNonPersistentIdentifier(),
+      method->classNameLength(),
+      method->classNameChars(),
+      method->nameLength(),
+      method->nameChars(),
+      method->signatureLength(),
+      method->signatureChars());
+   }
+
+void
+J9::ConstProvenanceGraph::trace(TR_OpaqueMethodBlock *method)
+   {
+   char buf[1024];
+   const char *sig =
+      _comp->fej9()->sampleSignature(method, buf, sizeof(buf), _comp->trMemory());
+
+   traceMsg(_comp, "method %p %s", method, sig);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(J9Method *method)
+   {
+   trace((TR_OpaqueMethodBlock*)method);
+   }
+
+void
+J9::ConstProvenanceGraph::trace(KnownObject koi)
+   {
+   traceMsg(_comp, "obj%d", koi._i);
+   }
+
+bool
+J9::ConstProvenanceGraph::isPermanentLoader(J9ClassLoader *loader)
+   {
+   // NOTE: Test for presence in _comp->permanentLoaders() instead of checking
+   // for J9CLASSLOADER_OUTLIVING_LOADERS_PERMANENT to ensure consistency with
+   // J9::RetainedMethodSet and consistency over time.
+   //
+   // -- RetainedMethodSet (RMS) --
+   //
+   // Because RMS uses _comp->permanentLoaders(), which is determined once for
+   // the compilation and cached, we'll get exactly the same loaders here.
+   //
+   // The actual requirement w.r.t. RMS is that every loader that it considers
+   // to be permanent in this compilation must also be considered permanent
+   // here. Otherwise, to see what kind of problem could arise, suppose loader
+   // L is known to be permanent by RMS but not ConstProvenanceGraph (CPG).
+   // It's possible to inline a profiled target or single implementer defined
+   // by L without a bond. If a known object is encountered starting from (a
+   // method defined by a class defined by) L, it won't necessarily be
+   // reachable in the graph from the outermost method, but it also won't
+   // necessarily be reachable from a bond method, since no bond was generated
+   // to allow the inlining. So the known object could be unreachable.
+   //
+   // Checking J9CLASSLOADER_OUTLIVING_LOADERS_PERMANENT wouldn't necessarily
+   // allow this requirement to be violated, depending on the detailed order in
+   // which operations are performed in the compilation, but by using the exact
+   // same loaders, it's obvious that the requirement is met.
+   //
+   // -- Consistency over time --
+   //
+   // It's important to use the same permanent loaders for CPG throughout the
+   // compilation, and looking for J9CLASSLOADER_OUTLIVING_LOADERS_PERMANENT
+   // could allow us to treat a loader first as unloadable but then later as
+   // permanent. To see the problem, suppose we're compiling a method defined
+   // by (a class defined by) some permanent loader L that, at the start of the
+   // compilation, is not yet known to the JIT to be permanent. Then suppose
+   // that we encounter a known object at some path starting from L. The first
+   // edge in the path will originate from L. If later during the compilation L
+   // is discovered to be permanent, and if the determination here is sensitive
+   // to that discovery, then when it eventually comes time to search the graph
+   // to attribute the known object to an owning class, the known object might
+   // not be reachable from the permanent root place, and in that case, it also
+   // won't be reachable from the outermost method, since at the time of the
+   // search the method would be identified as permanent and reduced to the
+   // permanent root place as well. So the known object could be unreachable.
+   //
+   auto permanentLoaders = _comp->permanentLoaders();
+   auto end = permanentLoaders.end();
+   return std::find(permanentLoaders.begin(), end, loader) != end;
+   }
+
+void
+J9::ConstProvenanceGraph::assertValidPlace(Place p)
+   {
+   switch (p.kind())
+      {
+      case PlaceKind_ClassLoader:
+         {
+         J9ClassLoader *loader = p.getClassLoader();
+         TR_ASSERT_FATAL(loader != NULL, "class loader place with null pointer");
+
+         // If the loader is permanent, then we should use the permanent root
+         // place instead.
+         TR_ASSERT_FATAL(
+            !isPermanentLoader(loader),
+            "class loader place for loader %p, which is permanent",
+            loader);
+
+         break;
+         }
+
+      case PlaceKind_AnonymousClass:
+         {
+         J9Class *clazz = p.getAnonymousClass();
+         TR_ASSERT_FATAL(clazz != NULL, "anonymous class place with null pointer");
+         TR_ASSERT_FATAL(
+            _comp->fej9()->isAnonymousClass((TR_OpaqueClassBlock*)clazz),
+            "anonymous class place for non-anonymous class %p",
+            p.getAnonymousClass());
+
+         break;
+         }
+
+      case PlaceKind_KnownObject:
+         {
+         TR::KnownObjectTable *knot = _comp->getKnownObjectTable();
+         TR_ASSERT_FATAL(
+            knot != NULL, "known object place without known object table");
+
+         TR::KnownObjectTable::Index koi = p.getKnownObject();
+         TR_ASSERT_FATAL(
+            0 <= koi && koi < knot->getEndIndex(),
+            "known object place koi=%d out of bounds (%d)",
+            koi,
+            knot->getEndIndex());
+
+         TR_ASSERT_FATAL(!knot->isNull(koi), "known object place with null index");
+         break;
+         }
+
+      default:
+         break;
+      }
+   }

--- a/runtime/compiler/env/J9ConstProvenanceGraph.hpp
+++ b/runtime/compiler/env/J9ConstProvenanceGraph.hpp
@@ -1,0 +1,436 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef J9_CONSTPROVENANCEGRAPH_INCL
+#define J9_CONSTPROVENANCEGRAPH_INCL
+
+#include "env/KnownObjectTable.hpp"
+#include "infra/Assert.hpp"
+#include "infra/map.hpp"
+#include "infra/set.hpp"
+
+namespace TR { class Compilation; }
+class TR_ResolvedMethod;
+
+namespace J9 {
+
+/**
+ * \brief ConstProvenanceGraph is a graph that tracks where known objects were
+ * found at compile time.
+ *
+ * The graph essentially consists of directed edges between \em places, where a
+ * \em place is one of the following:
+ * - a known object (which is what we're ultimately interested in),
+ * - an anonymous class,
+ * - a non-permanent class loader, or
+ * - "permanent root," which stands in for all permanent class loaders.
+ *
+ * When adding edges, the caller does not need to make the origin and referent
+ * fit into this categorization of place. Instead, the caller just passes
+ * methods or classes that will be mapped down to places according to simple
+ * lifetime relationships:
+ * - a method has the same lifetime as its defining class,
+ * - a (non-anonymous) class has the same lifetime as its defining loader, and
+ * - a permanent loader has the same lifetime as "permanent root."
+ *
+ * The loaders considered permanent for these purposes are those that are listed
+ * by TR::Compilation::permanentLoaders() for the current compilation.
+ *
+ * As an example of justifiable edges, suppose that some method C.foo() uses a
+ * static final field D.SOME_REF. This would justify an edge from C to D (since
+ * C refers to D in its constant pool) and an edge from D to the object that
+ * SOME_REF refers to.
+ *
+ * \b Motivation
+ *
+ * This information will be used to determine which classes should own which
+ * constant references in a given JIT body. The idea is that if some object, say
+ * obj3, was found to be reachable from a class C at compile time via a path of
+ * one or more "sufficiently constant" hops, i.e. references that aren't
+ * \em supposed to change, then even if there is technically still a possibility
+ * for references on the path to be mutated later, it's justifiable to give C a
+ * direct reference to obj3 for the lifetime of the JIT body.
+ *
+ * Using this kind of reachability as justification for a class to own a
+ * constant reference avoids a class of memory leak, where e.g.:
+ * 1. Foo.foo() calls Bar.bar()
+ * 2. It inlines a single implementer or profiled target BarImpl.bar().
+ * 3. There is no lifetime relationship between Foo and BarImpl.
+ * 4. BarImpl.bar() uses a constant reference, e.g. BarImpl.SOME_CONST_REF.
+ *
+ * In such a case, if Foo were to own all of the constant references for the JIT
+ * body of Foo.foo(), then it would have a direct reference to the object from
+ * (4). But that object wasn't necessarily reachable from Foo to begin with. For
+ * example, it could be an instance of BarImpl, and in that case, the constant
+ * reference would prevent unloading of BarImpl.
+ *
+ * Using the constant provenance graph in this example, the object from (4) will
+ * not be reachable from Foo in the graph, and so Foo will not own the constant
+ * reference. Instead, BarImpl will own it, preserving the possibility of
+ * unloading BarImpl before Foo.
+ */
+class ConstProvenanceGraph
+   {
+   public:
+   ConstProvenanceGraph(TR::Compilation *comp);
+
+   enum PlaceKind
+      {
+      PlaceKind_PermanentRoot,
+      PlaceKind_ClassLoader,
+      PlaceKind_AnonymousClass,
+      PlaceKind_KnownObject,
+      };
+
+   private: // TODO: will need to be made accessible for JITServer
+
+   /**
+    * \brief The internal representation of Place, for JITServer.
+    */
+   struct RawPlace
+      {
+      PlaceKind _kind;
+      union
+         {
+         J9ClassLoader *_classLoader;
+         J9Class *_anonymousClass;
+         TR::KnownObjectTable::Index _knownObjectIndex;
+         };
+      };
+
+   public:
+
+   /**
+    * \brief Place represents a \em place as described in ConstProvenanceGraph.
+    */
+   class Place
+      {
+      private:
+
+      Place() {}
+
+      public:
+
+      static Place makePermanentRoot()
+         {
+         Place result;
+         result._raw._kind = PlaceKind_PermanentRoot;
+         return result;
+         }
+
+      // The loader should not be permanent, but that isn't checked here since
+      // Place is just a thin wrapper around the pointer.
+      static Place makeClassLoader(J9ClassLoader *classLoader)
+         {
+         Place result;
+         result._raw._kind = PlaceKind_ClassLoader;
+         result._raw._classLoader = classLoader;
+         return result;
+         }
+
+      // The class should be anonymous, but that isn't checked here since Place
+      // is just a thin wrapper around the pointer.
+      static Place makeAnonymousClass(J9Class *clazz)
+         {
+         Place result;
+         result._raw._kind = PlaceKind_AnonymousClass;
+         result._raw._anonymousClass = clazz;
+         return result;
+         }
+
+      // The known object index should be in-bounds and not the null index, i.e.
+      // it should already have been assigned to some known object, but that
+      // isn't checked here since Place is just a thin wrapper around the index.
+      static Place makeKnownObject(TR::KnownObjectTable::Index koi)
+         {
+         Place result;
+         result._raw._kind = PlaceKind_KnownObject;
+         result._raw._knownObjectIndex = koi;
+         return result;
+         }
+
+      PlaceKind kind() const { return _raw._kind; }
+
+      J9ClassLoader *getClassLoader() const
+         {
+         assertKind(PlaceKind_ClassLoader);
+         return _raw._classLoader;
+         }
+
+      J9Class *getAnonymousClass() const
+         {
+         assertKind(PlaceKind_AnonymousClass);
+         return _raw._anonymousClass;
+         }
+
+      TR::KnownObjectTable::Index getKnownObject() const
+         {
+         assertKind(PlaceKind_KnownObject);
+         return _raw._knownObjectIndex;
+         }
+
+      bool operator==(const Place &other) const
+         {
+         PlaceKind k = kind();
+         if (k != other.kind())
+            {
+            return false;
+            }
+
+         switch (k)
+            {
+            case PlaceKind_PermanentRoot:
+               return true;
+            case PlaceKind_ClassLoader:
+               return getClassLoader() == other.getClassLoader();
+            case PlaceKind_AnonymousClass:
+               return getAnonymousClass() == other.getAnonymousClass();
+            case PlaceKind_KnownObject:
+               return getKnownObject() == other.getKnownObject();
+            }
+
+         TR_ASSERT_FATAL(false, "unreachable");
+         return false;
+         }
+
+      bool operator<(const Place &other) const
+         {
+         PlaceKind k1 = kind();
+         PlaceKind k2 = other.kind();
+         if (k1 != k2)
+            {
+            return k1 < k2;
+            }
+
+         std::less<void*> ptrLt;
+         switch (k1)
+            {
+            case PlaceKind_PermanentRoot:
+               return false;
+            case PlaceKind_ClassLoader:
+               return ptrLt(getClassLoader(), other.getClassLoader());
+            case PlaceKind_AnonymousClass:
+               return ptrLt(getAnonymousClass(), other.getAnonymousClass());
+            case PlaceKind_KnownObject:
+               return getKnownObject() < other.getKnownObject();
+            }
+
+         TR_ASSERT_FATAL(false, "unreachable");
+         return false;
+         }
+
+      // TODO: to/from raw for JITServer
+
+      private:
+
+      void assertKind(PlaceKind kind) const
+         {
+         TR_ASSERT_FATAL(
+            _raw._kind == kind, "expected kind %d but was %d", kind, _raw._kind);
+         }
+
+      RawPlace _raw;
+      };
+
+   /**
+    * \brief Get the set of targets of edges outgoing from \p origin.
+    * \param origin the starting place
+    * \return the set of referents
+    */
+   const TR::set<Place> &referents(Place origin);
+
+   /**
+    * \brief A strongly-typed wrapper for a known object index.
+    *
+    * This is suitable to pass to addEdge(), which uses the arguments' types to
+    * determine how to treat them.
+    */
+   struct KnownObject
+      {
+      explicit KnownObject(TR::KnownObjectTable::Index i) : _i(i) {}
+      TR::KnownObjectTable::Index _i;
+
+      bool operator==(const KnownObject &other) const { return _i == other._i; }
+      };
+
+   /**
+    * \brief Convenience method to construct KnownObject.
+    *
+    * Callers can avoid writing out J9::ConstProvenanceGraph::KnownObject(i).
+    *
+    * \param i the known object index
+    * \return a KnownObject with index \p i
+    */
+   static KnownObject knownObject(TR::KnownObjectTable::Index i)
+      {
+      return KnownObject(i);
+      }
+
+   /**
+    * \brief Add an edge from \p origin to \p referent.
+    *
+    * This indicates there is a path of one or more "sufficiently constant"
+    * references from \p origin to \p referent in the runtime environment, i.e.
+    * class statics, constant pool, Java heap.
+    *
+    * \param origin where the edge/path originates from
+    * \param referent the referent
+    */
+   template <typename T, typename U>
+   void addEdge(T origin, U referent)
+      {
+      // The equals() test isn't really necessary, since if origin and referent
+      // are equal, place() will map them to equal places, and addEdgeImpl()
+      // will ignore the edge. So the main point of equals() here is just to
+      // cut down on noise in the log, but it doesn't hurt to skip calling
+      // place() on both arguments when possible.
+      if (!isConstProvenanceEnabled()
+          || isNull(referent)
+          || equals(origin, referent))
+         {
+         return;
+         }
+
+      // Check whether these exact arguments have been seen before. This is
+      // also not strictly necessary, but cuts down on noise in the log. It's
+      // done regardless of tracing so that enabling tracing won't have any
+      // effect on the logic.
+      auto pair = std::make_pair(ArgKey(origin), ArgKey(referent));
+      if (_seenArgPairs.count(pair) != 0)
+         {
+         return; // We've already had these exact arguments.
+         }
+
+      _seenArgPairs.insert(pair);
+
+      if (trace())
+         {
+         trace("Const provenance: add edge: ");
+         trace(origin);
+         trace(" -> ");
+         trace(referent);
+         trace("\n");
+         }
+
+      // This forces all tracing from place(origin) to appear in the log before
+      // any tracing from place(referent).
+      Place originPlace = place(origin);
+      Place referentPlace = place(referent);
+      addEdgeImpl(originPlace, referentPlace);
+      }
+
+   /**
+    * \brief Determine whether constant provenance is enabled.
+    *
+    * If it's disabled, then ConstProvenanceGraph will still exist, but no edges
+    * will be added.
+    *
+    * \return true if constant provenance is enabled, false otherwise
+    */
+   bool isConstProvenanceEnabled();
+
+   bool trace(); // true if tracing is enabled for constant provenance
+
+   // Convert various types to Place. These are mainly used in addEdge(), but
+   // they can also be useful for callers to get a starting point from which to
+   // call referents().
+   Place place(J9ClassLoader *loader);
+   Place place(TR_OpaqueClassBlock *clazz);
+   Place place(J9Class *clazz);
+   Place place(J9ConstantPool *cp);
+   Place place(TR_ResolvedMethod *method);
+   Place place(TR_OpaqueMethodBlock *method);
+   Place place(J9Method *method);
+   Place place(KnownObject koi);
+
+   // Trace various kinds of values (whether trace() is true or not).
+   void trace(const char *s); // verbatim message
+   void trace(J9ClassLoader *loader);
+   void trace(TR_OpaqueClassBlock *clazz);
+   void trace(J9Class *clazz);
+   void trace(J9ConstantPool *cp);
+   void trace(TR_ResolvedMethod *method);
+   void trace(TR_OpaqueMethodBlock *method);
+   void trace(J9Method *method);
+   void trace(KnownObject koi);
+   void trace(Place p);
+
+   private:
+
+   void addEdgeImpl(Place origin, Place referent);
+
+   static bool isNull(void *p) { return p == NULL; }
+   static bool isNull(KnownObject koi) { return false; }
+
+   static bool equals(void *x, void *y) { return x == y; }
+   static bool equals(const KnownObject &x, const KnownObject &y) { return x == y; }
+   static bool equals(const KnownObject &x, void *y) { return false; }
+   static bool equals(void *x, const KnownObject &y) { return false; }
+
+   bool isPermanentLoader(J9ClassLoader *loader);
+   void assertValidPlace(Place p);
+
+   enum ArgKeyKind
+      {
+      ArgKeyKind_Pointer,
+      ArgKeyKind_KnownObject,
+      };
+
+   struct ArgKey
+      {
+      ArgKeyKind _kind;
+      union
+         {
+         void *_pointer;
+         TR::KnownObjectTable::Index _knownObjectIndex;
+         };
+
+      explicit ArgKey(void *p) : _kind(ArgKeyKind_Pointer), _pointer(p) {}
+      explicit ArgKey(KnownObject koi)
+         : _kind(ArgKeyKind_KnownObject), _knownObjectIndex(koi._i) {}
+
+      bool operator<(const ArgKey &other) const
+         {
+         if (_kind != other._kind)
+            {
+            return _kind < other._kind;
+            }
+         else if (_kind == ArgKeyKind_Pointer)
+            {
+            return std::less<void*>()(_pointer, other._pointer);
+            }
+         else
+            {
+            return _knownObjectIndex < other._knownObjectIndex;
+            }
+         }
+      };
+
+   TR::Compilation * const _comp;
+   TR::map<Place, TR::set<Place>> _edges;
+   const TR::set<Place> _emptyReferents;
+   TR::set<std::pair<ArgKey, ArgKey>> _seenArgPairs;
+   };
+
+} // namespace J9
+
+#endif // J9_CONSTPROVENANCEGRAPH_INCL


### PR DESCRIPTION
See the doxygen for `ConstProvenanceGraph` in J9ConstProvenanceGraph.hpp.

The type is essentially unused for the moment. A follow-up change will populate the graph with edges. After that, the implementation of const refs will include the necessary graph search.