### PR TITLE
Prevent excess logging from vector API when

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -3955,7 +3955,7 @@ remoteCompile(J9VMThread *vmThread, TR::Compilation *compiler, TR_ResolvedMethod
          metaData = remoteCompilationEnd(vmThread, compiler, compilee, method, compInfoPT, codeCacheStr, dataCacheStr);
          if (metaData)
             {
-            if (metaData->flags & JIT_METADATA_VECTORIZED_CODE)
+            if (TR::Options::getVerboseOption(TR_VerboseVectorAPI) && (metaData->flags & JIT_METADATA_VECTORIZED_CODE))
                {
                TR_VerboseLog::writeLineLocked(TR_Vlog_VECTOR_API, "JITServer processed vector ops");
                }


### PR DESCRIPTION
Add a check to avoid extraneous VectorAPI logging.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23082