### PR TITLE
Replace env var usage with command line option

### DIFF
--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -2920,8 +2920,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable (TR::X86Call
                                 interfaceClassReg, cg());
       }
 
-   static char *disableITableIterationsAfterLastITableCacheCheck = feGetEnv("TR_DisableITableIterationsAfterLastITableCacheCheck");
-   if (disableITableIterationsAfterLastITableCacheCheck)
+   if (comp()->getOption(TR_DisableITableIterationsAfterLastITableCacheCheck))
       {
       generateLongLabelInstruction(TR::InstOpCode::JNE4, callNode, lookupDispatchSnippetLabel, cg()); // PICBuilder needs this to have a 4-byte offset
       if (comp()->target().is32Bit())


### PR DESCRIPTION
An environment variable called `TR_DisableITableIterationsAfterLastITableCacheCheck` is used to disable the generation of code that iterates through iTable entries after the iTable cache check has failed. This commit replaces that env var with a command line option with the same name. Command line options have more flexibility because they can be applied per method rather than globally.