### PR TITLE
Implement jitDispatchJ9Method for MethodHandles on Aarch64

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -32,6 +32,7 @@
 #include "codegen/ConstantDataSnippet.hpp"
 #include "codegen/GCStackAtlas.hpp"
 #include "codegen/GenerateInstructions.hpp"
+#include "codegen/J9ARM64Snippet.hpp"
 #include "codegen/Linkage_inlines.hpp"
 #include "codegen/Machine.hpp"
 #include "codegen/MemoryReference.hpp"
@@ -181,7 +182,7 @@ J9::ARM64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
     _properties._framePointerRegister = TR::RealRegister::x29;
     _properties._computedCallTargetRegister = TR::RealRegister::x8;
     _properties._vtableIndexArgumentRegister = TR::RealRegister::x9;
-    _properties._j9methodArgumentRegister = TR::RealRegister::x0;
+    _properties._j9methodArgumentRegister = TR::RealRegister::x10;
 
 #if defined(OSX)
     // Volatile GPR (0-15) + FPR (0-31) + VFT Reg
@@ -952,10 +953,11 @@ int32_t J9::ARM64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
 
     TR::MethodSymbol *callSymbol = callNode->getSymbol()->castToMethodSymbol();
 
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp);
     bool isHelperCall = linkage == TR_Helper || linkage == TR_CHelper;
+    // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
     bool rightToLeft = isHelperCall &&
-        // we want the arguments for induceOSR to be passed from left to right as in any other non-helper call
-        !callNode->getSymbolReference()->isOSRInductionHelper();
+        !callNode->getSymbolReference()->isOSRInductionHelper() && !isJitDispatchJ9Method;
 
     if (rightToLeft) {
         from = callNode->getNumChildren() - 1;
@@ -986,6 +988,11 @@ int32_t J9::ARM64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
         default:
             break;
     }
