### PR TITLE
Handling multiple reserved region lists for numa off-heap case

### DIFF
--- a/runtime/gc_vlhgc/AllocationContextBalanced.cpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.cpp
@@ -384,25 +384,28 @@ MM_AllocationContextBalanced::lockedAllocateArrayletLeaf(MM_EnvironmentBase *env
 	}
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	else {
-		/*
-		 * For now, only a single list of reserved regions owned by the common AC is maintained.
-		 * This is a sub-optimal approach, since due to different order of how regions are reserved and released
-		 * (objects don't die in order they are allocated) it may lead to imbalance of how many regions are committed in each AC.
-		 * In future, allocations should remember (somewhere in Off-heap meta structures) how many regions came from each AC
-		 * \and release exact same number back to each AC.
-		 */
-		MM_AllocationContextTarok *commonContext = (MM_AllocationContextTarok *)env->getCommonAllocationContext();
-		if (this != commonContext) {
-			/* The common allocation context is always an instance of AllocationContextBalanced */
-			((MM_AllocationContextBalanced *)commonContext)->lockCommon();
+		/* TODO: try changing the type of _owningContext/_originalOwningContext to MM_AllocationContextBalanced * */
+		MM_AllocationContextTarok *context = leafAllocateData->_owningContext;
+		if (NULL != leafAllocateData->_originalOwningContext) {
+			context = leafAllocateData->_originalOwningContext;
 		}
 
-		leafAllocateData->pushRegionToArrayReservedRegionList(env, ((MM_AllocationContextBalanced *)commonContext)->getArrayReservedRegionListAddress());
-		((MM_AllocationContextBalanced *)commonContext)->incrementArrayReservedRegionCount();
+		Assert_MM_true(NULL != context);
+		/* set the resulting AC, that might be used from the top level caller */
+		allocateDescription->setAllocationContext(context);
+		if (this != context) {
+			/**
+			 * At this point we hold locks of 2 different ACs. There should be no scenario that another thread attempts to lock these same locks in opposite order,
+			 * since it would not able to successfully steal from us (our AC is already depleted).
+			 */
+			((MM_AllocationContextBalanced *)context)->lockCommon();
+		}
 
-		if (this != commonContext) {
-			/* The common allocation context is always an instance of AllocationContextBalanced */
-			((MM_AllocationContextBalanced *)commonContext)->unlockCommon();
+		leafAllocateData->pushRegionToArrayReservedRegionList(env, ((MM_AllocationContextBalanced *)context)->getArrayReservedRegionListAddress());
+		((MM_AllocationContextBalanced *)context)->incrementArrayReservedRegionCount();
+
+		if (this != context) {
+			((MM_AllocationContextBalanced *)context)->unlockCommon();
 		}
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
@@ -469,6 +472,14 @@ MM_AllocationContextBalanced::allocate(MM_EnvironmentBase *env, MM_ObjectAllocat
 	case MM_MemorySubSpace::ALLOCATION_TYPE_LEAF:
 		result = allocateArrayletLeaf(env, allocateDescription, false);
 		break;
+	case MM_MemorySubSpace::ALLOCATION_TYPE_SHARED_RESERVED:
+		{
+			uintptr_t dataSize = allocateDescription->getBytesRequested() - allocateDescription->getContiguousBytes();
+			uintptr_t regionSize = _heapRegionManager->getRegionSize();
+			uintptr_t fraction = dataSize % regionSize;
+			result = allocateFromSharedReservedRegion(env, allocateDescription, fraction, false);
+		}
+		break;
 	default:
 		Assert_MM_unreachable();
 		break;
@@ -488,6 +499,7 @@ MM_AllocationContextBalanced::lockedAllocate(MM_EnvironmentBase *env, MM_ObjectA
 		result = lockedAllocateTLH(env, allocateDescription, objectAllocationInterface);
 		break;
 	case MM_MemorySubSpace::ALLOCATION_TYPE_LEAF:
+	case MM_MemorySubSpace::ALLOCATION_TYPE_SHARED_RESERVED:
 		/* callers allocating an arraylet leaf should call lockedAllocateArrayletLeaf() directly */
 		Assert_MM_unreachable();
 		break;
@@ -953,7 +965,7 @@ MM_AllocationContextBalanced::lockedReplenishAndAllocate(MM_EnvironmentBase *env
 	UDATA regionSize = extensions->regionSize;
 	
 	UDATA contiguousAllocationSize;
-	if (MM_MemorySubSpace::ALLOCATION_TYPE_LEAF == allocationType) {
+	if ((MM_MemorySubSpace::ALLOCATION_TYPE_LEAF == allocationType) || (MM_MemorySubSpace::ALLOCATION_TYPE_SHARED_RESERVED == allocationType)) {
 		contiguousAllocationSize = regionSize;
 	} else {
 		contiguousAllocationSize = allocateDescription->getContiguousBytes();
@@ -966,12 +978,23 @@ MM_AllocationContextBalanced::lockedReplenishAndAllocate(MM_EnvironmentBase *env
 			/* acquire a free region */
 			MM_HeapRegionDescriptorVLHGC *leafRegion = acquireFreeRegionFromHeap(env);
 			if (NULL != leafRegion) {
-				result = lockedAllocateArrayletLeaf(env, allocateDescription, leafRegion);
 				leafRegion->_allocateData._owningContext = this;
+				result = lockedAllocateArrayletLeaf(env, allocateDescription, leafRegion);
 				Assert_MM_true(leafRegion->getLowAddress() == result);
 				Trc_MM_AllocationContextBalanced_lockedReplenishAndAllocate_acquiredFreeRegion(env->getLanguageVMThread(), regionSize);
+			} else {
+				allocateDescription->setAllocationContext(NULL);
 			}
 		}
+	} else if (MM_MemorySubSpace::ALLOCATION_TYPE_SHARED_RESERVED == allocationType) {
+		/**
+		 * (existing path to allocate a whole reserved region/leaf, that calls lockedAllocateArrayletLeaf, if not over tax threshold)
+		 * MM_AllocationContextBalanced::allocateFromSharedReservedRegion (this does not check tax threshold here, but it will check later)
+		 */
+		uintptr_t dataSize = allocateDescription->getBytesRequested() - allocateDescription->getContiguousBytes();
+		uintptr_t regionSize = _heapRegionManager->getRegionSize();
+		uintptr_t fraction = dataSize % regionSize;
+		result = allocateFromSharedReservedRegion(env, allocateDescription, fraction, false);
 	} else {
 		Assert_MM_true(NULL == _allocationRegion);
 		MM_HeapRegionDescriptorVLHGC *newRegion = internalReplenishActiveRegion(env, true);
@@ -1103,28 +1126,116 @@ MM_AllocationContextBalanced::setNumaAffinityForThread(MM_EnvironmentBase *env)
 }
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-bool
-MM_AllocationContextBalanced::allocateFromSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction)
+void *
+MM_AllocationContextBalanced::allocateFromSharedReservedRegion(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, uintptr_t fraction, bool shouldCollectOnFailure)
 {
+	void *reservedAddressLow = NULL;
+
+	bool needCollection = allocateFromSharedReservedRegionForNode(env, allocateDescription, fraction, &reservedAddressLow, this, true);
+	if (!needCollection) {
+		if (NULL == allocateDescription->getAllocationContext()) {
+			MM_AllocationContextBalanced *nextToSteal = _nextToSteal;
+			if (this == nextToSteal) {
+				/* never try to steal from ourselves since that wouldn't be possible and the code interprets this case as a uniform system */
+				nextToSteal = nextToSteal->getStealingCousin();
+			}
+
+			/* _nextToSteal will be this if NUMA is not enabled */
+			if (nextToSteal != this) {
+				Assert_MM_true(0 != MM_GCExtensions::getExtensions(env)->_numaManager.getAffinityLeaderCount());
+				/* we didn't get any memory yet we are in a NUMA system so we should steal from a foreign node */
+				MM_AllocationContextBalanced *firstTheftAttempt = nextToSteal;
+				do {
+					 nextToSteal->allocateFromSharedReservedRegionForNode(env, allocateDescription, fraction, &reservedAddressLow, this, false);
+					/* advance to the next node whether we succeeded or not since we want to distribute our "theft" as evenly as possible */
+					nextToSteal = nextToSteal->getStealingCousin();
+					if (this == nextToSteal) {
+						/* never try to steal from ourselves since that wouldn't be possible and the code interprets this case as a uniform system */
+						nextToSteal = nextToSteal->getStealingCousin();
+					}
+				} while ((NULL == allocateDescription->getAllocationContext()) && (firstTheftAttempt != nextToSteal));
+			}
+		}
+	} else {
+		/* payTax */
+	}
+
+	/* if that fails, try to invoke the collector */
+	if (shouldCollectOnFailure && (NULL == allocateDescription->getAllocationContext())) {
+		reservedAddressLow = _subspace->replenishAllocationContextFailed(env, _subspace, this, NULL, allocateDescription, MM_MemorySubSpace::ALLOCATION_TYPE_SHARED_RESERVED);
+	}
+
+	return reservedAddressLow;
+}
+
+bool
+MM_AllocationContextBalanced::allocateFromSharedReservedRegionForNode(MM_EnvironmentBase *env,
+																		  MM_AllocateDescription *allocateDescription,
+																		  uintptr_t fraction,
+																		  void **reservedAddressLow,
+																		  MM_AllocationContextBalanced *requestingContext,
+																		  bool payTax)
+{
+	bool needCollection = false;
 	const uintptr_t regionSize = _heapRegionManager->getRegionSize();
 	Assert_MM_true((regionSize > fraction) && (0 != fraction));
 
 	bool shouldAllocateNewSharedRegion = false;
+	*reservedAddressLow = NULL;
 
 	lockCommon();
 	if (0 == _sharedArrayReservedRegionsBytesUsed) {
 		shouldAllocateNewSharedRegion = true;
 	}
 	uintptr_t wholeRegionsBefore = _sharedArrayReservedRegionsBytesUsed / regionSize;
-	_sharedArrayReservedRegionsBytesUsed += fraction;
-	uintptr_t wholeRegionsAfter = _sharedArrayReservedRegionsBytesUsed / regionSize;
+	uintptr_t wholeRegionsAfter = (_sharedArrayReservedRegionsBytesUsed + fraction) / regionSize;
 
 	if (!shouldAllocateNewSharedRegion && (wholeRegionsBefore < wholeRegionsAfter)) {
 		shouldAllocateNewSharedRegion = true;
 	}
+
+	if (shouldAllocateNewSharedRegion) {
+		if (!payTax || !(needCollection = !_subspace->consumeFromTaxationThreshold(env, regionSize))) {
+			*reservedAddressLow = lockedSharedReserveRegionAllocateFromNode(env, allocateDescription, requestingContext);
+
+			if (NULL != *reservedAddressLow) {
+				_sharedArrayReservedRegionsBytesUsed += fraction;
+			}
+		} else {
+			/* PayTax */
+			allocateDescription->setAllocationContext(NULL);
+		}
+	} else {
+		*reservedAddressLow = NULL;
+		_sharedArrayReservedRegionsBytesUsed += fraction;
+		allocateDescription->setAllocationContext(this);
+	}
+
 	unlockCommon();
 
-	return shouldAllocateNewSharedRegion;
+	return needCollection;
+}
+
+void *
+MM_AllocationContextBalanced::lockedSharedReserveRegionAllocateFromNode(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_AllocationContextBalanced *requestingContext)
+{
+	void *result = NULL;
+
+	MM_HeapRegionDescriptorVLHGC *region = acquireFreeRegionFromNode(env);
+	if (NULL != region) {
+		if (requestingContext != this) {
+			region->_allocateData._originalOwningContext = this;
+		} else {
+			region->_allocateData._originalOwningContext = NULL;
+		}
+		region->_allocateData._owningContext = requestingContext;
+		result = lockedAllocateArrayletLeaf(env, allocateDescription, region);
+		Assert_MM_true(region->getLowAddress() == result);
+	} else {
+		allocateDescription->setAllocationContext(NULL);
+	}
+
+	return result;
 }
 
 bool
@@ -1136,7 +1247,10 @@ MM_AllocationContextBalanced::recycleToSharedArrayReservedRegion(MM_EnvironmentB
 
 	bool shouldReleaseCurrentSharedRegion = false;
 
-	lockCommon();
+	if (needLock) {
+		lockCommon();
+	}
+
 	uintptr_t wholeRegionsBefore = _sharedArrayReservedRegionsBytesUsed / regionSize;
 	_sharedArrayReservedRegionsBytesUsed -= fraction;
 	uintptr_t wholeRegionsAfter = _sharedArrayReservedRegionsBytesUsed / regionSize;
@@ -1144,8 +1258,14 @@ MM_AllocationContextBalanced::recycleToSharedArrayReservedRegion(MM_EnvironmentB
 	if ((0 == _sharedArrayReservedRegionsBytesUsed) || (wholeRegionsBefore > wholeRegionsAfter)) {
 		shouldReleaseCurrentSharedRegion = true;
 	}
-	unlockCommon();
 
+	if (shouldReleaseCurrentSharedRegion) {
+		recycleReservedRegionsForVirtualLargeObjectHeap(env, 1, false);
+	}
+
+	if (needLock) {
+		unlockCommon();
+	}
 	return shouldReleaseCurrentSharedRegion;
 }
 
@@ -1157,23 +1277,24 @@ MM_AllocationContextBalanced::getSharedArrayReservedRegionsCount()
 }
 
 void
-MM_AllocationContextBalanced::recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentVLHGC *env, uintptr_t reservedRegionCount, bool needLock)
+MM_AllocationContextBalanced::recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentBase *env, uintptr_t reservedRegionCount, bool needLock)
 {
 	MM_HeapRegionDescriptorVLHGC **head = getArrayReservedRegionListAddress();
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
+	MM_EnvironmentVLHGC *envVLHGC = MM_EnvironmentVLHGC::getEnvironment(env);
 
 	if (needLock) {
 		lockCommon();
 	}
 
 	while ((reservedRegionCount > 0) && (NULL != (region = *head))) {
-		region->_allocateData.popRegionFromArrayReservedRegionList(env, head);
+		region->_allocateData.popRegionFromArrayReservedRegionList(envVLHGC, head);
 		decrementArrayReservedRegionCount();
 
 		/* Restore/Recommit the reserved region that have been previously decommitted. */
 		 MM_GCExtensions::getExtensions(env)->heap->commitMemory(region->getLowAddress(), _heapRegionManager->getRegionSize());
 
-		region->getSubSpace()->recycleRegion(env, region);
+		region->getSubSpace()->recycleRegion(envVLHGC, region);
 		reservedRegionCount -= 1;
 	}
 

--- a/runtime/gc_vlhgc/AllocationContextBalanced.hpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.hpp
@@ -282,10 +282,11 @@ public:
 	 *
 	 * @param env[in] The current thread.
 	 * @param fraction[in] the remainder of array size from region size.
-	 * @return True if need to allocate new reserved region for sharing.
+	 * @return allocation context for SharedArrayReservedRegion, return NULL if there is no free space for sharing
 	 */
-	bool allocateFromSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction);
+	virtual void *allocateFromSharedReservedRegion(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, uintptr_t fraction, bool shouldCollectOnFailure);
 
+	bool allocateFromSharedReservedRegionForNode(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, uintptr_t fraction, void **reservedAddressLow, MM_AllocationContextBalanced *requestingContext, bool payTax);
 	/**
 	 * Remove the remainder bytes(need to share the reserved region) of large array from the sheard bytes
 	 * and check if need to recycle a shared reserved region.
@@ -294,8 +295,9 @@ public:
 	 * @param fraction[in] the remainder of array size from region size.
 	 * @return True if need to recycle a shared reserved region.
 	 */
-	bool recycleToSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction, bool needLock = false);
+	virtual bool recycleToSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction, bool needLock = false);
 
+	virtual void recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentBase *env, uintptr_t reservedRegionCount, bool needLock);
 	/**
 	 * Get total shared reserved region count.
 	 *
@@ -327,10 +329,6 @@ public:
 	{
 		_arrayReservedRegionCount -= 1;
 	}
-
-	virtual void recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentBase *env, uintptr_t reservedRegionCount, bool needLock) {}
-
-	void recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentVLHGC *env, uintptr_t reservedRegionCount, bool needLock = false);
 
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	
@@ -479,6 +477,8 @@ private:
 	 * @return The address of the leaf
 	 */
 	void *lockedAllocateArrayletLeaf(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_HeapRegionDescriptorVLHGC *freeRegionForArrayletLeaf);
+
+	void *lockedSharedReserveRegionAllocateFromNode(MM_EnvironmentBase *env, MM_AllocateDescription *allocateDescription, MM_AllocationContextBalanced *requestingContext);
 
 	/**
 	 * Common implementation for flush() and flushForShutdown()

--- a/runtime/gc_vlhgc/CollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/CollectionSetDelegate.cpp
@@ -593,12 +593,6 @@ MM_CollectionSetDelegate::rateOfReturnCalculationBeforeSweep(MM_EnvironmentVLHGC
 
 				sparseDataEntry = (MM_SparseDataTableEntry *)hashTableNextDo(&walkState);
 			}
-
-			MM_AllocationContextBalanced *commonContext = (MM_AllocationContextBalanced *)env->getCommonAllocationContext();
-			uintptr_t sharedArrayReservedRegionCount = commonContext->getSharedArrayReservedRegionsCount();
-			SetSelectionData *stats = &_setSelectionDataTable[compactGroupCount-1];
-			stats->_reclaimStats._regionCountBefore += sharedArrayReservedRegionCount;
-			stats->_reclaimStats._regionCountArrayletLeafBefore += sharedArrayReservedRegionCount;
 		}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	}
@@ -670,13 +664,6 @@ MM_CollectionSetDelegate::rateOfReturnCalculationAfterSweep(MM_EnvironmentVLHGC 
 
 				sparseDataEntry = (MM_SparseDataTableEntry *)hashTableNextDo(&walkState);
 			}
-
-			MM_AllocationContextBalanced *commonContext = (MM_AllocationContextBalanced *)env->getCommonAllocationContext();
-			uintptr_t sharedArrayReservedRegionCount = commonContext->getSharedArrayReservedRegionsCount();
-			SetSelectionData *stats = &_setSelectionDataTable[compactGroupCount-1];
-
-			stats->_reclaimStats._regionCountAfter += sharedArrayReservedRegionCount;
-			stats->_reclaimStats._regionCountArrayletLeafAfter += sharedArrayReservedRegionCount;
 		}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 

--- a/runtime/gc_vlhgc/GlobalAllocationManagerTarok.hpp
+++ b/runtime/gc_vlhgc/GlobalAllocationManagerTarok.hpp
@@ -66,6 +66,7 @@ public:
 	virtual bool acquireAllocationContext(MM_EnvironmentBase *env);
 	virtual void releaseAllocationContext(MM_EnvironmentBase *env);
 	virtual void printAllocationContextStats(MM_EnvironmentBase *env, UDATA eventNum, J9HookInterface** hookInterface);
+
 	/**
 	 * Called after the receiver and the subspace have been initialized to request that the receiver build the allocation contexts
 	 * it will manager over the course of the run.  The subspace is required because the allocation contexts need to know which

--- a/runtime/gc_vlhgc/HeapRegionManagerVLHGC.cpp
+++ b/runtime/gc_vlhgc/HeapRegionManagerVLHGC.cpp
@@ -222,14 +222,3 @@ MM_HeapRegionManagerVLHGC::getHeapMemorySnapshot(MM_GCExtensionsBase *extensions
 
 	return snapshot;
 }
-
-#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-void
-MM_HeapRegionManagerVLHGC::recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentBase *envBase, uintptr_t reservedRegionCount)
-{
-	MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(envBase);
-	MM_AllocationContextBalanced *commonContext = (MM_AllocationContextBalanced *)env->getCommonAllocationContext();
-
-	commonContext->recycleReservedRegionsForVirtualLargeObjectHeap(env, reservedRegionCount, true);
-}
-#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */

--- a/runtime/gc_vlhgc/HeapRegionManagerVLHGC.hpp
+++ b/runtime/gc_vlhgc/HeapRegionManagerVLHGC.hpp
@@ -42,10 +42,6 @@ public:
 
 	virtual MM_HeapMemorySnapshot *getHeapMemorySnapshot(MM_GCExtensionsBase *extensions, MM_HeapMemorySnapshot *snapshot, bool gcEnd);
 
-#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
-	void recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentBase *envBase, uintptr_t reservedRegionCount);
-#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-
 	static MM_HeapRegionManagerVLHGC *newInstance(MM_EnvironmentBase *env, uintptr_t regionSize, uintptr_t tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor);
 	MM_HeapRegionManagerVLHGC(MM_EnvironmentBase *env, uintptr_t regionSize, uintptr_t tableDescriptorSize, MM_RegionDescriptorInitializer regionDescriptorInitializer, MM_RegionDescriptorDestructor regionDescriptorDestructor);
 

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -775,8 +775,8 @@ MM_MemorySubSpaceTarok::lockedAllocate(MM_EnvironmentBase *env, MM_AllocationCon
 {
 	void* result = NULL;
 	
-	/* arraylet leaves need to be allocated directly after a new region has been found so fall through to the replenish path in that case */
-	if (MM_MemorySubSpace::ALLOCATION_TYPE_LEAF != allocationType) {
+	/* arraylet leaves/shared reserved regions need to be allocated directly after a new region has been found so fall through to the replenish path in that case */
+	if ((MM_MemorySubSpace::ALLOCATION_TYPE_LEAF != allocationType) && (MM_MemorySubSpace::ALLOCATION_TYPE_SHARED_RESERVED != allocationType)) {
 		result = ((MM_AllocationContextTarok *)context)->lockedAllocate(env, objectAllocationInterface, allocateDescription, allocationType);
 	}
 

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
@@ -593,12 +593,6 @@ MM_ProjectedSurvivalCollectionSetDelegate::rateOfReturnCalculationBeforeSweep(MM
 
 				sparseDataEntry = (MM_SparseDataTableEntry *)hashTableNextDo(&walkState);
 			}
-
-			MM_AllocationContextBalanced *commonContext = (MM_AllocationContextBalanced *)env->getCommonAllocationContext();
-			uintptr_t sharedArrayReservedRegionCount = commonContext->getSharedArrayReservedRegionsCount();
-			SetSelectionData *stats = &_setSelectionDataTable[compactGroupCount-1];
-			stats->_reclaimStats._regionCountBefore += sharedArrayReservedRegionCount;
-			stats->_reclaimStats._regionCountArrayletLeafBefore += sharedArrayReservedRegionCount;
 		}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 	}
@@ -670,13 +664,6 @@ MM_ProjectedSurvivalCollectionSetDelegate::rateOfReturnCalculationAfterSweep(MM_
 
 				sparseDataEntry = (MM_SparseDataTableEntry *)hashTableNextDo(&walkState);
 			}
-
-			MM_AllocationContextBalanced *commonContext = (MM_AllocationContextBalanced *)env->getCommonAllocationContext();
-			uintptr_t sharedArrayReservedRegionCount = commonContext->getSharedArrayReservedRegionsCount();
-			SetSelectionData *stats = &_setSelectionDataTable[compactGroupCount-1];
-
-			stats->_reclaimStats._regionCountAfter += sharedArrayReservedRegionCount;
-			stats->_reclaimStats._regionCountArrayletLeafAfter += sharedArrayReservedRegionCount;
 		}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 


