### PR TITLE
Run AIX jdk25+ testing on machine with the 17.1 C++ Runtime

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -278,6 +278,9 @@ ppc64_aix:
       all: 'unset LIBPATH'
     vars:
       all: 'PATH+XLC=/opt/IBM/xlC/16.1.0/bin:/opt/IBM/xlc/16.1.0/bin CC=xlclang CXX=xlclang++'
+  extra_test_labels:
+    25: 'sw.tool.c++runtime.17_1'
+    next: 'sw.tool.c++runtime.17_1'
 #========================================#
 # Linux x86 64bits
 #========================================#


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#22913 to reinstate https://github.com/eclipse-openj9/openj9/pull/22910