### PR TITLE
Fix build break from 22363

### DIFF
--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -498,7 +498,7 @@ class OMR_EXTENSIBLE Compilation : public OMR::CompilationConnector
    bool isOSRProhibitedOverRangeOfTrees() { return _osrProhibitedOverRangeOfTrees; }
 
 #if defined(PERSISTENT_COLLECTIONS_UNSUPPORTED)
-   void addAOTMethodDependency(TR_OpaqueClassBlock *ramClass, uintptr_t chainOffse = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSETt) {}
+   void addAOTMethodDependency(TR_OpaqueClassBlock *ramClass, uintptr_t chainOffset = TR_SharedCache::INVALID_CLASS_CHAIN_OFFSET) {}
 #else
    /**
     * \brief Add the provided class as an AOT Method Dependency


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9/pull/22363 introduced a build break; this PR fixes it.