### PR TITLE
Type checker should allow null targets to match ri

### DIFF
--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -489,9 +489,12 @@ isClassCompatible(J9BytecodeVerificationData *verifyData, UDATA sourceClass, UDA
 		return (IDATA) TRUE;
 	}
 
-	/* only NULL is compatible with NULL */
-	if ( targetClass == BCV_BASE_TYPE_NULL ) {
-		return (IDATA) FALSE;
+	/* If the target class is a null type there is no need to continue
+	 * checking for arity compatibility. A null target class can be assigned
+	 * any arity class.
+	 */
+	if (BCV_BASE_TYPE_NULL == targetClass) {
+		return (IDATA) TRUE;
 	}
 
 	sourceArity = J9CLASS_ARITY_FROM_CLASS_ENTRY(sourceClass);


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/22812

IBM 8: http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=105517
(verifier tests in progress for other versions)