### PR TITLE
Fix JITServer crash under verbose={dependencyTracking*}

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1692,10 +1692,24 @@ J9::Compilation::addAOTMethodDependency(uintptr_t chainOffset, bool ensureClassI
    if (self()->getOptions()->getVerboseOption(TR_VerboseDependencyTrackingDetails))
       {
       auto method = self()->getMethodBeingCompiled()->getPersistentIdentifier();
-      auto sharedCache = self()->fej9()->sharedCache();
-      auto romClassOffset = sharedCache->startingROMClassOffsetOfClassChain(sharedCache->pointerFromOffsetInSharedCache(chainOffset));
-      TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "Method %p dependency: chainOffset=%lu romClassOffset=%lu needsInit=%d",
-                                     method, chainOffset, romClassOffset, ensureClassIsInitialized);
+
+         {
+         TR_VerboseLog::CriticalSection addDepsCS;
+
+         TR_VerboseLog::write(TR_Vlog_INFO, "Method %p dependency: chainOffset=%lu ", method, chainOffset);
+
+         if (!self()->isOutOfProcessCompilation())
+            {
+            auto sharedCache = self()->fej9()->sharedCache();
+            auto romClassOffset =
+               sharedCache->startingROMClassOffsetOfClassChain(
+                  sharedCache->pointerFromOffsetInSharedCache(chainOffset));
+
+            TR_VerboseLog::write("romClassOffset=%lu ", romClassOffset);
+            }
+
+         TR_VerboseLog::writeLine("needsInit=%d", ensureClassIsInitialized);
+         }
       }
    }
 


### PR DESCRIPTION
Specifically, under `verbose={dependencyTracingDetails}`, the compiler will use the `startingROMClassOffsetOfClassChain` API to print out the offset of the starting ROMClass in the class chain that represents the depenency. However, it does not make sense to call this API on the server. Therefore, this commit prevents the compiler trying to get this data; the class chain offset is sufficient as it can be used to determine the starting ROMClass in the chain.