### PR TITLE
Code cleanup after knownObjectTable caching

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -632,16 +632,6 @@ handleResponse(JITServer::MessageType response, JITServer::ClientStream *client,
          client->write(response, result, isJL);
          }
          break;
-      case MessageType::VM_getObjectClassInfoFromObjectReferenceLocation:
-         {
-         auto recv = client->getRecvData<uintptr_t>();
-         uintptr_t objectReferenceLocation = std::get<0>(recv);
-         auto ci = fe->getObjectClassInfoFromObjectReferenceLocation(comp, objectReferenceLocation);
-         client->write(response,
-                       ci,
-                       knot->getPointerLocation(ci.knownObjectIndex));
-         }
-         break;
       case MessageType::VM_getObjectClassInfoFromKnotIndex:
          {
          auto recv = client->getRecvData<TR::KnownObjectTable::Index>();

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -653,19 +653,6 @@ public:
    virtual uintptr_t           getStaticReferenceFieldAtAddress(uintptr_t fieldAddress);
    virtual int32_t             getInt32FieldAt(uintptr_t objectPointer, uintptr_t fieldOffset);
 
-   /* Used to contain all information needed for getObjectClassInfoFromObjectReferenceLocation
-    * to create a VPKnownObject constraint.
-    */
-   struct ObjectClassInfo
-      {
-      TR_OpaqueClassBlock *clazz;
-      TR_OpaqueClassBlock *jlClass;
-      bool isFixedJavaLangClass;
-      bool isString;
-      TR::KnownObjectTable::Index knownObjectIndex;
-      };
-   virtual ObjectClassInfo getObjectClassInfoFromObjectReferenceLocation
-                                    (TR::Compilation *comp, uintptr_t objectReferenceLocation);
    virtual TR::KnownObjectTable::ObjectInfo getObjClassInfoFromKnotIndexNoCaching(TR::Compilation *comp, TR::KnownObjectTable::Index knotIndex);
    TR::KnownObjectTable::ObjectInfo getObjClassInfoFromKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index knotIndex);
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -963,19 +963,6 @@ TR_J9ServerVM::getStaticReferenceFieldAtAddress(uintptr_t fieldAddress)
    TR_ASSERT_FATAL(false, "getStaticReferenceFieldAtAddress() should not be called by JITServer");
    }
 
-TR_J9VMBase::ObjectClassInfo
-TR_J9ServerVM::getObjectClassInfoFromObjectReferenceLocation(TR::Compilation *comp, uintptr_t objectReferenceLocation)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getObjectClassInfoFromObjectReferenceLocation,
-                 objectReferenceLocation);
-   auto recv = stream->read<TR_J9VMBase::ObjectClassInfo, uintptr_t *>();
-   TR_J9VMBase::ObjectClassInfo result = std::get<0>(recv);
-   uintptr_t *objectReferenceLocationClient = std::get<1>(recv);
-   comp->getKnownObjectTable()->updateKnownObjectTableAtServer(result.knownObjectIndex, objectReferenceLocationClient);
-   return result;
-   }
-
 TR::KnownObjectTable::ObjectInfo
 TR_J9ServerVM::getObjClassInfoFromKnotIndexNoCaching(TR::Compilation *comp, TR::KnownObjectTable::Index knotIndex)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -113,11 +113,7 @@ public:
    virtual TR_OpaqueClassBlock *getObjectClassFromKnownObjectIndex(TR::Compilation *comp, TR::KnownObjectTable::Index idx) override;
    virtual TR_OpaqueClassBlock *getObjectClassFromKnownObjectIndex(TR::Compilation *comp, TR::KnownObjectTable::Index idx, bool *isJavaLangClass) override;
    virtual uintptr_t getStaticReferenceFieldAtAddress(uintptr_t fieldAddress) override;
-
-   virtual ObjectClassInfo getObjectClassInfoFromObjectReferenceLocation
-                              (TR::Compilation *comp, uintptr_t objectReferenceLocation) override;
    virtual TR::KnownObjectTable::ObjectInfo getObjClassInfoFromKnotIndexNoCaching(TR::Compilation *comp, TR::KnownObjectTable::Index knotIndex) override;
-
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz) override;
    virtual bool hasFinalFieldsInClass(TR_OpaqueClassBlock *clazz) override;
    virtual const char *sampleSignature(TR_OpaqueMethodBlock * aMethod, char *buf, int32_t bufLen, TR_Memory *memory) override;

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -119,7 +119,6 @@ const char *messageNames[] =
    "VM_getObjectClassAt",
    "VM_getObjectClassFromKnownObjectIndex",
    "VM_getObjectClassFromKnownObjectIndexJLClass",
-   "VM_getObjectClassInfoFromObjectReferenceLocation",
    "VM_stackWalkerMaySkipFrames",
    "VM_classInitIsFinished",
    "VM_getClassFromNewArrayType",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -130,7 +130,6 @@ enum MessageType : uint16_t
    VM_getObjectClassAt,
    VM_getObjectClassFromKnownObjectIndex,
    VM_getObjectClassFromKnownObjectIndexJLClass,
-   VM_getObjectClassInfoFromObjectReferenceLocation,
    VM_stackWalkerMaySkipFrames,
    VM_classInitIsFinished,
    VM_getClassFromNewArrayType,


### PR DESCRIPTION
OpenJ9 PR #23012 and omr PRs https://github.com/eclipse-omr/omr/pull/8056 and https://github.com/eclipse-omr/omr/pull/8062 implemented caching for the knownObjectTable.
This PR performs the code cleanup removing unused data structures and functions.