### PR TITLE
Compact putfield/getfield sizes for primitives

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -146,12 +146,24 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_indexableStoreObject,
 	j9gc_objaccess_indexableStoreAddress,
 	j9gc_objaccess_indexableDataDisplacement,
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	j9gc_objaccess_mixedObjectReadI8,
+	j9gc_objaccess_mixedObjectReadU8,
+	j9gc_objaccess_mixedObjectReadI16,
+	j9gc_objaccess_mixedObjectReadU16,
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	j9gc_objaccess_mixedObjectReadI32,
 	j9gc_objaccess_mixedObjectReadU32,
 	j9gc_objaccess_mixedObjectReadI64,
 	j9gc_objaccess_mixedObjectReadU64,
 	j9gc_objaccess_mixedObjectReadObject,
 	j9gc_objaccess_mixedObjectReadAddress,
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	j9gc_objaccess_mixedObjectStoreI8,
+	j9gc_objaccess_mixedObjectStoreU8,
+	j9gc_objaccess_mixedObjectStoreI16,
+	j9gc_objaccess_mixedObjectStoreU16,
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	j9gc_objaccess_mixedObjectStoreI32,
 	j9gc_objaccess_mixedObjectStoreU32,
 	j9gc_objaccess_mixedObjectStoreI64,

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -704,12 +704,87 @@ MM_ObjectAccessBarrier::mixedObjectReadAddress(J9VMThread *vmThread, J9Object *s
 	return result;
 }
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 /**
  * Read an object field: perform any pre-use barriers, calculate an effective address
  * and perform the work.
  * @param srcObject The object being used.
  * @param srcOffset The offset of the field.
  * @param isVolatile non-zero if the field is volatile.
+ * @return U_8
+ */
+ U_8
+MM_ObjectAccessBarrier::mixedObjectReadU8(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile)
+{
+	U_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, U_8);
+	protectIfVolatileBefore(vmThread, isVolatile, true, false);
+	U_8 result = readU8Impl(vmThread, srcObject, actualAddress, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, true, false);
+	return result;
+}
+
+/**
+ * Read an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param srcObject The object being used.
+ * @param srcOffset The offset of the field.
+ * @param isVolatile non-zero if the field is volatile.
+ * @return I_8
+ */
+ I_8
+MM_ObjectAccessBarrier::mixedObjectReadI8(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile)
+{
+	I_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, I_8);
+	protectIfVolatileBefore(vmThread, isVolatile, true, false);
+	I_8 result = readI8Impl(vmThread, srcObject, actualAddress, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, true, false);
+	return result;
+}
+
+/**
+ * Read an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param srcObject The object being used.
+ * @param srcOffset The offset of the field.
+ * @param isVolatile non-zero if the field is volatile.
+ * @return U_16
+ */
+ U_16
+MM_ObjectAccessBarrier::mixedObjectReadU16(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile)
+{
+	U_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, U_16);
+	protectIfVolatileBefore(vmThread, isVolatile, true, false);
+	U_16 result = readU16Impl(vmThread, srcObject, actualAddress, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, true, false);
+	return result;
+}
+
+/**
+ * Read an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param srcObject The object being used.
+ * @param srcOffset The offset of the field.
+ * @param isVolatile non-zero if the field is volatile.
+ * @return I_16
+ */
+ I_16
+MM_ObjectAccessBarrier::mixedObjectReadI16(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile)
+{
+	I_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, I_16);
+	protectIfVolatileBefore(vmThread, isVolatile, true, false);
+	I_16 result = readI16Impl(vmThread, srcObject, actualAddress, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, true, false);
+	return result;
+}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+
+/**
+ * Read an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param srcObject The object being used.
+ * @param srcOffset The offset of the field.
+ * @param isVolatile non-zero if the field is volatile.
+ * @return U_32
  */
  U_32
 MM_ObjectAccessBarrier::mixedObjectReadU32(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile)
