### PR TITLE
Set null return value on MethodExit via exception

### DIFF
--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -1821,7 +1821,9 @@ jvmtiHookMethodExit(J9HookInterface** hook, UDATA eventNum, void* eventData, voi
 				jmethodID methodID;
 				jvalue returnValue;
 
-				if (!poppedByException) {
+				if (poppedByException) {
+					memset(&returnValue, 0, sizeof(jvalue));
+				} else {
 					fillInJValue(signatureType, &returnValue, valueAddress,  (j9object_t*) currentThread->arg0EA);
 				}
 				methodID = getCurrentMethodID(currentThread, method);


### PR DESCRIPTION
Set returnValue structure to 0 for JVMTI MethodExit on exception. 
Fixes: #23174

Signed-off-by: Aditi Srinivas M Aditi.Srini@ibm.com

Passing test:
https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/57571/testReport/