### PR TITLE
Re-enable const provenance graph

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2730,9 +2730,6 @@ bool J9::Options::fePreProcess(void *base)
         self()->setOption(TR_EnableSharedCacheDisclaiming, false);
     }
 
-    // Temporarily disable constProvenanceGraph due to functional issues and large CompCPU overhead at the client
-    self()->setOption(TR_DisableConstProvenance);
-
     return true;
 }
 


### PR DESCRIPTION
Re-enable const provenance graph, which was previously disabled in #22901 due to a JITServer perf regression and functional failure #22885. #22885 has since been resolved in #23001, so the only pending task is to verify if the JITServer performance issue still persists. In WIP state until then.

Issue: #16616