### PR TITLE
Add external compiler option to ignore -Xtrace

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -300,6 +300,10 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
 
          isQuickstart = J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_TUNE_QUICKSTART);
 
+         // Determine if the JIT should ignore -Xtrace options
+         if (J9::Options::getExternalOptionIndex(J9::ExternalOptions::XXjitIgnoreXtrace) >= 0)
+            TR::Options::setIgnoreXtrace();
+
 #ifdef TR_HOST_X86
          // By default, disallow reservation of objects' monitors for which a
          // previous reservation has been cancelled (issue #1124). But allow it

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -317,6 +317,8 @@ bool J9::Options::_aggressiveLockReservation = false;
 
 bool J9::Options::_xrsSync = false;
 
+bool J9::Options::_ignoreXtrace = false;
+
 int32_t J9::Options::_jvmStarvationThreshold = 40; // 40% CPU utilization. Use 10 (or lower) to disable the feature
 
 void
@@ -432,8 +434,9 @@ J9::ExternalOptionsMetadata J9::Options::_externalOptionsMetadata[J9::ExternalOp
    { "-XX:+TrackAOTDependencies",                   EXACT_MATCH,         -1, true  }, // = 77
    { "-XX:-TrackAOTDependencies",                   EXACT_MATCH,         -1, true  }, // = 78
    { "-XX:+JITServerUseProfileCache",               EXACT_MATCH,         -1, true  }, // = 79
-   { "-XX:-JITServerUseProfileCache",               EXACT_MATCH,         -1, true  }  // = 80
-   // TR_NumExternalOptions                                                              = 81
+   { "-XX:-JITServerUseProfileCache",               EXACT_MATCH,         -1, true  }, // = 80
+   { "-XX:JITIgnoreXtrace",                         EXACT_MATCH,         -1, true  }, // = 81
+   // TR_NumExternalOptions                                                              = 82
    };
 
 //************************************************************************

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -135,7 +135,8 @@ enum ExternalOptions
    XXminusTrackAOTDependencies                   = 78,
    XXplusJITServerUseProfileCache                = 79,
    XXminusJITServerUseProfileCache               = 80,
-   TR_NumExternalOptions                         = 81
+   XXjitIgnoreXtrace                             = 81,
+   TR_NumExternalOptions                         = 82
    };
 
 /**
@@ -496,6 +497,8 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static bool _xrsSync;
 
+   static bool _ignoreXtrace;
+
    static int32_t _jvmStarvationThreshold;
 
    static ExternalOptionsMetadata _externalOptionsMetadata[ExternalOptions::TR_NumExternalOptions];
@@ -538,7 +541,23 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
 
    static void  printPID();
 
+   /**
+    * @brief Returns whether the JIT will generate code that ignores what is
+    *        specified in the -Xtrace option
+    *
+    * @return _ignoreXtrace
+    */
+   static bool ignoreXtrace() { return _ignoreXtrace; }
+
+   /**
+    * @brief Sets the flag that indicates whether the JIT will generate code
+    *        that ignores what is specified in the -Xtrace option
+    */
+   static void setIgnoreXtrace() { _ignoreXtrace = true; }
+
    OMR::Logger *createLoggerForLogFile(TR::FILE *file);
+
+
 
 
    static const char *kcaOffsets(const char *option, void *, TR::OptionTable *entry);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3143,7 +3143,7 @@ TR_J9VMBase::lowerAsyncCheck(TR::Compilation * comp, TR::Node * root, TR::TreeTo
 bool
 TR_J9VMBase::isMethodTracingEnabled(TR_OpaqueMethodBlock *method)
    {
-   return VM_VMHelpers::methodBeingTraced(_jitConfig->javaVM, (J9Method *)method);
+   return !TR::Options::ignoreXtrace() && VM_VMHelpers::methodBeingTraced(_jitConfig->javaVM, (J9Method *)method);
    }
 
 bool

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -1052,6 +1052,9 @@ TR_RelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
       featureFlags |= TR_FeatureFlag_CHTableEnabled;
       }
 
+   if (TR::Options::ignoreXtrace())
+      featureFlags |= TR_FeatureFlag_IgnoreXtrace;
+
    return featureFlags;
    }
 
@@ -1294,6 +1297,8 @@ TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(const TR_AOTHeader *hdrInCa
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_ARRAY_HEADER_SHAPE_MISMATCH, "AOT header validation failed: Array header shape mismatch.");
    if ((featureFlags & TR_FeatureFlag_CHTableEnabled) != (hdrInCache->featureFlags & TR_FeatureFlag_CHTableEnabled))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_CH_TABLE_MISMATCH, "AOT header validation failed: CH Table mismatch.");
+   if ((featureFlags & TR_FeatureFlag_IgnoreXtrace) != (hdrInCache->featureFlags & TR_FeatureFlag_IgnoreXtrace))
+      defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_IGNORE_XTRACE_MISMATCH, "AOT header validation failed: Ignore Xtrace mismatch");
    if ((featureFlags & TR_FeatureFlag_SanityCheckEnd) != (hdrInCache->featureFlags & TR_FeatureFlag_SanityCheckEnd))
       defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_END_SANITY_BIT_MANGLED, "AOT header validation failed: Trailing sanity bit mismatch.");
 

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -81,6 +81,7 @@ typedef enum TR_AOTFeatureFlags
    TR_FeatureFlag_IsVariableHeapSizeForBarrierRange0 = 0x00008000,
    TR_FeatureFlag_IsVariableActiveCardTableBase      = 0x00010000,
    TR_FeatureFlag_CHTableEnabled                     = 0x00020000,
+   TR_FeatureFlag_IgnoreXtrace                       = 0x00040000,
    TR_FeatureFlag_SanityCheckEnd                     = 0x80000000
    } TR_AOTFeatureFlags;
 

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -438,3 +438,11 @@ J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.explanation=The JVM was
 J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
 J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.user_response=Remove any (pre-checkpoint) option that would have resulted in this behaviour.
 # END NON-TRANSLATABLE
+
+J9NLS_RELOCATABLE_CODE_IGNORE_XTRACE_MISMATCH=Ignore Xtrace mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_IGNORE_XTRACE_MISMATCH.explanation=The JVM is not consistent with the usage of -XX:JITIgnoreXtrace compared to the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_IGNORE_XTRACE_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_IGNORE_XTRACE_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_IGNORE_XTRACE_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE


### PR DESCRIPTION
When -Xtrace is specified, the compiler generates code to call out to the appropriate hooks. For debugging purposes, it may be useful for the compiler to ignore -Xtrace - for example, when trying understand what is being interpreted.

This PR adds a new external option -XX:JITIgnoreXtrace that will trigger this behaviour. This PR includes a new AOT feature flag to ensure consistency between JVMs.

The one caveat here is that JNI compilations may still report to Xtrace.