### PR TITLE
Add cycle start and end time snapshots and apis for accessing the values

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -221,6 +221,8 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_get_explicit_GC_disabled,
 	j9gc_get_total_cycle_count,
 	j9gc_get_unique_cycle_ID,
+	j9gc_get_cycle_start_time,
+	j9gc_get_cycle_end_time,
 	j9gc_modron_global_collect,
 	j9gc_modron_global_collect_with_overrides,
 	j9gc_modron_local_collect,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -173,6 +173,8 @@ extern J9_CFUNC UDATA j9gc_get_object_total_footprint_in_bytes(J9JavaVM *javaVM,
 extern J9_CFUNC BOOLEAN j9gc_get_explicit_GC_disabled(J9JavaVM *javaVM);
 extern J9_CFUNC UDATA j9gc_get_total_cycle_count(J9JavaVM *javaVM);
 extern J9_CFUNC UDATA j9gc_get_unique_cycle_ID(J9VMThread *vmThread);
+extern J9_CFUNC U_64 j9gc_get_cycle_start_time(J9VMThread *vmThread);
+extern J9_CFUNC U_64 j9gc_get_cycle_end_time(J9VMThread *vmThread);
 extern J9_CFUNC UDATA j9gc_objaccess_compressedPointersShift(J9VMThread *vmThread);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreU64Split(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile);
 extern J9_CFUNC void cleanupMutatorModelJava(J9VMThread* vmThread);

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -1025,6 +1025,44 @@ j9gc_get_unique_cycle_ID(J9VMThread *vmThread)
 }
 
 /**
+ * API to return the start time of the cycle. Start time is a snapshot taken at the beggining of each cycle.
+ *
+ * @param[in] vmThread the J9VMThread
+ * @return start time of the cycle
+ */
+U_64
+j9gc_get_cycle_start_time(J9VMThread *vmThread)
+{
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+	U_64 result = 0;
+
+	if (NULL != env->_cycleState) {
+		result = env->_cycleState->_startTime;
+	}
+
+	return result;
+}
+
+/**
+ * API to return the end time of the cycle. End time is a snapshot taken at the end of each cycle.
+ *
+ * @param[in] vmThread the J9VMThread
+ * @return end time of the cycle
+ */
+U_64
+j9gc_get_cycle_end_time(J9VMThread *vmThread)
+{
+	MM_EnvironmentBase *env = MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread);
+	U_64 result = 0;
+
+	if (NULL != env->_cycleState) {
+		result = env->_cycleState->_endTime;
+	}
+
+	return result;
+}
+
+/**
  * Called whenever the allocation threshold values or enablement state changes.
  * 
  * @parm[in] currentThread The current VM Thread

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -93,6 +93,8 @@ UDATA j9gc_get_object_total_footprint_in_bytes(J9JavaVM *javaVM, j9object_t obje
 BOOLEAN j9gc_get_explicit_GC_disabled(J9JavaVM *javaVM);
 UDATA j9gc_get_total_cycle_count(J9JavaVM *javaVM);
 UDATA j9gc_get_unique_cycle_ID(J9VMThread *vmThread);
+U_64 j9gc_get_cycle_start_time(J9VMThread *vmThread);
+U_64 j9gc_get_cycle_end_time(J9VMThread *vmThread);
 j9object_t j9gc_get_memoryController(J9VMThread *vmContext, j9object_t objectPtr);
 void j9gc_set_memoryController(J9VMThread *vmThread, j9object_t objectPtr, j9object_t memoryController);
 void j9gc_set_allocation_sampling_interval(J9JavaVM *vm, UDATA samplingInterval);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4989,6 +4989,8 @@ typedef struct J9MemoryManagerFunctions {
 	BOOLEAN ( *j9gc_get_explicit_GC_disabled)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_get_total_cycle_count)(struct J9JavaVM *javaVM) ;
 	UDATA  ( *j9gc_get_unique_cycle_ID)(struct J9VMThread *vmThread) ;
+	U_64  ( *j9gc_get_cycle_start_time)(struct J9VMThread *vmThread) ;
+	U_64  ( *j9gc_get_cycle_end_time)(struct J9VMThread *vmThread) ;
 	UDATA  ( *j9gc_modron_global_collect)(struct J9VMThread *vmThread) ;
 	UDATA  ( *j9gc_modron_global_collect_with_overrides)(struct J9VMThread *vmThread, U_32 overrideFlags) ;
 	UDATA  ( *j9gc_modron_local_collect)(struct J9VMThread *vmThread) ;


### PR DESCRIPTION
This change:
 -Adds snapshots for start and end times for GC cycles.
 -Consolidates some other start and end time reporting.
 -Adds apis for accessing the cycle start and end times.

Needs https://github.com/eclipse-omr/omr/pull/8085