### PR TITLE
Fix test failures caused by #23197

### DIFF
--- a/test/functional/Java8andUp/playlist.xml
+++ b/test/functional/Java8andUp/playlist.xml
@@ -909,7 +909,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<variations>
 			<variation>-Xgcpolicy:nogc -Xms128m -Xmx1G -verbose:gc</variation>
 			<variation>-XX:+UseNoGC -Xms128m -Xmx1G</variation>
-			<variation>-XX:+GuardPageOnJavaStack</variation>
+			<variation>-XX:+UseNoGC -Xms128m -Xmx1G -XX:+GuardPageOnJavaStack</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
@@ -1638,7 +1638,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<variations>
 			<variation>NoOptions</variation>
 			<variation>-XX:RecreateClassfileOnload</variation>
-			<variation>-XX:+GuardPageOnJavaStack</variation>
 		</variations>
 		<command>$(MKDIR) -p $(REPORTDIR); \
 	cd $(REPORTDIR); \


### PR DESCRIPTION
Remove `-XX:+GuardPageOnJavaStack` variation from gcPolicyNogcTest and J9VMInternals_Test_SE80.

See https://github.com/eclipse-openj9/openj9/pull/23197#issuecomment-3776054824