### PR TITLE
Enable jitDispatchJ9Method for MethodHandles on 32 bit X

### DIFF
--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -588,8 +588,7 @@ J9::X86::CodeGenerator::reserveNTrampolines(int32_t numTrampolines)
 bool
 J9::X86::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
    {
-   if (symbol == TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol
-       && self()->comp()->target().is64Bit())
+   if (symbol == TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol)
       {
       return true;
       }

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -2030,14 +2030,6 @@ void J9::X86::PrivateLinkage::buildDirectCall(
       }
    else if (isJitDispatchJ9Method)
       {
-      // This should occur only on 64-bit because it's generated only for
-      // OpenJDK MethodHandles, which are not yet in use in Java 8, with Java 8
-      // being the last version to support 32-bit. This shouldn't necessarily
-      // be too hard to implement on 32-bit, but it is left unimplemented for
-      // now because we can't exercise it anyway until we start to get OpenJDK
-      // MethodHandles working on Java 8.
-      TR_ASSERT_FATAL(comp()->target().is64Bit(), "jitDispatchJ9Method on 32-bit");
-
       TR::LabelSymbol *interpreterCallLabel = generateLabelSymbol(cg());
 
       TR::Register *scratchReg = cg()->allocateRegister();
@@ -2072,19 +2064,23 @@ void J9::X86::PrivateLinkage::buildDirectCall(
 
       generateLabelInstruction(oolBranchOp, callNode, interpreterCallLabel, cg());
 
-      // The method is compiled - call through register to JIT entry point
-      generateRegMemInstruction(
-         TR::InstOpCode::L4RegMem,
-         callNode,
-         j9mReg, // can reuse because the actual J9Method isn't needed anymore
-         generateX86MemoryReference(scratchReg, -4, cg()),
-         cg());
+      // target entry point is already in the scratch register at this point on 32 bit
+      if (comp()->target().is64Bit())
+         {
+         // The method is compiled - call through register to JIT entry point
+         generateRegMemInstruction(
+            TR::InstOpCode::L4RegMem,
+            callNode,
+            j9mReg, // can reuse because the actual J9Method isn't needed anymore
+            generateX86MemoryReference(scratchReg, -4, cg()),
+            cg());
 
-      generateRegImmInstruction(
-         TR::InstOpCode::SHR4RegImm1, callNode, j9mReg, 16, cg());
+         generateRegImmInstruction(
+            TR::InstOpCode::SHR4RegImm1, callNode, j9mReg, 16, cg());
 
-      generateRegRegInstruction(
-         TR::InstOpCode::ADDRegReg(), callNode, scratchReg, j9mReg, cg());
+         generateRegRegInstruction(
+            TR::InstOpCode::ADDRegReg(), callNode, scratchReg, j9mReg, cg());
+         }
 
       callInstr = generateRegInstruction(
          TR::InstOpCode::CALLReg, callNode, scratchReg, cg());

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -222,14 +222,29 @@ int32_t J9::X86::I386::PrivateLinkage::buildArgs(
       receiverChildIndex = firstArgumentChild;
 
    if (!callNode->getSymbolReference()->isUnresolved())
+      {
       switch(callNode->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod())
          {
          case TR::java_lang_invoke_ComputedCalls_dispatchJ9Method:
          case TR::java_lang_invoke_ComputedCalls_dispatchVirtual:
          case TR::com_ibm_jit_JITHelpers_dispatchVirtual:
             linkageRegChildIndex = firstArgumentChild;
-            receiverChildIndex = callNode->getOpCode().isIndirect()? firstArgumentChild + 1 : -1;
+            receiverChildIndex = callNode->getOpCode().isIndirect() ? firstArgumentChild + 1 : -1;
          }
+      }
+
+   if (callNode->isJitDispatchJ9MethodCall(comp()))
+      {
+      firstArgumentChild = 1;
+      TR::Node *target = callNode->getChild(0);
+      TR::Register *reg = cg()->evaluate(target);
+      if (reg->getRegisterPair())
+         {
+         reg = reg->getRegisterPair()->getLowOrder();
+         }
+      dependencies->addPreCondition(reg, getProperties().getJ9MethodArgumentRegister(), cg());
+      cg()->decReferenceCount(target);
+      }
 
    for (int i = firstArgumentChild; i < callNode->getNumChildren(); i++)
       {


### PR DESCRIPTION
Adds linkage support for jitDispatchJ9Method MethodHandle optimization for 32 bit X86
- Do not push first child of jitDispatchJ9Method node to stack as an arg
- sets j9MethodArgumentRegister as a pre-dep for the first child's register