### PR TITLE
Add support for jitDispatchJ9Method for MH on P

### DIFF
--- a/runtime/compiler/p/codegen/CallSnippet.cpp
+++ b/runtime/compiler/p/codegen/CallSnippet.cpp
@@ -39,7 +39,8 @@
 #include "ras/Logger.hpp"
 #include "runtime/CodeCacheManager.hpp"
 
-uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg)
+uint8_t *TR::PPCCallSnippet::flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+    TR::CodeGenerator *cg)
 {
     int32_t intArgNum = 0, floatArgNum = 0, offset;
     TR::Compilation *comp = cg->comp();
@@ -48,8 +49,15 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
     TR::Linkage *linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
     const TR::PPCLinkageProperties &linkageProperties = linkage->getProperties();
     int32_t argStart = callNode->getFirstArgumentIndex();
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp);
+    if (isJitDispatchJ9Method) {
+        argStart += 1;
+    }
 
-    if (linkageProperties.getRightToLeft())
+    // jitDispatchJ9Method is a helper symbol, but it is used for java method dispatch
+    // so we must override the helper linkage properties
+    bool rightToLeft = linkageProperties.getRightToLeft() && !isJitDispatchJ9Method;
+    if (rightToLeft)
         offset = linkage->getOffsetToFirstParm();
     else
         offset = argSize + linkage->getOffsetToFirstParm();
@@ -60,29 +68,29 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
             case TR::Int8:
             case TR::Int16:
             case TR::Int32:
