### PR TITLE
Add a per-compilation VM_getClassFromSignature Null Cache

### DIFF
--- a/runtime/compiler/control/CompilationThread.hpp
+++ b/runtime/compiler/control/CompilationThread.hpp
@@ -550,8 +550,6 @@ class CompilationInfoPerThread : public TR::CompilationInfoPerThreadBase
 #if defined(J9VM_OPT_JITSERVER)
    TR_J9ServerVM         *_serverVM;
    TR_J9SharedCacheServerVM *_sharedCacheServerVM;
-   // The following hastable caches <classLoader,classname> --> <J9Class> mappings
-   // The cache only lives during a compilation due to class unloading concerns
    PersistentUnorderedSet<TR_OpaqueClassBlock*> *_classesThatShouldNotBeNewlyExtended;
 #endif /* defined(J9VM_OPT_JITSERVER) */
 

--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -299,6 +299,7 @@ TR::CompilationInfoPerThreadRemote::CompilationInfoPerThreadRemote(TR::Compilati
    _classOfStaticMap(NULL),
    _fieldAttributesCache(NULL),
    _staticAttributesCache(NULL),
+   _nullClassSignatureCache(NULL),
    _isUnresolvedStrCache(NULL),
    _classUnloadReadMutexDepth(0),
    _aotCacheStore(false),
@@ -1805,6 +1806,26 @@ TR::CompilationInfoPerThreadRemote::getCachedFieldOrStaticAttributes(TR_OpaqueCl
       return getCachedValueFromPerCompilationMap(_fieldAttributesCache, std::make_pair(ramClass, cpIndex), attrs);
    }
 
+void
+TR::CompilationInfoPerThreadRemote::addClassToNullClassSignatureCache(const ClassLoaderStringPair &clsp)
+   {
+   if (!_nullClassSignatureCache)
+      {
+      initializePerCompilationCache(_nullClassSignatureCache);
+      }
+   _nullClassSignatureCache->insert(clsp);
+   }
+
+bool
+TR::CompilationInfoPerThreadRemote::classIsInNullClassSignatureCache(const ClassLoaderStringPair &clsp)
+   {
+   if (!_nullClassSignatureCache)
+      {
+      return false;
+      }
+   return _nullClassSignatureCache->find(clsp) != _nullClassSignatureCache->end();
+   }
+
 /**
  * @brief Method executed by JITServer to cache unresolved string
  *
@@ -1845,6 +1866,7 @@ TR::CompilationInfoPerThreadRemote::clearPerCompilationCaches()
    clearPerCompilationCache(_classOfStaticMap);
    clearPerCompilationCache(_fieldAttributesCache);
    clearPerCompilationCache(_staticAttributesCache);
+   clearPerCompilationCache(_nullClassSignatureCache);
    clearPerCompilationCache(_isUnresolvedStrCache);
    }
 

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -35,6 +35,7 @@ using IPTableHeap_t = UnorderedMap<J9Method *, IPTableHeapEntry *>;
 using ResolvedMirrorMethodsPersistIP_t = Vector<TR_ResolvedJ9Method *>;
 using ClassOfStatic_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_OpaqueClassBlock *>;
 using FieldOrStaticAttrTable_t = UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_J9MethodFieldAttributes>;
+using NullClassSignatureCache_t = UnorderedSet<ClassLoaderStringPair>;
 
 using CompilationRequest = std::tuple<
    uint64_t, uint32_t, uint32_t, J9Method *, J9Class *, TR_OptimizationPlan, std::string,
@@ -108,6 +109,9 @@ public:
 
    void cacheFieldOrStaticAttributes(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, const TR_J9MethodFieldAttributes &attrs, bool isStatic);
    bool getCachedFieldOrStaticAttributes(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_J9MethodFieldAttributes &attrs, bool isStatic);
+
+   void addClassToNullClassSignatureCache(const ClassLoaderStringPair &clsp);
+   bool classIsInNullClassSignatureCache(const ClassLoaderStringPair &clsp);
 
    void cacheIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, const TR_IsUnresolvedString &stringAttrs);
    bool getCachedIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_IsUnresolvedString &stringAttrs);
@@ -208,6 +212,7 @@ private:
    ClassOfStatic_t *_classOfStaticMap;
    FieldOrStaticAttrTable_t *_fieldAttributesCache;
    FieldOrStaticAttrTable_t *_staticAttributesCache;
+   NullClassSignatureCache_t *_nullClassSignatureCache;
    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_IsUnresolvedString> *_isUnresolvedStrCache;
    int32_t _classUnloadReadMutexDepth;
    bool _aotCacheStore; // True if the result of this compilation will be stored in AOT cache


### PR DESCRIPTION
The JITServer message VM_getClassFromSignature asks the client to return the class corresponding to a given ClassLoader* and class signature. When the class has not yet been loaded, a NULL pointer is returned. Previously, this value is not cached as it could be loaded later. This led to large numbers of un-necessary messages. This PR adds a Per-compilation cache which stores NULLs, essentially assuming the class will not be loaded before the compilation finishes.

If the assumption mentioned above is not true, then the compiled code may not be as performant as possible. This is similar to the non-JITServer case where a class is loaded by another thread during compilation. Local experiments ran on AcmeAir showed no signs of this occurring, leading us to believe it is quite rate.
