### PR TITLE
Valhalla JDK27 bringup

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -542,11 +542,11 @@ final class Access implements JavaLangAccess {
 	/*[IF JAVA_SPEC_VERSION >= 20]*/
 	@Override
 	public void addEnableNativeAccessToAllUnnamed() {
-		/*[IF (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES]*/
+		/*[IF JAVA_SPEC_VERSION >= 26]*/
 		Module.addEnableNativeAccessToAllUnnamed();
-		/*[ELSE] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
+		/*[ELSE] JAVA_SPEC_VERSION >= 26 */
 		Module.implAddEnableNativeAccessToAllUnnamed();
-		/*[ENDIF] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
 	}
 	/*[ELSE] JAVA_SPEC_VERSION >= 20 */
 	@Override
@@ -561,15 +561,15 @@ final class Access implements JavaLangAccess {
 	/*[ENDIF] JAVA_SPEC_VERSION >= 20 */
 
 	@Override
-	/*[IF (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES]*/
+	/*[IF JAVA_SPEC_VERSION >= 26]*/
 	public void addEnableNativeAccess(Module mod) {
 		mod.implAddEnableNativeAccess();
 	}
-	/*[ELSE] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
+	/*[ELSE] JAVA_SPEC_VERSION >= 26 */
 	public Module addEnableNativeAccess(Module mod) {
 		return mod.implAddEnableNativeAccess();
 	}
-	/*[ENDIF] (JAVA_SPEC_VERSION >= 26) & !INLINE-TYPES */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
 
 	/*[IF (21 <= JAVA_SPEC_VERSION) & (JAVA_SPEC_VERSION < 24)]*/
 	@Override
@@ -995,7 +995,6 @@ final class Access implements JavaLangAccess {
 		return String.newStringWithLatin1Bytes(src);
 	}
 
-	/*[IF !INLINE-TYPES]*/
 	@Override
 	public void addEnableFinalMutationToAllUnnamed() {
 		Module.addEnableFinalMutationToAllUnnamed();
@@ -1020,6 +1019,5 @@ final class Access implements JavaLangAccess {
 	public boolean tryEnableFinalMutation(Module module) {
 		return module.tryEnableFinalMutation();
 	}
-	/*[ENDIF] !INLINE-TYPES */
 	/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
 }

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -4474,6 +4474,11 @@ public final class Unsafe {
 		Objects.requireNonNull(clz);
 		throw new Error("notifyStrictStaticAccess() unimplemented"); //$NON-NLS-1$
 	}
+
+	public int[] getFieldMap(Class<?> clz) {
+		Objects.requireNonNull(clz);
+		throw new Error("getFieldMap() unimplemented"); //$NON-NLS-1$
+	}
 	/*[ENDIF] INLINE-TYPES */
 
 	/**
@@ -7257,6 +7262,14 @@ public final class Unsafe {
 
 	public <V> Object getAndSetFlatValueAcquire(Object obj, long offset, int layout, Class<?> valueType, V newValue) {
 		return getAndSetFlatValue(obj, offset, layout, valueType, newValue);
+	}
+
+	public long arrayInstanceBaseOffset(Object[] array) {
+		throw new Error("jdk.internal.misc.Unsafe.arrayInstanceBaseOffset unimplemented"); //$NON-NLS-1$
+	}
+
+	public int arrayInstanceIndexScale(Object[] array) {
+		throw new Error("jdk.internal.misc.Unsafe.arrayInstanceIndexScale unimplemented"); //$NON-NLS-1$
 	}
 	/*[ENDIF] INLINE-TYPES */
 }

--- a/runtime/bcutil/jimageintf.c
+++ b/runtime/bcutil/jimageintf.c
@@ -91,7 +91,11 @@ lookupSymbolsInJImageLib(J9PortLibrary *portLibrary, UDATA libJImageHandle)
 		j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_JIMAGE_INTF_LIBJIMAGE_SYMBOL_LOOKUP_FAILED, "JIMAGE_Close");
 		goto _end;
 	}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	rc = j9sl_lookup_name(libJImageHandle, "JIMAGE_FindResource", (UDATA *)&libJImageFindResource, "JPPPZP");
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	rc = j9sl_lookup_name(libJImageHandle, "JIMAGE_FindResource", (UDATA *)&libJImageFindResource, "JPPPPP");
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	if (0 != rc) {
 		j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_JIMAGE_INTF_LIBJIMAGE_SYMBOL_LOOKUP_FAILED, "JIMAGE_FindResource");
 		goto _end;
@@ -321,7 +325,15 @@ jimageFindResource(J9JImageIntf *jimageIntf, UDATA handle, const char *moduleNam
 		JImageLocationRef *locationRef = (JImageLocationRef *)j9mem_allocate_memory(sizeof(*locationRef), J9MEM_CATEGORY_CLASSES);
 
 		if (NULL != locationRef) {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			/* Valhalla enables --enable-preview by default at jvminit.c;
+			 * The parameter is_preview_mode is set to TRUE which might require change
+			 * if the Valhalla project is merged into openjdk head stream.
+			 */
+			*locationRef = libJImageFindResource(jimage, moduleName, name, TRUE, (jlong *)size);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			*locationRef = libJImageFindResource(jimage, moduleName, JIMAGE_VERSION_NUMBER, name, (jlong *)size);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			if (JIMAGE_NOT_FOUND != *(I_64 *)locationRef) {
 				*resourceLocation = (UDATA)locationRef;
 			} else {

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -987,7 +987,7 @@ extern "C" {
 
 /* Class version minimum for value type support. */
 
-#define VALUE_TYPES_MAJOR_VERSION (44 + 26)
+#define VALUE_TYPES_MAJOR_VERSION (44 + 27)
 #define STRICT_FIELDS_MAJOR_VERSION VALUE_TYPES_MAJOR_VERSION
 #define PREVIEW_MINOR_VERSION 65535
 #define J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(classfileOrRomClass) (((classfileOrRomClass)->majorVersion >= VALUE_TYPES_MAJOR_VERSION) && (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion))

--- a/runtime/oti/libjimage.h
+++ b/runtime/oti/libjimage.h
@@ -32,8 +32,13 @@ typedef jlong JImageLocationRef;
 
 typedef JImageFile * (*libJImageOpenType)(const char *name, jint *error);
 typedef void (*libJImageCloseType)(JImageFile *jimage);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+typedef JImageLocationRef (*libJImageFindResourceType)(JImageFile *jimage,
+		const char *module_name, const char *name, BOOLEAN is_preview_mode, jlong *size);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 typedef JImageLocationRef (*libJImageFindResourceType)(JImageFile *jimage,
 		const char *module_name, const char *version, const char *name, jlong *size);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 typedef jlong (*libJImageGetResourceType)(JImageFile *jimage, JImageLocationRef location,
 		char *buffer, jlong size);
 #if JAVA_SPEC_VERSION < 26

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2735,6 +2735,12 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 				if (FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_ENABLE_PREVIEW, NULL) >= 0) {
 					vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW;
 				}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				else {
+					/* Valhalla enables --enable-preview by default. */
+					vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW;
+				}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			}
 			if ((argIndex = FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_XSIGQUITTOFILE, NULL)) >= 0) {
 				GET_OPTION_VALUE(argIndex, ':', &optionValue);

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -64,7 +64,7 @@
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
 			<compilerarg line='--add-exports java.base/jdk.internal.value=ALL-UNNAMED' />
 			<compilerarg line='--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED' />
-			<compilerarg line='--enable-preview -source 26'/>
+			<compilerarg line='--enable-preview -source 27'/>
 			<compilerarg line='-XDgenerateEarlyLarvalFrame'/>
 			<!-- uncomment when running with lw5 -->
 			<!--<compilerarg line='-XDenableNullRestrictedTypes' />-->

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -27,12 +27,12 @@ import static org.objectweb.asm.Opcodes.*;
 
 public class ValhallaUtils {
 	/**
-	 * Currently value type is built on JDK26, so use java file major version (44 + 26) for now.
+	 * Currently value type is built on JDK27, so use java file major version (44 + 27) for now.
 	 * If moved this needs to be incremented to the next class file version.
 	 * VALUE_TYPES_MAJOR_VERSION in oti/j9consts.h needs to be updated as well.
 	 * Minor version is in 16 most significant bits for asm.
 	 */
-	static final int VALUE_TYPE_CLASS_FILE_VERSION = (65535 << 16) | (44 + 26);
+	static final int VALUE_TYPE_CLASS_FILE_VERSION = (65535 << 16) | (44 + 27);
 
 	/* workaround till the new ASM is released */
 	static final int ACC_IDENTITY = 0x20;


### PR DESCRIPTION
Valhalla JDK27 bringup

Add stub methods for `jdk.internal.misc.Unsafe.arrayInstanceBaseOffset/arrayInstanceIndexScale/getFieldMap`;
Add `Access` methods for `Valhalla`;
Update `JIMAGE_FindResource API`;
Enable `--enable-preview` by default for `Valhalla`;
Update `VALUE_TYPES_MAJOR_VERSION` to `JDK27`;
Update `Valhalla` test.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/23

Passed [a personal build](https://hyc-runtimes-jenkins.swg-devops.com/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/2503/)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>