-                if (!linkageProperties.getRightToLeft())
+                if (!rightToLeft)
                     offset -= TR::Compiler->om.sizeofReferenceAddress();
                 if (intArgNum < linkageProperties.getNumIntArgRegs()) {
                     buffer = storeArgumentItem(TR::InstOpCode::stw, buffer,
                         machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                 }
                 intArgNum++;
-                if (linkageProperties.getRightToLeft())
+                if (rightToLeft)
                     offset += TR::Compiler->om.sizeofReferenceAddress();
                 break;
             case TR::Address:
-                if (!linkageProperties.getRightToLeft())
+                if (!rightToLeft)
                     offset -= TR::Compiler->om.sizeofReferenceAddress();
                 if (intArgNum < linkageProperties.getNumIntArgRegs()) {
                     buffer = storeArgumentItem(storeGPROp, buffer,
                         machine->getRealRegister(linkageProperties.getIntegerArgumentRegister(intArgNum)), offset, cg);
                 }
                 intArgNum++;
-                if (linkageProperties.getRightToLeft())
+                if (rightToLeft)
                     offset += TR::Compiler->om.sizeofReferenceAddress();
                 break;
             case TR::Int64:
-                if (!linkageProperties.getRightToLeft())
+                if (!rightToLeft)
                     offset -= 2 * TR::Compiler->om.sizeofReferenceAddress();
                 if (intArgNum < linkageProperties.getNumIntArgRegs()) {
                     buffer = storeArgumentItem(storeGPROp, buffer,
@@ -96,29 +104,29 @@ uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argS
                     }
                 }
                 intArgNum += comp->target().is64Bit() ? 1 : 2;
-                if (linkageProperties.getRightToLeft())
+                if (rightToLeft)
                     offset += 2 * TR::Compiler->om.sizeofReferenceAddress();
                 break;
             case TR::Float:
-                if (!linkageProperties.getRightToLeft())
+                if (!rightToLeft)
                     offset -= TR::Compiler->om.sizeofReferenceAddress();
                 if (floatArgNum < linkageProperties.getNumFloatArgRegs()) {
                     buffer = storeArgumentItem(TR::InstOpCode::stfs, buffer,
                         machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                 }
                 floatArgNum++;
-                if (linkageProperties.getRightToLeft())
+                if (rightToLeft)
                     offset += TR::Compiler->om.sizeofReferenceAddress();
                 break;
             case TR::Double:
-                if (!linkageProperties.getRightToLeft())
+                if (!rightToLeft)
                     offset -= 2 * TR::Compiler->om.sizeofReferenceAddress();
                 if (floatArgNum < linkageProperties.getNumFloatArgRegs()) {
                     buffer = storeArgumentItem(TR::InstOpCode::stfd, buffer,
                         machine->getRealRegister(linkageProperties.getFloatArgumentRegister(floatArgNum)), offset, cg);
                 }
                 floatArgNum++;
-                if (linkageProperties.getRightToLeft())
+                if (rightToLeft)
                     offset += 2 * TR::Compiler->om.sizeofReferenceAddress();
                 break;
         }
@@ -218,7 +226,7 @@ int32_t TR::PPCCallSnippet::instructionCountForArguments(TR::Node *callNode, TR:
     int32_t intArgNum = 0, floatArgNum = 0, count = 0;
     const TR::PPCLinkageProperties &linkage
         = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention())->getProperties();
-    int32_t argStart = callNode->getFirstArgumentIndex();
+    int32_t argStart = callNode->getFirstArgumentIndex() + (callNode->isJitDispatchJ9MethodCall(cg->comp()) ? 1 : 0);
 
     for (int i = argStart; i < callNode->getNumChildren(); i++) {
         TR::Node *child = callNode->getChild(i);
@@ -1077,7 +1085,8 @@ uint8_t *TR_Debug::printPPCArgumentsFlush(OMR::Logger *log, TR::Node *node, uint
     else
         offset = argSize + linkage->getOffsetToFirstParm();
 
-    for (int i = node->getFirstArgumentIndex(); i < node->getNumChildren(); i++) {
+    int firstArgumentIndex = node->getFirstArgumentIndex() + (node->isJitDispatchJ9MethodCall(_cg->comp()) ? 1 : 0);
+    for (int i = firstArgumentIndex; i < node->getNumChildren(); i++) {
         TR::Node *child = node->getChild(i);
         switch (child->getDataType()) {
             case TR::Int8:
@@ -1476,4 +1485,3 @@ void TR_Debug::print(OMR::Logger *log, TR::PPCInterfaceCallSnippet *snippet)
     printPrefix(log, NULL, cursor, sizeof(intptr_t));
     log->printf(".long \t" POINTER_PRINTF_FORMAT "\t\t; J2I thunk address for private", *(intptr_t *)cursor);
 }
-

--- a/runtime/compiler/p/codegen/CallSnippet.hpp
+++ b/runtime/compiler/p/codegen/CallSnippet.hpp
@@ -57,6 +57,8 @@ protected:
     TR::SymbolReference *_realMethodSymbolReference;
 
 public:
+    static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
+
     PPCCallSnippet(TR::CodeGenerator *cg, TR::Node *c, TR::LabelSymbol *lab, int32_t s)
         : TR::Snippet(cg, c, lab, needsGCMap(cg, c->getSymbolReference()))
         , sizeOfArguments(s)

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -720,3 +720,11 @@ void J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Reg
         }
     }
 }
+
+bool J9::Power::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
+{
+    if (symbol == TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol) {
+        return true;
+    }
+    return J9::CodeGenerator::supportsNonHelper(symbol);
+}

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -91,6 +91,7 @@ public:
     bool canEmitDataForExternallyRelocatableInstructions();
 
     bool canTransformUnsafeSetMemory();
+    bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
 
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
     bool suppressInliningOfCryptoMethod(TR::RecognizedMethod method);

--- a/runtime/compiler/p/codegen/J9PPCSnippet.cpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.cpp
@@ -42,6 +42,7 @@
 #include "p/codegen/PPCEvaluator.hpp"
 #include "p/codegen/PPCInstruction.hpp"
 #include "p/codegen/GenerateInstructions.hpp"
+#include "p/codegen/CallSnippet.hpp"
 #include "ras/Logger.hpp"
 #include "runtime/CodeCache.hpp"
 #include "runtime/CodeCacheManager.hpp"
@@ -275,7 +276,7 @@ void TR::PPCReadMonitorSnippet::print(OMR::Logger *log, TR_Debug *debug)
     log->printf("%s \t%s, [%s, %d]\t; Load", TR::InstOpCode::metadata[getLoadOpCode()].name,
         debug->getName(loadResultReg), debug->getName(loadBaseReg), getLoadOffset());
 
-    debug->print(log, (TR::PPCHelperCallSnippet *)this);
+    TR::PPCHelperCallSnippet::print(log, debug);
 }
 
 uint32_t TR::PPCReadMonitorSnippet::getLength(int32_t estimatedSnippetStart)
@@ -290,6 +291,50 @@ int32_t TR::PPCReadMonitorSnippet::setEstimatedCodeLocation(int32_t estimatedSni
     _recurCheckLabel->setEstimatedCodeLocation(estimatedSnippetStart);
     getSnippetLabel()->setEstimatedCodeLocation(estimatedSnippetStart + 28);
     return (estimatedSnippetStart);
+}
+
+uint8_t *TR::PPCArgFlushHelperCallSnippet::emitSnippetBody()
+{
+    uint8_t *buffer = cg()->getBinaryBufferCursor();
+
+    getSnippetLabel()->setCodeLocation(buffer);
+    buffer = TR::PPCCallSnippet::flushArgumentsToStack(buffer, this->getNode(), this->getSizeOfArguments(), cg());
+
+    if (this->getNode()->isJitDispatchJ9MethodCall(cg()->comp())) {
+        TR::RealRegister *j9MethodReg = cg()->machine()->getRealRegister(TR::RealRegister::gr11);
+        TR::RealRegister *interpreterReg = cg()->machine()->getRealRegister(TR::RealRegister::gr3);
+
+        // move r11 to r3 for the interpreter
+        TR::InstOpCode opcode;
+        opcode.setOpCodeValue(TR::InstOpCode::OR);
+        buffer = opcode.copyBinaryToBuffer(buffer);
+        interpreterReg->setRegisterFieldRA((uint32_t *)buffer);
+        j9MethodReg->setRegisterFieldRS((uint32_t *)buffer);
+        j9MethodReg->setRegisterFieldRB((uint32_t *)buffer);
+        buffer += PPC_INSTRUCTION_LENGTH;
+    }
+
+    return this->genHelperCall(buffer);
+}
+
+uint32_t TR::PPCArgFlushHelperCallSnippet::getLength(int32_t estimatedSnippetStart)
+{
+    uint32_t len = (1 + TR::PPCCallSnippet::instructionCountForArguments(getNode(), cg())) * PPC_INSTRUCTION_LENGTH;
+    return len + TR::PPCHelperCallSnippet::getLength(len + estimatedSnippetStart);
+}
+
+void TR::PPCArgFlushHelperCallSnippet::print(OMR::Logger *log, TR_Debug *debug)
+{
+    uint8_t *cursor = getSnippetLabel()->getCodeLocation();
+
+    debug->printSnippetLabel(log, getSnippetLabel(), cursor, "J9 Helper Call Snippet");
+
+    cursor = debug->printPPCArgumentsFlush(log, getNode(), cursor, getSizeOfArguments());
+
+    debug->printPrefix(log, NULL, cursor, 4);
+    log->printf("%s \t\t\t; %s", "mov gr3 gr11", "move j9method pointer to x0 for interpreter");
+    cursor += PPC_INSTRUCTION_LENGTH;
+    TR::PPCHelperCallSnippet::printInner(log, debug, cursor);
 }
 
 TR::PPCAllocPrefetchSnippet::PPCAllocPrefetchSnippet(TR::CodeGenerator *codeGen, TR::Node *node,

--- a/runtime/compiler/p/codegen/J9PPCSnippet.hpp
+++ b/runtime/compiler/p/codegen/J9PPCSnippet.hpp
@@ -68,6 +68,26 @@ public:
     int32_t getLoadOffset() { return _loadOffset; }
 };
 
+/**
+ * A helper call snippet that flushes argumments to the stack before calling the helper
+ */
+class PPCArgFlushHelperCallSnippet : public TR::PPCHelperCallSnippet {
+    int32_t _argSize;
+
+public:
+    PPCArgFlushHelperCallSnippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *snippetlab,
+        TR::SymbolReference *helper, TR::LabelSymbol *restartLabel = NULL, int32_t argSize = -1)
+        : TR::PPCHelperCallSnippet(cg, node, snippetlab, helper, restartLabel)
+        , _argSize(argSize)
+    {}
+
+    int32_t getSizeOfArguments() { return _argSize; }
+
+    virtual uint8_t *emitSnippetBody();
+    virtual uint32_t getLength(int32_t estimatedSnippetStart);
+    virtual void print(OMR::Logger *log, TR_Debug *);
+};
+
 class PPCAllocPrefetchSnippet : public TR::Snippet {
 public:
     PPCAllocPrefetchSnippet(TR::CodeGenerator *codeGen, TR::Node *node, TR::LabelSymbol *callLabel);

--- a/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
+++ b/runtime/compiler/p/codegen/PPCPrivateLinkage.cpp
@@ -49,6 +49,7 @@
 #include "il/TreeTop_inlines.hpp"
 #include "p/codegen/CallSnippet.hpp"
 #include "p/codegen/GenerateInstructions.hpp"
+#include "p/codegen/J9PPCSnippet.hpp"
 #include "p/codegen/PPCEvaluator.hpp"
 #include "p/codegen/PPCHelperCallSnippet.hpp"
 #include "p/codegen/PPCInstruction.hpp"
@@ -346,7 +347,7 @@ J9::Power::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
     _properties._computedCallTargetRegister
         = TR::RealRegister::gr0; // gr11 = interface, gr12 = virtual, so we need something else for computed
     _properties._vtableIndexArgumentRegister = TR::RealRegister::gr12;
-    _properties._j9methodArgumentRegister = TR::RealRegister::gr3; // TODO:JSR292: Confirm
+    _properties._j9methodArgumentRegister = TR::RealRegister::gr11; // TODO:JSR292: Confirm
 }
 
 const TR::PPCLinkageProperties &J9::Power::PrivateLinkage::getProperties() { return _properties; }
