### PR TITLE
JITServer: Fix verbose={inlining} bug

### DIFF
--- a/runtime/compiler/runtime/MethodMetaData.c
+++ b/runtime/compiler/runtime/MethodMetaData.c
@@ -1095,12 +1095,11 @@ void aotExceptionEntryFixEndian(J9JITExceptionTable * methodMetaData)
 U_32 getNumInlinedCallSites(J9JITExceptionTable * methodMetaData)
    {
    U_32 sizeOfInlinedCallSites, numInlinedCallSites = 0;
-   U_32 numExceptionRanges = methodMetaData->numExcptionRanges & 0x3FFF;
-   U_32 fourByteExceptionRanges = methodMetaData->numExcptionRanges & 0x8000;
-
    if (methodMetaData->inlinedCalls)
       {
 #if 0
+      U_32 numExceptionRanges = methodMetaData->numExcptionRanges & 0x3FFF;
+      U_32 fourByteExceptionRanges = methodMetaData->numExcptionRanges & 0x8000;
       if (fourByteExceptionRanges)
          {
          sizeOfInlinedCallSites = methodMetaData->size - ( sizeof(J9JITExceptionTable) + numExceptionRanges * 20);

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -712,12 +712,12 @@ TR_RelocationRuntime::relocateAOTCodeAndData(U_8 *tempDataStart,
             }
          }
 
-      if (_exceptionTable->inlinedCalls)
+      if (comp()->getOptions()->getVerboseOption(TR_VerboseInlining))
          {
-         if (comp()->getOptions()->getVerboseOption(TR_VerboseInlining))
+         int32_t jittedBodyHash = strHash(comp()->signature());
+         if (_exceptionTable->inlinedCalls)
             {
             U_32 numInlinedCallSites = getNumInlinedCallSites(_exceptionTable);
-            int32_t jittedBodyHash = strHash(comp()->signature());
             char callerBuf[501], calleeBuf[501];
             TR_VerboseLog::CriticalSection vlogLock;
             TR_VerboseLog::writeLine(TR_Vlog_INL, "%d methods inlined into %x %s @ %p", numInlinedCallSites, jittedBodyHash, comp()->signature(), _exceptionTable->startPC);
@@ -740,6 +740,10 @@ TR_RelocationRuntime::relocateAOTCodeAndData(U_8 *tempDataStart,
                   strHash(callerSig), site->_byteCodeInfo.getByteCodeIndex(),
                   strHash(calleeBuf), TR::Compiler->mtd.bytecodeSize(site->_methodInfo), calleeBuf);
                }
+            }
+         else
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_INL, "0 methods inlined into %x %s @ %p", jittedBodyHash, comp()->signature(), _exceptionTable->startPC);
             }
          }
 


### PR DESCRIPTION
`-Xjit:verbose={inlining}` prints to vlog the number of callees that were inlined in a jitted method as well as the identity of those callees. For a non-jitserver run this printing is done in J9Compilation::compile(), method which is not executed when the JVM is run in client mode. For a JITServer client the printing of the inlined call graph is done in
`TR_RelocationRuntime::relocateAOTCodeAndData()`. However, that code only prints something if there is at least one inlined call.

This commit changes the code so that the JITServer client will print "0 methods inlined into..." if there are no inlined callees. This behavior is similar to the behavior of a non-jitserver JVM.