### PR TITLE
Enable inlining along java/lang/reflect/Method invocations

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -565,6 +565,7 @@
 
    java_lang_reflect_Array_getLength,
    java_lang_reflect_Method_invoke,
+   java_lang_reflect_Method_acquireMethodAccessor,
    java_util_Arrays_fill,
    java_util_Arrays_equals,
    java_lang_String_equals,

--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -1272,6 +1272,16 @@ handleResponse(JITServer::MessageType response, JITServer::ClientStream *client,
          client->write(response, vhIndex, vhObj);
          }
          break;
+      case MessageType::VM_getMethodAccessorIndex:
+         {
+         auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
+         TR::KnownObjectTable::Index maIndex = fe->getMethodAccessorIndex(comp, std::get<0>(recv));
+         uintptr_t* maObj = NULL;
+         if (maIndex != TR::KnownObjectTable::UNKNOWN)
+            maObj = knot->getPointerLocation(maIndex);
+         client->write(response, maIndex, maObj);
+         }
+         break;
 #endif // J9VM_OPT_OPENJDK_METHODHANDLE
       case MessageType::VM_isStable:
          {

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -478,6 +478,17 @@ public:
     */
    virtual TR::KnownObjectTable::Index getLayoutVarHandle(TR::Compilation *comp, TR::KnownObjectTable::Index layoutIndex);
 
+   /**
+    * @brief Get the MethodAccessor Index of a java/lang/reflect/Method object, if the MethodAccessor has been set. When the Method object
+    * is known, and its methodAccessor field is populated, we can evaluate the result of
+    * java/lang/reflect/Method.acquireMethodAccessor()Ljdk/internal/reflect/MethodAccessor; at compile time.
+    *
+    * @param comp the compilation
+    * @param methodIndex the java/lang/reflect/Method known object index
+    * @return TR::KnownObjectTable::Index the known object index of the MethodAccessor object if valid, TR::KnownObjectTable::UNKNOWN otherwise
+    */
+   virtual TR::KnownObjectTable::Index getMethodAccessorIndex(TR::Compilation *comp, TR::KnownObjectTable::Index methodIndex);
+
    virtual TR::Method * createMethod(TR_Memory *, TR_OpaqueClassBlock *, int32_t);
    virtual TR_ResolvedMethod * createResolvedMethod(TR_Memory *, TR_OpaqueMethodBlock *, TR_ResolvedMethod * = 0, TR_OpaqueClassBlock * = 0);
    virtual TR_ResolvedMethod * createResolvedMethodWithVTableSlot(TR_Memory *, uint32_t vTableSlot, TR_OpaqueMethodBlock * aMethod, TR_ResolvedMethod * owningMethod = 0, TR_OpaqueClassBlock * classForNewInstance = 0);

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -2532,6 +2532,21 @@ TR_J9ServerVM::getLayoutVarHandle(TR::Compilation *comp, TR::KnownObjectTable::I
 
    }
 
+TR::KnownObjectTable::Index
+TR_J9ServerVM::getMethodAccessorIndex(TR::Compilation *comp, TR::KnownObjectTable::Index methodIndex)
+   {
+   TR::KnownObjectTable *knot = comp->getKnownObjectTable();
+   if (!knot) return TR::KnownObjectTable::UNKNOWN;
+
+   JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
+   stream->write(JITServer::MessageType::VM_getMethodAccessorIndex, methodIndex);
+   auto recv = stream->read<TR::KnownObjectTable::Index, uintptr_t *>();
+
+   TR::KnownObjectTable::Index maIndex = std::get<0>(recv);
+   knot->updateKnownObjectTableAtServer(maIndex, std::get<1>(recv));
+   return maIndex;
+   }
+
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
 TR::KnownObjectTable::Index

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -256,6 +256,7 @@ public:
    virtual int32_t getVarHandleAccessDescriptorMode(TR::Compilation *comp, TR::KnownObjectTable::Index adIndex) override;
    virtual TR::KnownObjectTable::Index getMethodHandleTableEntryIndex(TR::Compilation *comp, TR::KnownObjectTable::Index vhIndex, TR::KnownObjectTable::Index adIndex) override;
    virtual TR::KnownObjectTable::Index getLayoutVarHandle(TR::Compilation *comp, TR::KnownObjectTable::Index layoutIndex) override;
+   virtual TR::KnownObjectTable::Index getMethodAccessorIndex(TR::Compilation *comp, TR::KnownObjectTable::Index methodIndex) override;
 #endif
    virtual TR::KnownObjectTable::Index getMemberNameFieldKnotIndexFromMethodHandleKnotIndex(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, const char *fieldName) override;
    virtual bool isMethodHandleExpectedType(TR::Compilation *comp, TR::KnownObjectTable::Index mhIndex, TR::KnownObjectTable::Index expectedTypeIndex) override;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3162,6 +3162,7 @@ void TR_ResolvedJ9Method::construct()
    static X MethodMethods[] =
       {
       {  TR::java_lang_reflect_Method_invoke, 6, "invoke", (int16_t)-1, "*"},
+      {x(TR::java_lang_reflect_Method_acquireMethodAccessor, "acquireMethodAccessor", "()Ljdk/internal/reflect/MethodAccessor;")},
       {  TR::unknownMethod}
       };
 

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -129,7 +129,7 @@ protected:
    // likely to lose an increment when merging/rebasing/etc.
    //
    static const uint8_t MAJOR_NUMBER = 1;
-   static const uint16_t MINOR_NUMBER = 96; // ID: VpbBeePxHOTLt7LEWmmE
+   static const uint16_t MINOR_NUMBER = 97; // ID: gQiqjDBTvhqSEbGp5cZg
    static const uint8_t PATCH_NUMBER = 0;
    static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -192,6 +192,7 @@ const char *messageNames[] =
    "VM_getVarHandleAccessDescriptorMode",
    "VM_getMethodHandleTableEntryIndex",
    "VM_getLayoutVarHandle",
+   "VM_getMethodAccessorIndex",
    "VM_mutableCallSiteEpoch",
    "VM_numInterfacesImplemented",
    "VM_getObjectClassInfoFromKnotIndex",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -203,6 +203,7 @@ enum MessageType : uint16_t
    VM_getVarHandleAccessDescriptorMode,
    VM_getMethodHandleTableEntryIndex,
    VM_getLayoutVarHandle,
+   VM_getMethodAccessorIndex,
    VM_mutableCallSiteEpoch,
    VM_numInterfacesImplemented,
    VM_getObjectClassInfoFromKnotIndex,


### PR DESCRIPTION
This changeset addresses a number of issues that prevented inlining along reflection Method invocations, even when the Method object was known. Changes include:
* Added recognized method java/lang/reflect/Method.acquireMethodAccessor.
* Enabled folding of Method.acquireMethodAccessor() calls during MethodHandleTransformer opt during peeking ILGen.
* Expanded folding of indirect loads during MethodHandleTransformer to include fields that are safe to dereference at compile time.
* Added FE helper for obtaining MethodAccessor object index
* Enabled peeking ILGen for methods that are part of reflection Method invocations to allow object info propagation along call graphs.
* Provide ECS PrexArgInfo for peeking ILGen requests.
* Added JITServer support.