@@ -1380,30 +1381,32 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
     const TR::PPCLinkageProperties &properties = getProperties();
     TR::PPCMemoryArgument *pushToMemory = NULL;
     TR::Register *tempRegister;
-    int32_t argIndex = 0, memArgs = 0, from, to, step;
+    int32_t argIndex = 0, memArgs = 0, specialArgIndex = -1, firstRealArgIndex, lastArgIndex, step;
     int32_t argSize = -getOffsetToFirstParm(), totalSize = 0;
     uint32_t numIntegerArgs = 0;
     uint32_t numFloatArgs = 0;
     uint32_t firstExplicitArg = 0;
     TR::Node *child;
     void *smark;
-    uint32_t firstArgumentChild = callNode->getFirstArgumentIndex();
     TR::DataType resType = callNode->getType();
     TR_Array<TR::Register *> &tempLongRegisters = cg()->getTransientLongRegisters();
     TR::MethodSymbol *callSymbol = callNode->getSymbol()->castToMethodSymbol();
 
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp);
     bool isHelperCall = linkage == TR_Helper || linkage == TR_CHelper;
     bool rightToLeft = isHelperCall &&
         // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
-        !callNode->getSymbolReference()->isOSRInductionHelper();
+        // jitDispatchJ9Method is a helper symbol, but it is used for java method dispatch
+        // so we must override the helper linkage properties
+        !callNode->getSymbolReference()->isOSRInductionHelper() && !isJitDispatchJ9Method;
 
     if (rightToLeft) {
-        from = callNode->getNumChildren() - 1;
-        to = firstArgumentChild;
+        firstRealArgIndex = callNode->getNumChildren() - 1;
+        lastArgIndex = callNode->getFirstArgumentIndex();
         step = -1;
     } else {
-        from = firstArgumentChild;
-        to = callNode->getNumChildren() - 1;
+        firstRealArgIndex = callNode->getFirstArgumentIndex();
+        lastArgIndex = callNode->getNumChildren() - 1;
         step = 1;
     }
 
