### PR TITLE
VectorAPI: use mloadiFromArray/mstoreiToArray opcodes if available

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -1589,7 +1589,7 @@ TR_VectorAPIExpansion::boxChild(TR::TreeTop *treeTop, TR::Node *node, uint32_t i
       }
    else if (objectType == Mask)
       {
-      maskConv = getMaskToStoreConversion(numLanes, TR::DataType::createMaskType(elementType, vectorLength), maskStoreOpCode);
+      maskConv = getMaskToStoreConversion(comp(), numLanes, TR::DataType::createMaskType(elementType, vectorLength), maskStoreOpCode);
       boxingSupported = isOpCodeImplemented(comp(), maskConv);
       }
 
@@ -1643,7 +1643,7 @@ TR_VectorAPIExpansion::boxChild(TR::TreeTop *treeTop, TR::Node *node, uint32_t i
    if (!child->getOpCode().isVectorOpCode())  // not vectorized yet
       vloadNode = vectorizeLoadOrStore(this, child, opCodeType, true);
 
-   if (objectType == Mask)
+   if (objectType == Mask && TR::ILOpCode::getVectorOperation(maskConv) != TR::mstoreiToArray)
       {
       vloadNode = TR::Node::create(node, maskConv, 1, vloadNode);
       }
@@ -1731,7 +1731,7 @@ TR_VectorAPIExpansion::unboxNode(TR::Node *parentNode, TR::Node *operand, vapiOb
       }
    else if (operandObjectType == Mask)
       {
-      maskConv = getLoadToMaskConversion(numLanes, TR::DataType::createMaskType(elementType, vectorLength), maskLoadOpCode);
+      maskConv = getLoadToMaskConversion(comp(), numLanes, TR::DataType::createMaskType(elementType, vectorLength), maskLoadOpCode);
       unboxingSupported = isOpCodeImplemented(comp(), maskConv);
       }
 
@@ -1793,8 +1793,7 @@ TR_VectorAPIExpansion::unboxNode(TR::Node *parentNode, TR::Node *operand, vapiOb
    TR::Node *newOperand = TR::Node::createWithSymRef(operand, opcode, 1, vectorShadow);
    TR::Node *aladdNode = generateArrayElementAddressNode(comp(), payloadLoad, TR::Node::lconst(operand, 0), elementSize);
    newOperand->setAndIncChild(0, aladdNode);
-
-   if (operandObjectType == Mask)
+   if (operandObjectType == Mask && TR::ILOpCode::getVectorOperation(maskConv) != TR::mloadiFromArray)
       {
       newOperand = TR::Node::create(operand, maskConv, 1, newOperand);
       }
@@ -2400,9 +2399,14 @@ void TR_VectorAPIExpansion::astoreHandler(TR_VectorAPIExpansion *opt, TR::TreeTo
    }
 
 TR::ILOpCodes
-TR_VectorAPIExpansion::getLoadToMaskConversion(int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &loadOpCode)
+TR_VectorAPIExpansion::getLoadToMaskConversion(TR::Compilation *comp, int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &loadOpCode)
    {
-   TR::ILOpCodes op;
+   TR::ILOpCodes op = TR::ILOpCode::createVectorOpCode(TR::mloadiFromArray, maskType);
+   if (isOpCodeImplemented(comp, op))
+      {
+      loadOpCode = op;
+      return op;
+      }
 
    switch (numLanes)
       {
@@ -2442,9 +2446,14 @@ TR_VectorAPIExpansion::getLoadToMaskConversion(int32_t numLanes, TR::DataType ma
 
 
 TR::ILOpCodes
-TR_VectorAPIExpansion::getMaskToStoreConversion(int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &storeOpCode)
+TR_VectorAPIExpansion::getMaskToStoreConversion(TR::Compilation *comp, int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &storeOpCode)
    {
-   TR::ILOpCodes op;
+   TR::ILOpCodes op = TR::ILOpCode::createVectorOpCode(TR::mstoreiToArray, maskType);
+   if (isOpCodeImplemented(comp, op))
+      {
+      storeOpCode = op;
+      return op;
+      }
 
    switch (numLanes)
       {
@@ -2527,7 +2536,7 @@ TR::Node *TR_VectorAPIExpansion::loadIntrinsicHandler(TR_VectorAPIExpansion *opt
          TR::ILOpCodes maskConversionOpCode;
          TR::ILOpCodes unused;
 
-         maskConversionOpCode = getLoadToMaskConversion(numLanes, resultType, unused);
+         maskConversionOpCode = getLoadToMaskConversion(comp, numLanes, resultType, unused);
 
          if (maskConversionOpCode == TR::BadILOp)
             return NULL;
@@ -2600,11 +2609,11 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
       }
    else if (mode == doVectorization)
       {
-      TR::DataType vectorType = TR::DataType::createVectorType(elementType, vectorLength);
       TR::ILOpCodes op;
 
       if (objectType == Vector)
          {
+         TR::DataType vectorType = TR::DataType::createVectorType(elementType, vectorLength);
          TR::DataType symRefType = vectorType;
          TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateArrayShadowSymbolRef(symRefType, NULL);
          op = TR::ILOpCode::createVectorOpCode(TR::vloadi, vectorType);
@@ -2615,19 +2624,25 @@ TR::Node *TR_VectorAPIExpansion::transformLoadFromArray(TR_VectorAPIExpansion *o
          {
          TR::ILOpCodes loadOpCode;
 
-         op = getLoadToMaskConversion(numLanes, vectorType, loadOpCode);
+         op = getLoadToMaskConversion(comp, numLanes, TR::DataType::createMaskType(elementType, vectorLength), loadOpCode);
 
          if (op == TR::BadILOp)
             return NULL;
 
          TR::Node::recreate(node, op);
-
          // need to alias with boolean array elements, so creating GenericIntArrayShadow
          TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateGenericIntArrayShadowSymbolReference(0);
-
-         TR::Node *loadNode = TR::Node::createWithSymRef(node, loadOpCode, 1, symRef);
-         loadNode->setAndIncChild(0, aladdNode);
-         node->setAndIncChild(0, loadNode);
+         if (TR::ILOpCode::getVectorOperation(op) == TR::mloadiFromArray)
+            {
+            node->setSymbolReference(symRef);
+            node->setAndIncChild(0, aladdNode);
+            }
+         else
+            {
+            TR::Node *loadNode = TR::Node::createWithSymRef(node, loadOpCode, 1, symRef);
+            loadNode->setAndIncChild(0, aladdNode);
+            node->setAndIncChild(0, loadNode);
+            }
          }
 
       if (TR::Options::getVerboseOption(TR_VerboseVectorAPI))
@@ -2671,7 +2686,7 @@ TR::Node *TR_VectorAPIExpansion::storeIntrinsicHandler(TR_VectorAPIExpansion *op
 
          TR::DataType sourceType = TR::DataType::createMaskType(elementType, vectorLength);
          TR::ILOpCodes unused;
-         TR::ILOpCodes maskConversionOpCode = getMaskToStoreConversion(numLanes, sourceType, unused);
+         TR::ILOpCodes maskConversionOpCode = getMaskToStoreConversion(comp, numLanes, sourceType, unused);
 
          if (!isOpCodeImplemented(comp, maskConversionOpCode))
             return NULL;
@@ -2773,16 +2788,20 @@ TR::Node *TR_VectorAPIExpansion::transformStoreToArray(TR_VectorAPIExpansion *op
       else if (objectType == Mask)
          {
          TR::ILOpCodes storeOpCode;
-         op = getMaskToStoreConversion(numLanes, opCodeType, storeOpCode);
+         op = getMaskToStoreConversion(comp, numLanes, opCodeType, storeOpCode);
+
+         TR::Node::recreate(node, storeOpCode);
 
          // need to alias with boolean array elements, so creating GenericIntArrayShadow
          TR::SymbolReference *symRef = comp->getSymRefTab()->findOrCreateGenericIntArrayShadowSymbolReference(0);
-         TR::Node::recreate(node, storeOpCode);
          node->setSymbolReference(symRef);
 
-         TR::Node *convNode = TR::Node::create(node, op, 1);
-         convNode->setChild(0, valueToWrite);
-         node->setAndIncChild(1, convNode);
+         if (TR::ILOpCode::getVectorOperation(op) != TR::mstoreiToArray)
+            {
+            TR::Node *convNode = TR::Node::create(node, op, 1);
+            convNode->setChild(0, valueToWrite);
+            node->setAndIncChild(1, convNode);
+            }
          }
 
       if (TR::Options::getVerboseOption(TR_VerboseVectorAPI))

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -1817,6 +1817,9 @@ class TR_VectorAPIExpansion : public TR::Optimization
   /** \brief
    *    Returns opcode for converting a load from a byte array into a mask
    *
+   *   \param comp
+   *      Compilation
+   *
    *   \param numLanes
    *      Nubmer of lanes
    *
@@ -1829,11 +1832,14 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      conversion opcode
    */
-   static TR::ILOpCodes getLoadToMaskConversion(int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &loadOpCode);
+   static TR::ILOpCodes getLoadToMaskConversion(TR::Compilation *comp, int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &loadOpCode);
 
 
    /** \brief
    *    Returns opcode for storying mask into boolean array
+   *
+   *   \param comp
+   *      Compilation
    *
    *   \param numLanes
    *      Nubmer of lanes
@@ -1847,7 +1853,7 @@ class TR_VectorAPIExpansion : public TR::Optimization
    *   \return
    *      conversion opcode
    */
-   static TR::ILOpCodes getMaskToStoreConversion(int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &storeOpCode);
+   static TR::ILOpCodes getMaskToStoreConversion(TR::Compilation *comp, int32_t numLanes, TR::DataType maskType, TR::ILOpCodes &storeOpCode);
 
    };
 


### PR DESCRIPTION
Introduce optional use of the mloadiFromArray and mstoreiToArray intrinsics in the OpenJ9 JIT for Vector API mask loads/stores if the opcodes are implemented.