### PR TITLE
Support Valhalla latest update

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -887,26 +887,26 @@ final class Access implements JavaLangAccess {
 
 	/*[IF JAVA_SPEC_VERSION >= 22]*/
 	@Override
-	/*[IF (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES]*/
+	/*[IF JAVA_SPEC_VERSION >= 27]*/
 	public boolean bytesCompatible(String string, Charset charset, int srcIndex, int numChars) {
 		return string.bytesCompatible(charset, srcIndex, numChars);
 	}
-	/*[ELSE] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
+	/*[ELSE] JAVA_SPEC_VERSION >= 27 */
 	public boolean bytesCompatible(String string, Charset charset) {
 		return string.bytesCompatible(charset);
 	}
-	/*[ENDIF] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
 
 	@Override
-	/*[IF (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES]*/
+	/*[IF JAVA_SPEC_VERSION >= 27]*/
 	public void copyToSegmentRaw(String string, MemorySegment segment, long offset, int srcIndex, int srcLength) {
 		string.copyToSegmentRaw(segment, offset, srcIndex, srcLength);
 	}
-	/*[ELSE] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
+	/*[ELSE] JAVA_SPEC_VERSION >= 27 */
 	public void copyToSegmentRaw(String string, MemorySegment segment, long offset) {
 		string.copyToSegmentRaw(segment, offset);
 	}
-	/*[ENDIF] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
+	/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
 
 	@Override
 	public Method findMethod(Class<?> clazz, boolean publicOnly, String methodName, Class<?>... parameterTypes) {


### PR DESCRIPTION
Support Valhalla latest update

Valhalla is merged with the latest OpenJDK head stream contents.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/26

Signed-off-by: Jason Feng <fengj@ca.ibm.com>