### PR TITLE
Fix gpf in JavaCoreDumpWriter::writeEventDrivenTitle

### DIFF
--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -863,7 +863,7 @@ JavaCoreDumpWriter::writeEventDrivenTitle(void)
 
 	_OutputStream.writeCharacters(" received\n");
 
-	if (0 != eventData->siPid) {
+	if ((NULL != eventData) && (0 != eventData->siPid)) {
 		_OutputStream.writeCharacters("1TISIGPID      Signalling process id ");
 		_OutputStream.writeInteger64(eventData->siPid, "%llu");
 		if (NULL != eventData->detailData) {


### PR DESCRIPTION
Shows as `JVMDUMP012E Error in Java dump:`
javadump shows `1INTERNAL      In-flight data encountered. Output may be missing or incomplete.`

Related to https://github.com/eclipse-openj9/openj9/pull/22804

Testing https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/4769/