+
+    if (isJitDispatchJ9Method) {
+        specialArgReg = getProperties().getJ9MethodArgumentRegister();
+    }
+
     if (specialArgReg != TR::RealRegister::NoReg) {
         logprintf(comp->getOption(TR_TraceCG), comp->log(), "Special arg %s in %s\n",
             comp->getDebug()->getName(callNode->getChild(from)),
@@ -1002,6 +1009,7 @@ int32_t J9::ARM64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNode,
         totalSize += TR::Compiler->om.sizeofReferenceAddress();
     }
 
+    // will not process special args
     for (int32_t i = from; (rightToLeft && i >= to) || (!rightToLeft && i <= to); i += step) {
         child = callNode->getChild(i);
         childType = child->getDataType();
@@ -1232,22 +1240,80 @@ void J9::ARM64::PrivateLinkage::buildDirectCall(TR::Node *callNode, TR::SymbolRe
 {
     TR::Instruction *gcPoint;
     TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
+    bool isJitDispatchJ9Method = callNode->isJitDispatchJ9MethodCall(comp());
 
     TR_J9VMBase *fej9 = comp()->fej9();
 
-    if (callSymRef->getReferenceNumber() >= TR_ARM64numRuntimeHelpers)
+    if ((callSymRef->getReferenceNumber() >= TR_ARM64numRuntimeHelpers) && !isJitDispatchJ9Method)
         fej9->reserveTrampolineIfNecessary(comp(), callSymRef, false);
 
     bool forceUnresolvedDispatch = !fej9->isResolvedDirectDispatchGuaranteed(comp());
 
-    if (callSymbol->isJITInternalNative()
-        || (!callSymRef->isUnresolved() && !callSymbol->isInterpreted()
-            && (callSymbol->isHelper() || !forceUnresolvedDispatch))) {
+    if (!isJitDispatchJ9Method
+        && (callSymbol->isJITInternalNative()
+            || (!callSymRef->isUnresolved() && !callSymbol->isInterpreted()
+                && (callSymbol->isHelper() || !forceUnresolvedDispatch)))) {
         bool isMyself = comp()->isRecursiveMethodTarget(callSymbol);
 
         gcPoint = generateImmSymInstruction(cg(), TR::InstOpCode::bl, callNode,
             isMyself ? 0 : (uintptr_t)callSymbol->getMethodAddress(), dependencies,
             callSymRef ? callSymRef : callNode->getSymbolReference(), NULL);
+    } else if (isJitDispatchJ9Method) {
+        auto regMapMask = getProperties().getPreservedRegisterMapForGC();
+
+        TR::Register *scratchReg
+            = dependencies->searchPostConditionRegister(getProperties().getVTableIndexArgumentRegister());
+        TR::Register *j9MethodReg = dependencies->searchPreConditionRegister(getProperties().getJ9MethodArgumentRegister());
+
+        TR::LabelSymbol *startICFLabel = generateLabelSymbol(cg());
+        TR::LabelSymbol *doneLabel = generateLabelSymbol(cg());
+        TR::LabelSymbol *oolLabel = generateLabelSymbol(cg());
+        startICFLabel->setStartInternalControlFlow();
+        doneLabel->setEndInternalControlFlow();
+
+        TR::RegisterDependencyConditions *preDeps = dependencies->clone(cg());
+        preDeps->setNumPostConditions(0, trMemory());
+        preDeps->setAddCursorForPost(0);
+
+        TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
+        TR::SymbolReference *helperRef
+            = cg()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition, true, true, false);
+        TR::Snippet *interpCallSnippet = new (cg()->trHeapMemory())
+            TR::ARM64J9HelperCallSnippet(cg(), callNode, snippetLabel, helperRef, doneLabel, argSize);
+        interpCallSnippet->gcMap().setGCRegisterMask(regMapMask);
+        cg()->addSnippet(interpCallSnippet);
+
+        TR_ARM64OutOfLineCodeSection *slowCallOOL
+            = new (trHeapMemory()) TR_ARM64OutOfLineCodeSection(oolLabel, doneLabel, cg());
+        cg()->getARM64OutOfLineCodeSectionList().push_front(slowCallOOL);
+        slowCallOOL->swapInstructionListsWithCompilation();
+        generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, oolLabel);
+        gcPoint = generateLabelInstruction(cg(), TR::InstOpCode::b, callNode, snippetLabel);
+        gcPoint->ARM64NeedsGCMap(cg(), regMapMask);
+        generateLabelInstruction(cg(), TR::InstOpCode::b, callNode, doneLabel);
+        slowCallOOL->swapInstructionListsWithCompilation();
+
+        generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, startICFLabel, preDeps);
+
+        // test if compiled
+        generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmx, callNode, scratchReg,
+            TR::MemoryReference::createWithDisplacement(cg(), j9MethodReg, offsetof(J9Method, extra)));
+        // jump to snippet if interpreted (lsb of J9Method::extra is 1 if interpreted)
+        gcPoint = generateTestBitBranchInstruction(cg(), TR::InstOpCode::tbnz, callNode, scratchReg, 0, oolLabel);
+        gcPoint->ARM64NeedsGCMap(cg(), regMapMask);
+
+        // compiled - jump to jit entry point
+        generateTrg1MemInstruction(cg(), TR::InstOpCode::ldrimmw, callNode, j9MethodReg,
+            TR::MemoryReference::createWithDisplacement(cg(), scratchReg, -4));
+        generateArithmeticShiftRightImmInstruction(cg(), callNode, j9MethodReg, j9MethodReg, 16, false);
+        // sign extend
+        generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::sbfmx, callNode, j9MethodReg, j9MethodReg, 0x1F);
+        generateTrg1Src2Instruction(cg(), TR::InstOpCode::addx, callNode, scratchReg, j9MethodReg, scratchReg);
+        gcPoint = generateRegBranchInstruction(cg(), TR::InstOpCode::blr, callNode, scratchReg);
+        gcPoint->ARM64NeedsGCMap(cg(), regMapMask);
+
+        generateLabelInstruction(cg(), TR::InstOpCode::label, callNode, doneLabel, dependencies);
+        return;
     } else {
         TR::LabelSymbol *label = generateLabelSymbol(cg());
         TR::Snippet *snippet;

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -56,13 +56,16 @@ static uint8_t *storeArgumentItem(TR::InstOpCode::Mnemonic op, uint8_t *buffer, 
     return buffer + 4;
 }
 
-static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg)
+uint8_t *TR::ARM64CallSnippet::flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize,
+    TR::CodeGenerator *cg)
 {
     uint32_t intArgNum = 0, floatArgNum = 0, offset;
     TR::Machine *machine = cg->machine();
     TR::Linkage *linkage = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
     const TR::ARM64LinkageProperties &linkageProperties = linkage->getProperties();
     int32_t argStart = callNode->getFirstArgumentIndex();
+    if (callNode->isJitDispatchJ9MethodCall(cg->comp()))
+        argStart += 1;
 
     if (linkageProperties.getRightToLeft())
         offset = linkage->getOffsetToFirstParm();
@@ -135,12 +138,14 @@ static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32
     return buffer;
 }
 
