### PR TITLE
RAM Class Persistence: revise frozen class loading function

### DIFF
--- a/runtime/jcl/common/jcldefine.c
+++ b/runtime/jcl/common/jcldefine.c
@@ -167,7 +167,7 @@ retry:
 #if defined(J9VM_OPT_SNAPSHOTS)
 				if (IS_RESTORE_RUN(vm)) {
 					clazz = persistedClazz;
-					if (!vmFuncs->loadWarmClassFromSnapshot(currentThread, classLoader, clazz)) {
+					if (!vmFuncs->loadWarmClassFromSnapshot(currentThread, clazz)) {
 						clazz = NULL;
 						goto done;
 					}

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5499,7 +5499,7 @@ typedef struct J9InternalVMFunctions {
 #if defined(J9VM_OPT_SNAPSHOTS)
 	void (*initializeSnapshotClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);
 	struct J9Class * (*initializeSnapshotClassObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, struct J9Class *clazz);
-	BOOLEAN (*loadWarmClassFromSnapshot)(struct J9VMThread *vmThread, struct J9ClassLoader *classLoader, struct J9Class *clazz);
+	BOOLEAN (*loadWarmClassFromSnapshot)(struct J9VMThread *vmThread, struct J9Class *clazz);
 	void (*initializeBaseClasses)(struct J9JavaVM *javaVM);
 #endif /* defined(J9VM_OPT_SNAPSHOTS) */
 #if JAVA_SPEC_VERSION >= 24

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5595,11 +5595,10 @@ setInitialVMMethods(J9JavaVM *javaVM, J9Method **cInitialStaticMethod, J9Method 
  * Run class load hooks and assign class object to J9Class.
  *
  * @param vmThread[in] the current VM thread
- * @param classLoader[in] classloader of the J9Class
  * @param clazz[in] J9Class to be loaded
  */
 BOOLEAN
-loadWarmClassFromSnapshot(J9VMThread *vmThread, J9ClassLoader *classLoader, J9Class *clazz);
+loadWarmClassFromSnapshot(J9VMThread *vmThread, J9Class *clazz);
 
 /**
  * Perform post-snapshot fixups on the provided J9Class.

--- a/runtime/vm/VMSnapshotImpl.cpp
+++ b/runtime/vm/VMSnapshotImpl.cpp
@@ -99,15 +99,15 @@ VMSnapshotImpl::initBaseClasses()
 	struct J9InternalVMFunctions *vmFuncs = _vm->internalVMFunctions;
 	J9VMThread *vmThread = currentVMThread(_vm);
 
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->voidReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->booleanReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->charReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->floatReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->doubleReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->byteReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->shortReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->intReflectClass);
-	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->systemClassLoader, _vm->longReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->voidReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->booleanReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->charReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->floatReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->doubleReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->byteReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->shortReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->intReflectClass);
+	vmFuncs->loadWarmClassFromSnapshot(vmThread, _vm->longReflectClass);
 }
 
 bool


### PR DESCRIPTION
When loading frozen classes from RCP cache, the initial class loader passed to the frozen class loading functions is used to initialize all class objects referenced during the recursively loading process. This may result in an unexpected class loader assigned, which can cause access validation failures. The proposed changes are to use the cached class loader of the frozen class to initialize its class object.

Fixes: #22844