### PR TITLE
(0.57) Add sending pid tracepoint for signals handled in java

### DIFF
--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -389,13 +389,8 @@ static BOOLEAN librariesLoaded(void);
 #define LD_ENV_PATH "LIBPATH"
 #endif /* defined(J9ZTPF) */
 
-#define J9_SIG_ERR (-1)
-#define J9_SIG_IGNORED 1
-
 #define J9_PRE_DEFINED_HANDLER_CHECK 2
 #define J9_USE_OLD_JAVA_SIGNAL_HANDLER 2
-
-#define J9_SIG_PREFIX "SIG"
 
 /* Chosen based upon signal names listed in signalMap below. */
 #define J9_SIGNAME_BUFFER_LENGTH 16
@@ -403,123 +398,6 @@ static BOOLEAN librariesLoaded(void);
 static void dummySignalHandler(jint sigNum);
 static BOOLEAN isSignalUsedForShutdown(jint sigNum);
 static BOOLEAN isSignalReservedByJVM(jint sigNum);
-
-typedef struct {
-	const char *signalName;
-	jint signalValue;
-} J9SignalMapping;
-
-#if defined(WIN32)
-#define J9_SIGNAL_MAP_ENTRY(name, value) { name, value }
-#else /* defined(WIN32) */
-#define J9_SIGNAL_MAP_ENTRY(name, value) { "SIG" name, value }
-#endif /* defined(WIN32) */
-
-static const J9SignalMapping signalMap[] = {
-#if defined(SIGABRT)
-	J9_SIGNAL_MAP_ENTRY("ABRT", SIGABRT),
-#endif /* defined(SIGABRT) */
-#if defined(SIGALRM)
-	J9_SIGNAL_MAP_ENTRY("ALRM", SIGALRM),
-#endif /* defined(SIGALRM) */
-#if defined(SIGBREAK)
-	J9_SIGNAL_MAP_ENTRY("BREAK", SIGBREAK),
-#endif /* defined(SIGBREAK) */
-#if defined(SIGBUS)
-	J9_SIGNAL_MAP_ENTRY("BUS", SIGBUS),
-#endif /* defined(SIGBUS) */
-#if defined(SIGCHLD)
-	J9_SIGNAL_MAP_ENTRY("CHLD", SIGCHLD),
-#endif /* defined(SIGCHLD) */
-#if defined(SIGCONT)
-	J9_SIGNAL_MAP_ENTRY("CONT", SIGCONT),
-#endif /* defined(SIGCONT) */
-#if defined(SIGFPE)
-	J9_SIGNAL_MAP_ENTRY("FPE", SIGFPE),
-#endif /* defined(SIGFPE) */
-#if defined(SIGHUP)
-	J9_SIGNAL_MAP_ENTRY("HUP", SIGHUP),
-#endif /* defined(SIGHUP) */
-#if defined(SIGILL)
-	J9_SIGNAL_MAP_ENTRY("ILL", SIGILL),
-#endif /* defined(SIGILL) */
-#if defined(SIGINT)
-	J9_SIGNAL_MAP_ENTRY("INT", SIGINT),
-#endif /* defined(SIGINT) */
-#if defined(SIGIO)
-	J9_SIGNAL_MAP_ENTRY("IO", SIGIO),
-#endif /* defined(SIGIO) */
-#if defined(SIGPIPE)
-	J9_SIGNAL_MAP_ENTRY("PIPE", SIGPIPE),
-#endif /* defined(SIGPIPE) */
-#if defined(SIGPROF)
-	J9_SIGNAL_MAP_ENTRY("PROF", SIGPROF),
-#endif /* defined(SIGPROF) */
-#if defined(SIGQUIT)
-	J9_SIGNAL_MAP_ENTRY("QUIT", SIGQUIT),
-#endif /* defined(SIGQUIT) */
-#if defined(SIGSEGV)
-	J9_SIGNAL_MAP_ENTRY("SEGV", SIGSEGV),
-#endif /* defined(SIGSEGV) */
-#if defined(SIGSYS)
-	J9_SIGNAL_MAP_ENTRY("SYS", SIGSYS),
-#endif /* defined(SIGSYS) */
-#if defined(SIGTERM)
-	J9_SIGNAL_MAP_ENTRY("TERM", SIGTERM),
-#endif /* defined(SIGTERM) */
-#if defined(SIGTRAP)
-	J9_SIGNAL_MAP_ENTRY("TRAP", SIGTRAP),
-#endif /* defined(SIGTRAP) */
-#if defined(SIGTSTP)
-	J9_SIGNAL_MAP_ENTRY("TSTP", SIGTSTP),
-#endif /* defined(SIGTSTP) */
-#if defined(SIGTTIN)
-	J9_SIGNAL_MAP_ENTRY("TTIN", SIGTTIN),
-#endif /* defined(SIGTTIN) */
-#if defined(SIGTTOU)
-	J9_SIGNAL_MAP_ENTRY("TTOU", SIGTTOU),
-#endif /* defined(SIGTTOU) */
-#if defined(SIGURG)
-	J9_SIGNAL_MAP_ENTRY("URG", SIGURG),
-#endif /* defined(SIGURG) */
-#if defined(SIGUSR1)
-	J9_SIGNAL_MAP_ENTRY("USR1", SIGUSR1),
-#endif /* defined(SIGUSR1) */
-#if defined(SIGUSR2)
-	J9_SIGNAL_MAP_ENTRY("USR2", SIGUSR2),
-#endif /* defined(SIGUSR2) */
-#if defined(SIGVTALRM)
-	J9_SIGNAL_MAP_ENTRY("VTALRM", SIGVTALRM),
-#endif /* defined(SIGVTALRM) */
-#if defined(SIGWINCH)
-	J9_SIGNAL_MAP_ENTRY("WINCH", SIGWINCH),
-#endif /* defined(SIGWINCH) */
-#if defined(SIGXCPU)
-	J9_SIGNAL_MAP_ENTRY("XCPU", SIGXCPU),
-#endif /* defined(SIGXCPU) */
-#if defined(SIGXFSZ)
-	J9_SIGNAL_MAP_ENTRY("XFSZ", SIGXFSZ),
-#endif /* defined(SIGXFSZ) */
-#if defined(SIGRECONFIG)
-	J9_SIGNAL_MAP_ENTRY("RECONFIG", SIGRECONFIG),
-#endif /* defined(SIGRECONFIG) */
-#if defined(SIGKILL)
-	J9_SIGNAL_MAP_ENTRY("KILL", SIGKILL),
-#endif /* defined(SIGKILL) */
-#if defined(SIGSTOP)
-	J9_SIGNAL_MAP_ENTRY("STOP", SIGSTOP),
-#endif /* defined(SIGSTOP) */
-#if defined(SIGINFO)
-	J9_SIGNAL_MAP_ENTRY("INFO", SIGINFO),
-#endif /* defined(SIGINFO) */
-#if defined(SIGIOT)
-	J9_SIGNAL_MAP_ENTRY("IOT", SIGIOT),
-#endif /* defined(SIGIOT) */
-#if defined(SIGPOLL)
-	J9_SIGNAL_MAP_ENTRY("POLL", SIGPOLL),
-#endif /* defined(SIGPOLL) */
-	{NULL, J9_SIG_ERR}
-};
 
 /*
  * Attempt to update or remove the value of OPENJ9_JAVA_COMMAND_LINE in the
@@ -5052,7 +4930,6 @@ exit:
 jint JNICALL
 JVM_FindSignal(const char *sigName)
 {
-	const J9SignalMapping *mapping = NULL;
 	jint signalValue = J9_SIG_ERR;
 	BOOLEAN nameHasSigPrefix = FALSE;
 	const char *fullSigName = sigName;
@@ -5086,12 +4963,7 @@ JVM_FindSignal(const char *sigName)
 		}
 #endif /* !defined(WIN32) */
 
