### PR TITLE
Add metadata to allow client to log vectorization

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -215,6 +215,7 @@ J9::Compilation::Compilation(int32_t id,
    _serializationRecords(decltype(_serializationRecords)::allocator_type(heapMemoryRegion)),
    _thunkRecords(decltype(_thunkRecords)::allocator_type(heapMemoryRegion)),
    _numPermanentLoaders(numPermanentLoaders),
+   _vectorApiTransformationPerformed(false),
 #endif /* defined(J9VM_OPT_JITSERVER) */
 #if !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
    _aotMethodDependencies(decltype(_aotMethodDependencies)::allocator_type(heapMemoryRegion)),

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -396,6 +396,9 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    // fails serialization by setting _aotCacheStore to false if we are not ignoring the client's SCC, and otherwise
    // fails the compilation entirely.
    void addThunkRecord(const AOTCacheThunkRecord *record);
+
+   void setVectorApiTransformationPerformed(bool vectorApiTransformationPerformed) { _vectorApiTransformationPerformed = vectorApiTransformationPerformed; }
+   bool getVectorApiTransformationPerformed() const { return _vectorApiTransformationPerformed; }
 #else
    bool isDeserializedAOTMethod() const { return false; }
    bool ignoringLocalSCC() const { return false; }
@@ -642,6 +645,9 @@ private:
    // For the server, the number of permanent loaders the client has specified
    // we must use for this compilation.
    size_t _numPermanentLoaders;
+   // Records whether any vectorization optimizations have taken place
+   // in the compilation.
+   bool _vectorApiTransformationPerformed;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
 #if !defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3965,6 +3965,10 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
          metaData = remoteCompilationEnd(vmThread, compiler, compilee, method, compInfoPT, codeCacheStr, dataCacheStr);
          if (metaData)
             {
+            if (metaData->flags & JIT_METADATA_VECTORIZED_CODE)
+               {
+               TR_VerboseLog::writeLineLocked(TR_Vlog_VECTOR_API, "JITServer processed vector ops");
+               }
             // Must add the runtime assumptions received from the server to the RAT and
             // update the list in the comp object with persistent entries. A pointer to
             // this list will be copied into the metadata

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -691,6 +691,7 @@ TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node, bool verify
                   TR_VerboseLog::writeLine(TR_Vlog_VECTOR_API, "Not vectorizing node since it's used by %s",
                                         node->getOpCode().getName());
                   }
+               comp()->setVectorApiTransformationPerformed(true);
 #endif
                dontVectorizeNode(child);
                }
@@ -1092,6 +1093,7 @@ TR_VectorAPIExpansion::findVectorMethods(TR::Compilation *comp, bool reportFound
                logprintf(trace, log, "%s found Vector API method\n", OPT_DETAILS_VECTOR);
                return true;
                }
+            comp->setVectorApiTransformationPerformed(true);
             }
          }
       }
@@ -1698,6 +1700,7 @@ TR_VectorAPIExpansion::boxChild(TR::TreeTop *treeTop, TR::Node *node, uint32_t i
                                objectType == Vector ? "Vector" : "Mask", bitsLength, TR::DataType::getName(elementType),
                                comp()->signature(), comp()->getHotnessName(comp()->getMethodHotness()), comp()->isDLT() ? "DLT" : "");
       }
+   comp()->setVectorApiTransformationPerformed(true);
 
    return true;
    }
@@ -1809,6 +1812,7 @@ TR_VectorAPIExpansion::unboxNode(TR::Node *parentNode, TR::Node *operand, vapiOb
                                operandObjectType == Vector ? "Vector" : "Mask", bitsLength, TR::DataType::getName(elementType),
                                comp()->signature(), comp()->getHotnessName(comp()->getMethodHotness()), comp()->isDLT() ? "DLT" : "");
       }
+   comp()->setVectorApiTransformationPerformed(true);
 
    return newOperand;
    }
@@ -2637,6 +2641,8 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
                                   opcode.getName(), TR::DataType::getName(opcode.getVectorResultDataType()),
                                   comp->signature(), comp->getHotnessName(comp->getMethodHotness()), comp->isDLT() ? "DLT" : "");
          }
+
+      comp->setVectorApiTransformationPerformed(true);
       }
 
    return node;
@@ -2792,6 +2798,7 @@ TR::Node *TR_VectorAPIExpansion::transformStoreToArray(TR_VectorAPIExpansion *op
                                   opcode.getName(), TR::DataType::getName(opcode.getVectorResultDataType()),
                                   comp->signature(), comp->getHotnessName(comp->getMethodHotness()), comp->isDLT() ? "DLT" : "");
          }
