### PR TITLE
Format of java.vm.version information in 0.56.0

### DIFF
--- a/doc/release-notes/0.56/0.56.md
+++ b/doc/release-notes/0.56/0.56.md
@@ -69,6 +69,12 @@ The following table covers notable changes in v0.56.0. Further information about
 To record and analyze the SystemProcess JFR event on z/OS (2.5 and 3.1), you must install <a href="https://www.ibm.com/support/pages/apar/OA62757">APAR OA62757</a>.
 </td>
 </tr>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/22626">#22626</a></td>
+<td valign="top">The format of the <tt>java.vm.version</tt> system property value is updated to be compatible with the Runtime.Version parser.</td>
+<td valign="top">All versions</td>
+<td valign="top">Earlier, the format of the <tt>java.vm.version</tt> system property value was not standardized and structured and was not parse-able by the <tt>java.lang.Runtime.Version</tt> class.<br>With the new structured format, the <tt>java.lang.Runtime.Version</tt> class parses the value and you can extract specific information such as the information related to the VM version. This modification also changes the <tt>-version</tt> output. For example, <tt>build openj9-0.56.0</tt> changes to <tt>build 11.0.29+7-openj9-0.56.0</tt>.<br>This change was initiated in the 0.55.0 release and it affects 0.56.0 and all future releases.</td>
+</tr>
 </tbody>
 </table>
 


### PR DESCRIPTION
Based on https://github.com/eclipse-openj9/openj9-docs/issues/1617, added the information in the 0.56.0 release note also.

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com