### PR TITLE
JITServer: eliminate VM_getObjectClassFromKnownObjectIndexJLClass message

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -623,15 +623,6 @@ handleResponse(JITServer::MessageType response, JITServer::ClientStream *client,
          client->write(response, fe->getObjectClassFromKnownObjectIndex(comp, idx));
          }
          break;
-      case MessageType::VM_getObjectClassFromKnownObjectIndexJLClass:
-         {
-         auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
-         auto idx = std::get<0>(recv);
-         bool isJL;
-         TR_OpaqueClassBlock *result = fe->getObjectClassFromKnownObjectIndex(comp, idx, &isJL);
-         client->write(response, result, isJL);
-         }
-         break;
       case MessageType::VM_getObjectClassInfoFromKnotIndex:
          {
          auto recv = client->getRecvData<TR::KnownObjectTable::Index>();

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1227,25 +1227,20 @@ TR_J9VMBase::getObjectClassFromKnownObjectIndex(TR::Compilation *comp,
                                                 TR::KnownObjectTable::Index idx,
                                                 bool *isJavaLangClass)
    {
-   TR::VMAccessCriticalSection vpKnownObjectCriticalSection(comp);
-
    TR::KnownObjectTable *knot = comp->getKnownObjectTable();
    if (!knot)
       return NULL;
 
-   TR_OpaqueClassBlock *clazz = getObjectClass(knot->getPointer(idx));
-   TR_OpaqueClassBlock *jlClass = getClassClassPointer(clazz);
-   *isJavaLangClass = (clazz == jlClass);
-   if (*isJavaLangClass)
-      {
-      clazz = getClassFromJavaLangClass(knot->getPointer(idx));
-      }
+   TR::KnownObjectTable::ObjectInfo objInfo = getObjClassInfoFromKnotIndex(comp, idx);
+   *isJavaLangClass = objInfo._isFixedJavaLangClass;
 
-   J9::ConstProvenanceGraph *cpg = comp->constProvenanceGraph();
-   cpg->addEdge(cpg->knownObject(idx), clazz);
-
-   return clazz;
+   // Don't nedd to add an edge to comp->constProvenanceGraph() because this
+   // is done in getObjClassInfoFromKnotIndex() frontend query
+   //J9::ConstProvenanceGraph *cpg = comp->constProvenanceGraph();
+   //cpg->addEdge(cpg->knownObject(idx), clazz);
+   return objInfo._clazz;
    }
+
 uintptr_t
 TR_J9VMBase::getStaticReferenceFieldAtAddress(uintptr_t fieldAddress)
    {

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -945,18 +945,6 @@ TR_J9ServerVM::getObjectClassFromKnownObjectIndex(TR::Compilation *comp, TR::Kno
    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
    }
 
-TR_OpaqueClassBlock *
-TR_J9ServerVM::getObjectClassFromKnownObjectIndex(TR::Compilation *comp,
-                                                  TR::KnownObjectTable::Index idx,
-                                                  bool *isJavaLangClass)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getObjectClassFromKnownObjectIndexJLClass, idx);
-   auto recv = stream->read<TR_OpaqueClassBlock *, bool>();
-   *isJavaLangClass = std::get<1>(recv);
-   return std::get<0>(recv);
-   }
-
 uintptr_t
 TR_J9ServerVM::getStaticReferenceFieldAtAddress(uintptr_t fieldAddress)
    {

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -111,7 +111,6 @@ public:
    virtual TR_OpaqueClassBlock * getObjectClass(uintptr_t objectPointer) override;
    virtual TR_OpaqueClassBlock * getObjectClassAt(uintptr_t objectAddress) override;
    virtual TR_OpaqueClassBlock *getObjectClassFromKnownObjectIndex(TR::Compilation *comp, TR::KnownObjectTable::Index idx) override;
-   virtual TR_OpaqueClassBlock *getObjectClassFromKnownObjectIndex(TR::Compilation *comp, TR::KnownObjectTable::Index idx, bool *isJavaLangClass) override;
    virtual uintptr_t getStaticReferenceFieldAtAddress(uintptr_t fieldAddress) override;
    virtual TR::KnownObjectTable::ObjectInfo getObjClassInfoFromKnotIndexNoCaching(TR::Compilation *comp, TR::KnownObjectTable::Index knotIndex) override;
    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 95; // ID: CG1NgwI3xhSuaFWEztYD
+   static const uint16_t MINOR_NUMBER = 96; // ID: VpbBeePxHOTLt7LEWmmE
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -118,7 +118,6 @@ const char *messageNames[] =
    "VM_getObjectClass",
    "VM_getObjectClassAt",
    "VM_getObjectClassFromKnownObjectIndex",
-   "VM_getObjectClassFromKnownObjectIndexJLClass",
    "VM_stackWalkerMaySkipFrames",
    "VM_classInitIsFinished",
    "VM_getClassFromNewArrayType",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -129,7 +129,6 @@ enum MessageType : uint16_t
    VM_getObjectClass,
    VM_getObjectClassAt,
    VM_getObjectClassFromKnownObjectIndex,
-   VM_getObjectClassFromKnownObjectIndexJLClass,
    VM_stackWalkerMaySkipFrames,
    VM_classInitIsFinished,
    VM_getClassFromNewArrayType,


### PR DESCRIPTION
This message is used by JITServer as part of the following frontend query: `TR_J9VMBase::getObjectClassFromKnownObjectIndex(TR::Compilation*, TR::KnownObjectTable::Index, bool *)` 
Since PR #23163 eagerly populates the KnownObjectTable with desired information, we can avoid sending a message to the client and instead fetch the required information directly from the corresponding KnownObjectTable entry.
The `getObjectClassFromKnownObjectIndex()` frontend query no longer needs to be overridden at the server because the bulk of the work is done by `getObjClassInfoFromKnotIndex()` which has a specific server implementation.