### PR TITLE
Revert "Reenable CFG simplifier"

### DIFF
--- a/runtime/compiler/optimizer/J9CFGSimplifier.cpp
+++ b/runtime/compiler/optimizer/J9CFGSimplifier.cpp
@@ -35,8 +35,8 @@
 
 bool J9::CFGSimplifier::simplifyIfPatterns(bool needToDuplicateTree)
    {
-   static const char *disableCFGSimplification = feGetEnv("TR_disableCFGSimplification");
-   if (disableCFGSimplification != NULL)
+   static char *enableCFGSimplification = feGetEnv("TR_enableCFGSimplificaiton");
+   if (enableCFGSimplification == NULL)
       return false;
 
    return OMR::CFGSimplifier::simplifyIfPatterns(needToDuplicateTree)
@@ -74,9 +74,9 @@ bool J9::CFGSimplifier::simplifyUnresolvedRequireNonNull(bool needToDuplicateTre
    {
    OMR::Logger *log = comp()->log();
 
-   static const char *enableSimplifyExplicitNULLTest = feGetEnv("TR_enableSimplifyExplicitNULLTest");
-   static const char *enableSimplifyUnresolvedRequireNonNull = feGetEnv("TR_enableSimplifyUnresolvedRequireNonNull");
-   if (enableSimplifyExplicitNULLTest == NULL && enableSimplifyUnresolvedRequireNonNull == NULL)
+   static char *disableSimplifyExplicitNULLTest = feGetEnv("TR_disableSimplifyExplicitNULLTest");
+   static char *disableSimplifyUnresolvedRequireNonNull = feGetEnv("TR_disableSimplifyUnresolvedRequireNonNull");
+   if (disableSimplifyExplicitNULLTest != NULL || disableSimplifyUnresolvedRequireNonNull != NULL)
       return false;
 
    if (comp()->getOSRMode() == TR::involuntaryOSR)
@@ -237,9 +237,9 @@ bool J9::CFGSimplifier::simplifyResolvedRequireNonNull(bool needToDuplicateTree)
    {
    OMR::Logger *log = comp()->log();
 
-   static const char *enableSimplifyExplicitNULLTest = feGetEnv("TR_enableSimplifyExplicitNULLTest");
-   static const char *enableSimplifyResolvedRequireNonNull = feGetEnv("TR_enableSimplifyResolvedRequireNonNull");
-   if (enableSimplifyExplicitNULLTest == NULL && enableSimplifyResolvedRequireNonNull == NULL)
+   static char *disableSimplifyExplicitNULLTest = feGetEnv("TR_disableSimplifyExplicitNULLTest");
+   static char *disableSimplifyResolvedRequireNonNull = feGetEnv("TR_disableSimplifyResolvedRequireNonNull");
+   if (disableSimplifyExplicitNULLTest != NULL || disableSimplifyResolvedRequireNonNull != NULL)
       return false;
 
    if (comp()->getOSRMode() == TR::involuntaryOSR)


### PR DESCRIPTION
Enabling CFG Simplifier seems to have exposed another bug in 32-bit AIX code generation.  I will have to revert enabling it again.

Reverts eclipse-openj9/openj9#23283