### PR TITLE
JITServer: reduce number of VM_getObjectClassInfoFromKnotIndex messages

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -2752,7 +2752,8 @@ handleResponse(JITServer::MessageType response, JITServer::ClientStream *client,
          {
          uintptr_t *objectPointerReferenceServerQuery = std::get<0>(client->getRecvData<uintptr_t*>());
          TR::KnownObjectTable::Index index = knot->getOrCreateIndexAt(objectPointerReferenceServerQuery);
-         client->write(response, index, knot->getPointerLocation(index));
+         // Need to send back the entire knot entry
+         client->write(response, index, knot->getObjectInfo(index));
          }
          break;
       case MessageType::KnownObjectTable_getExistingIndexAt:

--- a/runtime/compiler/env/J9KnownObjectTable.hpp
+++ b/runtime/compiler/env/J9KnownObjectTable.hpp
@@ -127,6 +127,7 @@ public:
 
 #if defined(J9VM_OPT_JITSERVER)
    void updateKnownObjectTableAtServer(Index index, uintptr_t *objectReferenceLocationClient, bool isArrayWithConstantElements = false);
+   void updateKnownObjectTableAtServer(Index index, const struct ObjectInfo &objInfo, bool isArrayWithConstantElements = false);
    void getKnownObjectTableDumpInfo(std::vector<TR_KnownObjectTableDumpInfo> &knotDumpInfoList);
 #endif /* defined(J9VM_OPT_JITSERVER) */
 


### PR DESCRIPTION
This commit builds on top of https://github.com/eclipse-openj9/openj9/pull/23012 which has extended a KnownObjectTable entry to include additional information populated on demand. In this commit the additional information is populated eagerly when a new entry is added to the table as a result of a getOrCreateIndexAt() call.
On AcmeAir benchmark this commit reduces the number of VM_getObjectClassInfoFromKnotIndex by an order of magnitude. The average number of messages per compilation is reduced by 4%.