### PR TITLE
Use bigger buffers to get CPU features so they aren't truncated

### DIFF
--- a/runtime/jcl/common/vectornatives.cpp
+++ b/runtime/jcl/common/vectornatives.cpp
@@ -74,7 +74,7 @@ Java_jdk_internal_vm_vector_VectorSupport_getMaxLaneCount(JNIEnv *env, jclass cl
 jstring JNICALL
 Java_jdk_internal_vm_vector_VectorSupport_getCPUFeatures(JNIEnv *env, jclass clazz)
 {
-	char buf[1024];
+	char buf[2048];
 	OMRPORT_ACCESS_FROM_J9VMTHREAD((J9VMThread *)env);
 	OMRProcessorDesc processorDesc;
 	buf[0] = '\0';

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -5716,7 +5716,7 @@ JavaCoreDumpWriter::writeCPUinfo(void)
 			"2CITARGETCPU   Target CPUs: ");
 	_OutputStream.writeInteger(target, "%i\n");
 
-	char buff[1024];
+	char buff[2048];
 	intptr_t rc = -1;
 	if (NULL != _VirtualMachine->jitConfig) {
 		rc = omrsysinfo_get_processor_feature_string(&_VirtualMachine->jitConfig->targetProcessor, buff, sizeof(buff));

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -1260,7 +1260,7 @@ done:
 		/* Set CPU description */
 		OMRProcessorDesc desc = {};
 		omrsysinfo_get_processor_description(&desc);
-		char buffer[1024];
+		char buffer[2048];
 		omrsysinfo_get_processor_feature_string(&desc, buffer, sizeof(buffer));
 		UDATA len = strlen(buffer) + 1;
 		cpuInformation->description = (char *)j9mem_allocate_memory(len, J9MEM_CATEGORY_JFR);


### PR DESCRIPTION
Increase the buffer sizes from https://github.com/eclipse-openj9/openj9/pull/22253.

Looking at the flags in https://github.com/eclipse-openj9/openj9/issues/23249#issuecomment-3802665592, the current sizes may not be big enough.