### PR TITLE
fix `get_other_workspaces` to avoid clean up issue.

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
@@ -278,7 +278,11 @@ timeout(time: TIMEOUT_TIME.toInteger(), unit: TIMEOUT_UNITS) {
  */
 def get_other_workspaces(workspaceDir) {
     // fetch all directories in workspaceDir (this should not fail)
-    def workspaces = sh(script: "ls ${workspaceDir}", returnStdout: true).trim().tokenize(System.lineSeparator())
+    def workspaces = sh(
+                        script: """
+                            ls "${workspaceDir}"
+                        """,
+                        returnStdout: true).trim().tokenize(System.lineSeparator())
     // remove current build workspace
     def otherWS = workspaces.findAll { ws -> ws.startsWith(JOB_NAME) == false }
 


### PR DESCRIPTION
When cleaning nodes if there some space in job path it fails with error `No such file or directory`. By qouting the path, this means to fix it.

Singned-off-by: mahdi@ibm.com