### PR TITLE
Update bootjdk for Java 25+

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -157,8 +157,8 @@ boot_jdk_default:
       11: '11'
       17: '17'
       21: '21'
-      25: '24'
-      next: '24'
+      25: '25'
+      next: '25'
     dir_strip:
       all: '1'
     url:


### PR DESCRIPTION
Java 25 will soon be required in the head stream; for example, see:
* [8365699: Remove jdk.internal.javac.PreviewFeature.Feature enum values for features finalized in Java 25 or earlier](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/fa5f64e316c1f3fece3572fb7a39f6e59cd645cd)