### PR TITLE
Introduce a constantPool cache v2

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -131,9 +131,10 @@ public interface VMLangAccess {
 	 * Returns an InternalConstantPool object.
 	 *
 	 * @param addr - the native addr of the J9ConstantPool
+	 * @param clazz - the clazz object of the J9Class associated with the constantPool
 	 * @return An InternalConstantPool object
 	 */
-	public Object createInternalConstantPool(long addr);
+	public Object createInternalConstantPool(long addr, Class<?> clazz);
 
 	/**
 	 * Returns a ConstantPool object
@@ -148,9 +149,10 @@ public interface VMLangAccess {
 	 * natives expect an InternalConstantPool as the constantPoolOop parameter.
 	 *
 	 * @param j9class the native address of the J9Class
+	 * @param clazz the class object
 	 * @return InternalConstantPool a wrapper for a j9constantpool
 	 */
-	public Object getInternalConstantPoolFromJ9Class(long j9class);
+	public Object getInternalConstantPoolFromJ9Class(long j9class, Class<?> clazz);
 
 	/**
 	 * Returns an InternalConstantPool object from a Class. The ConstantPool
@@ -210,4 +212,14 @@ public interface VMLangAccess {
 	 */
 	public boolean getIncludeModuleVersion(StackTraceElement element);
 	/*[ENDIF] JAVA_SPEC_VERSION >= 11*/
+
+	/**
+	 * Returns a cached constantPool Object from a given java.lang.Class.
+	 *
+	 * @param clazz
+	 *
+	 * @return cpObject
+	 */
+	public ConstantPool getConstantPoolCache(Class<?> clazz);
+
 }

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -181,6 +181,8 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 	private transient long vmRef;
 	private transient ClassLoader classLoader;
 
+	transient ConstantPool constantPoolObject;
+
 	/*[IF JAVA_SPEC_VERSION >= 9]*/
 	private transient Module module;
 	/*[ENDIF] JAVA_SPEC_VERSION >= 9 */

