### PR TITLE
Add const provenance edges where necessary

### DIFF
--- a/runtime/compiler/env/J9RetainedMethodSet.cpp
+++ b/runtime/compiler/env/J9RetainedMethodSet.cpp
@@ -27,6 +27,7 @@
 #include "compile/ResolvedMethod.hpp"
 #include "env/ClassLoaderTable.hpp"
 #include "env/ClassTableCriticalSection.hpp"
+#include "env/J9ConstProvenanceGraph.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "ilgen/J9ByteCode.hpp"
 #include "ilgen/J9ByteCodeIterator.hpp"
@@ -348,6 +349,8 @@ J9::RetainedMethodSet::withLinkedCalleeAttested(TR_ByteCodeInfo bci)
             comp()->fej9()->targetMethodFromInvokeCacheArrayMemberNameObj(
                comp(), caller, invokeCacheArray);
 
+         comp()->constProvenanceGraph()->addEdge(caller, linkedCallee);
+
          break;
          }
 
@@ -530,6 +533,8 @@ J9::RetainedMethodSet::scan(J9Class *clazz)
                loader,
                outlivingLoader);
             }
+
+         comp()->constProvenanceGraph()->addEdge(loader, outlivingLoader);
 
          if (willRemainLoaded(outlivingLoader))
             {

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -28,6 +28,7 @@
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CompilerEnv.hpp"
+#include "env/J9ConstProvenanceGraph.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/StackMemoryRegion.hpp"
 #include "env/TypeLayout.hpp"
@@ -3492,6 +3493,10 @@ TR_J9ByteCodeIlGenerator::loadInvokeCacheArrayElements(TR::SymbolReference *tabl
 
       if (koi != TR::KnownObjectTable::UNKNOWN)
          {
+         // The caller got invokeCacheArray from _methodSymbol->getResolvedMethod().
+         J9::ConstProvenanceGraph *cpg = comp()->constProvenanceGraph();
+         cpg->addEdge(_methodSymbol->getResolvedMethod(), cpg->knownObject(koi));
+
          TR::Node *appendixNode = _stack->top();
          TR::SymbolReference *appendixSymRef =
             comp()->getSymRefTab()->findOrCreateSymRefWithKnownObject(

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -45,6 +45,7 @@
 #include "optimizer/TransformUtil.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "runtime/RuntimeAssumptions.hpp"
+#include "env/J9ConstProvenanceGraph.hpp"
 #include "env/J9JitMemory.hpp"
 #include "optimizer/HCRGuardAnalysis.hpp"
 #include "optimizer/VectorAPIExpansion.hpp"
@@ -1849,6 +1850,10 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                if (knot)
                   {
                   TR::KnownObjectTable::Index knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)(arrayComponentClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
+
+                  J9::ConstProvenanceGraph *cpg = comp()->constProvenanceGraph();
+                  cpg->addEdge(arrayComponentClass, cpg->knownObject(knownObjectIndex));
+
                   addBlockOrGlobalConstraint(node,
                         TR::VPClass::create(this,
                            TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),
@@ -2037,6 +2042,10 @@ J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                if (knot)
                   {
                   TR::KnownObjectTable::Index knownObjectIndex = knot->getOrCreateIndexAt((uintptr_t*)(superClass + comp()->fej9()->getOffsetOfJavaLangClassFromClassField()));
+
+                  J9::ConstProvenanceGraph *cpg = comp()->constProvenanceGraph();
+                  cpg->addEdge(superClass, cpg->knownObject(knownObjectIndex));
+
                   addBlockOrGlobalConstraint(node,
                         TR::VPClass::create(this,
                            TR::VPKnownObject::createForJavaLangClass(this, knownObjectIndex),


### PR DESCRIPTION
No edges are added in code that is used only for `J9VM_OPT_METHOD_HANDLE`, e.g. `runFEMacro`. Const refs will require `J9VM_OPT_OPENJDK_METHODHANDLE`.

With JITServer, it doesn't matter whether an edge is added on the server or on the client. When it comes time to search the const provenance graph near the end of the compilation, the client will send all of its edges to the server, which will incorporate them in the search. This communication is not implemented in this commit, but will be implemented along with the search itself in a later commit.