### PR TITLE
Improvements for mkdocker.sh

### DIFF
--- a/buildenv/docker/mkdocker.sh
+++ b/buildenv/docker/mkdocker.sh
@@ -500,12 +500,11 @@ else
 fi
   echo "# Update make."
   echo "RUN cd /tmp \\"
-  echo " && $wget_O make.tar.gz https://github.com/mirror/make/archive/$make_version.tar.gz \\"
+  echo " && $wget_O make.tar.gz https://ftp.gnu.org/gnu/make/make-$make_version.tar.gz \\"
   echo " && tar -xzf make.tar.gz \\"
   echo " && cd make-$make_version \\"
   echo " && ACLOCAL_PATH=/usr/share/aclocal autoreconf -i \\"
   echo " && ./configure \\"
-  echo " && make update \\"
   echo " && make \\"
   echo " && make install \\"
   echo " && ln -s make /usr/local/bin/gmake \\"


### PR DESCRIPTION
I typically mount host directories into my build env containers. Having control over the uid used inside the container for both Docker and Podman makes that much easier and avoids permission issues.

This PR contains

* a patch that gets rid of the hardcoded uid 1000 in favour of using the default assigned uid, which naturally avoids conflicts with pre-existing uids
* a patch that allows users to explicitly specify the uid, for the reason mentioned above
* a patch that stops recommending cent7 for ppc64le, since it's eol and no longer available in the centos vault
* a patch that fixes how GNU make is built to follow standard conventions and reduce points of failure (see commit message for details)