### PR TITLE
Allow MethodMetaData stores in UD-chain import (ExceptionMeta)

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -1538,8 +1538,8 @@ TR_CISCGraph::importUDchains(TR::Compilation *comp, TR_UseDefInfo *useDefInfo, b
             {
             TR_ASSERT_FATAL_WITH_NODE(
                trNode,
-               trNode->getSymbol()->isStatic(),
-               "direct store to non-auto, non-static");
+               trNode->getSymbol()->isStatic() || trNode->getSymbol()->isMethodMetaData(),
+               "direct store to non-auto, non-static, non-MethodMetaData");
 
             // Regardless of the uses that we can see within this method (which
             // may not even appear, since we won't necessarily get use-def


### PR DESCRIPTION
Idiom Recognition’s CISCGraph construction imports use/def chains and currently asserts that any direct store to a non-auto symbol must be static. This is too strict for loops that contain an in-loop exception handler: the catch path commonly contains a direct store to the method’s exception metadata slot. ExceptionMeta is neither auto nor static, so the existing assertion can fire even though the store is valid and expected.

This change relaxes the assertion to also allow symbols that are isMethodMetaData(), which covers ExceptionMeta stores. This relaxation does not make IR transform loops with exception handlers. It only prevents an overly conservative assertion from rejecting or aborting analysis when an exception handler writes MethodMetaData. The MemSet/MemCpy/etc. transformations are still gated by multiple later checks that remain unchanged

Fixes: #21417