### PR TITLE
Remove unnecessary casts in calls to omrthread_global()

### DIFF
--- a/runtime/vm/jniinv.c
+++ b/runtime/vm/jniinv.c
@@ -33,7 +33,7 @@
 #include "jni.h"
 #include "j9protos.h"
 #include "vmaccess.h"
-#include "j9consts.h"	
+#include "j9consts.h"
 #include "omrthread.h"
 #include "j9dump.h"
 #include "jvminit.h"
@@ -107,7 +107,6 @@ J9NameAndSignature const * const exceptionConstructors[] = {
 		&throwableClassClassNameAndSig,		/* J9ExceptionConstructorClassClass */
 		&throwableCauseNameAndSig,			/* J9ExceptionConstructorThrowable */
 };
-
 
 typedef struct {
 	J9JavaVM * vm;
@@ -280,7 +279,7 @@ jint JNICALL J9_GetCreatedJavaVMs(JavaVM ** vm_buf, jsize bufLen, jsize * nVMs)
 		count = 1;
 		*vm_buf = (JavaVM *) *pvmList;
 #endif
-	} 
+	}
 
 #if defined (LINUXPPC64) || (defined (AIXPPC) && defined (PPC64)) || defined (J9ZOS39064)
 	/* there was a bug in older VMs on these platforms where jsize was defined to
@@ -305,7 +304,6 @@ done:
 #endif
 	return result;
 }
-
 
 static UDATA
 protectedDestroyJavaVM(J9PortLibrary* portLibrary, void * userData)
@@ -386,8 +384,8 @@ protectedDestroyJavaVM(J9PortLibrary* portLibrary, void * userData)
 		(*(vm->sidecarExitHook))(vm);
 #endif /* defined(J9VM_OPT_SIDECAR) */
 
-	/* 
-	 * shutdown the finalizer BEFORE we shutdown daemon threads, as 
+	/*
+	 * shutdown the finalizer BEFORE we shutdown daemon threads, as
 	 * finalize methods could spawn more threads
 	 */
 	vm->memoryManagerFunctions->gcShutdownHeapManagement(vm);
@@ -432,7 +430,7 @@ protectedDestroyJavaVM(J9PortLibrary* portLibrary, void * userData)
 		/* run z/TPF OS exit hook */
 		cjvm_jvm_shutdown_hook();
 #endif
