### PR TITLE
Add JVM option to specify restore options file

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6548,6 +6548,7 @@ typedef struct J9JavaVM {
 #endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	J9CRIUCheckpointState checkpointState;
+	const char *restoreOptionsFile;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 #if JAVA_SPEC_VERSION >= 16
 	struct J9Pool *cifNativeCalloutDataCache;

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -443,6 +443,7 @@ enum INIT_STAGE {
 #define VMOPT_XXDISABLEDEBUGONRESTORE "-XX:-DebugOnRestore"
 #define VMOPT_XXENABLETIMECOMPENSATION "-XX:+EnableTimeCompensation"
 #define VMOPT_XXDISABLETIMECOMPENSATION "-XX:-EnableTimeCompensation"
+#define VMOPT_XXRESTOREOPTIONSFILE "-XX:RestoreOptionsFile="
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 #if defined(J9VM_OPT_CRAC_SUPPORT)

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -1569,6 +1569,25 @@ loadRestoreArguments(J9VMThread *currentThread, const char *optionsFile, char *e
 			result = RESTORE_ARGS_RETURN_OPTIONS_FILE_FAILED;
 			goto done;
 		}
+	} else if (NULL != vm->restoreOptionsFile) {
+		PORT_ACCESS_FROM_VMC(currentThread);
+		UDATA allocLength = LITERAL_STRLEN(VMOPT_XOPTIONSFILE_EQUALS) + strlen(vm->restoreOptionsFile) + 1;
+		char *restoreOptionsFile = (char *)j9mem_allocate_memory(allocLength, OMRMEM_CATEGORY_VM);
+
+		if (NULL == restoreOptionsFile) {
+			result = RESTORE_ARGS_RETURN_OOM;
+			goto done;
+		}
+
+		j9str_printf(restoreOptionsFile, allocLength, VMOPT_XOPTIONSFILE_EQUALS "%s", vm->restoreOptionsFile);
+		if (0 != addXOptionsFile(vm->portLibrary, restoreOptionsFile, &vmArgumentsList, 0)) {
+			result = RESTORE_ARGS_RETURN_OPTIONS_FILE_FAILED;
+		}
+
+		j9mem_free_memory(restoreOptionsFile);
+		if (RESTORE_ARGS_RETURN_OK != result) {
+			goto done;
+		}
 	}
 
 	if (NULL != envFile) {

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4217,6 +4217,15 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 		}
 	}
 
+	{
+		IDATA restoreOptIndex = FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_XXRESTOREOPTIONSFILE, NULL);
+		if (restoreOptIndex >= 0) {
+			char *restoreOptFile = NULL;
+			GET_OPTION_VALUE(restoreOptIndex, '=', &restoreOptFile);
+			vm->restoreOptionsFile = restoreOptFile;
+		}
+	}
+
 	vm->checkpointState.lastRestoreTimeInNanoseconds = -1;
 	vm->checkpointState.processRestoreStartTimeInNanoseconds = -1;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */


### PR DESCRIPTION
This enables specifying a restore file pre-checkpoint through a new 
"-XX:RestoreOptionsFile=" JVM option.

To store the path to the options file, a new field was added to the J9JavaVM object.

Closes #23284

Signed-off-by: Ernesto Enriquez ernesto@enriquez.dev