### PR TITLE
Force j9vm31 to be compiled with XL C/C++ toolchain

### DIFF
--- a/runtime/cmake/modules/CMakeDetermineJ9VM31_CCCompiler.cmake
+++ b/runtime/cmake/modules/CMakeDetermineJ9VM31_CCCompiler.cmake
@@ -1,0 +1,30 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CC_COMPILER_LIST xlc)
+set(CMAKE_J9VM31_CC_COMPILER_ENV_VAR J9VM31CC)
+find_program(CMAKE_J9VM31_CC_COMPILER xlc)
+
+configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeJ9VM31_CCCompiler.cmake.in
+	${CMAKE_PLATFORM_INFO_DIR}/CMakeJ9VM31_CCCompiler.cmake @ONLY)
+
+include(${CMAKE_CURRENT_LIST_DIR}/CMakeJ9VM31_CCInformation.cmake)

--- a/runtime/cmake/modules/CMakeDetermineJ9VM31_CXXCompiler.cmake
+++ b/runtime/cmake/modules/CMakeDetermineJ9VM31_CXXCompiler.cmake
@@ -1,0 +1,31 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CXX_COMPILER_LIST xlc++)
+set(CMAKE_J9VM31_CXX_COMPILER_ENV_VAR J9VM31CXX)
+
+find_program(CMAKE_J9VM31_CXX_COMPILER xlc++)
+
+configure_file(${CMAKE_CURRENT_LIST_DIR}/CMakeJ9VM31_CXXCompiler.cmake.in
+	${CMAKE_PLATFORM_INFO_DIR}/CMakeJ9VM31_CXXCompiler.cmake @ONLY)
+
+include(${CMAKE_CURRENT_LIST_DIR}/CMakeJ9VM31_CXXInformation.cmake)

--- a/runtime/cmake/modules/CMakeJ9VM31_CCCompiler.cmake.in
+++ b/runtime/cmake/modules/CMakeJ9VM31_CCCompiler.cmake.in
@@ -1,0 +1,32 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CC_COMPILER "@CMAKE_J9VM31_CC_COMPILER@")
+set(CMAKE_J9VM31_CC_COMPILER_ARG1 "@_CMAKE_J9VM31_CC_COMPILER_ARG1@")
+set(CMAKE_AR "@CMAKE_AR@")
+set(CMAKE_RANLIB "@CMAKE_RANLIB@")
+set(CMAKE_LINKER "@CMAKE_LINKER@")
+set(CMAKE_J9VM31_CC_COMPILER_LOADED 1)
+set(CMAKE_J9VM31_CC_COMPILER_ID zOS)
+
+set(CMAKE_J9VM31_CC_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)
+set(CMAKE_J9VM31_CC_LINKER_PREFERENCE 10)

--- a/runtime/cmake/modules/CMakeJ9VM31_CCInformation.cmake
+++ b/runtime/cmake/modules/CMakeJ9VM31_CCInformation.cmake
@@ -1,0 +1,27 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CC_DEFINE_FLAG -D)
+set(CMAKE_INCLUDE_FLAG_J9VM31_CC -I)
+set(CMAKE_J9VM31_CC_OUTPUT_EXTENSION .o)
+set(CMAKE_J9VM31_CC_COMPILE_OBJECT "<CMAKE_J9VM31_CC_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")
+set(CMAKE_J9VM31_CC_CREATE_SHARED_LIBRARY "<CMAKE_J9VM31_CC_COMPILER> <CMAKE_SHARED_LIBRARY_J9VM31_CC_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_J9VM31_CC_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")

--- a/runtime/cmake/modules/CMakeJ9VM31_CXXCompiler.cmake.in
+++ b/runtime/cmake/modules/CMakeJ9VM31_CXXCompiler.cmake.in
@@ -1,0 +1,32 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CXX_COMPILER "@CMAKE_J9VM31_CXX_COMPILER@")
+set(CMAKE_J9VM31_CXX_COMPILER_ARG1 "@_CMAKE_J9VM31_CXX_COMPILER_ARG1@")
+set(CMAKE_AR "@CMAKE_AR@")
+set(CMAKE_RANLIB "@CMAKE_RANLIB@")
+set(CMAKE_LINKER "@CMAKE_LINKER@")
+set(CMAKE_J9VM31_CXX_COMPILER_LOADED 1)
+set(CMAKE_J9VM31_CXX_COMPILER_ID zOS)
+
+set(CMAKE_J9VM31_CXX_IGNORE_EXTENSIONS h;H;o;O;obj;OBJ;def;DEF;rc;RC)
+set(CMAKE_J9VM31_CXX_LINKER_PREFERENCE 30)

