### PR TITLE
JDK27 Access API update

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -891,14 +891,26 @@ final class Access implements JavaLangAccess {
 
 	/*[IF JAVA_SPEC_VERSION >= 22]*/
 	@Override
+	/*[IF (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES]*/
+	public boolean bytesCompatible(String string, Charset charset, int srcIndex, int numChars) {
+		return string.bytesCompatible(charset, srcIndex, numChars);
+	}
+	/*[ELSE] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
 	public boolean bytesCompatible(String string, Charset charset) {
 		return string.bytesCompatible(charset);
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
 
 	@Override
+	/*[IF (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES]*/
+	public void copyToSegmentRaw(String string, MemorySegment segment, long offset, int srcIndex, int srcLength) {
+		string.copyToSegmentRaw(segment, offset, srcIndex, srcLength);
+	}
+	/*[ELSE] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
 	public void copyToSegmentRaw(String string, MemorySegment segment, long offset) {
 		string.copyToSegmentRaw(segment, offset);
 	}
+	/*[ENDIF] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
 
 	@Override
 	public Method findMethod(Class<?> clazz, boolean publicOnly, String methodName, Class<?>... parameterTypes) {


### PR DESCRIPTION
JDK27 Access API update

This is to fix abuild compilation errors:
```
00:31:20  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:72: error: Access is not abstract and does not override abstract method bytesCompatible(String,Charset,int,int) in JavaLangAccess
00:31:20  final class Access implements JavaLangAccess {
00:31:20        ^
00:31:20  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:512: error: bytesCompatible(String,Charset) in Access does not override or implement a method from a supertype
00:31:20  	@Override
00:31:20  	^
00:31:20  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:514: error: method bytesCompatible in class String cannot be applied to given types;
00:31:20  		return string.bytesCompatible(charset);
00:31:20  		             ^
00:31:20    required: Charset,int,int
00:31:20    found:    Charset
00:31:20    reason: actual and formal argument lists differ in length
00:31:20  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:517: error: copyToSegmentRaw(String,MemorySegment,long) in Access does not override or implement a method from a supertype
00:31:20  	@Override
00:31:20  	^
00:31:20  /home/jenkins/workspace/Build_JDKnext_aarch64_linux_OpenJDK/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:519: error: method copyToSegmentRaw in class String cannot be applied to given types;
00:31:20  		string.copyToSegmentRaw(segment, offset);
00:31:20  		      ^
00:31:20    required: MemorySegment,long,int,int
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>