### PR TITLE
Add missing JDK8 cp macros

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -277,6 +277,7 @@ final class VMAccess implements VMLangAccess {
 	public boolean getIncludeModuleVersion(StackTraceElement element) {
 		return element.getIncludeModuleVersion();
 	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 
 	/**
 	 * Returns a cached constantPool Object from a given java.lang.Class
@@ -288,5 +289,4 @@ final class VMAccess implements VMLangAccess {
 	public ConstantPool getConstantPoolCache(Class<?> clazz) {
 		return clazz.constantPoolObject;
 	}
-	/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 }

--- a/runtime/oti/vmconstantpool.xml
+++ b/runtime/oti/vmconstantpool.xml
@@ -193,7 +193,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<fieldref class="java/lang/Class" name="reflectCache" signature="Ljava/lang/Class$ReflectCache;"/>
 	<fieldref class="java/lang/Class" name="classLoader" signature="Ljava/lang/ClassLoader;"/>
 	<fieldref class="java/lang/Class" name="vmRef" signature="J" cast="struct J9Class *"/>
-	<fieldref class="java/lang/Class" name="constantPoolObject" signature="Ljdk/internal/reflect/ConstantPool;"/>
+	<fieldref class="java/lang/Class" name="constantPoolObject" signature="Ljdk/internal/reflect/ConstantPool;" versions="11-"/>
+	<fieldref class="java/lang/Class" name="constantPoolObject" signature="Lsun/reflect/ConstantPool;" versions="8"/>
 	<fieldref class="java/lang/Class" name="initializationLock" signature="Ljava/lang/J9VMInternals$ClassInitializationLock;"/>
 	<fieldref class="java/lang/Class" name="protectionDomain" signature="Ljava/security/ProtectionDomain;"/>
 	<fieldref class="java/lang/Class" name="classNameString" signature="Ljava/lang/String;"/>


### PR DESCRIPTION
Addresses compilation failure caused by https://github.com/eclipse-openj9/openj9/pull/22974