### PR TITLE
Strict static field support fixes

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
@@ -599,19 +599,23 @@ public class LinearDumper implements IClassWalkCallbacks {
 									flags += "J9StaticFieldRefDouble, ";
 								}
 							} else {
-								if (J9JavaAccessFlags.J9StaticFieldRefTypeObject == (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal)) {
+								long refType = (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal);
+								if (refType == J9JavaAccessFlags.J9StaticFieldIsNullRestricted) {
+									refType = J9JavaAccessFlags.J9StaticFieldRefTypeObject;
+								}
+								if (J9JavaAccessFlags.J9StaticFieldRefTypeObject == refType) {
 									flags += "J9StaticFieldRefTypeObject, ";
-								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeBoolean == (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal)) {
+								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeBoolean == refType) {
 									flags += "J9StaticFieldRefTypeBoolean, ";
-								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeByte == (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal)) {
+								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeByte == refType) {
 									flags += "J9StaticFieldRefTypeByte, ";
-								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeChar == (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal)) {
+								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeChar == refType) {
 									flags += "J9StaticFieldRefTypeChar, ";
-								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeShort == (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal)) {
+								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeShort == refType) {
 									flags += "J9StaticFieldRefTypeShort, ";
-								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeIntFloat == (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal)) {
+								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeIntFloat == refType) {
 									flags += "J9StaticFieldRefTypeIntFloat, ";
-								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeLongDouble == (J9JavaAccessFlags.J9StaticFieldRefTypeMask & slotAddressOriginal)) {
+								} else if (J9JavaAccessFlags.J9StaticFieldRefTypeLongDouble == refType) {
 									flags += "J9StaticFieldRefTypeLongDouble, ";
 								}
 							}

--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -2158,7 +2158,11 @@ old_slow_jitResolveStaticFieldImpl(J9VMThread *currentThread, UDATA parmCount, J
 		method = walkState->method;
 		resolveFlags |= J9_RESOLVE_FLAG_FIELD_SETTER;
 	}
-	UDATA field = (UDATA)vm->internalVMFunctions->resolveStaticFieldRef(currentThread, method, ramConstantPool, cpIndex, resolveFlags, NULL);
+	UDATA field = (UDATA)vm->internalVMFunctions->resolveStaticFieldRef(currentThread, method, ramConstantPool, cpIndex, resolveFlags, NULL
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+		, 0
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+	);
 	if ((UDATA)-1 == field) {
 		/* fetch result from floatTemp - stashed there in clinit case */
 		J9RAMStaticFieldRef *fakeRef = (J9RAMStaticFieldRef*)&currentThread->floatTemp1;

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -1316,7 +1316,11 @@ TR::SymbolValidationManager::validateStaticClassFromCPRecord(uint16_t classID, u
          // This relocation may be early enough that the referenced class is
          // loaded but not yet resolved at this index. Try to resolve the field
          // and get the class again.
-         _vmThread->javaVM->internalVMFunctions->resolveStaticFieldRef(_fej9->vmThread(), NULL, beholderCP, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, NULL);
+         _vmThread->javaVM->internalVMFunctions->resolveStaticFieldRef(_fej9->vmThread(), NULL, beholderCP, cpIndex, J9_RESOLVE_FLAG_JIT_COMPILE_TIME, NULL
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+            , 0
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+         );
          clazz = TR_ResolvedJ9Method::getClassOfStaticFromCP(_fej9, beholderCP, cpIndex);
          }
       }

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -213,7 +213,11 @@ initializeStaticField(J9JavaVM* vm, UDATA offset, UDATA resolveFlags)
 	U_32 * cpShapeDescription = J9ROMCLASS_CPSHAPEDESCRIPTION(jclROMClass);
 
 	if (J9CPTYPE_FIELD == J9_CP_TYPE(cpShapeDescription, offset)) {
-		if (NULL == vm->internalVMFunctions->resolveStaticFieldRef(vm->mainThread, NULL, jclConstantPool, offset, resolveFlags, NULL)) {
+		if (NULL == vm->internalVMFunctions->resolveStaticFieldRef(vm->mainThread, NULL, jclConstantPool, offset, resolveFlags, NULL
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+			, 0
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+		)) {
 			if (NULL == J9VMCONSTANTPOOL_CLASSREF_AT(vm, romFieldConstantPool[offset].classRefCPIndex)->value) {
 				Trc_JCL_initializeKnownClasses_ClassRefNotResolvedForStaticFieldRef(vm->mainThread, romFieldConstantPool[offset].classRefCPIndex, offset);
 			} else {
@@ -256,7 +260,11 @@ jint initializeKnownClasses(J9JavaVM* vm, U_32 runtimeFlags)
 				Trc_JCL_initializeKnownClasses_SkippingResolve(vm->mainThread, i, romClassRef, romClassRef->runtimeFlags, runtimeFlags);
 			} else {
 				/* Try resolving as a static fieldref, then as an instance fieldref. */
-				if (NULL != vmFuncs->resolveStaticFieldRef(vm->mainThread, NULL, jclConstantPool, i, J9_RESOLVE_FLAG_NO_THROW_ON_FAIL, NULL)) {
+				if (NULL != vmFuncs->resolveStaticFieldRef(vm->mainThread, NULL, jclConstantPool, i, J9_RESOLVE_FLAG_NO_THROW_ON_FAIL, NULL
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+					, 0
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+				)) {
 					Trc_JCL_initializeKnownClasses_ResolvedStaticFieldRef(vm->mainThread, i, J9RAMSTATICFIELDREF_VALUEADDRESS(staticFieldConstantPool + i));
 				} else if (-1 != vmFuncs->resolveInstanceFieldRef(vm->mainThread, NULL, jclConstantPool, i, J9_RESOLVE_FLAG_NO_THROW_ON_FAIL, NULL)) {
 					Trc_JCL_initializeKnownClasses_ResolvedInstanceFieldRef(vm->mainThread, i, instanceFieldConstantPool[i].valueOffset);

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2530,3 +2530,17 @@ J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_VALUE_CLASS.explanation=Please consult
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_VALUE_CLASS.system_action=The JVM will throw a verification or classloading related exception such as java.lang.ClassFormatError.
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_IN_VALUE_CLASS.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_GET_STRICT_STATIC_NOT_SET=Strict static field is unset before first read.
+# START NON-TRANSLATABLE
+J9NLS_VM_GET_STRICT_STATIC_NOT_SET.explanation=Strict static fields must be set to an initial value before being read.
+J9NLS_VM_GET_STRICT_STATIC_NOT_SET.system_action=The JVM will throw an IllegalStateException.
+J9NLS_VM_GET_STRICT_STATIC_NOT_SET.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+J9NLS_VM_PUT_FINAL_STRICT_STATIC_AFTER_READ=Final strict static field is set after read.
+# START NON-TRANSLATABLE
+J9NLS_VM_PUT_FINAL_STRICT_STATIC_AFTER_READ.explanation=The value of a final strict static field cannot change once it has been read.
+J9NLS_VM_PUT_FINAL_STRICT_STATIC_AFTER_READ.system_action=The JVM will throw an IllegalStateException.
+J9NLS_VM_PUT_FINAL_STRICT_STATIC_AFTER_READ.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE

--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -1278,7 +1278,12 @@ done:
 		 * that we do not use a stale flagsAndClass with non-zero value, as doing so may cause the
 		 * the StaticFieldRefDouble bit check to succeed when it shouldn't.
 		 */
-		return ((UDATA)-1 != valueOffset) && (flagsAndClass > 0);
+		return ((UDATA)-1 != valueOffset) &&
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+			((flagsAndClass & ~J9StaticFieldRefStrictInitFlagsAndClassMask) > 0);
+#else /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+			(flagsAndClass > 0);
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 	}
 
 	/**

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -224,7 +224,7 @@ typedef struct J9ClassLoaderWalkState {
 #define J9_ARRAY_DIMENSION_LIMIT 255
 
 #define J9FLAGSANDCLASS_FROM_CLASSANDFLAGS(classAndFlags) (((classAndFlags) >> J9_REQUIRED_CLASS_SHIFT) | ((classAndFlags) << (sizeof(UDATA) * 8 - J9_REQUIRED_CLASS_SHIFT)))
-#define J9CLASSANDFLAGS_FROM_FLAGSANDCLASS(flagsAndClass) (((flagsAndClass) >> (8 * sizeof(UDATA) - J9_REQUIRED_CLASS_SHIFT)) | ((flagsAndClass) << J9_REQUIRED_CLASS_SHIFT))
+#define J9CLASSANDFLAGS_FROM_FLAGSANDCLASS(flagsAndClass) ((J9StaticFieldRefFlagBits & ((flagsAndClass) >> (8 * sizeof(UDATA) - J9_REQUIRED_CLASS_SHIFT))) | ((flagsAndClass) << J9_REQUIRED_CLASS_SHIFT))
 #define J9RAMSTATICFIELDREF_CLASS(base) ((J9Class *) ((base)->flagsAndClass << J9_REQUIRED_CLASS_SHIFT))
 /* In a resolved J9RAMStaticFieldRef, the high bit of valueOffset is set, so it must be masked when adding valueOffset to the ramStatics address.
  * Note that ~IDATA_MIN has all but the high bit set. */

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -153,7 +153,13 @@
 /* Inform DDR that the static field ref constants support proper narrowing  */
 #define J9PutfieldNarrowing 1
 
-/* static field flags (low 8 bits of flagsAndClass) - low 3 bits are the field type for primitive types */
+/* static field flags (low 7 bits of flagsAndClass) - low 3 bits are the field type for primitive types */
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+#define J9_STATIC_FIELD_REF_TYPE(classAndFlags) \
+	(J9StaticFieldIsNullRestricted ==  (classAndFlags & J9StaticFieldRefTypeMask)) ? 0x0 : (classAndFlags & J9StaticFieldRefTypeMask)
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+#define J9_STATIC_FIELD_REF_TYPE(classAndFlags) (classAndFlags & J9StaticFieldRefTypeMask)
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #define J9StaticFieldRefFlagBits 0xFF
 #define J9StaticFieldRefTypeMask 0x7
 #define J9StaticFieldRefTypeObject 0x0
@@ -185,6 +191,8 @@
 #define J9StaticFieldRefStrictInitWritten 0x80
 #define J9StaticFieldRefStrictInitUnset 0xC0
 #define J9StaticFieldRefStrictInitMask 0xC0
+#define J9StaticFieldRefStrictInitFlagsAndClassMask \
+	((UDATA)J9StaticFieldRefStrictInitMask << (sizeof(UDATA) * 8 - J9_REQUIRED_CLASS_SHIFT))
 #define J9_STATIC_FIELD_STRICT_INIT_IS_UNSET(classAndFlags) \
 		(J9StaticFieldRefStrictInitUnset == ((classAndFlags) & J9StaticFieldRefStrictInitMask))
 #define J9_STATIC_FIELD_STRICT_INIT_WAS_WRITTEN_AND_READ(classAndFlags) \

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5114,7 +5114,11 @@ typedef struct J9InternalVMFunctions {
 	struct J9Method*  ( *resolveStaticSplitMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *ramCP, UDATA splitTableIndex, UDATA resolveFlags) ;
 	struct J9Method*  ( *resolveSpecialMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA cpIndex, UDATA resolveFlags) ;
 	struct J9Method*  ( *resolveSpecialSplitMethodRef)(struct J9VMThread *vmStruct, J9ConstantPool *constantPool, UDATA splitTableIndex, UDATA resolveFlags) ;
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+	void*  ( *resolveStaticFieldRef)(struct J9VMThread *vmStruct, J9Method *method, J9ConstantPool *constantPool, UDATA fieldIndex, UDATA resolveFlags, struct J9ROMFieldShape **resolvedField, UDATA strictInitFlags) ;
+#else /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 	void*  ( *resolveStaticFieldRef)(struct J9VMThread *vmStruct, J9Method *method, J9ConstantPool *constantPool, UDATA fieldIndex, UDATA resolveFlags, struct J9ROMFieldShape **resolvedField) ;
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 	IDATA  ( *resolveInstanceFieldRef)(struct J9VMThread *vmStruct, J9Method *method, J9ConstantPool *constantPool, UDATA fieldIndex, UDATA resolveFlags, struct J9ROMFieldShape **resolvedField) ;
 	struct J9ClassLoader*  ( *allocateClassLoader)(struct J9JavaVM* javaVM) ;
 	void  (JNICALL *internalSendExceptionConstructor)(struct J9VMThread *vmContext, struct J9Class *exceptionClass, j9object_t exception, j9object_t detailMessage, UDATA constructorIndex) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -3187,11 +3187,15 @@ resolveStaticFieldRefInto(J9VMThread *vmStruct, J9Method *method, J9ConstantPool
  * @param cpIndex
  * @param resolveFlags
  * @param **resolvedField
+ * @param strictInitFlags strict field initialization state
  * @return void *
  */
 void *
-resolveStaticFieldRef(J9VMThread *vmStruct, J9Method *method, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags, J9ROMFieldShape **resolvedField);
-
+resolveStaticFieldRef(J9VMThread *vmStruct, J9Method *method, J9ConstantPool *ramCP, UDATA cpIndex, UDATA resolveFlags, J9ROMFieldShape **resolvedField
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+	, UDATA strictInitFlags
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+);
 
 /**
  * @brief

--- a/runtime/vm/BytecodeAction.hpp
+++ b/runtime/vm/BytecodeAction.hpp
@@ -61,7 +61,8 @@ typedef enum {
 	THROW_CRIU_SINGLE_THREAD_MODE,
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 #if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
-	THROW_ILLEGAL_STATE_EXCEPTION,
+	THROW_GET_STRICT_STATIC_NOT_SET,
+	THROW_PUT_STRICT_STATIC_FINAL_AFTER_READ,
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 	/* All values after this line are for the debug interpreter only - add general values above this line */
 	GOTO_EXECUTE_BREAKPOINTED_BYTECODE,

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -3680,7 +3680,9 @@ fail:
 		J9ROMFieldWalkState fieldWalkState = {0};
 		J9ROMFieldShape *field = romFieldsStartDo(romClass, &fieldWalkState);
 		while (NULL != field) {
-			if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccStatic | J9AccStrictInit)) {
+			if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccStatic | J9AccStrictInit)
+				&& J9_ARE_NO_BITS_SET(field->modifiers, J9FieldFlagConstant)
+			) {
 				ramClass->strictStaticFieldCounter += 1;
 			}
 			field = romFieldsNextDo(&fieldWalkState);

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldGenerator.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldGenerator.java
@@ -101,6 +101,11 @@ public class StrictFieldGenerator extends ClassLoader {
         return generateTestPutGetStrictStaticField(className, true, true, false, false);
     }
 
+    public static Class<?> generateTestStrictStaticFieldPutTwice() {
+        String className = "TestStrictStaticFieldPutTwice";
+        return generateTestPutGetStrictStaticField(className, false, true, false, true);
+    }
+
     private static Class<?> generateTestPutGetStrictStaticField(String className, boolean secondField, boolean put1, boolean get, boolean put2) {
         String fieldName = "i";
         String fieldDesc = "I";

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/StrictFieldTests.java
@@ -50,7 +50,8 @@ public class StrictFieldTests {
 	}
 
 	/* If a strict static field in larval state is unset, getstatic throws an exception. */
-	@Test(expectedExceptions = IllegalStateException.class)
+	@Test(expectedExceptions = IllegalStateException.class,
+		expectedExceptionsMessageRegExp = ".*Strict static field is unset before first read.*")
 	static public void testGetStaticInLarvalForUnsetStrictField() throws Throwable {
 		Class<?> c = StrictFieldGenerator.generateTestGetStaticInLarvalForUnsetStrictField();
 		try {
@@ -63,7 +64,8 @@ public class StrictFieldTests {
 	/* If a strict static final field in larval state is set after it has been
 	 * read, an exception is thrown.
 	 */
-	@Test(expectedExceptions = IllegalStateException.class)
+	@Test(expectedExceptions = IllegalStateException.class,
+		expectedExceptionsMessageRegExp = ".*Final strict static field is set after read.*")
 	static public void testPutStaticInLarvalForReadStrictFinalField() throws Throwable {
 		Class<?> c = StrictFieldGenerator.generateTestPutStaticInLarvalForReadStrictFinalField();
 		try {
@@ -101,6 +103,13 @@ public class StrictFieldTests {
 		} catch (ExceptionInInitializerError e) {
 			throw e.getException();
 		}
+	}
+
+	/* Put field twice in a row to ensure field flags are retained. */
+	@Test
+	static public void testStrictStaticFieldPutTwice() throws Throwable {
+		Class<?> c = StrictFieldGenerator.generateTestStrictStaticFieldPutTwice();
+		c.newInstance();
 	}
 
 	/* A strict instance field must be assigned by putfield before invoking an


### PR DESCRIPTION
- support fields set through the ConstantValue attribute
- exclude 8th bit representing null restricted static field from type calculations
- verbose messages for IllegalStateException
- save unset strict field flags for final fields

This fixes more tests in `test/hotspot/jtreg/runtime/valhalla/inlinetypes/verifier/StrictStaticFieldsTest.java`. The final tests require the implementation of notifyStrictStaticAccess.

Related: https://github.com/eclipse-openj9/openj9/issues/21884