### PR TITLE
Fix J9ClassHasIdentity flag assignment

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2406,8 +2406,8 @@ nativeOOM:
 			}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
-		} else if (!(J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass) && J9ROMCLASS_IS_INTERFACE(romClass))) {
-			/* All classes before value type version are identity. */
+		} else if (!J9ROMCLASS_IS_VALUE(romClass) && !J9ROMCLASS_IS_INTERFACE(romClass)) {
+			/* All classes which are not value classes and are not interfaces are identity. */
 			classFlags |= J9ClassHasIdentity;
 		}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)


### PR DESCRIPTION
Set the J9ClassHasIdentity flag only if the class is
not a value class and not an interface.

Fixes the following failure in `test/jdk/valhalla/valuetypes/ValueClassTest.java`
```
[14:01:06.476] STARTED    ValueClassTest::testIsValueObjectCompatible 'testIsValueObjectCompatible()'
org.opentest4j.AssertionFailedError: interface: java.lang.Comparable ==> expected: <true> but was: <false>
	at org.junit.jupiter.api.AssertionFailureBuilder.build(AssertionFailureBuilder.java:151)
	at org.junit.jupiter.api.AssertionFailureBuilder.buildAndThrow(AssertionFailureBuilder.java:132)
	at org.junit.jupiter.api.AssertEquals.failNotEqual(AssertEquals.java:197)
	at org.junit.jupiter.api.AssertEquals.assertEquals(AssertEquals.java:188)
	at org.junit.jupiter.api.Assertions.assertEquals(Assertions.java:1167)
	at ValueClassTest.isValueObjectCompatibleCase(ValueClassTest.java:63)
	at ValueClassTest.testIsValueObjectCompatible(ValueClassTest.java:51)
	at java.base/java.lang.reflect.Method.invoke(Method.java:571)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
```