### PR TITLE
(0.57) Changes to memory disclaim heuristics

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -889,6 +889,12 @@ public:
    bool              isSwapMemoryDisabled() {return _isSwapMemoryDisabled;}
    void              setIsSwapMemoryDisabled(bool b) {_isSwapMemoryDisabled = b;}
 
+   bool              canDisclaimOnSwap() {return _canDisclaimOnSwap;}
+   void              setCanDisclaimOnSwap(bool b) {_canDisclaimOnSwap = b;}
+
+   bool              canDisclaimOnFile() {return _canDisclaimOnFile;}
+   void              setCanDisclaimOnFile(bool b) {_canDisclaimOnFile = b;}
+
    TR_LinkHead0<TR_ClassHolder> *getListOfClassesToCompile() { return &_classesToCompileList; }
    int32_t getCompilationLag();
    int32_t getCompilationLagUnlocked() { return getCompilationLag(); } // will go away
@@ -1341,6 +1347,8 @@ private:
 #endif
    bool                   _isInShutdownMode;
    bool                   _isSwapMemoryDisabled;
+   bool                   _canDisclaimOnSwap; // true if swap is present, has free space and disclaim is not disabled
+   bool                   _canDisclaimOnFile; // true if /tmp has free space and is mounted on a suitable filesystem
    int32_t                _numCompThreads; // Number of usable compilation threads that does not include the diagnostic thread
    int32_t                _numDiagnosticThreads;
    int32_t                _numAllocatedCompThreads; // Number of allocated compilation threads that does not include the diagnostic thread

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -434,6 +434,7 @@ class OMR_EXTENSIBLE Options : public OMR::OptionsConnector
    static int32_t _sleepMsBeforeCheckpoint;
 #endif
 
+   static uint32_t _minDiskSpaceForDisclaimMB; // MB
    static int32_t _minTimeBetweenMemoryDisclaims; // ms
    static int32_t _mallocTrimPeriod; // seconds
 

--- a/runtime/compiler/env/PersistentAllocator.cpp
+++ b/runtime/compiler/env/PersistentAllocator.cpp
@@ -705,13 +705,12 @@ PersistentAllocator::disclaimAllSegments()
 #ifdef LINUX
    bool verbose = TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance);
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get(_javaVM.jitConfig);
-   bool canDisclaimOnSwap = TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) && !compInfo->isSwapMemoryDisabled();
    j9thread_monitor_enter(_segmentMonitor);
    for (auto segmentIterator = _segments.begin(); segmentIterator != _segments.end(); ++segmentIterator)
       {
       J9MemorySegment &segment = *segmentIterator;
-      if (segment.vmemIdentifier.allocator == OMRPORT_VMEM_RESERVE_USED_MMAP_SHM || // Can disclaim to file
-        ((segment.vmemIdentifier.mode & J9PORT_VMEM_MEMORY_MODE_VIRTUAL) && canDisclaimOnSwap)) // Can disclaim to swap
+      if ((segment.vmemIdentifier.allocator == OMRPORT_VMEM_RESERVE_USED_MMAP_SHM && compInfo->canDisclaimOnFile()) ||
+          ((segment.vmemIdentifier.mode & J9PORT_VMEM_MEMORY_MODE_VIRTUAL) && compInfo->canDisclaimOnSwap()))
          {
          size_t segLength = segment.heapTop - segment.heapBase;
 #ifdef DEBUG_DISCLAIM

--- a/runtime/compiler/runtime/DataCache.hpp
+++ b/runtime/compiler/runtime/DataCache.hpp
@@ -343,7 +343,7 @@ private:
    TR_DataCache *allocateNewDataCache(uint32_t minimumSize);
    uint8_t *allocateDataCacheSpace(uint32_t size); // Made private for data cache reclamation.
    void freeDataCacheList(TR_DataCache *& head);
-   int disclaimSegment(J9MemorySegment *seg, bool canDisclaimOnSwap); // disclaim memory used for the indicated segment
+   int disclaimSegment(J9MemorySegment *seg, bool canDisclaimOnSwap, bool canDisclaimOnFile); // disclaim memory used for the indicated segment
 
    // Added as part of data cache reclamation
    void addToPool(Allocation *);

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -577,7 +577,7 @@ TR_IProfiler::createPersistentAllocator(J9JITConfig *jitConfig)
       PORT_ACCESS_FROM_JITCONFIG(jitConfig);
       memoryType |= MEMORY_TYPE_VIRTUAL; // Force the usage of mmap for allocation
       TR::CompilationInfo * compInfo = TR::CompilationInfo::get(jitConfig);
-      if (!TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) || compInfo->isSwapMemoryDisabled())
+      if (!compInfo->canDisclaimOnSwap())
          {
          memoryType |= MEMORY_TYPE_DISCLAIMABLE_TO_FILE;
          }

--- a/runtime/compiler/runtime/J9CodeCache.cpp
+++ b/runtime/compiler/runtime/J9CodeCache.cpp
@@ -882,7 +882,7 @@ extern "C"
 
 
 int32_t
-J9::CodeCache::disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap)
+J9::CodeCache::disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap, bool canDisclaimOnFile)
    {
    int32_t disclaimDone = 0;
 

--- a/runtime/compiler/runtime/J9CodeCache.hpp
+++ b/runtime/compiler/runtime/J9CodeCache.hpp
@@ -105,7 +105,7 @@ public:
    */
    void resetCodeCache();
 
-   int32_t disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap);
+   int32_t disclaim(TR::CodeCacheManager *manager, bool canDisclaimOnSwap, bool canDisclaimOnFile);
 
    private:
    /**

--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -436,7 +436,7 @@ J9::CodeCacheManager::allocateCodeCacheSegment(size_t segmentSize,
          // If swap is enabled, we can allocate memory with mmap(MAP_ANOYNMOUS|MAP_PRIVATE) and disclaim to swap
          // If swap is not enabled we can disclaim to a backing file
          TR::CompilationInfo * compInfo = TR::CompilationInfo::get(_jitConfig);
-         if (!TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) || compInfo->isSwapMemoryDisabled())
+         if (!compInfo->canDisclaimOnSwap())
             {
             segmentType |= MEMORY_TYPE_DISCLAIMABLE_TO_FILE;
             }
@@ -828,12 +828,11 @@ J9::CodeCacheManager::disclaimAllCodeCaches()
 
 #ifdef LINUX
    TR::CompilationInfo *compInfo = TR::CompilationInfo::get(_jitConfig);
-   bool canDisclaimOnSwap = TR::Options::getCmdLineOptions()->getOption(TR_PreferSwapForMemoryDisclaim) && !compInfo->isSwapMemoryDisabled();
 
    CacheListCriticalSection scanCacheList(self());
    for (TR::CodeCache *codeCache = self()->getFirstCodeCache(); codeCache; codeCache = codeCache->next())
       {
-      numDisclaimed += codeCache->disclaim(self(), canDisclaimOnSwap);
+      numDisclaimed += codeCache->disclaim(self(), compInfo->canDisclaimOnSwap(), compInfo->canDisclaimOnFile());
       }
 #endif // LINUX
 


### PR DESCRIPTION
This commit performs the following changes to memory disclaim heuristics:
- The prefered location for disclaimed memory is now swap (used to be /tmp)
- If swap is not available (or disallowed through -Xjit:dontDisclaimMemoryOnSwap) then the JIT will attempt to use /tmp
- Disclaim is avoided if less than 1GB of disk space is available (on swap or /tmp respectively). This threshold can be changed with -Xjit:minDiskSpaceForDisclaim=<NNN> (in MB)

Cherry-pick of #23049