### PR TITLE
Changes to memory disclaim heuristics

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -889,6 +889,12 @@ public:
    bool              isSwapMemoryDisabled() {return _isSwapMemoryDisabled;}
    void              setIsSwapMemoryDisabled(bool b) {_isSwapMemoryDisabled = b;}
 
+   bool              canDisclaimOnSwap() {return _canDisclaimOnSwap;}
+   void              setCanDisclaimOnSwap(bool b) {_canDisclaimOnSwap = b;}
+
+   bool              canDisclaimOnFile() {return _canDisclaimOnFile;}
+   void              setCanDisclaimOnFile(bool b) {_canDisclaimOnFile = b;}
+
    TR_LinkHead0<TR_ClassHolder> *getListOfClassesToCompile() { return &_classesToCompileList; }
    int32_t getCompilationLag();
    int32_t getCompilationLagUnlocked() { return getCompilationLag(); } // will go away
@@ -1341,6 +1347,8 @@ private:
 #endif
    bool                   _isInShutdownMode;
    bool                   _isSwapMemoryDisabled;
+   bool                   _canDisclaimOnSwap; // true if swap is present, has free space and disclaim is not disabled
+   bool                   _canDisclaimOnFile; // true if /tmp has free space and is mounted on a suitable filesystem
    int32_t                _numCompThreads; // Number of usable compilation threads that does not include the diagnostic thread
    int32_t                _numDiagnosticThreads;
    int32_t                _numAllocatedCompThreads; // Number of allocated compilation threads that does not include the diagnostic thread

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -223,6 +223,7 @@ int32_t J9::Options::_TLHPrefetchStaggeredLineCount = 0;
 int32_t J9::Options::_TLHPrefetchBoundaryLineCount = 0;
 int32_t J9::Options::_TLHPrefetchTLHEndLineCount = 0;
 
+uint32_t J9::Options::_minDiskSpaceForDisclaimMB = 1024; // 1 GB
 int32_t J9::Options::_minTimeBetweenMemoryDisclaims = 500; // ms
 int32_t J9::Options::_mallocTrimPeriod = 0; // seconds; 0 means disabled
 
@@ -1159,6 +1160,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_maxCheckcastProfiledClassTests, 0, "F%d", NOT_IN_SUBSET},
    {"maxOnsiteCacheSlotForInstanceOf=", "R<nnn>\tnumber of onsite cache slots for instanceOf",
       TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_maxOnsiteCacheSlotForInstanceOf, 0, "F%d", NOT_IN_SUBSET},
+   {"minDiskSpaceForDisclaim=",  "M<nnn>\tMinimum available disk space (MB) needed to enable memory disclaim",
+        TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_minDiskSpaceForDisclaimMB, 1024,"F%d", NOT_IN_SUBSET},
    {"minSamplingPeriod=", "R<nnn>\tminimum number of milliseconds between samples for hotness",
         TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_minSamplingPeriod, 0, "P%d", NOT_IN_SUBSET},
    {"minSuperclassArraySize=", "I<nnn>\t set the size of the minimum superclass array size",
@@ -3006,6 +3009,9 @@ J9::Options::disableMemoryDisclaimIfNeeded(J9JITConfig *jitConfig)
    PORT_ACCESS_FROM_JAVAVM(javaVM); // for j9vmem_supported_page_sizes
    OMRPORT_ACCESS_FROM_J9PORT(javaVM->portLibrary); // for omrsysinfo_os_kernel_info
    bool shouldDisableMemoryDisclaim = false;
+   TR::CompilationInfo *compInfo = TR::CompilationInfo::get(jitConfig);
+   compInfo->setCanDisclaimOnSwap(false); // pessimistic
+   compInfo->setCanDisclaimOnFile(false); // pessimistic
 
    // For memory disclaim to work we need the kernel to be at least version 5.4
    struct OMROSKernelInfo kernelInfo = {0};
@@ -3035,59 +3041,62 @@ J9::Options::disableMemoryDisclaimIfNeeded(J9JITConfig *jitConfig)
       }
    if (!shouldDisableMemoryDisclaim)
       {
-      // The backing file for the disclaimed memory is on /tmp.
-      // Do not disclaim if the filesystem for /tmp is tmpfs or ramfs because they use RAM memory.
-      // Also, do not disclaim if /tmp is on nfs because the latency is unpredictable.
-      // In these cases, attempt to disclaim on swap if possible.
-       TR::CompilationInfo *compInfo = TR::CompilationInfo::get(jitConfig);
-       if (TR::Options::getCmdLineOptions()->getOption(TR_DontDisclaimMemoryOnSwap) ||
-          !TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) ||
-          compInfo->isSwapMemoryDisabled())
+      // Check whether disclaiming on swap is possible
+      if (!TR::Options::getCmdLineOptions()->getOption(TR_DontDisclaimMemoryOnSwap) &&
+          !compInfo->isSwapMemoryDisabled())
          {
-         // Disclaim on backing file is preferred (or the only possibility)
-         // TODO: enhance the omr portlib (omrfile_stat/updateJ9FileStat/J9FileStat) to give us the desired information
-         struct statfs statfsbuf;
-         int retVal = statfs("/tmp", &statfsbuf);
-         if (retVal != 0 ||
-            statfsbuf.f_type == TMPFS_MAGIC ||
-            statfsbuf.f_type == RAMFS_MAGIC ||
-            statfsbuf.f_type == NFS_SUPER_MAGIC)
+         // Do we have enough free space?
+         J9MemoryInfo memInfo;
+         if ((omrsysinfo_get_memory_info(&memInfo) == 0) && (memInfo.availSwap >= ((uint64_t)J9::Options::_minDiskSpaceForDisclaimMB << 20)))
             {
-            // Check whether swap is available and whether the user allows the usage of swap.
-            if (TR::Options::getCmdLineOptions()->getOption(TR_DontDisclaimMemoryOnSwap) || compInfo->isSwapMemoryDisabled())
-               {
-               shouldDisableMemoryDisclaim = true;
-               if (TR::Options::getVerboseOption(TR_VerbosePerformance))
-                  {
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "WARNING: Disclaim feature disabled because /tmp is not suitable and swap is not available/allowed");
-                  }
-               TR::Options::getCmdLineOptions()->setOption(TR_PreferSwapForMemoryDisclaim, false);
-               }
-            else
-               {
-               // Force the usage of swap space for disclaiming.
-               TR::Options::getCmdLineOptions()->setOption(TR_PreferSwapForMemoryDisclaim);
-               if (TR::Options::getVerboseOption(TR_VerbosePerformance))
-                  {
-                  TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Memory disclaim will be done on swap because /tmp is not suitable");
-                  }
-               }
+            compInfo->setCanDisclaimOnSwap(true);
             }
          }
