### PR TITLE
Ensure relo error is printed immediately after compilation error

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -11737,6 +11737,12 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
                                  _methodBeingCompiled->getMethodDetails().getMethod(),
                                  translationTime,
                                  compilationErrorNames[_methodBeingCompiled->_compErrCode]);
+            if (entry->isAotLoad())
+               {
+               TR_RelocationRuntime *reloRuntime = compiler->reloRuntime();
+               if (reloRuntime)
+                  TR_VerboseLog::write(" (%s)", reloRuntime->getReloErrorCodeName(reloRuntime->getReloErrorCode()));
+               }
             uintptr_t vmState = vmThread->omrVMThread->vmState;
             TR_VerboseLog::write(" VmState=0x%08.8x", (unsigned int)vmState);
             int jitPhase = (vmState >> 8) & 0xFF;
@@ -11747,12 +11753,6 @@ TR::CompilationInfoPerThreadBase::processExceptionCommonTasks(
                OMR::Optimizations jitPhaseOMROpt = static_cast<OMR::Optimizations>(jitPhase);
                TR_VerboseLog::write(" OptIdx=%d", compiler->getOptIndex());
                TR_VerboseLog::write(" OptName=%s", OMR::Optimizer::getOptimizationName(jitPhaseOMROpt));
-               }
-            if (entry->isAotLoad())
-               {
-               TR_RelocationRuntime *reloRuntime = compiler->reloRuntime();
-               if (reloRuntime)
-                  TR_VerboseLog::write(" (%s)", reloRuntime->getReloErrorCodeName(reloRuntime->getReloErrorCode()));
                }
             TR_VerboseLog::write(" memLimit=%zu KB", scratchSegmentProvider.allocationLimit() >> 10);
 


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/22639 added the vmstate to the compilation failure line; however, it printed it out between the compilation error and the relo error. This ensures the relo error is printed immediately after compilation error.