### PR TITLE
Add compile commands to the gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,6 @@ com.ibm.jvmti.tests
 .DS_Store
 doc/.DS_Store
 doc/release-notes/.DS_Store
+
+# config cmake file for vim autocompletion
+compile_commands.json


### PR DESCRIPTION
Adding compile_commands.json to the .gitignore.

(This mirrors the OMR repo https://github.com/eclipse-omr/omr/blob/65d1e95349197eb5065506ebaf916cf5aeb8aae1/.gitignore#L186)