### PR TITLE
Fix compile failure on win64

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -518,7 +518,7 @@ typedef struct J9JFRYoungGarbageCollection {
 	J9JFR_EVENT_COMMON_FIELDS
 	I_64 duration;
 	UDATA gcID;
-	U_32 tenureThreshold;
+	UDATA tenureThreshold;
 } J9JFRYoungGarbageCollection;
 
 typedef struct J9JFRGarbageCollection {

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -304,7 +304,7 @@ struct YoungGarbageCollectionEntry {
 	I_64 ticks;
 	I_64 duration;
 	UDATA gcID;
-	U_32 tenureThreshold;
+	UDATA tenureThreshold;
 };
 
 struct GarbageCollectionEntry {


### PR DESCRIPTION
This change fixes a compile issue "conversion from 'UDATA' to 'U_32'".