### PR TITLE
Restrict invokeinterface error sendMethod search to Java 8

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -8322,6 +8322,7 @@ foundITableCache:
 						rc = GOTO_THROW_CURRENT_EXCEPTION;
 						goto done;
 					}
+#if JAVA_SPEC_VERSION < 11
 					if (J9_ARE_ALL_BITS_SET(romMethod->modifiers, J9AccAbstract)
 						&& !J9ROMCLASS_IS_INTERFACE(J9_CLASS_FROM_METHOD(_sendMethod)->romClass)
 					) {
@@ -8337,6 +8338,7 @@ foundITableCache:
 							NULL,
 							J9_LOOK_INTERFACE | J9_LOOK_NO_THROW | J9_LOOK_INVOKE_INTERFACE);
 					}
+#endif /* JAVA_SPEC_VERSION < 11 */
 					profileInvokeReceiver(REGISTER_ARGS, receiverClass, _literals, _sendMethod);
 					_pc += offset;
 					goto done;


### PR DESCRIPTION
The change introduced in https://github.com/eclipse-openj9/openj9/pull/22698 is not helpful for Java 11+. In Java 8 private methods can be resolved for invokeinterface but in Java 11+ they are skipped. The IAE for Java 11+ will be caught either during the bytecode execution or in throwUnsatisfiedLinkOrAbstractMethodError.

Related to https://github.ibm.com/runtimes/javanext/issues/551