### PR TITLE
JDK27 renamed StackTraceElement.of() to finishInit()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1028,4 +1028,11 @@ final class Access implements JavaLangAccess {
 		return module.tryEnableFinalMutation();
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
+
+	/*[IF JAVA_SPEC_VERSION >= 27]*/
+	@Override
+	public void finishInit(StackTraceElement[] stackTrace) {
+		StackTraceElement.finishInit(stackTrace);
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -341,7 +341,11 @@ public String toString() {
 }
 
 /*[IF JAVA_SPEC_VERSION >= 19]*/
+/*[IF JAVA_SPEC_VERSION >= 27]*/
+static StackTraceElement[] finishInit(StackTraceElement[] stackTrace) {
+/*[ELSE] JAVA_SPEC_VERSION >= 27 */
 static StackTraceElement[] of(StackTraceElement[] stackTrace) {
+/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
 	// TODO: determine need action before return
 	return stackTrace;
 }


### PR DESCRIPTION
JDK27 renamed `StackTraceElement.of()` to `finishInit()`

Also added `Access.finishInit()`.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1166

Signed-off-by: Jason Feng <fengj@ca.ibm.com>