### PR TITLE
Stop using jimagePackageToModule for jdk26+

### DIFF
--- a/runtime/bcutil/jimageintf.c
+++ b/runtime/bcutil/jimageintf.c
@@ -408,18 +408,17 @@ jimageGetResource(J9JImageIntf *jimageIntf, UDATA handle, UDATA resourceLocation
 	return rc;
 }
 
+#if JAVA_SPEC_VERSION < 26
 const char *
 jimagePackageToModule(J9JImageIntf *jimageIntf, UDATA handle, const char *packageName)
 {
-#if JAVA_SPEC_VERSION < 26
 	if (0 != jimageIntf->libJImageHandle) {
 		JImageFile *jimage = (JImageFile *)handle;
 		return libJImagePackageToModule(jimage, packageName);
-	} else
-#endif /* JAVA_SPEC_VERSION < 26 */
-	{
+	} else {
 		PORT_ACCESS_FROM_PORT(jimageIntf->portLib);
 		J9JImage *jimage = (J9JImage *)handle;
 		return j9bcutil_findModuleForPackage(PORTLIB, jimage, packageName);
 	}
 }
+#endif /* JAVA_SPEC_VERSION < 26 */

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -752,16 +752,19 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_LOAD_AGENT_MODULE)
 		&& (NULL != vm->modulesPathEntry->extraInfo))
 	{
+		const char *moduleName = "jdk.management.agent";
+#if JAVA_SPEC_VERSION < 26
 		const char *packageName = "jdk/internal/agent";
-		const char *expectedModuleName = "jdk.management.agent";
-		const char *moduleName = vm->jimageIntf->jimagePackageToModule(
+		const char *actualModuleName = vm->jimageIntf->jimagePackageToModule(
 				vm->jimageIntf, (UDATA) vm->modulesPathEntry->extraInfo,
 				packageName);
-		if (NULL == moduleName) {
+		if (NULL == actualModuleName) {
 			Trc_JCL_initializeRequiredClasses_moduleForPackageNotFound(vmThread, packageName);
-		} else if (0 != strcmp(expectedModuleName, moduleName)) {
-			Trc_JCL_initializeRequiredClasses_unexpectedModuleForPackage(vmThread, packageName, moduleName, expectedModuleName);
-		} else {
+		} else if (0 != strcmp(moduleName, actualModuleName)) {
+			Trc_JCL_initializeRequiredClasses_unexpectedModuleForPackage(vmThread, packageName, actualModuleName, moduleName);
+		} else
+#endif /* JAVA_SPEC_VERSION < 26 */
+		{
 			J9VMSystemProperty *systemProperty = NULL;
 			Trc_JCL_initializeRequiredClasses_addAgentModuleEntry(vmThread, moduleName);
 			/* Handle the case where there are no user-specified modules. In this case, there
@@ -790,17 +793,20 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_LOAD_HEALTHCENTER_MODULE)
 		&& (NULL != vm->modulesPathEntry->extraInfo))
 	{
+		const char *moduleName = "ibm.healthcenter";
+#if JAVA_SPEC_VERSION < 26
 		const char *packageName = "com/ibm/java/diagnostics/healthcenter/agent";
-		const char *expectedModuleName = "ibm.healthcenter";
-		const char *moduleName = vm->jimageIntf->jimagePackageToModule(
+		const char *actualModuleName = vm->jimageIntf->jimagePackageToModule(
 				vm->jimageIntf, (UDATA) vm->modulesPathEntry->extraInfo,
 				packageName);
 		if (NULL == moduleName) {
 			Trc_JCL_initializeRequiredClasses_moduleForPackageNotFound(vmThread, packageName);
-		} else if (0 != strcmp(expectedModuleName, moduleName)) {
+		} else if (0 != strcmp(moduleName, actualModuleName)) {
 			// package %s found in module %s (expected %s) - not loading"
-			Trc_JCL_initializeRequiredClasses_unexpectedModuleForPackage(vmThread, packageName, moduleName, expectedModuleName);
-		} else {
+			Trc_JCL_initializeRequiredClasses_unexpectedModuleForPackage(vmThread, packageName, actualModuleName, moduleName);
+		} else
+#endif /* JAVA_SPEC_VERSION < 26 */
+		{
 			J9VMSystemProperty *systemProperty = NULL;
 			Trc_JCL_initializeRequiredClasses_addAgentModuleEntry(vmThread, moduleName);
 			/* Handle the case where there are no user-specified modules. In this case, there

--- a/runtime/oti/bcutil_api.h
+++ b/runtime/oti/bcutil_api.h
@@ -381,6 +381,7 @@ jimageFreeResourceLocation(J9JImageIntf *jimageIntf, UDATA handle, UDATA resourc
 I_32
 jimageGetResource(J9JImageIntf *jimageIntf, UDATA handle, UDATA resourceLocation, char *buffer, I_64 bufferSize, I_64 *resourceSize);
 
+#if JAVA_SPEC_VERSION < 26
 /**
  * Finds the module for the given package.
  *
@@ -392,6 +393,7 @@ jimageGetResource(J9JImageIntf *jimageIntf, UDATA handle, UDATA resourceLocation
  */
 const char *
 jimagePackageToModule(J9JImageIntf *jimageIntf, UDATA handle, const char *packageName);
+#endif /* JAVA_SPEC_VERSION < 26 */
 
 /* ---------------- jimagereader.c ----------------*/
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2096,7 +2096,9 @@ typedef struct J9JImageIntf {
 	I_32 (* jimageFindResource)(struct J9JImageIntf *jimageIntf, UDATA handle, const char *moduleName, const char* name, UDATA *resourceLocation, I_64 *size);
 	void (* jimageFreeResourceLocation)(struct J9JImageIntf *jimageIntf, UDATA handle, UDATA resourceLocation);
 	I_32 (* jimageGetResource)(struct J9JImageIntf *jimageIntf, UDATA handle, UDATA resourceLocation, char *buffer, I_64 bufferSize, I_64 *resourceSize);
+#if JAVA_SPEC_VERSION < 26
 	const char * (* jimagePackageToModule)(struct J9JImageIntf *jimageIntf, UDATA handle, const char *packageName);
+#endif /* JAVA_SPEC_VERSION < 26 */
 } J9JImageIntf;
 
 /* @ddr_namespace: map_to_type=J9TranslationBufferSet */


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/22533 removed jimagePackageToModule() from being assigned in the interface, which is valid because j9bcutil_findModuleForPackage() can't be used unless the jimage is opened with j9bcutil, which it's not because jimageOpen() uses libjimage. Just stop calling jimagePackageToModule(), which was only used to validate packages are in the expected modules.

Fixes https://github.com/eclipse-openj9/openj9/issues/22853