### PR TITLE
Do not check iTable entries after lastITable cache test at warm

### DIFF
--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -2920,7 +2920,8 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable (TR::X86Call
                                 interfaceClassReg, cg());
       }
 
-   if (comp()->getOption(TR_DisableITableIterationsAfterLastITableCacheCheck))
+   if (comp()->getOption(TR_DisableITableIterationsAfterLastITableCacheCheck) ||
+       (comp()->getOptLevel() <= warm && !comp()->getOption(TR_EnableITableIterationsAfterLastITableCacheCheckAtWarm)))
       {
       generateLongLabelInstruction(TR::InstOpCode::JNE4, callNode, lookupDispatchSnippetLabel, cg()); // PICBuilder needs this to have a 4-byte offset
       if (comp()->target().is32Bit())

--- a/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390PrivateLinkage.cpp
@@ -1538,9 +1538,8 @@ getITableIterationsNumber(TR::Compilation * comp, TR::SymbolReference * methodSy
 
    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
    bool trace = comp->getOption(TR_TraceCG);
-   static bool disableITableIterationsAfterLastITableCacheCheck = feGetEnv("TR_DisableITableIterationsAfterLastITableCacheCheck") != NULL;
 
-   if (disableITableIterationsAfterLastITableCacheCheck)
+   if (comp->getOption(TR_DisableITableIterationsAfterLastITableCacheCheck))
       {
       if (trace)
          traceMsg(comp, "ITable iteration after lastITable check is disabled.\n");


### PR DESCRIPTION
PR https://github.com/eclipse-openj9/openj9/pull/22216 introduced a change in the code generator for x86 to check a few entries from the iTable if the lastITable cache test fails. While this change improves the score of some benchmarks (like pmd from DaCapo) it may regress others (Daytrader8 1%, AcmeAirEE8 0.8%, Liberty startup 2%).

This commit allows the iTable entries check only for compilations at `hot` or above opt levels.
To allow the iTable entries check at opt levels lower than `hot` the user needs to use the following Xjit/Xaot command line option:`enableITableIterationsAfterLastITableCacheCheckAtWarm`
To disable the iTable entries check at all opt levels, the user needs to use the following Xjit/Xaot option: `disableITableIterationsAfterLastITableCacheCheck`

Depends on: https://github.com/eclipse-omr/omr/pull/8009