--- a/runtime/cmake/modules/CMakeJ9VM31_CXXInformation.cmake
+++ b/runtime/cmake/modules/CMakeJ9VM31_CXXInformation.cmake
@@ -1,0 +1,27 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CXX_DEFINE_FLAG -D)
+set(CMAKE_INCLUDE_FLAG_J9VM31_CXX -I)
+set(CMAKE_J9VM31_CXX_OUTPUT_EXTENSION .o)
+set(CMAKE_J9VM31_CXX_COMPILE_OBJECT "<CMAKE_J9VM31_CXX_COMPILER> <DEFINES> <INCLUDES> <FLAGS> -o <OBJECT> -c <SOURCE>")
+set(CMAKE_J9VM31_CXX_CREATE_SHARED_LIBRARY "<CMAKE_J9VM31_CXX_COMPILER> <CMAKE_SHARED_LIBRARY_J9VM31_CXX_FLAGS> <LINK_FLAGS> <CMAKE_SHARED_LIBRARY_CREATE_J9VM31_CXX_FLAGS> <SONAME_FLAG><TARGET_SONAME> -o <TARGET> <OBJECTS> <LINK_LIBRARIES>")

--- a/runtime/cmake/modules/CMakeTestJ9VM31_CCCompiler.cmake
+++ b/runtime/cmake/modules/CMakeTestJ9VM31_CCCompiler.cmake
@@ -1,0 +1,23 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CC_COMPILER_WORKS 1 CACHE INTERNAL "")

--- a/runtime/cmake/modules/CMakeTestJ9VM31_CXXCompiler.cmake
+++ b/runtime/cmake/modules/CMakeTestJ9VM31_CXXCompiler.cmake
@@ -1,0 +1,23 @@
+################################################################################
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+################################################################################
+
+set(CMAKE_J9VM31_CXX_COMPILER_WORKS 1 CACHE INTERNAL "")

--- a/runtime/j9vm31/CMakeLists.txt
+++ b/runtime/j9vm31/CMakeLists.txt
@@ -22,6 +22,18 @@
 
 set(OMR_ENHANCED_WARNINGS OFF)
 