+      comp->setVectorApiTransformationPerformed(true);
       }
 
    return node;
@@ -2994,6 +3001,7 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
             TR_VerboseLog::writeLine(TR_Vlog_VECTOR_API, "Scalarized using %s in %s at %s",
                                      opcode.getName(), comp->signature(), comp->getHotnessName(comp->getMethodHotness()));
             }
+         comp->setVectorApiTransformationPerformed(true);
          }
       }
    else
@@ -3085,6 +3093,7 @@ TR::Node *TR_VectorAPIExpansion::naryIntrinsicHandler(TR_VectorAPIExpansion *opt
                                      opcode.getName(), TR::DataType::getName(opcode.getVectorResultDataType()),
                                      comp->signature(), comp->getHotnessName(comp->getMethodHotness()), comp->isDLT() ? "DLT" : "");
             }
+         comp->setVectorApiTransformationPerformed(true);
 
          }
       }
@@ -3211,6 +3220,7 @@ TR::Node *TR_VectorAPIExpansion::fromBitsCoercedIntrinsicHandler(TR_VectorAPIExp
          {
          TR_VerboseLog::writeLine(TR_Vlog_VECTOR_API, "Scalarized fromBitsCoerced for %s in %s at%s", TR::DataType::getName(elementType), comp->signature(), comp->getHotnessName(comp->getMethodHotness()));
          }
+      comp->setVectorApiTransformationPerformed(true);
       }
    else if (mode == doVectorization)
       {
@@ -3227,6 +3237,7 @@ TR::Node *TR_VectorAPIExpansion::fromBitsCoercedIntrinsicHandler(TR_VectorAPIExp
                                   TR::DataType::getName(ilOpCode.getVectorResultDataType()), comp->signature(),
                                   comp->getHotnessName(comp->getMethodHotness()), comp->isDLT() ? "DLT" : "");
          }
+      comp->setVectorApiTransformationPerformed(true);
       }
 
    return node;

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -399,6 +399,10 @@ class TR_VectorAPIExpansion : public TR::Optimization
             TR_VerboseLog::writeLine(TR_Vlog_VECTOR_API, "VectorLength%d is not implemented in %s at %s %s\n",
                                      vectorLength, comp->signature(), comp->getHotnessName(comp->getMethodHotness()), comp->isDLT() ? "DLT" : "");
             }
+         if (length == TR::NoVectorLength)
+            {
+            comp->setVectorApiTransformationPerformed(true);
+            }
 
          return length;
          }
@@ -1772,6 +1776,10 @@ class TR_VectorAPIExpansion : public TR::Optimization
                                   TR::DataType::getName(opCode.getVectorResultDataType()),
                                   comp->signature(), comp->getHotnessName(comp->getMethodHotness()), comp->isDLT() ? "DLT" : "");
          }
+      if (!result)
+         {
+         comp->setVectorApiTransformationPerformed(true);
+         }
 
       return result;
       }
@@ -1809,6 +1817,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
                                   withMask ? "with Mask" : "",
                                   comp->signature(), comp->getHotnessName(comp->getMethodHotness()), comp->isDLT() ? "DLT" : "");
          }
+      comp->setVectorApiTransformationPerformed(true);
 
       return TR::BadILOp;
       }

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1557,6 +1557,10 @@ createMethodMetaData(
       {
       data->flags |= JIT_METADATA_IS_DESERIALIZED_COMP;
       }
+   if (comp->getVectorApiTransformationPerformed())
+      {
+      data->flags |= JIT_METADATA_VECTORIZED_CODE;
+      }
 #endif
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -801,6 +801,7 @@ typedef struct J9JITExceptionTable {
 #define JIT_METADATA_IS_DESERIALIZED_COMP 0x20
 #define JIT_METADATA_IS_PRECHECKPOINT_COMP 0x40
 #define JIT_METADATA_IS_FSD_COMP 0x80
+#define JIT_METADATA_VECTORIZED_CODE 0x100
 
 typedef struct J9JIT16BitExceptionTableEntry {
 	U_16 startPC;


### PR DESCRIPTION
Fixes https://github.com/eclipse-openj9/openj9/issues/23038

This is the complete design of the fix as described in the issue linked above.

- Create a flag in J9:Compilation called _vectorApiTransformationPerformed and a similar flag in TR_MethodMetaData
- Whenever the JIT issues a "#VECTOR API" verbose log message, set the J9:Compilation::_vectorApiTransformationPerformed flag
- At the end of the compilation, if that flag was set, write it into the metadata.
- The metadata is sent from the server to the client together with the compiled body. This already happens today.
- The client receives the metadata, inspects the flag and issues a single "#VECTOR API" verbose log message