### PR TITLE
Revert "(0.57) Release VM access before calling JNI getStringUTFChars"

### DIFF
--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -833,9 +833,7 @@ Java_jdk_internal_misc_Unsafe_objectFieldOffset1(JNIEnv *env, jobject receiver, 
 	}
 
 	if (NULL == romField) {
-		vmFuncs->internalExitVMToJNI(currentThread);
 		char *errormsg = createErrorMsgHelper(env, clazz, name, " is not found");
-		vmFuncs->internalEnterVMFromJNI(currentThread);
 		if (NULL == errormsg) {
 			vmFuncs->setCurrentException(
 					currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR,
@@ -848,9 +846,7 @@ Java_jdk_internal_misc_Unsafe_objectFieldOffset1(JNIEnv *env, jobject receiver, 
 		}
 	} else if (J9_ARE_ANY_BITS_SET(romField->modifiers, J9AccStatic)) {
 #if JAVA_SPEC_VERSION >= 26
-		vmFuncs->internalExitVMToJNI(currentThread);
 		char *errormsg = createErrorMsgHelper(env, clazz, name, " is a static field");
-		vmFuncs->internalEnterVMFromJNI(currentThread);
 		if (NULL == errormsg) {
 			vmFuncs->setCurrentException(
 					currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR,


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#23210

See https://github.com/eclipse-openj9/openj9/pull/23210#issuecomment-3762109341