### PR TITLE
Gate IDENTITY modifier on Valhalla preview features in native code

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2420,7 +2420,7 @@ public int getModifiers() {
 	} else {
 		rawModifiers &= Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
 /*[IF INLINE-TYPES]*/
-				| AccessFlag.IDENTITY.mask() | Modifier.STRICT
+				| AccessFlag.IDENTITY.mask()
 /*[ENDIF] INLINE-TYPES */
 				| Modifier.STATIC | Modifier.FINAL | Modifier.INTERFACE
 				| Modifier.ABSTRACT | SYNTHETIC | ENUM | ANNOTATION;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -7002,7 +7002,16 @@ TR_J9VMBase::javaLangClassGetModifiersImpl(TR_OpaqueClassBlock * clazzPointer, i
    if (isArray)
       {
       // OR in the required Sun bits
-      result |= (J9AccAbstract + J9AccFinal);
+      result |= (J9AccAbstract | J9AccFinal);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+      if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass))
+         {
+         if (J9_ARE_ANY_BITS_SET(vmThread()->javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW))
+            {
+            result |= J9AccClassHasIdentity;
+            }
+         }
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
       }
    return true;
    }

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -3221,7 +3221,9 @@ done:
 			modifiers |= (J9AccAbstract | J9AccFinal);
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-			if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass)) {
+			if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass)
+				&& J9_ARE_ANY_BITS_SET(_vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW)
+			) {
 				modifiers |= J9AccClassHasIdentity;
 			}
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */

--- a/runtime/vm/FastJNI_java_lang_Class.cpp
+++ b/runtime/vm/FastJNI_java_lang_Class.cpp
@@ -190,7 +190,14 @@ Fast_java_lang_Class_getModifiersImpl(J9VMThread *currentThread, j9object_t rece
 	
 	if (isArray) {
 		/* OR in the required Sun bits */
-		modifiers |= (J9AccAbstract + J9AccFinal);
+		modifiers |= (J9AccAbstract | J9AccFinal);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass)
+			&& J9_ARE_ANY_BITS_SET(currentThread->javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW)
+		) {
+			modifiers |= J9AccClassHasIdentity;
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	}
 	return (jint)modifiers;
 }

--- a/runtime/vm/romclasses.c
+++ b/runtime/vm/romclasses.c
@@ -127,10 +127,6 @@ initializeArrayROMClass(J9ROMArrayClass *romClass, J9UTF8 *className, U_32 array
 	NNSRP_SET(romClass->className, className);
 	NNSRP_SET(romClass->superclassName, &arrayROMClasses.objectClassName);
 	romClass->modifiers = J9AccFinal | J9AccPublic | J9AccClassArray | J9AccAbstract;
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	/* Arrays are always identity classes. */
-	romClass->modifiers |= J9AccClassHasIdentity;
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	romClass->extraModifiers = J9AccClassCloneable | J9AccClassIsUnmodifiable;
 	romClass->interfaceCount = sizeof(arrayROMClasses.interfaceClasses) / sizeof(J9SRP);
 	NNSRP_SET(romClass->interfaces, &arrayROMClasses.interfaceClasses);


### PR DESCRIPTION
Description:
- Previously, the IDENTITY modifier was enforced in the Java implementation. This change moves the gate to the native implementation, ensuring that the JVM reports the IDENTITY class modifier only when Valhalla preview features are enabled at runtime.

What changed:
- Native code now checks the Valhalla preview runtime flag before setting the IDENTITY modifier.
- Fixed IsIdentityTest failures, including array classes.

Motivation:
- To ensure JVM behavior is consistent with Valhalla design expectations.

Impact:
- JVM correctness for identity/value type detection.
- Test suite passes reliably.