-		
+
 		if (vm->exitHook) {
 #if defined(J9VM_ZOS_3164_INTEROPERABILITY)
 			if (J9_IS_31BIT_INTEROP_TARGET(vm->exitHook)) {
@@ -504,7 +502,7 @@ jint JNICALL DestroyJavaVM(JavaVM * javaVM)
 	/* There is a cyclic dependency when using HealthCenter which causes JVM to hang during shutdown.
 	 * To break this cycle, thread doing the shutdown needs to be detached to notify Healthcenter that
 	 * it has terminated, and then re-attached as "DestroyJavaVM helper thread".
-	 * As part of this fix, Healthcenter also needs to be modified to not do the join on "DestroyJavaVM helper thread". 
+	 * As part of this fix, Healthcenter also needs to be modified to not do the join on "DestroyJavaVM helper thread".
 	 * Therefore, if ever this thread name is modified, HealthCenter should be informed to adapt accordingly.
 	 */
 	result = DetachCurrentThread(javaVM);
@@ -527,7 +525,7 @@ jint JNICALL DestroyJavaVM(JavaVM * javaVM)
 	}
 
 	/* we only allow shutdown code to run once */
-	
+
 	if(vm->runtimeFlags & J9_RUNTIME_SHUTDOWN_STARTED) {
 		if(vm->runtimeFlagsMutex != NULL) {
 			omrthread_monitor_exit(vm->runtimeFlagsMutex);
@@ -547,9 +545,9 @@ jint JNICALL DestroyJavaVM(JavaVM * javaVM)
 	PORTLIB->self_handle = NULL;
 
 	if (j9sig_protect(
-		protectedDestroyJavaVM, vmThread, 
+		protectedDestroyJavaVM, vmThread,
 		structuredSignalHandler, vmThread,
-		J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION, 
+		J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION,
 		&result)
 	) {
 		result = JNI_ERR;
@@ -570,12 +568,10 @@ jint JNICALL DestroyJavaVM(JavaVM * javaVM)
 	return (jint) result;
 }
 
-
 jint JNICALL AttachCurrentThread(JavaVM * vm, void ** p_env, void * thr_args)
 {
 	return attachCurrentThread(vm, p_env, thr_args, 0);
 }
-
 
 static UDATA
 protectedDetachCurrentThread(J9PortLibrary* portLibrary, void * userData)
@@ -609,7 +605,7 @@ jint JNICALL DetachCurrentThread(JavaVM * javaVM)
 		 */
 		if (J9_ARE_ALL_BITS_SET(vm->runtimeFlags, J9_RUNTIME_EXIT_STARTED)) {
 			if (J9_ARE_NO_BITS_SET(vmThread->privateFlags, J9_PRIVATE_FLAGS_SYSTEM_THREAD)) {
-				goto done;	
+				goto done;
 			}
 		}
 
@@ -618,9 +614,9 @@ jint JNICALL DetachCurrentThread(JavaVM * javaVM)
 		/* Perform thread cleanup */
 
 		if (j9sig_protect(
-			protectedDetachCurrentThread, vmThread, 
+			protectedDetachCurrentThread, vmThread,
 			structuredSignalHandler, vmThread,
-			J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION, 
+			J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION,
 			&result)
 		) {
 			result = JNI_ERR;
@@ -635,7 +631,6 @@ jint JNICALL DetachCurrentThread(JavaVM * javaVM)
 done:
 	return (jint) result;
 }
-
 
 static UDATA
 protectedInternalAttachCurrentThread(J9PortLibrary* portLibrary, void * userData)
@@ -726,10 +721,10 @@ protectedInternalAttachCurrentThread(J9PortLibrary* portLibrary, void * userData
 		internalReleaseVMAccess(env);
 #endif /* J9VM_INTERP_ATOMIC_FREE_JNI */
 		initializeAttachedThread(
-			env, 
+			env,
 			threadName,
 			threadGroup,
-			(threadType & J9_PRIVATE_FLAGS_DAEMON_THREAD) != 0, 
+			(threadType & J9_PRIVATE_FLAGS_DAEMON_THREAD) != 0,
 			env);
 		j9mem_free_memory(modifiedThreadName);
 		if ((env->currentException != NULL) || (env->threadObject == NULL)) {
@@ -754,8 +749,7 @@ protectedInternalAttachCurrentThread(J9PortLibrary* portLibrary, void * userData
 	return JNI_OK;
 }
 
-
-IDATA 
+IDATA
 internalAttachCurrentThread(J9JavaVM * vm, J9VMThread ** p_env, J9JavaVMAttachArgs * thr_args, UDATA threadType, void * osThread)
 {
 	PORT_ACCESS_FROM_PORT(vm->portLibrary);
@@ -769,9 +763,9 @@ internalAttachCurrentThread(J9JavaVM * vm, J9VMThread ** p_env, J9JavaVMAttachAr
 	args.osThread = osThread;
 
 	if (j9sig_protect(
-		protectedInternalAttachCurrentThread, &args, 
+		protectedInternalAttachCurrentThread, &args,
 		structuredSignalHandlerVM, vm,
-		J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION, 
+		J9PORT_SIG_FLAG_SIGALLSYNC | J9PORT_SIG_FLAG_MAY_CONTINUE_EXECUTION,
 		&result)
 	) {
 		result = JNI_ERR;
@@ -784,7 +778,7 @@ static J9ThreadEnv threadEnv = {
 		omrthread_get_priority,
 		omrthread_set_priority,
 		omrthread_self,
-		(uintptr_t * (*)(const char *))omrthread_global, /* the cast here is temporary */
+		omrthread_global,
 		omrthread_attach,
 		omrthread_sleep,
 		omrthread_create,
@@ -803,7 +797,6 @@ static J9ThreadEnv threadEnv = {
 		omrthread_tls_alloc,
 		omrthread_tls_free
 };
-
 
 /**
  * JVMTI_VERSION_1_0 		0x30010000
@@ -852,15 +845,15 @@ jint JNICALL GetEnv(JavaVM *jvm, void **penv, jint version)
 	}
 
 	if (version == UTE_VERSION_1_1) {
-		if (vm->j9rasGlobalStorage != NULL) {	
+		if (vm->j9rasGlobalStorage != NULL) {
 			*penv = ((RasGlobalStorage *)vm->j9rasGlobalStorage)->utIntf;
-		} 
+		}
 		return *penv == NULL ? JNI_EVERSION : JNI_OK;
 	}
 
 	if (version == JVMRAS_VERSION_1_1 || version == JVMRAS_VERSION_1_3 || version == JVMRAS_VERSION_1_5 ) {
 		PORT_ACCESS_FROM_JAVAVM(vm);
-		if (vm->j9rasGlobalStorage == NULL) {	
+		if (vm->j9rasGlobalStorage == NULL) {
 			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_JVMRI_REQUESTED_WITHOUT_TRACE);
 			return JNI_EINVAL;
 		}
@@ -899,8 +892,7 @@ jint JNICALL GetEnv(JavaVM *jvm, void **penv, jint version)
 	return rc;
 }
 
-
-IDATA 
+IDATA
 attachSystemDaemonThread(J9JavaVM * vm, J9VMThread ** p_env, const char * threadName)
 {
 	J9JavaVMAttachArgs attachArgs;
@@ -915,8 +907,8 @@ attachSystemDaemonThread(J9JavaVM * vm, J9VMThread ** p_env, const char * thread
 	attachArgs.name = threadName;
 	attachArgs.group = vm->systemThreadGroupRef;
 	rc = internalAttachCurrentThread(
-		vm, p_env, &attachArgs, 
-		J9_PRIVATE_FLAGS_SYSTEM_THREAD | J9_PRIVATE_FLAGS_DAEMON_THREAD, 
+		vm, p_env, &attachArgs,
+		J9_PRIVATE_FLAGS_SYSTEM_THREAD | J9_PRIVATE_FLAGS_DAEMON_THREAD,
 		osThread);
 
 	if (rc != JNI_OK) {
@@ -926,10 +918,7 @@ attachSystemDaemonThread(J9JavaVM * vm, J9VMThread ** p_env, const char * thread
 	return rc;
 }
 
-
-
-
-#if (defined(J9VM_OPT_VM_LOCAL_STORAGE)) 
+#if (defined(J9VM_OPT_VM_LOCAL_STORAGE))
 void initializeVMLocalStorage(J9JavaVM * vm)
 {
 	extern J9VMLSFunctionTable J9VMLSFunctions;
@@ -963,8 +952,7 @@ void initializeVMLocalStorage(J9JavaVM * vm)
 
 #endif /* J9VM_OPT_VM_LOCAL_STORAGE */
 
-
-#if (defined(J9VM_OPT_VM_LOCAL_STORAGE)) 
+#if (defined(J9VM_OPT_VM_LOCAL_STORAGE))
 UDATA JNICALL J9VMLSAllocKeys(JNIEnv * env, UDATA * pInitCount, ...)
 {
 	va_list args;
@@ -1010,8 +998,8 @@ UDATA JNICALL J9VMLSAllocKeys(JNIEnv * env, UDATA * pInitCount, ...)
 			*pKey = (void *) key;
 
 			/* Initialize the value of the key to NULL this VM and all other known VMs. VMs which are being created
-			   (i.e. not in the list yet) will have all VMLS values set to NULL already.  The current VM may or may not 
-			   be in the list, which means that the list may be empty.  The global monitor protects the VM list as well 
+			   (i.e. not in the list yet) will have all VMLS values set to NULL already.  The current VM may or may not
+			   be in the list, which means that the list may be empty.  The global monitor protects the VM list as well
 			   as the key list. */
 
 			VM_FROM_ENV(env)->vmLocalStorage[key - 1] = NULL;
@@ -1043,8 +1031,7 @@ UDATA JNICALL J9VMLSAllocKeys(JNIEnv * env, UDATA * pInitCount, ...)
 
 #endif /* J9VM_OPT_VM_LOCAL_STORAGE */
 
-
-#if (defined(J9VM_OPT_VM_LOCAL_STORAGE)) 
+#if (defined(J9VM_OPT_VM_LOCAL_STORAGE))
 void JNICALL J9VMLSFreeKeys(JNIEnv * env, UDATA * pInitCount, ...)
 {
 	va_list args;
@@ -1087,8 +1074,7 @@ void JNICALL J9VMLSFreeKeys(JNIEnv * env, UDATA * pInitCount, ...)
 }
 #endif /* J9VM_OPT_VM_LOCAL_STORAGE */
 
-
-#if (defined(J9VM_OPT_VM_LOCAL_STORAGE)) 
+#if (defined(J9VM_OPT_VM_LOCAL_STORAGE))
 void * JNICALL J9VMLSGet(JNIEnv * env, void * key)
 {
 #ifdef J9VM_OPT_MULTI_VM
@@ -1099,8 +1085,7 @@ void * JNICALL J9VMLSGet(JNIEnv * env, void * key)
 }
 #endif /* J9VM_OPT_VM_LOCAL_STORAGE */
 
-
-#if (defined(J9VM_OPT_VM_LOCAL_STORAGE)) 
+#if (defined(J9VM_OPT_VM_LOCAL_STORAGE))
 void * JNICALL J9VMLSSet(JNIEnv * env, void ** pKey, void * value)
 {
 #ifdef J9VM_OPT_MULTI_VM
@@ -1116,7 +1101,6 @@ jint JNICALL AttachCurrentThreadAsDaemon(JavaVM * vm, void ** p_env, void * thr_
 {
 	return attachCurrentThread(vm, p_env, thr_args, J9_PRIVATE_FLAGS_DAEMON_THREAD);
 }
-
 
 #if defined(J9VM_OPT_SIDECAR)
 /* run the shutdown method in java.lang.Shutdown */
@@ -1138,9 +1122,7 @@ void sidecarShutdown(J9VMThread* shutdownThread) {
 }
 #endif /* defined(J9VM_OPT_SIDECAR) */
 
-
-
-static jint 
+static jint
 attachCurrentThread(JavaVM *vm, void **p_env, void *thr_args, UDATA threadType)
 {
 	omrthread_t osThread = NULL;
@@ -1177,14 +1159,12 @@ attachCurrentThread(JavaVM *vm, void **p_env, void *thr_args, UDATA threadType)
 	return rc;
 }
 
-
 #if defined(J9VM_OPT_SIDECAR)
 jint JNICALL QueryGCStatus(JavaVM *vm, jint *nHeaps, GCStatus *status, jint statusSize)
 {
 	return ((J9JavaVM *)vm)->memoryManagerFunctions->queryGCStatus(vm, nHeaps, status, statusSize);
 }
 #endif /* defined(J9VM_OPT_SIDECAR) */
-
 
 /* kill all remaining threads, except:
  *   1) the current thread
@@ -1241,7 +1221,7 @@ static UDATA terminateRemainingThreads(J9VMThread* vmThread) {
 			}
 		}
 		currentThread = nextThread;
-	} 
+	}
 
 	/* If the disable shutdown flag is set, pretend to have a remaining thread */
 
@@ -1256,8 +1236,6 @@ static UDATA terminateRemainingThreads(J9VMThread* vmThread) {
 
 	return rc;
 }
-
-
 
 static jint verifyCurrentThreadAttached(J9JavaVM * vm, J9VMThread ** pvmThread)
 {
@@ -1288,8 +1266,6 @@ static jint verifyCurrentThreadAttached(J9JavaVM * vm, J9VMThread ** pvmThread)
 	return JNI_OK;
 }
 
-
-
 #if defined(J9VM_OPT_SIDECAR)
 jint JNICALL QueryJavaVM(JavaVM *vm,  jint nQueries, JavaVMQuery *queries)
 {
@@ -1302,7 +1278,7 @@ jint JNICALL ResetJavaVM(JavaVM *vm)
 }
 
 /* run the shutdown method in java.lang.Shutdown */
-void 
+void
 sidecarExit(J9VMThread* shutdownThread) {
 	/* static void java.lang.Shutdown.exit(int status)
 	 *

--- a/runtime/vm/threadhelp.cpp
+++ b/runtime/vm/threadhelp.cpp
@@ -484,7 +484,7 @@ timeCompensationHelper(J9VMThread *vmThread, U_8 threadHelperType, omrthread_mon
 continueTimeCompensation:
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 #if defined(OMR_THR_YIELD_ALG)
-	UDATA parkPolicy = **(UDATA **)omrthread_global((char *)"parkPolicy");
+	UDATA parkPolicy = **(UDATA **)omrthread_global("parkPolicy");
 	if (OMRTHREAD_PARK_POLICY_SLEEP == parkPolicy) {
 		J9JavaVM *vm = vmThread->javaVM;
 		PORT_ACCESS_FROM_JAVAVM(vm);
@@ -515,7 +515,7 @@ continueTimeCompensation:
 							UDATA cpuTimeDelta = currentProcCPUTimes._systemTime + currentProcCPUTimes._userTime - vm->prevProcCPUTime;
 							double util = cpuTimeDelta / timeElapsedAllCores * 100;
 
-							**(UDATA **)omrthread_global((char *)"cpuUtilCache") = (UDATA)util;
+							**(UDATA **)omrthread_global("cpuUtilCache") = (UDATA)util;
 							Trc_VM_timeCompensationHelper_CPU_util(vmThread, numberOfCpus, timeDelta, cpuTimeDelta, util);
 
 							vm->prevProcCPUTime = currentProcCPUTimes._userTime + currentProcCPUTimes._systemTime;

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -401,8 +401,6 @@ fail:
 	return NULL;
 }
 
-
-
 IDATA J9THREAD_PROC javaThreadProc(void *entryarg)
 {
 	J9JavaVM * vm = (J9JavaVM*)entryarg;
@@ -422,15 +420,12 @@ IDATA J9THREAD_PROC javaThreadProc(void *entryarg)
 	return 0;
 }
 
-
-
 #if (defined(J9VM_DBG))
 static void badness(char *description)
 {
 	printf("\n<badness: %s>\n", description);
 }
 #endif /* J9VM_DBG */
-
 
 void OMRNORETURN
 exitJavaThread(J9JavaVM * vm)
@@ -447,7 +442,6 @@ currentVMThread(J9JavaVM *vm)
 {
 	return getVMThreadFromOMRThread(vm, omrthread_self());
 }
-
 
 void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 {
@@ -489,7 +483,6 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 	acquireVMAccess(vmThread);
 	cleanUpAttachedThread(vmThread);
 	releaseVMAccess(vmThread);
-
 
 #if defined(OMR_GC_CONCURRENT_SCAVENGER) && defined(J9VM_ARCH_S390)
 	/* Concurrent scavenge enabled and JIT loaded implies running on supported h/w.
@@ -623,7 +616,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 		UDATA *gtw;
 
 		/* Supply default thread weight, may be overridden below. */
-		gtw = omrthread_global((char*)"thread_weight");
+		gtw = omrthread_global("thread_weight");
 		*gtw = (UDATA)"medium";
 
 		/* different defaults for z/OS */
@@ -646,8 +639,8 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #endif
 
 #if defined(OMR_THR_YIELD_ALG)
-	**(UDATA**)omrthread_global((char*)"yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_SCHED_YIELD;
-	**(UDATA**)omrthread_global((char*)"yieldUsleepMultiplier") = 1;
+	**(UDATA **)omrthread_global("yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_SCHED_YIELD;
+	**(UDATA **)omrthread_global("yieldUsleepMultiplier") = 1;
 #endif /* defined(OMR_THR_YIELD_ALG) */
 
 #if defined(LINUX)
@@ -664,9 +657,9 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 	 */
 	if ('0' == j9util_sched_compat_yield_value(vm)) {
 #if defined(OMR_THR_YIELD_ALG)
-		**(UDATA**)omrthread_global((char*)"yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_INCREASING_USLEEP;
+		**(UDATA **)omrthread_global("yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_INCREASING_USLEEP;
 #if defined(OMR_THR_THREE_TIER_LOCKING)
-		**(UDATA **)omrthread_global((char*)"defaultMonitorSpinCount3") = 270;
+		**(UDATA **)omrthread_global("defaultMonitorSpinCount3") = 270;
 #endif /* defined(OMR_THR_THREE_TIER_LOCKING) */
 		vm->thrMaxYieldsBeforeBlocking = 270;
 		vm->thrMaxTryEnterYieldsBeforeBlocking = 270;
@@ -695,18 +688,18 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #endif
 
 #if defined(OMR_THR_ADAPTIVE_SPIN)
-	*(UDATA*)omrthread_global((char*)"adaptSpinHoldtimeEnable")=1;
-	*(UDATA*)omrthread_global((char*)"adaptSpinSlowPercentEnable")=1;
-	**(UDATA**)omrthread_global((char*)"adaptSpinHoldtime")=1000000;
-	**(UDATA**)omrthread_global((char*)"adaptSpinSlowPercent")=10;
-	**(UDATA**)omrthread_global((char*)"adaptSpinSampleThreshold")=1000;
-	**(UDATA**)omrthread_global((char*)"adaptSpinSampleStopCount")=10;
-	**(UDATA**)omrthread_global((char*)"adaptSpinSampleCountStopRatio")=150;
+	*(UDATA *)omrthread_global("adaptSpinHoldtimeEnable") = 1;
+	*(UDATA *)omrthread_global("adaptSpinSlowPercentEnable") = 1;
+	**(UDATA **)omrthread_global("adaptSpinHoldtime") = 1000000;
+	**(UDATA **)omrthread_global("adaptSpinSlowPercent") = 10;
+	**(UDATA **)omrthread_global("adaptSpinSampleThreshold") = 1000;
+	**(UDATA **)omrthread_global("adaptSpinSampleStopCount") = 10;
+	**(UDATA **)omrthread_global("adaptSpinSampleCountStopRatio") = 150;
 	omrthread_lib_set_flags(J9THREAD_LIB_FLAG_ADAPTIVE_SPIN_KEEP_SAMPLING);
 #if defined(J9VM_INTERP_CUSTOM_SPIN_OPTIONS)
 #if defined(OMR_THR_CUSTOM_SPIN_OPTIONS)
 	/* Handle allocation and initialization of JLM tracing data structures for class-specific spin parameters */
-	*(UDATA*)omrthread_global((char*)"customAdaptSpinEnabled") = customAdaptSpinEnabled;
+	*(UDATA *)omrthread_global("customAdaptSpinEnabled") = customAdaptSpinEnabled;
 #endif /* OMR_THR_CUSTOM_SPIN_OPTIONS */
 #endif /* J9VM_INTERP_CUSTOM_SPIN_OPTIONS */
 #endif /* OMR_THR_ADAPTIVE_SPIN */
@@ -714,7 +707,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #if defined(OMR_THR_THREE_TIER_LOCKING)
 	/* There is no advantage from spinning when running on a single processor. */
 	if (cpus <= 1) {
-		**(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount1") = 1;
+		**(UDATA **)omrthread_global("defaultMonitorSpinCount1") = 1;
 	}
 	omrthread_lib_clear_flags(J9THREAD_LIB_FLAG_SECONDARY_SPIN_OBJECT_MONITORS_ENABLED | J9THREAD_LIB_FLAG_FAST_NOTIFY);
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
@@ -731,35 +724,33 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 		} else {
 			maxSpinThreadsLocal = cpus/4;
 		}
-		**(UDATA**)omrthread_global((char*)"maxSpinThreads") = maxSpinThreadsLocal;
+		**(UDATA **)omrthread_global("maxSpinThreads") = maxSpinThreadsLocal;
 	}
-	**(UDATA**)omrthread_global((char*)"maxWakeThreads") = OMRTHREAD_MINIMUM_WAKE_THREADS;
+	**(UDATA **)omrthread_global("maxWakeThreads") = OMRTHREAD_MINIMUM_WAKE_THREADS;
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
 #endif /* defined(OMR_THR_THREE_TIER_LOCKING) */
 
-
 #if defined(OMR_THR_YIELD_ALG)
 #if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390)
-	**(UDATA **)omrthread_global((char *)"parkPolicy") = OMRTHREAD_PARK_POLICY_SLEEP;
+	**(UDATA **)omrthread_global("parkPolicy") = OMRTHREAD_PARK_POLICY_SLEEP;
 #else /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) */
-	**(UDATA **)omrthread_global((char *)"parkPolicy") = OMRTHREAD_PARK_POLICY_NONE;
+	**(UDATA **)omrthread_global("parkPolicy") = OMRTHREAD_PARK_POLICY_NONE;
 #endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) */
-	**(UDATA **)omrthread_global((char *)"parkSleepMultiplier") = 0;
-	**(UDATA **)omrthread_global((char *)"parkSpinCount") = 0;
-	**(UDATA **)omrthread_global((char *)"parkSleepCount") = 2;
-
+	**(UDATA **)omrthread_global("parkSleepMultiplier") = 0;
+	**(UDATA **)omrthread_global("parkSpinCount") = 0;
+	**(UDATA **)omrthread_global("parkSleepCount") = 2;
 #if defined(J9VM_ARCH_POWER)
-	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 99;
-	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 400;
+	**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = 99;
+	**(UDATA **)omrthread_global("parkSleepTime") = 400;
 #elif defined(J9VM_ARCH_X86) /* defined(OMR_ARCH_POWER) */
-	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 80;
-	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 400;
+	**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = 80;
+	**(UDATA **)omrthread_global("parkSleepTime") = 400;
 #elif defined(J9VM_ARCH_S390) /* defined(OMR_ARCH_X86) */
-	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 99;
-	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 100;
+	**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = 99;
+	**(UDATA **)omrthread_global("parkSleepTime") = 100;
 #else /* defined(J9VM_ARCH_S390) */
-	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 100;
-	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 0;
+	**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = 100;
+	**(UDATA **)omrthread_global("parkSleepTime") = 0;
 #endif /* defined(J9VM_ARCH_POWER) */
 
 	vm->cpuUtilCacheInterval = 5;
@@ -776,7 +767,6 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 
 		/* ignore separators */
 		try_scan(&scan_start, ",");
-
 
 #if defined(J9VM_GC_REALTIME)
 		{
@@ -859,7 +849,6 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
-
 		if (try_scan(&scan_start, "staggerStep=")) {
 			if (scan_udata(&scan_start, &vm->thrStaggerStep)) {
 				goto _error;
@@ -912,7 +901,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &maxSpinThreads)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"maxSpinThreads") = maxSpinThreads;
+			**(UDATA **)omrthread_global("maxSpinThreads") = maxSpinThreads;
 			continue;
 		}
 		if (try_scan(&scan_start, "maxWakeThreads=")) {
@@ -923,7 +912,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (maxWakeThreads < OMRTHREAD_MINIMUM_WAKE_THREADS) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"maxWakeThreads") = maxWakeThreads;
+			**(UDATA **)omrthread_global("maxWakeThreads") = maxWakeThreads;
 			continue;
 		}
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
@@ -935,7 +924,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 				if (0 == spinCount) {
 					goto _error;
 				}
-				**(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount1") = spinCount;
+				**(UDATA **)omrthread_global("defaultMonitorSpinCount1") = spinCount;
 				continue;
 		}
 		if (try_scan(&scan_start, "threeTierSpinCount2=")) {
@@ -946,7 +935,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 				if (0 == spinCount) {
 					goto _error;
 				}
-				**(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount2") = spinCount;
+				**(UDATA **)omrthread_global("defaultMonitorSpinCount2") = spinCount;
 				continue;
 		}
 		if (try_scan(&scan_start, "threeTierSpinCount3=")) {
@@ -957,7 +946,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 				if (0 == spinCount) {
 					goto _error;
 				}
-				**(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount3") = spinCount;
+				**(UDATA **)omrthread_global("defaultMonitorSpinCount3") = spinCount;
 				continue;
 		}
 #endif /* defined(OMR_THR_THREE_TIER_LOCKING) */
@@ -965,12 +954,12 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 		if (try_scan(&scan_start, "minimizeUserCPU")) {
 			initMinCPUSpinCounts(vm);
 #ifdef OMR_THR_ADAPTIVE_SPIN
-			*(UDATA*)omrthread_global((char*)"adaptSpinHoldtimeEnable") = 0;
-			*(UDATA*)omrthread_global((char*)"adaptSpinSlowPercentEnable") = 0;
+			*(UDATA *)omrthread_global("adaptSpinHoldtimeEnable") = 0;
+			*(UDATA *)omrthread_global("adaptSpinSlowPercentEnable") = 0;
 #endif
 
 #if defined(OMR_THR_YIELD_ALG)
-			**(UDATA**)omrthread_global((char*)"yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_SCHED_YIELD;
+			**(UDATA **)omrthread_global("yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_SCHED_YIELD;
 #endif /* defined(OMR_THR_YIELD_ALG) */
 			continue;
 		}
@@ -982,7 +971,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 				if (scan_hex(&scan_start, &clockSkewHi)) {
 					goto _error;
 				}
-				*omrthread_global((char*)"clockSkewHi") = clockSkewHi;
+				*omrthread_global("clockSkewHi") = clockSkewHi;
 				continue;
 		}
 #endif
@@ -1147,7 +1136,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 
 #if defined(OMR_THR_CUSTOM_SPIN_OPTIONS)
 #if defined(OMR_THR_ADAPTIVE_SPIN)
-			*(UDATA*)omrthread_global((char*)"customAdaptSpinEnabled") = customAdaptSpinEnabled;
+			*(UDATA *)omrthread_global("customAdaptSpinEnabled") = customAdaptSpinEnabled;
 #endif /* OMR_THR_ADAPTIVE_SPIN */
 #endif /* OMR_THR_CUSTOM_SPIN_OPTIONS */
 			continue;
@@ -1160,8 +1149,8 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &adaptSpinHoldtime)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"adaptSpinHoldtime") = adaptSpinHoldtime;
-			*(UDATA*)omrthread_global((char*)"adaptSpinHoldtimeEnable") = (0 != adaptSpinHoldtime);
+			**(UDATA **)omrthread_global("adaptSpinHoldtime") = adaptSpinHoldtime;
+			*(UDATA *)omrthread_global("adaptSpinHoldtimeEnable") = (0 != adaptSpinHoldtime);
 			continue;
 		}
 
@@ -1170,8 +1159,8 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &adaptSpinSlowPercent)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"adaptSpinSlowPercent") = adaptSpinSlowPercent;
-			*(UDATA*)omrthread_global((char*)"adaptSpinSlowPercentEnable") = (0 != adaptSpinSlowPercent);
+			**(UDATA **)omrthread_global("adaptSpinSlowPercent") = adaptSpinSlowPercent;
+			*(UDATA *)omrthread_global("adaptSpinSlowPercentEnable") = (0 != adaptSpinSlowPercent);
 			continue;
 		}
 
@@ -1180,7 +1169,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &adaptSpinSampleThreshold)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"adaptSpinSampleThreshold") = adaptSpinSampleThreshold;
+			**(UDATA **)omrthread_global("adaptSpinSampleThreshold") = adaptSpinSampleThreshold;
 			continue;
 		}
 
@@ -1189,7 +1178,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &adaptSpinSampleStopCount)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"adaptSpinSampleStopCount") = adaptSpinSampleStopCount;
+			**(UDATA **)omrthread_global("adaptSpinSampleStopCount") = adaptSpinSampleStopCount;
 			continue;
 		}
 
@@ -1198,7 +1187,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &adaptSpinSampleCountStopRatio)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"adaptSpinSampleCountStopRatio") = adaptSpinSampleCountStopRatio;
+			**(UDATA **)omrthread_global("adaptSpinSampleCountStopRatio") = adaptSpinSampleCountStopRatio;
 			continue;
 		}
 
@@ -1213,14 +1202,14 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 		}
 
 		if (try_scan(&scan_start, "adaptSpin")) {
-			*(UDATA*)omrthread_global((char*)"adaptSpinHoldtimeEnable") = 1;
-			*(UDATA*)omrthread_global((char*)"adaptSpinSlowPercentEnable") = 1;
+			*(UDATA *)omrthread_global("adaptSpinHoldtimeEnable") = 1;
+			*(UDATA *)omrthread_global("adaptSpinSlowPercentEnable") = 1;
 			continue;
 		}
 
 		if (try_scan(&scan_start, "noAdaptSpin")) {
-			*(UDATA*)omrthread_global((char*)"adaptSpinHoldtimeEnable") = 0;
-			*(UDATA*)omrthread_global((char*)"adaptSpinSlowPercentEnable") = 0;
+			*(UDATA *)omrthread_global("adaptSpinHoldtimeEnable") = 0;
+			*(UDATA *)omrthread_global("adaptSpinSlowPercentEnable") = 0;
 			continue;
 		}
 #endif
@@ -1253,7 +1242,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &yieldAlgorithm)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"yieldAlgorithm") = yieldAlgorithm;
+			**(UDATA **)omrthread_global("yieldAlgorithm") = yieldAlgorithm;
 			continue;
 		}
 
@@ -1262,7 +1251,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &yieldUsleepMultiplier)) {
 				goto _error;
 			}
