### PR TITLE
Fix IsIdentityClassTest for array IDENTITY modifiers and access flags

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -3218,7 +3218,13 @@ done:
 
 		if (isArray) {
 			/* OR in the required Sun bits */
-			modifiers |= (J9AccAbstract + J9AccFinal);
+			modifiers |= (J9AccAbstract | J9AccFinal);
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass)) {
+				modifiers |= J9AccClassHasIdentity;
+			}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		}
 		returnSingleFromINL(REGISTER_ARGS, modifiers, 1);
 		return EXECUTE_BYTECODE;

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -27,9 +27,10 @@ import static org.objectweb.asm.Opcodes.*;
 
 public class ValhallaUtils {
 	/**
-	 * Currently value type is built on JDK27, so use java file major version (44 + 27) for now.
+	 * Currently value types are built on JDK27, so use java file major version (44 + 27) for now.
 	 * If moved this needs to be incremented to the next class file version.
 	 * VALUE_TYPES_MAJOR_VERSION in oti/j9consts.h needs to be updated as well.
+	 * Also update CLASSFILE_MAJOR_VALHALLA/CLASSFILE_MINOR_PREVIEW in Class.java when the version changes.
 	 * Minor version is in 16 most significant bits for asm.
 	 */
 	static final int VALUE_TYPE_CLASS_FILE_VERSION = (65535 << 16) | (44 + 27);


### PR DESCRIPTION
Fixes IsIdentityClassTest from the list of failing tests (see issue #[20404](https://github.com/eclipse-openj9/openj9/issues/20404)).
Ensures that array classes correctly report the IDENTITY modifier and access flags when Valhalla preview features are enabled.