### PR TITLE
Add JEP 401 verification for strict instance fields

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -1687,6 +1687,9 @@ checkFields(J9PortLibrary* portLib, J9CfrClassFile * classfile, U_8 * segment, U
 	U_32 value, maskedValue, errorCode, offset = 0;
 	U_32 i;
 	U_8 sigChar, sigTag, constantTag;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	BOOLEAN valueTypeClass = J9_IS_CLASSFILE_VALUETYPE(classfile);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 	for (i = 0; i < classfile->fieldsCount; i++) {
 		field = &(classfile->fields[i]);
@@ -1717,6 +1720,17 @@ checkFields(J9PortLibrary* portLib, J9CfrClassFile * classfile, U_8 * segment, U
 			errorCode = J9NLS_CFR_ERR_FINAL_VOLATILE_FIELD__ID;
 			goto _errorFound;
 		}
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (valueTypeClass) {
+			if (J9_ARE_NO_BITS_SET(field->accessFlags, CFR_ACC_STATIC)) {
+				if (!J9_ARE_ALL_BITS_SET(field->accessFlags, CFR_ACC_FINAL | CFR_ACC_STRICT_INIT)) {
+					errorCode = J9NLS_CFR_ERR_NON_STATIC_FIELD_MUST_BE_FINAL_STRICT_INIT__ID;
+					goto _errorFound;
+				}
+			}
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 		offset = 2;
 		value = field->nameIndex;

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -1120,6 +1120,14 @@ _inconsistentStack2:
 							errorStackIndex = stackTop - liveStack->stackElements;
 							goto _inconsistentStack;
 						}
+					} else {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+						if ((JBifacmpeq == bc) || (JBifacmpne == bc) || (JBifnonnull == bc) || (JBifnull == bc)) {
+							errorType = J9NLS_BCV_ERR_UNINITIALIZED_VALUE_OBJECT__ID;
+							storeVerifyErrorData(verifyData, (I_16)bc, (U_32)errorStackIndex, (UDATA)-1, (UDATA)-1, start);
+							goto _verifyError;
+						}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 					}
 				} else {
 					POP_TOS_INTEGER;

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1833,3 +1833,10 @@ J9NLS_CFR_ERR_LOADABLEDESCRIPTORS_ENTRY_NOT_UTF8_TYPE.explanation=Please consult
 J9NLS_CFR_ERR_LOADABLEDESCRIPTORS_ENTRY_NOT_UTF8_TYPE.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
 J9NLS_CFR_ERR_LOADABLEDESCRIPTORS_ENTRY_NOT_UTF8_TYPE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+J9NLS_CFR_ERR_NON_STATIC_FIELD_MUST_BE_FINAL_STRICT_INIT=Non-static field declared in a value class does not have its ACC_FINAL and ACC_STRICT_INIT flags set.
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_NON_STATIC_FIELD_MUST_BE_FINAL_STRICT_INIT.explanation=In a valid value class, a field without its ACC_STATIC flag set must have ACC_FINAL and ACC_STRICT_INIT flags set.
+J9NLS_CFR_ERR_NON_STATIC_FIELD_MUST_BE_FINAL_STRICT_INIT.system_action=The JVM will throw a verification or classloading exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_NON_STATIC_FIELD_MUST_BE_FINAL_STRICT_INIT.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/nls/vrfy/j9bcv.nls
+++ b/runtime/nls/vrfy/j9bcv.nls
@@ -438,3 +438,11 @@ J9NLS_BCV_ERR_BC_NEW_ARRAY.system_action=The JVM will throw a verification or cl
 J9NLS_BCV_ERR_BC_NEW_ARRAY.user_response=Contact the provider of the classfile for a corrected version.
 
 # END NON-TRANSLATABLE
+
+J9NLS_BCV_ERR_UNINITIALIZED_VALUE_OBJECT=Uninitialized value object used with acmpeq, acmpne, ifnonnull, or ifnull.
+# START NON-TRANSLATABLE
+J9NLS_BCV_ERR_UNINITIALIZED_VALUE_OBJECT.explanation=Verification failed because a newly created but uninitialized value object was used with if_acmpeq, if_acmpne, ifnonnull or ifnull.
+J9NLS_BCV_ERR_UNINITIALIZED_VALUE_OBJECT.system_action=The JVM will throw a verification or classloading related exception such as java.lang.VerifyError.
+J9NLS_BCV_ERR_UNINITIALIZED_VALUE_OBJECT.user_response=Contact the provider of the classfile for a corrected version.
+
+# END NON-TRANSLATABLE

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
@@ -139,4 +139,44 @@ public class StrictFieldTests {
 		Class<?> c = StrictFieldGenerator.generateTestInstanceStrictNonFinalFieldSetAfterThisInit();
 		c.newInstance();
 	}
+
+	/* If an uninitialized 'this' reference is used with IFNONNULL,
+	 * verification must fail with a VerifyError.
+	 */
+	@Test(expectedExceptions = VerifyError.class,
+		expectedExceptionsMessageRegExp = ".*<init>.*JBifnonnull.*")
+	static public void testIfNonNullUninitializedThis() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestIfNonNullUninitializedThis();
+		c.newInstance();
+	}
+
+	/* If an uninitialized 'this' reference is used with IFNULL,
+	 * verification must fail with a VerifyError.
+	 */
+	@Test(expectedExceptions = VerifyError.class,
+		expectedExceptionsMessageRegExp = ".*<init>.*JBifnull.*")
+	static public void testIfNullUninitializedThis() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestIfNullUninitializedThis();
+		c.newInstance();
+	}
+
+	/* If a newly created value object of  uninitialized type is used with IF_ACMPEQ
+	 * verification must fail with a VerifyError.
+	 */
+	@Test(expectedExceptions = VerifyError.class,
+		expectedExceptionsMessageRegExp = ".*<init>.*JBifacmpeq.*")
+	static public void testIfAcmpeqUninitializedValue() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestIfAcmpeqUninitializedValue();
+		c.newInstance();
+	}
+
+	/* If a newly created value object of uninitialized type is used with IF_ACMPNE
+	 * verification must fail with a VerifyError.
+	 */
+	@Test(expectedExceptions = VerifyError.class,
+		expectedExceptionsMessageRegExp = ".*<init>.*JBifacmpne.*")
+	static void testIfAcmpneUninitializedValue() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestIfAcmpneUninitializedValue();
+		c.newInstance();
+	}
 }

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -23,6 +23,8 @@ package org.openj9.test.lworld;
 
 import org.objectweb.asm.*;
 
+import static org.objectweb.asm.Opcodes.*;
+
 public class ValhallaUtils {
 	/**
 	 * Currently value type is built on JDK26, so use java file major version (44 + 26) for now.
@@ -34,6 +36,7 @@ public class ValhallaUtils {
 
 	/* workaround till the new ASM is released */
 	static final int ACC_IDENTITY = 0x20;
+	static final int ACC_STRICT_INIT = ACC_STRICT;
 
 	/* ImplicitCreation flags */
 	static final int ACC_DEFAULT = 0x1;


### PR DESCRIPTION
Fixes: #22697
Implement JEP 401 verification to ensure that
instance fields of value classes have their
ACC_FINAL and ACC_STRICT_INIT flags set.
Throw ClassFormatError if any of the flags is missing. 
Throw VerifyError if IF_ACMPEQ, IF_ACMPNE, or IFNONNULL 
is used with newly created value objects of uninitialized type.