### PR TITLE
Restore some OpenJ9 MXBean helper classes to fix build breaks

### DIFF
--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryNotificationInfo.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
  * Copyright IBM Corp. and others 2005
  *

--- a/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
+++ b/jcl/src/java.management/share/classes/java/lang/management/MemoryUsage.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF (JAVA_SPEC_VERSION == 8) & !Sidecar18-SE-OpenJ9]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
  * Copyright IBM Corp. and others 2005
  *


### PR DESCRIPTION
Restore MemoryNotificationInfo and MemoryUsage.

Fixes https://github.com/eclipse-openj9/openj9/issues/23015