### PR TITLE
Add safety checks to options check in writeTimeStamp

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -9968,7 +9968,9 @@ void TR_VerboseLog::vwrite(const char *format, va_list args)
 
 void TR_VerboseLog::writeTimeStamp()
    {
-   if (TR::Options::getCmdLineOptions()->getOption(TR_PrintAbsoluteTimestampInVerboseLog))
+   if (TR::Options::getCmdLineOptions()
+       && TR::Options::getCmdLineOptions()->isFullyInitialized()
+       && TR::Options::getCmdLineOptions()->getOption(TR_PrintAbsoluteTimestampInVerboseLog))
       {
       char timestamp[32];
       TR::CompilationInfo *compInfo = TR::CompilationInfo::get();


### PR DESCRIPTION
Add two checks to `TR::Options::getCmdLineOptions()->getOption(TR_PrintAbsoluteTimestampInVerboseLog))` to prevent crashes in the future
- check for null
- check to ensure options are initialized

This fix was inspired by this issue

https://github.com/eclipse-openj9/openj9/issues/22807