### PR TITLE
Update ValueClass api null restricted array support

### DIFF
--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -476,9 +476,9 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_NewNullableAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
-	[_X(JVM_NewNullRestrictedAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length)])
+	[_X(JVM_NewNullRestrictedAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length, jobject initialValue)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
-	[_X(JVM_NewNullRestrictedNonAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass elmClass, jint len, jobject initVal)])
+	[_X(JVM_NewNullRestrictedNonAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass elmClass, jint len, jobject initialValue)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
 _IF([JAVA_SPEC_VERSION == 22],

--- a/runtime/vm/ClassInitialization.cpp
+++ b/runtime/vm/ClassInitialization.cpp
@@ -602,22 +602,6 @@ doVerify:
 						bool isStatic = J9_VM_FCC_ENTRY_IS_STATIC_FIELD(entry);
 
 						if (isStatic) {
-							U_32 fieldModifiers = entry->field->modifiers;
-							if (J9_ARE_ALL_BITS_SET(fieldModifiers, J9FieldFlagIsNullRestricted)) {
-								J9ROMClass *entryRomClass = entryClazz->romClass;
-								/* A NullRestricted field must be in a value class with an
-								* ImplicitCreation attribute. The attribute must have the ACC_DEFAULT flag set.
-								*/
-								if (!J9ROMCLASS_IS_VALUE(entryRomClass)
-									|| J9_ARE_NO_BITS_SET(entryRomClass->optionalFlags, J9_ROMCLASS_OPTINFO_IMPLICITCREATION_ATTRIBUTE)
-									|| J9_ARE_NO_BITS_SET(getImplicitCreationFlags(entryRomClass), J9AccImplicitCreateHasDefaultValue)
-								) {
-									J9UTF8 *romClassName = J9ROMCLASS_CLASSNAME(entryRomClass);
-									setCurrentExceptionNLSWithArgs(currentThread, J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_DEFAULT_IMPLICITCREATION_VALUE_CLASS, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, J9UTF8_LENGTH(romClassName), J9UTF8_DATA(romClassName));
-									goto done;
-								}
-							}
-
 							initializationLock = enterInitializationLock(currentThread, initializationLock);
 							if (J9_OBJECT_MONITOR_ENTER_FAILED(initializationLock)) {
 								goto done;

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -99,11 +99,6 @@
 	</test>
 	<test>
 		<testCaseName>ValueTypeArrayTests</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/22642</comment>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xgcpolicy:optthruput</variation>
 			<variation>-Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999 -XX:-EnableArrayFlattening</variation>
@@ -348,11 +343,6 @@
 	</test>
 	<test>
 		<testCaseName>ValueTypeSystemArraycopyTests</testCaseName>
-		<disables>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/22642</comment>
-			</disable>
-		</disables>
 		<variations>
 			<variation>-Xint</variation>
 			<variation>-Xint -Xgcpolicy:optthruput -XX:ValueTypeFlatteningThreshold=99999</variation>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaAttributeTests.java
@@ -145,33 +145,6 @@ public class ValhallaAttributeTests {
 		ValhallaAttributeGenerator.generateNullRestrictedFieldWhereICHasNoDefaultFlag(false, "TestNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlag", "TestNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlagField");
 	}
 
-	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
-	 * Static fields should fail during the preparation stage of linking.
-	 */
-	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*A static field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
-	public static void testStaticNullRestrictedFieldMustBeInValueClass() throws Throwable {
-		Class<?> c = ValhallaAttributeGenerator.generateNullRestrictedAttributeInIdentityClass(true, "TestStaticNullRestrictedFieldMustBeInValueClass", "TestStaticNullRestrictedFieldMustBeInValueClassField");
-		c.newInstance();
-	}
-
-	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
-	 * Static fields should fail during the preparation stage of linking.
-	 */
-	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*A static field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
-	public static void testStaticNullRestrictedFieldClassMustHaveImplicitCreation() throws Throwable {
-		Class<?> c = ValhallaAttributeGenerator.generateNullRestrictedAttributeInValueClassWithoutIC(true, "TestStaticNullRestrictedFieldClassMustHaveImplicitCreation", "TestStaticNullRestrictedFieldClassMustHaveImplicitCreationField");
-		c.newInstance();
-	}
-
-	/* The descriptor_index of the field should name a value class that has an ImplicitCreation attribute with its ACC_DEFAULT flag is set.
-	 * Static fields should fail during the preparation stage of linking.
-	 */
-	@Test(expectedExceptions = java.lang.IncompatibleClassChangeError.class, expectedExceptionsMessageRegExp = ".*A static field with a NullRestricted attribute must be in a value class with an implicit constructor.*")
-	public static void testStaticNullRestrictedFieldWhereImplicitCreationHasNoDefaultFlag() throws Throwable {
-		Class<?> c = ValhallaAttributeGenerator.generateNullRestrictedFieldWhereICHasNoDefaultFlag(true, "TestStaticNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlag", "TestStaticNullRestrictedAttributeWhereImplicitCreationHasNoDefaultFlagField");
-		c.newInstance();
-	}
-
 	@Test
 	public static void testPutFieldNullToValueTypeField() throws Throwable {
 		Class<?> c = ValhallaAttributeGenerator.generatePutFieldNullToField("TestPutFieldNullToValueTypeField", "TestPutFieldNullToValueTypeFieldField", false);

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/DDRValueTypeTest.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/DDRValueTypeTest.java
@@ -63,8 +63,6 @@ public class DDRValueTypeTest {
 		Object valueTypeWithVolatileFields = ValueTypeTests.createValueTypeWithVolatileFields();
 
 		Object[] valArray = ValueClass.newNullRestrictedAtomicArray(assortedValueWithSingleAlignmentClass, 2, assortedValueWithSingleAlignment);
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		valArray[0] = assortedValueWithSingleAlignment;
 		valArray[1] = assortedValueWithSingleAlignmentAlt;
 
 		ValueTypeTests.checkObject(assortedValueWithSingleAlignment, 

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -312,10 +312,6 @@ public class ValueTypeTests {
 		Object point2D = makePoint2D.invoke(x1, y1);
 		Object[] array = ValueClass.newNullRestrictedAtomicArray(point2DClass, 8, point2D);
 
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		for (int i = 0; i < 8; i++) {
-			array[i] = point2D;
-		}
 		System.gc();
 
 		Object value = array[0];
@@ -326,11 +322,6 @@ public class ValueTypeTests {
 		Object[] array = ValueClass.newNullRestrictedAtomicArray(assortedValueWithSingleAlignmentClass, 4,
 				createAssorted(makeAssortedValueWithSingleAlignment, typeWithSingleAlignmentFields));
 
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		for (int i = 0; i < 4; i++) {
-			Object object = createAssorted(makeAssortedValueWithSingleAlignment, typeWithSingleAlignmentFields);
-			array[i] = object;
-		}
 		System.gc();
 
 		for (int i = 0; i < 4; i++) {
@@ -343,11 +334,6 @@ public class ValueTypeTests {
 		Object[] array = ValueClass.newNullRestrictedAtomicArray(assortedValueWithObjectAlignmentClass, 4,
 				createAssorted(makeAssortedValueWithObjectAlignment, typeWithObjectAlignmentFields));
 
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		for (int i = 0; i < 4; i++) {
-			Object object = createAssorted(makeAssortedValueWithObjectAlignment, typeWithObjectAlignmentFields);
-			array[i] = object;
-		}
 		System.gc();
 
 		for (int i = 0; i < 4; i++) {
@@ -360,11 +346,6 @@ public class ValueTypeTests {
 		Object[] array = ValueClass.newNullRestrictedAtomicArray(assortedValueWithLongAlignmentClass, genericArraySize,
 				createAssorted(makeAssortedValueWithLongAlignment, typeWithLongAlignmentFields));
 
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		for (int i = 0; i < genericArraySize; i++) {
-			Object object = createAssorted(makeAssortedValueWithLongAlignment, typeWithLongAlignmentFields);
-			array[i] = object;
-		}
 		System.gc();
 
 		for (int i = 0; i < genericArraySize; i++) {
@@ -377,11 +358,6 @@ public class ValueTypeTests {
 		Object[] array = ValueClass.newNullRestrictedAtomicArray(largeObjectValueClass, 4, createLargeObject(new Object()));
 		Object largeObjectRef = createLargeObject(new Object());
 
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		for (int i = 0; i < 4; i++) {
-			array[i] = largeObjectRef;
-		}
-
 		System.gc();
 
 		Object value = array[0];
@@ -391,13 +367,6 @@ public class ValueTypeTests {
 	static public void testGCFlattenedMegaObjectArray() throws Throwable {
 		Object[] array = ValueClass.newNullRestrictedAtomicArray(megaObjectValueClass, 4, createMegaObject(new Object()));
 		Object megaObjectRef = createMegaObject(new Object());
-
-		System.gc();
-
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		for (int i = 0; i < 4; i++) {
-			array[i] = megaObjectRef;
-		}
 		System.gc();
 
 		Object value = array[0];
@@ -542,8 +511,6 @@ public class ValueTypeTests {
 		Object line2D_2 = makeFlattenedLine2D.invoke(st2, en2);
 
 		Object[] arrayObject = ValueClass.newNullRestrictedAtomicArray(flattenedLine2DClass, 2, line2D_1);
-		// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		arrayObject[0] = line2D_1;
 		arrayObject[1] = line2D_2;
 		Object line2D_1_check = arrayObject[0];
 		Object line2D_2_check = arrayObject[1];
@@ -2306,8 +2273,7 @@ public class ValueTypeTests {
 		checkCastRefClassOnNull.invoke();
 	}
 
-	// TODO: Disabled as per https://github.com/eclipse-openj9/openj9/issues/22642.
-	@Test(priority=1, enabled=false)
+	@Test(priority=1)
 	static public void testClassIsInstanceNullableArrays() throws Throwable {
 		ValueTypePoint2D[] nonNullableArray = (ValueTypePoint2D[]) ValueClass.newNullRestrictedAtomicArray(
 				ValueTypePoint2D.class, 1, new ValueTypePoint2D(new ValueTypeInt(0), new ValueTypeInt(0)));
@@ -2322,18 +2288,14 @@ public class ValueTypeTests {
 	/*
 	 * Maintain a buffer of flattened arrays with long-aligned valuetypes while keeping a certain amount of classes alive at any
 	 * single time. This forces the GC to unload the classes.
+	 * Fix with https://github.com/eclipse-openj9/openj9/issues/22642
 	 */
-	@Test(priority=5, invocationCount=2)
+	@Test(priority=5, invocationCount=2, enabled=false)
 	static public void testValueWithLongAlignmentGCScanning() throws Throwable {
 		ArrayList<Object> longAlignmentArrayList = new ArrayList<Object>(objectGCScanningIterationCount);
 		for (int i = 0; i < objectGCScanningIterationCount; i++) {
 			Object newLongAlignmentArray = ValueClass.newNullRestrictedAtomicArray(assortedValueWithLongAlignmentClass,
 					genericArraySize, createAssorted(makeAssortedValueWithLongAlignment, typeWithLongAlignmentFields));
-			// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-			for (int j = 0; j < genericArraySize; j++) {
-				Object assortedValueWithLongAlignment = createAssorted(makeAssortedValueWithLongAlignment, typeWithLongAlignmentFields);
-				Array.set(newLongAlignmentArray, j, assortedValueWithLongAlignment);
-			}
 			longAlignmentArrayList.add(newLongAlignmentArray);
 		}
 
@@ -2349,19 +2311,15 @@ public class ValueTypeTests {
 	/*
 	 * Maintain a buffer of flattened arrays with object-aligned valuetypes while keeping a certain amount of classes alive at any
 	 * single time. This forces the GC to unload the classes.
+	 * Fix with https://github.com/eclipse-openj9/openj9/issues/22642
 	 */
-	@Test(priority=5, invocationCount=2)
+	@Test(priority=5, invocationCount=2, enabled=false)
 	static public void testValueWithObjectAlignmentGCScanning() throws Throwable {
 		ArrayList<Object> objectAlignmentArrayList = new ArrayList<Object>(objectGCScanningIterationCount);
 		for (int i = 0; i < objectGCScanningIterationCount; i++) {
 			Object newObjectAlignmentArray = ValueClass.newNullRestrictedAtomicArray(
 					assortedValueWithObjectAlignmentClass, genericArraySize,
 					createAssorted(makeAssortedValueWithObjectAlignment, typeWithObjectAlignmentFields));
-			// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-			for (int j = 0; j < genericArraySize; j++) {
-				Object assortedValueWithObjectAlignment = createAssorted(makeAssortedValueWithObjectAlignment, typeWithObjectAlignmentFields);
-				Array.set(newObjectAlignmentArray, j, assortedValueWithObjectAlignment);
-			}
 			objectAlignmentArrayList.add(newObjectAlignmentArray);
 		}
 
@@ -2377,19 +2335,15 @@ public class ValueTypeTests {
 	/*
 	 * Maintain a buffer of flattened arrays with single-aligned valuetypes while keeping a certain amount of classes alive at any
 	 * single time. This forces the GC to unload the classes.
+	 * Fix with https://github.com/eclipse-openj9/openj9/issues/22642
 	 */
-	@Test(priority=5, invocationCount=2)
+	@Test(priority=5, invocationCount=2, enabled=false)
 	static public void testValueWithSingleAlignmentGCScanning() throws Throwable {
 		ArrayList<Object> singleAlignmentArrayList = new ArrayList<Object>(objectGCScanningIterationCount);
 		for (int i = 0; i < objectGCScanningIterationCount; i++) {
 			Object newSingleAlignmentArray = ValueClass.newNullRestrictedAtomicArray(
 					assortedValueWithSingleAlignmentClass, genericArraySize,
 					createAssorted(makeAssortedValueWithSingleAlignment, typeWithSingleAlignmentFields));
-			// TODO: Remove following initialization as per https://github.com/eclipse-openj9/openj9/issues/22642.
-			for (int j = 0; j < genericArraySize; j++) {
-				Object assortedValueWithSingleAlignment = createAssorted(makeAssortedValueWithSingleAlignment, typeWithSingleAlignmentFields);
-				Array.set(newSingleAlignmentArray, j, assortedValueWithSingleAlignment);
-			}
 			singleAlignmentArrayList.add(newSingleAlignmentArray);
 		}
 

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeUnsafeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeUnsafeTests.java
@@ -95,13 +95,11 @@ public class ValueTypeUnsafeTests {
 		vtPoint = new ValueTypePoint2D(new ValueTypeInt(7), new ValueTypeInt(8));
 
 		vtPointAry = null;
-		// TODO: Disabled as per https://github.com/eclipse-openj9/openj9/issues/22642.
-		// vtPointAry = (ValueTypePoint2D[]) ValueClass.newNullRestrictedAtomicArray(ValueTypePoint2D.class, 2,
-		//		new ValueTypePoint2D(new ValueTypeInt(0), new ValueTypeInt(0)));
-		// vtPointAry[0] = new ValueTypePoint2D(new ValueTypeInt(5), new ValueTypeInt(10));
-		// vtPointAry[1] = new ValueTypePoint2D(new ValueTypeInt(10), new ValueTypeInt(20));
+		vtPointAry = (ValueTypePoint2D[]) ValueClass.newNullRestrictedAtomicArray(ValueTypePoint2D.class, 2,
+				new ValueTypePoint2D(new ValueTypeInt(5), new ValueTypeInt(10)));
+		vtPointAry[1] = new ValueTypePoint2D(new ValueTypeInt(10), new ValueTypeInt(20));
 
-		// vtPointAryOffset1 = vtPointAryOffset0 + arrayElementSize(vtPointAry);
+		vtPointAryOffset1 = vtPointAryOffset0 + arrayElementSize(vtPointAry);
 		vtIntAry = new ValueTypeInt[] { new ValueTypeInt(1), new ValueTypeInt(2) };
 		vtIntAryOffset1 = vtIntAryOffset0 + arrayElementSize(vtIntAry);
 	}
@@ -151,8 +149,7 @@ public class ValueTypeUnsafeTests {
 		assertEquals(isFlattened, isFlatteningEnabled);
 	}
 
-	// TODO: Disabled as per https://github.com/eclipse-openj9/openj9/issues/22642.
-	@Test(enabled = false)
+	@Test
 	static public void testFlattenedArrayIsFlattened() throws Throwable {
 		boolean isArrayFlattened = myUnsafe.isFlatArray(vtPointAry.getClass());
 		assertEquals(isArrayFlattened, isArrayFlatteningEnabled);
@@ -282,7 +279,7 @@ public class ValueTypeUnsafeTests {
 		}
 	}
 
-	// TODO: Disabled as per https://github.com/eclipse-openj9/openj9/issues/22642.
+	// TODO this should be fixed by strict field support
 	@Test(enabled = false)
 	static public void testGetValueOfZeroSizeVTArrayDoesNotCauseError() throws Throwable {
 		ZeroSizeValueType[] zsvtAry = new ZeroSizeValueType[] {
@@ -293,7 +290,7 @@ public class ValueTypeUnsafeTests {
 		assertNotNull(myUnsafe.getValue(zsvtAry, zsvtAryOffset0, ZeroSizeValueType.class));
 	}
 
-	// TODO: Disabled as per https://github.com/eclipse-openj9/openj9/issues/22642.
+	// TODO this should be fixed by strict field support
 	@Test(enabled = false)
 	static public void testGetValueOfZeroSizeVTObjectDoesNotCauseError() throws Throwable {
 		ZeroSizeValueTypeWrapper zsvtw = new ZeroSizeValueTypeWrapper();


### PR DESCRIPTION
- Implement JVM_IsAtomicArray
- Implement JVM_NewNullRestrictedNonAtomicArray
- Update JVM_NewNullRestrictedAtomicArray
- Remove vm restriction that null restricted fields must have implicit creation attributes.

Related https://github.com/eclipse-openj9/openj9/issues/22642