@@ -727,6 +802,7 @@ MM_ObjectAccessBarrier::mixedObjectReadU32(J9VMThread *vmThread, J9Object *srcOb
  * @param srcObject The object being used.
  * @param srcOffset The offset of the field.
  * @param isVolatile non-zero if the field is volatile.
+ * @return I_32
  */
  I_32
 MM_ObjectAccessBarrier::mixedObjectReadI32(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile)
@@ -811,12 +887,82 @@ MM_ObjectAccessBarrier::mixedObjectStoreAddress(J9VMThread *vmThread, J9Object *
 	protectIfVolatileAfter(vmThread, isVolatile, false, false);
 }
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 /**
  * Store an object field: perform any pre-use barriers, calculate an effective address
  * and perform the work.
  * @param destObject The object being used.
  * @param destOffset The offset of the field.
- * @param value The value to be stored
+ * @param value The U_8 value to be stored
+ * @param isVolatile non-zero if the field is volatile.
+ */
+void
+MM_ObjectAccessBarrier::mixedObjectStoreU8(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, U_8 value, bool isVolatile)
+{
+	U_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(destObject, destOffset, U_8);
+	protectIfVolatileBefore(vmThread, isVolatile, false, false);
+	storeU8Impl(vmThread, destObject, actualAddress, value, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, false, false);
+}
+
+/**
+ * Store an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param destObject The object being used.
+ * @param destOffset The offset of the field.
+ * @param value The I_8 value to be stored
+ * @param isVolatile non-zero if the field is volatile.
+ */
+void
+MM_ObjectAccessBarrier::mixedObjectStoreI8(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, I_8 value, bool isVolatile)
+{
+	I_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(destObject, destOffset, I_8);
+	protectIfVolatileBefore(vmThread, isVolatile, false, false);
+	storeI8Impl(vmThread, destObject, actualAddress, value, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, false, false);
+}
+
+/**
+ * Store an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param destObject The object being used.
+ * @param destOffset The offset of the field.
+ * @param value The U_16 value to be stored
+ * @param isVolatile non-zero if the field is volatile.
+ */
+void
+MM_ObjectAccessBarrier::mixedObjectStoreU16(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, U_16 value, bool isVolatile)
+{
+	U_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(destObject, destOffset, U_16);
+	protectIfVolatileBefore(vmThread, isVolatile, false, false);
+	storeU16Impl(vmThread, destObject, actualAddress, value, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, false, false);
+}
+
+/**
+ * Store an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param destObject The object being used.
+ * @param destOffset The offset of the field.
+ * @param value The I_16 value to be stored
+ * @param isVolatile non-zero if the field is volatile.
+ */
+void
+MM_ObjectAccessBarrier::mixedObjectStoreI16(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, I_16 value, bool isVolatile)
+{
+	I_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(destObject, destOffset, I_16);
+	protectIfVolatileBefore(vmThread, isVolatile, false, false);
+	storeI16Impl(vmThread, destObject, actualAddress, value, isVolatile);
+	protectIfVolatileAfter(vmThread, isVolatile, false, false);
+}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+
+/**
+ * Store an object field: perform any pre-use barriers, calculate an effective address
+ * and perform the work.
+ * @param destObject The object being used.
+ * @param destOffset The offset of the field.
+ * @param value The U_32 value to be stored
  * @param isVolatile non-zero if the field is volatile.
  */
 void
@@ -833,7 +979,7 @@ MM_ObjectAccessBarrier::mixedObjectStoreU32(J9VMThread *vmThread, J9Object *dest
  * and perform the work.
  * @param destObject The object being used.
  * @param destOffset The offset of the field.
- * @param value The value to be stored
+ * @param value The I_32 value to be stored
  * @param isVolatile non-zero if the field is volatile.
  */
 void

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -209,6 +209,12 @@ public:
 
 	virtual J9Object *mixedObjectReadObject(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
 	virtual void *mixedObjectReadAddress(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	virtual U_8 mixedObjectReadU8(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
+	virtual I_8 mixedObjectReadI8(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
+	virtual U_16 mixedObjectReadU16(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
+	virtual I_16 mixedObjectReadI16(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	virtual U_32 mixedObjectReadU32(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
 	virtual I_32 mixedObjectReadI32(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
 	virtual U_64 mixedObjectReadU64(J9VMThread *vmThread, J9Object *srcObject, UDATA srcOffset, bool isVolatile=false);
@@ -216,6 +222,12 @@ public:
 
 	virtual void mixedObjectStoreObject(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, J9Object *value, bool isVolatile=false);
 	virtual void mixedObjectStoreAddress(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, void *value, bool isVolatile=false);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	virtual void mixedObjectStoreU8(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, U_8 value, bool isVolatile=false);
+	virtual void mixedObjectStoreI8(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, I_8 value, bool isVolatile=false);
+	virtual void mixedObjectStoreU16(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, U_16 value, bool isVolatile=false);
+	virtual void mixedObjectStoreI16(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, I_16 value, bool isVolatile=false);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	virtual void mixedObjectStoreU32(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, U_32 value, bool isVolatile=false);
 	virtual void mixedObjectStoreI32(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, I_32 value, bool isVolatile=false);
 	virtual void mixedObjectStoreU64(J9VMThread *vmThread, J9Object *destObject, UDATA destOffset, U_64 value, bool isVolatile=false);

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -62,6 +62,56 @@ j9gc_objaccess_mixedObjectStoreAddress(J9VMThread *vmThread, J9Object *destObjec
 	barrier->mixedObjectStoreAddress(vmThread, destObject, offset, value, 0 != isVolatile);
 }
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+U_8
+j9gc_objaccess_mixedObjectReadU8(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->mixedObjectReadU8(vmThread, srcObject, offset, 0 != isVolatile);
+}
+
+void
+j9gc_objaccess_mixedObjectStoreU8(J9VMThread *vmThread, J9Object *destObject, UDATA offset, U_8 value, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	barrier->mixedObjectStoreU8(vmThread, destObject, offset, value, 0 != isVolatile);
+}
+
+I_8
+j9gc_objaccess_mixedObjectReadI8(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->mixedObjectReadI8(vmThread, srcObject, offset, 0 != isVolatile);
+}
+
+void
+j9gc_objaccess_mixedObjectStoreI8(J9VMThread *vmThread, J9Object *destObject, UDATA offset, I_8 value, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	barrier->mixedObjectStoreI8(vmThread, destObject, offset, value, 0 != isVolatile);
+}
+
+U_16
+j9gc_objaccess_mixedObjectReadU16(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->mixedObjectReadU16(vmThread, srcObject, offset, 0 != isVolatile);
+}
+
+void
+j9gc_objaccess_mixedObjectStoreU16(J9VMThread *vmThread, J9Object *destObject, UDATA offset, U_16 value, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	barrier->mixedObjectStoreU16(vmThread, destObject, offset, value, 0 != isVolatile);
+}
+
+I_16
+j9gc_objaccess_mixedObjectReadI16(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	return barrier->mixedObjectReadI16(vmThread, srcObject, offset, 0 != isVolatile);
+}
+
+void
+j9gc_objaccess_mixedObjectStoreI16(J9VMThread *vmThread, J9Object *destObject, UDATA offset, I_16 value, UDATA isVolatile) {
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
+	barrier->mixedObjectStoreI16(vmThread, destObject, offset, value, 0 != isVolatile);
+}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+
 UDATA
 j9gc_objaccess_mixedObjectReadU32(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile) {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -268,6 +268,17 @@ extern J9_CFUNC void j9gc_get_offheap_data(J9JavaVM *javaVM, void **offheapContr
 extern J9_CFUNC void j9gc_get_CPU_times(J9JavaVM *javaVM, U_64* mainCpuMillis, U_64* workerCpuMillis, U_32* maxThreads, U_32* currentThreads);
 extern J9_CFUNC void j9gc_ensureLockedSynchronizersIntegrity(J9VMThread *vmThread);
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+extern J9_CFUNC I_8 j9gc_objaccess_mixedObjectReadI8(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile);
+extern J9_CFUNC U_8 j9gc_objaccess_mixedObjectReadU8(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile);
+extern J9_CFUNC I_16 j9gc_objaccess_mixedObjectReadI16(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile);
+extern J9_CFUNC U_16 j9gc_objaccess_mixedObjectReadU16(J9VMThread *vmThread, J9Object *srcObject, UDATA offset, UDATA isVolatile);
+extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreI8(J9VMThread *vmThread, J9Object *destObject, UDATA offset, I_8 value, UDATA isVolatile);
+extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreU8(J9VMThread *vmThread, J9Object *destObject, UDATA offset, U_8 value, UDATA isVolatile);
+extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreI16(J9VMThread *vmThread, J9Object *destObject, UDATA offset, I_16 value, UDATA isVolatile);
+extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreU16(J9VMThread *vmThread, J9Object *destObject, UDATA offset, U_16 value, UDATA isVolatile);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 extern J9_CFUNC void j9gc_prepare_for_checkpoint(J9VMThread *vmThread);
 extern J9_CFUNC BOOLEAN j9gc_reinitialize_for_restore(J9VMThread *vmThread, const char **nlsMsgFormat);

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -617,6 +617,216 @@ public:
 #endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
 	}
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	/**
+	 * Read an I_8 field: perform any pre-use barriers, calculate an effective address
+	 * and perform the work.
+	 *
+	 * @param srcObject The object being used.
+	 * @param srcOffset The offset of the field.
+	 * @param isVolatile non-zero if the field is volatile.
+	 * @return I_8
+	 */
+	VMINLINE I_8
+	inlineMixedObjectReadI8(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		return vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectReadI8(vmThread, srcObject, srcOffset, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		I_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, I_8);
+
+		protectIfVolatileBefore(isVolatile, true);
+		I_8 result = readI8Impl(vmThread, actualAddress, isVolatile);
+		protectIfVolatileAfter(isVolatile, true);
+
+		return result;
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+
+	/**
+	 * Store an I_8 value into an object.
+	 *
+	 * This function performs all of the necessary barriers and calls OOL when it can not handle
+	 * the barrier itself.
+	 *
+	 * @param srcObject the object being stored into
+	 * @param srcOffset the offset with in srcObject to store value
+	 * @param value the value to be stored
+	 * @param isVolatile non-zero if the field is volatile, zero otherwise
+	 */
+	VMINLINE void
+	inlineMixedObjectStoreI8(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, I_8 value, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectStoreI8(vmThread, srcObject, srcOffset, value, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		I_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, I_8);
+
+		protectIfVolatileBefore(isVolatile, false);
+		storeI8Impl(vmThread, actualAddress, value, isVolatile);
+		protectIfVolatileAfter(isVolatile, false);
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+
+	/**
+	 * Read a U_8 field: perform any pre-use barriers, calculate an effective address
+	 * and perform the work.
+	 *
+	 * @param srcObject The object being used.
+	 * @param srcOffset The offset of the field.
+	 * @param isVolatile non-zero if the field is volatile.
+	 * @return U_8
+	 */
+	VMINLINE U_8
+	inlineMixedObjectReadU8(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		return vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectReadU8(vmThread, srcObject, srcOffset, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		U_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, U_8);
+
+		protectIfVolatileBefore(isVolatile, true);
+		U_8 result = readU8Impl(vmThread, actualAddress, isVolatile);
+		protectIfVolatileAfter(isVolatile, true);
+
+		return result;
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+
+	/**
+	 * Store a U_8 value into an object.
+	 *
+	 * This function performs all of the necessary barriers and calls OOL when it can not handle
+	 * the barrier itself.
+	 *
+	 * @param srcObject the object being stored into
+	 * @param srcOffset the offset with in srcObject to store value
+	 * @param value the value to be stored
+	 * @param isVolatile non-zero if the field is volatile, zero otherwise
+	 */
+	VMINLINE void
+	inlineMixedObjectStoreU8(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, U_8 value, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectStoreU8(vmThread, srcObject, srcOffset, value, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		U_8 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, U_8);
+
+		protectIfVolatileBefore(isVolatile, false);
+		storeU8Impl(vmThread, actualAddress, value, isVolatile);
+		protectIfVolatileAfter(isVolatile, false);
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+
+	/**
+	 * Read an I_16 field: perform any pre-use barriers, calculate an effective address
+	 * and perform the work.
+	 *
+	 * @param srcObject The object being used.
+	 * @param srcOffset The offset of the field.
+	 * @param isVolatile non-zero if the field is volatile.
+	 * @return I_16
+	 */
+	VMINLINE I_16
+	inlineMixedObjectReadI16(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		return vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectReadI16(vmThread, srcObject, srcOffset, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		I_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, I_16);
+
+		protectIfVolatileBefore(isVolatile, true);
+		I_16 result = readI16Impl(vmThread, actualAddress, isVolatile);
+		protectIfVolatileAfter(isVolatile, true);
+
+		return result;
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+
+	/**
+	 * Store an I_16 value into an object.
+	 *
+	 * This function performs all of the necessary barriers and calls OOL when it can not handle
+	 * the barrier itself.
+	 *
+	 * @param srcObject the object being stored into
+	 * @param srcOffset the offset with in srcObject to store value
+	 * @param value the value to be stored
+	 * @param isVolatile non-zero if the field is volatile, zero otherwise
+	 */
+	VMINLINE void
+	inlineMixedObjectStoreI16(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, I_16 value, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectStoreI16(vmThread, srcObject, srcOffset, value, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		I_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, I_16);
+
+		protectIfVolatileBefore(isVolatile, false);
+		storeI16Impl(vmThread, actualAddress, value, isVolatile);
+		protectIfVolatileAfter(isVolatile, false);
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+
+	/**
+	 * Read a U_16 field: perform any pre-use barriers, calculate an effective address
+	 * and perform the work.
+	 *
+	 * @param srcObject The object being used.
+	 * @param srcOffset The offset of the field.
+	 * @param isVolatile non-zero if the field is volatile.
+	 * @return U_16
+	 */
+	VMINLINE U_16
+	inlineMixedObjectReadU16(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		return vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectReadU16(vmThread, srcObject, srcOffset, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		U_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, U_16);
+
+		protectIfVolatileBefore(isVolatile, true);
+		U_16 result = readU16Impl(vmThread, actualAddress, isVolatile);
+		protectIfVolatileAfter(isVolatile, true);
+
+		return result;
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+
+	/**
+	 * Store a U_16 value into an object.
+	 *
+	 * This function performs all of the necessary barriers and calls OOL when it can not handle
+	 * the barrier itself.
+	 *
+	 * @param srcObject the object being stored into
+	 * @param srcOffset the offset with in srcObject to store value
+	 * @param value the value to be stored
+	 * @param isVolatile non-zero if the field is volatile, zero otherwise
+	 */
+	VMINLINE void
+	inlineMixedObjectStoreU16(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, U_16 value, bool isVolatile = false) {
+#if defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER)
+		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_mixedObjectStoreU16(vmThread, srcObject, srcOffset, value, isVolatile);
+#elif defined(J9VM_GC_COMBINATION_SPEC)
+		U_16 *actualAddress = J9OAB_MIXEDOBJECT_EA(srcObject, srcOffset, U_16);
+
+		protectIfVolatileBefore(isVolatile, false);
+		storeU16Impl(vmThread, actualAddress, value, isVolatile);
+		protectIfVolatileAfter(isVolatile, false);
+#else /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+#error unsupported barrier
+#endif /* J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER */
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+
 	/**
 	 * Read an I_32 field: perform any pre-use barriers, calculate an effective address
 	 * and perform the work.
@@ -624,6 +834,7 @@ public:
 	 * @param srcObject The object being used.
 	 * @param srcOffset The offset of the field.
 	 * @param isVolatile non-zero if the field is volatile.
+	 * @return I_32
 	 */
 	VMINLINE I_32
 	inlineMixedObjectReadI32(J9VMThread *vmThread, j9object_t srcObject, UDATA srcOffset, bool isVolatile = false)

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4923,12 +4923,24 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9gc_objaccess_indexableStoreObject)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, j9object_t value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_indexableStoreAddress)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, void *value, UDATA isVolatile) ;
 	IDATA  ( *j9gc_objaccess_indexableDataDisplacement)(struct J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst) ;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	I_8  ( *j9gc_objaccess_mixedObjectReadI8)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
+	U_8  ( *j9gc_objaccess_mixedObjectReadU8)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
+	I_16  ( *j9gc_objaccess_mixedObjectReadI16)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
+	U_16  ( *j9gc_objaccess_mixedObjectReadU16)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	IDATA  ( *j9gc_objaccess_mixedObjectReadI32)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
 	UDATA  ( *j9gc_objaccess_mixedObjectReadU32)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
 	I_64  ( *j9gc_objaccess_mixedObjectReadI64)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
 	U_64  ( *j9gc_objaccess_mixedObjectReadU64)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
 	j9object_t  ( *j9gc_objaccess_mixedObjectReadObject)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
 	void*  ( *j9gc_objaccess_mixedObjectReadAddress)(struct J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile) ;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	void  ( *j9gc_objaccess_mixedObjectStoreI8)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, I_8 value, UDATA isVolatile) ;
+	void  ( *j9gc_objaccess_mixedObjectStoreU8)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_8 value, UDATA isVolatile) ;
+	void  ( *j9gc_objaccess_mixedObjectStoreI16)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, I_16 value, UDATA isVolatile) ;
+	void  ( *j9gc_objaccess_mixedObjectStoreU16)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_16 value, UDATA isVolatile) ;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	void  ( *j9gc_objaccess_mixedObjectStoreI32)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, I_32 value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_mixedObjectStoreU32)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_32 value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_mixedObjectStoreI64)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, I_64 value, UDATA isVolatile) ;


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/21251
Depends on: https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1162

I have verified that this passes Valhalla functional tests locally except for some JIT variations which will require additional support.