### PR TITLE
Mark GPR15 volatile for JIT Helper calls on 64-bit z/OS

### DIFF
--- a/runtime/compiler/z/codegen/S390CHelperLinkage.cpp
+++ b/runtime/compiler/z/codegen/S390CHelperLinkage.cpp
@@ -66,7 +66,6 @@ J9::Z::CHelperLinkage::CHelperLinkage(TR::CodeGenerator * codeGen,TR_LinkageConv
    setRegisterFlag(TR::RealRegister::GPR10, Preserved);
    setRegisterFlag(TR::RealRegister::GPR11, Preserved);
    setRegisterFlag(TR::RealRegister::GPR13, Preserved);
-   setRegisterFlag(TR::RealRegister::GPR15, Preserved);
 
 #if defined(ENABLE_PRESERVED_FPRS)
    // In case of 32bit Linux on Z, System Linkage only preserves FPR4 and FPR6. For all other targets, FPR8-FPR15 is
@@ -95,6 +94,7 @@ J9::Z::CHelperLinkage::CHelperLinkage(TR::CodeGenerator * codeGen,TR_LinkageConv
       setRegisterFlag(TR::RealRegister::GPR6, Preserved);
       setRegisterFlag(TR::RealRegister::GPR7, Preserved);
       setRegisterFlag(TR::RealRegister::GPR12, Preserved);
+      setRegisterFlag(TR::RealRegister::GPR15, Preserved);
 
       setReturnAddressRegister(TR::RealRegister::GPR14);
       setIntegerReturnRegister(TR::RealRegister::GPR2);
@@ -123,10 +123,11 @@ J9::Z::CHelperLinkage::CHelperLinkage(TR::CodeGenerator * codeGen,TR_LinkageConv
          {
          setRegisterFlag(TR::RealRegister::GPR12, Preserved);
 
-         setPreservedRegisterMapForGC(0x0000FF00);
+         setPreservedRegisterMapForGC(0x00007F00);
          }
       else
          {
+         setRegisterFlag(TR::RealRegister::GPR15, Preserved);
          // 31-Bit zOS will need GPR12 for CAA register so it won't be preserved. For all other variant it is preserved
          setPreservedRegisterMapForGC(0x0000EF00);
          }


### PR DESCRIPTION
Call from JIT compiled code to JIT helper functions implemented in C
is made using S390CHelperLinkage which prepares the call dispatch
sequecne following the fast XPLINK ABI on z/OS. As per XPLINK GPR15 is
preserved register. In case of Synchronized Virtual Thread, a virtual
thread trying to enter a monitor can be unmounted from the carrier
thread if monitor is bloked, in such it can be mounted to different
carrier thread. From JIT compiled code, such task is done through the
C helper function, where upon mounting, return back to JIT compiled
code would happen from interpreter. For such case, GPR15 is used to
branch back from interpreter. To ensure we do not have any live values
in GPR15, changes in this commit marks GPR15 volatile for
S390CHelperLinkage on 64-bit z/OS. Given that only in case of
synchronized virtual thread which would only available in JDK24 and
newer which is not available on 31-bit JVM, this change is kept
limited to 64-bit z/OS.
