### PR TITLE
Replace references to fields being removed from OMR_VMThread

### DIFF
--- a/runtime/gc_base/GCExtensions.hpp
+++ b/runtime/gc_base/GCExtensions.hpp
@@ -302,19 +302,6 @@ public:
 		_tenureBase = base;
 		_tenureSize = size;
 
-		/* todo: dagar move back to MemorySubSpaceGeneric addTenureRange() and removeTenureRange() once
-		 * heapBaseForBarrierRange0 heapSizeForBarrierRange0 can be removed from J9VMThread
-		 *
-		 * setTenureAddressRange() can be removed fromo GCExtensions.hpp and made inline again
-		 */
-		GC_OMRVMThreadListIterator omrVMThreadListIterator(_omrVM);
-		while (OMR_VMThread* walkThread = omrVMThreadListIterator.nextOMRVMThread()) {
-			walkThread->lowTenureAddress = heapBaseForBarrierRange0;
-			walkThread->highTenureAddress = (void*)((uintptr_t)heapBaseForBarrierRange0 + heapSizeForBarrierRange0);
-			walkThread->heapBaseForBarrierRange0 = heapBaseForBarrierRange0;
-			walkThread->heapSizeForBarrierRange0 = heapSizeForBarrierRange0;
-		}
-
 		GC_VMThreadListIterator vmThreadListIterator((J9JavaVM*)_omrVM->_language_vm);
 		while (J9VMThread* walkThread = vmThreadListIterator.nextVMThread()) {
 			walkThread->lowTenureAddress = heapBaseForBarrierRange0;

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -95,13 +95,13 @@ public:
 	internalPostBatchStoreObjectCardTableAndGenerational(J9VMThread *vmThread, j9object_t object)
 	{
 		/* Check to see if object is old.  If object is not old neither barrier is required
-		 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0) then old
+		 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0) then old
 		 *
 		 * Since card dirtying also requires this calculation remember these values
 		 */
-		UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+		UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 		UDATA objectDelta = (UDATA)object - base;
-		UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+		UDATA size = vmThread->heapSizeForBarrierRange0;
 		if (objectDelta < size) {
 			/* object is old so check for concurrent barrier */
 			if (0 != (vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE)) {
@@ -118,13 +118,13 @@ public:
 	internalPostBatchStoreObjectGenerational(J9VMThread *vmThread, j9object_t object)
 	{
 		/* Check to see if object is old.  If object is not old neither barrier is required
-		 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0) then old
+		 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0) then old
 		 *
 		 * Since card dirtying also requires this calculation remember these values
 		 */
-		UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+		UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 		UDATA objectDelta = (UDATA)object - base;
-		UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+		UDATA size = vmThread->heapSizeForBarrierRange0;
 		if (objectDelta < size) {
 			/* generational barrier is required if object is old*/
 			rememberObject(vmThread, object);
@@ -135,13 +135,13 @@ public:
 	internalPostBatchStoreObjectCardTableIncremental(J9VMThread *vmThread, j9object_t object)
 	{
 		/* Check to see if object is within the barrier range.
-		 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0)
+		 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0)
 		 *
 		 * Since card dirtying also requires this calculation remember these values
 		 */
-		UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+		UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 		UDATA objectDelta = (UDATA)object - base;
-		UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+		UDATA size = vmThread->heapSizeForBarrierRange0;
 		if (objectDelta < size) {
 			/* Object is within the barrier range.  Dirty the card */
 			dirtyCard(vmThread, objectDelta);
@@ -152,13 +152,13 @@ public:
 	internalPostBatchStoreObjectCardTable(J9VMThread *vmThread, j9object_t object)
 	{
 		/* Check to see if object is old.  If object is not old neither barrier is required
-		 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0) then old
+		 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0) then old
 		 *
 		 * Since card dirtying also requires this calculation remember these values
 		 */
-		UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+		UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 		UDATA objectDelta = (UDATA)object - base;
-		UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+		UDATA size = vmThread->heapSizeForBarrierRange0;
 		if (objectDelta < size) {
 			/* object is old so check for concurrent barrier */
 			if (0 != (vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE)) {
@@ -182,13 +182,13 @@ public:
 		/* if value is NULL neither barrier is required */
 		if (NULL != value) {
 			/* Check to see if object is old.  If object is not old neither barrier is required
-			 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0) then old
+			 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0) then old
 			 *
 			 * Since card dirtying also requires this calculation remember these values
 			 */
-			UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+			UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 			UDATA objectDelta = (UDATA)object - base;
-			UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+			UDATA size = vmThread->heapSizeForBarrierRange0;
 			if (objectDelta < size) {
 				/* object is old so check for concurrent barrier */
 				if (0 != (vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE)) {
@@ -221,13 +221,13 @@ public:
 		/* if value is NULL neither barrier is required */
 		if (NULL != value) {
 			/* Check to see if object is old.
-			 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0) then old
+			 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0) then old
 			 *
 			 * Since card dirtying also requires this calculation remember these values
 			 */
-			UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+			UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 			UDATA objectDelta = (UDATA)object - base;
-			UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+			UDATA size = vmThread->heapSizeForBarrierRange0;
 			if (objectDelta < size) {
 				/* object is old so check for concurrent barrier */
 				if (0 != (vmThread->privateFlags & J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE)) {
@@ -252,13 +252,13 @@ public:
 		/* if value is NULL neither barrier is required */
 		if (NULL != value) {
 			/* Check to see if object is within the barrier range.
-			 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0)
+			 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0)
 			 *
 			 * Since card dirtying also requires this calculation remember these values
 			 */
-			UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+			UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 			UDATA objectDelta = (UDATA)object - base;
-			UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+			UDATA size = vmThread->heapSizeForBarrierRange0;
 			if (objectDelta < size) {
 				/* Object is within the barrier range.  Dirty the card */
 				dirtyCard(vmThread, objectDelta);
@@ -280,13 +280,13 @@ public:
 		/* if value is NULL neither barrier is required */
 		if (NULL != value) {
 			/* Check to see if object is old.
-			 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0) then old
+			 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0) then old
 			 *
 			 * Since card dirtying also requires this calculation remember these values
 			 */
-			UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+			UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 			UDATA objectDelta = (UDATA)object - base;
-			UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+			UDATA size = vmThread->heapSizeForBarrierRange0;
 			if (objectDelta < size) {
 				/* generational barrier is required if object is old and value is new */
 				/* Check to see if value is new using the same optimization as above */
@@ -311,13 +311,13 @@ public:
 	internalPostObjectStoreGenerationalNoValueCheck(J9VMThread *vmThread, j9object_t object)
 	{
 		/* Check to see if object is old.
-		 * if ((object - vmThread->omrVMThread->heapBaseForBarrierRange0) < vmThread->omrVMThread->heapSizeForBarrierRange0) then old
+		 * if ((object - vmThread->heapBaseForBarrierRange0) < vmThread->heapSizeForBarrierRange0) then old
 		 *
 		 * Since card dirtying also requires this calculation remember these values
 		 */
-		UDATA base = (UDATA)vmThread->omrVMThread->heapBaseForBarrierRange0;
+		UDATA base = (UDATA)vmThread->heapBaseForBarrierRange0;
 		UDATA objectDelta = (UDATA)object - base;
-		UDATA size = vmThread->omrVMThread->heapSizeForBarrierRange0;
+		UDATA size = vmThread->heapSizeForBarrierRange0;
 		if (objectDelta < size) {
 			rememberObject(vmThread, object);
 		}


### PR DESCRIPTION
Replace references to fields being removed from OMR_VMThread

The following fields are being removed from OMR_VMThread:
- lowTenureAddress
- highTenureAddress;
- heapBaseForBarrierRange0;
- heapSizeForBarrierRange0

This PR replaces all references to the above using identical fields in J9VMThread.

This reverts changes from a previous (unfinished) work to transfer these fields from J9VMThread to OMR_VMThread.

Signed-off-by: Shadman Siddiqui shadman2606@gmail.com