### PR TITLE
Only run ArrayletAllocateTest in -Xgcpolicy:balanced mode

### DIFF
--- a/test/functional/VM_Test/src/j9vm/test/arraylets/ArrayletAllocateTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/arraylets/ArrayletAllocateTest.java
@@ -21,6 +21,9 @@
  */
 package j9vm.test.arraylets;
 
+import com.ibm.lang.management.MemoryMXBean;
+import java.lang.management.ManagementFactory;
+
 /*
  * Test allocation of arrays near powers of two.
  * This can expose errors in arraylet calculations, resulting in crashes (such as CMVC 168253).
@@ -36,6 +39,12 @@ public class ArrayletAllocateTest {
 	public static Object[] objects = null;
 	
 	public static void main(String[] args) {
+		MemoryMXBean mb = (MemoryMXBean)ManagementFactory.getMemoryMXBean();
+		if (!("-Xgcpolicy:balanced".equals(mb.getGCMode()))) {
+			System.out.println("Only runs in -Xgcpolicy:balanced mode.");
+			return;
+		}
+
 		long maxMemory = Runtime.getRuntime().freeMemory();
 		
 		/* first, run the traditional version of the test */


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/9969

Tested via https://openj9-jenkins.osuosl.org/view/Test/job/Grinder/4960

Without balanced:
```
16:48:42  Only run in -Xgcpolicy:balanced mode.
16:48:42  --- Test PASSED ---
```

With balanced:
```
16:58:47  +++ j9vm.test.arraylets.ArrayletAllocateTest: +++
16:58:47  command: /home/jenkins/workspace/Grinder/jdkbinary/j2sdk-image/bin/java  -Xjit -Xgcpolicy:balanced -Xnocompressedrefs  -Xdump -Xms63m -Xmx63m  -Xdisableexcessivegc   -classpath /home/jenkins/workspace/Grinder/aqa-tests/TKG/../../jvmtest/functional/VM_Test/VM_Test.jar:/home/jenkins/workspace/Grinder/../../externalDependency/lib/asm-all.jar  j9vm.test.arraylets.ArrayletAllocateTest 
16:58:47  
16:58:47  Testing array allocation...
```