-			**(UDATA**)omrthread_global((char*)"yieldUsleepMultiplier") = yieldUsleepMultiplier;
+			**(UDATA **)omrthread_global("yieldUsleepMultiplier") = yieldUsleepMultiplier;
 			continue;
 		}
 
@@ -1271,25 +1260,24 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			/* Use yield algorithm for CFS systems.
 			 * We set the algorithm again here so that the last argument wins.
 			 */
-			**(UDATA**)omrthread_global((char*)"yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_INCREASING_USLEEP;
+			**(UDATA **)omrthread_global("yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_INCREASING_USLEEP;
 			continue;
 		}
 
 		if (try_scan(&scan_start, "noCfsYield")) {
 			/* use pthread yield */
-			**(UDATA**)omrthread_global((char*)"yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_SCHED_YIELD;
+			**(UDATA **)omrthread_global("yieldAlgorithm") = J9THREAD_LIB_YIELD_ALGORITHM_SCHED_YIELD;
 			initMinCPUSpinCounts(vm);
 			continue;
 		}
 
 #endif /* defined(OMR_THR_YIELD_ALG) */
 
-
 #if defined(J9ZOS390)
 		if (try_scan(&scan_start, "tw=")) {
 			char *old_scan_start = scan_start; /* for error handling */
 			char *tw = scan_to_delim(PORTLIB, &scan_start, ',');
-			UDATA *gtw = omrthread_global((char*)"thread_weight");
+			UDATA *gtw = omrthread_global("thread_weight");
 			if (tw && !strcmp(tw, "HEAVY")) {
 				tw = "heavy";
 			} else if (tw && (!strcmp(tw, "MEDIUM") || !strcmp(tw, "NATIVE") || !strcmp(tw, "native") || !strcmp(tw, ""))) {
@@ -1332,7 +1320,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &parkPolicy)) {
 				goto _error;
 			}
-			**(UDATA **)omrthread_global((char *)"parkPolicy") = parkPolicy;
+			**(UDATA **)omrthread_global("parkPolicy") = parkPolicy;
 			continue;
 		}
 
@@ -1341,7 +1329,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &parkSleepMultiplier)) {
 				goto _error;
 			}
