### PR TITLE
(0.57) Compile jdk25+ with OpenXL using bootjdk 25

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -157,8 +157,8 @@ boot_jdk_default:
       11: '11'
       17: '17'
       21: '21'
-      25: '24'
-      next: '24'
+      25: '25'
+      next: '25'
     dir_strip:
       all: '1'
     url:


### PR DESCRIPTION
Cherry pick and modify the changes from the head stream, removing the lines for jdk26.
https://github.com/eclipse-openj9/openj9/pull/22910
https://github.com/eclipse-openj9/openj9/pull/23070
https://github.com/eclipse-openj9/openj9/pull/23086