### PR TITLE
Don't override error codes from bytecode verification

### DIFF
--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -187,7 +187,7 @@ j9rtv_verifyBytecodes (J9BytecodeVerificationData *verifyData)
 
 			verifyData->errorModule = J9NLS_BCV_ERR_VERIFY_OUT_OF_MEMORY__MODULE;
 			verifyData->errorCode = J9NLS_BCV_ERR_VERIFY_OUT_OF_MEMORY__ID;
-		} else {
+		} else if (BCV_ERR_NOT_THROWABLE == result) {
 			verifyData->errorModule = J9NLS_BCV_ERR_NOT_THROWABLE__MODULE;
 			verifyData->errorCode = J9NLS_BCV_ERR_NOT_THROWABLE__ID;
 		}
@@ -2498,7 +2498,7 @@ _outOfMemoryError:
 
 /*
  * returns BCV_SUCCESS on success
- * returns BCV_FAIL on error
+ * returns BCV_ERR_NOT_THROWABLE on error
  * returns BCV_ERR_INSUFFICIENT_MEMORY on OOM
  */
 static IDATA
@@ -2552,7 +2552,7 @@ verifyExceptions (J9BytecodeVerificationData *verifyData)
 						(UDATA) J9UTF8_LENGTH(J9ROMMETHOD_SIGNATURE(romMethod)),
 						J9UTF8_DATA(J9ROMMETHOD_SIGNATURE(romMethod)),
 						i, J9UTF8_LENGTH(catchName), J9UTF8_DATA(catchName));
-					rc = BCV_FAIL;
+					rc = BCV_ERR_NOT_THROWABLE;
 					break;
 				}
 			}

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -603,6 +603,7 @@ extern "C" {
 #if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
 #define BCV_ERR_STRICT_FIELDS_UNASSIGNED                -37
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+#define BCV_ERR_NOT_THROWABLE                           -38
 
 #define J9_GC_OBJ_HEAP_HOLE 0x1
 #define J9_GC_MULTI_SLOT_HOLE 0x1


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/13444 changes the order of verification for exceptions and bytecodes. This resulted in the error message "thrown object not throwable" for exception verification to be set for bytecode verification failures. This change does not override error codes for bytecode verification which was being done previously.

This was pointed out in https://github.com/eclipse-openj9/openj9/issues/22812.

With this change 
`java.lang.VerifyError: JVMVRFY021 thrown object not throwable; class=com/acme/FailVerify, method=explode(Ljava/lang/String;)V, pc=4`

becomes:

`Exception in thread "main" java.lang.VerifyError: JVMVRFY012 stack shape inconsistent; class=com/acme/FailVerify, method=explode(Ljava/lang/String;)V, pc=4`