-			**(UDATA **)omrthread_global((char *)"parkSleepMultiplier") = parkSleepMultiplier;
+			**(UDATA **)omrthread_global("parkSleepMultiplier") = parkSleepMultiplier;
 			continue;
 		}
 
@@ -1350,7 +1338,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &parkSleepTime)) {
 				goto _error;
 			}
-			**(UDATA **)omrthread_global((char *)"parkSleepTime") = parkSleepTime;
+			**(UDATA **)omrthread_global("parkSleepTime") = parkSleepTime;
 			continue;
 		}
 
@@ -1359,7 +1347,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &parkSpinCount)) {
 				goto _error;
 			}
-			**(UDATA **)omrthread_global((char *)"parkSpinCount") = parkSpinCount;
+			**(UDATA **)omrthread_global("parkSpinCount") = parkSpinCount;
 			continue;
 		}
 
@@ -1368,7 +1356,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &parkSleepCount)) {
 				goto _error;
 			}
-			**(UDATA **)omrthread_global((char *)"parkSleepCount") = parkSleepCount;
+			**(UDATA **)omrthread_global("parkSleepCount") = parkSleepCount;
 			continue;
 		}
 
@@ -1386,7 +1374,7 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 			if (scan_udata(&scan_start, &threshold)) {
 				goto _error;
 			}
