### PR TITLE
Fix child order in vsetelem transformation in EscapeAnalysis

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -6585,8 +6585,8 @@ bool TR_EscapeAnalysis::fixupFieldAccessForNonContiguousAllocation(TR::Node *nod
             TR::Node *newValue = TR::Node::create(node, TR::ILOpCode::createVectorOpCode(TR::vsetelem, autoSymRefDataType), 3);
             newValue->setAndIncChild(0, TR::Node::create(node, TR::ILOpCode::createVectorOpCode(TR::vload, autoSymRefDataType), 0));
             newValue->getFirstChild()->setSymbolReference(autoSymRef);
-            newValue->setChild(1, value);
-            newValue->setAndIncChild(2, TR::Node::create(node, TR::iconst, 0, elem-1));
+            newValue->setAndIncChild(1, TR::Node::create(node, TR::iconst, 0, elem-1));
+            newValue->setChild(2, value);
             node->setAndIncChild(0, newValue);
             }
          }


### PR DESCRIPTION
During the EscapeAnalysis optimization, a transformation replaces certain nodes with a vsetelem node. This node expects its children in the following order: vector, index, and value. However, the transformation was incorrectly swapping the index and value operands, resulting in an invalid node structure. This caused incorrect behavior and, in some cases, failures during execution.
Correct the operand order, ensuring that the index is set as the second child and the value as the third child of the vsetelem node.