### PR TITLE
Remove jdk24 support from defaults.yml

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -40,10 +40,6 @@ openjdk:
     default:
       repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk21.git'
       branch: 'openj9'
-  24:
-    default:
-      repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk24.git'
-      branch: 'openj9'
   25:
     default:
       repoUrl: 'https://github.com/ibmruntimes/openj9-openjdk-jdk25.git'
@@ -114,7 +110,6 @@ build_discarder:
     OpenJDK11: 3
     OpenJDK17: 3
     OpenJDK21: 3
-    OpenJDK24: 3
     OpenJDK25: 3
     OpenJDK: 3
     Personal: 30
@@ -162,7 +157,6 @@ boot_jdk_default:
       11: '11'
       17: '17'
       21: '21'
-      24: '24'
       25: '24'
       next: '24'
     dir_strip:
@@ -188,7 +182,6 @@ disable_javac_server:
     11: '--disable-javac-server'
     17: '--disable-javac-server'
     21: '--disable-javac-server'
-    24: '--disable-javac-server'
     25: '--disable-javac-server'
     next: '--disable-javac-server'
 #========================================#
@@ -278,7 +271,6 @@ ppc64_aix:
     11: '--disable-warnings-as-errors'
     17: '--disable-warnings-as-errors'
     21: '--disable-warnings-as-errors'
-    24: '--disable-warnings-as-errors'
     25: '--disable-warnings-as-errors'
     next: '--disable-warnings-as-errors'
   build_env:
@@ -310,7 +302,6 @@ x86-64_linux:
     11: '!sw.os.cent.6'
     17: '!sw.os.cent.6'
     21: '!sw.os.cent.6'
-    24: '!sw.os.cent.6'
     25: '!sw.os.cent.6'
     next: '!sw.os.cent.6'
 #========================================#


### PR DESCRIPTION
This avoids loading https://github.com/ibmruntimes/openj9-openjdk-jdk24.git as a reference repo, since it's no longer needed.