### PR TITLE
Enable SIGABEND handling for z/OS in jit390Handler

### DIFF
--- a/runtime/compiler/runtime/SignalHandler.c
+++ b/runtime/compiler/runtime/SignalHandler.c
@@ -1004,7 +1004,18 @@ UDATA jit390Handler(J9VMThread* vmThread, U_32 sigType, void* sigInfo)
          {
          trapType = TRAP_TYPE_INTERNAL_ERROR;
          }
-#endif
+#endif /* defined(TR_TARGET_S390) && defined(LINUX) */
+#if defined(J9ZOS390)
+      else if (sigType == J9PORT_SIG_FLAG_SIGABEND)
+         {
+         /* Unsafe.get*() APIs may trigger a SIGABEND on z/OS which should be converted to a java/lang/InternalError. */
+         infoType = j9sig_info(sigInfo, J9PORT_SIG_GPR, 7, &infoName, &infoValue);
+         entryPointRegister = (UDATA *) infoValue;
+
+         trapType = TRAP_TYPE_INTERNAL_ERROR;
+         }
+#endif /* defined(J9ZOS390) */
+
       /* end of trying to catch traps */
       if (TRAP_TYPE_UNKNOWN == trapType)
          {


### PR DESCRIPTION
Compiled load instructions for Unsafe.get*() APIs may result in a SIGABEND abend. These need to be caught and surfaced as a java/lang/ InternalError SIGBUS error to be consistent with VM handler behaviour.