### PR TITLE
Update references to use OMR_ISSPACE

### DIFF
--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -326,10 +326,10 @@ hasEnvOption(const char *envOptions, const char *option)
 	UDATA optionLength = strlen(option);
 
 	while (NULL != start) {
-		if ((start == envOptions) || isspace(start[-1])) {
+		if ((start == envOptions) || OMR_ISSPACE(start[-1])) {
 			const char *end = start + optionLength;
 
-			if ((*end == '\0') || isspace(*end)) {
+			if ((*end == '\0') || OMR_ISSPACE(*end)) {
 				success = TRUE;
 				break;
 			}
@@ -355,11 +355,11 @@ findStartOfMostRightOption(const char *envOptions, const char *option)
 	char *result = strstr(envOptions, option);
 	UDATA optionSize = strlen(option);
 	if (NULL != result) {
-		if ((result == envOptions) || isspace(result[-1])) {
+		if ((result == envOptions) || OMR_ISSPACE(result[-1])) {
 			char *cursor = result;
 			char *next = NULL;
 			while (NULL != (next = strstr(cursor + optionSize, option))) {
-				if (isspace(next[-1])) {
+				if (OMR_ISSPACE(next[-1])) {
 					result = next;
 				}
 				cursor = next;

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3267,8 +3267,8 @@ static BOOLEAN
 isEmpty(const char * str)
 {
 	BOOLEAN isEmpty = TRUE;
-	while('\0' != *str) {
-		if (0 == isspace((unsigned char) *str)) {
+	while ('\0' != *str) {
+		if (0 == OMR_ISSPACE(*str)) {
 			isEmpty = FALSE;
 			break;
 		}

--- a/runtime/vm/logsupport.c
+++ b/runtime/vm/logsupport.c
@@ -202,7 +202,7 @@ parseLogOptions(char *options, UDATA *optionsFlags, UDATA *parseSucceeded)
 
 	/* remove any whitespace from the options string */
 	for (i = 0, j = 0; i < optlen; i++) {
-		if (!isspace(options[i])) {
+		if (!OMR_ISSPACE(options[i])) {
 			options[j] = options[i];
 			j++;
 		}


### PR DESCRIPTION
OMR_ISSPACE is a macro that provides a more flexible implementation to find spaces for a given parameter. It will conditionally use the BIMODAL function `__isspace_a()` when the ASCII version of the function is required on z/OS.

This depends on: https://github.com/eclipse-omr/omr/pull/8017

tag: Open XL