### PR TITLE
Introduce a constantPool cache

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
@@ -631,6 +631,11 @@ public static native boolean isRCPRestoreRun();
  * constantpool associated with clazz
  */
 public static ConstantPool getConstantPoolFromAnnotationBytes(Class<?> clazz, byte[] array) {
+	/* Check the cp cache on the Class object first */
+	ConstantPool cp = VM.getVMLangAccess().getConstantPoolCache(clazz);
+	if (null != cp) {
+		return cp;
+	}
 	if (null == array) {
 		return getVMLangAccess().getConstantPool(clazz);
 	}
@@ -642,7 +647,7 @@ public static ConstantPool getConstantPoolFromAnnotationBytes(Class<?> clazz, by
 	} else {
 		ramCPAddr = Unsafe.getUnsafe().getLong(array, offset);
 	}
-	Object internalCP = getVMLangAccess().createInternalConstantPool(ramCPAddr);
+	Object internalCP = getVMLangAccess().createInternalConstantPool(ramCPAddr, clazz);
 	return getVMLangAccess().getConstantPool(internalCP);
 }
 

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -131,9 +131,10 @@ public interface VMLangAccess {
 	 * Returns an InternalConstantPool object.
 	 *
 	 * @param addr - the native addr of the J9ConstantPool
+	 * @param clazz - the clazz object of the J9Class associated with the constantPool
 	 * @return An InternalConstantPool object
 	 */
-	public Object createInternalConstantPool(long addr);
+	public Object createInternalConstantPool(long addr, Class<?> clazz);
 
 	/**
 	 * Returns a ConstantPool object
@@ -148,9 +149,10 @@ public interface VMLangAccess {
 	 * natives expect an InternalConstantPool as the constantPoolOop parameter.
 	 *
 	 * @param j9class the native address of the J9Class
+	 * @param clazz the class object
 	 * @return InternalConstantPool a wrapper for a j9constantpool
 	 */
-	public Object getInternalConstantPoolFromJ9Class(long j9class);
+	public Object getInternalConstantPoolFromJ9Class(long j9class, Class<?> clazz);
 
 	/**
 	 * Returns an InternalConstantPool object from a Class. The ConstantPool
@@ -210,4 +212,14 @@ public interface VMLangAccess {
 	 */
 	public boolean getIncludeModuleVersion(StackTraceElement element);
 	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
+
+	/**
+	 * Returns a cached constantPool Object from a given java.lang.Class
+	 *
+	 * @param clazz
+	 *
+	 * @return cpObject
+	 */
+	public ConstantPool getConstantPoolCache(Class<?> clazz);
+
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -181,6 +181,8 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 	private transient long vmRef;
 	private transient ClassLoader classLoader;
 
+	transient ConstantPool constantPoolObject;
+
 	/*[IF JAVA_SPEC_VERSION >= 9]*/
 	private transient Module module;
 	/*[ENDIF] JAVA_SPEC_VERSION >= 9 */

--- a/jcl/src/java.base/share/classes/java/lang/InternalConstantPool.java
+++ b/jcl/src/java.base/share/classes/java/lang/InternalConstantPool.java
@@ -29,8 +29,10 @@ package java.lang;
 final class InternalConstantPool {
 	@SuppressWarnings("unused")
 	private final long vmRef;
+	private final Class<?> clazz;
 
-	public InternalConstantPool(long addr) {
-		vmRef = addr;
+	public InternalConstantPool(long addr, Class<?> clazz) {
+		this.vmRef = addr;
+		this.clazz = clazz;
 	}
 }

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -189,8 +189,8 @@ final class VMAccess implements VMLangAccess {
 	 * @return An InternalConstantPool reference object
 	 */
 	@Override
-	public Object createInternalConstantPool(long addr) {
-		return new InternalConstantPool(addr);
+	public Object createInternalConstantPool(long addr, Class<?> clazz) {
+		return new InternalConstantPool(addr, clazz);
 	}
 
 	/**
@@ -208,11 +208,12 @@ final class VMAccess implements VMLangAccess {
 	 * natives expect an InternalConstantPool as the constantPoolOop parameter.
 	 *
 	 * @param j9class the native address of the J9Class
+	 * @param clazz the class object
 	 * @return InternalConstantPool a wrapper for a j9constantpool
 	 */
-	public Object getInternalConstantPoolFromJ9Class(long j9class) {
+	public Object getInternalConstantPoolFromJ9Class(long j9class, Class<?> clazz) {
 		long j9constantpool = VM.getJ9ConstantPoolFromJ9Class(j9class);
-		return createInternalConstantPool(j9constantpool);
+		return createInternalConstantPool(j9constantpool, clazz);
 	}
 
 	/**
@@ -230,7 +231,7 @@ final class VMAccess implements VMLangAccess {
 		} else {
 			j9class = helpers.getJ9ClassFromClass64(clazz);
 		}
-		return getInternalConstantPoolFromJ9Class(j9class);
+		return getInternalConstantPoolFromJ9Class(j9class, clazz);
 	}
 
 	/*[IF JAVA_SPEC_VERSION >= 9]*/
@@ -277,4 +278,16 @@ final class VMAccess implements VMLangAccess {
 		return element.getIncludeModuleVersion();
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
+
+	/**
+	 * Returns a cached constantPool Object from a given java.lang.Class
+	 *
+	 * @param clazz
+	 *
+	 * @return cpObject
+	 */
+	@Override
+	public ConstantPool getConstantPoolCache(Class<?> clazz) {
+		return clazz.constantPoolObject;
+	}
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
@@ -115,8 +115,8 @@ final class MethodHandleResolver {
 		Object result = null;
 
 		VMLangAccess access = VM.getVMLangAccess();
-		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class);
 		Class<?> classObject = getClassFromJ9Class(j9class);
+		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class, classObject);
 
 		Class<?> typeClass = fromFieldDescriptorString(fieldDescriptor, access.getClassloader(classObject));
 
@@ -241,8 +241,8 @@ final class MethodHandleResolver {
 	private static final Object resolveInvokeDynamic(long j9class, String name, String methodDescriptor, long bsmData) throws Throwable {
 /*[IF OPENJDK_METHODHANDLES]*/
 		VMLangAccess access = VM.getVMLangAccess();
-		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class);
 		Class<?> classObject = getClassFromJ9Class(j9class);
+		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class, classObject);
 
 		MethodType type = null;
 		Object[] result = new Object[2];
@@ -340,8 +340,8 @@ final class MethodHandleResolver {
 		try {
 /*[ENDIF] JAVA_SPEC_VERSION < 11 */
 			VMLangAccess access = VM.getVMLangAccess();
-			Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class);
 			Class<?> classObject = getClassFromJ9Class(j9class);
+			Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class, classObject);
 
 			type = MethodTypeHelper.vmResolveFromMethodDescriptorString(methodDescriptor, access.getClassloader(classObject), null);
 			final MethodHandles.Lookup lookup = new MethodHandles.Lookup(classObject, false);

--- a/runtime/jcl/common/java_lang_Access.c
+++ b/runtime/jcl/common/java_lang_Access.c
@@ -20,6 +20,8 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
+#include "j9cp.h"
+#include "j9vmconstantpool.h"
 #include "jni.h"
 #include "jcl.h"
 #include "jclprots.h"
@@ -36,16 +38,16 @@
  *
  * @return a ConstantPool object reference or NULL on error.
  */
-jobject JNICALL 
+jobject JNICALL
 Java_java_lang_Access_getConstantPool(JNIEnv *env, jclass unusedClass, jobject classToIntrospect)
 {
 	jclass sun_reflect_ConstantPool = JCL_CACHE_GET(env,CLS_sun_reflect_ConstantPool);
-	jfieldID constantPoolOop;
 	jobject constantPool;
 	J9VMThread *vmThread = (J9VMThread *)env;
 	J9InternalVMFunctions *vmFunctions = vmThread->javaVM->internalVMFunctions;
 	J9MemoryManagerFunctions *gcFunctions = vmThread->javaVM->memoryManagerFunctions;
 	j9object_t classObject = NULL;
+	J9Class *clazz = NULL;
 
 	/* lazy-initialize the cached field IDs */
 	if (NULL == sun_reflect_ConstantPool) {
@@ -54,7 +56,7 @@ Java_java_lang_Access_getConstantPool(JNIEnv *env, jclass unusedClass, jobject c
 		}
 		sun_reflect_ConstantPool = JCL_CACHE_GET(env, CLS_sun_reflect_ConstantPool);
 	}
-	
+
 	/* allocate the new ConstantPool object */
 	constantPool = (*env)->AllocObject(env, sun_reflect_ConstantPool);
 	if (NULL == constantPool) {
@@ -65,8 +67,8 @@ Java_java_lang_Access_getConstantPool(JNIEnv *env, jclass unusedClass, jobject c
 	vmFunctions->internalEnterVMFromJNI(vmThread);
 	classObject = J9_JNI_UNWRAP_REFERENCE(classToIntrospect);
 	if (J9VMJAVALANGCLASS_OR_NULL(vmThread->javaVM) == J9OBJECT_CLAZZ(vmThread, classObject)) {
-		J9Class *clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, classObject);
-		J9ConstantPool *constantPool = (J9ConstantPool *)clazz->ramConstantPool;
+		clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, classObject);
+		J9ConstantPool *j9CP = (J9ConstantPool *)clazz->ramConstantPool;
 		J9Class *internalConstantPool = J9VMJAVALANGINTERNALCONSTANTPOOL_OR_NULL(vmThread->javaVM);
 		Assert_JCL_notNull(internalConstantPool);
 		j9object_t internalConstantPoolObject = gcFunctions->J9AllocateObject(vmThread, internalConstantPool, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
@@ -75,14 +77,26 @@ Java_java_lang_Access_getConstantPool(JNIEnv *env, jclass unusedClass, jobject c
 			vmFunctions->internalExitVMToJNI(vmThread);
 			return NULL;
 		}
-		J9VMJAVALANGINTERNALCONSTANTPOOL_SET_VMREF(vmThread, internalConstantPoolObject, constantPool);
+		J9VMJAVALANGINTERNALCONSTANTPOOL_SET_VMREF(vmThread, internalConstantPoolObject, j9CP);
+		J9VMJAVALANGINTERNALCONSTANTPOOL_SET_CLAZZ(vmThread, internalConstantPoolObject, classObject);
 		classToIntrospect = vmFunctions->j9jni_createLocalRef(env, internalConstantPoolObject);
+	}
+
+#if JAVA_SPEC_VERSION == 8
+	J9VMSUNREFLECTCONSTANTPOOL_SET_CONSTANTPOOLOOP(vmThread, J9_JNI_UNWRAP_REFERENCE(constantPool), J9_JNI_UNWRAP_REFERENCE(classToIntrospect));
+#else /* JAVA_SPEC_VERSION == 8 */
+	J9VMJDKINTERNALREFLECTCONSTANTPOOL_SET_CONSTANTPOOLOOP(vmThread, J9_JNI_UNWRAP_REFERENCE(constantPool), J9_JNI_UNWRAP_REFERENCE(classToIntrospect));
+#endif /* JAVA_SPEC_VERSION == 8 */
+
+	if (NULL == clazz) {
+		/* If we are here then classToIntrospect is an InternalConstantPool object, find the class object. */
+		classObject = J9VMJAVALANGINTERNALCONSTANTPOOL_CLAZZ(vmThread, J9_JNI_UNWRAP_REFERENCE(classToIntrospect));
+		clazz = J9VM_J9CLASS_FROM_HEAPCLASS(vmThread, classObject);
+	}
+	if (NULL == clazz->replacedClass) {
+		J9VMJAVALANGCLASS_SET_CONSTANTPOOLOBJECT(vmThread, classObject, J9_JNI_UNWRAP_REFERENCE(constantPool));
 	}
 	vmFunctions->internalExitVMToJNI(vmThread);
 
-	/* and set the private constantPoolOop member */
-	constantPoolOop = JCL_CACHE_GET(env, FID_sun_reflect_ConstantPool_constantPoolOop);
-	(*env)->SetObjectField(env, constantPool, constantPoolOop, classToIntrospect);
-	
 	return constantPool;
 }

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -130,7 +130,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<classref name="java/lang/Module" versions="9-"/>
 	<classref name="java/lang/invoke/VarHandleInvokeHandle" versions="9-" flags="opt_methodHandle"/>
 	<classref name="java/lang/invoke/FieldVarHandle" versions="9-" flags="opt_methodHandle"/>
-	<classref name="jdk/internal/reflect/ConstantPool" versions="26-"/>
+	<classref name="jdk/internal/reflect/ConstantPool" versions="11-"/>
+	<classref name="sun/reflect/ConstantPool" versions="8"/>
 
 	<!-- Common class references shared between OpenJ9 and OpenJDK MethodHandles. -->
 	<classref name="java/lang/invoke/MethodType" flags="opt_methodHandleCommon"/>
@@ -192,6 +193,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/Class" name="reflectCache" signature="Ljava/lang/Class$ReflectCache;"/>
 	<fieldref class="java/lang/Class" name="classLoader" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/Class" name="vmRef" signature="J" cast="struct J9Class *"/>
+	<fieldref class="java/lang/Class" name="constantPoolObject" signature="Ljdk/internal/reflect/ConstantPool;"  versions="11-"/>
+	<fieldref class="java/lang/Class" name="constantPoolObject" signature="Lsun/reflect/ConstantPool;"  versions="8"/>
 	<fieldref class="java/lang/Class" name="initializationLock" signature="Ljava/lang/J9VMInternals$ClassInitializationLock;"/>
 	<fieldref class="java/lang/Class" name="protectionDomain" signature="Ljava/security/ProtectionDomain;"/>
 	<fieldref class="java/lang/Class" name="classNameString" signature="Ljava/lang/String;"/>
@@ -407,6 +410,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/Module" name="name" signature="Ljava/lang/String;" versions="9-"/>
 
 	<fieldref class="java/lang/InternalConstantPool" name="vmRef" signature="J" cast="struct J9ConstantPool *"/>
+	<fieldref class="java/lang/InternalConstantPool" name="clazz" signature="Ljava/lang/Class;"/>
 
 	<fieldref class="com/ibm/oti/util/WeakReferenceNode" name="next" signature="Lcom/ibm/oti/util/WeakReferenceNode;" flags="opt_methodHandle"/>
 
@@ -475,7 +479,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="jdk/internal/foreign/NativeMemorySegmentImpl" name="scope" signature="Ljava/lang/foreign/SegmentScope;" flags="opt_openjdkFfi" versions="20"/>
 	<fieldref class="jdk/internal/foreign/NativeMemorySegmentImpl" name="scope" signature="Ljdk/internal/foreign/MemorySessionImpl;" flags="opt_openjdkFfi" versions="21-"/>
 
-	<fieldref class="jdk/internal/reflect/ConstantPool" name="constantPoolOop" signature="Ljava/lang/Object;" versions="26-"/>
+	<fieldref class="jdk/internal/reflect/ConstantPool" name="constantPoolOop" signature="Ljava/lang/Object;" versions="11-"/>
+	<fieldref class="sun/reflect/ConstantPool" name="constantPoolOop" signature="Ljava/lang/Object;" versions="8"/>
 
 <!--
 	NOTE: the resolution code in jclcinit.c only looks at the J9ROMClassRef->runtimeFlags to determine

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2489,6 +2489,7 @@ flushClassLoaderReflectCache(J9VMThread * currentThread, J9HashTable * classPair
 			j9object_t classObject = J9VM_J9CLASS_TO_HEAPCLASS(replacementRAMClass);
 			J9VMJAVALANGCLASS_SET_ANNOTATIONCACHE(currentThread, classObject, NULL);
 			J9VMJAVALANGCLASS_SET_REFLECTCACHE(currentThread, classObject, NULL);
+			J9VMJAVALANGCLASS_SET_CONSTANTPOOLOBJECT(currentThread, classObject, NULL);
 		}
 		classPair = hashTableNextDo(&hashTableState);
 	}


### PR DESCRIPTION
Cache the constantPool object off the j.l.Class after the first
invocation of Access::getConstantPool. Given that the ConstantPool
instance is associated with a single version of the class, as soon as
the class is redefined the cache is invalidated and disabled.