### PR TITLE
(0.57) Release VM access before calling JNI getStringUTFChars

### DIFF
--- a/runtime/jcl/common/sun_misc_Unsafe.cpp
+++ b/runtime/jcl/common/sun_misc_Unsafe.cpp
@@ -793,14 +793,19 @@ Java_sun_misc_Unsafe_shouldBeInitialized(JNIEnv *env, jobject receiver, jclass c
 }
 
 #if JAVA_SPEC_VERSION >= 10
-/* The return value needs to be freed. */
+/* The return value needs to be freed.
+ * The caller should have VM access.
+ */
 static char *
 createErrorMsgHelper(JNIEnv *env, jclass clazz, jstring name, const char *message)
 {
 	J9VMThread *currentThread = (J9VMThread *)env;
+	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
 	PORT_ACCESS_FROM_ENV(env);
 	J9UTF8 *className = J9ROMCLASS_CLASSNAME(J9VM_J9CLASS_FROM_JCLASS(currentThread, clazz)->romClass);
+	vmFuncs->internalExitVMToJNI(currentThread);
 	const char *nameUTF = env->GetStringUTFChars(name, NULL);
+	vmFuncs->internalEnterVMFromJNI(currentThread);
 	size_t namelen = strlen(nameUTF);
 	size_t msglen = strlen(message) + 1; /* include the NULL */
 	size_t totallen = namelen + J9UTF8_LENGTH(className) + msglen + 1; /* include the '.' */


### PR DESCRIPTION
This avoids entering VM twice which is illegal.

Related: https://github.com/eclipse-openj9/openj9/issues/23118

Port of https://github.com/eclipse-openj9/openj9/pull/23213