### PR TITLE
 Raise exception for non-identity classes on weak ref creation

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -231,7 +231,7 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	 */
 	void initReference (T r) {
 /*[IF INLINE-TYPES]*/
-		if ((null != r) && r.getClass().isValue()) {
+		if ((null != r) && !r.getClass().isIdentity()) {
 			throw new IdentityException(r.getClass());
 		}
 /*[ENDIF] INLINE-TYPES */
@@ -248,7 +248,7 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	 */
 	void initReference (T r, ReferenceQueue q) {
 /*[IF INLINE-TYPES]*/
-		if ((null != r) && r.getClass().isValue()) {
+		if ((null != r) && !r.getClass().isIdentity()) {
 			throw new IdentityException(r.getClass());
 		}
 /*[ENDIF] INLINE-TYPES */


### PR DESCRIPTION
Ensure that identity exception is raised for all non-identity classes 
not only value classes.
This change addresses the review comments on #23295 

Signed-off-by: Aditi Srinivas M Aditi.Srini@ibm.com