### PR TITLE
JDK26+ modifies JVM_VirtualThread method names

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -417,11 +417,22 @@ if(NOT JAVA_SPEC_VERSION LESS 21)
 		JVM_IsContainerized
 		JVM_IsForeignLinkerSupported
 		JVM_PrintWarningAtDynamicAgentLoad
-		JVM_VirtualThreadEnd
-		JVM_VirtualThreadMount
-		JVM_VirtualThreadStart
-		JVM_VirtualThreadUnmount
 	)
+	if(JAVA_SPEC_VERSION LESS 26)
+		jvm_add_exports(jvm
+			JVM_VirtualThreadEnd
+			JVM_VirtualThreadMount
+			JVM_VirtualThreadStart
+			JVM_VirtualThreadUnmount
+		)
+	else()
+		jvm_add_exports(jvm
+			JVM_VirtualThreadEndFirstTransition
+			JVM_VirtualThreadEndTransition
+			JVM_VirtualThreadStartFinalTransition
+			JVM_VirtualThreadStartTransition
+		)
+	endif()
 endif()
 
 if(JAVA_SPEC_VERSION LESS 22)

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -509,7 +509,11 @@ JVM_PrintWarningAtDynamicAgentLoad()
 }
 
 JNIEXPORT void JNICALL
+#if JAVA_SPEC_VERSION >= 26
+JVM_VirtualThreadStartTransition(JNIEnv* env, jobject vthread, jboolean hide)
+#else /* JAVA_SPEC_VERSION >= 26 */
 JVM_VirtualThreadMount(JNIEnv *env, jobject vthread, jboolean hide)
+#endif /* JAVA_SPEC_VERSION >= 26 */
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
@@ -522,7 +526,11 @@ JVM_VirtualThreadMount(JNIEnv *env, jobject vthread, jboolean hide)
 	if (hide) {
 		virtualThreadMountBegin(env, vthread);
 	} else {
+#if JAVA_SPEC_VERSION >= 26
+		virtualThreadUnmountBegin(env, vthread);
+#else /* JAVA_SPEC_VERSION >= 26 */
 		virtualThreadMountEnd(env, vthread);
+#endif /* JAVA_SPEC_VERSION >= 26 */
 	}
 
 	vmFuncs->internalExitVMToJNI(currentThread);
@@ -531,7 +539,11 @@ JVM_VirtualThreadMount(JNIEnv *env, jobject vthread, jboolean hide)
 }
 
 JNIEXPORT void JNICALL
+#if JAVA_SPEC_VERSION >= 26
+JVM_VirtualThreadEndTransition(JNIEnv* env, jobject vthread, jboolean hide)
+#else /* JAVA_SPEC_VERSION >= 26 */
 JVM_VirtualThreadUnmount(JNIEnv *env, jobject vthread, jboolean hide)
+#endif /* JAVA_SPEC_VERSION >= 26 */
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
@@ -542,7 +554,11 @@ JVM_VirtualThreadUnmount(JNIEnv *env, jobject vthread, jboolean hide)
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 
 	if (hide) {
+#if JAVA_SPEC_VERSION >= 26
+		virtualThreadMountEnd(env, vthread);
+#else /* JAVA_SPEC_VERSION >= 26 */
 		virtualThreadUnmountBegin(env, vthread);
+#endif /* JAVA_SPEC_VERSION >= 26 */
 	} else {
 		virtualThreadUnmountEnd(env, vthread);
 	}
@@ -559,7 +575,11 @@ JVM_IsForeignLinkerSupported()
 }
 
 JNIEXPORT void JNICALL
+#if JAVA_SPEC_VERSION >= 26
+JVM_VirtualThreadEndFirstTransition(JNIEnv* env, jobject vthread)
+#else /* JAVA_SPEC_VERSION >= 26 */
 JVM_VirtualThreadStart(JNIEnv *env, jobject vthread)
+#endif /* JAVA_SPEC_VERSION >= 26 */
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
@@ -578,7 +598,11 @@ JVM_VirtualThreadStart(JNIEnv *env, jobject vthread)
 }
 
 JNIEXPORT void JNICALL
+#if JAVA_SPEC_VERSION >= 26
+JVM_VirtualThreadStartFinalTransition(JNIEnv* env, jobject vthread)
+#else /* JAVA_SPEC_VERSION >= 26 */
 JVM_VirtualThreadEnd(JNIEnv *env, jobject vthread)
+#endif /* JAVA_SPEC_VERSION >= 26 */
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -455,13 +455,13 @@ _IF([JAVA_SPEC_VERSION >= 21],
 	[_X(JVM_IsForeignLinkerSupported, JNICALL, false, jboolean, void)])
 _IF([JAVA_SPEC_VERSION >= 21],
 	[_X(JVM_PrintWarningAtDynamicAgentLoad, JNICALL, false, jboolean, void)])
-_IF([JAVA_SPEC_VERSION >= 21],
+_IF([(21 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 26)],
 	[_X(JVM_VirtualThreadEnd, JNICALL, false, void, JNIEnv *env, jobject vthread)])
-_IF([JAVA_SPEC_VERSION >= 21],
+_IF([(21 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 26)],
 	[_X(JVM_VirtualThreadMount, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
-_IF([JAVA_SPEC_VERSION >= 21],
+_IF([(21 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 26)],
 	[_X(JVM_VirtualThreadStart, JNICALL, false, void, JNIEnv *env, jobject vthread)])
-_IF([JAVA_SPEC_VERSION >= 21],
+_IF([(21 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 26)],
 	[_X(JVM_VirtualThreadUnmount, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_CopyOfSpecialArray, JNICALL, false, jarray, JNIEnv *env, jarray orig, jint from, jint to)])
@@ -499,3 +499,11 @@ _IF([JAVA_SPEC_VERSION >= 25],
 	[_X(JVM_CreateThreadSnapshot, JNICALL, false, jobject, JNIEnv *env, jobject thread)])
 _IF([JAVA_SPEC_VERSION >= 25],
 	[_X(JVM_NeedsClassInitBarrierForCDS, JNICALL, false, jboolean, JNIEnv *env, jclass clazz)])
+_IF([JAVA_SPEC_VERSION >= 26],
+	[_X(JVM_VirtualThreadEndFirstTransition, JNICALL, false, void, JNIEnv *env, jobject vthread)])
+_IF([JAVA_SPEC_VERSION >= 26],
+	[_X(JVM_VirtualThreadStartFinalTransition, JNICALL, false, void, JNIEnv *env, jobject vthread)])
+_IF([JAVA_SPEC_VERSION >= 26],
+	[_X(JVM_VirtualThreadStartTransition, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])
+_IF([JAVA_SPEC_VERSION >= 26],
+	[_X(JVM_VirtualThreadEndTransition, JNICALL, false, void, JNIEnv *env, jobject vthread, jboolean hide)])


### PR DESCRIPTION
JDK26+ modifies JVM_VirtualThread method names

This is to adopt upstream update https://github.com/ibmruntimes/openj9-openjdk-jdk26/commit/55ee6e0a61021175514ed65d0b51db82f5eb9eb9.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk26/pull/2

Signed-off-by: Jason Feng <fengj@ca.ibm.com>