-      else // Disclaim on swap is preferred
+      // Check whether disclaiming on a file is possible.
+      // Do not disclaim if the filesystem for /tmp is tmpfs or ramfs because they use RAM memory.
+      // Also, do not disclaim if /tmp is on nfs because the latency is unpredictable.
+      // Also, do not disclaim if there is little available space.
+      // TODO: enhance the omr portlib (omrfile_stat/updateJ9FileStat/J9FileStat) to give us the desired information
+      struct statfs statfsbuf;
+      int retVal = statfs("/tmp", &statfsbuf);
+      if (retVal == 0 &&
+          statfsbuf.f_type != TMPFS_MAGIC &&
+          statfsbuf.f_type != RAMFS_MAGIC &&
+          statfsbuf.f_type != NFS_SUPER_MAGIC &&
+          ((uint64_t)statfsbuf.f_bavail * statfsbuf.f_bsize) >= ((uint64_t)J9::Options::_minDiskSpaceForDisclaimMB << 20)
+         )
          {
-
+         compInfo->setCanDisclaimOnFile(true);
+         if (!compInfo->canDisclaimOnSwap() && TR::Options::getVerboseOption(TR_VerbosePerformance))
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Memory disclaim will be done on /tmp because swap is not suitable");
+            }
+         }
+      else
+         {
+         if (TR::Options::getVerboseOption(TR_VerbosePerformance))
+            {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "WARNING: Disclaim feature disabled because swap and /tmp are not suitable");
+            }
          }
       }
-   if (shouldDisableMemoryDisclaim)
+   if (!compInfo->canDisclaimOnSwap() && !compInfo->canDisclaimOnFile())
       {
       TR::Options::getCmdLineOptions()->setOption(TR_DisableDataCacheDisclaiming);
       TR::Options::getCmdLineOptions()->setOption(TR_DisableIProfilerDataDisclaiming);
       TR::Options::getCmdLineOptions()->setOption(TR_EnableCodeCacheDisclaiming, false);
+      }
+   // SCC disclaiming does not need swap or additional files
+   if (shouldDisableMemoryDisclaim)
+      {
       TR::Options::getCmdLineOptions()->setOption(TR_EnableSharedCacheDisclaiming, false);
       }
    return shouldDisableMemoryDisclaim;
 #else /* if defined(LINUX) */
+   TR::Options::getCmdLineOptions()->setOption(TR_DisableDataCacheDisclaiming);
+   TR::Options::getCmdLineOptions()->setOption(TR_DisableIProfilerDataDisclaiming);
+   TR::Options::getCmdLineOptions()->setOption(TR_EnableCodeCacheDisclaiming, false);
+   TR::Options::getCmdLineOptions()->setOption(TR_EnableSharedCacheDisclaiming, false);
    return true;
 #endif
    }

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -435,6 +435,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _sleepMsBeforeCheckpoint;
 #endif
 
+   static uint32_t _minDiskSpaceForDisclaimMB; // MB
    static int32_t _minTimeBetweenMemoryDisclaims; // ms
    static int32_t _mallocTrimPeriod; // seconds
 

