### PR TITLE
Add -Xaot:dontCompile= to selectively prevent AOT compilation

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -956,7 +956,7 @@ public:
    bool importantMethodForStartup(J9Method *method);
    bool shouldDowngradeCompReq(TR_MethodToBeCompiled *entry);
 
-   bool isMethodIneligibleForAot(J9Method *method);
+   bool isMethodIneligibleForAot(J9Method *method, TR_Memory *trMemory, TR_J9VMBase *fe);
 
    int32_t computeDynamicDumbInlinerBytecodeSizeCutoff(TR::Options *options);
    TR_YesNoMaybe shouldActivateNewCompThread();

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1139,7 +1139,7 @@ TR_ResolvedRelocatableJ9Method::isCompilable(TR_Memory * trMemory)
    {
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get(fej9()->_jitConfig);
 
-   if (compInfo->isMethodIneligibleForAot(ramMethod()))
+   if (compInfo->isMethodIneligibleForAot(ramMethod(), trMemory, fej9()))
       return false;
 
    return TR_ResolvedJ9Method::isCompilable(trMemory);


### PR DESCRIPTION
Add an additional option to prevent AOT compilation on specified methods. (see issue 22828 linked below). 

We add the syntax `-Xaot:dontCompile={...}` to disable AOT on specified methods.

See the comment on the GitHub issue for more context.

Depends on https://github.com/eclipse-omr/omr/pull/8008
solve https://github.com/eclipse-openj9/openj9/issues/22828