### PR TITLE
(0.57) Revert "Java 8 classloader initialization matches 11+ for RCP"

### DIFF
--- a/runtime/vm/VMSnapshotImpl.cpp
+++ b/runtime/vm/VMSnapshotImpl.cpp
@@ -890,9 +890,7 @@ VMSnapshotImpl::saveJ9JavaVMStructures()
 	saveMemorySegments();
 	savePrimitiveAndArrayClasses();
 	saveHiddenInstanceFields();
-#if JAVA_SPEC_VERSION > 8
 	saveModularityData();
-#endif /* JAVA_SPEC_VERSION > 8 */
 	_snapshotHeader->vm = _vm;
 }
 
@@ -909,9 +907,7 @@ VMSnapshotImpl::restoreJ9JavaVMStructures()
 	restoreMemorySegments();
 	restorePrimitiveAndArrayClasses();
 	restoreHiddenInstanceFields();
-#if JAVA_SPEC_VERSION > 8
 	restoreModularityData();
-#endif /* JAVA_SPEC_VERSION > 8 */
 
 	if (J9THREAD_RWMUTEX_OK != omrthread_rwmutex_init(&_vm->systemClassLoader->cpEntriesMutex, 0, "classPathEntries Mutex")) {
 		success = false;

--- a/runtime/vm/VMSnapshotImpl.hpp
+++ b/runtime/vm/VMSnapshotImpl.hpp
@@ -112,10 +112,8 @@ public:
 	void restoreClassLoaderBlocks();
 	void saveMemorySegments();
 	void restoreMemorySegments();
-#if JAVA_SPEC_VERSION > 8
 	void saveModularityData();
 	void restoreModularityData();
-#endif /* JAVA_SPEC_VERSION > 8 */
 
 	bool setupRestoreRun();
 	bool setupSnapshotRun();

--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -1087,7 +1087,6 @@ loadWarmClassFromSnapshotInternal(J9VMThread *vmThread, J9ClassLoader *classLoad
 			}
 		}
 
-#if JAVA_SPEC_VERSION > 8
 		/* TODO: Handle/trace error/NULL paths. */
 		classObject = clazz->classObject;
 		if (NULL != classObject) {
@@ -1102,7 +1101,6 @@ loadWarmClassFromSnapshotInternal(J9VMThread *vmThread, J9ClassLoader *classLoad
 				J9VMJAVALANGCLASS_SET_MODULE(vmThread, classObject, J9VMJAVALANGCLASSLOADER_UNNAMEDMODULE(vmThread, clazz->classLoader->classLoaderObject));
 			}
 		}
-#endif /* JAVA_SPEC_VERSION > 8 */
 
 		Trc_VM_snapshot_loadWarmClassFromSnapshot_ClassInfo(vmThread, clazz, className);
 	}


### PR DESCRIPTION
Revert "Java 8 classloader initialization matches 11+ for RCP"

This reverts commit https://github.com/eclipse-openj9/openj9/commit/e21f221ab20184508026c059b83580fb33056749.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/23068

Signed-off-by: Jason Feng [fengj@ca.ibm.com](mailto:fengj@ca.ibm.com)