### PR TITLE
Add NULL check before calling createResolvedMethodWithSignature

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -55,6 +55,7 @@
 // Reasons for interrupting a compilation
 const uint8_t GC_COMP_INTERRUPT       = 1;
 const uint8_t SHUTDOWN_COMP_INTERRUPT = 2;
+const uint8_t COMP_EXCEPTION_THROWN   = 3;
 
 const  int32_t IDLE_THRESHOLD       = 50;  // % CPU
 

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -206,11 +206,10 @@ static bool
 handleResponse(JITServer::MessageType response, JITServer::ClientStream *client, TR::CompilationInfoPerThread *compInfoPT, TR::Compilation *comp, TR_J9VM *fe, J9VMThread *vmThread)
    {
    using JITServer::MessageType;
+
    TR::CompilationInfo *compInfo = compInfoPT->getCompilationInfo();
-   TR_Memory *trMemory = compInfoPT->getCompilation()->trMemory();
-
+   TR_Memory *trMemory = comp->trMemory();
    TR::KnownObjectTable *knot = comp->getOrCreateKnownObjectTable();
-
 
    bool done = false;
 
@@ -3108,6 +3107,9 @@ handleServerMessage(JITServer::ClientStream *client, TR_J9VM *fe, JITServer::Mes
       }
    catch(std::exception &e)
       {
+      interruptReason = COMP_EXCEPTION_THROWN;
+      compInfoPT->setCompilationShouldBeInterrupted(interruptReason);
+
       client->writeError(MessageType::compilationInterrupted, 0 /* placeholder */);
 
       if (TR::Options::isAnyVerboseOptionSet(TR_VerboseJITServer, TR_VerboseCompilationDispatch))

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7450,7 +7450,17 @@ TR_ResolvedJ9Method::getResolvedDynamicMethod(TR::Compilation * comp, I_32 callS
       // the call site table entry to be resolved instead. The resolved method we construct is
       // linkToStatic, which is a VM internal native method that will prepare the call frame for
       // the actual method to be invoked using the last argument we push to stack (memberName object)
-      TR_OpaqueMethodBlock *dummyInvoke = _fe->getMethodFromName("java/lang/invoke/MethodHandle", "linkToStatic", "([Ljava/lang/Object;)Ljava/lang/Object;");
+      const char * className = "java/lang/invoke/MethodHandle";
+      const char * methodName = "linkToStatic";
+      const char * methodSignature = "([Ljava/lang/Object;)Ljava/lang/Object;";
+      TR_OpaqueMethodBlock *dummyInvoke = _fe->getMethodFromName(className, methodName, methodSignature);
+
+      // It is possible for getMethodFromName to return NULL in relocatable compilations
+      if (!dummyInvoke && comp->compileRelocatableCode())
+         comp->failCompilation<J9::AOTHasInvokeHandle>("getResolvedDynamicMethod: Failed to get method %s.%s%s from name", className, methodName, methodSignature);
+
+      TR_ASSERT_FATAL(dummyInvoke, "getResolvedDynamicMethod: dummyInvoke must exist %s.%s%s\n", className, methodName, methodSignature);
+
       int32_t signatureLength;
       char * linkToStaticSignature = _fe->getSignatureForLinkToStaticForInvokeDynamic(comp, signature, signatureLength);
       result = _fe->createResolvedMethodWithSignature(comp->trMemory(), dummyInvoke, NULL, linkToStaticSignature, signatureLength, this);
@@ -7525,7 +7535,17 @@ TR_ResolvedJ9Method::getResolvedHandleMethod(TR::Compilation * comp, I_32 cpInde
       // the method type table entry to be resolved instead. The resolved method we construct is
       // linkToStatic, which is a VM internal native method that will prepare the call frame for
       // the actual method to be invoked using the last argument we push to stack (memberName object)
-      TR_OpaqueMethodBlock *dummyInvoke = _fe->getMethodFromName("java/lang/invoke/MethodHandle", "linkToStatic", "([Ljava/lang/Object;)Ljava/lang/Object;");
+      const char * className = "java/lang/invoke/MethodHandle";
+      const char * methodName = "linkToStatic";
+      const char * methodSignature = "([Ljava/lang/Object;)Ljava/lang/Object;";
+      TR_OpaqueMethodBlock *dummyInvoke = _fe->getMethodFromName(className, methodName, methodSignature);
+
+      // It is possible for getMethodFromName to return NULL in relocatable compilations
+      if (!dummyInvoke && comp->compileRelocatableCode())
+         comp->failCompilation<J9::AOTHasInvokeHandle>("getResolvedHandleMethod: Failed to get method %s.%s%s from name", className, methodName, methodSignature);
+
+      TR_ASSERT_FATAL(dummyInvoke, "getResolvedHandleMethod: dummyInvoke must exist %s.%s%s\n", className, methodName, methodSignature);
+
       int32_t signatureLength;
       char * linkToStaticSignature = _fe->getSignatureForLinkToStaticForInvokeHandle(comp, signature, signatureLength);
       result = _fe->createResolvedMethodWithSignature(comp->trMemory(), dummyInvoke, NULL, linkToStaticSignature, signatureLength, this);

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1182,8 +1182,17 @@ TR_ResolvedJ9JITServerMethod::getResolvedHandleMethod(TR::Compilation *comp, I_3
          }
       else
          {
+         const char * className = "java/lang/invoke/MethodHandle";
+         const char * methodName = "linkToStatic";
+         const char * methodSignature = "([Ljava/lang/Object;)Ljava/lang/Object;";
+
          // Call getMethodFromName to create an SVM record
-         auto dummyInvoke = _fe->getMethodFromName("java/lang/invoke/MethodHandle", "linkToStatic", "([Ljava/lang/Object;)Ljava/lang/Object;");
+         auto dummyInvoke = _fe->getMethodFromName(className, methodName, methodSignature);
+
+         // It is possible for getMethodFromName to return NULL in relocatable compilations
+         if (!dummyInvoke)
+            comp->failCompilation<J9::AOTHasInvokeHandle>("getResolvedHandleMethod: Failed to get method %s.%s%s from name", className, methodName, methodSignature);
+
          TR_ASSERT_FATAL(ramMethod == dummyInvoke, "%p != %p; Unresolved targetMethod not dummyInvoke\n", ramMethod, dummyInvoke);
          }
       }
@@ -1278,8 +1287,17 @@ TR_ResolvedJ9JITServerMethod::getResolvedDynamicMethod(TR::Compilation *comp, I_
          }
       else
          {
+         const char * className = "java/lang/invoke/MethodHandle";
+         const char * methodName = "linkToStatic";
+         const char * methodSignature = "([Ljava/lang/Object;)Ljava/lang/Object;";
+
          // Call getMethodFromName to create an SVM record
-         auto dummyInvoke = _fe->getMethodFromName("java/lang/invoke/MethodHandle", "linkToStatic", "([Ljava/lang/Object;)Ljava/lang/Object;");
+         auto dummyInvoke = _fe->getMethodFromName(className, methodName, methodSignature);
+
+         // It is possible for getMethodFromName to return NULL in relocatable compilations
+         if (!dummyInvoke)
+            comp->failCompilation<J9::AOTHasInvokeHandle>("getResolvedDynamicMethod: Failed to get method %s.%s%s from name", className, methodName, methodSignature);
+
          TR_ASSERT_FATAL(ramMethod == dummyInvoke, "%p != %p; Unresolved targetMethod not dummyInvoke\n", ramMethod, dummyInvoke);
          }
       }

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 94; // ID: GiHmIVRabgHnEehwsKs1
+   static const uint16_t MINOR_NUMBER = 95; // ID: CG1NgwI3xhSuaFWEztYD
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 


### PR DESCRIPTION
`getMethodFromName` can return NULL in AOT for various runtime reasons. If one does not check for this before calling
`createResolvedMethodWithSignature`, it can result in crashes.

This PR also refactors the code in `handleServerMessage` that processes the response and wraps it in a try/catch to ensure the compilation termination occurs gracefully.

Fixes https://github.com/eclipse-openj9/openj9/issues/22994

This is similar to https://github.com/eclipse-omr/omr/pull/4418