### PR TITLE
Make JNI compilations local

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7877,7 +7877,10 @@ TR::CompilationInfoPerThreadBase::preCompilationTasks(J9VMThread * vmThread,
       if ((persistentInfo->getRemoteCompilationMode() == JITServer::CLIENT) &&
           TR::Options::canJITCompile())
          {
-         bool doLocalCompilation = entry->isAotLoad() || cannotDoRemoteCompilation || preferLocalComp(entry);
+         bool doLocalCompilation = entry->isAotLoad()
+            || cannotDoRemoteCompilation
+            || preferLocalComp(entry)
+            || entry->isJNINative();
 
          // If this is a remote sync compilation, change it to a local sync compilation.
          // After the local compilation is completed successfully, a remote async compilation


### PR DESCRIPTION
When using JITServer, ensure that JNI compilations are local.

The justification for this is described here
https://github.com/eclipse-openj9/openj9/issues/23322