+# Open XL incorrectly handles static init structs containing function pointers used in
+# jnicsup.cpp and jniinv.cpp, resulting in an 0C4 ABEND when invoked via a CEL4RO31 call.
+# Temporarily force libjvm31.so to be compiled with XL C/C++ toolchain as a workaround.
+if(OMR_TOOLCONFIG STREQUAL "openxl")
+	enable_language(J9VM31_CC)
+	enable_language(J9VM31_CXX)
+	set(USE_J9VM31_LANGUAGES TRUE)
+	message(STATUS "j9vm31: Using custom J9VM31_CC and J9VM31_CXX languages with XL C/C++ toolchain.")
+else()
+	set(USE_J9VM31_LANGUAGES FALSE)
+endif()
+
 # libjvm31 is a standalone 31-bit shim library in what is otherwise a 64-bit build.
 add_library(jvm31 SHARED
 	j9cel4ro64.c
@@ -33,6 +45,32 @@ add_library(jvm31 SHARED
 	jnimisc.cpp
 	jnireflect.cpp
 )
+
+if(USE_J9VM31_LANGUAGES)
+	set_source_files_properties(
+		j9cel4ro64.c
+		PROPERTIES LANGUAGE J9VM31_CC)
+
+	set_source_files_properties(
+		jnicgen.cpp
+		jnicsup.cpp
+		jnifield.cpp
+		jniinv.cpp
+		jnimisc.cpp
+		jnireflect.cpp
+		PROPERTIES LANGUAGE J9VM31_CXX
+	)
+	set_target_properties(jvm31 PROPERTIES LINKER_LANGUAGE J9VM31_CXX)
+
+	# XL C/C++ generates the sidedeck file in the working directory. Copy it
+	# to the target directory where Open XL would have generated the file.
+	add_custom_command(TARGET jvm31 POST_BUILD
+			COMMAND ${CMAKE_COMMAND} -E copy_if_different
+					"${CMAKE_CURRENT_BINARY_DIR}/libjvm31.x"
+					"${CMAKE_CURRENT_BINARY_DIR}/../libjvm31.x"
+			VERBATIM
+	)
+endif()
 
 # Note: These include directories need to be declared ahead of the removals of compile flags
 # below, otherwise, the directories will not be added.
@@ -61,25 +99,69 @@ set(compile_flags_to_remove
 	"-m64"
 )
 
-if(OMR_TOOLCONFIG STREQUAL "openxl")
-	set(compile_flags_to_append
-		"-m32n"
-		"-mzos-float-kind=ieee"
-		"-Wno-c++11-narrowing"
+if(USE_J9VM31_LANGUAGES)
+	# Set the default XL C/C++ compilation / linking flags.
+	omr_stringify(CMAKE_J9VM31_CC_FLAGS
+		-O3
+		-qdebug=nohook
+		-qnogonumber
+		-qstackprotect
+		"\"-Wc,ARCH(10)\""
+		-Wc,DLL,EXPORTALL
+		"\"-Wc,inline(auto,noreport,600,5000)\""
+		"\"-Wc,langlvl(extc99)\""
+		"\"-Wc,list(),offset,gonumber\""
+		"\"-Wc,TUNE(12)\""
 	)
+
+	omr_stringify(CMAKE_J9VM31_CXX_FLAGS
+		-O3
+		-qdebug=nohook
+		-qnoeh
+		-qnogonumber
+		-qstackprotect
+		-Wc,rostring
+		"\"-Wc,enum(4)\""
+		"\"-Wc,FLOAT(IEEE,FOLD,AFP)\""
+		-Wa,goff
+		"\"-Wc,inline(auto,noreport,600,5000)\""
+		"\"-Wc,list(),offset,gonumber\""
+		-Wc,NOANSIALIAS
+		"\"-Wc,TARGET(zOSV2R3)\""
+		-+
+		"\"-Wc,ARCH(10)\""
+		-Wc,DLL,EXPORTALL
+		"\"-Wc,TUNE(12)\""
+		-qasm
+		-qlanglvl=extended0x
+		-qnortti
+	)
+
+	omr_stringify(CMAKE_SHARED_LIBRARY_J9VM31_CXX_FLAGS
+		-Wl,compat=zOSV2R3
+		-Wl,dll
+	)
+else()
+	if(OMR_TOOLCONFIG STREQUAL "openxl")
+		set(compile_flags_to_append
+			"-m32n"
+			"-mzos-float-kind=ieee"
+			"-Wno-c++11-narrowing"
+		)
+	endif()
+
+	foreach(flag IN LISTS compile_flags_to_remove)
+		omr_remove_flags(CMAKE_C_FLAGS "${flag}")
+		omr_remove_flags(CMAKE_CXX_FLAGS "${flag}")
+		omr_remove_flags(CMAKE_ASM_FLAGS "${flag}")
+	endforeach()
+
+	foreach(flag IN LISTS compile_flags_to_append)
+		omr_append_flags(CMAKE_C_FLAGS "${flag}")
+		omr_append_flags(CMAKE_CXX_FLAGS "${flag}")
+		omr_append_flags(CMAKE_ASM_FLAGS "${flag}")
+	endforeach()
 endif()
-
-foreach(flag IN LISTS compile_flags_to_remove)
-	omr_remove_flags(CMAKE_C_FLAGS "${flag}")
-	omr_remove_flags(CMAKE_CXX_FLAGS "${flag}")
-	omr_remove_flags(CMAKE_ASM_FLAGS "${flag}")
-endforeach()
-
-foreach(flag IN LISTS compile_flags_to_append)
-	omr_append_flags(CMAKE_C_FLAGS "${flag}")
-	omr_append_flags(CMAKE_CXX_FLAGS "${flag}")
-	omr_append_flags(CMAKE_ASM_FLAGS "${flag}")
-endforeach()
 
 # Flags to be removed when linking.
 set(link_flags_to_remove


### PR DESCRIPTION
Open XL on z/OS incorrectly handles static init structs containing function pointers used in jnicsup.cpp and jniinv.cpp, resulting in an 0C4 ABEND when invoked via CEL4RO31 call.

Temporarily force libjvm31.so to be compiled with XL C/C++ toolchain as a workaround.