@@ -1418,26 +1421,32 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
     TR::RealRegister::RegNum specialArgReg = TR::RealRegister::NoReg;
     switch (callSymbol->getMandatoryRecognizedMethod()) {
         // Node: special long args are still only passed in one GPR
-        case TR::java_lang_invoke_ComputedCalls_dispatchJ9Method:
-            specialArgReg = getProperties().getJ9MethodArgumentRegister();
+        case TR::java_lang_invoke_ComputedCalls_dispatchJ9Method: // old MH implementation
+            specialArgReg = TR::RealRegister::gr11;
             // Other args go in memory
             numIntArgRegs = 0;
             numFloatArgRegs = 0;
             break;
         case TR::java_lang_invoke_ComputedCalls_dispatchVirtual:
         case TR::com_ibm_jit_JITHelpers_dispatchVirtual:
-            specialArgReg = getProperties().getVTableIndexArgumentRegister();
+            specialArgReg = TR::RealRegister::gr12;
             break;
         default:
             break;
     }
 
+    if (isJitDispatchJ9Method) {
+        specialArgReg = TR::RealRegister::gr11;
+    }
+
     if (specialArgReg != TR::RealRegister::NoReg) {
-        logprintf(trace, log, "Special arg %s in %s\n", comp->getDebug()->getName(callNode->getChild(from)),
+        logprintf(trace, log, "Special arg %s in %s\n",
+            comp->getDebug()->getName(callNode->getChild(firstRealArgIndex)),
             comp->getDebug()->getName(cg()->machine()->getRealRegister(specialArgReg)));
 
         // Skip the special arg in the first loop
-        from += step;
+        specialArgIndex = firstRealArgIndex;
+        firstRealArgIndex += step;
     }
 
     // C helpers have an implicit first argument (the VM thread) that we have to account for
@@ -1447,7 +1456,10 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
         totalSize += TR::Compiler->om.sizeofReferenceAddress();
     }
 