--- a/jcl/src/java.base/share/classes/java/lang/InternalConstantPool.java
+++ b/jcl/src/java.base/share/classes/java/lang/InternalConstantPool.java
@@ -29,8 +29,10 @@ package java.lang;
 final class InternalConstantPool {
 	@SuppressWarnings("unused")
 	private final long vmRef;
+	private final Class<?> clazz;
 
-	public InternalConstantPool(long addr) {
-		vmRef = addr;
+	public InternalConstantPool(long addr, Class<?> clazz) {
+		this.vmRef = addr;
+		this.clazz = clazz;
 	}
 }

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -189,8 +189,8 @@ final class VMAccess implements VMLangAccess {
 	 * @return An InternalConstantPool reference object
 	 */
 	@Override
-	public Object createInternalConstantPool(long addr) {
-		return new InternalConstantPool(addr);
+	public Object createInternalConstantPool(long addr, Class<?> clazz) {
+		return new InternalConstantPool(addr, clazz);
 	}
 
 	/**
@@ -208,11 +208,12 @@ final class VMAccess implements VMLangAccess {
 	 * natives expect an InternalConstantPool as the constantPoolOop parameter.
 	 *
 	 * @param j9class the native address of the J9Class
+	 * @param clazz the class object
 	 * @return InternalConstantPool a wrapper for a j9constantpool
 	 */
-	public Object getInternalConstantPoolFromJ9Class(long j9class) {
+	public Object getInternalConstantPoolFromJ9Class(long j9class, Class<?> clazz) {
 		long j9constantpool = VM.getJ9ConstantPoolFromJ9Class(j9class);
-		return createInternalConstantPool(j9constantpool);
+		return createInternalConstantPool(j9constantpool, clazz);
 	}
 
 	/**
@@ -230,7 +231,7 @@ final class VMAccess implements VMLangAccess {
 		} else {
 			j9class = helpers.getJ9ClassFromClass64(clazz);
 		}
-		return getInternalConstantPoolFromJ9Class(j9class);
+		return getInternalConstantPoolFromJ9Class(j9class, clazz);
 	}
 
 	/*[IF JAVA_SPEC_VERSION >= 9]*/
@@ -275,6 +276,17 @@ final class VMAccess implements VMLangAccess {
 	@Override
 	public boolean getIncludeModuleVersion(StackTraceElement element) {
 		return element.getIncludeModuleVersion();
+	}
+
+	/**
+	 * Returns a cached constantPool Object from a given java.lang.Class
+	 *
+	 * @param clazz
+	 *
+	 * @return cpObject
+	 */
+	public ConstantPool getConstantPoolCache(Class<?> clazz) {
+		return clazz.constantPoolObject;
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
+++ b/jcl/src/java.base/share/classes/java/lang/invoke/MethodHandleResolver.java
@@ -115,8 +115,8 @@ final class MethodHandleResolver {
 		Object result = null;
 
 		VMLangAccess access = VM.getVMLangAccess();
-		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class);
 		Class<?> classObject = getClassFromJ9Class(j9class);
+		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class, classObject);
 
 		Class<?> typeClass = fromFieldDescriptorString(fieldDescriptor, access.getClassloader(classObject));
 
@@ -241,8 +241,8 @@ final class MethodHandleResolver {
 	private static final Object resolveInvokeDynamic(long j9class, String name, String methodDescriptor, long bsmData) throws Throwable {
 /*[IF OPENJDK_METHODHANDLES]*/
 		VMLangAccess access = VM.getVMLangAccess();
-		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class);
 		Class<?> classObject = getClassFromJ9Class(j9class);
+		Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class, classObject);
 
 		MethodType type = null;
 		Object[] result = new Object[2];
@@ -340,8 +340,8 @@ final class MethodHandleResolver {
 		try {
 /*[ENDIF] JAVA_SPEC_VERSION < 11 */
 			VMLangAccess access = VM.getVMLangAccess();
-			Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class);
 			Class<?> classObject = getClassFromJ9Class(j9class);
+			Object internalConstantPool = access.getInternalConstantPoolFromJ9Class(j9class, classObject);
 
 			type = MethodTypeHelper.vmResolveFromMethodDescriptorString(methodDescriptor, access.getClassloader(classObject), null);
 			final MethodHandles.Lookup lookup = new MethodHandles.Lookup(classObject, false);

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -130,7 +130,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<classref name="java/lang/Module" versions="9-"/>
 	<classref name="java/lang/invoke/VarHandleInvokeHandle" versions="9-" flags="opt_methodHandle"/>
 	<classref name="java/lang/invoke/FieldVarHandle" versions="9-" flags="opt_methodHandle"/>
-	<classref name="jdk/internal/reflect/ConstantPool" versions="26-"/>
+	<classref name="jdk/internal/reflect/ConstantPool" versions="11-"/>
+	<classref name="sun/reflect/ConstantPool" versions="8"/>
 
 	<!-- Common class references shared between OpenJ9 and OpenJDK MethodHandles. -->
 	<classref name="java/lang/invoke/MethodType" flags="opt_methodHandleCommon"/>
@@ -192,6 +193,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/Class" name="reflectCache" signature="Ljava/lang/Class$ReflectCache;"/>
 	<fieldref class="java/lang/Class" name="classLoader" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/Class" name="vmRef" signature="J" cast="struct J9Class *"/>
+	<fieldref class="java/lang/Class" name="constantPoolObject" signature="Ljdk/internal/reflect/ConstantPool;"/>
 	<fieldref class="java/lang/Class" name="initializationLock" signature="Ljava/lang/J9VMInternals$ClassInitializationLock;"/>
 	<fieldref class="java/lang/Class" name="protectionDomain" signature="Ljava/security/ProtectionDomain;"/>
 	<fieldref class="java/lang/Class" name="classNameString" signature="Ljava/lang/String;"/>
@@ -407,6 +409,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/Module" name="name" signature="Ljava/lang/String;" versions="9-"/>
 
 	<fieldref class="java/lang/InternalConstantPool" name="vmRef" signature="J" cast="struct J9ConstantPool *"/>
+	<fieldref class="java/lang/InternalConstantPool" name="clazz" signature="Ljava/lang/Class;"/>
 
 	<fieldref class="com/ibm/oti/util/WeakReferenceNode" name="next" signature="Lcom/ibm/oti/util/WeakReferenceNode;" flags="opt_methodHandle"/>
 
@@ -475,7 +478,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="jdk/internal/foreign/NativeMemorySegmentImpl" name="scope" signature="Ljava/lang/foreign/SegmentScope;" flags="opt_openjdkFfi" versions="20"/>
 	<fieldref class="jdk/internal/foreign/NativeMemorySegmentImpl" name="scope" signature="Ljdk/internal/foreign/MemorySessionImpl;" flags="opt_openjdkFfi" versions="21-"/>
 
-	<fieldref class="jdk/internal/reflect/ConstantPool" name="constantPoolOop" signature="Ljava/lang/Object;" versions="26-"/>
+	<fieldref class="jdk/internal/reflect/ConstantPool" name="constantPoolOop" signature="Ljava/lang/Object;" versions="11-"/>
+	<fieldref class="sun/reflect/ConstantPool" name="constantPoolOop" signature="Ljava/lang/Object;" versions="8"/>
 
 <!--
 	NOTE: the resolution code in jclcinit.c only looks at the J9ROMClassRef->runtimeFlags to determine

--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2489,6 +2489,7 @@ flushClassLoaderReflectCache(J9VMThread * currentThread, J9HashTable * classPair
 			j9object_t classObject = J9VM_J9CLASS_TO_HEAPCLASS(replacementRAMClass);
 			J9VMJAVALANGCLASS_SET_ANNOTATIONCACHE(currentThread, classObject, NULL);
 			J9VMJAVALANGCLASS_SET_REFLECTCACHE(currentThread, classObject, NULL);
+			J9VMJAVALANGCLASS_SET_CONSTANTPOOLOBJECT(currentThread, classObject, NULL);
 		}
 		classPair = hashTableNextDo(&hashTableState);
 	}


### PR DESCRIPTION
Cache the constantPool object off the j.l.Class after the first invocation of Access::getConstantPool. Given that the ConstantPool instance is associated with a single version of the class, as soon as the class is redefined the cache is invalidated and disabled.