### PR TITLE
Add implementation for the getAndSetReference method

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -4450,7 +4450,12 @@ public final class Unsafe {
 
 	/*[IF INLINE-TYPES]*/
 	public final Object getAndSetReference(Object obj, long offset, Class<?> valueType, Object value) {
-		throw new Error("getAndSetReference() unimplemented"); //$NON-NLS-1$
+		for (;;) {
+			Object objectAtOffset = getReferenceVolatile(obj, offset);
+			if(compareAndSetReference(obj, offset, valueType, objectAtOffset, value)) {
+				return objectAtOffset;
+			}
+		}
 	}
 
 	public final Object getAndSetReferenceAcquire(Object obj, long offset, Class<?> valueType, Object value) {


### PR DESCRIPTION
Related: #22642
Add implementation for getAndSetReference(Object obj, long offset, Class<?> valueType, Object value) method.
With this change the following jdk_valhalla tests are passing:
```
java/lang/invoke/VarHandles/VarHandleTestMethodHandleAccessString.java
java/lang/invoke/VarHandles/VarHandleTestMethodTypeString.java
java/lang/invoke/VarHandles/VarHandleTestMethodTypeValue.java
valhalla/valuetypes/ArrayElementVarHandleTest.java
java/lang/invoke/VarHandles/VarHandleTestAccessString.java
```