### PR TITLE
Clean up temp directory

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy
@@ -186,9 +186,13 @@ timeout(time: TIMEOUT_TIME.toInteger(), unit: TIMEOUT_UNITS) {
 
                                     def cleanDirsStr = "/tmp/${cleanDirs.join(' /tmp/')}"
                                     if (nodeLabels.contains('sw.os.windows')) {
+                                        def tempDir = "${env.TEMP}" ?: "/cygdrive/c/temp"
+                                        // convert to unix path
+                                        tempDir = sh(script: "cygpath -u '${tempDir}'", returnStdout: true).trim()
                                         // test resources
                                         cleanDirsStr += " ${buildWorkspace}/../../"
                                         cleanDirsStr += cleanDirs.join(" ${buildWorkspace}/../../")
+                                        cleanDirsStr += " ${tempDir}/${cleanDirs.join(' ${tempDir}/')}"
                                         // shared classes cache
                                         cleanDirsStr += " ${buildWorkspace}/../../javasharedresources /tmp/javasharedresources /temp/javasharedresources"
                                     }


### PR DESCRIPTION
The current [cleanup script](https://github.com/eclipse-openj9/openj9/blob/master/buildenv/jenkins/jobs/infrastructure/Cleanup-Nodes.groovy) only removes temporary files from the /tmp directory, which is insufficient for Windows machines running Jenkins agents. Some Windows machines are getting disconnected due to low disk space. Upon investigation, it was found that C:\temp (or the directory specified by the TEMP environment variable) accumulates around 75GB of data, causing disk space exhaustion.

To resolve this, the cleanup script needs to be enhanced to include commands for clearing files from C:\temp or the machine’s designated TEMP directory. This will help prevent disconnections and ensure consistent performance of Jenkins agents by freeing up disk space
#https://github.ibm.com/runtimes/infrastructure/issues/10482