### PR TITLE
Check the runtimeflags to see if preview enabled

### DIFF
--- a/runtime/bcutil/jimageintf.c
+++ b/runtime/bcutil/jimageintf.c
@@ -326,11 +326,10 @@ jimageFindResource(J9JImageIntf *jimageIntf, UDATA handle, const char *moduleNam
 
 		if (NULL != locationRef) {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-			/* Valhalla enables --enable-preview by default at jvminit.c;
-			 * The parameter is_preview_mode is set to TRUE which might require change
-			 * if the Valhalla project is merged into openjdk head stream.
-			 */
-			*locationRef = libJImageFindResource(jimage, moduleName, name, TRUE, (jlong *)size);
+			J9JavaVM *vm = jimageIntf->vm;
+			BOOLEAN enablePreview = J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW);
+
+			*locationRef = libJImageFindResource(jimage, moduleName, name, enablePreview, (jlong *)size);
 #else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			*locationRef = libJImageFindResource(jimage, moduleName, JIMAGE_VERSION_NUMBER, name, (jlong *)size);
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2735,12 +2735,6 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 				if (FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_ENABLE_PREVIEW, NULL) >= 0) {
 					vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW;
 				}
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-				else {
-					/* Valhalla enables --enable-preview by default. */
-					vm->extendedRuntimeFlags2 |= J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW;
-				}
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			}
 			if ((argIndex = FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_XSIGQUITTOFILE, NULL)) >= 0) {
 				GET_OPTION_VALUE(argIndex, ':', &optionValue);


### PR DESCRIPTION
libJImageFindResource() takes preview as an input parameter. 
Rather than pass in TRUE unconditionally, check
J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW.