### PR TITLE
Change minimum region size to 1M on ZOS

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -56,8 +56,6 @@
 #include "SweepPoolManagerVLHGC.hpp"
 #include  "SparseVirtualMemory.hpp"
 
-#define TAROK_MINIMUM_REGION_SIZE_BYTES (512 * 1024)
-
 MM_Configuration *
 MM_ConfigurationIncrementalGenerational::newInstance(MM_EnvironmentBase *env)
 {
@@ -457,7 +455,7 @@ bool
 MM_ConfigurationIncrementalGenerational::verifyRegionSize(MM_EnvironmentBase *env, UDATA regionSize)
 {
 	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-	return extensions->isRegionSizeWithOverrideSpecified || (regionSize >= TAROK_MINIMUM_REGION_SIZE_BYTES);
+	return extensions->isRegionSizeWithOverrideSpecified || (regionSize >= _minimumRegionSizeInBytes);
 }
 
 bool

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
@@ -46,7 +46,13 @@ class MM_ConfigurationIncrementalGenerational : public MM_Configuration
 public:
 protected:
 private:
-	static const uintptr_t _tarokMinimumRegionSizeInBytes = (512 * 1024);
+
+#if defined(J9ZOS39064)
+	/* Set minimum region size to 1m for ZOS to match 1m pageable page */
+	static const uintptr_t _minimumRegionSizeInBytes = (1024 * 1024);
+#else /* defined(J9ZOS39064) */
+	static const uintptr_t _minimumRegionSizeInBytes = (512 * 1024);
+#endif /* defined(J9ZOS39064) */
 
 /* Methods */
 public:
@@ -112,12 +118,12 @@ private:
 		UDATA regionSize = 0;
 
 		MM_GCExtensionsBase *extensions = env->getExtensions();
-		UDATA regionCount = extensions->memoryMax / _tarokMinimumRegionSizeInBytes;
+		UDATA regionCount = extensions->memoryMax / _minimumRegionSizeInBytes;
 		/* try to select region size such that the resulting region count is in the range of [1024, 2048] */
 		if (regionCount < 1024 || regionCount > 2048) {
-			regionSize = OMR_MAX(extensions->memoryMax / 1024, _tarokMinimumRegionSizeInBytes);
+			regionSize = OMR_MAX(extensions->memoryMax / 1024, _minimumRegionSizeInBytes);
 		} else {
-			regionSize = _tarokMinimumRegionSizeInBytes;
+			regionSize = _minimumRegionSizeInBytes;
 		}
 
 		return regionSize;


### PR DESCRIPTION
Set minimum region size to 1M to match default page on ZOS 1m,pageable. This change should make commit/decommit operations for the region to be precise.