### PR TITLE
Remove J9StaticFieldRefStrict, bit is in use

### DIFF
--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -224,7 +224,7 @@ typedef struct J9ClassLoaderWalkState {
 #define J9_ARRAY_DIMENSION_LIMIT 255
 
 #define J9FLAGSANDCLASS_FROM_CLASSANDFLAGS(classAndFlags) (((classAndFlags) >> J9_REQUIRED_CLASS_SHIFT) | ((classAndFlags) << (sizeof(UDATA) * 8 - J9_REQUIRED_CLASS_SHIFT)))
-#define J9CLASSANDFLAGS_FROM_FLAGSANDCLASS(flagsAndClass) ((J9StaticFieldRefFlagBits & ((flagsAndClass) >> (8 * sizeof(UDATA) - J9_REQUIRED_CLASS_SHIFT))) | ((flagsAndClass) << J9_REQUIRED_CLASS_SHIFT))
+#define J9CLASSANDFLAGS_FROM_FLAGSANDCLASS(flagsAndClass) (((flagsAndClass) >> (8 * sizeof(UDATA) - J9_REQUIRED_CLASS_SHIFT)) | ((flagsAndClass) << J9_REQUIRED_CLASS_SHIFT))
 #define J9RAMSTATICFIELDREF_CLASS(base) ((J9Class *) ((base)->flagsAndClass << J9_REQUIRED_CLASS_SHIFT))
 /* In a resolved J9RAMStaticFieldRef, the high bit of valueOffset is set, so it must be masked when adding valueOffset to the ramStatics address.
  * Note that ~IDATA_MIN has all but the high bit set. */

--- a/runtime/oti/j9javaaccessflags.h
+++ b/runtime/oti/j9javaaccessflags.h
@@ -178,8 +178,8 @@
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 #define J9StaticFieldRefNullRestricted 0x40
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
-#define J9StaticFieldRefStrict 0x80
-#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
+/* The bit 0x80 is reserved and used to indicate when a field is
+ * unresolved. See VMHelpers::staticFieldRefIsResolved.
+ */
 
 #endif /*J9JAVAACCESSFLAGS_H */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2122,14 +2122,21 @@ typedef struct J9FlattenedClassCache {
 
 #define J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, index) (((J9FlattenedClassCacheEntry *)((flattenedClassCache) + 1)) + (index))
 #define J9_VM_FCC_ENTRY_FROM_CLASS(clazz, index) J9_VM_FCC_ENTRY_FROM_FCC((clazz)->flattenedClassCache, index)
-#define J9_VM_FCC_CLASS_FROM_ENTRY(entry) ((J9Class *)((UDATA)(entry)->clazz & ~J9_VM_FCC_CLASS_FLAGS_MASK))
-#define J9_VM_FCC_ENTRY_IS_STATIC_FIELD(entry) J9_ARE_ALL_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STATIC_FIELD)
-#define J9_VM_FCC_ENTRY_IS_STRICT_STATIC_UNSET(entry) J9_ARE_NO_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_WRITTEN)
-#define J9_VM_FCC_ENTRY_IS_STRICT_STATIC_READ(entry) J9_ARE_ALL_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_READ)
-#define J9_VM_FCC_ENTRY_IS_STRICT_STATIC_PRIMITIVE(entry) J9_ARE_ALL_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_PRIMITIVE)
+#define J9_VM_FCC_CLASS_FROM_ENTRY(entry) \
+	((J9Class *)((UDATA)(entry)->clazz & ~J9_VM_FCC_CLASS_FLAGS_MASK))
+#define J9_VM_FCC_ENTRY_IS_STATIC_FIELD(entry) \
+	J9_ARE_ANY_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STATIC_FIELD)
+#define J9_VM_FCC_ENTRY_IS_STRICT_STATIC_UNSET(entry) \
+	J9_ARE_NO_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_WRITTEN)
+#define J9_VM_FCC_ENTRY_IS_STRICT_STATIC_READ(entry) \
+	J9_ARE_ANY_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_READ)
+#define J9_VM_FCC_ENTRY_IS_STRICT_STATIC_PRIMITIVE(entry) \
+	J9_ARE_ANY_BITS_SET((UDATA)(entry)->clazz, J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_PRIMITIVE)
 
