### PR TITLE
Postpone registering for exception events

### DIFF
--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -68,11 +68,15 @@ typedef enum J9RASdumpMatchResult
 static UDATA rasDumpSuspendKey = 0;
 static UDATA rasDumpFirstThread = 0;
 
-/* Postpone GC and thread event hooks
+/* Postpone exception, GC and thread event hooks
  * until later phases of VM initialization.
  */
 static UDATA rasDumpPostponeHooks = 0
 		| J9RAS_DUMP_ON_CLASS_UNLOAD
+		| J9RAS_DUMP_ON_EXCEPTION_CATCH
+		| J9RAS_DUMP_ON_EXCEPTION_DESCRIBE
+		| J9RAS_DUMP_ON_EXCEPTION_SYSTHROW
+		| J9RAS_DUMP_ON_EXCEPTION_THROW
 		| J9RAS_DUMP_ON_EXCESSIVE_GC
 		| J9RAS_DUMP_ON_GLOBAL_GC
 		| J9RAS_DUMP_ON_OBJECT_ALLOCATION
@@ -1355,9 +1359,13 @@ rasDumpFlushHooks(J9JavaVM *vm, IDATA stage)
 	switch (stage) {
 	case TRACE_ENGINE_INITIALIZED:
 		/* Intermediate stage, enable all remaining hooks
-		 * except the thread event ones.
+		 * except the exception and thread event ones.
 		 */
 		*postponeHooks = 0
+				| J9RAS_DUMP_ON_EXCEPTION_CATCH
+				| J9RAS_DUMP_ON_EXCEPTION_DESCRIBE
+				| J9RAS_DUMP_ON_EXCEPTION_SYSTHROW
+				| J9RAS_DUMP_ON_EXCEPTION_THROW
 				| J9RAS_DUMP_ON_THREAD_BLOCKED
 				| J9RAS_DUMP_ON_THREAD_START
 				| J9RAS_DUMP_ON_THREAD_END


### PR DESCRIPTION
In Java 25+, `jdk.internal.misc.Unsafe.INVALID_FIELD_OFFSET` has type `long`, not `int`, so a `NoSuchFieldError` was thrown by `GetStaticFieldID()` called within `sun.misc.Unsafe.registerNatives()` (prior to #22949). Normally that error is just ignored, but if a user supplies an `-Xdump` option which requires checking the call stack, that check fails because the offset of `Throwable.walkback` has not been captured for use by `J9VMJAVALANGTHROWABLE_WALKBACK()`, etc. The result is that the lock word (at offset zero after the header) is read and interpreted as a heap reference. On must platforms, the initial lock word is zero which behaves like `null` which `iterateStackTraceImpl()` handles as an unavailable `walkback` object. On POWER, however, the initial lock is normally non-zero (but not a valid heap reference), resulting in a crash.

This change avoids problems like this early in the lifetime of a JVM by not registering dump hooks for exception events until after all the known classes, fields and methods have been resolved (including the offset of `Throwable.walkback`).

The underlying issue motivated these related changes:
1. the removal of useless/problematic code from `sun.misc.Unsafe.registerNatives()` (#22949)
2. a general cleanup of `trigger.c`, with an improvement to error checking (#22947)

Related to RTC 153110.