### PR TITLE
Verify the data types in Class.forName

### DIFF
--- a/runtime/vm/classsupport.c
+++ b/runtime/vm/classsupport.c
@@ -780,7 +780,9 @@ callLoadClass(J9VMThread* vmThread, U_8* className, UDATA classNameLength, J9Cla
 			omrthread_monitor_enter(vm->classTableMutex);
 			/* Verify that the actual name matches the expected */
 			foundClassName = J9ROMCLASS_CLASSNAME(foundClass->romClass);
-			if (!J9UTF8_DATA_EQUALS(className, classNameLength, J9UTF8_DATA(foundClassName), J9UTF8_LENGTH(foundClassName))) {
+			if (!J9UTF8_DATA_EQUALS(className, classNameLength, J9UTF8_DATA(foundClassName), J9UTF8_LENGTH(foundClassName))
+				|| J9ROMCLASS_IS_PRIMITIVE_TYPE(foundClass->romClass)
+			) {
 				/* force failure */
 				foundClass = NULL;
 			} else {


### PR DESCRIPTION
The proposed change is to make Class.forName() compliant with the Java specification, throw ClassNotFoundException when the primitive data types are used in the method to define class by a user-defined class loader.

Fixes: #23263, #22164