### PR TITLE
Part 1 of stack walker ROM method cache

### DIFF
--- a/runtime/oti/j9modifiers_api.h
+++ b/runtime/oti/j9modifiers_api.h
@@ -116,8 +116,9 @@
 /* Composite Flag checks */
 
 #define J9ROMCLASS_IS_PRIMITIVE_OR_ARRAY(romClass) _J9ROMCLASS_SUNMODIFIER_IS_ANY_SET((romClass), J9AccClassArray | J9AccClassInternalPrimitiveType)
-#define J9ROMMETHOD_IS_NON_EMPTY_OBJECT_CONSTRUCTOR(romMethod) \
-	((((romMethod)->modifiers) & (J9AccMethodObjectConstructor | J9AccEmptyMethod)) == J9AccMethodObjectConstructor)
+#define J9ROMMETHOD_MODIFIERS_IS_NON_EMPTY_OBJECT_CONSTRUCTOR(modifiers) \
+	(((modifiers) & (J9AccMethodObjectConstructor | J9AccEmptyMethod)) == J9AccMethodObjectConstructor)
+#define J9ROMMETHOD_IS_NON_EMPTY_OBJECT_CONSTRUCTOR(romMethod) J9ROMMETHOD_MODIFIERS_IS_NON_EMPTY_OBJECT_CONSTRUCTOR((romMethod)->modifiers)
 
 /* Class instances are allocated via the new bytecode */
 #define J9ROMCLASS_ALLOCATES_VIA_NEW(romClass) \

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1147,12 +1147,32 @@ typedef struct J9CudaGlobals {
 	jmethodID runnable_run;
 } J9CudaGlobals;
 
-#define J9_MAP_CACHE_SLOTS 2
+/* Cache slot sizes must all be multiples of 2 */
+#define J9_STACKMAP_CACHE_SLOTS 2
+#define J9_LOCALMAP_CACHE_SLOTS 2
+#define J9_ARGBITS_CACHE_SLOTS 2
 
-typedef struct J9MapCacheEntry {
+/* Flag values for J9ROMMethodInfo */
+#define J9MAPCACHE_STACKMAP_CACHED 1
+#define J9MAPCACHE_LOCALMAP_CACHED 2
+#define J9MAPCACHE_ARGBITS_CACHED 4
+#define J9MAPCACHE_METHOD_IS_CONSTRUCTOR 8
+#define J9MAPCACHE_VALID 128
+
+/* J9ROMMethodInfo must be a multiple of 8 bytes in size */
+typedef struct J9ROMMethodInfo {
 	void *key;
-	U_32 bits[J9_MAP_CACHE_SLOTS];
-} J9MapCacheEntry;
+	U_32 stackmap[J9_STACKMAP_CACHE_SLOTS];
+	U_32 localmap[J9_ARGBITS_CACHE_SLOTS];
+	U_32 argbits[J9_ARGBITS_CACHE_SLOTS];
+	U_32 modifiers;
+	U_16 tempCount;
+	U_8 argCount;
+	U_8 flags;
+#if !defined(J9VM_ENV_DATA64)
+	U_32 padTo64;
+#endif /* !defined(J9VM_ENV_DATA64) */
+} J9ROMMethodInfo;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
 
@@ -2808,6 +2828,7 @@ typedef struct J9StackWalkState {
 	void* stackMap;
 	void* inlineMap;
 	UDATA loopBreaker;
+	J9ROMMethodInfo romMethodInfo; /* 64-bit aligned */
 	/* The size of J9StackWalkState must be a multiple of 8 because it is inlined into
 	 * J9VMThread where alignment assumotions are being made.
 	 */
@@ -3740,9 +3761,7 @@ typedef struct J9ClassLoader {
 	UDATA initClassPathEntryCount;
 	UDATA asyncGetCallTraceUsed;
 	omrthread_monitor_t mapCacheMutex;
-	struct J9HashTable* localmapCache;
-	struct J9HashTable* argsbitsCache;
-	struct J9HashTable* stackmapCache;
+	struct J9HashTable* romMethodInfoCache;
 #if defined(J9VM_OPT_JFR)
 	J9HashTable *typeIDs;
 #endif /* defined(J9VM_OPT_JFR) */

--- a/runtime/oti/stackmap_api.h
+++ b/runtime/oti/stackmap_api.h
@@ -196,30 +196,15 @@ j9stackmap_StackBitsForPC(J9PortLibrary * portLib, UDATA pc, J9ROMClass * romCla
 		UDATA * (* getBuffer) (void * userData), 
 		void (* releaseBuffer) (void * userData));
 
+/* ---------------- mapcache.cpp ---------------- */
 
-/* ------------------- mapcache.cpp ----------------- */
-
-/* These are cache wrapper functions with the same parameters as the j9localmap_ versions,
- * with VM and J9ClassLoader added on the end.
- */
-
-IDATA
-j9cached_StackBitsForPC(UDATA pc, J9ROMClass * romClass, J9ROMMethod * romMethod,
-								U_32 * resultArrayBase, UDATA resultArraySize,
-								void * userData,
-								UDATA * (* getBuffer) (void * userData),
-								void (* releaseBuffer) (void * userData),
-								J9JavaVM *vm, J9ClassLoader *classLoader);
-
+/**
+* @brief
+* @param walkState
+* @param romMethod
+*/
 void
-j9cached_ArgBitsForPC0(J9ROMClass *romClass, J9ROMMethod *romMethod, U_32 *resultArrayBase, J9JavaVM *vm, J9ClassLoader *classLoader);
-
-IDATA
-j9cached_LocalBitsForPC(J9ROMClass * romClass, J9ROMMethod * romMethod, UDATA pc, U_32 * resultArrayBase,
-								void * userData,
-								UDATA * (* getBuffer) (void * userData),
-								void (* releaseBuffer) (void * userData),
-								J9JavaVM *vm, J9ClassLoader * classLoader);
+initializeBasicROMMethodInfo(J9StackWalkState *walkState, J9ROMMethod *romMethod);
 
 #ifdef __cplusplus
 }

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -67,17 +67,9 @@ U_32 classPropagationTable[CLASS_PROPAGATION_TABLE_SIZE] = {
 void
 freeMapCaches(J9ClassLoader *classLoader)
 {
-	if (NULL != classLoader->localmapCache) {
-		hashTableFree(classLoader->localmapCache);
-		classLoader->localmapCache = NULL;
-	}
-	if (NULL != classLoader->argsbitsCache) {
-		hashTableFree(classLoader->argsbitsCache);
-		classLoader->argsbitsCache = NULL;
-	}
-	if (NULL != classLoader->stackmapCache) {
-		hashTableFree(classLoader->stackmapCache);
-		classLoader->stackmapCache = NULL;
+	if (NULL != classLoader->romMethodInfoCache) {
+		hashTableFree(classLoader->romMethodInfoCache);
+		classLoader->romMethodInfoCache = NULL;
 	}
 }
 


### PR DESCRIPTION
- replaces direct references to J9ROMMethod fields with the local shadow
- has a lot of ifdeffed-out code I'd like left in to facilitate the next phase
- does not enable compile-time map cache debug
- removes previous caching implementation