### PR TITLE
Remove tight loop in unblocker thread

### DIFF
--- a/runtime/vm/ContinuationHelpers.cpp
+++ b/runtime/vm/ContinuationHelpers.cpp
@@ -1201,9 +1201,7 @@ takeVirtualThreadListToUnblock(J9VMThread *currentThread)
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions const * const vmFuncs = vm->internalVMFunctions;
 
-	if (J9_ARE_NO_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)
-	|| (NULL == vm->blockedContinuations)
-	) {
+	if (J9_ARE_NO_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)) {
 		return NULL;
 	}
 


### PR DESCRIPTION
There is a path where the unblocker may spin in a tight loop. This occurs if the continuation list is empty.

This case is handled by removing the (NULL == vm->blockedContinuations) check at the start of the function.