### PR TITLE
Optimize Unsafe_objectFieldOffset1 and throw error messages

### DIFF
--- a/runtime/jcl/jcl_internal.h
+++ b/runtime/jcl/jcl_internal.h
@@ -67,6 +67,21 @@ j9object_t getMethodDefaultAnnotationData(struct J9VMThread *vmThread, struct J9
 
 jobjectArray getMethodParametersAsArray(JNIEnv *env, jobject jlrMethod);
 
+#if JAVA_SPEC_VERSION >= 10
+/**
+ * The caller must have VM access.
+ * Return a J9ROMFieldShape * for a field specified with a name and a declaring class.
+ * Throw NullPointerException if declaringClass or fieldName is null.
+ * @param[in] vmThread The current vmThread.
+ * @param[in] declaringClass The declaring class. Must be non-null.
+ * @param[in] fieldName The name of the field. Must be non-null.
+ * @param[out] offsetResult The field offset.
+ * @return J9ROMFieldShape *
+ */
+J9ROMFieldShape *
+getROMFieldHelper(J9VMThread *vmThread, jclass declaringClass, jstring fieldName, UDATA *offsetResult);
+#endif /* JAVA_SPEC_VERSION >= 10 */
+
 /**
  * The caller must have VM access. 
  * Build a java.lang.reflect.Field object for a field specified with a name and a declaring class.


### PR DESCRIPTION
jdk26 behavior of Unsafe.objectFieldOffset() changed to throw InternalError for static fields. Optimize the objectFieldOffset1 native to avoid creating unnecessary objects or JNI IDs. Throw error messages for unfound or static fields.

Related to https://github.com/eclipse-openj9/openj9/issues/22862