-			**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = threshold;
+			**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = threshold;
 			continue;
 		}
 #endif /* defined(OMR_THR_YIELD_ALG) */
@@ -1409,9 +1397,9 @@ static void
 initMinCPUSpinCounts(J9JavaVM *vm)
 {
 #if defined(OMR_THR_THREE_TIER_LOCKING)
-	**(UDATA **)omrthread_global((char*)"defaultMonitorSpinCount1") = 1;
-	**(UDATA **)omrthread_global((char*)"defaultMonitorSpinCount2") = 1;
-	**(UDATA **)omrthread_global((char*)"defaultMonitorSpinCount3") = 1;
+	**(UDATA **)omrthread_global("defaultMonitorSpinCount1") = 1;
+	**(UDATA **)omrthread_global("defaultMonitorSpinCount2") = 1;
+	**(UDATA **)omrthread_global("defaultMonitorSpinCount3") = 1;
 #endif /* defined(OMR_THR_THREE_TIER_LOCKING) */
 
 	/* In ObjectMonitor.cpp:objectMonitorEnterNonBlocking, we converted
@@ -1480,7 +1468,6 @@ dumpThreadingInfo(J9JavaVM* jvm)
 	j9mem_free_memory(envbuf);
 #endif
 
-
 	j9tty_printf(PORTLIB, "-Xthr:\n");
 	j9tty_printf(PORTLIB, LEADING_SPACE "staggerMax=%zu,\n", jvm->thrStaggerMax);
 	j9tty_printf(PORTLIB, LEADING_SPACE "staggerStep=%zu,\n", jvm->thrStaggerStep);
@@ -1502,22 +1489,22 @@ dumpThreadingInfo(J9JavaVM* jvm)
 		(jvm->thrDeflationPolicy == J9VM_DEFLATION_POLICY_NEVER) ? "never" : "smart");
 #if defined(OMR_THR_THREE_TIER_LOCKING)
 	j9tty_printf(PORTLIB, ",\n");
-	j9tty_printf(PORTLIB, LEADING_SPACE "threeTierSpinCount1=%zu,\n", **(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount1"));
-	j9tty_printf(PORTLIB, LEADING_SPACE "threeTierSpinCount2=%zu,\n", **(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount2"));
-	j9tty_printf(PORTLIB, LEADING_SPACE "threeTierSpinCount3=%zu,\n", **(UDATA**)omrthread_global((char*)"defaultMonitorSpinCount3"));
+	j9tty_printf(PORTLIB, LEADING_SPACE "threeTierSpinCount1=%zu,\n", **(UDATA **)omrthread_global("defaultMonitorSpinCount1"));
+	j9tty_printf(PORTLIB, LEADING_SPACE "threeTierSpinCount2=%zu,\n", **(UDATA **)omrthread_global("defaultMonitorSpinCount2"));
+	j9tty_printf(PORTLIB, LEADING_SPACE "threeTierSpinCount3=%zu,\n", **(UDATA **)omrthread_global("defaultMonitorSpinCount3"));
 	j9tty_printf(PORTLIB, LEADING_SPACE "%sastNotify", J9_ARE_ALL_BITS_SET(omrthread_lib_get_flags(), J9THREAD_LIB_FLAG_FAST_NOTIFY) ? "f" : "noF");
 #if defined(OMR_THR_SPIN_WAKE_CONTROL)
-	j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "maxSpinThreads=%zu,\n", **(UDATA**)omrthread_global((char*)"maxSpinThreads"));
-	j9tty_printf(PORTLIB, LEADING_SPACE "maxWakeThreads=%zu", **(UDATA**)omrthread_global((char*)"maxWakeThreads"));
+	j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "maxSpinThreads=%zu,\n", **(UDATA **)omrthread_global("maxSpinThreads"));
+	j9tty_printf(PORTLIB, LEADING_SPACE "maxWakeThreads=%zu", **(UDATA **)omrthread_global("maxWakeThreads"));
 #endif /* defined(OMR_THR_SPIN_WAKE_CONTROL) */
 #endif /* defined(OMR_THR_THREE_TIER_LOCKING) */
 #ifdef OMR_THR_JLM_HOLD_TIMES
 	j9tty_printf(PORTLIB, ",\n");
-	j9tty_printf(PORTLIB, LEADING_SPACE "clockSkewHi=0x%zx", *omrthread_global((char*)"clockSkewHi") );
+	j9tty_printf(PORTLIB, LEADING_SPACE "clockSkewHi=0x%zx", *omrthread_global("clockSkewHi") );
 #endif
 #ifdef J9ZOS390
 	{
-		char* pThreadWeight = *((char**)omrthread_global((char*)"thread_weight"));
+		const char *pThreadWeight = *((const char **)omrthread_global("thread_weight"));
 		if (NULL != pThreadWeight) {
 			j9tty_printf(PORTLIB, ",\n");
 			j9tty_printf(PORTLIB, LEADING_SPACE "tw=%s", pThreadWeight);
@@ -1536,13 +1523,13 @@ dumpThreadingInfo(J9JavaVM* jvm)
 #endif /* defined(OMR_THR_THREE_TIER_LOCKING) */
 
 #ifdef OMR_THR_ADAPTIVE_SPIN
-	if ((0 != *(UDATA*)omrthread_global((char*)"adaptSpinHoldtimeEnable")) || (0 != *(UDATA*)omrthread_global((char*)"adaptSpinSlowPercentEnable"))) {
+	if ((0 != *(UDATA *)omrthread_global("adaptSpinHoldtimeEnable")) || (0 != *(UDATA *)omrthread_global("adaptSpinSlowPercentEnable"))) {
 		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpin");
-		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinHoldtime=%zu", **(UDATA**)omrthread_global((char*)"adaptSpinHoldtime"));
-		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSlowPercent=%zu", **(UDATA**)omrthread_global((char*)"adaptSpinSlowPercent"));
-		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSampleThreshold=%zu",**(UDATA**)omrthread_global((char*)"adaptSpinSampleThreshold"));
-		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSampleStopCount=%zu",**(UDATA**)omrthread_global((char*)"adaptSpinSampleStopCount"));
-		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSampleCountStopRatio=%zu",**(UDATA**)omrthread_global((char*)"adaptSpinSampleCountStopRatio"));
+		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinHoldtime=%zu", **(UDATA **)omrthread_global("adaptSpinHoldtime"));
+		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSlowPercent=%zu", **(UDATA **)omrthread_global("adaptSpinSlowPercent"));
+		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSampleThreshold=%zu",**(UDATA **)omrthread_global("adaptSpinSampleThreshold"));
+		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSampleStopCount=%zu",**(UDATA **)omrthread_global("adaptSpinSampleStopCount"));
+		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpinSampleCountStopRatio=%zu",**(UDATA **)omrthread_global("adaptSpinSampleCountStopRatio"));
 		j9tty_printf(PORTLIB, ",\n" LEADING_SPACE "adaptSpin%sKeepSampling",
 			J9_ARE_ALL_BITS_SET(omrthread_lib_get_flags(), J9THREAD_LIB_FLAG_ADAPTIVE_SPIN_KEEP_SAMPLING) ? "" : "No");
 	} else {
@@ -1558,8 +1545,6 @@ dumpThreadingInfo(J9JavaVM* jvm)
 
 	j9tty_printf(PORTLIB, "\n");
 }
-
-
 
 J9JavaStack *
 allocateJavaStack(J9JavaVM * vm, UDATA stackSize, J9JavaStack * previousStack)
@@ -1624,7 +1609,6 @@ allocateJavaStack(J9JavaVM * vm, UDATA stackSize, J9JavaStack * previousStack)
 	return stack;
 }
 
-
 void
 freeJavaStack(J9JavaVM * vm, J9JavaStack * stack)
 {
@@ -1636,7 +1620,6 @@ freeJavaStack(J9JavaVM * vm, J9JavaStack * stack)
 		j9mem_free_memory(stack);
 	}
 }
-
 
 void
 fatalRecursiveStackOverflow(J9VMThread *currentThread)
@@ -1917,7 +1900,6 @@ createCachedOutOfMemoryError(J9VMThread * currentThread, j9object_t threadObject
 	jlOutOfMemoryError = internalFindKnownClass(currentThread, J9VMCONSTANTPOOL_JAVALANGOUTOFMEMORYERROR, J9_FINDKNOWNCLASS_FLAG_INITIALIZE);
 	threadObject = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
 
-
 	outOfMemoryError = gcFuncs->J9AllocateObject(
 		currentThread, jlOutOfMemoryError, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
 	if (outOfMemoryError != NULL) {
@@ -1942,7 +1924,6 @@ createCachedOutOfMemoryError(J9VMThread * currentThread, j9object_t threadObject
 
 	return outOfMemoryError;
 }
-
 
 UDATA
 startJavaThread(J9VMThread * currentThread, j9object_t threadObject, UDATA privateFlags,
@@ -2152,7 +2133,6 @@ startJavaThreadInternal(J9VMThread * currentThread, UDATA privateFlags, UDATA os
 	return J9_THREAD_START_NO_ERROR;
 }
 
-
 #if defined(J9ZOS390)
 /**
  * Set the current exception when omrthread_create() fails with an OS-specific errno.
@@ -2235,9 +2215,6 @@ setFailedToForkThreadException(J9VMThread *currentThread, IDATA retVal, omrthrea
 
 #endif /* !J9ZOS390 */
 
-
-
-
 static UDATA
 javaProtectedThreadProc(J9PortLibrary* portLibrary, void * entryarg)
 {
@@ -2272,8 +2249,6 @@ javaProtectedThreadProc(J9PortLibrary* portLibrary, void * entryarg)
 
 	return 0;
 }
-
-
 
 /*
  * Deadlock detection
@@ -2578,7 +2553,6 @@ getJavaThreadPriority(struct J9JavaVM *vm, J9VMThread* thread )
 	return J9VMJAVALANGTHREAD_PRIORITY(thread, thread->threadObject);
 #endif /* JAVA_SPEC_VERSION >= 19 */
 }
-
 
 /**
  * Perform thread setup before any java code is run on the thread.


### PR DESCRIPTION
Builds upon https://github.com/eclipse-openj9/openj9/pull/23020 and reverts addition of cast from #23020.
In draft mode as this depends on https://github.com/eclipse-omr/omr/pull/8057.