-		for (mapping = signalMap; NULL != mapping->signalName; mapping++) {
-			if (0 == strcmp(fullSigName, mapping->signalName)) {
-				signalValue = mapping->signalValue;
-				break;
-			}
-		}
+		signalValue = BFUjavaVM->internalVMFunctions->signalNameToValue(fullSigName);
 	}
 
 #if !defined(WIN32)

--- a/runtime/jcl/common/sigquit.c
+++ b/runtime/jcl/common/sigquit.c
@@ -123,7 +123,9 @@ sigQuitHandler(struct J9PortLibrary* portLibrary, void* userData)
 
 	eventData.siPid = rasAsyncPidInfo->siPid;
 	eventData.detailData = rasAsyncPidInfo->siPidName;
-	Trc_JCL_signal_pid("SIGQUIT", eventData.siPid, eventData.detailData);
+	if (0 != eventData.siPid) {
+		Trc_JCL_signal_pid("SIGQUIT", eventData.siPid, eventData.detailData);
+	}
 
 	J9DMP_TRIGGER(vm, NULL, J9RAS_DUMP_ON_USER_SIGNAL, &eventData);
 
@@ -149,22 +151,23 @@ sigQuitWrapper(struct J9PortLibrary* portLibrary, U_32 gpType, void* gpInfo, voi
 	J9JavaVM *vm = userData;
 	UDATA result = 0;
 	J9RASAsyncPidInfo rasAsyncPidInfo = { 0 };
-	const char *infoName = NULL;
-	void *infoValue = NULL;
-	U_32 infoType = 0;
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
 	rasAsyncPidInfo.vm = vm;
-	infoType = omrsig_info(gpInfo, OMRPORT_SIG_SIGNAL, OMRPORT_SIG_SENDER_PID, &infoName, &infoValue);
-	if (OMRPORT_SIG_VALUE_32 == infoType) {
-		rasAsyncPidInfo.siPid = *(U_32 *)infoValue;
-	} else if (OMRPORT_SIG_VALUE_64 == infoType) {
-		rasAsyncPidInfo.siPid = (UDATA)*(U_64 *)infoValue;
-	}
-	if (0 != rasAsyncPidInfo.siPid) {
-		/* siPidName needs to be freed after use. */
-		rasAsyncPidInfo.siPidName = omrsysinfo_get_process_name(rasAsyncPidInfo.siPid);
+	if (NULL != gpInfo) {
+		OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+		const char *infoName = NULL;
+		void *infoValue = NULL;
+		U_32 infoType = omrsig_info(gpInfo, OMRPORT_SIG_SIGNAL, OMRPORT_SIG_SENDER_PID, &infoName, &infoValue);
+		if (OMRPORT_SIG_VALUE_32 == infoType) {
+			rasAsyncPidInfo.siPid = *(U_32 *)infoValue;
+		} else if (OMRPORT_SIG_VALUE_64 == infoType) {
+			rasAsyncPidInfo.siPid = (UDATA)*(U_64 *)infoValue;
+		}
+		if (0 != rasAsyncPidInfo.siPid) {
+			/* siPidName needs to be freed after use. */
+			rasAsyncPidInfo.siPidName = omrsysinfo_get_process_name(rasAsyncPidInfo.siPid);
+		}
 	}
 
 	j9sig_protect(sigQuitHandler, &rasAsyncPidInfo,

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5514,6 +5514,7 @@ typedef struct J9InternalVMFunctions {
 	void (*releaseTargetVMThreadHelper)(struct J9VMThread *currentThread, struct J9VMThread *targetThread, jthread thread);
 	BOOLEAN (*disclaimClassMemory)(struct J9JavaVM *vm, UDATA flags);
 	UDATA (*totalNumberOfDisclaimableClassMemorySegments)(struct J9JavaVM *vm);
+	jint (*signalNameToValue)(const char *signalName);
 } J9InternalVMFunctions;
 
 /* Jazz 99339: define a new structure to replace JavaVM so as to pass J9NativeLibrary to JVMTIEnv  */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3583,6 +3583,30 @@ disclaimClassMemory(J9JavaVM *vm, UDATA flags);
 UDATA
 totalNumberOfDisclaimableClassMemorySegments(J9JavaVM *vm);
 
+/* ---------------- sighelp.c ---------------- */
+#define J9_SIG_ERR (-1)
+#define J9_SIG_IGNORED 1
+
+#define J9_SIG_PREFIX "SIG"
+
+/**
+ * @brief Return the signal number from the name, or J9_SIG_ERR (-1)
+ * if not found.
+ * @param signame
+ * @return jint
+ */
+jint
+signalNameToValue(const char *signalName);
+
+/**
+ * @brief Return the signal name from the number, or NULL
+ * if not found.
+ * @param signal
+ * @return const char *
+ */
+const char *
+signalValueToName(jint signal);
+
 /* ---------------- statistics.c ---------------- */
 /**
 * @brief

--- a/runtime/vm/CMakeLists.txt
+++ b/runtime/vm/CMakeLists.txt
@@ -174,6 +174,7 @@ set(main_sources
 	romclasses.c
 	romutil.c
 	segment.c
+	sighelp.c
 	StackDumper.c
 	statistics.c
 	stringhelpers.cpp

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -497,4 +497,5 @@ J9InternalVMFunctions J9InternalFunctions = {
 	releaseTargetVMThreadHelper,
 	disclaimClassMemory,
 	totalNumberOfDisclaimableClassMemorySegments,
+	signalNameToValue,
 };

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1036,3 +1036,5 @@ TraceException=Trc_VM_criu_notCheckpointSafeOrClinitFrameWalkFunction_foundTarge
 
 TraceEvent=Trc_Segment_disclaimClassMemory_result NoEnv Overhead=1 Level=3 Template="Disclaim class memory segment=%p, heapBase=%p, size=%zu, type=%zX, baseAddress=%p, result=%zi"
 TraceEvent=Trc_Segment_disclaimClassMemory_error NoEnv Overhead=1 Level=3 Template="Disclaim class memory failed result=%zi errno=%zi"
+
+TraceEvent=Trc_VM_signal_pid Overhead=1 Level=1 Template="%s received from process id %zu name '%s'"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -8630,6 +8630,26 @@ predefinedHandlerWrapper(struct J9PortLibrary *portLibrary, U_32 gpType, void *g
 		return 1;
 	}
 
+#if !defined(WIN32)
+	if (NULL != gpInfo) {
+		OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+		const char *infoName = NULL;
+		void *infoValue = NULL;
+		UDATA pid = 0;
+		U_32 infoType = omrsig_info(gpInfo, OMRPORT_SIG_SIGNAL, OMRPORT_SIG_SENDER_PID, &infoName, &infoValue);
+		if (OMRPORT_SIG_VALUE_32 == infoType) {
+			pid = *(U_32 *)infoValue;
+		} else if (OMRPORT_SIG_VALUE_64 == infoType) {
+			pid = *(U_64 *)infoValue;
+		}
+		if (0 != pid) {
+			char *pidName = omrsysinfo_get_process_name(pid);
+			Trc_VM_signal_pid(vmThread, signalValueToName(signal), pid, pidName);
+			j9mem_free_memory((void *)pidName);
+		}
+	}
+#endif /* !defined(WIN32) */
+
 	/* Run handler (Java code). */
 	signalDispatch(vmThread, signal);
 

--- a/runtime/vm/sighelp.c
+++ b/runtime/vm/sighelp.c
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#include "j9.h"
+#include "vm_api.h"
+
+typedef struct J9SignalMapping {
+	const char *signalName;
+	jint signalValue;
+} J9SignalMapping;
+
+#if defined(WIN32)
+#define J9_SIGNAL_MAP_ENTRY(name, value) { name, value }
+#else /* defined(WIN32) */
+#define J9_SIGNAL_MAP_ENTRY(name, value) { J9_SIG_PREFIX name, value }
+#endif /* defined(WIN32) */
+
+static const J9SignalMapping signalMap[] = {
+#if defined(SIGABRT)
+	J9_SIGNAL_MAP_ENTRY("ABRT", SIGABRT),
+#endif /* defined(SIGABRT) */
+#if defined(SIGALRM)
+	J9_SIGNAL_MAP_ENTRY("ALRM", SIGALRM),
+#endif /* defined(SIGALRM) */
+#if defined(SIGBREAK)
+	J9_SIGNAL_MAP_ENTRY("BREAK", SIGBREAK),
+#endif /* defined(SIGBREAK) */
+#if defined(SIGBUS)
+	J9_SIGNAL_MAP_ENTRY("BUS", SIGBUS),
+#endif /* defined(SIGBUS) */
+#if defined(SIGCHLD)
+	J9_SIGNAL_MAP_ENTRY("CHLD", SIGCHLD),
+#endif /* defined(SIGCHLD) */
+#if defined(SIGCONT)
+	J9_SIGNAL_MAP_ENTRY("CONT", SIGCONT),
+#endif /* defined(SIGCONT) */
+#if defined(SIGFPE)
+	J9_SIGNAL_MAP_ENTRY("FPE", SIGFPE),
+#endif /* defined(SIGFPE) */
+#if defined(SIGHUP)
+	J9_SIGNAL_MAP_ENTRY("HUP", SIGHUP),
+#endif /* defined(SIGHUP) */
+#if defined(SIGILL)
+	J9_SIGNAL_MAP_ENTRY("ILL", SIGILL),
+#endif /* defined(SIGILL) */
+#if defined(SIGINT)
+	J9_SIGNAL_MAP_ENTRY("INT", SIGINT),
+#endif /* defined(SIGINT) */
+#if defined(SIGIO)
+	J9_SIGNAL_MAP_ENTRY("IO", SIGIO),
+#endif /* defined(SIGIO) */
+#if defined(SIGPIPE)
+	J9_SIGNAL_MAP_ENTRY("PIPE", SIGPIPE),
+#endif /* defined(SIGPIPE) */
+#if defined(SIGPROF)
+	J9_SIGNAL_MAP_ENTRY("PROF", SIGPROF),
+#endif /* defined(SIGPROF) */
+#if defined(SIGQUIT)
+	J9_SIGNAL_MAP_ENTRY("QUIT", SIGQUIT),
+#endif /* defined(SIGQUIT) */
+#if defined(SIGSEGV)
+	J9_SIGNAL_MAP_ENTRY("SEGV", SIGSEGV),
+#endif /* defined(SIGSEGV) */
+#if defined(SIGSYS)
+	J9_SIGNAL_MAP_ENTRY("SYS", SIGSYS),
+#endif /* defined(SIGSYS) */
+#if defined(SIGTERM)
+	J9_SIGNAL_MAP_ENTRY("TERM", SIGTERM),
+#endif /* defined(SIGTERM) */
+#if defined(SIGTRAP)
+	J9_SIGNAL_MAP_ENTRY("TRAP", SIGTRAP),
+#endif /* defined(SIGTRAP) */
+#if defined(SIGTSTP)
+	J9_SIGNAL_MAP_ENTRY("TSTP", SIGTSTP),
+#endif /* defined(SIGTSTP) */
+#if defined(SIGTTIN)
+	J9_SIGNAL_MAP_ENTRY("TTIN", SIGTTIN),
+#endif /* defined(SIGTTIN) */
+#if defined(SIGTTOU)
+	J9_SIGNAL_MAP_ENTRY("TTOU", SIGTTOU),
+#endif /* defined(SIGTTOU) */
+#if defined(SIGURG)
+	J9_SIGNAL_MAP_ENTRY("URG", SIGURG),
+#endif /* defined(SIGURG) */
+#if defined(SIGUSR1)
+	J9_SIGNAL_MAP_ENTRY("USR1", SIGUSR1),
+#endif /* defined(SIGUSR1) */
+#if defined(SIGUSR2)
+	J9_SIGNAL_MAP_ENTRY("USR2", SIGUSR2),
+#endif /* defined(SIGUSR2) */
+#if defined(SIGVTALRM)
+	J9_SIGNAL_MAP_ENTRY("VTALRM", SIGVTALRM),
+#endif /* defined(SIGVTALRM) */
+#if defined(SIGWINCH)
+	J9_SIGNAL_MAP_ENTRY("WINCH", SIGWINCH),
+#endif /* defined(SIGWINCH) */
+#if defined(SIGXCPU)
+	J9_SIGNAL_MAP_ENTRY("XCPU", SIGXCPU),
+#endif /* defined(SIGXCPU) */
+#if defined(SIGXFSZ)
+	J9_SIGNAL_MAP_ENTRY("XFSZ", SIGXFSZ),
+#endif /* defined(SIGXFSZ) */
+#if defined(SIGRECONFIG)
+	J9_SIGNAL_MAP_ENTRY("RECONFIG", SIGRECONFIG),
+#endif /* defined(SIGRECONFIG) */
+#if defined(SIGKILL)
+	J9_SIGNAL_MAP_ENTRY("KILL", SIGKILL),
+#endif /* defined(SIGKILL) */
+#if defined(SIGSTOP)
+	J9_SIGNAL_MAP_ENTRY("STOP", SIGSTOP),
+#endif /* defined(SIGSTOP) */
+#if defined(SIGINFO)
+	J9_SIGNAL_MAP_ENTRY("INFO", SIGINFO),
+#endif /* defined(SIGINFO) */
+#if defined(SIGIOT)
+	J9_SIGNAL_MAP_ENTRY("IOT", SIGIOT),
+#endif /* defined(SIGIOT) */
+#if defined(SIGPOLL)
+	J9_SIGNAL_MAP_ENTRY("POLL", SIGPOLL),
+#endif /* defined(SIGPOLL) */
+	{NULL, J9_SIG_ERR}
+};
+
+const char *
+signalValueToName(jint signal)
+{
+	const J9SignalMapping *mapping = NULL;
+	for (mapping = signalMap; NULL != mapping->signalName; mapping++) {
+		if (signal == mapping->signalValue) {
+			return mapping->signalName;
+		}
+	}
+	return NULL;
+}
+
+jint
+signalNameToValue(const char *signalName)
+{
+	const J9SignalMapping *mapping = NULL;
+	for (mapping = signalMap; NULL != mapping->signalName; mapping++) {
+		if (0 == strcmp(signalName, mapping->signalName)) {
+			return mapping->signalValue;
+		}
+	}
+	return J9_SIG_ERR;
+}


### PR DESCRIPTION
Modify the predefinedHandlerWrapper(), which handles signals registered from java code such as TERM, HUP, INT, to call a tracepoint with the sending pid.

Move the mapping of signal names and values into the vm so it can be shared by libjvm and libj9vm.

Check for non-NULL sigInfo, and non-zero pid.

Cherry pick https://github.com/eclipse-openj9/openj9/pull/22945