### PR TITLE
Reenable CFG simplifier

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -35,8 +35,8 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
-   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
-   if (enableCFGSimplification == NULL)
+   static const char *disableCFGSimplification = feGetEnv("TR_disableCFGSimplification");
+   if (disableCFGSimplification != NULL)
       return false;
 
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)


### PR DESCRIPTION
This pull request delivers changes that were previously delivered under pull request #22838.  Those changes had to be reverted under pull request #23267 as they exposed a bug in 32-bit AIX Power code generation.  That bug has since been fixed under OMR pull request eclipse-omr/omr#8104, which has been promoted to the openj9 branch of https://github.com/eclipse-openj9/openj9-omr.

The `J9::CFGSimplifier::simplifyIfPatterns` method of CFG Simplification had been disabled by default due to bugs in the upstream implementation of `OMR::CFGSimplifier::simplifyIfPatterns` as well as bugs exposed by those transformations.  The problematic transformations in OMR have been temporarily disabled by [OMR Pull Request 8005](https://github.com/eclipse-omr/omr/pull/8005), allowing J9's `simplifyIfPatterns` to be enabled again by default.

Also, the `simplifyUnresolvedRequireNonNull` and `simplifyResolvedRequireNonNull` transformations of CFG Simplifier have never been fully tested.  This change disables those transformations so that other transformations performed by CFG Simplifier that are known to be safe can be re-enabled.  The intention is that the "Requires non-null" transformations will themselves be re-eenabled once they have been more thoroughly tested and any necessary bug fixes have been applied.