### PR TITLE
Simplify PrintStream.print(String.format(...)) to format(...)

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/BaseWindowsOSThread.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/BaseWindowsOSThread.java
@@ -145,8 +145,8 @@ public abstract class BaseWindowsOSThread implements IOSThread
 		long ip = getInstructionPointer();
 		long rsp = getStackPointer();
 
-		// System.err.println(String.format("Initial rsp = 0x%08x", rsp));
-		// System.err.println(String.format("Initial ip = 0x%08x", ip));
+		// System.err.format("Initial rsp = 0x%08x%n", rsp);
+		// System.err.format("Initial ip = 0x%08x%n", ip);
 
 		while( ip != 0x0) {		
 
@@ -188,8 +188,8 @@ public abstract class BaseWindowsOSThread implements IOSThread
 				rsp += 8;
 			}
 
-			// System.err.println(String.format("Next rsp = 0x%08x", rsp));
-			// System.err.println(String.format("Next ip = 0x%08x", ip));
+			// System.err.format("Next rsp = 0x%08x%n", rsp);
+			// System.err.format("Next ip = 0x%08x%n", ip);
 		}
 	}
 	

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/RuntimeFunction.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/RuntimeFunction.java
@@ -44,7 +44,7 @@ public class RuntimeFunction implements Comparable<RuntimeFunction> {
 	}
 
 	public boolean contains(long address) {
-		// System.err.println(String.format("Checking 0x%08x <= 0x%08x < 0x%08x", startOffset, address, endOffset ));
+		// System.err.format("Checking 0x%08x <= 0x%08x < 0x%08x%n", startOffset, address, endOffset);
 		if (address >= startOffset && address < endOffset) {
 			return true;
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindInfo.java
@@ -130,7 +130,7 @@ public class UnwindInfo {
 			long unwindCodeAddr = OFFSET_UNWINDCODE + address;
 
 			for (byte codeIndex = 0; codeIndex < countOfCodes;) {
-				//System.err.println(String.format("Stack pointer is: 0x%08x", stackPointer));
+				// System.err.format("Stack pointer is: 0x%08x%n", stackPointer);
 				UnwindCode c = new UnwindCode(process, module, this, unwindCodeAddr);
 
 				//System.err.println("Applying: " + c.formatOp());

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindModule.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/minidump/unwind/UnwindModule.java
@@ -99,7 +99,7 @@ public class UnwindModule extends Module {
 		output.println("Dumping unwind info for: " + getName());
 		try {
 			for( RuntimeFunction rf: runtimeFunctionEntries) {
-				output.println(String.format("Found ImageRuntimeFunctionEntry %s", rf));
+				output.format("Found ImageRuntimeFunctionEntry %s%n", rf);
 				// Skip chained entries, they don't have real info. They are handled in the
 				// get code above so their existence is transparent to everyone else.
 				if( rf.getUnwindInfoAddress() % 2 == 0 ) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/AddStructureBlob.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/AddStructureBlob.java
@@ -138,8 +138,8 @@ public class AddStructureBlob {
 			StructureKey key = new StructureKey(keyString);
 			store.add(key, structureName, true);
 			store.updateSuperset();
-			System.out.println(String.format("Added %s to %s/%s as %s", structureName, directoryName, store.getSuperSetFileName(), keyString));
-		}		
+			System.out.format("Added %s to %s/%s as %s%n", structureName, directoryName, store.getSuperSetFileName(), keyString);
+		}
 	}
 	
 	//the order in which files are added is controlled by a properties file, it expects the -f parameter to point to a directory containing
@@ -158,7 +158,7 @@ public class AddStructureBlob {
 				StructureKey key = new StructureKey(file.getName() + "." + keyString);
 				store.add(key, file.getPath(), false);
 				store.updateSuperset();
-				System.out.println(String.format("Added %s to %s/%s as %s", file.getAbsolutePath(), directoryName, store.getSuperSetFileName(), key));
+				System.out.format("Added %s to %s/%s as %s%n", file.getAbsolutePath(), directoryName, store.getSuperSetFileName(), key);
 			} else {
 				System.out.println("WARNING : The specified structure file " + file.getName() + " does not exist and was ignored");
 			}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/PointerGenerator.java
@@ -1402,9 +1402,9 @@ public class PointerGenerator {
 			writer.println("import com.ibm.j9ddr.CorruptDataException;");
 		}
 		String version = opts.get("-v");
-		writer.println(String.format("import com.ibm.j9ddr.vm%s.pointer.*;", version));
-		writer.println(String.format("import com.ibm.j9ddr.vm%s.structure.*;", version));
-		writer.println(String.format("import com.ibm.j9ddr.vm%s.types.*;", version));
+		writer.format("import com.ibm.j9ddr.vm%s.pointer.*;%n", version);
+		writer.format("import com.ibm.j9ddr.vm%s.structure.*;%n", version);
+		writer.format("import com.ibm.j9ddr.vm%s.types.*;%n", version);
 		if (cacheClass) {
 			writer.println("import java.util.HashMap;");
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/BaseStructureCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/BaseStructureCommand.java
@@ -155,7 +155,7 @@ public abstract class BaseStructureCommand implements ICommand
 			out.println();
 
 			for (StructureDescriptor desc : inheritanceStack) {
-				out.println(String.format("  Fields for %s:", desc.getName()));
+				out.format("  Fields for %s:%n", desc.getName());
 				for (FieldDescriptor thisField : desc.getFields()) {
 					if (!thisField.isPresent()) {
 						continue;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/BaseStructureFormatter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/BaseStructureFormatter.java
@@ -86,8 +86,8 @@ public abstract class BaseStructureFormatter implements IStructureFormatter
 		}
 		
 		if (! found) {
-			//Default behaviour - write out !j9x address
-			out.print(String.format("!j9x 0x%x", address));
+			// Default behaviour - write out !j9x address
+			out.format("!j9x 0x%x", address);
 		}
 		
 		/* postFormat */

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/FindInMemoryCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/FindInMemoryCommand.java
@@ -218,7 +218,7 @@ public class FindInMemoryCommand extends Command
 	private boolean findFirst(PrintStream out, IProcess process) {
 		out.print("Scanning memory for ");
 		for (int i = 0; i < currentPattern.length; i++) {
-			out.print(String.format("%02x ", currentPattern[i] & 0xFF));
+			out.format("%02x ", currentPattern[i] & 0xFF);
 		}
 		out.println("aligned to " + currentAlignment + " starting from 0x" + Long.toHexString(currentAddress));
 		long result = process.findPattern(currentPattern, currentAlignment, currentAddress);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/J9XCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/J9XCommand.java
@@ -99,27 +99,27 @@ public class J9XCommand extends Command
 				
 		while (bytesToPrint > 0) {
 			if (column % numColumns == 0) {
-				out.print(String.format("0x%08X : ", addr));
+				out.format("0x%08X : ", addr);
 				asciiIndex = 0;
 			}
-			
+
 			out.append(" ");
-			
+
 			switch (width) {
 			case 1:
-				out.print(String.format("%02x", context.process.getByteAt(addr)));
+				out.format("%02x", context.process.getByteAt(addr));
 				break;
-			case 2:				
-				out.print(String.format("%04x", context.process.getShortAt(addr)));
+			case 2:
+				out.format("%04x", context.process.getShortAt(addr));
 				break;
 			case 4:
-				out.print(String.format("%08x", context.process.getIntAt(addr)));
+				out.format("%08x", context.process.getIntAt(addr));
 				break;
 			case 8:
-				out.print(String.format("%016x", context.process.getLongAt(addr)));
+				out.format("%016x", context.process.getLongAt(addr));
 				break;
 			default:
-				out.print(String.format("Invalid width specified\n"));
+				out.println("Invalid width specified");
 				return;
 			}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/MemoryRangesCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/tools/ddrinteractive/MemoryRangesCommand.java
@@ -38,16 +38,16 @@ public class MemoryRangesCommand extends Command
 	public void run(String command, String[] args, Context context, PrintStream out)	throws DDRInteractiveCommandException 
 	{
 		IProcess process = context.process;
-		
+
 		String format = "0x%0" + (process.bytesPerPointer() * 2) + "x%" + (16 - process.bytesPerPointer()) + "s";
 		Collection<? extends IMemoryRange> ranges = process.getMemoryRanges();
-		if( ranges != null && !ranges.isEmpty() ) {
+		if (ranges != null && !ranges.isEmpty()) {
 			out.println("Base                  Top                   Size");
-			for(IMemoryRange range : ranges) {
-				out.print(String.format(format, range.getBaseAddress(), " "));
-				out.print(String.format(format, range.getTopAddress(), " "));
-				out.print(String.format(format, range.getSize(), " "));
-				out.print("\n");
+			for (IMemoryRange range : ranges) {
+				out.format(format, range.getBaseAddress(), " ");
+				out.format(format, range.getTopAddress(), " ");
+				out.format(format, range.getSize(), " ");
+				out.println();
 			}
 		} else {
 			out.println("No memory ranges found (Note: this has not yet been implemented for execution from a native debugger such as gdb)");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/AbstractPointer.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/AbstractPointer.java
@@ -340,9 +340,9 @@ public abstract class AbstractPointer extends DataType {
 			try {
 				int word = getIntAtOffset(i * 4);
 				if (i % 4 == 0) {
-					stream.print(String.format("%08X : ", getAddress() + (i * 4)));
+					stream.format("%08X : ", getAddress() + (i * 4));
 				}
-				stream.print(String.format("%08X ", word));
+				stream.format("%08X ", word);
 				if (i % 4 == 3) {
 					stream.println();
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ClassSummaryHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ClassSummaryHelper.java
@@ -65,12 +65,10 @@ public class ClassSummaryHelper {
 		}
 
 		// Print the global stats
-		out.println(String.format("%d classes, using: %d bytes or %d kB",
-				numberOfClasses, totalSize, totalSize / 1024));
+		out.format("%d classes, using: %d bytes or %d kB%n", numberOfClasses, totalSize, totalSize / 1024);
 
 		// Print the sections
-		out.println(String.format("%-39s %-8s %-8s %-6s",
-				"Section", "Byte", "kB", "%"));
+		out.format("%-39s %-8s %-8s %-6s%n", "Section", "Byte", "kB", "%");
 		for (Map.Entry<String, Long> entry : data.entrySet()) {
 			out.println(printSize(entry.getKey(), entry.getValue(), totalSize));
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/LinearDumper.java
@@ -459,24 +459,24 @@ public class LinearDumper implements IClassWalkCallbacks {
 		} else if (nesting > nestingThreshold) {
 			return;
 		}
-		
+
 		/* section start */
 		if (region != null) {
 			String str = String.format("Section Start: %s (%d bytes)", region.getName(), region.getLength());
 			out.println();
-			out.println(String.format("=== %-85s ===", str));
+			out.format("=== %-85s ===%n", str);
 		}
-		
+
 		/* subsections */
-		for (J9ClassRegionNode classRegionNode:regionNode.getChildren()) {
+		for (J9ClassRegionNode classRegionNode : regionNode.getChildren()) {
 			printAllRegions(out, clazz, nestingThreshold, classRegionNode, nesting + 1);
 		}
-		
+
 		/* section end */
 		if (region != null) {
 			String str = String.format("Section End: %s", region.getName());
 			out.println();
-			out.println(String.format("=== %-85s ===", str));
+			out.format("=== %-85s ===%n", str);
 		}
 	}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ThreadsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/ThreadsCommand.java
@@ -42,8 +42,6 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.MonitorsCommand;
 
 public class ThreadsCommand extends Command
 {
-	private static final String nl = System.getProperty("line.separator");
-
 	public ThreadsCommand()
 	{
 		addCommand("threads", "cmd|help", "Lists VM threads");
@@ -59,8 +57,7 @@ public class ThreadsCommand extends Command
 			if (argument.equalsIgnoreCase("help")) {
 				help(out);
 			} else {
-				out.append("Attached Threads List. For more options, run !threads help\n");
-				out.append(nl);
+				out.format("Attached Threads List. For more options, run !threads help%n%n");
 				if (argument.equalsIgnoreCase("stack")) {
 					stack(out, context, "");
 				} else if (argument.equalsIgnoreCase("stackslots")) {
@@ -110,7 +107,7 @@ public class ThreadsCommand extends Command
 				J9VMThreadPointer threadCursor = vm.mainThread();
 
 				do {
-					out.append(String.format("    !stack 0x%s  !j9vmthread 0x%s  !j9thread 0x%s  tid 0x%s (%d) !utthreaddata 0x%s // %s",
+					out.append(String.format("    !stack 0x%s  !j9vmthread 0x%s  !j9thread 0x%s  tid 0x%s (%d) !utthreaddata 0x%s // %s%n",
 							Long.toHexString(threadCursor.getAddress()),
 							Long.toHexString(threadCursor.getAddress()),
 							Long.toHexString(threadCursor.osThread().getAddress()),
@@ -118,7 +115,6 @@ public class ThreadsCommand extends Command
 							threadCursor.osThread().tid().longValue(),
 							Long.toHexString(threadCursor.omrVMThread()._trace$uteThread().getAddress()),
 							getThreadName(threadCursor)));
-					out.append(nl);
 					threadCursor = threadCursor.linkNext();
 				} while (!threadCursor.eq(mainThread));
 			}
@@ -148,11 +144,12 @@ public class ThreadsCommand extends Command
 
 				if (!currentMonitorTable.equals(previousMonitorTable)) {
 					/* Print header for new monitor table */
-					out.append("Table = " + currentMonitorTable.getTableName() + ", itemCount=" + currentMonitorTable.getCount());
-					out.append(nl);
+					out.format("Table = %s, itemCount=%s%n",
+							currentMonitorTable.getTableName(), currentMonitorTable.getCount());
 				}
-				out.append(String.format("\n    !j9thread 0x%s    !j9threadmonitor 0x%s", Long.toHexString(objectMonitorPointer.monitor().owner().getAddress()), Long.toHexString(objectMonitorPointer.monitor().getAddress())));
-				out.append(nl);
+				out.format("%n    !j9thread 0x%s    !j9threadmonitor 0x%s%n",
+						Long.toHexString(objectMonitorPointer.monitor().owner().getAddress()),
+						Long.toHexString(objectMonitorPointer.monitor().getAddress()));
 
 				previousMonitorTable = currentMonitorTable;
 			}
@@ -170,13 +167,13 @@ public class ThreadsCommand extends Command
 
 				do {
 					if (threadCursor.osThread().tid().eq(tid)) {
-						out.println(String.format("\t!stack 0x%08x\t!j9vmthread 0x%08x\t!j9thread 0x%08x\ttid 0x%x (%d) // %s",
+						out.format("\t!stack 0x%08x\t!j9vmthread 0x%08x\t!j9thread 0x%08x\ttid 0x%x (%d) // %s%n",
 								threadCursor.getAddress(),
 								threadCursor.getAddress(),
 								threadCursor.osThread().getAddress(),
 								threadCursor.osThread().tid().longValue(),
 								threadCursor.osThread().tid().longValue(),
-								getThreadName(threadCursor)));
+								getThreadName(threadCursor));
 						break;
 					}
 					threadCursor = threadCursor.linkNext();
@@ -194,10 +191,17 @@ public class ThreadsCommand extends Command
 			if (mainThread.notNull()) {
 				J9VMThreadPointer threadCursor = vm.mainThread();
 
-				do {//
-					out.append(String.format("    !j9vmthread 0x%s %s %s %s %s %s %s %s %s", Long.toHexString(threadCursor.getAddress()), Long.toHexString(threadCursor.debugEventData1().longValue()), Long.toHexString(threadCursor.debugEventData2().longValue()), Long.toHexString(threadCursor.debugEventData3().longValue()), Long.toHexString(threadCursor.debugEventData4()
-							.longValue()), Long.toHexString(threadCursor.debugEventData5().longValue()), Long.toHexString(threadCursor.debugEventData6().longValue()), Long.toHexString(threadCursor.debugEventData7().longValue()), Long.toHexString(threadCursor.debugEventData8().longValue())));
-					out.append(nl);
+				do {
+					out.format("    !j9vmthread 0x%s %s %s %s %s %s %s %s %s%n",
+							Long.toHexString(threadCursor.getAddress()),
+							Long.toHexString(threadCursor.debugEventData1().longValue()),
+							Long.toHexString(threadCursor.debugEventData2().longValue()),
+							Long.toHexString(threadCursor.debugEventData3().longValue()),
+							Long.toHexString(threadCursor.debugEventData4().longValue()),
+							Long.toHexString(threadCursor.debugEventData5().longValue()),
+							Long.toHexString(threadCursor.debugEventData6().longValue()),
+							Long.toHexString(threadCursor.debugEventData7().longValue()),
+							Long.toHexString(threadCursor.debugEventData8().longValue()));
 					threadCursor = threadCursor.linkNext();
 				} while (!threadCursor.eq(mainThread));
 			}
@@ -214,13 +218,12 @@ public class ThreadsCommand extends Command
 				J9VMThreadPointer threadCursor = vm.mainThread();
 
 				do {
-					out.append(String.format("    !j9vmthread 0x%s publicFlags=%s privateFlags=%s inNative=%s // %s",
+					out.append(String.format("    !j9vmthread 0x%s publicFlags=%s privateFlags=%s inNative=%s // %s%n",
 							Long.toHexString(threadCursor.getAddress()),
 							Long.toHexString(threadCursor.publicFlags().longValue()),
 							Long.toHexString(threadCursor.privateFlags().longValue()),
 							Long.toHexString(threadCursor.inNative().longValue()),
 							getThreadName(threadCursor)));
-					out.append(nl);
 					threadCursor = threadCursor.linkNext();
 				} while (!threadCursor.eq(mainThread));
 			}
@@ -239,16 +242,15 @@ public class ThreadsCommand extends Command
 				J9VMThreadPointer threadCursor = vm.mainThread();
 
 				do {
-					out.println(String.format("\t!stack 0x%08x\t!j9vmthread 0x%08x\t!j9thread 0x%08x\ttid 0x%x (%d) // %s",
+					out.format("\t!stack 0x%08x\t!j9vmthread 0x%08x\t!j9thread 0x%08x\ttid 0x%x (%d) // %s%n%n",
 							threadCursor.getAddress(),
 							threadCursor.getAddress(),
 							threadCursor.osThread().getAddress(),
 							threadCursor.osThread().tid().longValue(),
 							threadCursor.osThread().tid().longValue(),
-							getThreadName(threadCursor)));
-					out.append(nl);
+							getThreadName(threadCursor));
 					walkCommand.run(command, new String[] { Long.toString(threadCursor.getAddress()) }, context, out);
-					out.append(nl);
+					out.println();
 
 					threadCursor = threadCursor.linkNext();
 				} while (!threadCursor.eq(mainThread));
@@ -287,13 +289,13 @@ public class ThreadsCommand extends Command
 				J9VMThreadPointer threadCursor = vm.mainThread();
 
 				do {
-					out.println(String.format("\t!stack 0x%08x\t!j9vmthread 0x%08x\t!j9thread 0x%08x\ttid 0x%x (%d) // (%s)",
+					out.format("\t!stack 0x%08x\t!j9vmthread 0x%08x\t!j9thread 0x%08x\ttid 0x%x (%d) // (%s)%n",
 							threadCursor.getAddress(),
 							threadCursor.getAddress(),
 							threadCursor.osThread().getAddress(),
 							threadCursor.osThread().tid().longValue(),
 							threadCursor.osThread().tid().longValue(),
-							getThreadName(threadCursor)));
+							getThreadName(threadCursor));
 
 					threadCursor = threadCursor.linkNext();
 				} while (!threadCursor.eq(mainThread));

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AnalyseRomClassUTF8Command.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/AnalyseRomClassUTF8Command.java
@@ -222,7 +222,7 @@ public class AnalyseRomClassUTF8Command extends Command {
 						int count = 0;
 						for (String string : entry.getValue()) {
 							long weight = (timesDuplicated - 1) * string.length();
-							out.println(String.format("%-5d %-11d %-5d \"%s\"", count++, timesDuplicated, weight, string));
+							out.format("%-5d %-11d %-5d \"%s\"%n", count++, timesDuplicated, weight, string);
 						}
 					}
 				}
@@ -327,7 +327,7 @@ public class AnalyseRomClassUTF8Command extends Command {
 						int count = 0;
 						for (String string : entry.getValue()) {
 							long weight = (timesDuplicated - 1) * string.length();
-							out.println(String.format("%-5d %-11d %-5d \"%s\"", count++, timesDuplicated, weight, string));
+							out.format("%-5d %-11d %-5d \"%s\"%n", count++, timesDuplicated, weight, string);
 						}
 					}
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ClassForNameCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ClassForNameCommand.java
@@ -55,23 +55,22 @@ public class ClassForNameCommand extends Command
 
 			int hitCount = 0;
 			String searchClassName = args[0];
-			PatternString pattern = new PatternString (searchClassName);
-			
-			out.println(String.format(
-					"Searching for classes named '%1$s' in VM=%2$s",
-					searchClassName, Long.toHexString(vm.getAddress())));
+			PatternString pattern = new PatternString(searchClassName);
+
+			out.format(
+					"Searching for classes named '%1$s' in VM=%2$s%n",
+					searchClassName, Long.toHexString(vm.getAddress()));
 			while (iterator.hasNext()) {
 				J9ClassPointer classPointer = (J9ClassPointer) iterator.next();
 				String javaName = J9ClassHelper.getJavaName(classPointer);
 				if (pattern.isMatch(javaName)) {
 					hitCount++;
-					
+
 					String hexString = classPointer.getHexAddress();
-					out.println(String.format("!j9class %1$s named %2$s", hexString, javaName));					
+					out.format("!j9class %1$s named %2$s%n", hexString, javaName);
 				}
 			}
-			out.println(String.format("Found %1$d class(es) named %2$s",
-					hitCount, searchClassName));
+			out.format("Found %1$d class(es) named %2$s%n", hitCount, searchClassName);
 		} catch (CorruptDataException e) {
 			throw new DDRInteractiveCommandException(e);
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CompressedRefMappingCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/CompressedRefMappingCommand.java
@@ -73,7 +73,7 @@ public class CompressedRefMappingCommand extends Command
 			}
 
 			if (command.startsWith("!fj9objecttoj9object")) {
-				out.println(String.format("!fj9object %s -> !j9object %s", ptr.getHexAddress(), mappedValue.getHexAddress()));
+				out.format("!fj9object %s -> !j9object %s%n", ptr.getHexAddress(), mappedValue.getHexAddress());
 			} else {
 				context.execute("!j9object", new String[] { mappedValue.getHexAddress() }, out);
 			}
@@ -84,7 +84,7 @@ public class CompressedRefMappingCommand extends Command
 			} else {
 				tokenValue = ptr.getAddress();
 			}
-			out.println(String.format("!j9object %s -> !fj9object 0x%s\n", ptr.getHexAddress(), Long.toHexString(tokenValue)));
+			out.format("!j9object %s -> !fj9object 0x%s%n%n", ptr.getHexAddress(), Long.toHexString(tokenValue));
 		}
 	}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpAllRamClassLinearCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpAllRamClassLinearCommand.java
@@ -71,8 +71,7 @@ public class DumpAllRamClassLinearCommand extends Command
 				J9ClassPointer classPointer = (J9ClassPointer)classSegmentIterator.next();
 				out.println("!dumpramclasslinear " +  classPointer.getHexAddress());
 				//RAM Class 'org/apache/tomcat/util/buf/MessageBytes' at 0x0DCF9008:
-				out.println(String.format("RAM Class '%s' at %s", J9ClassHelper.getJavaName(classPointer), classPointer.getHexAddress()));
-				out.println();
+				out.format("RAM Class '%s' at %s%n%n", J9ClassHelper.getJavaName(classPointer), classPointer.getHexAddress());
 				ClassWalker classWalker = new RamClassWalker(classPointer, context);
 				new LinearDumper().gatherLayoutInfo(out, classWalker, nestingThreashold);
 				out.println();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpAllRomClassLinearCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpAllRomClassLinearCommand.java
@@ -71,8 +71,7 @@ public class DumpAllRomClassLinearCommand extends Command
 				J9ROMClassPointer classPointer = iterator.next();
 				out.println("!dumpromclasslinear " +  classPointer.getHexAddress());
 				//ROM Class 'org/apache/tomcat/util/buf/MessageBytes' at 0x0DCF9008:
-				out.println(String.format("ROM Class '%s' at %s", J9UTF8Helper.stringValue(classPointer.className()), classPointer.getHexAddress()));
-				out.println();
+				out.format("ROM Class '%s' at %s%n%n", J9UTF8Helper.stringValue(classPointer.className()), classPointer.getHexAddress());
 				ClassWalker classWalker = new RomClassWalker(classPointer, context);
 				new LinearDumper().gatherLayoutInfo(out, classWalker, nestingThreashold);
 				out.println();

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpContendedLoadTable.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpContendedLoadTable.java
@@ -90,14 +90,12 @@ public class DumpContendedLoadTable extends Command
 						ldStatus = "ILLEGAL VALUE: " + entryPointer.status();
 					}
 					J9VMThreadPointer loadingThread = entryPointer.thread();
-					out.print(
-							String.format("\tClassname: %s;\n\t\tLoader:  %s; Loading thread: %s %s\n\t\tStatus: %s; Table entry hash 0x%X\n",
-									entryPointer.className().getCStringAtOffset(0, entryPointer.classNameLength().longValue()), 
-									entryPointer.classLoader().formatShortInteractive(), 
-									J9VMThreadHelper.getName(loadingThread), loadingThread.formatShortInteractive(),
-									ldStatus, 
-									entryPointer.hashValue().longValue())
-							);
+					out.format("\tClassname: %s;%n\t\tLoader:  %s; Loading thread: %s %s%n\t\tStatus: %s; Table entry hash 0x%X%n",
+							entryPointer.className().getCStringAtOffset(0, entryPointer.classNameLength().longValue()),
+							entryPointer.classLoader().formatShortInteractive(),
+							J9VMThreadHelper.getName(loadingThread), loadingThread.formatShortInteractive(),
+							ldStatus,
+							entryPointer.hashValue().longValue());
 				}
 
 				MonitorIterator iterator = new MonitorIterator(javaVM);
@@ -114,9 +112,9 @@ public class DumpContendedLoadTable extends Command
 								for (J9ThreadPointer tp: waitingThreads) {
 									J9VMThreadPointer vmThread = J9ThreadHelper.getVMThread(tp);
 									if (vmThread.notNull()) {
-										out.print(String.format("\t%s\t%s\n", vmThread.formatShortInteractive(), J9VMThreadHelper.getName(vmThread)));
+										out.format("\t%s\t%s%n", vmThread.formatShortInteractive(), J9VMThreadHelper.getName(vmThread));
 									} else {
-										out.print(String.format("\t%s\t%s\n", tp.formatShortInteractive(), "[osthread]"));
+										out.format("\t%s\t%s%n", tp.formatShortInteractive(), "[osthread]");
 									}
 								}
 							}
@@ -130,10 +128,7 @@ public class DumpContendedLoadTable extends Command
 		} catch (CorruptDataException e) {
 			throw new DDRInteractiveCommandException(e);
 		}
-
 	}
-
-
 
 	private void help(PrintStream out) {
 		out.append("!dumpcontload       -- the contents of the VM contended class load table");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleDirectedExportsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpModuleDirectedExportsCommand.java
@@ -78,7 +78,7 @@ public class DumpModuleDirectedExportsCommand extends Command
 					String hexAddress = exportModulePtr.getHexAddress();
 					out.printf("%-30s !j9module %s%n", moduleName, hexAddress);
 				}
-				out.println(String.format("Found %d module(s) that the package is exported to\n", hitCount));
+				out.format("Found %d module(s) that the package is exported to%n%n", hitCount);
 			}
 		} catch (CorruptDataException e) {
 			throw new DDRInteractiveCommandException(e);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRamClassLinearCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRamClassLinearCommand.java
@@ -57,7 +57,7 @@ public class DumpRamClassLinearCommand extends Command
 		}
 		J9ClassPointer clazz = J9ClassPointer.cast(addr);
 		try {
-			out.println(String.format("RAM Class '%s' at %s", J9UTF8Helper.stringValue(clazz.romClass().className()), clazz.getHexAddress()));
+			out.format("RAM Class '%s' at %s%n", J9UTF8Helper.stringValue(clazz.romClass().className()), clazz.getHexAddress());
 			ClassWalker classWalker = new RamClassWalker(clazz, context);
 			new LinearDumper().gatherLayoutInfo(out, classWalker, nestingThreshold);
 		} catch (CorruptDataException e) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRomClassCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRomClassCommand.java
@@ -85,15 +85,12 @@ public class DumpRomClassCommand extends Command {
 						hitCount++;
 						J9ROMClassPointer clazz = classPointer.romClass();
 						String hexString = clazz.getHexAddress();
-						out.println(String.format("ROMClass %1$s named %2$s\n",
-								hexString, javaName));
+						out.format("ROMClass %1$s named %2$s%n%n", hexString, javaName);
 
 						J9BCUtil.j9bcutil_dumpRomClass(out, clazz, maps);
 					}
 				}
-				out.println(String.format(
-						"Found %1$d class(es) with name %2$s\n", hitCount,
-						searchClassName));
+				out.format("Found %1$d class(es) with name %2$s%n%n", hitCount, searchClassName);
 			} else {
 				/* treat argument as address */
 				long addr = CommandUtils.parsePointer(args[0], J9BuildFlags.J9VM_ENV_DATA64);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRomClassLinearCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRomClassLinearCommand.java
@@ -57,8 +57,8 @@ public class DumpRomClassLinearCommand extends Command
 		}
 		J9ROMClassPointer clazz = J9ROMClassPointer.cast(addr);
 		try {
-			//ROM Class 'org/apache/tomcat/util/buf/MessageBytes' at 0x0DCF9008:
-			out.println(String.format("ROM Class '%s' at %s", J9UTF8Helper.stringValue(clazz.className()), clazz.getHexAddress()));
+			// ROM Class 'org/apache/tomcat/util/buf/MessageBytes' at 0x0DCF9008:
+			out.format("ROM Class '%s' at %s%n", J9UTF8Helper.stringValue(clazz.className()), clazz.getHexAddress());
 			ClassWalker classWalker = new RomClassWalker(clazz, context);
 			new LinearDumper().gatherLayoutInfo(out, classWalker, nestingThreshold);
 		} catch (CorruptDataException e) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRomMethodCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpRomMethodCommand.java
@@ -106,8 +106,8 @@ public class DumpRomMethodCommand extends Command {
 					throw new DDRInteractiveCommandException(e);
 				}
 			}
-			for (J9ROMClassAndMethod mi: methodIterator) {
-				out.println(String.format("Class: %s",  J9UTF8Helper.stringValue(mi.romClass.className())));
+			for (J9ROMClassAndMethod mi : methodIterator) {
+				out.format("Class: %s%n", J9UTF8Helper.stringValue(mi.romClass.className()));
 				J9BCUtil.j9bcutil_dumpRomMethod(out, mi.romMethod, mi.romClass, dumpFlags, J9BCUtil.BCUtil_DumpAnnotations);
 			}
 		} catch (CorruptDataException e) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpStringTableCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/DumpStringTableCommand.java
@@ -79,9 +79,9 @@ public class DumpStringTableCommand extends Command {
 			} catch (CorruptDataException e) {
 				// ignore
 			}
-			
-			String hexAddr = objectPointer.formatShortInteractive();				
-			out.println(String.format("%s value = <%s>", hexAddr, value));
+
+			String hexAddr = objectPointer.formatShortInteractive();
+			out.format("%s value = <%s>%n", hexAddr, value);
 		}
 		out.println("Table Size = " + stringTableObjects.size());
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/J9BCUtil.java
@@ -972,8 +972,8 @@ public class J9BCUtil {
 		U16Pointer bsmIndices = U16Pointer.cast(callSiteData.addOffset(4*callSiteCount));
 
 		if (0 != callSiteCount) {
-			out.println(String.format("  Call Sites (%d):\n", callSiteCount));
-			for(int i = 0; i < callSiteCount; i++){
+			out.format("  Call Sites (%d):%n%n", callSiteCount);
+			for (int i = 0; i < callSiteCount; i++) {
 				J9ROMNameAndSignaturePointer nameAndSig = J9ROMNameAndSignaturePointer.cast(callSiteData.add(i).get());
 				out.println("    Name: " + J9UTF8Helper.stringValue(nameAndSig.name()));
 				out.println("    Signature: " + J9UTF8Helper.stringValue(nameAndSig.signature()));
@@ -987,8 +987,8 @@ public class J9BCUtil {
 			U32Pointer cpShapeDescription = J9ROMClassHelper.cpShapeDescription(romClass);
 			U16Pointer bsmDataCursor = bsmIndices.add(callSiteCount);
 
-			out.println(String.format("  Bootstrap Methods (%d):", bsmCount));
-			for(int i = 0; i < bsmCount; i++){
+			out.format("  Bootstrap Methods (%d):%n", bsmCount);
+			for (int i = 0; i < bsmCount; i++) {
 				J9ROMMethodHandleRefPointer methodHandleRef = J9ROMMethodHandleRefPointer.cast(constantPool.add(bsmDataCursor.at(0).longValue()));
 				bsmDataCursor = bsmDataCursor.add(1);
 				/* methodRef will be either a field or a method ref - they both have the same shape so we can pretend it is always a methodref */
@@ -1003,7 +1003,7 @@ public class J9BCUtil {
 
 				out.println("    Signature: " + J9UTF8Helper.stringValue(nameAndSig.signature()));
 
-				out.println(String.format("    Bootstrap Method Arguments (%d):", bsmArgumentCount));
+				out.format("    Bootstrap Method Arguments (%d):%n", bsmArgumentCount);
 
 				for (; 0 != bsmArgumentCount; bsmArgumentCount--) {
 					long argCPIndex = bsmDataCursor.at(0).longValue();
@@ -1104,12 +1104,12 @@ public class J9BCUtil {
 	{
 		int splitTableCount = romClass.staticSplitMethodRefCount().intValue();
 		if (splitTableCount > 0) {
-			out.println(String.format("Static Split Table (%d):\n", splitTableCount));
+			out.format("Static Split Table (%d):%n%n", splitTableCount);
 			out.println("    SplitTable Index -> CP Index");
 			U16Pointer cursor = romClass.staticSplitMethodRefIndexes();
 			for (int i = 0; i < splitTableCount; i++) {
 				cursor.add(i);
-				out.println(String.format("    %16d -> %d", i, cursor.at(i).intValue()));
+				out.format("    %16d -> %d%n", i, cursor.at(i).intValue());
 			}
 		}
 	}
@@ -1127,12 +1127,12 @@ public class J9BCUtil {
 	{
 		int splitTableCount = romClass.specialSplitMethodRefCount().intValue();
 		if (splitTableCount > 0) {
-			out.println(String.format("Special Split Table (%d):\n", splitTableCount));
+			out.format("Special Split Table (%d):%n%n", splitTableCount);
 			out.println("    SplitTable Index -> CP Index");
 			U16Pointer cursor = romClass.specialSplitMethodRefIndexes();
 			for (int i = 0; i < splitTableCount; i++) {
 				cursor.add(i);
-				out.println(String.format("    %16d -> %d", i, cursor.at(i).intValue()));
+				out.format("    %16d -> %d%n", i, cursor.at(i).intValue());
 			}
 		}
 	}
@@ -1234,23 +1234,23 @@ public class J9BCUtil {
 		J9MethodParametersDataPointer methodParameters = ROMHelp.getMethodParametersFromROMMethod(romMethod);
 		if (methodParameters != J9MethodParametersDataPointer.NULL) {
 			J9MethodParameterPointer parameters = methodParameters.parameters();
-			out.println(String.format("  Method Parameters (%d):\n", methodParameters.parameterCount().longValue()));
+			out.format("  Method Parameters (%d):%n%n", methodParameters.parameterCount().longValue());
 			for (int i = 0 ; i < methodParameters.parameterCount().longValue(); i++) {
 				J9UTF8Pointer name = J9UTF8Pointer.cast(parameters.nameEA().get());
 				long parameterFlags = parameters.flags().longValue();
+				out.print("    ");
 				if (name.isNull()) {
-					out.print("    <no name>");
+					out.print("<no name>");
 				} else {
-					out.print("    " + J9UTF8Helper.stringValue(name));
+					out.print(J9UTF8Helper.stringValue(name));
 				}
 
-				out.print(String.format("    0x%x ( ", parameterFlags));
+				out.format("    0x%x ( ", parameterFlags);
 				dumpModifiers(out, parameterFlags, MODIFIERSOURCE_METHODPARAMETER, ONLY_SPEC_MODIFIERS, false);
-				out.println(" )\n");
+				out.format(" )%n%n");
 			}
 			out.println("\n");
 		}
-
 	}
 
 	static U8Pointer dumpStackMapSlots(PrintStream out, J9ROMClassPointer classfile, U8Pointer slotData, long slotCount) throws CorruptDataException

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/MonitorsCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/MonitorsCommand.java
@@ -327,11 +327,11 @@ public class MonitorsCommand extends Command
 			}
 
 			// Step 1: Print the general info for the VM and native threads:
-			out.println(String.format(
-					"!j9vmthread 0x%08x\t!j9thread 0x%08x\t// %s",
+			out.format(
+					"!j9vmthread 0x%08x\t!j9thread 0x%08x\t// %s%n",
 					thread.getAddress(),
 					thread.osThread().getAddress(),
-					J9VMThreadHelper.getName(thread)));
+					J9VMThreadHelper.getName(thread));
 			
 			printMonitorsForJ9VMThread(out, vm, thread);
 			
@@ -352,20 +352,20 @@ public class MonitorsCommand extends Command
 				ObjectMonitor objMon = (ObjectMonitor) current;
 				// Step 2: Print any monitors that the thread is the owner of:
 				if (thread.equals(objMon.getOwner())) {
-					out.print("Owns Object Monitor:\n\t");
+					out.format("Owns Object Monitor:%n\t");
 					writeObjectMonitor(defaultFilter, objMon, out);
 				}
 				// Step 3: Print any monitors that the thread is blocking on::
 				for (J9VMThreadPointer threadPtr : objMon.getBlockedThreads()) {
 					if (threadPtr.equals(thread)) {
-						out.print(String.format("Blocking on (Enter Waiter):\n\t"));
+						out.format("Blocking on (Enter Waiter):%n\t");
 						writeObjectMonitor(defaultFilter, objMon, out);
 					}
 				}
 				// Step 4: Print any monitors that the thread is waiting on:
 				for (J9VMThreadPointer threadPtr : objMon.getWaitingThreads()) {
 					if (threadPtr.equals(thread)) {
-						out.print(String.format("Waiting on (Notify Waiter):\n\t"));
+						out.format("Waiting on (Notify Waiter):%n\t");
 						writeObjectMonitor(defaultFilter, objMon, out);
 					}
 				}
@@ -422,16 +422,14 @@ public class MonitorsCommand extends Command
 			J9VMThreadPointer vmThread = J9ThreadHelper.getVMThread(osThreadPtr);
 			
 			// Step 1: Print the general info for the VM and native threads:
-			out.println(String.format(
-					"%s\t%s\t// %s",
+			out.format(
+					"%s\t%s\t// %s%n",
 					osThreadPtr.formatShortInteractive(),
 					vmThread.notNull() ? vmThread.formatShortInteractive() : "<none>",
-					vmThread.notNull() ? J9VMThreadHelper.getName(vmThread) : "[osthread]")
-			);
-			
+					vmThread.notNull() ? J9VMThreadHelper.getName(vmThread) : "[osthread]");
+
 			printMonitorsForJ9Thread(out, vm, osThreadPtr);
-		
-		}  catch (CorruptDataException e) {
+		} catch (CorruptDataException e) {
 			throw new DDRInteractiveCommandException(e);
 		}
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/RomClassForNameCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/RomClassForNameCommand.java
@@ -55,23 +55,22 @@ public class RomClassForNameCommand extends Command
 
 			int hitCount = 0;
 			String searchClassName = args[0];
-			PatternString pattern = new PatternString (searchClassName);
-			
-			out.println(String.format(
-					"Searching for ROMClasses named '%1$s' in VM=%2$s",
-					searchClassName, Long.toHexString(vm.getAddress())));
+			PatternString pattern = new PatternString(searchClassName);
+
+			out.format(
+					"Searching for ROMClasses named '%1$s' in VM=%2$s%n",
+					searchClassName, Long.toHexString(vm.getAddress()));
 			while (iterator.hasNext()) {
 				J9ROMClassPointer romClassPointer = iterator.next();
 				String javaName = J9UTF8Helper.stringValue(romClassPointer.className());
 				if (pattern.isMatch(javaName)) {
 					hitCount++;
-					
+
 					String hexString = romClassPointer.getHexAddress();
-					out.println(String.format("!j9romclass %1$s named %2$s", hexString, javaName));					
+					out.format("!j9romclass %1$s named %2$s%n", hexString, javaName);
 				}
 			}
-			out.println(String.format("Found %1$d ROMClass(es) named %2$s",
-					hitCount, searchClassName));
+			out.format("Found %1$d ROMClass(es) named %2$s%n", hitCount, searchClassName);
 		} catch (CorruptDataException e) {
 			throw new DDRInteractiveCommandException(e);
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/SearchStringTableCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/SearchStringTableCommand.java
@@ -38,17 +38,17 @@ public class SearchStringTableCommand extends Command{
 	public SearchStringTableCommand() {
 		addCommand("searchstringtable", "<address>", "Search for J9Object* in string table");
 	}
-	
+
 	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException {
 		try {
 			if (1 == args.length) {
 				J9ObjectPointer objectPointer = J9ObjectPointer.cast(CommandUtils.parsePointer(args[0], J9BuildFlags.J9VM_ENV_DATA64));
 				J9ObjectPointer data = StringTable.from().search(objectPointer);
-				
+
 				if (data.notNull()) {
-					String stringValue = J9ObjectHelper.stringValue(data);					
+					String stringValue = J9ObjectHelper.stringValue(data);
 					String hexAddr = data.formatShortInteractive();
-					out.println(String.format("%s <%s>", hexAddr, stringValue));
+					out.format("%s <%s>%n", hexAddr, stringValue);
 				} else {
 					out.println("Not found");
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/SegmentsUtil.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/SegmentsUtil.java
@@ -119,9 +119,9 @@ public class SegmentsUtil {
 
 	private static void printMemoryUsed(PrintStream out, long totalMemory, long totalMemoryInUse) {
 		long totalMemoryFree = totalMemory - totalMemoryInUse;
-		out.println(String.format("Total memory:           %016d (%016x)", totalMemory, totalMemory));
-		out.println(String.format("Total memory in use:    %016d (%016x)", totalMemoryInUse, totalMemoryInUse));
-		out.println(String.format("Total memory free:      %016d (%016x)", totalMemoryFree, totalMemoryFree));
+		out.format("Total memory:           %016d (%016x)%n", totalMemory, totalMemory);
+		out.format("Total memory in use:    %016d (%016x)%n", totalMemoryInUse, totalMemoryInUse);
+		out.format("Total memory free:      %016d (%016x)%n", totalMemoryFree, totalMemoryFree);
 	}
 
 	private static class SegmentSortException extends RuntimeException {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/WalkJ9PoolCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/WalkJ9PoolCommand.java
@@ -107,7 +107,7 @@ public class WalkJ9PoolCommand extends Command
 			int i = 0;
 			while (poolIterator.hasNext()) {
 				currentElement = poolIterator.next();
-				out.println(String.format("\t[%d]\t=\t%s", i++, currentElement.getHexAddress()));
+				out.format("\t[%d]\t=\t%s%n", i++, currentElement.getHexAddress());
 			}
 		} catch (CorruptDataException e) {
 			throw new DDRInteractiveCommandException("Either address is not a valid pool address or pool itself is corrupted.");

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckClassLoaders.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckClassLoaders.java
@@ -63,13 +63,13 @@ class CheckClassLoaders extends Check
 	{
 		try {
 			GCClassLoaderIterator classLoaderIterator = GCClassLoaderIterator.from();
-			getReporter().println(String.format("<gc check: Start scan classLoaderBlocks (%s)>", formatPointer(getJavaVM().classLoaderBlocks())));
-			while(classLoaderIterator.hasNext()) {
+			getReporter().format("<gc check: Start scan classLoaderBlocks (%s)>%n", formatPointer(getJavaVM().classLoaderBlocks()));
+			while (classLoaderIterator.hasNext()) {
 				J9ClassLoaderPointer classLoader = classLoaderIterator.next();
-				getReporter().println(String.format("  <classLoader (%s)>", formatPointer(classLoader)));
-				getReporter().println(String.format("    <flags=%d, classLoaderObject=%s>", classLoader.gcFlags().longValue(), formatPointer(classLoader.classLoaderObject())));
+				getReporter().format("  <classLoader (%s)>%n", formatPointer(classLoader));
+				getReporter().format("    <flags=%d, classLoaderObject=%s>%n", classLoader.gcFlags().longValue(), formatPointer(classLoader.classLoaderObject()));
 			}
-			getReporter().println(String.format("<gc check: End scan classLoaderBlocks (%s)>", formatPointer(getJavaVM().classLoaderBlocks())));
+			getReporter().format("<gc check: End scan classLoaderBlocks (%s)>%n", formatPointer(getJavaVM().classLoaderBlocks()));
 		} catch (CorruptDataException e) {
 			// TODO: handle exception
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckEngine.java
@@ -1448,7 +1448,9 @@ class CheckEngine
 		boolean ret = true;
 		if ((UNINITIALIZED_SIZE != _ownableSynchronizerObjectCountOnList) && (UNINITIALIZED_SIZE != _ownableSynchronizerObjectCountOnHeap)) {
 			if (_ownableSynchronizerObjectCountOnList != _ownableSynchronizerObjectCountOnHeap) {
-				_reporter.println(String.format("<gc check: found count=%d of OwnableSynchronizerObjects on Heap doesn't match count=%d on lists>", _ownableSynchronizerObjectCountOnHeap, _ownableSynchronizerObjectCountOnList));
+				_reporter.format(
+						"<gc check: found count=%d of OwnableSynchronizerObjects on Heap doesn't match count=%d on lists>%n",
+						_ownableSynchronizerObjectCountOnHeap, _ownableSynchronizerObjectCountOnList);
 				ret = false;
 			}
 		}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckReporter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckReporter.java
@@ -64,6 +64,7 @@ public abstract class CheckReporter
 	/**
 	 * Output non-error information
 	 */
+	public abstract void format(String format, Object... arguments);
 	public abstract void print(String arg);
 	public abstract void println(String arg);
 	public void print()

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckReporterTTY.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckReporterTTY.java
@@ -142,17 +142,24 @@ public class CheckReporterTTY extends CheckReporter
 					default:
 						slotValue = UDATAPointer.cast(slot).at(0);
 				}
-				out.println(String.format("  <gc check (%d): %s: %s: %sslot %x(%x) -> %x: %s>", error._errorNumber, "from debugger", error._check.getCheckName(), error._elementName, error._object.getAddress(), slot.getAddress(), slotValue.longValue(), getErrorType(error._errorCode)));
+				format("  <gc check (%d): %s: %s: %sslot %x(%x) -> %x: %s>%n",
+						error._errorNumber, "from debugger", error._check.getCheckName(), error._elementName,
+						error._object.getAddress(), slot.getAddress(), slotValue.longValue(),
+						getErrorType(error._errorCode));
 			} else {
-				out.println(String.format("  <gc check (%d): %s: %s: %s%x: %s>", error._errorNumber, "from debugger", error._check.getCheckName(), error._elementName, error._object.getAddress(), getErrorType(error._errorCode)));
-				
+				format("  <gc check (%d): %s: %s: %s%x: %s>%n",
+						error._errorNumber, "from debugger", error._check.getCheckName(), error._elementName,
+						error._object.getAddress(), getErrorType(error._errorCode));
+
 				/* If the basic checks have been made (alignment, etc.) display header info. */
 				if (error._objectType == check_type_object) {
 					reportObjectHeader(error, J9ObjectPointer.cast(error._object), "");
-				}	
+				}
 			}
 		} catch (CorruptDataException cde) {
-			out.println(String.format("  <gc check (%d): %s: %s: %s%x: %s>", error._errorNumber, "from debugger", error._check.getCheckName(), error._elementName, error._object.getAddress(), getErrorType(error._errorCode)));
+			format("  <gc check (%d): %s: %s: %s%x: %s>%n",
+					error._errorNumber, "from debugger", error._check.getCheckName(), error._elementName,
+					error._object.getAddress(), getErrorType(error._errorCode));
 		}
 	}
 
@@ -169,18 +176,18 @@ public class CheckReporterTTY extends CheckReporter
 	public void reportClass(CheckError error, J9ClassPointer clazz, String prefix)
 	{
 		String prefixString = prefix == null ? "" : prefix;
-		
-		if(!shouldReport(error)) {
+
+		if (!shouldReport(error)) {
 			return;
-		}		
-		
-		out.println(String.format("  <gc check (%d): %sClass %x>", error._errorNumber, prefixString, clazz.getAddress()));
+		}
+
+		format("  <gc check (%d): %sClass %x>%n", error._errorNumber, prefixString, clazz.getAddress());
 	}
 
 	@Override
 	public void reportFatalError(CheckError error)
 	{
-		out.println(String.format("  <gc check (%d): Cannot resolve problem detected on heap, aborting check>", error._errorNumber));
+		format("  <gc check (%d): Cannot resolve problem detected on heap, aborting check>%n", error._errorNumber);
 	}
 
 	@Override
@@ -196,7 +203,7 @@ public class CheckReporterTTY extends CheckReporter
 				}
 			}
 		} else {
-			out.println(String.format("  <gc check (%d): %x was first object encountered on heap>", error._errorNumber, error._object.getAddress()));
+			format("  <gc check (%d): %x was first object encountered on heap>%n", error._errorNumber, error._object.getAddress());
 		}
 	}
 
@@ -218,21 +225,25 @@ public class CheckReporterTTY extends CheckReporter
 				isIndexable = ObjectModel.isIndexable(object);
 			}
 			isValid = true;
-		} catch (CorruptDataException cde) {}
+		} catch (CorruptDataException cde) {
+		}
 
-		if(isValid) {
-			if(isIndexable) {
-				out.print(String.format("  <gc check (%d): %sIObject %x header:", error._errorNumber, prefixString, object.getAddress()));
+		if (isValid) {
+			if (isIndexable) {
+				format("  <gc check (%d): %sIObject %x header:",
+						error._errorNumber, prefixString, object.getAddress());
 			} else {
 				String elementName = isHole ? "Hole" : "Object";
-				out.print(String.format("  <gc check (%d): %s%s %x header:", error._errorNumber, prefixString, elementName, object.getAddress()));
+				format("  <gc check (%d): %s%s %x header:",
+						error._errorNumber, prefixString, elementName, object.getAddress());
 			}
 		} else {
-			out.print(String.format("  <gc check (%d): %s%s %x header:", error._errorNumber, prefixString, "Corrupt", object.getAddress()));
+			format("  <gc check (%d): %s%s %x header:",
+					error._errorNumber, prefixString, "Corrupt", object.getAddress());
 		}
-		
-		int headerSize = (int)J9ObjectHelper.headerSize();
-		if(isHole) {
+
+		int headerSize = (int) J9ObjectHelper.headerSize();
+		if (isHole) {
 			headerSize = (int)MM_HeapLinkedFreeHeader.SIZEOF;
 		} else {
 			try {
@@ -243,7 +254,7 @@ public class CheckReporterTTY extends CheckReporter
 		try {
 			U32Pointer data = U32Pointer.cast(object);
 			for(int i = 0; i < headerSize / U32.SIZEOF; i++) {
-				out.print(String.format(" %08X", data.at(i).longValue()));
+				format(" %08X", data.at(i).longValue());
 			}
 		} catch (CorruptDataException cde) {
 		}
@@ -251,11 +262,16 @@ public class CheckReporterTTY extends CheckReporter
 	}
 
 	@Override
+	public void format(String format, Object... arguments) {
+		out.format(format, arguments);
+	}
+
+	@Override
 	public void println(String arg)
 	{
 		out.println(arg);
 	}
-	
+
 	public void print(String arg)
 	{
 		out.print(arg);
@@ -264,6 +280,6 @@ public class CheckReporterTTY extends CheckReporter
 	@Override
 	public void reportForwardedObject(J9ObjectPointer object, J9ObjectPointer newObject)
 	{
-		out.println(String.format("  <gc check: found forwarded pointer %x -> %x>", object.getAddress(), newObject.getAddress()));
+		format("  <gc check: found forwarded pointer %x -> %x>%n", object.getAddress(), newObject.getAddress());
 	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckVMThreadStacks.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/CheckVMThreadStacks.java
@@ -138,11 +138,11 @@ class CheckVMThreadStacks extends Check
 						// TODO Auto-generated catch block
 					}
 				}
-				
-				if(walkState.method.isNull()) {
-					getReporter().println(String.format("0x%08X %s (unknown method)", walkState.pc.getAddress(), className));
+
+				if (walkState.method.isNull()) {
+					getReporter().format("0x%08X %s (unknown method)%n", walkState.pc.getAddress(), className);
 				} else {
-					if(walkState.jitInfo.isNull()) {
+					if (walkState.jitInfo.isNull()) {
 						boolean isNative = false;
 						U8Pointer bytecodes = U8Pointer.NULL;
 						String name = "(corrupt)";
@@ -159,18 +159,18 @@ class CheckVMThreadStacks extends Check
 						} catch (CorruptDataException e) {
 							// This should never happen
 						}
-						
-						if(isNative) {
-							getReporter().println(String.format(" NATIVE   %s.%s%s", 
-									className, 
-									name, 
-									sig));	
+
+						if (isNative) {
+							getReporter().format(" NATIVE   %s.%s%s%n",
+									className,
+									name,
+									sig);
 						} else {
-							getReporter().println(String.format(" %08X %s.%s%s", 
+							getReporter().format(" %08X %s.%s%s%n",
 									walkState.pc.sub(bytecodes).longValue(),
-									className, 
-									name, 
-									sig));
+									className,
+									name,
+									sig);
 						}
 					} else {
 						boolean isInlined = walkState.inlineDepth != 0; 
@@ -187,20 +187,20 @@ class CheckVMThreadStacks extends Check
 						} catch (CorruptDataException e) {
 							// This should never happen
 						}
-						
-						if(isInlined) {
-							getReporter().println(String.format(" INLINED  %s.%s%s  (@%s)", 
-									className, 
-									name, 
-									sig, 
-									formatPointer(walkState.pc)));	
+
+						if (isInlined) {
+							getReporter().format(" INLINED  %s.%s%s  (@%s)%n",
+									className,
+									name,
+									sig,
+									formatPointer(walkState.pc));
 						} else {
-							getReporter().println(String.format(" %08X %s.%s%s  (@%s)", 
-									jitPC.getAddress(), 
-									className, 
-									name, 
-									sig, 
-									formatPointer(walkState.pc)));	
+							getReporter().format(" %08X %s.%s%s  (@%s)%n",
+									jitPC.getAddress(),
+									className,
+									name,
+									sig,
+									formatPointer(walkState.pc));
 						}
 					}
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/ScanFormatter.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/gccheck/ScanFormatter.java
@@ -34,13 +34,13 @@ class ScanFormatter
 	public ScanFormatter(Check check, String title, AbstractPointer pointer)
 	{
 		_reporter = check.getReporter();
-		_reporter.println(String.format("<gc check: Start scan %s (%s)>", title, formatPointer(pointer)));
+		_reporter.format("<gc check: Start scan %s (%s)>%n", title, formatPointer(pointer));
 	}
 
 	public ScanFormatter(Check check, String title)
 	{
 		_reporter = check.getReporter();
-		_reporter.println(String.format("<gc check: Start scan %s>", title));
+		_reporter.format("<gc check: Start scan %s>%n", title);
 	}
 
 	static String formatPointer(AbstractPointer pointer)
@@ -54,13 +54,13 @@ class ScanFormatter
 
 	public void section(String type)
 	{
-		_reporter.println(String.format("  <%s>", type));
+		_reporter.format("  <%s>%n", type);
 		_currentCount = 0;
 	}
 
 	public void section(String type, AbstractPointer pointer)
 	{
-		_reporter.println(String.format("  <%s (%s)>", type, formatPointer(pointer)));
+		_reporter.format("  <%s (%s)>%n", type, formatPointer(pointer));
 		_currentCount = 0;
 	}
 
@@ -93,7 +93,7 @@ class ScanFormatter
 		if ((0 != _currentCount) && _displayedData) {
 			_reporter.println(">");
 		}
-		_reporter.println(String.format("<gc check: End scan %s (%s)>", type, formatPointer(pointer)));
+		_reporter.format("<gc check: End scan %s (%s)>%n", type, formatPointer(pointer));
 	}
 
 	public void end(String type)
@@ -101,6 +101,6 @@ class ScanFormatter
 		if ((0 != _currentCount) && _displayedData) {
 			_reporter.println(">");
 		}
-		_reporter.println(String.format("<gc check: End scan %s>", type));
+		_reporter.format("<gc check: End scan %s>%n", type);
 	}
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/monitors/DeadlockUtils.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/monitors/DeadlockUtils.java
@@ -275,7 +275,7 @@ public class DeadlockUtils
 		// Based on JavaCoreDumpWriter::writeSystemMonitor()
 		//			JavaCoreDumpWriter::writeMonitor()
 		//			JavaCoreDumpWriter::writeMonitorObject()
-		
+
 		if (null != node.javaLock) {
 			String monitorName = "[system]";
 			if (node.javaLock.name().notNull()) {
@@ -283,27 +283,24 @@ public class DeadlockUtils
 			}
 			out.print("\t\t" + monitorName);
 			out.println(" lock (" + node.javaLock.formatShortInteractive() + ")");
-		}
-		else if ((null == node.javaLock) && (null != node.lockObject)) {
-			
+		} else if ((null == node.javaLock) && (null != node.lockObject)) {
 			String className = J9ObjectHelper.getClassName(node.lockObject);
-			out.format("\t\t%s\t\"%s\"\n",node.lockObject.formatShortInteractive(), className);
+			out.format("\t\t%s\t\"%s\"%n", node.lockObject.formatShortInteractive(), className);
 			ObjectMonitor objMon = (ObjectMonitor) objectMonitorsMap.get(node.lockObject);
 			J9ObjectMonitorPointer j9objMonPtr = objMon.getJ9ObjectMonitorPointer();
-			
+
 			if ((null != j9objMonPtr) && (j9objMonPtr.notNull())) {
-				out.print(String.format("\t\t%s\n", j9objMonPtr.formatShortInteractive()));
-				out.print(String.format("\t\t%s\n", j9objMonPtr.monitor().formatShortInteractive()));
-				out.print(String.format("\t\t%s\n", objMon.getOwner().osThread().formatShortInteractive()));
+				out.format("\t\t%s%n", j9objMonPtr.formatShortInteractive());
+				out.format("\t\t%s%n", j9objMonPtr.monitor().formatShortInteractive());
+				out.format("\t\t%s%n", objMon.getOwner().osThread().formatShortInteractive());
 			}
-		}
-		else if (null != node.nativeLock) { // Case of a Java thread blocking on a system monitor		
+		} else if (null != node.nativeLock) { // case of a Java thread blocking on a system monitor
 			printNativeLockHelper(node.nativeLock, out);
 		}
-		
+
 		out.println("\twhich is owned by:");
 	}
-	
+
 	/**
 	 * 
 	 * @param node

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/junit/framework/BootstrapJUnitTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/junit/framework/BootstrapJUnitTest.java
@@ -80,7 +80,7 @@ public abstract class BootstrapJUnitTest implements IBootstrapRunnable {
 	@Test
 	public void runTests() throws Exception {
 		int testCount = 0;
-		System.out.println(String.format("Running tests in: %s", getClass().getName()));
+		System.out.format("Running tests in: %s%n", getClass().getName());
 		Method[] methods = this.getClass().getMethods();
 		for (int i = 0; i < methods.length; i++) {
 			Method method = methods[i];
@@ -89,11 +89,11 @@ public abstract class BootstrapJUnitTest implements IBootstrapRunnable {
 				vmData.bootstrap(getClass().getName(), new Object[] { method.getName() });
 			}
 		}
-		
+
 		if (testCount == 0) {
 			fail(String.format("No tests found.  Define some *Impl methods"));
 		} else {
-			System.out.println(String.format("Ran %s tests.", testCount));
+			System.out.format("Ran %s tests.%n", testCount);
 		}
 	}
 

--- a/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaRuntimeTest.java
+++ b/debugtools/DDR_VM/testsrc/com/ibm/j9ddr/view/dtfj/test/JavaRuntimeTest.java
@@ -271,7 +271,7 @@ public class JavaRuntimeTest extends DTFJUnitTest {
 				List bucket = map.get(key);
 				
 				if (bucket == null) {
-					System.out.println(String.format("Jextract found %s at address: %s.  Element #: %s that ddr does not know about", name, Long.toHexString(key), j));
+					System.out.format("Jextract found %s at address: %s.  Element #: %s that ddr does not know about%n", name, Long.toHexString(key), j);
 					result = false;
 					continue;
 				}
@@ -302,7 +302,7 @@ public class JavaRuntimeTest extends DTFJUnitTest {
 				Iterator<Object> contentsIter = bucket.iterator();
 				while (contentsIter.hasNext()) {
 					Object obj = contentsIter.next();
-					System.out.println(String.format("%s) %s", ++count, obj));
+					System.out.format("%s) %s%n", ++count, obj);
 				}
 			}
 		}

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/NewElfDump.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/NewElfDump.java
@@ -1238,7 +1238,7 @@ public class NewElfDump extends CoreReaderSupport {
 				}
 				soname = readSONAMEFromProgramHeader(entry);
 				if (soname != null) {
-					// System.err.println(String.format("Found module name %s, adding to _additionalFileNames", soname));
+					// System.err.format("Found module name %s, adding to _additionalFileNames%n", soname);
 					break;
 				}
 			}

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/tools/impl/HelpTool.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/tools/impl/HelpTool.java
@@ -119,7 +119,10 @@ public class HelpTool extends Tool
 		ToolsRegistry.executeJdmpviewCommand(JDMPVIEW_HELP_COMMAND, out);
 		for (ITool aTool : ToolsRegistry.getAllTools()) {
 			if (aTool instanceof HelpTool == false) {
-				out.println(String.format(COMMAND_FORMAT, aTool.getCommandName(), aTool.getArgumentDescription(), aTool.getHelpDescription()));
+				out.format(COMMAND_FORMAT + "%n",
+						aTool.getCommandName(),
+						aTool.getArgumentDescription(),
+						aTool.getHelpDescription());
 			}
 		}
 	}


### PR DESCRIPTION
* add `%n` to format string when replacing calls to `println()`
* add `CheckReporter.format()`
* use `%n` instead of `\n` for portability