### PR TITLE
Change ShareClassesCMLTests to use a bigger cache size

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -1435,7 +1435,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 
 	<test id="Test 67-a: Test classes are being stored to the persistent shared cache" timeout="600" runPath=".">
-		<command>$JAVA_EXE$ $currentMode$,verboseIO,persistent -Xscmx4m $CP_HANOI$ $PROGRAM_HANOI$</command>
+		<command>$JAVA_EXE$ $currentMode$,verboseIO,persistent -Xscmx16m $CP_HANOI$ $PROGRAM_HANOI$</command>
 		<output type="success" caseSensitive="yes" regex="no">Puzzle solved!</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Stored class java/.* in shared cache for class-loader id 0 with URL .* \(index</output>
 		<output type="required" caseSensitive="yes" regex="yes" javaUtilPattern="yes">Stored class org/openj9/test/ivj/.* in shared cache for class-loader id [2-9].*[\\/]utils.jar \(index 0\)</output>


### PR DESCRIPTION
4MB is too small on Java 25 as more bootstrap classes are loaded