### PR TITLE
JDK26 Access API update

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -645,16 +645,12 @@ final class Access implements JavaLangAccess {
 	/*[ENDIF] JAVA_SPEC_VERSION < 25 */
 
 	@Override
-	/*[IF (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION >= 27) ]*/
+	/*[IF JAVA_SPEC_VERSION >= 25]*/
 	public int uncheckedEncodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ELSE] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION >= 27) */
+	/*[ELSE] JAVA_SPEC_VERSION >= 25 */
 	public int encodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ENDIF] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION >= 27) */
-		/*[IF JAVA_SPEC_VERSION == 26]*/
-		return StringCoding.encodeAsciiArray(sa, sp, da, dp, len);
-		/*[ELSE] JAVA_SPEC_VERSION == 26 */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
 		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);
-		/*[ENDIF] JAVA_SPEC_VERSION == 26 */
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 


### PR DESCRIPTION
JDK26 Access API update

Replace `encodeASCII()` with `uncheckedEncodeASCII()`.

This addresses JDK26 abuild compilation failure at https://openj9-jenkins.osuosl.org/job/Build_JDK26_aarch64_linux_OpenJDK26/5/consoleFull
```
23:55:08  /home/jenkins/workspace/Build_JDK26_aarch64_linux_OpenJDK26/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:72: error: Access is not abstract and does not override abstract method uncheckedEncodeASCII(char[],int,byte[],int,int) in JavaLangAccess
23:55:08  final class Access implements JavaLangAccess {
23:55:08        ^
23:55:08  /home/jenkins/workspace/Build_JDK26_aarch64_linux_OpenJDK26/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:356: error: encodeASCII(char[],int,byte[],int,int) in Access does not override or implement a method from a supertype
23:55:08  	@Override
23:55:08  	^
23:55:08  /home/jenkins/workspace/Build_JDK26_aarch64_linux_OpenJDK26/build/linux-aarch64-server-release/support/j9jcl/java.base/share/classes/java/lang/Access.java:358: error: cannot find symbol
23:55:08  		return StringCoding.encodeAsciiArray(sa, sp, da, dp, len);
23:55:08  		                   ^
23:55:08    symbol:   method encodeAsciiArray(char[],int,byte[],int,int)
23:55:08    location: class StringCoding
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>