### PR TITLE
Enable park sleep on AArch64 Linux by default

### DIFF
--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -738,11 +738,11 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #endif /* defined(OMR_THR_THREE_TIER_LOCKING) */
 
 #if defined(OMR_THR_YIELD_ALG)
-#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390)
+#if defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_AARCH64)
 	**(UDATA **)omrthread_global("parkPolicy") = OMRTHREAD_PARK_POLICY_SLEEP;
-#else /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) */
+#else /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_AARCH64) */
 	**(UDATA **)omrthread_global("parkPolicy") = OMRTHREAD_PARK_POLICY_NONE;
-#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) */
+#endif /* defined(J9VM_ARCH_X86) || defined(J9VM_ARCH_POWER) || defined(J9VM_ARCH_S390) || defined(J9VM_ARCH_AARCH64) */
 	**(UDATA **)omrthread_global("parkSleepMultiplier") = 0;
 	**(UDATA **)omrthread_global("parkSpinCount") = 0;
 	**(UDATA **)omrthread_global("parkSleepCount") = 2;
@@ -755,7 +755,10 @@ threadParseArguments(J9JavaVM *vm, char *optArg)
 #elif defined(J9VM_ARCH_S390) /* defined(OMR_ARCH_X86) */
 	**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = 99;
 	**(UDATA **)omrthread_global("parkSleepTime") = 100;
-#else /* defined(J9VM_ARCH_S390) */
+#elif defined(J9VM_ARCH_AARCH64) /* defined(J9VM_ARCH_S390) */
+	**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = 98;
+	**(UDATA **)omrthread_global("parkSleepTime") = 400;
+#else /* defined(J9VM_ARCH_AARCH64) */
 	**(UDATA **)omrthread_global("parkSleepCpuUtilThreshold") = 100;
 	**(UDATA **)omrthread_global("parkSleepTime") = 0;
 #endif /* defined(J9VM_ARCH_POWER) */


### PR DESCRIPTION
This PR enables park sleep on AArch64 Linux in the same way as on other Linux platforms.