### PR TITLE
Add trace points to inline cast check

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1080,6 +1080,7 @@ handleResponse(JITServer::MessageType response, JITServer::ClientStream *client,
          auto recv = client->getRecvData<J9Class*, J9Class*>();
          auto clazz1 = std::get<0>(recv);
          auto clazz2 = std::get<1>(recv);
+         Trc_JITServerHandleInstanceOfOrCastCheck(vmThread, clazz1, clazz2);
          client->write(response, fe->instanceOfOrCheckCastNoCacheUpdate(clazz1, clazz2));
          }
          break;

--- a/runtime/compiler/env/j9jit.tdf
+++ b/runtime/compiler/env/j9jit.tdf
@@ -136,3 +136,4 @@ TraceEvent=Trc_JITServerCompThreadCrashed    Overhead=1 Level=1 Test Template="J
 TraceEvent=Trc_JITServerClearCaches    Overhead=1 Level=1 Test Template="JITServer: compThreadID=%d clientSessionData=%p clientUID=%llu clearing all the caches due to class redefinition."
 
 TraceEvent=Trc_JIT_MethodUnloadInvalidated Group=perfmon Overhead=1 Level=1 Test Template="JIT: Compiled body _startPC=%p invalidated by unloading of inlined code"
+TraceEvent=Trc_JITServerHandleInstanceOfOrCastCheck     Overhead=1 Level=1 Test Template="JITClient: instanceOfOrCastCheck, instanceClass=%p castClass=%p"


### PR DESCRIPTION
This PR adds a trace point to the JITClient handler for VM_instanceOfOrCheckCastNoCacheUpdate to help diagnose issues as they arise in this infrequently executed code path.