### PR TITLE
JDK27 Access.uncheckedEncodeASCII() replaces encodeASCII()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -645,16 +645,16 @@ final class Access implements JavaLangAccess {
 	/*[ENDIF] JAVA_SPEC_VERSION < 25 */
 
 	@Override
-	/*[IF JAVA_SPEC_VERSION == 25]*/
+	/*[IF (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION >= 27) ]*/
 	public int uncheckedEncodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ELSE] JAVA_SPEC_VERSION == 25 */
+	/*[ELSE] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION >= 27) */
 	public int encodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ENDIF] JAVA_SPEC_VERSION == 25 */
-		/*[IF JAVA_SPEC_VERSION >= 26]*/
+	/*[ENDIF] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION >= 27) */
+		/*[IF JAVA_SPEC_VERSION == 26]*/
 		return StringCoding.encodeAsciiArray(sa, sp, da, dp, len);
-		/*[ELSE] JAVA_SPEC_VERSION >= 26 */
+		/*[ELSE] JAVA_SPEC_VERSION == 26 */
 		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);
-		/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
+		/*[ENDIF] JAVA_SPEC_VERSION == 26 */
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 


### PR DESCRIPTION
JDK27 `Access.uncheckedEncodeASCII()` replaces `encodeASCII()`

Related to upstream update - https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/03978a260ec5b2763fefb19015677a4fce2b23d2

This fixes abuild compilation failures:
```
03:00:27  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:72: error: Access is not abstract and does not override abstract method uncheckedEncodeASCII(char[],int,byte[],int,int) in JavaLangAccess
03:00:27  final class Access implements JavaLangAccess {
03:00:27        ^
03:00:27  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:356: error: encodeASCII(char[],int,byte[],int,int) in Access does not override or implement a method from a supertype
03:00:27  	@Override
03:00:27  	^
03:00:27  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:358: error: cannot find symbol
03:00:27  		return StringCoding.encodeAsciiArray(sa, sp, da, dp, len);
03:00:27  		                   ^
03:00:27    symbol:   method encodeAsciiArray(char[],int,byte[],int,int)
03:00:27    location: class StringCoding
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>

