### PR TITLE
Valhalla doesn't have finishInit()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1029,10 +1029,10 @@ final class Access implements JavaLangAccess {
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 26 */
 
-	/*[IF JAVA_SPEC_VERSION >= 27]*/
+	/*[IF (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES]*/
 	@Override
 	public void finishInit(StackTraceElement[] stackTrace) {
 		StackTraceElement.finishInit(stackTrace);
 	}
-	/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
+	/*[ENDIF] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
 }

--- a/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
+++ b/jcl/src/java.base/share/classes/java/lang/StackTraceElement.java
@@ -341,11 +341,11 @@ public String toString() {
 }
 
 /*[IF JAVA_SPEC_VERSION >= 19]*/
-/*[IF JAVA_SPEC_VERSION >= 27]*/
+/*[IF (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES]*/
 static StackTraceElement[] finishInit(StackTraceElement[] stackTrace) {
-/*[ELSE] JAVA_SPEC_VERSION >= 27 */
+/*[ELSE] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
 static StackTraceElement[] of(StackTraceElement[] stackTrace) {
-/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
+/*[ENDIF] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
 	// TODO: determine need action before return
 	return stackTrace;
 }


### PR DESCRIPTION
Valhalla doesn't have `finishInit()`

Exclude `Access.finishInit()` for Valhalla, and no change to `StackTraceElement.of()`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>