### PR TITLE
JEP500 adds --enable-final-field-mutation/--illegal-final-field-mutation

### DIFF
--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -704,6 +704,10 @@ enum INIT_STAGE {
 #define VMOPT_ILLEGAL_ACCESS "--illegal-access="
 #define VMOPT_ENABLE_NATIVE_ACCESS "--enable-native-access"
 #define VMOPT_ILLEGAL_NATIVE_ACCESS "--illegal-native-access="
+#if JAVA_SPEC_VERSION >= 26
+#define VMOPT_ENABLE_FINAL_FIELD_MUTATION "--enable-final-field-mutation"
+#define VMOPT_ILLEGAL_FINAL_FIELD_MUTATION "--illegal-final-field-mutation="
+#endif /* JAVA_SPEC_VERSION >= 26 */
 
 /* JEP 421: Deprecate Finalization for Removal */
 #define VMOPT_DISABLE_FINALIZATION "--finalization="
@@ -744,6 +748,12 @@ enum INIT_STAGE {
 #define SYSPROP_SUN_MISC_UNSAFE_MEMORY_ACCESS "sun.misc.unsafe.memory.access"
 #endif /* JAVA_SPEC_VERSION >= 23 */
 #define SYSPROP_JDK_MODULE_ILLEGALNATIVEACCESS "jdk.module.illegal.native.access"
+#if JAVA_SPEC_VERSION >= 26
+/* Match the system properties in jdk.internal.module.ModuleBootstrap.decodeEnableFinalFieldMutation(). */
+#define SYSPROP_JDK_MODULE_ENABLE_FINAL_FIELD_MUTATION "jdk.module.enable.final.field.mutation."
+/* Match the system properties in jdk.internal.module.ModuleBootstrap.decodeIllegalFinalFieldMutation(). */
+#define SYSPROP_JDK_MODULE_ILLEGAL_FINAL_FIELD_MUTATION "jdk.module.illegal.final.field.mutation"
+#endif /* JAVA_SPEC_VERSION >= 26 */
 #define JAVA_BASE_MODULE "java.base"
 
 #define SYSPROP_COM_SUN_MANAGEMENT "-Dcom.sun.management."


### PR DESCRIPTION
JEP500 adds `--enable-final-field-mutation`/`--illegal-final-field-mutation`

Use `addPropertiesForOptionWithAssignArg()` to find all `--enable-final-field-mutation` options, `addPropertyForOptionWithEqualsArg()` to find and consume the last `--illegal-final-field-mutation` options.

Passes following tests:
```
java/lang/invoke/unreflect/UnreflectTest.java
java/lang/invoke/VarHandles/accessibility/TestFieldLookupAccessibility.java
java/lang/reflect/AccessibleObject/HiddenClassTest.java
java/lang/reflect/Field/mutateFinals/cli/CommandLineTest.java
java/lang/reflect/Field/mutateFinals/jar/ExecutableJarTest.java
java/lang/reflect/Field/mutateFinals/jni/JNIAttachMutatorTest.java
java/lang/reflect/Field/mutateFinals/modules/Driver.java
java/lang/reflect/Field/mutateFinals/MutateFinalsTest.java
java/lang/reflect/Field/NegativeTest.java
java/lang/reflect/Field/Set.java
java/util/jar/Attributes/NullAndEmptyKeysAndValues.java
java/util/logging/FileHandlerLongLimit.java
```

Related to 
* https://github.com/eclipse-openj9/openj9/issues/22959

Signed-off-by: Jason Feng <fengj@ca.ibm.com>