### PR TITLE
Optimize getMethodFromName calls in J9VMServer

### DIFF
--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -1483,21 +1483,52 @@ TR_J9ServerVM::getClassFlagsValue(TR_OpaqueClassBlock *clazz)
    }
 
 TR_OpaqueMethodBlock *
-TR_J9ServerVM::getMethodFromName(const char *className, const char *methodName, const char *signature)
-   {
-   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-   stream->write(JITServer::MessageType::VM_getMethodFromName, std::string(className, strlen(className)),
-         std::string(methodName, strlen(methodName)), std::string(signature, strlen(signature)));
-   return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
-   }
-
-TR_OpaqueMethodBlock *
 TR_J9ServerVM::getMethodFromClass(TR_OpaqueClassBlock *methodClass, const char *methodName, const char *signature, TR_OpaqueClassBlock *callingClass)
    {
+   ClassMethodNamePair key{(J9Class*)methodClass, std::string(methodName) + signature};
+   PersistentUnorderedMap<ClassMethodNamePair, TR_OpaqueMethodBlock*> &methodMap = _compInfoPT->getClientData()->getMethodByNameMap();
+   // If callingClass is non-null, a visibility check will be done during the look up.
+   // Only methods visible to the callingClass will be returned. The caching mechanism
+   // becomes simpler when we only use it when callingClass is (nil).
+   if (!callingClass)
+      {
+      OMR::CriticalSection getMethodFromClassCS(_compInfoPT->getClientData()->getMethodMapMonitor());
+      auto it = methodMap.find(key);
+      if (it != methodMap.end())
+         return it->second;
+      }
    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
    stream->write(JITServer::MessageType::VM_getMethodFromClass, methodClass, std::string(methodName, strlen(methodName)),
          std::string(signature, strlen(signature)), callingClass);
-   return std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
+   TR_OpaqueMethodBlock *method = std::get<0>(stream->read<TR_OpaqueMethodBlock *>());
+
+   if (method)
+      {
+      // we only cache methods whose class loader is known to
+      // be the system class loader. This is because it allows
+      // us to optimize the cache invalidation when classes are
+      // unloaded
+      bool cache = false;
+         {
+         OMR::CriticalSection getClassLoader(_compInfoPT->getClientData()->getROMMapMonitor());
+         auto &romClassMap = _compInfoPT->getClientData()->getROMClassMap();
+         auto it = romClassMap.find((J9Class*)methodClass);
+         if (it != romClassMap.end())
+            {
+            J9ClassLoader *classLoader = (J9ClassLoader*)it->second._classLoader;
+            ClientSessionData::VMInfo *vminfo = _compInfoPT->getClientData()->getOrCacheVMInfo(_compInfoPT->getMethodBeingCompiled()->_stream);
+            J9ClassLoader *systemClassLoader = (J9ClassLoader*)(vminfo->_systemClassLoader);
+            cache = (classLoader == systemClassLoader);
+            }
+         }
+      if (cache)
+         {
+         OMR::CriticalSection getMethodFromClassCS(_compInfoPT->getClientData()->getMethodMapMonitor());
+         methodMap[key] = method;
+         }
+      }
+
+   return method;
    }
 
 bool
@@ -3530,15 +3561,6 @@ TR_J9SharedCacheServerVM::getClassFromNewArrayType(int32_t arrayType)
    if (comp && comp->getOption(TR_UseSymbolValidationManager))
       return TR_J9ServerVM::getClassFromNewArrayType(arrayType);
    return NULL;
-   }
-
-TR_OpaqueMethodBlock *
-TR_J9SharedCacheServerVM::getMethodFromName(const char *className, const char *methodName, const char *signature)
-   {
-   // The TR_J9VM version of this method implicitly creates SVM record during AOT compilation.
-   // The TR_J9ServerVM version doesn't account for that, so need to override it
-   // The downside is that this results in 2 remote calls, instead of 1.
-   return TR_J9VM::getMethodFromName(className, methodName, signature);
    }
 
 TR_OpaqueMethodBlock *

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -167,7 +167,6 @@ public:
    virtual bool hasFinalizer(TR_OpaqueClassBlock *clazz) override;
    virtual uintptr_t getClassDepthAndFlagsValue(TR_OpaqueClassBlock *clazz) override;
    virtual uintptr_t getClassFlagsValue(TR_OpaqueClassBlock * clazz) override;
-   virtual TR_OpaqueMethodBlock *getMethodFromName(const char *className, const char *methodName, const char *signature) override;
    virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *methodClass, const char *methodName, const char *signature, TR_OpaqueClassBlock *callingClass) override;
    virtual bool isStable(J9Class *fieldClass, int32_t cpIndex) override;
    virtual bool isForceInline(TR_ResolvedMethod *method) override;
