### PR TITLE
JDK26 adopts JavaLangAccess API changes

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -542,7 +542,11 @@ final class Access implements JavaLangAccess {
 	/*[IF JAVA_SPEC_VERSION >= 20]*/
 	@Override
 	public void addEnableNativeAccessToAllUnnamed() {
+		/*[IF (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES]*/
+		Module.addEnableNativeAccessToAllUnnamed();
+		/*[ELSE] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 		Module.implAddEnableNativeAccessToAllUnnamed();
+		/*[ENDIF] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 	}
 	/*[ELSE] JAVA_SPEC_VERSION >= 20 */
 	@Override
@@ -557,9 +561,15 @@ final class Access implements JavaLangAccess {
 	/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 
 	@Override
+	/*[IF (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES]*/
+	public void addEnableNativeAccess(Module mod) {
+		mod.implAddEnableNativeAccess();
+	}
+	/*[ELSE] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 	public Module addEnableNativeAccess(Module mod) {
 		return mod.implAddEnableNativeAccess();
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 
 	/*[IF (21 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24)]*/
 	@Override
@@ -984,5 +994,32 @@ final class Access implements JavaLangAccess {
 	public String uncheckedNewStringWithLatin1Bytes(byte[] src) {
 		return String.newStringWithLatin1Bytes(src);
 	}
+
+	/*[IF !INLINE-TYPES]*/
+	@Override
+	public void addEnableFinalMutationToAllUnnamed() {
+		Module.addEnableFinalMutationToAllUnnamed();
+	}
+
+	@Override
+	public boolean isFinalMutationEnabled(Module module) {
+		return module.isFinalMutationEnabled();
+	}
+
+	@Override
+	public boolean isStaticallyExported(Module module, String packageName, Module other) {
+		return module.isStaticallyExported(packageName, other);
+	}
+
+	@Override
+	public boolean isStaticallyOpened(Module module, String packageName, Module other) {
+		return module.isStaticallyOpened(packageName, other);
+	}
+
+	@Override
+	public boolean tryEnableFinalMutation(Module module) {
+		return module.tryEnableFinalMutation();
+	}
+	/*[ENDIF] !INLINE-TYPES */
 	/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
 }


### PR DESCRIPTION
JDK26 adopts `JavaLangAccess` API changes

Resolve JDKnext abuild compilation failures at https://openj9-jenkins.osuosl.org/job/Build_JDKnext_aarch64_linux_OpenJDK/928/consoleFull
```
05:22:19  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:72: error: Access is not abstract and does not override abstract method isStaticallyOpened(Module,String,Module) in JavaLangAccess
05:22:19  final class Access implements JavaLangAccess {
05:22:19        ^
05:22:19  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:337: error: addEnableNativeAccess(Module) in Access cannot implement addEnableNativeAccess(Module) in JavaLangAccess
05:22:19  	public Module addEnableNativeAccess(Module mod) {
05:22:19  	              ^
05:22:19    return type Module is not compatible with void
05:22:19  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:333: error: cannot find symbol
05:22:19  		Module.implAddEnableNativeAccessToAllUnnamed();
05:22:19  		      ^
05:22:19    symbol:   method implAddEnableNativeAccessToAllUnnamed()
05:22:19    location: class Module
05:22:19  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:336: error: addEnableNativeAccess(Module) in Access does not override or implement a method from a supertype
05:22:19  	@Override

```


Signed-off-by: Jason Feng <fengj@ca.ibm.com>