--- a/runtime/compiler/env/PersistentAllocator.cpp
+++ b/runtime/compiler/env/PersistentAllocator.cpp
@@ -705,13 +705,12 @@ PersistentAllocator::disclaimAllSegments()
 #ifdef LINUX
    bool verbose = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance);
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get(_javaVM.jitConfig);
-   bool canDisclaimOnSwap = TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) && !compInfo->isSwapMemoryDisabled();
    j9thread_monitor_enter(_segmentMonitor);
    for (auto segmentIterator = _segments.begin(); segmentIterator != _segments.end(); ++segmentIterator)
       {
       J9MemorySegment &segment = *segmentIterator;
-      if (segment.vmemIdentifier.allocator == OMRPORT_VMEM_RESERVE_USED_MMAP_SHM || // Can disclaim to file
-        ((segment.vmemIdentifier.mode & J9PORT_VMEM_MEMORY_MODE_VIRTUAL) && canDisclaimOnSwap)) // Can disclaim to swap
+      if ((segment.vmemIdentifier.allocator == OMRPORT_VMEM_RESERVE_USED_MMAP_SHM && compInfo->canDisclaimOnFile()) ||
+          ((segment.vmemIdentifier.mode & J9PORT_VMEM_MEMORY_MODE_VIRTUAL) && compInfo->canDisclaimOnSwap()))
          {
          size_t segLength = segment.heapTop - segment.heapBase;
 #ifdef DEBUG_DISCLAIM

--- a/runtime/compiler/runtime/DataCache.hpp
+++ b/runtime/compiler/runtime/DataCache.hpp
@@ -343,7 +343,7 @@ private:
    TR_DataCache *allocateNewDataCache(uint32_t minimumSize);
    uint8_t *allocateDataCacheSpace(uint32_t size); // Made private for data cache reclamation.
    void freeDataCacheList(TR_DataCache *& head);
-   int disclaimSegment(J9MemorySegment *seg, bool canDisclaimOnSwap); // disclaim memory used for the indicated segment
+   int disclaimSegment(J9MemorySegment *seg, bool canDisclaimOnSwap, bool canDisclaimOnFile); // disclaim memory used for the indicated segment
 
    // Added as part of data cache reclamation
    void addToPool(Allocation *);

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -573,7 +573,7 @@ TR_IProfiler::createPersistentAllocator(J9JITConfig *jitConfig)
       PORT_ACCESS_FROM_JITCONFIG(jitConfig);
       memoryType |= MEMORY_TYPE_VIRTUAL; // Force the usage of mmap for allocation
       TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
-      if (!TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) || compInfo->isSwapMemoryDisabled())
+      if (!compInfo->canDisclaimOnSwap())
          {
          memoryType |= MEMORY_TYPE_DISCLAIMABLE_TO_FILE;
          }

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -882,7 +882,7 @@ extern "C"
 
 
 int32_t
-J9::CodeCache::disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap)
+J9::CodeCache::disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap, bool canDisclaimOnFile)
    {
    int32_t disclaimDone = 0;
 

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -105,7 +105,7 @@ public:
    */
    void resetCodeCache();
 
-   int32_t disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap);
+   int32_t disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap, bool canDisclaimOnFile);
 
    private:
    /**

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -436,7 +436,7 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
          // If swap is enabled, we can allocate memory with mmap(MAP_ANOYNMOUS|MAP_PRIVATE) and disclaim to swap
          // If swap is not enabled we can disclaim to a backing file
          TR::CompilationInfo * compInfo = TR::CompilationInfo::get(_jitConfig);
-         if (!TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) || compInfo->isSwapMemoryDisabled())
+         if (!compInfo->canDisclaimOnSwap())
             {
             segmentType |= MEMORY_TYPE_DISCLAIMABLE_TO_FILE;
             }
@@ -828,12 +828,11 @@ J9::CodeCacheManager::disclaimAllCodeCaches()
 
 #ifdef LINUX
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get(_jitConfig);
-   bool canDisclaimOnSwap = TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) && !compInfo->isSwapMemoryDisabled();
 
    CacheListCriticalSection scanCacheList(self());
    for (TR::CodeCache *codeCache = self()->getFirstCodeCache(); codeCache; codeCache = codeCache->next())
       {
-      numDisclaimed += codeCache->disclaim(self(), canDisclaimOnSwap);
+      numDisclaimed += codeCache->disclaim(self(), compInfo->canDisclaimOnSwap(), compInfo->canDisclaimOnFile());
       }
 #endif // LINUX
 


### PR DESCRIPTION
This commit performs the following changes to memory disclaim heuristics:
- The prefered location for disclaimed memory is now swap (used to be /tmp)
- If swap is not available (or disallowed through -Xjit:dontDisclaimMemoryOnSwap) then the JIT will attempt to use /tmp
- Disclaim is avoided if less than 1GB of disk space is available (on swap or /tmp respectively). This threshold can be changed with -Xjit:minDiskSpaceForDisclaim=<NNN> (in MB)