### PR TITLE
JDK26+ overlay HotSpotAOTCacheImpl.java

### DIFF
--- a/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotAOTCacheImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/sun/management/internal/HotSpotAOTCacheImpl.java
@@ -1,0 +1,22 @@
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 26]*/
+/*
+ * Copyright IBM Corp. and others 2025
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */


### PR DESCRIPTION
JDK26+ overlay `HotSpotAOTCacheImpl.java`

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk26/pull/5

Signed-off-by: Jason Feng <fengj@ca.ibm.com>