### PR TITLE
Introduce recycleReservedRegions stub

### DIFF
--- a/runtime/gc_vlhgc/AllocationContextBalanced.cpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.cpp
@@ -1128,7 +1128,7 @@ MM_AllocationContextBalanced::allocateFromSharedArrayReservedRegion(MM_Environme
 }
 
 bool
-MM_AllocationContextBalanced::recycleToSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction)
+MM_AllocationContextBalanced::recycleToSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction, bool needLock)
 {
 	const uintptr_t regionSize = _heapRegionManager->getRegionSize();
 	Assert_MM_true((regionSize > fraction) && (0 != fraction));

--- a/runtime/gc_vlhgc/AllocationContextBalanced.hpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.hpp
@@ -294,7 +294,7 @@ public:
 	 * @param fraction[in] the remainder of array size from region size.
 	 * @return True if need to recycle a shared reserved region.
 	 */
-	bool recycleToSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction);
+	bool recycleToSharedArrayReservedRegion(MM_EnvironmentBase *env, uintptr_t fraction, bool needLock = false);
 
 	/**
 	 * Get total shared reserved region count.
@@ -327,6 +327,8 @@ public:
 	{
 		_arrayReservedRegionCount -= 1;
 	}
+
+	virtual void recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentBase *env, uintptr_t reservedRegionCount, bool needLock) {}
 
 	void recycleReservedRegionsForVirtualLargeObjectHeap(MM_EnvironmentVLHGC *env, uintptr_t reservedRegionCount, bool needLock = false);
 


### PR DESCRIPTION
This is an preparation step for a new implementation of recycleReservedRegionsForVirtualLargeObjectHeap that will use Base Env (instead of VLHGC specific env), since it will be invoked by common (non VLHGC path - Indexable allocation).

To be able to call it from the common path, it has to be virtual in the base class AllocationContext, which is defined in OMR.

The old variant is to be removed, but in interim OMR acceptance build both of them exist. Some compilers are confused since the signatures are different, but based on the name it's trying to associate them.

This explicit definition should help the compiler not to try to associate them.