-    for (int32_t i = from; (rightToLeft && i >= to) || (!rightToLeft && i <= to); i += step) {
+    // if there is a special child, it will not be processed in this loop
+    // special children are not arguments, but may be used for calling the J9Method
+    for (int32_t i = firstRealArgIndex; (rightToLeft && i >= lastArgIndex) || (!rightToLeft && i <= lastArgIndex);
+         i += step) {
         child = callNode->getChild(i);
         switch (child->getDataType()) {
             case TR::Int8:
@@ -1495,9 +1507,6 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
         pushToMemory = new (trStackMemory()) TR::PPCMemoryArgument[memArgs];
     }
 
-    if (specialArgReg)
-        from -= step; // we do want to process special args in the following loop
-
     numIntegerArgs = 0;
     numFloatArgs = 0;
 
@@ -1514,19 +1523,26 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
         firstExplicitArg = 1;
     }
 
+    TR::Register *j9MethodReg = NULL; // for jitDispatchJ9Method
     // Helper linkage preserves all argument registers except the return register
     // TODO: C helper linkage does not, this code needs to make sure argument registers are killed in post dependencies
-    for (int32_t i = from; (rightToLeft && i >= to) || (!rightToLeft && i <= to); i += step) {
+    int32_t specialOrFirstArgIndex = (specialArgIndex != -1 ? specialArgIndex : firstRealArgIndex);
+    int32_t firstArgumentChild = callNode->getFirstArgumentIndex();
+    for (int32_t i = specialOrFirstArgIndex; (rightToLeft && i >= lastArgIndex) || (!rightToLeft && i <= lastArgIndex);
+         i += step) {
         TR::MemoryReference *mref = NULL;
         TR::Register *argRegister;
         child = callNode->getChild(i);
-        bool isSpecialArg = (i == from && specialArgReg != TR::RealRegister::NoReg);
+        bool isSpecialArg = (i == specialArgIndex);
         switch (child->getDataType()) {
             case TR::Int8:
             case TR::Int16:
             case TR::Int32:
             case TR::Address: // have to do something for GC maps here
-                if (i == firstArgumentChild && callNode->getOpCode().isIndirect()) {
+                // first child holds the J9MethodPointer for jitDispatchJ9Method. we do not want to push this arg
+                if (isSpecialArg && isJitDispatchJ9Method) {
+                    argRegister = cg()->evaluate(child);
+                } else if (i == firstArgumentChild && callNode->getOpCode().isIndirect()) {
                     argRegister = pushThis(child);
                 } else {
                     if (child->getDataType() == TR::Address) {
@@ -1546,6 +1562,8 @@ int32_t J9::Power::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
                         dependencies->addPostCondition(resultReg, properties.getIntegerReturnRegister(0));
                     } else {
                         TR::addDependency(dependencies, argRegister, specialArgReg, TR_GPR, cg());
+                        if (isJitDispatchJ9Method)
+                            cg()->decReferenceCount(child);
                     }
                 } else {
                     argSize += TR::Compiler->om.sizeofReferenceAddress();
@@ -2736,19 +2754,67 @@ void J9::Power::PrivateLinkage::buildDirectCall(TR::Node *callNode, TR::SymbolRe
     TR::ResolvedMethodSymbol *sym = callSymbol->getResolvedMethodSymbol();
     TR_ResolvedMethod *vmm = (sym == NULL) ? NULL : sym->getResolvedMethod();
     bool myself = comp()->isRecursiveMethodTarget(vmm);
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp());
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
 
-    if (callSymRef->getReferenceNumber() >= TR_PPCnumRuntimeHelpers)
+    if ((callSymRef->getReferenceNumber() >= TR_PPCnumRuntimeHelpers) && !isJitDispatchJ9Method)
         fej9->reserveTrampolineIfNecessary(comp(), callSymRef, false);
 
     bool forceUnresolvedDispatch = !fej9->isResolvedDirectDispatchGuaranteed(comp());
-    if ((callSymbol->isJITInternalNative()
+    if (!isJitDispatchJ9Method
+        && (callSymbol->isJITInternalNative()
             || (!callSymRef->isUnresolved() && !callSymbol->isInterpreted()
-                && ((forceUnresolvedDispatch && callSymbol->isHelper()) || !forceUnresolvedDispatch)))) {
+                && (callSymbol->isHelper() || !forceUnresolvedDispatch)))) {
         gcPoint = generateDepImmSymInstruction(cg(), TR::InstOpCode::bl, callNode,
             myself ? 0 : (uintptr_t)callSymbol->getMethodAddress(), dependencies,
             callSymRef ? callSymRef : callNode->getSymbolReference());
+    } else if (isJitDispatchJ9Method) {
+        auto regMapMask = pp.getPreservedRegisterMapForGC();
+
+        TR::Register *scratchReg = dependencies->searchPostConditionRegister(TR::RealRegister::gr12);
+        TR::Register *scratchReg2 = dependencies->searchPreConditionRegister(TR::RealRegister::gr0);
+        TR::Register *cndReg = dependencies->searchPreConditionRegister(TR::RealRegister::cr0);
+        TR::Register *j9MethodReg = dependencies->searchPreConditionRegister(TR::RealRegister::gr11);
+
+        TR::LabelSymbol *startICFLabel = generateLabelSymbol(cg());
+        TR::LabelSymbol *doneLabel = generateLabelSymbol(cg());
+        startICFLabel->setStartInternalControlFlow();
+        doneLabel->setEndInternalControlFlow();
+
+        TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
+        TR::SymbolReference *helperRef
+            = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, true, true, false);
+        TR::Snippet *interpCallSnippet = new (cg()->trHeapMemory())
+            TR::PPCArgFlushHelperCallSnippet(cg(), callNode, snippetLabel, helperRef, doneLabel, argSize);
+        interpCallSnippet->gcMap().setGCRegisterMask(regMapMask);
+        cg()->addSnippet(interpCallSnippet);
+
+        generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, startICFLabel);
+
+        // test if compiled
+        generateTrg1MemInstruction(cg(), TR::InstOpCode::ld, callNode, scratchReg,
+            TR::MemoryReference::createWithDisplacement(cg(), j9MethodReg, offsetof(J9Method, extra),
+                TR::Compiler->om.sizeofReferenceAddress()));
+        generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::andi_r, callNode, scratchReg2, scratchReg, 1);
+
+        if (cg()->stressJitDispatchJ9MethodJ2I()) {
+            generateLabelInstruction(cg(), TR::InstOpCode::b, callNode, snippetLabel);
+        } else {
+            generateConditionalBranchInstruction(cg(), TR::InstOpCode::bne, callNode, snippetLabel, cndReg);
+        }
+
+        // compiled - jump to jit entry point
+        generateTrg1MemInstruction(cg(), TR::InstOpCode::lwz, callNode, j9MethodReg,
+            TR::MemoryReference::createWithDisplacement(cg(), scratchReg, -4, 4));
+        generateShiftRightLogicalImmediate(cg(), callNode, j9MethodReg, j9MethodReg, 16);
+        generateTrg1Src2Instruction(cg(), TR::InstOpCode::add, callNode, scratchReg2, scratchReg, j9MethodReg);
+        generateSrc1Instruction(cg(), TR::InstOpCode::mtctr, callNode, scratchReg2);
+        gcPoint = generateInstruction(cg(), TR::InstOpCode::bctrl, callNode);
+        gcPoint->PPCNeedsGCMap(regMapMask);
+
+        generateDepLabelInstruction(cg(), TR::InstOpCode::label, callNode, doneLabel, dependencies);
+        return;
     } else {
         TR::LabelSymbol *label = generateLabelSymbol(cg());
         TR::Snippet *snippet;


### PR DESCRIPTION
Enables transformation of invokeBasic, linkToStatic, and linkToSpecial calls into jitDispatchJ9Method acall nodes. Codegen recognizes this node in private linkage and produces code to directly call the MethodHandletarget at runtime
- using a new PPCArgFlushHelperCallSnippet snippet when the
              target is interpreted
 - otherwise branch and link to jit start pc of target

