### PR TITLE
Valhalla adds !INLINE-TYPES for MemoryMXBean.getTotalGcCpuTime()

### DIFF
--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java
@@ -903,7 +903,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 		return objectName;
 	}
 
-/*[IF JAVA_SPEC_VERSION >= 26]*/
+/*[IF (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES]*/
 	private native long getTotalGcCpuTimeImpl();
 
 	/**
@@ -913,7 +913,7 @@ public class MemoryMXBeanImpl extends LazyDelegatingNotifier implements MemoryMX
 	public long getTotalGcCpuTime() {
 		return getTotalGcCpuTimeImpl();
 	}
-/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
 
 	/**
 	 * Ensure the notification thread (where appropriate) is running.


### PR DESCRIPTION
Valhalla adds `!INLINE-TYPES` for `MemoryMXBean.getTotalGcCpuTime()`

Valhalla doesn't have latest `MemoryMXBean.getTotalGcCpuTime()` yet, adding `!INLINE-TYPES` to workaround the nightly build failure.

```
21:14:43  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/build/linux-x86_64-server-release/support/j9jcl/java.management/share/classes/com/ibm/java/lang/management/internal/MemoryMXBeanImpl.java:785: error: method does not override or implement a method from a supertype
21:14:43  	@Override
21:14:43  	^
21:14:43  1 error
```

Related to https://github.com/eclipse-openj9/openj9/pull/22972

Signed-off-by: Jason Feng <fengj@ca.ibm.com>