### PR TITLE
Avoid NullPointerException in CheckEngine.checkSlotFinalizableList()

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
@@ -1424,7 +1424,9 @@ class CheckEngine
 	{
 		int result = checkObjectIndirect(object);
 		if (J9MODRON_GCCHK_RC_OK != result) {
-			CheckError error = new CheckError(object, null, _cycle, _currentCheck, result, _cycle.nextErrorCount(), CheckError.check_type_finalizable);
+			CheckError error = new CheckError(
+					object, PointerPointer.NULL, _cycle, _currentCheck, result,
+					_cycle.nextErrorCount(), CheckError.check_type_finalizable);
 			_reporter.report(error);
 		}
 		return J9MODRON_SLOT_ITERATOR_OK;


### PR DESCRIPTION
This unexpected failure has been observed on z/OS:
```
<gc check (51325): from debugger: UNFINALIZED: slot 50199da580(0) -> 8006a680: object not in an object region>
<gc check (51326): from debugger: UNFINALIZED: slot 50199da580(0) -> 8006a708: object not in an object region>
<gc check (51327): from debugger: UNFINALIZED: slot 50199da580(0) -> 8006a860: object not in an object region>
<gc check (51328): from debugger: UNFINALIZED: slot 50199da580(0) -> 8006a8d0: object not in an object region>
<gc check (51329): from debugger: UNFINALIZED: slot 50199da580(0) -> 8006a988: object not in an object region>
done (5 ms).
Checking FINALIZABLE...Problem running command:
java.lang.NullPointerException
    at com.ibm.j9ddr.vm29.pointer.VoidPointer.cast(VoidPointer.java:39)
    at com.ibm.j9ddr.vm29.tools.ddrinteractive.gccheck.CheckError.<init>(CheckError.java:73)
    at com.ibm.j9ddr.vm29.tools.ddrinteractive.gccheck.CheckEngine.checkSlotFinalizableList(CheckEngine.java:1426)
    at com.ibm.j9ddr.vm29.tools.ddrinteractive.gccheck.CheckFinalizableList.check(CheckFinalizableList.java:35)
    at com.ibm.j9ddr.vm29.tools.ddrinteractive.gccheck.Check.run(Check.java:55)
    at com.ibm.j9ddr.vm29.tools.ddrinteractive.gccheck.CheckCycle.run(CheckCycle.java:472)
    at com.ibm.j9ddr.vm29.tools.ddrinteractive.gccheck.GCCheckRunner.run(GCCheckRunner.java:59)
    at com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.GCCheckCommand.run(GCCheckCommand.java:46)
...
```
This change avoids the `NullPointerException` so `gccheck` can report the remainder of its findings and complete normally.