### PR TITLE
Remove unnecessary checks on String methods (Nov 2025)

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -232,6 +232,8 @@
    java_lang_String_isLatin1,
    java_lang_String_startsWith,
 
+   java_lang_String_valueOf_C,
+
    java_lang_StringLatin1_indexOf,
    java_lang_StringLatin1_indexOfChar,
    java_lang_StringLatin1_inflate_BICII,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2801,6 +2801,7 @@ void TR_ResolvedJ9Method::construct()
       {x(TR::java_lang_String_decodeUTF8_UTF16,    "decodeUTF8_UTF16",    "([BII[BIZ)I")},
       {x(TR::java_lang_String_isLatin1,            "isLatin1",            "()Z")},
       {x(TR::java_lang_String_startsWith,          "startsWith",          "(Ljava/lang/String;I)Z")},
+      {x(TR::java_lang_String_valueOf_C,           "valueOf",             "(C)Ljava/lang/String;")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -234,6 +234,9 @@ static TR::RecognizedMethod stringCanSkipNullChecks[] =
    TR::java_lang_StringLatin1_toUpperCase,
    TR::java_lang_StringUTF16_toLowerCase,
    TR::java_lang_StringUTF16_toUpperCase,
+   TR::java_lang_String_equals,
+   TR::java_lang_String_regionMatchesInternal,
+   TR::java_lang_String_valueOf_C,
    TR::unknownMethod
    };
 
@@ -362,6 +365,7 @@ static TR::RecognizedMethod stringCanSkipBoundChecks[] =
    TR::java_lang_StringUTF16_replace_CharSequence,
    TR::java_lang_StringLatin1_toLowerCase,
    TR::java_lang_StringLatin1_toUpperCase,
+   TR::java_lang_String_valueOf_C,
    TR::unknownMethod
    };
 


### PR DESCRIPTION
Removes boundchks and nullchks for trusted String methods that will never trigger the checks. This includes:
```
String.equals
String.regionMatchesInternal
String.valueOf
```
The checks can be restored by setting the `TR_DisableStringChkSkips` envvar.

This is the same idea as the previous PR (https://github.com/eclipse-openj9/openj9/pull/21770) but is extended to a few more methods.