### PR TITLE
Ensure Weak References only to identity instances

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -230,6 +230,11 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	 * @param r the referent
 	 */
 	void initReference (T r) {
+/*[IF INLINE-TYPES]*/
+		if ((null != r) && r.getClass().isValue()) {
+			throw new IdentityException(r.getClass());
+		}
+/*[ENDIF] INLINE-TYPES */
 		state = STATE_INITIAL;
 		referent = r;
 	}
@@ -242,6 +247,11 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	 * @param q the ReferenceQueue
 	 */
 	void initReference (T r, ReferenceQueue q) {
+/*[IF INLINE-TYPES]*/
+		if ((null != r) && r.getClass().isValue()) {
+			throw new IdentityException(r.getClass());
+		}
+/*[ENDIF] INLINE-TYPES */
 		/*[PR 101461] Reference should allow null queues */
 		queue = q;
 		state = STATE_INITIAL;


### PR DESCRIPTION
Throw IdentityException if a weak reference
is created to a value type instance.
Fixes: valhalla/valuetypes/WeakReferenceTest.java

Passing Test: https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/58006/

Signed-off-by: Aditi Srinivas M Aditi.Srini@ibm.com