### PR TITLE
RAM Class Persistence: Remove dynamic Proxy classes from RCP cache

### DIFF
--- a/runtime/vm/VMSnapshotImpl.cpp
+++ b/runtime/vm/VMSnapshotImpl.cpp
@@ -644,6 +644,11 @@ VMSnapshotImpl::fixupClasses()
 			if (NULL == currentClass->lastITable) {
 				currentClass->lastITable = VMSnapshotImpl::getInvalidITable();
 			}
+			/* Remove dynamic Proxy classes along with unsafe classes. */
+			if (J9ROMCLASS_IS_UNSAFE(romClass)) {
+				J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
+				hashClassTableDelete(classloader, J9UTF8_DATA(className), J9UTF8_LENGTH(className));
+			}
 
 			currentClass = allLiveClassesNextDo(&walkState);
 		}


### PR DESCRIPTION
Dynamic Proxy names are assigned in OpenJDK according to the order of the method Proxy.newProxyInstance() invoked from applications. It's problem in restore run, because the order of the method Proxy.newProxyInstance() invoked from applications may be changed on conditions or events and the class lookup by the names of $ProxyN {0...n} from RCP cache may be wrong result. The changes are proposed to remove the classes along with unsafe classes from RCP cache.

Fixes: #22841

Co-authored-by: Tobi Ajila tobi_ajila@ca.ibm.com