### PR TITLE
Initialize fields of J9::Compilation in constructor

### DIFF
--- a/runtime/compiler/compile/Compilation.hpp
+++ b/runtime/compiler/compile/Compilation.hpp
@@ -53,6 +53,8 @@ class OMR_EXTENSIBLE Compilation : public J9::CompilationConnector
          TR::Environment *target
 #if defined(J9VM_OPT_JITSERVER)
          , size_t numPermanentLoaders
+         , bool isRemoteCompilation
+         , JITServer::ServerStream *stream
 #endif
          ) :
       J9::CompilationConnector(
@@ -69,6 +71,8 @@ class OMR_EXTENSIBLE Compilation : public J9::CompilationConnector
          target
 #if defined(J9VM_OPT_JITSERVER)
          , numPermanentLoaders
+         , isRemoteCompilation
+         , stream
 #endif
          )
       {}

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -155,6 +155,8 @@ J9::Compilation::Compilation(int32_t id,
       TR::Environment *target
 #if defined(J9VM_OPT_JITSERVER)
       , size_t numPermanentLoaders
+      , bool isRemoteCompilation
+      , JITServer::ServerStream *stream
 #endif
       )
    : OMR::CompilationConnector(
@@ -200,10 +202,10 @@ J9::Compilation::Compilation(int32_t id,
    _skippedJProfilingBlock(false),
    _reloRuntime(reloRuntime),
 #if defined(J9VM_OPT_JITSERVER)
-   _remoteCompilation(false),
+   _remoteCompilation(isRemoteCompilation),
    _serializedRuntimeAssumptions(getTypedAllocator<SerializedRuntimeAssumption *>(self()->allocator())),
    _clientData(NULL),
-   _stream(NULL),
+   _stream(stream),
    _globalMemory(*::trPersistentMemory, heapMemoryRegion),
    _perClientMemory(_trMemory),
    _methodsRequiringTrampolines(getTypedAllocator<TR_OpaqueMethodBlock *>(self()->allocator())),

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -105,6 +105,8 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
          TR::Environment *target
 #if defined(J9VM_OPT_JITSERVER)
          , size_t numPermanentLoaders
+         , bool isRemoteCompilation
+         , JITServer::ServerStream *stream
 #endif
          );
 

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9300,6 +9300,8 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                &target
 #if defined(J9VM_OPT_JITSERVER)
                , p->_numPermanentLoaders
+               , that->_methodBeingCompiled->isRemoteCompReq()
+               , that->_methodBeingCompiled->_stream
 #endif
                );
 
@@ -9341,21 +9343,9 @@ TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrary *portLib, void * 
                }
             }
 #if defined(J9VM_OPT_JITSERVER)
-         // JITServer TODO: put info in optPlan so that compilation constructor can do this
-         if (that->_methodBeingCompiled->isRemoteCompReq())
+         if (that->_methodBeingCompiled->isOutOfProcessCompReq())
             {
-            compiler->setRemoteCompilation();
-            // Create the KOT by default at the client if it's a remote compilation.
-            // getOrCreateKnownObjectTable() checks if TR_DisableKnownObjectTable is set or not.
-            compiler->getOrCreateKnownObjectTable();
-            }
-         else if (that->_methodBeingCompiled->isOutOfProcessCompReq())
-            {
-            compiler->setOutOfProcessCompilation();
-            // Create the KOT by default at the server as long as it is not disabled at the client.
-            compiler->getOrCreateKnownObjectTable();
             compiler->setClientData(that->getClientData());
-            compiler->setStream(that->_methodBeingCompiled->_stream);
             auto compInfoPTRemote = static_cast<TR::CompilationInfoPerThreadRemote *>(that);
             compiler->setAOTCacheStore(compInfoPTRemote->isAOTCacheStore());
 


### PR DESCRIPTION
Some of the fields of J9::Compilation were initialized immediately after the compilation object was created and not in the constructor. In particular, the field `JITServer::ServerStream *_stream` was initialized after the comp object was created, but it was used in the constructor when adding a new object to the knownObjectTable, and this caused a crash in the jitserver.
This commit rectifies the error by adding the relevant parameters to the J9::Compilation constructor and
initializing the fields that were not initialized. Also, `J9::Compilation::_outOfProcessCompilation` is no longer a static, but a member field initialized in the constructor.

Fixes: #23053