-static int32_t instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg)
+int32_t TR::ARM64CallSnippet::instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg)
 {
     uint32_t intArgNum = 0, floatArgNum = 0, count = 0;
     const TR::ARM64LinkageProperties &linkage
         = cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention())->getProperties();
     int32_t argStart = callNode->getFirstArgumentIndex();
+    if (callNode->isJitDispatchJ9MethodCall(cg->comp()))
+        argStart += 1;
 
     for (int32_t i = argStart; i < callNode->getNumChildren(); i++) {
         TR::Node *child = callNode->getChild(i);
@@ -316,8 +321,10 @@ uint8_t *TR_Debug::printARM64ArgumentsFlush(OMR::Logger *log, TR::Node *callNode
     TR::Linkage *linkage = _cg->getLinkage(callNode->getSymbol()->castToMethodSymbol()->getLinkageConvention());
     const TR::ARM64LinkageProperties &linkageProperties = linkage->getProperties();
     int32_t argStart = callNode->getFirstArgumentIndex();
-    TR::RealRegister *stackPtr = _cg->getStackPointerRegister();
+    if (callNode->isJitDispatchJ9MethodCall(_cg->comp()))
+        argStart += 1;
 
+    TR::RealRegister *stackPtr = _cg->getStackPointerRegister();
     if (linkageProperties.getRightToLeft())
         offset = linkage->getOffsetToFirstParm();
     else

--- a/runtime/compiler/aarch64/codegen/CallSnippet.hpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.hpp
@@ -65,6 +65,8 @@ public:
     static uint8_t *generateVIThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
     static TR_MHJ2IThunk *generateInvokeExactJ2IThunk(TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg,
         char *signature);
+    static uint8_t *flushArgumentsToStack(uint8_t *buffer, TR::Node *callNode, int32_t argSize, TR::CodeGenerator *cg);
+    static int32_t instructionCountForArguments(TR::Node *callNode, TR::CodeGenerator *cg);
 };
 
 class ARM64UnresolvedCallSnippet : public TR::ARM64CallSnippet {

--- a/runtime/compiler/aarch64/codegen/J9ARM64Snippet.cpp
+++ b/runtime/compiler/aarch64/codegen/J9ARM64Snippet.cpp
@@ -23,6 +23,7 @@
 #include "j9.h"
 
 #include "codegen/ARM64Instruction.hpp"
+#include "codegen/CallSnippet.hpp"
 #include "codegen/CodeGenerator.hpp"
 #include "codegen/GCStackAtlas.hpp"
 #include "codegen/J9ARM64Snippet.hpp"
@@ -242,4 +243,48 @@ int32_t TR::ARM64MonitorExitSnippet::setEstimatedCodeLocation(int32_t estimatedS
     _decLabel->setEstimatedCodeLocation(estimatedSnippetStart);
     getSnippetLabel()->setEstimatedCodeLocation(estimatedSnippetStart + 6 * ARM64_INSTRUCTION_LENGTH);
     return estimatedSnippetStart;
+}
+
+uint8_t *TR::ARM64J9HelperCallSnippet::emitSnippetBody()
+{
+    uint8_t *cursor = cg()->getBinaryBufferCursor();
+    getSnippetLabel()->setCodeLocation(cursor);
+    cursor = TR::ARM64CallSnippet::flushArgumentsToStack(cursor, this->getNode(), this->getSizeOfArguments(), cg());
+    if (this->getNode()->isJitDispatchJ9MethodCall(cg()->comp())) {
+        /*
+         * move value in x10 to x0 for the interpreter
+         * This is needed since x0 is an argument register, so private linkage cannot use x0 for the j9method pointer
+         * and we must wait until we are inside the snippet, where we know the target method is interpreted, to move the
+         * j9method pointer to x0 where j2iTransition expects it
+         *
+         * orr x0 x10 x10
+         * 10101010 00 0 01010 000000 01010 00000
+         */
+        *(int32_t *)cursor = 0xAA0A0140;
+        cursor += ARM64_INSTRUCTION_LENGTH;
+    }
+
+    return emitSnippetBodyInner(cursor);
+}
+
+uint32_t TR::ARM64J9HelperCallSnippet::getLength(int32_t estimatedSnippetStart)
+{
+    // register move adds an instruction
+    int32_t len = (1 + TR::ARM64CallSnippet::instructionCountForArguments(getNode(), cg())) * ARM64_INSTRUCTION_LENGTH;
+    return len + TR::ARM64HelperCallSnippet::getLength(estimatedSnippetStart + len);
+}
+
+void TR::ARM64J9HelperCallSnippet::print(OMR::Logger *log, TR_Debug *debug)
+{
+    uint8_t *bufferPos = getSnippetLabel()->getCodeLocation();
+
+    debug->printSnippetLabel(log, getSnippetLabel(), bufferPos, debug->getName(this),
+        getNode()->isJitDispatchJ9MethodCall(cg()->comp()) ? "j2iTransition" : NULL);
+
+    bufferPos = debug->printARM64ArgumentsFlush(log, getNode(), bufferPos, getSizeOfArguments());
+
+    debug->printPrefix(log, NULL, bufferPos, 4);
+    log->printf("%s \t\t\t; %s", "mov x0 x10", "move j9method pointer to x0 for interpreter");
+    bufferPos += ARM64_INSTRUCTION_LENGTH;
+    TR::ARM64HelperCallSnippet::printInner(log, debug, bufferPos);
 }

--- a/runtime/compiler/aarch64/codegen/J9ARM64Snippet.hpp
+++ b/runtime/compiler/aarch64/codegen/J9ARM64Snippet.hpp
@@ -126,6 +126,32 @@ public:
      */
     TR::LabelSymbol *getDecLabel() { return _decLabel; }
 };
+
+/** \brief
+ *     A special type of helper call snippet that flushes in register arguments to the
+ *     stack before calling the helper
+ */
+class ARM64J9HelperCallSnippet : public TR::ARM64HelperCallSnippet {
+    int32_t _argSize;
+
+public:
+    ARM64J9HelperCallSnippet(TR::CodeGenerator *cg, TR::Node *node, TR::LabelSymbol *snippetlab,
+        TR::SymbolReference *helper, TR::LabelSymbol *restartLabel = NULL, int32_t argSize = -1)
+        : TR::ARM64HelperCallSnippet(cg, node, snippetlab, helper, restartLabel)
+        , _argSize(argSize)
+    {}
+
+    int32_t getSizeOfArguments() { return _argSize; }
+
+    virtual uint8_t *emitSnippetBody();
+
+    virtual uint32_t getLength(int32_t estimatedSnippetStart);
+
+    /**
+     * @brief Prints the Snippet
+     */
+    virtual void print(OMR::Logger *log, TR_Debug *);
+};
 } // namespace TR
 
 #endif

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -275,3 +275,12 @@ bool J9::ARM64::CodeGenerator::callUsesHelperImplementation(TR::Symbol *sym)
             && sym->castToMethodSymbol()->getMandatoryRecognizedMethod()
                 == TR::java_lang_invoke_ComputedCalls_dispatchJ9Method);
 }
+
+bool J9::ARM64::CodeGenerator::supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol)
+{
+    if (symbol == TR::SymbolReferenceTable::jitDispatchJ9MethodSymbol) {
+        return true;
+    }
+
+    return J9::CodeGenerator::supportsNonHelper(symbol);
+}

--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.hpp
@@ -120,6 +120,7 @@ public:
     bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
 
     bool callUsesHelperImplementation(TR::Symbol *sym);
+    bool supportsNonHelper(TR::SymbolReferenceTable::CommonNonhelperSymbol symbol);
 };
 
 }} // namespace J9::ARM64


### PR DESCRIPTION
Private linkage code generation implementation for jitDispatchJ9Method on aarch64.
    
Adds new kind of snippet ARM64J9HelperCallSnippet, which is a helper call snippet that can flush in register argumnets to the stack. This also adds a register move for jitDispatchJ9Method call nodes to move the j9method pointer into x0, as expected by the j2iTransition helper.

Changes _j9methodArgumentRegister to `x10` so that it does not overlap with the first integer argument register.

depends on https://github.com/eclipse-omr/omr/pull/8068
