### PR TITLE
JDK25+ adds BadEnclosingMethod checks

### DIFF
--- a/runtime/jcl/common/java_lang_Class.cpp
+++ b/runtime/jcl/common/java_lang_Class.cpp
@@ -856,10 +856,32 @@ Java_java_lang_Class_getEnclosingObject(JNIEnv *env, jobject recv)
 #if JAVA_SPEC_VERSION >= 25
 					} else {
 						/* There is an enclosing constructor or method from getEnclosingMethodForROMClass(),
-						 * but it can't be found, return its descriptor string for error handling.
+						 * but it can't be found, return its name/descriptor string for error handling.
 						 */
-						resultObject = vm->memoryManagerFunctions->j9gc_createJavaLangString(
-								currentThread, J9UTF8_DATA(enclosingMethodSigUTF), J9UTF8_LENGTH(enclosingMethodSigUTF), 0);
+						J9MemoryManagerFunctions *mmFuncs = vm->memoryManagerFunctions;
+						resultObject = mmFuncs->J9AllocateIndexableObject(
+								currentThread, ((J9Class *)J9VMJAVALANGSTRING_OR_NULL(vm))->arrayClass,
+								2, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+						if (NULL == resultObject) {
+							vmFuncs->setHeapOutOfMemoryError(currentThread);
+							/* j9jni_createLocalRef() returns NULL in this case. */
+						} else {
+							PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, resultObject);
+							j9object_t methodName = mmFuncs->j9gc_createJavaLangString(
+									currentThread, J9UTF8_DATA(enclosingMethodNameUTF),
+									J9UTF8_LENGTH(enclosingMethodNameUTF), 0);
+							resultObject = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+
+							J9JAVAARRAYOFOBJECT_STORE(currentThread, resultObject, 0, methodName);
+
+							PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, resultObject);
+							j9object_t methodDescriptor = mmFuncs->j9gc_createJavaLangString(
+									currentThread, J9UTF8_DATA(enclosingMethodSigUTF),
+									J9UTF8_LENGTH(enclosingMethodSigUTF), 0);
+							resultObject = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+
+							J9JAVAARRAYOFOBJECT_STORE(currentThread, resultObject, 1, methodDescriptor);
+						}
 #endif /* JAVA_SPEC_VERSION >= 25 */
 					}
 				}

--- a/runtime/verutil/sigverify.c
+++ b/runtime/verutil/sigverify.c
@@ -129,6 +129,13 @@ verifyIdentifierUtf8Impl (U_8* identifierStart, U_8 *limit, BOOLEAN allowSlashes
 	U_8 *cursor = identifierStart;
 	BOOLEAN slash = FALSE;
 
+#if JAVA_SPEC_VERSION >= 25
+	/* Keep pre-JDK25 behaviour intact until OpenJDK backports this new check. */
+	if ((cursor < limit) && ('/' == *cursor)) {
+		/* Identifier must not start with /. */
+		return -1;
+	}
+#endif /* JAVA_SPEC_VERSION >= 25 */
 	while ((';' != *cursor) && (cursor < limit)) {
 		/* check for subset of illegal characters:  46(.) 47(/) 91([) in JVMS 4.2.2*/
 		switch (*cursor) {
@@ -150,7 +157,7 @@ verifyIdentifierUtf8Impl (U_8* identifierStart, U_8 *limit, BOOLEAN allowSlashes
 		}
 		++cursor;
 	}
-	/* Identifier must not end in / (i.e. must have specified a type name after any package name) */
+	/* Identifier must not end with / (i.e. must have specified a type name after any package name). */
 	if (slash) {
 		return -1;
 	}


### PR DESCRIPTION
JDK25+ adds BadEnclosingMethod checks

Add check that the identifier must not start in `/`;
`Java_java_lang_Class_getEnclosingObject` returns `name`/`descriptor` string for error handling in case the enclosing constructor or method from `getEnclosingMethodForROMClass()` can't be found;
`Class.getEnclosingConstructor()/getEnclosingMethod()` check returning `name/descriptor` if the enclosing `constructor/method` wasn't found.

closes https://github.com/eclipse-openj9/openj9/issues/21732

Signed-off-by: Jason Feng <fengj@ca.ibm.com>