-#define J9_VM_FCC_ENTRY_SET_AS_READ(entry) (entry)->clazz = (J9Class *)((UDATA)(entry)->clazz | J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_READ)
-#define J9_VM_FCC_ENTRY_SET_AS_WRITTEN(entry) (entry)->clazz = (J9Class *)((UDATA)(entry)->clazz | J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_WRITTEN)
+#define J9_VM_FCC_ENTRY_SET_AS_READ(entry) \
+	(entry)->clazz = (J9Class *)((UDATA)(entry)->clazz | J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_READ)
+#define J9_VM_FCC_ENTRY_SET_AS_WRITTEN(entry) \
+	(entry)->clazz = (J9Class *)((UDATA)(entry)->clazz | J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_WRITTEN)
 
 struct J9TranslationBufferSet;
 typedef struct J9VerboseStruct {

--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -590,26 +590,26 @@ done:
 	/**
 	 * Finds the J9FlattenedClassCacheEntry in the ramClass corresponding
 	 * to an offset. Asserts that an entry exists to a strict field.
-	 * @param ramClass class to search for field entry
+	 * @param ramClass class with a flattened class cache to search for field entry
 	 * @param matchOffset static field offset
-	 * @return J9FlattenedClassCacheEntry corresponding to matchOffset.
+	 * @return J9FlattenedClassCacheEntry corresponding to matchOffset, or
+	 * null if no match exists
 	 */
 	static VMINLINE J9FlattenedClassCacheEntry *
 	findJ9FlattenedClassCacheEntryForStaticAddress(J9Class *ramClass, UDATA matchOffset)
 	{
 		J9FlattenedClassCacheEntry *entry = NULL;
-		UDATA numberOfEntries = 0;
-		Assert_VM_true(NULL != ramClass->flattenedClassCache);
-		numberOfEntries = ramClass->flattenedClassCache->numberOfEntries;
+		UDATA numberOfEntries = ramClass->flattenedClassCache->numberOfEntries;
 		for (UDATA i = 0; i < numberOfEntries; i++) {
 			J9FlattenedClassCacheEntry *tempEntry = J9_VM_FCC_ENTRY_FROM_CLASS(ramClass, i);
-			if (tempEntry->offset == matchOffset) {
+			if (J9_VM_FCC_ENTRY_IS_STATIC_FIELD(tempEntry)
+				&& (tempEntry->offset == matchOffset)
+			) {
+				Assert_VM_true(J9ROMFIELD_IS_STRICT(tempEntry->field->modifiers));
 				entry = tempEntry;
 				break;
 			}
 		}
-		Assert_VM_true(NULL != entry);
-		Assert_VM_true(J9_VM_FCC_ENTRY_IS_STATIC_FIELD(entry));
 		return entry;
 	}
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2080,13 +2080,14 @@ loadFlattenableFieldClasses(J9VMThread *currentThread, J9ClassLoader *classLoade
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 		} else {
 			/* All static null-restricted fields should also be strict. This will be verified
-			 * during the preparation stage of linking. */
+			 * during the preparation stage of linking.
+			 */
 			if (J9_ARE_ANY_BITS_SET(modifiers, J9AccStrictInit | J9FieldFlagIsNullRestricted)) {
 				J9FlattenedClassCacheEntry *entry = J9_VM_FCC_ENTRY_FROM_FCC(flattenedClassCache, numberOfCacheEntries);
 				UDATA flags = J9_VM_FCC_CLASS_FLAGS_STATIC_FIELD;
-				if (J9_ARE_ALL_BITS_SET(modifiers, J9AccStrictInit)) {
+				if (J9_ARE_ANY_BITS_SET(modifiers, J9AccStrictInit)) {
 					/* If field is initialized through the ConstantValue attribute set as written. */
-					if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagConstant)) {
+					if (J9_ARE_ANY_BITS_SET(modifiers, J9FieldFlagConstant)) {
 						flags |= J9_VM_FCC_CLASS_FLAGS_STRICT_STATIC_FIELD_WRITTEN;
 					} else {
 						strictStaticFieldCounter += 1;

--- a/runtime/vm/resolvesupport.cpp
+++ b/runtime/vm/resolvesupport.cpp
@@ -865,11 +865,6 @@ illegalAccess:
 				if ((modifiers & J9AccFinal) == J9AccFinal) {
 					localClassAndFlagsData |= J9StaticFieldRefFinal;
 				}
-#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
-				if (J9_ARE_ANY_BITS_SET(modifiers, J9AccStrictInit)) {
-					localClassAndFlagsData |= J9StaticFieldRefStrict;
-				}
-#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 				if (0 != (resolveFlags & J9_RESOLVE_FLAG_FIELD_SETTER)) {
 					localClassAndFlagsData |= J9StaticFieldRefPutResolved;
 				}


### PR DESCRIPTION
The highest bit of flagsAndClass from J9RAMStaticFieldRef is
used to determine the resolution state of the field (see
VMHelpers::staticFieldRefIsResolved).
Instead this flag can be removed entirely and the
flattenedClassCaches of each class can be relied on to
determine the initialization state of strict static fields.

Revert J9CLASSANDFLAGS_FROM_FLAGSANDCLASS to the logic used
prior to strict static field implementation.