### PR TITLE
Ensure consistent directory path handling across platforms

### DIFF
--- a/runtime/port/common/j9shmem.c
+++ b/runtime/port/common/j9shmem.c
@@ -328,6 +328,8 @@ j9shmem_handle_stat(struct J9PortLibrary *portLibrary, struct j9shmem_handle *ha
  * The directory will be passed to the other shmem or shmem_deprecated functions.
  *
  * If ctrlDirName is NULL, a platform specific directory will be chosen.
+ *
+ * The returned path always ends with a DIR_SEPARATOR, ensuring it represents a directory.
  * 
  * @param[in] portLibrary The port library
  * @param[in] ctrlDirName The name of the control directory, ignored if cacheDirName is set

--- a/runtime/port/sysvipc/j9shmem.c
+++ b/runtime/port/sysvipc/j9shmem.c
@@ -1363,8 +1363,8 @@ j9shmem_getDir(struct J9PortLibrary* portLibrary, const char* ctrlDirName, uint3
 					buffer,
 					bufLength,
 					SHM_STRING_ENDS_WITH_CHAR(rootDir, DIR_SEPARATOR)
-						? "%s%s" DIR_SEPARATOR_STR
-						: "%s" DIR_SEPARATOR_STR "%s" DIR_SEPARATOR_STR,
+						? "%s%s"
+						: "%s" DIR_SEPARATOR_STR "%s",
 					rootDir,
 					J9SH_BASEDIR) >= bufLength
 			) {

--- a/runtime/port/win32/j9shmem.c
+++ b/runtime/port/win32/j9shmem.c
@@ -788,13 +788,26 @@ j9shmem_getDir(struct J9PortLibrary* portLibrary, const char* ctrlDirName, uint3
 	Trc_PRT_j9shmem_getDir_Entry();
 
 	if (NULL != ctrlDirName) {
+		size_t ctrlDirLen = strlen(ctrlDirName);
+		BOOLEAN cdEndsWithSep = (0 != ctrlDirLen) && ('\\' == ctrlDirName[ctrlDirLen - 1]);
 		if (appendBaseDir) {
-			if (omrstr_printf(shmemdir, bufLength, "%s\\%s", ctrlDirName, J9SH_BASEDIR) == bufLength - 1) {
+			if (omrstr_printf(
+					shmemdir,
+					bufLength,
+					cdEndsWithSep ? "%s%s" : "%s\\%s",
+					ctrlDirName,
+					J9SH_BASEDIR) == (bufLength - 1)
+			) {
 				Trc_PRT_j9shmem_getDir_ExitFailedOverflow();
 				return J9PORT_ERROR_SHMEM_GET_DIR_BUF_OVERFLOW;
 			}
 		} else {
-			if (omrstr_printf(shmemdir, bufLength, "%s\\", ctrlDirName) == bufLength - 1) {
+			if (omrstr_printf(
+					shmemdir,
+					bufLength,
+					cdEndsWithSep ? "%s" : "%s\\",
+					ctrlDirName) == (bufLength - 1)
+			) {
 				Trc_PRT_j9shmem_getDir_ExitFailedOverflow();
 				return J9PORT_ERROR_SHMEM_GET_DIR_BUF_OVERFLOW;
 			}
@@ -812,8 +825,9 @@ j9shmem_getDir(struct J9PortLibrary* portLibrary, const char* ctrlDirName, uint3
 		 * %APPDATA%, %TEMP%, c:\\temp, c:\\
 		 */
 		rc = SHGetFolderPathW( NULL, CSIDL_LOCAL_APPDATA, NULL, 0, (wchar_t*)appdatadir);
-		if(SUCCEEDED(rc)) {
+		if (SUCCEEDED(rc)) {
 			/* Convert Unicode to UTF8 */
+
 			if (appendBaseDir) {
 				if (omrstr_printf(shmemdir, bufLength, "%ls\\%s", appdatadir, J9SH_BASEDIR) == bufLength - 1) {
 					Trc_PRT_j9shmem_getDir_ExitFailedOverflow();
@@ -826,8 +840,12 @@ j9shmem_getDir(struct J9PortLibrary* portLibrary, const char* ctrlDirName, uint3
 				}
 			}
 		} else {
-			/*	The preference of share class cache file storage location is from 
-				ENV_LOCALAPPDATA, ENV_APPDATA, ENV_TEMP, DIR_TEMP, DIR_CROOT */				
+			size_t appDataLen = 0;
+			BOOLEAN adEndsWithSep = FALSE;
+
+			/* The preference of shared class cache file storage location is from
+			 * ENV_LOCALAPPDATA, ENV_APPDATA, ENV_TEMP, DIR_TEMP, DIR_CROOT.
+			 */
 			if (-1 == omrsysinfo_get_env(ENV_LOCALAPPDATA, appdatadir, J9SH_MAXPATH)) {
 				if (-1 == omrsysinfo_get_env(ENV_APPDATA, appdatadir, J9SH_MAXPATH)) {
 					if (-1 == omrsysinfo_get_env(ENV_TEMP, appdatadir, J9SH_MAXPATH)) {
@@ -839,13 +857,28 @@ j9shmem_getDir(struct J9PortLibrary* portLibrary, const char* ctrlDirName, uint3
 					}
 				}
 			}
+
+			appDataLen = strlen(appdatadir);
+			adEndsWithSep = (0 != appDataLen) && ('\\' == appdatadir[appDataLen - 1]);
+
 			if (appendBaseDir) {
-				if (omrstr_printf(shmemdir, bufLength, "%s\\%s", appdatadir, J9SH_BASEDIR) == bufLength - 1) {
+				if (omrstr_printf(
+						shmemdir,
+						bufLength,
+						adEndsWithSep ? "%s%s" : "%s\\%s",
+						appdatadir,
+						J9SH_BASEDIR) == (bufLength - 1)
+				) {
 					Trc_PRT_j9shmem_getDir_ExitFailedOverflow();
 					return J9PORT_ERROR_SHMEM_GET_DIR_BUF_OVERFLOW;
 				}
 			} else {
-				if (omrstr_printf(shmemdir, bufLength, "%s\\", appdatadir) == bufLength - 1) {
+				if (omrstr_printf(
+						shmemdir,
+						bufLength,
+						adEndsWithSep ? "%s" : "%s\\",
+						appdatadir) == (bufLength - 1)
+				) {
 					Trc_PRT_j9shmem_getDir_ExitFailedOverflow();
 					return J9PORT_ERROR_SHMEM_GET_DIR_BUF_OVERFLOW;
 				}


### PR DESCRIPTION
The changes reflect the fix for issue https://github.com/eclipse-openj9/openj9/pull/23102 and resolves the comment 

Update the parent directory(.cache) permission to 01700.

Fixes bug in : https://github.com/eclipse-openj9/openj9/pull/23102
Signed-off-by: Konark Shah <[konark.shah@ibm.com](mailto:konark.shah@ibm.com)>