### PR TITLE
JITServer: create env var to perform all compilations locally

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7340,10 +7340,12 @@ TR::CompilationInfoPerThreadBase::cannotPerformRemoteComp(
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 )
    {
+   static char *suppressAllRemoteCompilations = feGetEnv("TR_SuppressAllRemoteCompilations");
    return
 #if defined(J9VM_OPT_CRIU_SUPPORT)
           (_jitConfig->javaVM->internalVMFunctions->isCheckpointAllowed(_jitConfig->javaVM) && !_compInfo.getCRRuntime()->canPerformRemoteCompilationInCRIUMode()) ||
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+          suppressAllRemoteCompilations ||
           !JITServer::ClientStream::isServerCompatible(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary)) ||
           (!JITServerHelpers::isServerAvailable() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))) ||
 	  (!JITServer::CommunicationStream::shouldReadRetry() && !JITServerHelpers::shouldRetryConnection(OMRPORT_FROM_J9PORT(_jitConfig->javaVM->portLibrary))) ||


### PR DESCRIPTION
Due to technical reasons some of the optimizations are not applied when the JVM runs in client mode. To evaluate the effect of those suppressed optimizations as a whole, this commit introduces a new environment variable: TR_SuppressAllRemoteCompilations When this env var is set, a JVM running in client mode will perform all compilations locally.