### PR TITLE
Enable park sleep on zLinux by default

### DIFF
--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -739,22 +739,29 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 
 
 #if defined(OMR_THR_YIELD_ALG)
-#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390)
 	**(UDATA **)omrthread_global((char *)"parkPolicy") = OMRTHREAD_PARK_POLICY_SLEEP;
-#else /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) */
+#else /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) */
 	**(UDATA **)omrthread_global((char *)"parkPolicy") = OMRTHREAD_PARK_POLICY_NONE;
-#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) */
 	**(UDATA **)omrthread_global((char *)"parkSleepMultiplier") = 0;
-	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 400;
 	**(UDATA **)omrthread_global((char *)"parkSpinCount") = 0;
 	**(UDATA **)omrthread_global((char *)"parkSleepCount") = 2;
+
 #if defined(J9VM_ARCH_POWER)
 	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 99;
+	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 400;
 #elif defined(J9VM_ARCH_X86) /* defined(OMR_ARCH_POWER) */
 	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 80;
-#else /* defined(J9VM_ARCH_X86) */
+	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 400;
+#elif defined(J9VM_ARCH_S390) /* defined(OMR_ARCH_X86) */
+	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 99;
+	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 100;
+#else /* defined(J9VM_ARCH_S390) */
 	**(UDATA **)omrthread_global((char *)"parkSleepCpuUtilThreshold") = 100;
+	**(UDATA **)omrthread_global((char *)"parkSleepTime") = 0;
 #endif /* defined(J9VM_ARCH_POWER) */
+
 	vm->cpuUtilCacheInterval = 5;
 #endif /* defined(OMR_THR_YIELD_ALG) */
 


### PR DESCRIPTION
With this configuration, regression on low load is within 2% and improvement on high load is 8-9%.