### PR TITLE
Remove unnecessary MXBean related class implementations

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/BufferPoolMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/BufferPoolMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2011
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ClassLoadingMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/CompilationMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/GarbageCollectorMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ManagementPermission.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryManagerMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryPoolMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryType.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/OperatingSystemMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/PlatformLoggingMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/RuntimeMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/ThreadMXBean.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
+/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
 /*
  * Copyright IBM Corp. and others 2005
  *


### PR DESCRIPTION
These classes, interfaces, enums, classes that aren't OpenJ9 specific, are implemented in the extensions and don't need to be implemented by OpenJ9.