### PR TITLE
RAM Class Persistence: enable snapshot reallocation

### DIFF
--- a/runtime/vm/VMSnapshotImpl.cpp
+++ b/runtime/vm/VMSnapshotImpl.cpp
@@ -1030,6 +1030,7 @@ setupVMSnapshotImplPortLibrary(J9PortLibrary *portLibrary)
 	OMRPORT_ACCESS_FROM_J9PORT(portLibrary);
 	memcpy(&(vmSnapshotImplPortLibrary->portLibrary), privateOmrPortLibrary, sizeof(OMRPortLibrary));
 	vmSnapshotImplPortLibrary->portLibrary.mem_allocate_memory = snapshot_mem_allocate_memory;
+	vmSnapshotImplPortLibrary->portLibrary.mem_reallocate_memory = snapshot_mem_reallocate_memory;
 	vmSnapshotImplPortLibrary->portLibrary.mem_free_memory = snapshot_mem_free_memory;
 	vmSnapshotImplPortLibrary->portLibrary.mem_allocate_memory32 = snapshot_mem_allocate_memory32;
 	vmSnapshotImplPortLibrary->portLibrary.mem_free_memory32 = snapshot_mem_free_memory32;


### PR DESCRIPTION
The reallocation function for the snapshot run is not called by the snapshot port library, instead the default reallocation function is called. This results in the memory space is not allocated from RCP heap and the pointer becomes dangling pointer in the restore run.

Fixes: #23095