### PR TITLE
Disable provenanceGraph

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2797,6 +2797,9 @@ J9::Options::fePreProcess(void * base)
       self()->setOption(TR_EnableSharedCacheDisclaiming, false);
       }
 
+   // Temporarily disable constProvenanceGraph due to functional issues and large CompCPU overhead at the client
+   self()->setOption(TR_DisableConstProvenance);
+
    return true;
    }
 


### PR DESCRIPTION
PR https://github.com/eclipse-openj9/openj9/pull/22837 added code related to constant provenance graphs.
This code was found to cause functional issues (see issue https://github.com/eclipse-openj9/openj9/issues/22885) as well as 4.5% CPU overhead for clients connected to a JITServer.
This commit temporarily disables the provenance graph code until issues are sorted out.