### PR TITLE
Revert "Enable if pattern simplification and disable requireNonNull simplifications of CFG simplifier"

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -35,8 +35,8 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
-   static const char *disableCFGSimplification = feGetEnv("TR_disableCFGSimplification");
-   if (disableCFGSimplification != NULL)
+   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
+   if (enableCFGSimplification == NULL)
       return false;
 
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
@@ -74,9 +74,9 @@ bool J9::CFGSimplifier::simplifyUnresolvedRequireNonNull(bool needToDuplicateTre
    {
    OMR::Logger *log = comp()->log();
 
-   static const char *enableSimplifyExplicitNULLTest = feGetEnv("TR_enableSimplifyExplicitNULLTest");
-   static const char *enableSimplifyUnresolvedRequireNonNull = feGetEnv("TR_enableSimplifyUnresolvedRequireNonNull");
-   if (enableSimplifyExplicitNULLTest == NULL && enableSimplifyUnresolvedRequireNonNull == NULL)
+   static char *disableSimplifyExplicitNULLTest = feGetEnv("TR_disableSimplifyExplicitNULLTest");
+   static char *disableSimplifyUnresolvedRequireNonNull = feGetEnv("TR_disableSimplifyUnresolvedRequireNonNull");
+   if (disableSimplifyExplicitNULLTest != NULL || disableSimplifyUnresolvedRequireNonNull != NULL)
       return false;
 
    if (comp()->getOSRMode() == TR::involuntaryOSR)
@@ -237,9 +237,9 @@ bool J9::CFGSimplifier::simplifyResolvedRequireNonNull(bool needToDuplicateTree)
    {
    OMR::Logger *log = comp()->log();
 
-   static const char *enableSimplifyExplicitNULLTest = feGetEnv("TR_enableSimplifyExplicitNULLTest");
-   static const char *enableSimplifyResolvedRequireNonNull = feGetEnv("TR_enableSimplifyResolvedRequireNonNull");
-   if (enableSimplifyExplicitNULLTest == NULL && enableSimplifyResolvedRequireNonNull == NULL)
+   static char *disableSimplifyExplicitNULLTest = feGetEnv("TR_disableSimplifyExplicitNULLTest");
+   static char *disableSimplifyResolvedRequireNonNull = feGetEnv("TR_disableSimplifyResolvedRequireNonNull");
+   if (disableSimplifyExplicitNULLTest != NULL || disableSimplifyResolvedRequireNonNull != NULL)
       return false;
 
    if (comp()->getOSRMode() == TR::involuntaryOSR)


### PR DESCRIPTION
Enabling CFG Simplifier appears to have exposed a bug in code generation for Power.  Reverting this change until that problem can be investigated and resolved.

Reverts eclipse-openj9/openj9#22838