### PR TITLE
Enable CHTable Opts when Xnojit is set to allow AOT

### DIFF
--- a/runtime/compiler/control/DLLMain.cpp
+++ b/runtime/compiler/control/DLLMain.cpp
@@ -566,13 +566,15 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void * reserved)
 
             if (!TR::Options::canJITCompile()) // -Xnojit, then recompilation is not supported
                                               // Ensure JIT and AOT flags are set appropriately
-              {
-              TR::Options::getAOTCmdLineOptions()->setAllowRecompilation(false);
-              TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableCHOpts);
-
-              TR::Options::getJITCmdLineOptions()->setAllowRecompilation(false);
-              TR::Options::getJITCmdLineOptions()->setOption(TR_DisableCHOpts);
-              }
+               {
+               TR::Options::getAOTCmdLineOptions()->setAllowRecompilation(false);
+               TR::Options::getJITCmdLineOptions()->setAllowRecompilation(false);
+               }
+            else if (!TR::Options::getCmdLineOptions()->allowRecompilation() || !TR::Options::getAOTCmdLineOptions()->allowRecompilation())
+               {
+               TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableCHOpts);
+               TR::Options::getJITCmdLineOptions()->setOption(TR_DisableCHOpts);
+               }
 
             if (!isJIT)
                {

--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -2102,11 +2102,6 @@ aboutToBootstrap(J9JavaVM * javaVM, J9JITConfig * jitConfig)
       return -1;
       }
 
-   if (!TR::Options::getCmdLineOptions()->allowRecompilation() || !TR::Options::getAOTCmdLineOptions()->allowRecompilation())
-      {
-      TR::Options::getCmdLineOptions()->setOption(TR_DisableCHOpts);
-      TR::Options::getAOTCmdLineOptions()->setOption(TR_DisableCHOpts);
-      }
 
    // Get local var names if available (ie. classfile was compiled with -g).
    // We just check getDebug() for lack of a reliable way to check whether there are any methods being logged.


### PR DESCRIPTION
Fixes issue:
https://github.com/eclipse-openj9/openj9/issues/17918

Previously, there was an issue that when -Xnojit was set, AOT loads were disabled. This is because -Xnotjit disabled CHTable Ops, which were needed for AOT header validation.

This PR enforces that if -Xnojit is specified, then AOT compilations are prohibited but CHTable optimizations are still enabled. Otherwise if recompilations are disabled for any other reason, we also disable CHTable ops.

This PR borrows a lot from https://github.com/eclipse-openj9/openj9/pull/18543
