### PR TITLE
Reserve hooks that are postponed so they can be registered later

### DIFF
--- a/runtime/rasdump/j9dmp.tdf
+++ b/runtime/rasdump/j9dmp.tdf
@@ -44,3 +44,4 @@ TraceExit=Trc_trcengine_criu_criuReloadXDumpAgents_Exit Overhead=1 Level=5 Templ
 TraceEntry=Trc_trcengine_criu_criuReloadXDumpAgents_Entry Overhead=1 Level=5 Template="criuReloadXDumpAgents()"
 
 TraceEvent=Trc_dump_signal_pid Overhead=1 Level=1 Template="%s received from process id %zu name '%s'"
+TraceEvent=Trc_dump_failed_hooks NoEnv Overhead=1 Level=1 Template="rasDumpEnableHooks: events=0x%zx skip=0x%zx failed=0x%zx"


### PR DESCRIPTION
Reserve hooks that are postponed so they can be registered later.

Also, detect any failure of J9HookRegisterWithCallSite, not just the last call. Add a tracepoint to capture more detail on failure.

One-shot events are disabled after they occur and cannot be re-enabled. During a CRIU snapshot or after a CRIU restore, attempting to register or reserve those events will fail - such failures must be ignored.

The first commit is a rebased copy of the first commit in https://github.com/eclipse-openj9/openj9/pull/22886.