### PR TITLE
Reject loop candidates that contain catch blocks

### DIFF
--- a/runtime/compiler/optimizer/IdiomRecognition.cpp
+++ b/runtime/compiler/optimizer/IdiomRecognition.cpp
@@ -2061,6 +2061,27 @@ TR_CISCTransformer::createLoopCandidates(List<TR_RegionStructure> *loopCandidate
             logprintf(enableTracing, log, "\tRejected loop %d - cold loop.\n", naturalLoop->getNumber());
             continue;     // cold loop
             }
+
+         // Reject if any catch handler block appears in the loop region (including nested blocks).
+         bool containsCatchBlock = false;
+         TR_ScratchList<TR::Block> blocksInLoop(trMemory());
+         naturalLoop->getBlocks(&blocksInLoop);
+         ListIterator<TR::Block> blocksIt(&blocksInLoop);
+         TR::Block *nextBlock;
+
+         for (nextBlock = blocksIt.getFirst(); nextBlock; nextBlock = blocksIt.getNext())
+            if (nextBlock->isCatchBlock())
+               {
+               containsCatchBlock = true;
+               break;
+               }
+
+         if (containsCatchBlock)
+            {
+            logprintf(enableTracing, log, "\tRejected loop %d - loop has catch block (Exception handler).\n", naturalLoop->getNumber());
+            continue;
+            }
+
          loopCount++;
          loopCandidates->add(naturalLoop);
 


### PR DESCRIPTION
Reject natural loops as idiom candidates if any catch handler block appears in the loop region (including nested blocks). Loops containing catch blocks are not suitable for CISC idiom transformations (e.g., MemSet/MemCpy) because the exception path alters the loop region’s CFG and prevents extraction/alignment of the required idiom region. This change avoids wasted idiom analysis on loops whose CFG contains exception-handler paths.

Related: #21417