### PR DESCRIPTION
In PR https://github.com/eclipse-openj9/openj9/pull/22116 and https://github.com/eclipse-openj9/openj9/pull/22546, _arrayReservedRegionList and _sharedArrayReservedRegionsBytesUsed has been introduced to share fraction of reserved regions. _arrayReservedRegionList is set in commonAllocationContext(single global list), For numa case, the reserved regions for large array could be allocated from different allocation context(allocation context per numa node and in case there is no free region for the numa note, it could borrow from neighbor numa node). during recycling, there are no extra information indicate which reserved regions are for recycling off-heap array, so potentially it might cause imbalance free memory among numa notes, then affect runtime performance in some cases.

Undate to manage reserved region list per allocation context(numa note) to avoid imbalance free memory caused by reserved regions.

1, new _allocationContextArray in SparseVirtualMemory(omr PR https://github.com/eclipse-omr/omr/pull/8070) to store allocation context for the reserved regions of large array in getSparseAddressAndDecommitLeaves().

2, during recycling the large array, retrieve the related allocation context for recycling the reserved regions.

3, handle allocation failure during getSparseAddressAndDecommitLeaves().

3, new APIs allocateFromSharedArrayReservedRegion and
 allocateFromSharedReservedRegionForNode to handle sharing fraction and
 allocating shared reserved regions in the context(numa node).

4, Using new allocation Type ALLOCATION_TYPE_SHARED_RESERVED to handle
 the different re-allocate processing after GC.

5, Via new field _allocationContext in MM_AllocateDescription to pass the related allocation context back to the caller in order to keep the common interfaces signature unchanged.

6, In allocateFromSharedArrayReservedRegion() use local variable instead of instance variable for keeping nextToSteal
(ToBorrowFreeRegionFromForeignNode) to avoid race condition.

#depend: https://github.com/eclipse-omr/omr/pull/8070