@@ -387,7 +386,6 @@ public:
    virtual void *findPersistentMHJ2IThunk(char *signatureChars) override { TR_ASSERT_FATAL(0, "findPersistentMHJ2IThunk should not be called on the server"); return NULL; }
    virtual J9Class *getClassForAllocationInlining(TR::Compilation *comp, TR::SymbolReference *classSymRef) override;
    virtual bool ensureOSRBufferSize(TR::Compilation *comp, uintptr_t osrFrameSizeInBytes, uintptr_t osrScratchBufferSizeInBytes, uintptr_t osrStackFrameSizeInBytes) override;
-   virtual TR_OpaqueMethodBlock *getMethodFromName(const char *className, const char *methodName, const char *signature) override;
    virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock *classObject, int32_t cpIndex, bool ignoreReResolve = true) override;
    virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod, TR_OpaqueClassBlock *classObject, int32_t cpIndex) override;
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -138,6 +138,7 @@ class TR_J9MethodFieldAttributes
 using TR_FieldAttributesCache = PersistentUnorderedMap<int32_t, TR_J9MethodFieldAttributes>;
 
 using ClassLoaderStringPair = std::pair<J9ClassLoader *, std::string>;
+using ClassMethodNamePair = std::pair<J9Class *, std::string>;
 
 
 struct ClassUnloadedData
@@ -406,6 +407,7 @@ public:
    PersistentUnorderedMap<J9Class *, ClassInfo> &getROMClassMap() { return _romClassMap; }
    PersistentUnorderedMap<J9Method *, J9MethodInfo> &getJ9MethodMap() { return _J9MethodMap; }
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock *> &getClassBySignatureMap() { return _classBySignatureMap; }
+   PersistentUnorderedMap<ClassMethodNamePair, TR_OpaqueMethodBlock *> &getMethodByNameMap() { return _methodByNameMap; }
    PersistentUnorderedSet<J9Method*> &getDLTedMethodSet() { return _DLTedMethodSet; }
    PersistentUnorderedMap<J9Class *, ClassChainData> &getClassChainDataMap() { return _classChainDataMap; }
    PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock *> &getConstantPoolToClassMap() { return _constantPoolToClassMap; }
@@ -414,6 +416,7 @@ public:
    void processIllegalFinalFieldModificationList(const std::vector<TR_OpaqueClassBlock*> &classes);
    TR::Monitor *getROMMapMonitor() { return _romMapMonitor; }
    TR::Monitor *getClassMapMonitor() { return _classMapMonitor; }
+   TR::Monitor *getMethodMapMonitor() { return _methodMapMonitor; }
    TR::Monitor *getDLTSetMonitor() { return _DLTSetMonitor; }
    TR::Monitor *getClassChainDataMapMonitor() { return _classChainDataMapMonitor; }
    TR_IPBytecodeHashTableEntry *getCachedIProfilerInfo(TR_OpaqueMethodBlock *method, uint32_t byteCodeIndex, bool *methodInfoPresent);
@@ -604,6 +607,8 @@ private:
    // The following hashtable caches <classname> --> <J9Class> mappings
    // All classes in here are loaded by the systemClassLoader so we know they cannot be unloaded
    PersistentUnorderedMap<ClassLoaderStringPair, TR_OpaqueClassBlock*> _classBySignatureMap;
+   // The following hashtable caches <J9Class*,methodName> --> <J9Method*> mappings
+   PersistentUnorderedMap<ClassMethodNamePair, TR_OpaqueMethodBlock*> _methodByNameMap;
    // The set of j9methods that have been DLTed. This may be queried by the Inliner. Protected by _DLTSetMonitor.
    PersistentUnorderedSet<J9Method*> _DLTedMethodSet;
 
@@ -612,6 +617,7 @@ private:
    PersistentUnorderedMap<J9ConstantPool *, TR_OpaqueClassBlock *> _constantPoolToClassMap;
    TR::Monitor *_romMapMonitor;
    TR::Monitor *_classMapMonitor;
+   TR::Monitor *_methodMapMonitor;
    TR::Monitor *_DLTSetMonitor; // Protects the set of methods that have been DLTed: _DLTedMethodSet
    TR::Monitor *_classChainDataMapMonitor;
    // The following monitor is used to protect access to _lastProcessedCriticalSeqNo and


### PR DESCRIPTION
Optimize `fe->getMethodFromName(...)`

Replace getMethodFromName on J9VMServer with the
base implementation, and add caching for getMethodFromClass
to reduce the number of total messages.