### PR TITLE
Remove useless/problematic code from sun.misc.Unsafe.registerNatives()

### DIFF
--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -193,15 +193,6 @@ Java_sun_misc_Unsafe_registerNatives(JNIEnv *env, jclass clazz)
 {
 	Trc_JCL_sun_misc_Unsafe_registerNatives_Entry(env);
 
-	/* If Unsafe has a static int field called INVALID_FIELD_OFFSET, set it to -1 */
-	jfieldID fid = env->GetStaticFieldID(clazz, "INVALID_FIELD_OFFSET", "I");
-
-	if (NULL == fid) {
-		env->ExceptionClear();
-	} else {
-		env->SetStaticIntField(clazz, fid, -1);
-	}
-
 	Trc_JCL_sun_misc_Unsafe_registerNatives_Exit(env);
 }
 
@@ -1115,7 +1106,6 @@ Java_jdk_internal_misc_Unsafe_registerNatives(JNIEnv *env, jclass clazz)
 	jint numNatives = sizeof(nativeMethods) / sizeof(nativeMethods[0]);
 
 	/* clazz can't be null */
-	Java_sun_misc_Unsafe_registerNatives(env, clazz);
 	env->RegisterNatives(clazz, nativeMethods, numNatives);
 #if defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT)
 	clearNonZAAPEligibleBit(env, clazz, nativeMethods, numNatives);


### PR DESCRIPTION
In Java 25+, `jdk.internal.misc.Unsafe.INVALID_FIELD_OFFSET` has type `long`, not `int`, so a `NoSuchFieldError` is thrown by `GetStaticFieldID()`. This occurs before the VM is capable of properly handling exception dump filters (internally, the offset of `Throwable.walkback` has not been captured for use by `J9VMJAVALANGTHROWABLE_WALKBACK()`, etc.).

If the field exists, it is assigned the value -1, but, in all Java versions, the field would already have that value. This removes the code that is problematic in Java 25+ and just useless in general.

This cherry-picks the third commit of https://github.com/eclipse-openj9/openj9/pull/22886.

Related to RTC 153110.