### PR TITLE
Fix assertion error when using JITserver enable recompilation

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -353,7 +353,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    static void setOutOfProcessCompilation() { _outOfProcessCompilation = true; }
 
    bool isRemoteCompilation() const { return _remoteCompilation; } // client side
-   void setRemoteCompilation() { _remoteCompilation = true; }
+   void setRemoteCompilation(bool remoteCompilation = true) { _remoteCompilation = remoteCompilation; }
 
    TR::list<SerializedRuntimeAssumption *> &getSerializedRuntimeAssumptions() { return _serializedRuntimeAssumptions; }
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -4057,10 +4057,13 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
             intptr_t rtn = 0;
             try
                {
+               compiler->setRemoteCompilation(false);
                rtn = compiler->compile();
+               compiler->setRemoteCompilation();
                }
             catch(...)
                {
+               compiler->setRemoteCompilation();
                // This compilation wasn't started from TR::CompilationInfoPerThreadBase::compile,
                // so we need to make sure that we release the class unload monitor on exception.
                if (compileWithoutVMAccess)


### PR DESCRIPTION
- Change the API for `setRemoteCompilation` to enable resetting the `_remoteCompilation` flag.
- Use this API change to toggle the `_remoteCompilation` flag before and after the local debugging compilation triggered by `TR_JITServerFollowRemoteCompileWithLocalCompile`.

This prevents assertion errors when trying to access `retainedMethods`.

fixes:
https://github.com/eclipse-openj9/openj9/issues/22917