### PR TITLE
Fix warnings as errors on Windows 32-bit

### DIFF
--- a/runtime/jcl/common/sigquit.c
+++ b/runtime/jcl/common/sigquit.c
@@ -159,7 +159,7 @@ sigQuitWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo, voi
 	if (OMRPORT_SIG_VALUE_32 == infoType) {
 		rasAsyncPidInfo.siPid = *(U_32 *)infoValue;
 	} else if (OMRPORT_SIG_VALUE_64 == infoType) {
-		rasAsyncPidInfo.siPid = *(U_64 *)infoValue;
+		rasAsyncPidInfo.siPid = (UDATA)*(U_64 *)infoValue;
 	}
 	if (0 != rasAsyncPidInfo.siPid) {
 		/* siPidName needs to be freed after use. */

--- a/runtime/jcl/common/sigusr2.c
+++ b/runtime/jcl/common/sigusr2.c
@@ -138,7 +138,7 @@ sigUsr2Wrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, voi
 	if (OMRPORT_SIG_VALUE_32 == infoType) {
 		rasAsyncPidInfo.siPid = *(U_32 *)infoValue;
 	} else if (OMRPORT_SIG_VALUE_64 == infoType) {
-		rasAsyncPidInfo.siPid = *(U_64 *)infoValue;
+		rasAsyncPidInfo.siPid = (UDATA)*(U_64 *)infoValue;
 	}
 	if (0 != rasAsyncPidInfo.siPid) {
 		/* siPidName needs to be freed after use. */

--- a/runtime/oti/j9dump.h
+++ b/runtime/oti/j9dump.h
@@ -122,12 +122,12 @@ typedef struct J9RASdumpEventData {
 	UDATA detailLength;
 	char* detailData;
 	j9object_t* exceptionRef;
-	U_64 siPid;
+	UDATA siPid;
 } J9RASdumpEventData;
 
 typedef struct J9RASAsyncPidInfo {
 	struct J9JavaVM *vm;
-	U_64 siPid;
+	UDATA siPid;
 	char *siPidName;
 } J9RASAsyncPidInfo;
 


### PR DESCRIPTION
common/sigquit.c(166): error C2220: the following warning is treated as an error
common/sigquit.c(166): warning C4244: 'function': conversion from 'U_64' to 'uintptr_t', possible loss of data