### PR TITLE
Remove unnecessary nullchecks on StringConcatHelper.newArray

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -270,6 +270,8 @@
    java_lang_StringUTF16_toUpperCase,
    java_lang_StringUTF16_trim,
 
+   java_lang_StringConcatHelper_newArray,
+
    java_lang_StringBuffer_append,
    java_lang_StringBuffer_capacityInternal,
    java_lang_StringBuffer_ensureCapacityImpl,

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -2353,9 +2353,12 @@ J9::SymbolReferenceTable::immutableConstructorId(TR::MethodSymbol *methodSymbol)
    TR::RecognizedMethod method = methodSymbol->getRecognizedMethod();
    switch (method)
       {
+      case TR::java_lang_String_init_AbstractStringBuilder_Void:
+      case TR::java_lang_String_init_int_int_char_boolean:
+      case TR::java_lang_String_init_int_String_int_String_String:
       case TR::java_lang_String_init_String:
       case TR::java_lang_String_init_String_char:
-      case TR::java_lang_String_init_int_int_char_boolean:
+      case TR::java_lang_String_init_StringBuilder:
          // All String constructors share the same ID
          method = TR::java_lang_String_init;
          break;

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2843,6 +2843,12 @@ void TR_ResolvedJ9Method::construct()
       {  TR::unknownMethod}
       };
 
+   static X StringConcatHelperMethods[] =
+      {
+      {x(TR::java_lang_StringConcatHelper_newArray, "newArray", "(J)[B")},
+      {  TR::unknownMethod}
+      };
+
    static X StringCoding_StringDecoderMethods[] =
       {
       {x(TR::java_lang_StringCoding_StringDecoder_decode, "decode", "([BII)[C")},
@@ -4310,6 +4316,7 @@ void TR_ResolvedJ9Method::construct()
       { "java/lang/invoke/CatchHandle", CatchHandleMethods },
       { "com/ibm/tenant/TenantContext", MTTenantContext },
       { "java/util/stream/IntPipeline", JavaUtilStreamIntPipelineMethods },
+      { "java/lang/StringConcatHelper", StringConcatHelperMethods },
       { 0 }
       };
 

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -237,6 +237,7 @@ static TR::RecognizedMethod stringCanSkipNullChecks[] =
    TR::java_lang_String_subString,
    TR::java_lang_String_valueOf_C,
    TR::java_lang_StringBuilder_append_String,
+   TR::java_lang_StringConcatHelper_newArray,
    TR::java_lang_StringLatin1_charAt,
    TR::java_lang_StringLatin1_indexOf_BB,
    TR::java_lang_StringLatin1_indexOf_BIII,


### PR DESCRIPTION
Removes nullchks from trusted String methods that will never trigger the checks. This includes:

```
java/lang/StringConcatHelper.newArray(J)[B
```

The checks can be restored by setting the `TR_DisableStringChkSkips` envvar.

Updates `immutableConstructorId` to include more recognized methods that alias with `java/lang/String.<init>`.