### PR TITLE
Tidy up indentation in header files

### DIFF
--- a/runtime/compiler/optimizer/EscapeAnalysis.hpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.hpp
@@ -145,7 +145,7 @@ class Candidate : public TR_Link<Candidate>
         _callSites(c->trMemory()),
         _dememoizedMethodSymRef(NULL),
         _dememoizedConstructorCall(NULL),
-    	_virtualCallSitesToBeFixed(c->trMemory()),
+        _virtualCallSitesToBeFixed(c->trMemory()),
         _coldBlockEscapeInfo(c->trMemory())
          {
           static const char *forceContinguousAllocation = feGetEnv("TR_forceContinguousAllocation");

--- a/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
+++ b/runtime/compiler/optimizer/J9EstimateCodeSize.hpp
@@ -171,9 +171,9 @@ class TR_J9EstimateCodeSize : public TR_EstimateCodeSize
 
 #define NUM_PREV_BC 5
 class TR_prevArgs
-{
+   {
    public:
-      TR_prevArgs() { for (int32_t i = 0 ; i < NUM_PREV_BC ; i++ ) { _prevBC[i] = J9BCunknown ; } }
+      TR_prevArgs() { for (int32_t i = 0 ; i < NUM_PREV_BC ; i++ ) { _prevBC[i] = J9BCunknown; } }
 
       void printIndexes(TR::Compilation *comp)
          {
@@ -230,18 +230,14 @@ class TR_prevArgs
                 count++;
                 break;
              default:
-            	 break;
+                break;
              }
          }
       return count;
       }
 
-
    protected:
       TR_J9ByteCode _prevBC[NUM_PREV_BC];
-};
-
-
-
+   };
 
 #endif

--- a/runtime/gc_api/HeapRootScanner.hpp
+++ b/runtime/gc_api/HeapRootScanner.hpp
@@ -45,18 +45,18 @@ protected:
 	bool _nurseryReferencesOnly;  /**< Should the iterator only scan structures that currently contain nursery references */
 	bool _nurseryReferencesPossibly;  /**< Should the iterator only scan structures that may contain nursery references */
 	bool _includeStackFrameClassReferences;  /**< Should the iterator include Classes which have a method running on the stack */
-#if defined(J9VM_GC_MODRON_SCAVENGER)		 
+#if defined(J9VM_GC_MODRON_SCAVENGER)
 	bool _includeRememberedSetReferences;  /**< Should the iterator include references in the Remembered Set (if applicable) */
-#endif /* J9VM_GC_MODRON_SCAVENGER */	 	
+#endif /* J9VM_GC_MODRON_SCAVENGER */
 	bool _classDataAsRoots; /**< Should all classes (and class loaders) be treated as roots. Default true, should set to false when class unloading */
 	bool _includeJVMTIObjectTagTables; /**< Should the iterator include the JVMTIObjectTagTables. Default true, should set to false when doing JVMTI object walks */
 	bool _trackVisibleStackFrameDepth; /**< Should the stack walker be told to track the visible frame depth. Default false, should set to true when doing JVMTI walks that report stack slots */
-	
-	RootScannerEntity _scanningEntity; /**< The root scanner entity that is currently being scanned. Defaults to RootScannerEntity_None. */ 
+
+	RootScannerEntity _scanningEntity; /**< The root scanner entity that is currently being scanned. Defaults to RootScannerEntity_None. */
 	RootScannerEntity _lastScannedEntity; /**< The root scanner entity that was last scanned. Defaults to RootScannerEntity_None. */
-	
+
 	RootScannerEntityReachability _scanningEntityReachability;/**< Reachability of the root scanner entity that is currently being scanned. */
-	
+
 	/**
 	 * Sets the currently scanned root entity to scanningEntity. This is mainly for
 	 * debug purposes.
@@ -69,7 +69,7 @@ protected:
 		assume0(RootScannerEntity_None == _scanningEntity);
 		_scanningEntity = scanningEntity;
 	}
-	
+
 	/**
 	 * Sets the currently scanned root entity to scanningEntity. This is mainly for
 	 * debug purposes.
@@ -80,7 +80,7 @@ protected:
 	{
 		_scanningEntityReachability = reachability;
 	}
-	
+
 	/**
 	 * Sets the currently scanned root entity to None and sets the last scanned root
 	 * entity to scannedEntity. This is mainly for debug purposes.
@@ -107,7 +107,7 @@ public:
 		_includeStackFrameClassReferences(true),
 #if defined(J9VM_GC_MODRON_SCAVENGER)
 		_includeRememberedSetReferences(false),
-#endif /* J9VM_GC_MODRON_SCAVENGER */	 
+#endif /* J9VM_GC_MODRON_SCAVENGER */
 		_classDataAsRoots(true),
 		_includeJVMTIObjectTagTables(true),
 		_trackVisibleStackFrameDepth(false),
@@ -116,7 +116,7 @@ public:
 	{
 		_typeId = __FUNCTION__;
 	}
-	
+
 #if defined(J9VM_GC_MODRON_SCAVENGER)
 	/** Set whether the iterator will only scan structures which contain nursery references */
 	void setNurseryReferencesOnly(bool nurseryReferencesOnly) {
@@ -159,7 +159,7 @@ public:
 
 	/** General class handler to be reimplemented by specializing class. This handler is called once per class. */
 	virtual void doClass(J9Class *clazz) = 0;
-	
+
 	virtual void doObject(J9Object* slotPtr) = 0;
 
 #if defined(J9VM_GC_MODRON_SCAVENGER)
@@ -169,8 +169,8 @@ public:
 	virtual void scanClasses();
 	virtual void scanVMClassSlots();
 
- 	virtual bool scanOneThread(J9VMThread* walkThread);
-	
+	virtual bool scanOneThread(J9VMThread* walkThread);
+
 	virtual void scanClassLoaders();
 	virtual void scanThreads();
 #if defined(J9VM_GC_FINALIZATION)
@@ -198,7 +198,7 @@ public:
 
 #if defined(J9VM_OPT_JVMTI)
 	void scanJVMTIObjectTagTables();
-#endif /* J9VM_OPT_JVMTI */ 
+#endif /* J9VM_OPT_JVMTI */
 
 	virtual void doClassLoader(J9ClassLoader *classLoader);
 
@@ -229,6 +229,5 @@ public:
 	virtual void doVMClassSlot(J9Class *classPtr);
 	virtual void doVMThreadSlot(J9Object **slotPtr, GC_VMThreadIterator *vmThreadIterator);
 };
-
 
 #endif /* HEAPROOTSCANNER_HPP_ */

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -53,21 +52,21 @@ class MM_CollectorLanguageInterfaceImpl;
 
 /**
  * General interface for scanning all object and class slots in the system that are not part of the heap.
- * 
+ *
  * MM_RootScanner provides an abstract class that can be specialized to scan particular slots
  * in the system, including all, root specific and clearable slots.  The purpose of the class is
  * to provide a central location for general slot scanners within Modron (e.g., root scanning,
  * all slots do, etc).
- * 
+ *
  * There are two levels of specialization for the scanner, structure walking and handling of elements.
  * Structure walking specialization, where the implementer can override the way in which we walk elements,
  * should be done rarely and in only extreme circumstances.  Handling of elements can be specialized for all
  * elements as well as for specific types of structures.
- * 
+ *
  * The core routines to be reimplemented are doSlot(J9Object **), doClassSlot(J9Class *) and doClass(J9Class *).
- * All other slot types are forwarded by default to these routines for processing.  To handle structure slots in 
+ * All other slot types are forwarded by default to these routines for processing.  To handle structure slots in
  * specific ways, the slot handler for that type should be overridden.
- * 
+ *
  * @ingroup GC_Base
  */
 class MM_RootScanner : public MM_BaseVirtual
@@ -90,9 +89,9 @@ protected:
 	bool _nurseryReferencesOnly;  /**< Should the iterator only scan structures that currently contain nursery references */
 	bool _nurseryReferencesPossibly;  /**< Should the iterator only scan structures that may contain nursery references */
 	bool _includeStackFrameClassReferences;  /**< Should the iterator include Classes which have a method running on the stack */
-#if defined(J9VM_GC_MODRON_SCAVENGER)		 
+#if defined(J9VM_GC_MODRON_SCAVENGER)
 	bool _includeRememberedSetReferences;  /**< Should the iterator include references in the Remembered Set (if applicable) */
-#endif /* J9VM_GC_MODRON_SCAVENGER */	 	
+#endif /* J9VM_GC_MODRON_SCAVENGER */
 	bool _classDataAsRoots; /**< Should all classes (and class loaders) be treated as roots. Default true, should set to false when class unloading */
 	bool _includeJVMTIObjectTagTables; /**< Should the iterator include the JVMTIObjectTagTables. Default true, should set to false when doing JVMTI object walks */
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
@@ -106,7 +105,7 @@ protected:
 	U_64 _entityStartScanTime; /**< The start time of the scan of the current scanning entity, or 0 if no entity is being scanned.  Defaults to 0. */
 	U_64 _entityIncrementStartTime; /**< Start time of current increment with a scan entity (Metronome may have several increment for each entity) */
 	U_64 _entityIncrementEndTime; /**< End time of the current increment */
-	RootScannerEntity _scanningEntity; /**< The root scanner entity that is currently being scanned. Defaults to RootScannerEntity_None. */ 
+	RootScannerEntity _scanningEntity; /**< The root scanner entity that is currently being scanned. Defaults to RootScannerEntity_None. */
 	RootScannerEntity _lastScannedEntity; /**< The root scanner entity that was last scanned. Defaults to RootScannerEntity_None. */
 
 	/*
@@ -140,9 +139,9 @@ private:
 protected:
 	/* Family of yielding methods to be overridden by incremental scanners such
 	 * as the RealtimeRootScanner. The default implementations of these do
-	 * nothing. 
+	 * nothing.
 	 */
-	
+
 	/**
 	 * Root scanning methods that have been incrementalized are responsible for
 	 * calling this method periodically during class scan to check when they should
@@ -189,9 +188,9 @@ protected:
 	 * @return true if yielded, false otherwise
 	 */
 	virtual bool condYield(U_64 timeSlackNanoSec = 0);
-	
+
 	virtual void flushRequiredNonAllocationCaches(MM_EnvironmentBase *envModron){}
-	
+
 	/**
 	 * Sets the currently scanned root entity to scanningEntity. This is mainly for
 	 * debug purposes.
@@ -203,20 +202,20 @@ protected:
 		/* Ensures reportScanningEnded was called previously. */
 		assume0(RootScannerEntity_None == _scanningEntity);
 		_scanningEntity = scanningEntity;
-		
+
 		if (_extensions->rootScannerStatsEnabled) {
 			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
-			_entityStartScanTime = omrtime_hires_clock();	
+			_entityStartScanTime = omrtime_hires_clock();
 			_entityIncrementStartTime = _entityStartScanTime;
 		}
 	}
-	
+
 	MMINLINE void updateScanStats(uint64_t endTime)
 	{
 		if (_entityIncrementStartTime >= endTime) {
 			/* overflow */
- 			_env->_rootScannerStats._entityScanTime[_scanningEntity] += 1;
- 		} else {
+			_env->_rootScannerStats._entityScanTime[_scanningEntity] += 1;
+		} else {
 			uint64_t duration = endTime - _entityIncrementStartTime;
 			_env->_rootScannerStats._entityScanTime[_scanningEntity] += duration;
 			if (duration > _env->_rootScannerStats._maxIncrementTime) {
@@ -224,8 +223,8 @@ protected:
 				_env->_rootScannerStats._maxIncrementEntity = _scanningEntity;
 			}
 		}
-	}	
-	
+	}
+
 	/**
 	 * Sets the currently scanned root entity to None and sets the last scanned root
 	 * entity to scannedEntity. This is mainly for debug purposes.
@@ -236,27 +235,30 @@ protected:
 	{
 		/* Ensures scanning ended for the currently scanned entity. */
 		Assert_MM_true(_scanningEntity == scannedEntity);
-		
+
 		if (_extensions->rootScannerStatsEnabled) {
 			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
- 			uint64_t entityEndScanTime = omrtime_hires_clock();
-			
+			uint64_t entityEndScanTime = omrtime_hires_clock();
+
 			_env->_rootScannerStats._statsUsed = true;
 			_extensions->rootScannerStatsUsed = true;
-							
+
 			updateScanStats(entityEndScanTime);
- 			
- 			_entityStartScanTime = 0;
- 			/* In theory, it would be cleaner to reset _entityIncrementStartTime to 0, but sometimes increments could be dis-associated from any entity.
- 			    For example sync barrier between two entities. Since they can suspend, they will try to report the duration of the increment,
- 			    but the start point 0 would lead to invalid (too long duration). Hence, we set the start point to the current time, just in case it 
- 			    is used be non-tracked increments.
- 			 */
+
+			_entityStartScanTime = 0;
+			/* In theory, it would be cleaner to reset _entityIncrementStartTime to 0,
+			 * but sometimes increments could be dis-associated from any entity.
+			 * For example sync barrier between two entities. Since they can suspend,
+			 * they will try to report the duration of the increment, but the start
+			 * point 0 would lead to invalid (too long duration). Hence, we set the
+			 * start point to the current time, just in case it is used be non-tracked
+			 * increments.
+			 */
 			_entityIncrementStartTime = entityEndScanTime;
- 		}
+		}
 
 		_lastScannedEntity = _scanningEntity;
- 		_scanningEntity = RootScannerEntity_None;
+		_scanningEntity = RootScannerEntity_None;
 	}
 
 	/**
@@ -277,31 +279,31 @@ public:
 		return 	_includeStackFrameClassReferences;
 	}
 
-	/** 
-	 * Maintain start/end increment times when scan is suspended. Add the diff (duration) to scan entity time. 
+	/**
+	 * Maintain start/end increment times when scan is suspended. Add the diff (duration) to scan entity time.
 	 * Also maintain max increment duration and its entity
-	 */	
+	 */
 	MMINLINE void
 	reportScanningSuspended()
 	{
 		if (_extensions->rootScannerStatsEnabled) {
 			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
 			_entityIncrementEndTime = omrtime_hires_clock();
-			
+
 			updateScanStats(_entityIncrementEndTime);
 		}
 	}
 
-	/** 
+	/**
 	 * Maintain start/end increment times, when scan is resumed.
-	 */	
+	 */
 	MMINLINE void
 	reportScanningResumed()
 	{
 		if (_extensions->rootScannerStatsEnabled) {
 			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
 			_entityIncrementStartTime = omrtime_hires_clock();
-			_entityIncrementEndTime = 0;	
+			_entityIncrementEndTime = 0;
 		}
 	}
 
@@ -318,7 +320,7 @@ public:
 		, _nurseryReferencesOnly(false)
 		, _nurseryReferencesPossibly(false)
 		, _includeStackFrameClassReferences(true)
-#if defined(J9VM_GC_MODRON_SCAVENGER)		 
+#if defined(J9VM_GC_MODRON_SCAVENGER)
 		, _includeRememberedSetReferences(_extensions->scavengerEnabled ? true : false)
 #endif /* J9VM_GC_MODRON_SCAVENGER */
 		, _classDataAsRoots(true)
@@ -332,12 +334,12 @@ public:
 		, _trackVisibleStackFrameDepth(false)
 		, _entityStartScanTime(0)
 		, _entityIncrementStartTime(0)
-		, _entityIncrementEndTime(0)		
+		, _entityIncrementEndTime(0)
 		, _scanningEntity(RootScannerEntity_None)
 		, _lastScannedEntity(RootScannerEntity_None)
 	{
 		_typeId = __FUNCTION__;
-		
+
 		OMRPORT_ACCESS_FROM_ENVIRONMENT(env);
 		_entityIncrementStartTime = omrtime_hires_clock();
 
@@ -418,7 +420,7 @@ public:
 	 * @param slotObject for field
 	 */
 	virtual void doFieldSlot(GC_SlotObject *slotObject);
-	
+
 	virtual void scanRoots(MM_EnvironmentBase *env);
 	virtual void scanClearable(MM_EnvironmentBase *env);
 	virtual void scanAllSlots(MM_EnvironmentBase *env);
@@ -426,17 +428,17 @@ public:
 #if defined(J9VM_GC_MODRON_SCAVENGER)
 	virtual void scanRememberedSet(MM_EnvironmentBase *env);
 #endif /* J9VM_GC_MODRON_SCAVENGER */
-	
+
 	virtual void scanClasses(MM_EnvironmentBase *env);
 	virtual void scanVMClassSlots(MM_EnvironmentBase *env);
-	
+
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	void scanPermanentClasses(MM_EnvironmentBase *env);
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 	virtual CompletePhaseCode scanClassesComplete(MM_EnvironmentBase *env);
 
 	virtual bool scanOneThread(MM_EnvironmentBase *env, J9VMThread *walkThread, void *localData);
-	
+
 	virtual void scanClassLoaders(MM_EnvironmentBase *env);
 	virtual void scanThreads(MM_EnvironmentBase *env);
 	virtual void scanSingleThread(MM_EnvironmentBase *env, J9VMThread *walkThread);
@@ -517,10 +519,10 @@ public:
 	virtual void doFinalizableObject(J9Object *objectPtr) = 0;
 	/**
 	 * Handle an unfinalized object
-	 * 
+	 *
 	 * @param objectPtr the unfinalized object
 	 * @param list the list which this object belongs too.
-	 * 
+	 *
 	 * @NOTE If a subclass does not override this function to provide an implementation it must override
 	 * scanUnfinalizedObjects so that this function is not called.
 	 */
@@ -538,10 +540,10 @@ public:
 	 */
 	virtual void doOwnableSynchronizerObject(J9Object *objectPtr, MM_OwnableSynchronizerObjectList *list);
 	virtual void doContinuationObject(J9Object *objectPtr, MM_ContinuationObjectList *list);
-	
+
 	/**
 	 * @todo Provide function documentation
-	 */	
+	 */
 	virtual CompletePhaseCode scanOwnableSynchronizerObjectsComplete(MM_EnvironmentBase *env);
 	virtual CompletePhaseCode scanContinuationObjectsComplete(MM_EnvironmentBase *env);
 
@@ -573,7 +575,7 @@ public:
 	 */
 	virtual void doObjectInVirtualLargeObjectHeap(J9Object *objectPtr, GC_HashTableIterator *sparseDataEntryIterator);
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-	
+
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	/**
 	 * Frees double mapped region associated to objectPtr (arraylet spine) if objectPtr
@@ -592,17 +594,17 @@ public:
 
 	/**
 	 * Called for each object stack slot. Subclasses may override.
-	 * 
+	 *
 	 * @param slotPtr[in/out] a pointer to the stack slot or a copy of the stack slot.
 	 * @param walkState[in] the J9StackWalkState
-	 * @param stackLocation[in] the actual pointer to the stack slot. Use only for reporting. 
+	 * @param stackLocation[in] the actual pointer to the stack slot. Use only for reporting.
 	 */
 	virtual void doStackSlot(J9Object **slotPtr, void *walkState, const void *stackLocation);
 };
 
 typedef struct StackIteratorData {
-    MM_RootScanner *rootScanner;
-    MM_EnvironmentBase *env;
+	MM_RootScanner *rootScanner;
+	MM_EnvironmentBase *env;
 } StackIteratorData;
 
 #endif /* ROOTSCANNER_HPP_ */

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -209,12 +209,12 @@ public:
 		uintptr_t numberOfArraylets = numArraylets(dataSizeInBytes);
 		return arrayletSize(objPtr, index, dataSizeInBytes, numberOfArraylets);
 	}
-	
+
 	/**
 	 * Get the spine size for the given indexable object
 	 * @param objPtr Pointer to an array object
- 	 * @param layout layout for array object
- 	 * @return The total size in bytes of objPtr's array spine;
+	 * @param layout layout for array object
+	 * @return The total size in bytes of objPtr's array spine;
 	 * 			includes header, arraylet ptrs, and (if present) padding & inline data
 	 */
 	MMINLINE uintptr_t
@@ -226,8 +226,8 @@ public:
 	/**
 	 * Get the spine size for the given indexable object
 	 * @param clazzPtr Pointer to the preserved J9Class, used in scavenger
- 	 * @param layout layout for array object
- 	 * @param size Size of indexable object
+	 * @param layout layout for array object
+	 * @param size Size of indexable object
 	 * @return The total size in bytes of objPtr's array spine;
 	 * 			includes header, arraylet ptrs, and (if present) padding & inline data
 	 */
@@ -240,8 +240,8 @@ public:
 	/**
 	 * Get the spine size without header for the given indexable object
 	 * @param clazzPtr Pointer to the preserved J9Class, used in scavenger
- 	 * @param layout layout for array object
- 	 * @param size Size of indexable object
+	 * @param layout layout for array object
+	 * @param size Size of indexable object
 	 * @return The size in bytes of objPtr's array spine without header;
 	 * 			includes arraylet ptrs, padding and inline data (if any is present)
 	 */
@@ -362,7 +362,7 @@ public:
 	 */
 	MMINLINE uintptr_t
 	getDataSizeInBytes(J9Class *clazzPtr, uintptr_t numberOfElements)
-	{	
+	{
 		uintptr_t stride = J9ARRAYCLASS_GET_STRIDE(clazzPtr);
 		uintptr_t size = numberOfElements * stride;
 		uintptr_t alignedSize = UDATA_MAX;
@@ -462,10 +462,10 @@ public:
 				GC_SlotObject destSlotObject(_omrVM, GC_SlotObject::addToSlotAddress(destArraylets, i, compressed));
 				void* srcLeafAddress = srcSlotObject.readReferenceFromSlot();
 				void* destLeafAddress = destSlotObject.readReferenceFromSlot();
-				
+
 
 				uintptr_t copySize = _omrVM->_arrayletLeafSize;
-				
+
 				if (i == arrayletCount - 1) {
 					copySize = arrayletSize(srcObject, i);
 				}
@@ -542,7 +542,7 @@ public:
 					}
 				}
 				break;
-				
+
 			default :
 				// unreachable since we currently do not expect anything other than primitive arrays to be using them.
 				{
@@ -786,7 +786,7 @@ public:
 						arrayletElementOffset = 0;
 					}
 					break;
-					
+
 				default :
 					// unreachable since we currently do not expect anything other than primitive arrays to be using them.
 					{
@@ -820,7 +820,7 @@ public:
 	MMINLINE uintptr_t
 	getSizeInBytesWithHeader(J9Class *clazz, uintptr_t numberOfElements)
 	{
-		ArrayLayout layout = InlineContiguous; 
+		ArrayLayout layout = InlineContiguous;
 		if(0 == numberOfElements) {
 			layout = Discontiguous;
 		}
@@ -1234,7 +1234,7 @@ public:
 	MMINLINE uintptr_t
 	getHashcodeOffset(J9Class *clazzPtr, uintptr_t numberOfElements)
 	{
-		ArrayLayout layout = InlineContiguous; 
+		ArrayLayout layout = InlineContiguous;
 		if(0 == numberOfElements) {
 			layout = Discontiguous;
 		}
@@ -1270,7 +1270,7 @@ public:
 		ArrayLayout layout = getArrayLayout(arrayPtr);
 		return getHashcodeOffset(J9GC_J9OBJECT_CLAZZ(arrayPtr, this), layout, getSizeInElements(arrayPtr));
 	}
-	
+
 	MMINLINE void
 	expandArrayletSubSpaceRange(MM_MemorySubSpace * subSpace, void * rangeBase, void * rangeTop, uintptr_t largestDesirableArraySpineSize)
 	{
@@ -1349,11 +1349,11 @@ public:
 
 	/**
 	 * Initialize the receiver, a new instance of GC_ObjectModel
-	 * 
+	 *
 	 * @return true on success, false on failure
 	 */
 	bool initialize(MM_GCExtensionsBase *extensions);
-	
+
 	/**
 	 * Tear down the receiver
 	 */

--- a/runtime/gc_glue_java/JNICriticalRegion.hpp
+++ b/runtime/gc_glue_java/JNICriticalRegion.hpp
@@ -20,7 +20,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-
 /**
  * @file
  * @ingroup GC_Base
@@ -69,7 +68,7 @@ public:
 		if (J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION)) {
 			/* Nested critical region; increment the count */
 			vmThread->jniCriticalDirectCount += 1;
-	  	} else {
+		} else {
 			UDATA const criticalFlags = J9_PUBLIC_FLAGS_JNI_CRITICAL_REGION | J9_PUBLIC_FLAGS_JNI_CRITICAL_ACCESS;
 #if defined(J9VM_INTERP_ATOMIC_FREE_JNI)
 			UDATA const expectedFlags = J9_PUBLIC_FLAGS_VM_ACCESS;
@@ -114,7 +113,7 @@ public:
 				}
 				omrthread_monitor_exit_using_threadId(publicFlagsMutex, osThread);
 			}
-	 	}
+		}
 	}
 
 	/**

--- a/runtime/gc_glue_java/MetronomeDelegate.hpp
+++ b/runtime/gc_glue_java/MetronomeDelegate.hpp
@@ -73,12 +73,12 @@ public:
 		_javaVM((J9JavaVM *)env->getOmrVM()->_language_vm) {}
 
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
- 	bool _unmarkedImpliesClasses; /**< if true the mark bit can be used to check is class alive or not */
+	bool _unmarkedImpliesClasses; /**< if true the mark bit can be used to check is class alive or not */
 #endif /* defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING) */
 	bool _unmarkedImpliesCleared;
 	bool _unmarkedImpliesStringsCleared; /**< If true, we can assume that unmarked strings in the string table will be cleared */
-	
-#if defined(J9VM_GC_FINALIZATION)	
+
+#if defined(J9VM_GC_FINALIZATION)
 	bool _finalizationRequired;
 #endif /* J9VM_GC_FINALIZATION */
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
@@ -93,7 +93,7 @@ public:
 	bool allocateAndInitializeOwnableSynchronizerObjectLists(MM_EnvironmentBase *env);
 	bool allocateAndInitializeContinuationObjectLists(MM_EnvironmentBase *env);
 
-#if defined(J9VM_GC_FINALIZATION)	
+#if defined(J9VM_GC_FINALIZATION)
 	bool isFinalizationRequired() { return _finalizationRequired; }
 #endif /* J9VM_GC_FINALIZATION */
 
@@ -249,7 +249,7 @@ public:
 		default:
 			Assert_MM_unreachable();
 		}
-		
+
 		return pointersScanned;
 	}
 
@@ -257,7 +257,7 @@ public:
 	scanPointerRange(MM_EnvironmentRealtime *env, fj9object_t *startScanPtr, fj9object_t *endScanPtr)
 	{
 		UDATA pointerField = 0;
-	
+
 		if (env->compressObjectReferences()) {
 			uint32_t *scanPtr = (uint32_t *)startScanPtr;
 			uint32_t *endPtr = (uint32_t *)endScanPtr;
@@ -297,7 +297,7 @@ public:
 		UDATA *leafPtr = NULL;
 		UDATA leafBits = 0;
 #endif /* J9VM_GC_LEAF_BITS */
-		
+
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 		if (isDynamicClassUnloadingEnabled()) {
 			markClassOfObject(env, objectPtr);
@@ -358,7 +358,7 @@ public:
 	{
 		UDATA pointerFields = 0;
 		bool const compressed = env->compressObjectReferences();
-		
+
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 		if (isDynamicClassUnloadingEnabled()) {
 			markClassOfObject(env, (J9Object *)objectPtr);
@@ -428,13 +428,13 @@ public:
 		UDATA *leafPtr = NULL;
 		UDATA leafBits = 0;
 #endif /* J9VM_GC_LEAF_BITS */
-		
+
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 		if (isDynamicClassUnloadingEnabled()) {
 			markClassOfObject(env, objectPtr);
 		}
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
-		
+
 		descriptionPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr, env)->instanceDescription;
 #if defined(J9VM_GC_LEAF_BITS)
 		leafPtr = (UDATA *)J9GC_J9OBJECT_CLAZZ(objectPtr, env)->instanceLeafDescription;
@@ -492,7 +492,7 @@ public:
 				env->getGCEnvironment()->_referenceObjectBuffer->add(env, objectPtr);
 			}
 		}
-		
+
 		UDATA pointerFields = 0;
 		while (scanPtr < endScanPtr) {
 			/* Determine if the slot should be processed */
@@ -518,9 +518,9 @@ public:
 			}
 			scanPtr = GC_SlotObject::addToSlotAddress(scanPtr, 1, compressed);
 		}
-		
+
 		env->incScannedObjects();
-		
+
 		return pointerFields;
 	}
 
@@ -580,7 +580,6 @@ private:
 	 */
 	void markPermanentClassloader(MM_EnvironmentRealtime *env, J9ClassLoader *classLoader);
 
-
 	/*
 	 * Friends
 	 */
@@ -597,4 +596,3 @@ typedef struct StackIteratorData4RealtimeMarkingScheme {
 #endif /* defined(J9VM_GC_REALTIME) */
 
 #endif /* defined(METRONOMEDELEGATE_HPP_) */
-

--- a/runtime/gc_glue_java/ObjectModel.hpp
+++ b/runtime/gc_glue_java/ObjectModel.hpp
@@ -103,8 +103,8 @@ private:
 protected:
 public:
 	/**
- 	* Return values for getScanType().
- 	*/
+	 * Return values for getScanType().
+	 */
 	enum ScanType {
 		SCAN_INVALID_OBJECT = 0,
 		SCAN_MIXED_OBJECT = 1,
@@ -126,11 +126,11 @@ public:
 	 */
 	enum ReferenceState {
 		REF_STATE_INITIAL = 0, /**< indicates the initial (normal) state for a Reference object. Referent is weak. */
-		REF_STATE_CLEARED = 1, /**< indicates that the Reference object has been cleared, either by the GC or by the Java clear() API. Referent is null or strong. */ 
+		REF_STATE_CLEARED = 1, /**< indicates that the Reference object has been cleared, either by the GC or by the Java clear() API. Referent is null or strong. */
 		REF_STATE_ENQUEUED = 2, /**< indicates that the Reference object has been cleared and enqueued on its ReferenceQueue. Referent is null or strong. */
 		REF_STATE_REMEMBERED = 3, /**< indicates that the Reference object was discovered by a global cycle and that the current local GC cycle must return it to that list and restore the state to INITIAL. */
 	};
-	
+
 /*
  * Member functions
  */
@@ -139,10 +139,10 @@ private:
 	 * Determine the scan type for an instant of the specified class.
 	 * The class has the J9AccClassGCSpecial bit set.
 	 * @param[in] objectClazz the class of the object to identify
-	 * @return one of the ScanType constants 
+	 * @return one of the ScanType constants
 	 */
 	ScanType getSpecialClassScanType(J9Class *objectClazz);
-	
+
 	/**
 	 * Examine all classes as they are loaded to determine if they require the J9AccClassGCSpecial bit.
 	 * These classes are handled specially by GC_ObjectModel::getScanType()
@@ -154,7 +154,7 @@ private:
 	 * redefinition has occurred.
 	 */
 	static void classesRedefinedHook(J9HookInterface** hook, uintptr_t eventNum, void* eventData, void* userData);
-	
+
 	/**
 	 * Returns the shape of an class.
 	 * @param objectPtr Pointer to object whose shape is required.
@@ -235,7 +235,7 @@ public:
 		J9Class *clazz = J9GC_J9OBJECT_CLAZZ(objectPtr, this);
 		return getScanType(clazz);
 	}
-	
+
 	/**
 	 * Returns the depth of an object.
 	 * @param objectPtr Pointer to object whose depth is required.
@@ -280,7 +280,7 @@ public:
 	{
 		return isObjectArray((J9Object*)objectPtr);
 	}
-	
+
 	/**
 	 * Returns TRUE if an object is primitive array, FALSE otherwise.
 	 * @param objectPtr Pointer to an object
@@ -314,7 +314,7 @@ public:
 	{
 		return isPrimitiveArray((J9Object*)objectPtr);
 	}
-	
+
 	/**
 	 * Determine whether or not the given object is a double array
 	 *
@@ -335,7 +335,7 @@ public:
 	{
 		return isDoubleArray((J9Object*)objectPtr);
 	}
-	
+
 	/**
 	 * Check is indexable bit set properly:
 	 * must be set for arrays and primitive arrays
@@ -359,13 +359,13 @@ public:
 		}
 		return result;
 	}
-	
+
 	/**
 	 * Determine the basic hash code for the specified object. This may modify the object. For example, it may
 	 * set the HAS_BEEN_HASHED bit in the object's header. Object must not be NULL.
-	 * 
+	 *
 	 * @param object[in] the object to be hashed
-	 * @return the persistent, basic hash code for the object 
+	 * @return the persistent, basic hash code for the object
 	 */
 	MMINLINE int32_t
 	getObjectHashCode(J9JavaVM *vm, J9Object *object)
@@ -675,11 +675,11 @@ public:
 
 	/**
 	 * Initialize the receiver, a new instance of GC_ObjectModel
-	 * 
+	 *
 	 * @return true on success, false on failure
 	 */
 	virtual bool initialize(MM_GCExtensionsBase *extensions);
-	
+
 	/**
 	 * Tear down the receiver
 	 */

--- a/runtime/gc_glue_java/ObjectModelDelegate.hpp
+++ b/runtime/gc_glue_java/ObjectModelDelegate.hpp
@@ -317,9 +317,9 @@ public:
 
 	/**
 	 * The following methods (defined(OMR_GC_MODRON_SCAVENGER)) are required if generational GC is
- 	 * configured for the build (--enable-OMR_GC_MODRON_SCAVENGER in configure_includes/configure_*.mk).
- 	 * They typically involve a MM_ForwardedHeader object, and allow information about the forwarded
- 	 * object to be obtained.
+	 * configured for the build (--enable-OMR_GC_MODRON_SCAVENGER in configure_includes/configure_*.mk).
+	 * They typically involve a MM_ForwardedHeader object, and allow information about the forwarded
+	 * object to be obtained.
 	 */
 #if defined(OMR_GC_MODRON_SCAVENGER)
 	/**
@@ -391,7 +391,7 @@ public:
 		if (hotClass->hotFieldsInfo != NULL) {
 			return hotClass->hotFieldsInfo->hotFieldOffset1;
 		}
-		
+
 		return U_8_MAX;
 	}
 
@@ -409,8 +409,8 @@ public:
 		if (hotClass->hotFieldsInfo != NULL) {
 			return hotClass->hotFieldsInfo->hotFieldOffset2;
 		}
-		
-		return U_8_MAX;	
+
+		return U_8_MAX;
 	}
 
 	/**
@@ -427,8 +427,8 @@ public:
 		if (hotClass->hotFieldsInfo != NULL) {
 			return hotClass->hotFieldsInfo->hotFieldOffset3;
 		}
-		
-		return U_8_MAX;	
+
+		return U_8_MAX;
 	}
 
 	/**

--- a/runtime/gc_realtime/MemorySubSpaceMetronome.hpp
+++ b/runtime/gc_realtime/MemorySubSpaceMetronome.hpp
@@ -40,7 +40,7 @@ class MM_MemoryPool;
 class MM_MemorySubSpaceMetronome : public MM_MemorySubSpaceSegregated
 {
 private:
-	/* TODO: this is temporary as a way to avoid dup code in MemorySubSpaceMetronome::allocate. 
+	/* TODO: this is temporary as a way to avoid dup code in MemorySubSpaceMetronome::allocate.
 	 * We will specifically fix this allocate method in a separate design.
 	 */
 	void *allocateMixedObjectOrArraylet(MM_EnvironmentBase *env, MM_AllocateDescription *allocDescription, AllocateType allocType);
@@ -67,11 +67,10 @@ public:
 		MM_EnvironmentBase *env, MM_PhysicalSubArena *physicalSubArena, MM_MemoryPool *memoryPool,
 		bool usesGlobalCollector, UDATA minimumSize, UDATA initialSize, UDATA maximumSize
 	)
- 		: MM_MemorySubSpaceSegregated(env, physicalSubArena, memoryPool, usesGlobalCollector, minimumSize, initialSize, maximumSize)
+		: MM_MemorySubSpaceSegregated(env, physicalSubArena, memoryPool, usesGlobalCollector, minimumSize, initialSize, maximumSize)
 	{
 		_typeId = __FUNCTION__;
 	};
 };
 
 #endif /* MEMORYSUBSPACEMETRONOME_HPP_ */
-

--- a/runtime/gc_realtime/RealtimeGC.hpp
+++ b/runtime/gc_realtime/RealtimeGC.hpp
@@ -68,7 +68,7 @@ private:
 	bool _sweepingArraylets;
 
 	uintptr_t _gcPhase; /**< What gc phase are we currently in? */
-	
+
 	MM_CycleState _cycleState;  /**< Embedded cycle state to be used as the main cycle state for GC activity */
 	MM_CollectionStatistics _collectionStatistics;  /** Common collect stats (memory, time etc.) */
 
@@ -100,7 +100,7 @@ protected:
 	virtual void internalPreCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription, U_32 gcCode);
 	virtual void internalPostCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace);
 	virtual bool internalGarbageCollect(MM_EnvironmentBase *env, MM_MemorySubSpace *subSpace, MM_AllocateDescription *allocDescription);
-	
+
 	void reportMarkStart(MM_EnvironmentBase *env);
 	void reportMarkEnd(MM_EnvironmentBase *env);
 	void reportSweepStart(MM_EnvironmentBase *env);
@@ -109,7 +109,7 @@ protected:
 	void reportGCEnd(MM_EnvironmentBase *env);
 	void reportGCIncrementStart(MM_EnvironmentBase *env);
 	void reportGCIncrementEnd(MM_EnvironmentBase *env);
-	
+
 public:
 	void mainSetupForGC(MM_EnvironmentBase *env);
 	void mainCleanupAfterGC(MM_EnvironmentBase *env);
@@ -124,7 +124,7 @@ public:
 		 */
 		return this;
 	}
-	
+
 	virtual void deleteSweepPoolState(MM_EnvironmentBase *env, void *sweepPoolState)
 	{
 		/*
@@ -144,13 +144,13 @@ public:
 	void reportGCCycleFinalIncrementEnding(MM_EnvironmentBase *env);
 
 	void flushCachesForGC(MM_EnvironmentBase *env) {
-	    	/* we do not want to flush caches for each increment, unless there is a reason to walk the heap
-	    	 * (for instance, fillFromOverflow requires heap be walkable) */
-	    	if (_workPackets->getIncrementalOverflowHandler()->isOverflowThisGCCycle()) {
-	    		GC_OMRVMInterface::flushCachesForGC(env);
-	    	}
-    	}
-    
+		/* we do not want to flush caches for each increment, unless there is a reason to walk the heap
+		 * (for instance, fillFromOverflow requires heap be walkable) */
+		if (_workPackets->getIncrementalOverflowHandler()->isOverflowThisGCCycle()) {
+			GC_OMRVMInterface::flushCachesForGC(env);
+		}
+	}
+
 	/**
 	 * helper function that determines if non-deterministic sweep is enabled
 	 */
@@ -176,9 +176,9 @@ public:
 	MMINLINE bool isCollectorUnloadingClassLoaders() { return (_gcPhase == GC_PHASE_UNLOADING_CLASS_LOADERS); }
 	MMINLINE bool isCollectorSweeping()			{ return (_gcPhase == GC_PHASE_SWEEP); }
 	MMINLINE bool isCollectorConcurrentTracing() { return (_gcPhase == GC_PHASE_CONCURRENT_TRACE); }
-	MMINLINE bool isCollectorConcurrentSweeping() { return (_gcPhase == GC_PHASE_CONCURRENT_SWEEP); }	
+	MMINLINE bool isCollectorConcurrentSweeping() { return (_gcPhase == GC_PHASE_CONCURRENT_SWEEP); }
 	MMINLINE bool isCollectorSweepingArraylets() { return _sweepingArraylets; }
-	MMINLINE bool isFixHeapForWalk() { return _fixHeapForWalk; }	
+	MMINLINE bool isFixHeapForWalk() { return _fixHeapForWalk; }
 
 	MMINLINE void setCollectorIdle()			{ _gcPhase = GC_PHASE_IDLE; _sched->_gcPhaseSet |= GC_PHASE_IDLE; }
 	MMINLINE void setCollectorRootMarking()		{ _gcPhase = GC_PHASE_ROOT; _sched->_gcPhaseSet |= GC_PHASE_ROOT; }
@@ -248,7 +248,7 @@ public:
 		, _osInterface(NULL)
 		, _sched(NULL)
 		, _fixHeapForWalk(false)
-		, _avgPercentFreeHeapAfterCollect(0)	
+		, _avgPercentFreeHeapAfterCollect(0)
 		, _workPackets(NULL)
 		, _stopTracing(false)
 		, _realtimeDelegate(env)

--- a/runtime/gc_realtime/RealtimeMarkingScheme.hpp
+++ b/runtime/gc_realtime/RealtimeMarkingScheme.hpp
@@ -98,17 +98,17 @@ public:
 		_markMap->atomicSetBit((omrobjectptr_t)((1 << J9VMGC_SIZECLASSES_LOG_SMALLEST) + (uintptr_t)objectPtr));
 	}
 
-	MMINLINE bool 
+	MMINLINE bool
 	markObject(MM_EnvironmentRealtime *env, omrobjectptr_t objectPtr, bool leafType = false)
-	{	
+	{
 		if (objectPtr == NULL) {
 			return false;
 		}
 
 		if (isMarked(objectPtr)) {
-	 		return false;
+			return false;
 		}
-		
+
 		if (!_markMap->atomicSetBit(objectPtr)) {
 			return false;
 		}

--- a/runtime/gc_realtime/Scheduler.hpp
+++ b/runtime/gc_realtime/Scheduler.hpp
@@ -91,7 +91,7 @@ public:
 	MM_RealtimeGC *_gc;
 	OMR_VM *_vm;
 	MM_GCExtensionsBase *_extensions;
- 	bool _doSchedulingBarrierEvents;
+	bool _doSchedulingBarrierEvents;
 
 	uint32_t _gcOn; /**< Are we in some long GC cycle? */
 
@@ -288,4 +288,3 @@ public:
 };
 
 #endif /* SCHEDULER_HPP_ */
-

--- a/runtime/gc_trace/TgcExtensions.hpp
+++ b/runtime/gc_trace/TgcExtensions.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -160,7 +159,7 @@ protected:
 	 * @param extensions[in] the GC extensions
 	 */
 	MM_TgcExtensions(MM_GCExtensions *extensions);
-	
+
 	/**
 	 * Tear down a TGC extensions object
 	 * @param extensions[in] the GC extensions
@@ -173,41 +172,41 @@ public:
 	 * @return the cached port library pointer
 	 */
 	J9PortLibrary* getPortLibrary() { return _portLibrary; }
-	
+
 	/**
 	 * Print TGC output to stderr or the TGC output file
 	 * @param format[in] a format string, see j9tty_printf
 	 * @param args[in] arguments to be formatted
 	 */
 	void vprintf(const char *format, va_list args);
-	
+
 	/**
 	 * Print TGC output to stderr or the TGC output file
 	 * @param format[in] a format string, see j9tty_printf
 	 * @param ...[in] arguments to be formatted
 	 */
 	void printf(const char *format, ...);
-	
+
 	/**
 	 * Set the output file for TGC output.
 	 * @param filename[in] the name of the file to open
 	 * @return true on success, false on failure
 	 */
 	bool setOutputFile(const char* filename);
-	
+
 	/**
 	 * Allocate and initialize a new TGC extensions object
 	 * @param extensions[in] the GC extensions
 	 * @return an initialized instance, or NULL on failure
 	 */
 	static MM_TgcExtensions * newInstance(MM_GCExtensions *extensions);
-	
+
 	/**
 	 * Tear down and free the TGC extensions object
- 	 * @param extensions[in] the GC extensions
+	 * @param extensions[in] the GC extensions
 	 */
 	void kill(MM_GCExtensions *extensions);
-	
+
 	/**
 	 * Get the TGC extensions object from the GC Extensions object
 	 * @param extensions[in] the GC extensions object
@@ -238,4 +237,3 @@ public:
 };
 
 #endif /* TGCEXTENSIONS_HPP_ */
-

--- a/runtime/gc_verbose_old_events/VerboseEventAFStart.hpp
+++ b/runtime/gc_verbose_old_events/VerboseEventAFStart.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -20,10 +19,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
- 
+
 #if !defined(EVENT_AF_START_HPP_)
 #define EVENT_AF_START_HPP_
- 
+
 #include "j9.h"
 #include "j9cfg.h"
 #include "mmhook.h"
@@ -36,27 +35,27 @@
  */
 class MM_VerboseEventAFStart : public MM_VerboseEventGCStart
 {
-private:	
+private:
 	/**
 	 * Passed Data
-	 * @{ 
+	 * @{
 	 */
 	UDATA _requestedBytes; /**< the minimum number of bytes requested */
 	UDATA _subSpaceType; /**< the type of subspace, old or new */
 	/** @} */
- 	
+
 	/**
 	 * External Data
-	 * @{ 
+	 * @{
 	 */
 	U_64 _lastAFTime; /**< the timestamp of the last AF of the same subspace type */
 	UDATA _AFCount; /**< the allocation failure count */
 	/** @} */
-	
+
 public:
 
 	static MM_VerboseEvent *newInstance(MM_AllocationFailureStartEvent *event, J9HookInterface** hookInterface);
-	
+
 	UDATA getSubSpaceType(void)		{	return _subSpaceType;	};
 	virtual void consumeEvents();
 	virtual void formattedOutput(MM_VerboseOutputAgent *agent);

--- a/runtime/gc_verbose_old_events/VerboseEventGCEnd.hpp
+++ b/runtime/gc_verbose_old_events/VerboseEventGCEnd.hpp
@@ -19,10 +19,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
- 
+
 #if !defined(EVENT_GC_END_HPP_)
 #define EVENT_GC_END_HPP_
- 
+
 #include "j9.h"
 #include "j9cfg.h"
 #include "mmhook.h"
@@ -39,20 +39,20 @@ class MM_VerboseEventGCEnd : public MM_VerboseEvent
 protected:
 	/**
 	 * Passed Data
-	 * @{ 
+	 * @{
 	 */
 	MM_CommonGCEndData _gcEndData; /**< data which is common to all GC end events */
 	/** @} */
- 	
+
 	/**
 	 * External Data
-	 * @{ 
+	 * @{
 	 */
 	I_64 _timeInMilliSeconds;
 	/** @} */
-	
+
 	void initialize(void);
-	
+
 	bool hasDetailedTenuredOutput();
 	//void tlhFormattedOutput(MM_VerboseOutputAgent *agent);
 	void loaFormattedOutput(MM_VerboseOutputAgent *agent);

--- a/runtime/gc_verbose_old_events/VerboseEventGCStart.hpp
+++ b/runtime/gc_verbose_old_events/VerboseEventGCStart.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -20,10 +19,10 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
- 
+
 #if !defined(EVENT_GC_START_HPP_)
 #define EVENT_GC_START_HPP_
- 
+
 #include "j9.h"
 #include "j9cfg.h"
 #include "mmhook.h"
@@ -39,20 +38,20 @@ class MM_VerboseEventGCStart : public MM_VerboseEvent
 protected:
 	/**
 	 * Passed Data
-	 * @{ 
+	 * @{
 	 */
 	MM_CommonGCStartData _gcStartData; /**< data which is common to all GC start events */
 	/** @} */
- 	
+
 	/**
 	 * External Data
-	 * @{ 
+	 * @{
 	 */
 	I_64 _timeInMilliSeconds;
 	/** @} */
-	
+
 	void initialize(void);
-	
+
 	bool hasDetailedTenuredOutput();
 	void tlhFormattedOutput(MM_VerboseOutputAgent *agent);
 	void loaFormattedOutput(MM_VerboseOutputAgent *agent);

--- a/runtime/gc_vlhgc/ClassLoaderRememberedSet.hpp
+++ b/runtime/gc_vlhgc/ClassLoaderRememberedSet.hpp
@@ -52,10 +52,10 @@ private:
 	J9Pool *_bitVectorPool; /**< A pool of bit vectors to associate with J9ClassLoaders */
 	MM_LightweightNonReentrantLock _lock; /**< A lock to protect _bitVectorPool */
 	UDATA *_bitsToClear; /**< A bit vector which is built up before a garbage collection */
-	
+
 private:
 	MM_ClassLoaderRememberedSet(MM_EnvironmentBase *env);
-	
+
 	/**
 	 * Allocation helper for J9Pool.
 	 */
@@ -65,7 +65,7 @@ private:
 	 * Deallocation helper for J9Pool.
 	 */
 	static void poolFreeHelper(void *userData, void *address, U_32 type);
-	
+
 	/**
 	 * Upgrade the specified class loader from a single remembered region to a full bit vector.
 	 * If a bit vector can't be installed, set the loader to overflowed.
@@ -73,7 +73,7 @@ private:
 	 * @param gcRememberedSetAddress[in/out] an address of gcRememberedSet slot
 	 */
 	void installBitVector(MM_EnvironmentBase *env, volatile UDATA *gcRememberedSetAddress);
-	
+
 	/**
 	 * Atomically set the specified bit in the specified bit vector.
 	 * @param env[in] the current thread
@@ -81,13 +81,13 @@ private:
 	 * @param bit the index of the bit to set
 	 */
 	void setBit(MM_EnvironmentBase *env, volatile UDATA *bitVector, UDATA bit);
-	
+
 	/**
 	 * Determine if the specified gcRememberedSet field value represents an overflowed set.
 	 * @param rememberedSet the value of a J9ClassLoader's gcRememberedSet field
 	 * @return true if the remembered set is overflowed
 	 */
-	MMINLINE bool isOverflowedRemememberedSet(UDATA rememberedSet) { return UDATA_MAX == rememberedSet; } 
+	MMINLINE bool isOverflowedRemememberedSet(UDATA rememberedSet) { return UDATA_MAX == rememberedSet; }
 
 	/**
 	 * Determine if the specified gcRememberedSet field value represents a tagged region index.
@@ -96,30 +96,30 @@ private:
 	 * @return true if the remembered set is a tagged region index (or overflowed), false otherwise
 	 */
 	MMINLINE bool isTaggedRegionIndex(UDATA rememberedSet) { return 1 == (1 & rememberedSet); }
-	
+
 	/**
 	 * Convert the specified region index into a tagged value suitable to be stored in the gcRememberedSet field.
 	 * @param regionIndex the index to store
 	 * @return the tagged version of the index
 	 */
 	MMINLINE UDATA asTaggedRegionIndex(UDATA regionIndex) { return (regionIndex << 1) | 1; }
-	
+
 	/**
 	 * Convert a tagged region index back to the actual value
 	 * @param rememberedSet the value of a J9ClassLoader's gcRememberedSet field
 	 * @return the region index it represents
 	 */
 	MMINLINE UDATA asUntaggedRegionIndex(UDATA rememberedSet) { return rememberedSet >> 1; }
-	
+
 	/**
 	 * Determine if the specified bit is set in the specified bit vector.
 	 * @param env[in] the current thread
 	 * @param bitVector[in] the bit vector to test
 	 * @param bit the index of the bit to test
-	 * @return true if the bit is set, false otherwise 
+	 * @return true if the bit is set, false otherwise
 	 */
 	bool isBitSet(MM_EnvironmentBase *env, volatile UDATA *bitVector, UDATA bit);
-	
+
 	/**
 	 * Implementation helper for rememberInstance() based on region index.
 	 *
@@ -174,14 +174,14 @@ public:
 
 	/*
 	 * Teardown ClassLoaderRememberedSet
-	 */	
+	 */
 	virtual void tearDown(MM_EnvironmentBase *env);
 
 	/**
 	 * Update the remembered set data for the specified object's class loader to record the object.
-	 * 
-	 * The object's region and class loader are identified, and the relationship between them is recorded in the class loader. 
-	 * 
+	 *
+	 * The object's region and class loader are identified, and the relationship between them is recorded in the class loader.
+	 *
 	 * @param env[in] the current thread
 	 * @param object[in] the object to remember
 	 */
@@ -191,7 +191,7 @@ public:
 	 * Determine if there are any instances of classes defined by specified class loader.
 	 * @param env[in] the current thread
 	 * @param classLoader[in] the loader to examine
-	 * @return true if there are instances (or the loader is overflowed), false otherwise  
+	 * @return true if there are instances (or the loader is overflowed), false otherwise
 	 */
 	bool isRemembered(MM_EnvironmentBase *env, J9ClassLoader *classLoader);
 
@@ -205,20 +205,20 @@ public:
 
 	/**
 	 * Determine if the specified object is remembered in its class loader.
-	 * @note This is intended primarily for verification 
+	 * @note This is intended primarily for verification
 	 * @param env[in] the current thread
 	 * @param object[in] the object to test
-	 * @return true if the object is properly remembered  
+	 * @return true if the object is properly remembered
 	 */
 	bool isInstanceRemembered(MM_EnvironmentBase *env, J9Object *object);
-	
+
 	/**
 	 * Delete any resources associated with the remembered set for the specified class loader.
 	 * @param env[in] the current thread
 	 * @param classLoader[in] the loader to modify
 	 */
 	void killRememberedSet(MM_EnvironmentBase *env, J9ClassLoader *classLoader);
-	
+
 	/**
 	 * Called before a partial GC to initialize the preserved regions bit vector.
 	 * All bits are 1 (preserved) once this call completes.
@@ -226,7 +226,7 @@ public:
 	 * @param env[in] the current thread
 	 */
 	void resetRegionsToClear(MM_EnvironmentBase *env);
-	
+
 	/**
 	 * Ensure that the remembered bits for the specified region will be cleared when #clearRememberedSets() is called.
 	 * This may safely be called from multiple threads.
@@ -234,19 +234,19 @@ public:
 	 * @param region[in] a region which is part of the collection set and should be cleared
 	 */
 	void prepareToClearRememberedSetForRegion(MM_EnvironmentBase *env, MM_HeapRegionDescriptor *region);
-	
+
 	/**
-	 * Called before a partial GC to clear remembered sets in all class loaders for regions 
+	 * Called before a partial GC to clear remembered sets in all class loaders for regions
 	 * which have been marked using #prepareToClearRememberedSetForRegion()
 	 * @param env[in] the current thread
 	 */
 	void clearRememberedSets(MM_EnvironmentBase *env);
-	
+
 	/**
- 	 * Called by the main thread before a GC cycle to perform any setup required before a collection.
- 	 * @param env[in] the current thread
- 	 */
-	void setupBeforeGC(MM_EnvironmentBase *env); 
+	 * Called by the main thread before a GC cycle to perform any setup required before a collection.
+	 * @param env[in] the current thread
+	 */
+	void setupBeforeGC(MM_EnvironmentBase *env);
 };
 
 #endif /* CLASSLOADERREMEMBEREDSET_HPP */

--- a/runtime/gc_vlhgc/CompactGroupPersistentStats.hpp
+++ b/runtime/gc_vlhgc/CompactGroupPersistentStats.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -73,7 +72,7 @@ public:
 	double _projectedInstantaneousSurvivalRatePerAgeUnit; /**< fraction of _projectedInstantaneousSurvivalRate, in case age group is a multiple of age units. this is an average of _projectedInstantaneousSurvivalRateThisPGCPerAgeUnit */
 	double _projectedInstantaneousSurvivalRateThisPGCPerAgeUnit; /**< same as _projectedInstantaneousSurvivalRatePerAgeUnit, but for this PGC (not an average over time) */
 
-	
+
 	UDATA _projectedLiveBytes; /** < The sum of projected live bytes of all regions in the compact group */
 	UDATA _liveBytesAbsoluteDeviation; /** < sum of the absolute value _projectedLiveBytesDeviation of every region in the compact group */
 	UDATA _regionCount; /** < count of the number of regions in the compact group */
@@ -83,7 +82,7 @@ public:
 /* member functions */
 private:
 	/* Checks if a compactGroup has been collected and set _statsHaveBeenUpdatedThisCycle to true if that is the case.
-	 * Also updates some stats (projectedInstantaneousSurvivalRate, historicalSurvivalRate, weightedSurvivalRate) that are dependant on the 
+	 * Also updates some stats (projectedInstantaneousSurvivalRate, historicalSurvivalRate, weightedSurvivalRate) that are dependant on the
 	 * live bytes stats if they have not been updated yet.
 	 *
 	 * @param env[in] the current thread
@@ -99,10 +98,10 @@ private:
 	 * @param compactGroup[in] compactGroup for which instantaneousSurvivalRate is calculated
 	 */
 	static void updateProjectedSurvivalRate(MM_EnvironmentVLHGC *env, MM_CompactGroupPersistentStats *persistentStats, UDATA compactGroup);
-	
+
 	/**
 	 * Auxiliary function used by updateProjectedSurvivalRate. If an age group is at the boundary of Eden, it returns the size fractions on either sides.
- 	 * @param env[in] The Main GC thread
+	 * @param env[in] The Main GC thread
 	 * @param ageInThisAgeGroup[in] Age-size of the age group
 	 * @param ageInThisCompactGroup[in] Age-size of the compact group
 	 * @param currentAge[in] Current age of objects in this group
@@ -123,7 +122,7 @@ private:
 	 * The init value is set to current consumed space (according to memory pool).
 	 *
 	 * TODO: Create a new class for this as it's not really tied to compact groups
- 	 * @param env[in] The Main GC thread
+	 * @param env[in] The Main GC thread
 	 */
 	static void initProjectedLiveBytes(MM_EnvironmentVLHGC *env);
 
@@ -131,15 +130,15 @@ private:
 	 * Updates the projectedLiveBytes for all regions by multiplying by their compact group's instantaneous survivor rate
 	 *
 	 * TODO: Create a new class for this as it's not really tied to compact groups
- 	 * @param env[in] The Main GC thread
+	 * @param env[in] The Main GC thread
 	 */
 	static void decayProjectedLiveBytesForRegions(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Given the input list of compact group stats with initialized _historicalSurvivalRate fields, initialize the _weightedSurvivalRate fields.
 	 * The survival rate is weighted using survival data from older groups to project the future survival rate of the group.
 	 * This is used to favour compacting more stable compact groups.
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param persistentStats[in] an array of MM_CompactGroupPersistentStats with as many elements as there are compact groups
 	 */
@@ -147,7 +146,7 @@ private:
 
 	/**
 	 * Auxiliary function to calculation various values for measured/projected live bytes before current/after previous PGC, invoked for each region in Collection Set
-  	 * @param env[in] The Main GC thread
+	 * @param env[in] The Main GC thread
 	 * @param persistentStats[in] The list of per-compact group persistent stats
 	 * @param region[in] The region for which we take measured/projected live bytes values
 	 * @param measuredLiveBytes Passing in the actual value for measuredLiveBytes (already calculated by the caller for its own purpose)
@@ -160,14 +159,14 @@ public:
 	/**
 	 * Allocate a list of compact group stats
 	 * @param env[in] the current thread
-	 * @return an array of MM_CompactGroupPersistentStats, or NULL 
+	 * @return an array of MM_CompactGroupPersistentStats, or NULL
 	 */
 	static MM_CompactGroupPersistentStats * allocateCompactGroupPersistentStats(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Free the list of compact group stats
 	 * @param env[in] the current thread
-	 * @param persistentStats[in] the list to free 
+	 * @param persistentStats[in] the list to free
 	 */
 	static void killCompactGroupPersistentStats(MM_EnvironmentVLHGC *env, MM_CompactGroupPersistentStats *persistentStats);
 

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -115,7 +115,7 @@ private:
 	uintptr_t _maxCacheSize;  /**< Maximum size in bytes that will be requested for a general purpose cache area */
 
 	MM_ParallelDispatcher *_dispatcher;
-	
+
 	MM_CopyScanCacheListVLHGC _cacheFreeList;  /**< Caches which are not bound to heap memory and available to be populated */
 	MM_CopyScanCacheListVLHGC *_cacheScanLists;  /**< An array of per-node caches which contains objects still to be scanned (1+node_count elements in array)*/
 	uintptr_t _scanCacheListSize;	/**< The number of entries in _cacheScanLists */
@@ -150,7 +150,7 @@ private:
 
 	bool _tracingEnabled;  /**< Temporary variable to enable tracing of activity */
 	MM_AllocationContextTarok *_commonContext;	/**< The common context is used as an opaque token to represent cases where we don't want to relocate objects during NUMA-aware copy-forward since relocating to the common context is currently disabled */
-	MM_CopyForwardCompactGroup *_compactGroupBlock; /**< A block of MM_CopyForwardCompactGroup structs which is subdivided among the GC threads */ 
+	MM_CopyForwardCompactGroup *_compactGroupBlock; /**< A block of MM_CopyForwardCompactGroup structs which is subdivided among the GC threads */
 	uintptr_t _arraySplitSize; /**< The number of elements to be scanned in each array chunk (this determines the degree of parallelization) */
 
 	uintptr_t _regionSublistContentionThreshold	/**< The number of threads which must be contending on the same region sublist for us to decide that another sublist should be created to alleviate contention (reset at the beginning of every CopyForward task) */;
@@ -196,10 +196,10 @@ private:
 
 	/**
 	 * Discard any remaining memory in the specified copy cache, returning it to the pool if possible, and updating
-	 * memory statistics. The implementation will attempt to return any unused portion of the cache to the owning pool 
-	 * if possible (and will internally lock to corresponding region list to ensure that the allocation pointer can be 
-	 * updated safely).  The copy cache flag is unset.  Additionally, the top of the cache will be updated to reflect 
-	 * that no further allocation is possible if the excess at the top of the cache was successfully returned to the 
+	 * memory statistics. The implementation will attempt to return any unused portion of the cache to the owning pool
+	 * if possible (and will internally lock to corresponding region list to ensure that the allocation pointer can be
+	 * updated safely).  The copy cache flag is unset.  Additionally, the top of the cache will be updated to reflect
+	 * that no further allocation is possible if the excess at the top of the cache was successfully returned to the
 	 * pool.
 	 * @param env[in] A GC thread
 	 * @param cache[in] The copy cache to retire
@@ -207,7 +207,7 @@ private:
 	 * @param wastedMemory[in] The number of bytes of memory which couldn't be used in the allocated portion of the copy cache and should be considered free memory when flushed back to the pool
 	 */
 	void discardRemainingCache(MM_EnvironmentVLHGC *env, MM_CopyScanCacheVLHGC *cache, MM_LightweightNonReentrantLock *cacheLock, uintptr_t wastedMemory);
-	
+
 	/**
 	 * Determine whether the object pointer is found within the heap proper.
 	 * @return Boolean indicating if the object pointer is within the heap boundaries.
@@ -217,7 +217,7 @@ private:
 		return (_heapBase <= (uint8_t *)objectPtr) && (_heapTop > (uint8_t *)objectPtr);
 	}
 
- 	/**
+	/**
 	 * Determine whether the object is live relying on survivor/evacuate region flags and mark map. null object is considered marked.
 	 * @return Boolean true if object is live
 	 */
@@ -273,7 +273,7 @@ private:
 	 * @param nextIndex[in] The next index in the array to scan
 	 */
 	MMINLINE void reinitArraySplitCache(MM_EnvironmentVLHGC *env, MM_CopyScanCacheVLHGC *cache, J9IndexableObject *array, uintptr_t nextIndex);
-	
+
 	MM_CopyScanCacheVLHGC *getFreeCache(MM_EnvironmentVLHGC *env);
 	/**
 	 * Adds the given newCacheEntry to the free cache list.
@@ -289,7 +289,7 @@ private:
 	 * @param newCacheEntry[in] The entry to add to cacheList
 	 */
 	void addCacheEntryToScanCacheListAndNotify(MM_EnvironmentVLHGC *env, MM_CopyScanCacheVLHGC *newCacheEntry);
-	
+
 	void flushCache(MM_EnvironmentVLHGC *env, MM_CopyScanCacheVLHGC *cache);
 	bool clearCache(MM_EnvironmentVLHGC *env, MM_CopyScanCacheVLHGC *cache);
 
@@ -333,7 +333,7 @@ private:
 	 * @param reason to scan (dirty card, packet, scan cache, overflow)	 *
 	 */
 	void  scanReferenceObjectSlots(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
-	
+
 	/**
 	 * Called by the root scanner to scan all WeakReference objects discovered by the mark phase,
 	 * clearing and enqueuing them if necessary.
@@ -354,7 +354,7 @@ private:
 	 * @param env[in] the current thread
 	 */
 	void scanPhantomReferenceObjects(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Set region as survivor. Also set the special state if region was created by phantom reference processing.
 	 * @param env[in] the current thread
@@ -369,20 +369,20 @@ private:
 	 * SoftReferences have their ages incremented.
 	 * @param env[in] the current thread
 	 * @param region[in] the region all the objects in the list belong to
-	 * @param headOfList[in] the first object in the linked list 
+	 * @param headOfList[in] the first object in the linked list
 	 * @param referenceStats copy forward stats substructure to be updated
 	 */
 	void processReferenceList(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, J9Object *headOfList, MM_ReferenceStats *referenceStats);
-	
+
 	/**
 	 * Walk the list of reference objects recorded in the specified list, changing them to the REMEMBERED state.
 	 * @param env[in] the current thread
-	 * @param headOfList[in] the first object in the linked list 
+	 * @param headOfList[in] the first object in the linked list
 	 */
 	void rememberReferenceList(MM_EnvironmentVLHGC *env, J9Object *headOfList);
 
 	/**
-	 * Walk all regions in the evacuate set in parallel, remembering any objects on their reference 
+	 * Walk all regions in the evacuate set in parallel, remembering any objects on their reference
 	 * lists so that they may be restored at the end of the PGC.
 	 * @param env[in] the current thread
 	 */
@@ -418,7 +418,7 @@ private:
 	 * @return number of slots scanned
 	 */
 	uintptr_t scanPointerArrayObjectSlotsSplit(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9IndexableObject *arrayPtr, uintptr_t startIndex, bool currentSplitUnitOnly = false);
-	
+
 	/**
 	 * For the given object and current starting index, determine the number of slots being scanned now, and create a work unit for the rest of the array.
 	 * Works for both copy-scan cache and workstack driven phases.
@@ -496,7 +496,7 @@ private:
 	 * @param newRegion[in] The region which the implementation must add to regionList (the implementation assumes that newRegion is not already in a region list)
 	 */
 	void insertRegionIntoLockedList(MM_EnvironmentVLHGC *env, MM_ReservedRegionListHeader::Sublist *regionList, MM_HeapRegionDescriptorVLHGC *newRegion);
-	
+
 	/**
 	 * Release a region as it is deemed to be full and no longer useful.
 	 * @param env GC thread.
@@ -522,7 +522,7 @@ private:
 	 * @param region[in] The region to remove
 	 */
 	void removeFreeMemoryCandidate(MM_EnvironmentVLHGC *env, MM_ReservedRegionListHeader *regionList, MM_HeapRegionDescriptorVLHGC *region);
-	
+
 	/**
 	 * Reserve memory for an object to be copied to survivor space.
 	 * @param env[in] GC thread.
@@ -563,7 +563,7 @@ private:
 	MMINLINE MM_CopyScanCacheVLHGC *reserveMemoryForCopy(MM_EnvironmentVLHGC *env, J9Object *objectToEvacuate, MM_AllocationContextTarok *reservingContext, uintptr_t objectReserveSizeInBytes);
 
 	void flushCaches(MM_CopyScanCacheVLHGC *cache);
-	
+
 	/**
 	 * Called at the end of the copy forward operation to flush any remaining data from copy caches and return them to the free list.
 	 * @param env[in] the thread whose copy caches should be flushed
@@ -662,8 +662,8 @@ private:
 	 * @param env[in] the current thread
 	 * @param reservingContext[in] The context to which we would prefer to copy any objects discovered in this method
 	 * @param objectPtr[in] current object being scanned
- 	 * @param reason[in] reason to scan (dirty card, packet, scan cache, overflow)
- 	 */
+	 * @param reason[in] reason to scan (dirty card, packet, scan cache, overflow)
+	 */
 	MMINLINE void scanObject(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, J9Object *objectPtr, ScanReason reason);
 
 	/**
@@ -673,7 +673,7 @@ private:
 	 * @param reason[in] reason to scan (dirty card, packet, scan cache, overflow)
 	 */
 	MMINLINE void updateScanStats(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
-	
+
 	MMINLINE uintptr_t scanToCopyDistance(MM_CopyScanCacheVLHGC *cache);
 	MMINLINE bool bestCacheForScanning(MM_CopyScanCacheVLHGC *copyCache, MM_CopyScanCacheVLHGC **scanCache);
 
@@ -688,7 +688,7 @@ private:
 	 * @return true if the nextScanCache has been updated with the best cache to scan.
 	 */
 	MMINLINE bool aliasToCopyCache(MM_EnvironmentVLHGC *env, MM_CopyScanCacheVLHGC **nextScanCache);
-	
+
 	/**
 	 * Scans the slots of a MixedObject, remembering objects as required. Scanning is interrupted
 	 * as soon as there is a copy cache that is preferred to the current scan cache. This is returned
@@ -865,19 +865,19 @@ private:
 	 * @return an object pointer representing the new location of the object, or the original object pointer on failure.
 	 */
 	J9Object *copy(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *reservingContext, MM_ForwardedHeader *forwardedHeader, bool leafType = false);
-	
+
 
 	/* Depth copy the hot fields of an object.
 	 * @param forwardedHeader - forwarded header of an object
 	 * @param destinationObjectPtr - destinationObjectPtr of the object described by the forwardedHeader
-	 */ 
+	 */
 	MMINLINE void depthCopyHotFields(MM_EnvironmentVLHGC *env, J9Class *clazz, J9Object *destinationObjectPtr, MM_AllocationContextTarok *reservingContext);
-	
+
 	/* Copy the hot field of an object.
 	 * Valid if scavenger dynamicBreadthScanOrdering is enabled.
 	 * @param destinationObjectPtr - the object who's hot field will be copied
-	 * @param offset  - the object field offset of the hot field to be copied 
-	 */ 
+	 * @param offset  - the object field offset of the hot field to be copied
+	 */
 	MMINLINE void copyHotField(MM_EnvironmentVLHGC *env, J9Object *destinationObjectPtr, uint8_t offset, MM_AllocationContextTarok *reservingContext);
 	/**
 	 * Push any remaining cached mark map data out before the copy scan cache is released.
@@ -924,10 +924,10 @@ private:
 	/**
 	 * Determine the desired copy cache size for the specified compact group for the current thread.
 	 * The size is chosen to balance the opposing problems of fragmentation and contention.
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param compactGroup the compact group to calculate the size for
-	 * @return the desired copy cache size, in bytes 
+	 * @return the desired copy cache size, in bytes
 	 */
 	uintptr_t getDesiredCopyCacheSize(MM_EnvironmentVLHGC *env, uintptr_t compactGroup);
 
@@ -943,10 +943,10 @@ private:
 
 	/**
 	 * Scan the root set, copying-and-forwarding any objects found.
-	 * @param env[in] the current thread 
+	 * @param env[in] the current thread
 	 */
 	void scanRoots(MM_EnvironmentVLHGC *env);
-	
+
 #if defined(J9VM_GC_LEAF_BITS)
 	/**
 	 * Copy any leaf children of the specified object.
@@ -989,13 +989,13 @@ private:
 protected:
 
 	MM_CopyForwardScheme(MM_EnvironmentVLHGC *env, MM_HeapRegionManager *manager);
-	
+
 	/**
 	 * Initialize the receivers internal support structures and state.
 	 * @param env[in] Main thread.
 	 */
 	bool initialize(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Clean up the receivers internal support structures and state.
 	 * @param env[in] Main thread.

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.hpp
@@ -83,14 +83,14 @@ private:
 	bool _timeLimitWasHit;	/**< true if any requests to check the time came in after we had hit our time threshold */
 	const U_64 _timeThreshold;	/**< The ticks which represents the end of this increment */
 	MM_CycleState *_cycleState; /**< Current cycle state information */
-	
+
 public:
 	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_MARK; };
-	
+
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);
 	virtual void cleanup(MM_EnvironmentBase *env);
-	
+
 	virtual void mainSetup(MM_EnvironmentBase *env);
 	virtual void mainCleanup(MM_EnvironmentBase *env);
 
@@ -111,8 +111,8 @@ public:
 	 * Create a ParallelMarkTask object.
 	 */
 	MM_ParallelGlobalMarkTask(MM_EnvironmentBase *env,
-			MM_ParallelDispatcher *dispatcher, 
-			MM_GlobalMarkingScheme *markingScheme, 
+			MM_ParallelDispatcher *dispatcher,
+			MM_GlobalMarkingScheme *markingScheme,
 			MarkAction action,
 			U_64 timeThreshold,
 			MM_CycleState *cycleState) :
@@ -143,8 +143,8 @@ public:
 private:
 protected:
 public:
-	virtual UDATA getVMStateID() 
-	{ 
+	virtual UDATA getVMStateID()
+	{
 		return OMRVMSTATE_GC_CONCURRENT_MARK_TRACE;
 	}
 
@@ -164,8 +164,8 @@ public:
 	 * Create a MM_ConcurrentGlobalMarkTask object.
 	 */
 	MM_ConcurrentGlobalMarkTask(MM_EnvironmentBase *env,
-			MM_ParallelDispatcher *dispatcher, 
-			MM_GlobalMarkingScheme *markingScheme, 
+			MM_ParallelDispatcher *dispatcher,
+			MM_GlobalMarkingScheme *markingScheme,
 			MarkAction action,
 			UDATA bytesToScan,
 			volatile bool *forceExit,
@@ -198,7 +198,7 @@ private:
 	MM_MarkMap *_markMap;
 	UDATA _arraySplitSize;
 	MM_HeapRegionManager *const _heapRegionManager;	/**< This HRM is retained since it is needed to quickly resolve the table region of a given object */
-	
+
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
 	bool _dynamicClassUnloadingEnabled;  /**< Local cached value from cycle state for performance reasons (TODO: Reevaluate) */
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
@@ -214,8 +214,8 @@ private:
 		SCAN_REASON_DIRTY_CARD = 2, /**< Indicates the object being scanned was found in a dirty card */
 		SCAN_REASON_OVERFLOWED_REGION = 3, /**< Indicates the object being scanned was in an overflowed region */
 	};
-	
-	/* 
+
+	/*
 	 * Function members
 	 */
 private:
@@ -251,13 +251,13 @@ private:
 	 * @param env[in] the current thread
 	 */
 	void scanPhantomReferenceObjects(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Process the list of reference objects recorded in the specified list.
 	 * References with unmarked referents are cleared and optionally enqueued.
 	 * SoftReferences have their ages incremented.
 	 * @param env[in] the current thread
-	 * @param headOfList[in] the first object in the linked list 
+	 * @param headOfList[in] the first object in the linked list
 	 * @param referenceStats copy forward stats substructure to be updated
 	 */
 	void processReferenceList(MM_EnvironmentVLHGC *env, J9Object* headOfList, MM_ReferenceStats *referenceStats);
@@ -315,13 +315,13 @@ private:
 	 * 1. Mark any objects it points to, optionally including it's class
 	 * 2. Enqueue those objects for scanning, if necessary
 	 * 3. Update the remembered set
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param objectPtr[in] the mixed object to scan
- 	 * @param reason a code indicating why the object is being scanned
+	 * @param reason a code indicating why the object is being scanned
 	 */
 	void scanMixedObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
-	
+
 	void scanContinuationNativeSlots(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
 	void scanContinuationObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
 
@@ -332,25 +332,25 @@ private:
 	 * 3. Mark and enqueue any objects in the constant pool
 	 * 4. Also scan any replaced (how-swapped) versions of the class
 	 * @note This may safely be called for initialized or uninitialized class objects.
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param objectPtr[in] an instance of java.lang.Class
 	 * @param reason a code indicating why the object is being scanned
 	 */
 	void scanClassObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
-	
+
 	/**
 	 * Scan the specified instance of java.lang.ClassClassLoader, or one of its subclasses.
 	 * 1. Scan the object itself, as in scanMixedObject()
 	 * 2. Mark and enqueue any classes found in the class table
 	 * @note This may safely be called for initialized or uninitialized class loader objects.
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param objectPtr[in] an instance of java.lang.ClassLoader or one of its subclasses
 	 * @param reason a code indicating why the object is being scanned
 	 */
 	void scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
-	
+
 	/**
 	 * Scan the slots of a J9ClassLoader object.
 	 * Mark all relevant slots values found in the object.  This includes the java.lang.ClassLoader object.
@@ -368,18 +368,18 @@ private:
 	 * 1. Scan the object itself, as in scanMixedObject()
 	 * 2. Except, use special handling for the weak referent field
 	 * @note The reference object must be on one of the reference object queues.
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param objectPtr[in] an instance of a reference object
 	 * @param reason a code indicating why the object is being scanned
 	 */
 	void scanReferenceMixedObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, ScanReason reason);
-	
+
 	/**
 	 * Scan the specified portion of the specified object array.
 	 * If the function does not scan to the end of the array, the remaining portion of the
 	 * array is enqueued for further scanning.
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param objectPtr[in] an object array
 	 * @param indexArg the index to start scanning from
@@ -391,7 +391,7 @@ private:
 	 * Scan the specified object array.
 	 * If the function does not scan to the end of the array, the remaining portion of the
 	 * array is enqueued for further scanning.
-	 * 
+	 *
 	 * @param env[in] the current thread
 	 * @param objectPtr[in] an object array
 	 * @param reason a code indicating why the object is being scanned
@@ -408,7 +408,7 @@ private:
 	 * Rescan all objects in the specified overflowed region.
 	 */
 	void cleanRegion(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, U_8 flagToClean);
-		
+
 	/**
 	 * Clean cards for the purpose of finding "roots" into the collection set.
 	 * @param env A GC thread involved in the cleaning.
@@ -438,9 +438,9 @@ protected:
 	}
 
 public:
-	static MM_GlobalMarkingScheme *newInstance(MM_EnvironmentVLHGC *env); 
+	static MM_GlobalMarkingScheme *newInstance(MM_EnvironmentVLHGC *env);
 	virtual void kill(MM_EnvironmentVLHGC *env);
-	
+
 	void mainSetupForGC(MM_EnvironmentVLHGC *env);
 	void mainCleanupAfterGC(MM_EnvironmentVLHGC *env);
 	void workerSetupForGC(MM_EnvironmentVLHGC *env);
@@ -460,29 +460,29 @@ public:
 	/**
 	 *  Initialization for Mark
 	 *  Actual startup for Mark procedure
-	 *  @param[in] env - passed Environment 
+	 *  @param[in] env - passed Environment
 	 */
 	void markLiveObjectsInit(MM_EnvironmentVLHGC *env);
 
 	/**
 	 *  Mark Roots
 	 *  Create Root Scanner and Mark all roots including classes and classloaders if dynamic class unloading is enabled
-	 *  @param[in] env - passed Environment 
+	 *  @param[in] env - passed Environment
 	 */
 	void markLiveObjectsRoots(MM_EnvironmentVLHGC *env);
 
 	/**
 	 *  Scan (complete)
 	 *  Process all work packets from queue, including classes and work generated during this phase.
-	 *  On return, all live objects will be marked, although some unreachable objects (such as finalizable 
+	 *  On return, all live objects will be marked, although some unreachable objects (such as finalizable
 	 *  objects) may still be revived by subsequent stages.
-	 *  @param[in] env - passed Environment 
+	 *  @param[in] env - passed Environment
 	 */
 	void markLiveObjectsScan(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 *  Final Mark services including scanning of Clearables
-	 *  @param[in] env - passed Environment 
+	 *  @param[in] env - passed Environment
 	 */
 	void markLiveObjectsComplete(MM_EnvironmentVLHGC *env);
 
@@ -495,7 +495,7 @@ public:
 	bool markObject(MM_EnvironmentVLHGC *env, J9Object *objectPtr, bool leafType = false);
 
 	void completeScan(MM_EnvironmentVLHGC *env);
-	
+
 	bool heapAddRange(MM_EnvironmentVLHGC *env, MM_MemorySubSpace *subspace, UDATA size, void *lowAddress, void *highAddress);
 	bool heapRemoveRange(MM_EnvironmentVLHGC *env, MM_MemorySubSpace *subspace, UDATA size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
 
@@ -503,7 +503,7 @@ public:
 	 * Scans the marked objects in the [lowAddress..highAddress) range.  If rememberedObjectsOnly is set, we will further constrain
 	 * this scanned set by only scanning objects in the range which have the OBJECT_HEADER_REMEMBERED bit set.  The receiver uses
 	 * its _markMap to determine which objects in the range are marked.
-	 * 
+	 *
 	 * @param env[in] A GC thread (note that this method could be called by multiple threads, in parallel, but on disjoint address ranges)
 	 * @param lowAddress[in] The heap address where the receiver will begin walking objects
 	 * @param highAddress[in] The heap address after the last address we will potentially find a live object
@@ -515,7 +515,7 @@ public:
 	 * @param env[in] the current thread
 	 */
 	void flushBuffers(MM_EnvironmentVLHGC *env);
-	
+
 	MMINLINE void doSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr);
 #if JAVA_SPEC_VERSION >= 24
 	void doContinuationSlot(MM_EnvironmentVLHGC *env, J9Object *fromObject, J9Object** slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);
@@ -541,7 +541,7 @@ public:
 	{
 		_typeId = __FUNCTION__;
 	}
-	
+
 	/*
 	 * Friends
 	 */

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -68,31 +67,31 @@ protected:
 
 private:
 	J9PortLibrary *_portLibrary;
-	
+
 	MM_HeapRegionManager *_regionManager;	/**< The manager which will be walked to configure the collection flags on regions in the heap */
-	
+
 	MM_MemorySubSpaceTarok *_configuredSubspace;	/**< The subspace which is configured in the system and triggers early AF - must be reset after a collection to allow the mutator to proceed */
-	
+
 	MM_MarkMapManager *_markMapManager;  /**< Tracking and managing all mark map assets */
 
 	MM_InterRegionRememberedSet *_interRegionRememberedSet;	/**< An abstraction layer over the tracking of inter-region references which is built by marking and used/updated by compact */
 
 	MM_ClassLoaderRememberedSet *_classLoaderRememberedSet;	/**< An abstraction layer over the tracking where instances defined by each class loader can be found*/
-	
+
 	MM_CopyForwardDelegate _copyForwardDelegate;  /**< Delegate responsible for handling copy and forward GC operations */
 
 	MM_GlobalMarkDelegate _globalMarkDelegate; /**< Delegate for marking in global collections */
 
 	MM_ReclaimDelegate _reclaimDelegate;
-	
+
 	MM_SchedulingDelegate _schedulingDelegate;
-	
+
 	MM_CollectionSetDelegate _collectionSetDelegate;
 	MM_ProjectedSurvivalCollectionSetDelegate _projectedSurvivalCollectionSetDelegate;	/** Collection set delegate based on using a region's projected survival rate in order to select collection set */
 
 	MM_CollectionStatisticsVLHGC _globalCollectionStatistics;	 /** Common collect stats (memory, time etc.), specifically for Global collects */
 	MM_CollectionStatisticsVLHGC _partialCollectionStatistics;	 /** Common collect stats (memory, time etc.), specifically for Partial collects */
-	
+
 	MM_ConcurrentPhaseStatsBase _concurrentPhaseStats; /**< GMP concurrent stats */
 
 	MM_WorkPacketsVLHGC *_workPacketsForPartialGC; /**< WorkPackets used by Partial Mark-Sweep Collector */
@@ -101,11 +100,11 @@ private:
 	UDATA _taxationThreshold;	/**< The number of bytes which can be allocated between taxation points */
 	UDATA _allocatedSinceLastPGC;	/**< The number of bytes which can be allocated between PGCs */
 
-	MM_MainGCThread _mainGCThread; /**< An object which manages the state of the main GC thread */ 
-	
+	MM_MainGCThread _mainGCThread; /**< An object which manages the state of the main GC thread */
+
 	MM_CycleStateVLHGC _persistentGlobalMarkPhaseState; /**< Since the GMP can be fragmented into increments running across several pauses, we need to store the cycle state data */
 	volatile bool _forceConcurrentTermination;	/**< Setting this to true will cause any concurrent GMP work being done for this collector to stop and return.  It is volatile because it is shared state between this and the concurrent task's increment manager */
-	
+
 	UDATA _globalMarkPhaseIncrementBytesStillToScan;	/**< The number of bytes which must be scanned in the next GMP increment.  This is used by the concurrent GMP task to determine when it can terminate */
 
 private:
@@ -114,14 +113,14 @@ private:
 	static void globalGCHookAFCycleEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 	static void globalGCHookSysStart(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 	static void globalGCHookSysEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
-	static void globalGCHookIncrementStart(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData); 
-	static void globalGCHookIncrementEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData); 
+	static void globalGCHookIncrementStart(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
+	static void globalGCHookIncrementEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* userData);
 
 	/**
 	 * Called after an operation which has completed the env's mark map (either a GMP completed, a global mark
 	 * completed, a partial mark completed, or a copy-forward completed) so that operations which rely on a
 	 * mark map can be performed (class unloading and finalization).
-	 * 
+	 *
 	 * @param env[in] The main GC thread
 	 */
 	void postMarkMapCompletion(MM_EnvironmentVLHGC *env);
@@ -216,12 +215,12 @@ public:
 	void initializeTaxationThreshold(MM_EnvironmentVLHGC *env);
 
 	virtual void kill(MM_EnvironmentBase *env);
-	
+
 	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_COLLECTOR_GLOBALGC; };
-	
+
 	virtual bool collectorStartup(MM_GCExtensionsBase* extensions);
 	virtual void collectorShutdown(MM_GCExtensionsBase *extensions);
-	
+
 	virtual bool heapAddRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, UDATA size, void *lowAddress, void *highAddress);
 	virtual bool heapRemoveRange(MM_EnvironmentBase *env, MM_MemorySubSpace *subspace, UDATA size, void *lowAddress, void *highAddress, void *lowValidAddress, void *highValidAddress);
 	virtual void heapReconfigured(MM_EnvironmentBase *env, HeapReconfigReason reason, MM_MemorySubSpace *subspace, void *lowAddress, void *highAddress);
@@ -237,7 +236,7 @@ public:
 	 * @return true if resize is successful
 	 */
 	bool attemptHeapResize(MM_EnvironmentVLHGC *env, MM_AllocateDescription *allocDescription);
-	
+
 	virtual	U_32 getGCTimePercentage(MM_EnvironmentBase *env);
 
 	/**
@@ -253,7 +252,7 @@ public:
 	 * Get the last (actual) sden size
 	 * @returns eden size
 	 */
-	
+
 	UDATA getAllocatedSinceLastPGC() {
 		return _allocatedSinceLastPGC;
 	}
@@ -262,7 +261,7 @@ public:
 	 * The _configuredSubspace ivar is mutable via this method only to simplify start-up in the Configuration framework but it should only be set once (implementation asserts this).
 	 */
 	void setConfiguredSubspace(MM_EnvironmentBase *env, MM_MemorySubSpaceTarok *configuredSubspace);
-		
+
 	/**
 	 * Increment the nursery age of every region which contains objects, up to the maximum age.
 	 * @param env[in] The main GC thread
@@ -294,7 +293,7 @@ public:
 	 * @param env[in] The main GC thread
 	 */
 	void setRegionAgesToMax(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * flush RS Lists for CollectionSet and dirty card table
 	 */
@@ -313,7 +312,7 @@ public:
 	bool isGlobalMarkPhaseRunning() { return (MM_CycleState::state_mark_idle != _persistentGlobalMarkPhaseState._markDelegateState); }
 
 	/**
-	 * @return The number of bytes we have scanned so far in the current Global Mark Phase.  
+	 * @return The number of bytes we have scanned so far in the current Global Mark Phase.
 	 * If we are not currently running in a GMP, returns 0.
 	 */
 	UDATA getBytesScannedInGlobalMarkPhase();
@@ -324,22 +323,22 @@ public:
 	void setupBeforeGC(MM_EnvironmentBase *env);
 
 	/**
- 	* Request to create sweepPoolState class for pool
- 	* @param  memoryPool memory pool to attach sweep state to
- 	* @return pointer to created class
- 	*/
+	 * Request to create sweepPoolState class for pool
+	 * @param  memoryPool memory pool to attach sweep state to
+	 * @return pointer to created class
+	 */
 	virtual void *createSweepPoolState(MM_EnvironmentBase *env, MM_MemoryPool *memoryPool);
 
 	/**
- 	* Request to destroy sweepPoolState class for pool
- 	* @param  sweepPoolState class to destroy
- 	*/
+	 * Request to destroy sweepPoolState class for pool
+	 * @param  sweepPoolState class to destroy
+	 */
 	virtual void deleteSweepPoolState(MM_EnvironmentBase *env, void *sweepPoolState);
 
 	/**
- 	* Get InterRegionRememberedSet. InterRegionRememberedSet exposed only if tgc. 
- 	* TODO: Try fetching it through cycleState (currently not doable, due to relative order of reportGCStart and cycleState initialization)
- 	*/
+	 * Get InterRegionRememberedSet. InterRegionRememberedSet exposed only if tgc.
+	 * TODO: Try fetching it through cycleState (currently not doable, due to relative order of reportGCStart and cycleState initialization)
+	 */
 	MM_InterRegionRememberedSet *getInterRegionRememberedSet() { return _interRegionRememberedSet; }
 
 	/**
@@ -408,7 +407,7 @@ public:
 	 * @param env[in] the current thread
 	 */
 	virtual void preMainGCThreadInitialize(MM_EnvironmentBase *env);
-	
+
 	virtual MM_ConcurrentPhaseStatsBase *getConcurrentPhaseStats() { return &_concurrentPhaseStats; }
 
 	MMINLINE UDATA getCurrentEdenSizeInBytes(MM_EnvironmentVLHGC *env)
@@ -486,7 +485,7 @@ private:
 	 * @param packets[in] The packets structure to verify is empty
 	 */
 	void assertWorkPacketsEmpty(MM_EnvironmentVLHGC *env, MM_WorkPacketsVLHGC *packets);
-	
+
 	/**
 	 * Tests that all marked objects in the given mark map have the following properties:
 	 * 1)  refer only to other marked objects
@@ -554,7 +553,7 @@ private:
 	 * @param env[in] The main GC thread
 	 */
 	void triggerGlobalGCEndHook(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Report the start of a copy forward operation.
 	 * @param env a GC thread.

--- a/runtime/gc_vlhgc/MarkMapManager.hpp
+++ b/runtime/gc_vlhgc/MarkMapManager.hpp
@@ -62,9 +62,9 @@ public:
 	void kill(MM_EnvironmentVLHGC *env);
 
 	/**
- 	 * Perform any initialization required by the delegate once the VM is up and ready to start.
- 	 * @return TRUE if startup completes OK, FALSE otherwise 
- 	 */
+	 * Perform any initialization required by the delegate once the VM is up and ready to start.
+	 * @return TRUE if startup completes OK, FALSE otherwise
+	 */
 	bool collectorStartup(MM_GCExtensions *extensions);
 
 	/**
@@ -106,7 +106,7 @@ public:
 	MM_MarkMap *getPartialGCMap() {
 		return _previousMarkMap;
 	}
-	
+
 	/**
 	 * Swaps the _inProgressMarkMap and the _completeMarkMap.  Called at the end of a GMP when it has completed a new map.
 	 */

--- a/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.hpp
+++ b/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.hpp
@@ -1,4 +1,3 @@
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -67,11 +66,11 @@ protected:
 
 public:
 	virtual UDATA getVMStateID() { return OMRVMSTATE_GC_SWEEP; };
-	
+
 	virtual void run(MM_EnvironmentBase *env);
 	virtual void setup(MM_EnvironmentBase *env);
 	virtual void cleanup(MM_EnvironmentBase *env);
-	
+
 	void mainSetup(MM_EnvironmentBase *env);
 	void mainCleanup(MM_EnvironmentBase *env);
 
@@ -103,7 +102,7 @@ class MM_ParallelSweepSchemeVLHGC : public MM_BaseVirtual
  * Data members
  */
 private:
-	UDATA _chunksPrepared; 
+	UDATA _chunksPrepared;
 	MM_GCExtensions *_extensions;
 	MM_ParallelDispatcher *_dispatcher;
 	MM_CycleState _cycleState;  /**< Current cycle state information used to formulate receiver state for any operations  */
@@ -114,19 +113,19 @@ private:
 
 	MM_SweepHeapSectioning *_sweepHeapSectioning;	/**< pointer to Sweep Heap Sectioning */
 
-	J9Pool *_poolSweepPoolState;				/**< Memory pools for SweepPoolState*/ 
+	J9Pool *_poolSweepPoolState;				/**< Memory pools for SweepPoolState*/
 	omrthread_monitor_t _mutexSweepPoolState;	/**< Monitor to protect memory pool operations for sweepPoolState*/
 	bool _noCompactionAfterSweep;	/**< if true, no compaction would be expected after current sweep */
-	
+
 protected:
 public:
-	
+
 /*
  * Function members
  */
 private:
 protected:
-	
+
 	virtual bool initialize(MM_EnvironmentVLHGC *env);
 	virtual void tearDown(MM_EnvironmentVLHGC *env);
 
@@ -145,27 +144,27 @@ protected:
 	 * Leading dark matter (before the first marked object) is not included.
 	 * Trailing dark matter (after the last marked object) is included, even if it falls outside of the
 	 * mark map range.
-	 * 
+	 *
 	 * For each heap visit, collect information whether the object is scannable.
 	 *
 	 * @param sweepChunk[in] the sweepChunk to be measured
-	 * @param markMapCurrent[in] the address of the mark map word to be measured 
+	 * @param markMapCurrent[in] the address of the mark map word to be measured
 	 * @param heapSlotFreeCurrent[in] the first slot in the section of heap to be measured
-	 * 
-	 * @return the dark matter, measured in bytes, in the range 
+	 *
+	 * @return the dark matter, measured in bytes, in the range
 	 */
 	UDATA performSamplingCalculations(MM_ParallelSweepChunk *sweepChunk, UDATA* markMapCurrent, UDATA* heapSlotFreeCurrent);
 
 	/**
 	 * Accurately measure the dark matter within the specified sweepChunk.
 	 *
-	 * @param env[in] the current thread 
+	 * @param env[in] the current thread
 	 * @param sweepChunk[in] the sweepChunk to be measured
-	 * 
-	 * @return the dark matter, measured in bytes, in the chunk 
+	 *
+	 * @return the dark matter, measured in bytes, in the chunk
 	 */
 	UDATA measureAllDarkMatter(MM_EnvironmentVLHGC *env, MM_ParallelSweepChunk *sweepChunk);
-	
+
 	virtual void connectChunk(MM_EnvironmentVLHGC *env, MM_ParallelSweepChunk *chunk);
 	void connectAllChunks(MM_EnvironmentVLHGC *env, UDATA totalChunkCount);
 
@@ -183,7 +182,7 @@ protected:
 	MMINLINE MM_Heap *getHeap() { return _extensions->heap; };
 
 	void internalSweep(MM_EnvironmentVLHGC *env);
-	
+
 	virtual void setupForSweep(MM_EnvironmentVLHGC *env);
 
 	void recycleFreeRegions(MM_EnvironmentVLHGC *env);
@@ -194,20 +193,20 @@ protected:
 	void updateProjectedLiveBytesAfterSweep(MM_EnvironmentVLHGC *env);
 
 public:
-	static MM_ParallelSweepSchemeVLHGC *newInstance(MM_EnvironmentVLHGC *env); 
+	static MM_ParallelSweepSchemeVLHGC *newInstance(MM_EnvironmentVLHGC *env);
 	virtual void kill(MM_EnvironmentVLHGC *env);
-	
+
 	/**
- 	* Request to create sweepPoolState class for pool
- 	* @param  memoryPool memory pool to attach sweep state to
- 	* @return pointer to created class
- 	*/
+	 * Request to create sweepPoolState class for pool
+	 * @param  memoryPool memory pool to attach sweep state to
+	 * @return pointer to created class
+	 */
 	virtual void *createSweepPoolState(MM_EnvironmentBase *env, MM_MemoryPool *memoryPool);
 
 	/**
- 	* Request to destroy sweepPoolState class for pool
- 	* @param  sweepPoolState class to destroy
- 	*/
+	 * Request to destroy sweepPoolState class for pool
+	 * @param  sweepPoolState class to destroy
+	 */
 	virtual void deleteSweepPoolState(MM_EnvironmentBase *env, void *sweepPoolState);
 
 	virtual void sweep(MM_EnvironmentVLHGC *env);
@@ -238,7 +237,7 @@ public:
 	 * Called after the heap geometry changes to allow any data structures dependent on this to be updated.
 	 * This call could be triggered by memory ranges being added to or removed from the heap or memory being
 	 * moved from one subspace to another.
-	 * @param env[in] The thread which performed the change in heap geometry 
+	 * @param env[in] The thread which performed the change in heap geometry
 	 */
 	void heapReconfigured(MM_EnvironmentVLHGC *env);
 

--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -107,7 +107,7 @@ private:
 		uintptr_t historicalBytesScanned;		/**< Historical number of bytes scanned for mark operations */
 		uint64_t historicalScanMicroseconds;	/**< Historical scan times for mark operations */
 		double microSecondsPerByteScanned; /**< The average scan rate, measured in microseconds per byte */
-		
+
 		MM_SchedulingDelegate_ScanRateStats() :
 			historicalBytesScanned(0),
 			historicalScanMicroseconds(0),
@@ -120,10 +120,10 @@ private:
 
 protected:
 public:
-	
+
 	/* Member Functions */
-	
-	
+
+
 	/* Add up macro defragmentation work for this region for total work accumulated during this PGC, as we find out
 	 * that the region is retired and its RSCL is still valid.
 	 * The work is the min of two: free spece (used as dest region) or occupied space (used as source).
@@ -142,8 +142,8 @@ public:
 private:
 	/**
 	 * Internal helper for determining the next taxation threshold. This does all
-	 * of the work, except that it does not honour the GMP intermission. 
-	 * getNextTaxationThreshold calls this in a loop until the intermission has 
+	 * of the work, except that it does not honour the GMP intermission.
+	 * getNextTaxationThreshold calls this in a loop until the intermission has
 	 * been consumed.
 	 */
 	uintptr_t getNextTaxationThresholdInternal(MM_EnvironmentVLHGC *env);
@@ -206,13 +206,13 @@ private:
 	double predictPgcTime(MM_EnvironmentVLHGC *env, uintptr_t currentEdenSize, intptr_t edenSizeChange);
 
 	/**
-	 * @return The estimated number of bytes which we have remaining to scan for the current GMP cycle.  
+	 * @return The estimated number of bytes which we have remaining to scan for the current GMP cycle.
 	 * If there is not currently a GMP running, returns calculateEstimatedGlobalBytesToScan()
 	 */
 	uintptr_t estimateRemainingGlobalBytesToScan() const;
 
 	/**
-	 * @return The estimated amount of time (wall-clock time in millis) we need to spend scanning to finish the current GMP.  
+	 * @return The estimated amount of time (wall-clock time in millis) we need to spend scanning to finish the current GMP.
 	 * If there is no GMP currently running, returns the estimated amount of time we'd need to scan
 	 * to finish a GMP.
 	 */
@@ -227,23 +227,23 @@ private:
 	 * @return the estimated number of increments required
 	 */
 	uintptr_t estimateGlobalMarkIncrements(MM_EnvironmentVLHGC *env, double liveSetAdjustedForScannableBytesRatio) const;
-	
+
 	/**
 	 * Monitor influx of regions into the oldest age group,
 	 * measure their occupancy and estimate how much extra compact work
 	 * has to be done do defragment those regions.
- 	 * @param env[in] the current thread
+	 * @param env[in] the current thread
 	 */
 	void estimateMacroDefragmentationWork(MM_EnvironmentVLHGC *env);
 
 	/**
-	 * Using the region reclaimability and consumption data collected after the most recent PGC, 
-	 * estimate the number of PGCs remaining until allocation failure will occur. 
+	 * Using the region reclaimability and consumption data collected after the most recent PGC,
+	 * estimate the number of PGCs remaining until allocation failure will occur.
 	 * @param env[in] The main GC thread
 	 * @return the estimated number of PGCs remaining before AF (anything from 0 to UDATA_MAX)
 	 */
 	uintptr_t estimatePartialGCsRemaining(MM_EnvironmentVLHGC *env) const;
-	
+
 	/**
 	 * Called after a PGC has been completed in order to measure the region consumption and update
 	 * the consumption rate.
@@ -252,7 +252,7 @@ private:
 	 * @param defragmentReclaimableRegions he estimated number of reclaimable defragment regions
 	 */
 	void measureConsumptionForPartialGC(MM_EnvironmentVLHGC *env, uintptr_t currentReclaimableRegions, uintptr_t defragmentReclaimableRegions);
-	
+
 	/**
 	 * Called after marking to update statistics related to the scan rate. This data is used
 	 * to estimate how long a GMP will take.
@@ -260,17 +260,17 @@ private:
 	 * @param env[in] the main GC thread
 	 */
 	void measureScanRate(MM_EnvironmentVLHGC *env, double historicWeight);
-	
+
 	/**
 	 * Recalculate the intermission until kick-off based on current estimates, if automatic
 	 * intermissions are enabled. Store the result in _remainingGMPIntermissionIntervals.
 	 * @param env[in] the main GC thread
 	 */
 	void calculateAutomaticGMPIntermission(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Following a GC, recalculate the Eden size for the next PGC.
-	 * This is typically the same as GCExtensions->tarokeEdenSize, but may be smaller if 
+	 * This is typically the same as GCExtensions->tarokeEdenSize, but may be smaller if
 	 * insufficient memory is available
 	 * @param env[in] the main GC thread
 	 */
@@ -398,7 +398,7 @@ private:
 	uintptr_t calculateKickoffHeadroom(MM_EnvironmentVLHGC *env, uintptr_t totalFreeMemory);
 
 protected:
-	
+
 public:
 	/**
 	 * Initialize the receiver.
@@ -424,13 +424,13 @@ public:
 
 	/**
 	 * Determine what work should be performed during the current increment.
-	 * 
+	 *
 	 * @param env[in] the main GC thread
 	 * @param doPartialGarbageCollection[out] set to true if a PGC should be performed, false otherwise
 	 * @param doGlobalMarkPhase[out] set to true if a GMP increment should be performed, false otherwise
 	 */
 	void getIncrementWork(MM_EnvironmentVLHGC *env, bool* doPartialGarbageCollection, bool* doGlobalMarkPhase);
-	
+
 	/**
 	 * Return region consumption rate.
 	 */
@@ -445,7 +445,7 @@ public:
 
 	/**
 	 * Returns the average copy forward rate.  Disregards time spent related to RSCL clearing. Measured in bytes/microseconds
-	 * 
+	 *
 	 * @return the average copy forward rate.
 	 */
 	double getAverageCopyForwardRate() { return _averageCopyForwardRate; }
@@ -454,9 +454,9 @@ public:
 	 * Returns the scan time cost (in microseconds) we attribute to performing a GMP.  Attempts to
 	 * factor in stop-the-world global mark increment time as well as any concurrent global marking which
 	 * slows down the mutator.
-	 * 
-	 * @return the scan time cost (in microseconds) we attribute to performing a GMP.  
-	 * 
+	 *
+	 * @return the scan time cost (in microseconds) we attribute to performing a GMP.
+	 *
 	 */
 	uint64_t getScanTimeCostPerGMP(MM_EnvironmentVLHGC *env);
 
@@ -498,7 +498,7 @@ public:
 	 * Calculate how much of live-set-data-after-PGC increase is real and how much of it garbage
 	 */
 	void calculateHeapOccupancyTrend(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * recalculate PGCCompactionRate, HeapOccupancyTrend, ScannableBytesRatio at the end of First PGC After GMP
 	 * it should be called before estimating defragmentReclaimableRegions in order to calculate GMPIntermission more accurate.
@@ -572,7 +572,7 @@ public:
 	 * @param env[in] the main GC thread
 	 */
 	void globalMarkPhaseCompleted(MM_EnvironmentVLHGC *env);
-	
+
 	/**
 	 * Inform the receiver that an increment in the Global Mark Phase, or the mark portion of a global collect, has completed
 	 * @param env[in] the main GC thread
@@ -586,7 +586,7 @@ public:
 	 * @param defragmentReclaimableRegions[in] an estimate of the reclaimable defragment memory
 	 */
 	void globalGarbageCollectCompleted(MM_EnvironmentVLHGC *env, uintptr_t reclaimableRegions, uintptr_t defragmentReclaimableRegions);
-	
+
 	/**
 	 * Inform the receiver that a Partial GC has started.
 	 * @param env[in] the main GC thread
@@ -658,11 +658,10 @@ public:
 	 * Adjust internal structures to reflect the change in heap size.
 	 */
 	void heapReconfigured(MM_EnvironmentVLHGC *env);
-	
+
 	double getAvgEdenSurvivalRateCopyForward(MM_EnvironmentVLHGC *env) { return _edenSurvivalRateCopyForward; }
 
 	MM_SchedulingDelegate(MM_EnvironmentVLHGC *env, MM_HeapRegionManager *manager);
 };
-
 
 #endif /* THRESHOLDDELEGATE_HPP_ */

--- a/runtime/oti/j9port.h
+++ b/runtime/oti/j9port.h
@@ -255,13 +255,13 @@ typedef struct J9ControlFileStatus {
  * This structure must be initialized using @ref j9shsem_params_init
  */
 typedef struct  J9PortShSemParameters {
- 	const char *semName; /* Unique identifier of the semaphore. */
- 	uint32_t setSize; /* number of semaphores to be created in this set */
- 	uint32_t permission; /* Posix-style file permissions */
- 	const char* controlFileDir; /* Directory in which to create control files (SysV semaphores only) */
- 	uint8_t proj_id; /* parameter used with semName to generate semaphore key */
- 	uint32_t deleteBasefile : 1; /* delete the base file (used to generate the semaphore key) when destroying the semaphore */
- 	uint32_t global : 1; /* Windows only: use the global namespace for the sempahore */
+	const char *semName; /* Unique identifier of the semaphore. */
+	uint32_t setSize; /* number of semaphores to be created in this set */
+	uint32_t permission; /* Posix-style file permissions */
+	const char* controlFileDir; /* Directory in which to create control files (SysV semaphores only) */
+	uint8_t proj_id; /* parameter used with semName to generate semaphore key */
+	uint32_t deleteBasefile : 1; /* delete the base file (used to generate the semaphore key) when destroying the semaphore */
+	uint32_t global : 1; /* Windows only: use the global namespace for the sempahore */
 } J9PortShSemParameters;
 /**
  * @name Process Handle
@@ -270,7 +270,6 @@ typedef struct  J9PortShSemParameters {
  * J9ProcessHandle represents a J9Port Library process.
  */
 typedef struct J9ProcessHandleStruct *J9ProcessHandle;
-
 
 /**
  * @name Process Streams

--- a/runtime/port/sysvipc/j9shsem.h
+++ b/runtime/port/sysvipc/j9shsem.h
@@ -45,7 +45,7 @@ typedef struct j9shsem_handle {
 	int32_t nsems;
 	char* baseFile;
 	int64_t timestamp;
- 	uint32_t deleteBasefile : 1; /* delete the base file (used to generate the semaphore key) when destroying the semaphore */
+	uint32_t deleteBasefile : 1; /* delete the base file (used to generate the semaphore key) when destroying the semaphore */
 	/* int32_t baseFilefd deleted: it is never assigned or used. */
 } j9shsem_handle;
 
@@ -60,5 +60,3 @@ typedef struct j9shsem_handle {
 #endif
 
 #endif     /* j9shsem_h */
-
-

--- a/runtime/shared_common/CacheMap.hpp
+++ b/runtime/shared_common/CacheMap.hpp
@@ -72,7 +72,7 @@ typedef struct CacheAddressRange {
 	void* cacheEnd;
 } CacheAddressRange;
 
-/* 
+/*
  * Implementation of SH_SharedCache interface
  */
 class SH_CacheMap : public SH_SharedCache, public SH_CacheMapStats
@@ -116,9 +116,9 @@ public:
 	virtual const U_8* storeSharedData(J9VMThread* currentThread, const char* key, UDATA keylen, const J9SharedDataDescriptor* data);
 
 	/* @see SharedCache.hpp */
-		virtual const U_8* findAttachedDataAPI(J9VMThread* currentThread, const void* addressInCache, J9SharedDataDescriptor* data, IDATA *corruptOffset) ;
+	virtual const U_8* findAttachedDataAPI(J9VMThread* currentThread, const void* addressInCache, J9SharedDataDescriptor* data, IDATA *corruptOffset) ;
 
- 	/* @see SharedCache.hpp */
+	/* @see SharedCache.hpp */
 	virtual UDATA storeAttachedData(J9VMThread* currentThread, const void* addressInCache, const J9SharedDataDescriptor* data, UDATA forceReplace) ;
 
 	/* @see SharedCache.hpp */
@@ -180,7 +180,7 @@ public:
 
 	/* @see SharedCache.hpp */
 	virtual void printShutdownStats(void);
-	
+
 	/* @see SharedCache.hpp */
 	virtual void runExitCode(J9VMThread* currentThread);
 
@@ -198,7 +198,7 @@ public:
 
 	/* @see SharedCache.hpp */
 	virtual void notifyClasspathEntryStateChange(J9VMThread* currentThread, const char* path, UDATA newState);
-	
+
 	static IDATA createPathString(J9VMThread* currentThread, J9SharedClassConfig* config, char** pathBuf, UDATA pathBufSize, ClasspathEntryItem* cpei, const char* className, UDATA classNameLen, bool* doFreeBuffer);
 
 	/* @see SharedCache.hpp */
@@ -218,13 +218,12 @@ public:
 
 	/* @see CacheMapStats.hpp */
 	IDATA shutdownForStats(J9VMThread* currentThread);
-	
+
 	/* @see CacheMapStats.hpp */
 	void* getAddressFromJ9ShrOffset(const J9ShrOffset* offset);
-	
+
 	/* @see CacheMapStats.hpp */
 	U_8* getDataFromByteDataWrapper(const ByteDataWrapper* bdw);
-
 
 	//New Functions To Support New ROM Class Builder
 	IDATA startClassTransaction(J9VMThread* currentThread, bool lockCache, const char* caller);
@@ -250,15 +249,15 @@ public:
 	UDATA getReadWriteBytes(void);
 
 	UDATA getStringTableBytes(void);
-	
+
 	void* getStringTableBase(void);
 
 	void setStringTableInitialized(bool);
-	
+
 	bool isStringTableInitialized(void);
-	
+
 	BOOLEAN isAddressInCacheDebugArea(void *address, UDATA length);
-	
+
 	U_32 getDebugBytes(void);
 
 	bool isCacheInitComplete(void);
@@ -278,26 +277,26 @@ public:
 	void increaseUnstoredBytes(U_32 blockBytes, U_32 aotBytes = 0, U_32 jitBytes = 0);
 
 	void getUnstoredBytes(U_32 *softmxUnstoredBytes, U_32 *maxAOTUnstoredBytes, U_32 *maxJITUnstoredBytes) const;
-	
+
 	bool isAddressInCache(const void *address, UDATA length, bool includeHeaderReadWriteArea, bool useCcHeadOnly) const;
 
 	void setExtraStartupHints(J9VMThread* currentThread);
 
 private:
-	SH_CompositeCacheImpl* _cc;					/* current cache */
+	SH_CompositeCacheImpl* _cc; /* current cache */
 
 	/* See other _writeHash fields below. Put U_64 at the top so the debug
 	 * extensions can more easily mirror the shape.
 	 */
 	U_64 _writeHashStartTime;
 	J9SharedClassConfig* _sharedClassConfig;
-	
-	SH_CompositeCacheImpl* _ccHead;				/* head of supercache list */
+
+	SH_CompositeCacheImpl* _ccHead; /* head of supercache list */
 	SH_CompositeCacheImpl* _ccTail;
-		
+
 	CacheAddressRange _cacheAddressRangeArray[J9SH_LAYER_NUM_MAX_VALUE + 1];
 	UDATA _numOfCacheLayers;
-	
+
 	SH_ClasspathManager* _cpm;
 	SH_TimestampManager* _tsm;
 	SH_ROMClassManager* _rcm;
@@ -327,9 +326,9 @@ private:
 	int32_t _metadataReleaseCounter;
 
 	bool _isAssertEnabled; /* flag to turn on/off assertion before acquiring local mutex */
-	
+
 	SH_Managers * _managers;
-	
+
 	void initialize(J9JavaVM* vm, J9SharedClassConfig* sharedClassConfig, BlockPtr memForConstructor, const char* cacheName, I_32 newPersistentCacheReqd, I_8 topLayer, bool startupForStats);
 
 	IDATA readCacheUpdates(J9VMThread* currentThread);
@@ -340,14 +339,14 @@ private:
 
 	ClasspathWrapper* addClasspathToCache(J9VMThread* currentThread, ClasspathItem* obj);
 
-	const J9UTF8* addScopeToCache(J9VMThread* currentThread, const J9UTF8* scope, U_16 type = TYPE_SCOPE); 
+	const J9UTF8* addScopeToCache(J9VMThread* currentThread, const J9UTF8* scope, U_16 type = TYPE_SCOPE);
 
 	const void* addROMClassResourceToCache(J9VMThread* currentThread, const void* romAddress, SH_ROMClassResourceManager* localRRM, SH_ROMClassResourceManager::SH_ResourceDescriptor* resourceDescriptor, const char** p_subcstr);
 
 	BlockPtr addByteDataToCache(J9VMThread* currentThread, SH_Manager* localBDM, const J9UTF8* tokenKeyInCache, const J9SharedDataDescriptor* data, SH_CompositeCacheImpl* forceCache, bool writeWithoutMetadata);
 
 	J9MemorySegment* addNewROMImageSegment(J9VMThread* currentThread, U_8* segmentBase, U_8* segmentEnd);
-	
+
 	J9MemorySegment* createNewSegment(J9VMThread* currentThread, UDATA type, J9MemorySegmentList* segmentList, U_8* baseAddress, U_8* heapBase, U_8* heapTop, U_8* heapAlloc);
 
 	const void* storeROMClassResource(J9VMThread* currentThread, const void* romAddress, SH_ROMClassResourceManager* localRRM, SH_ROMClassResourceManager::SH_ResourceDescriptor* resourceDescriptor, UDATA forceReplace, const char** p_subcstr);
@@ -367,7 +366,7 @@ private:
 	UDATA initializeROMSegmentList(J9VMThread* currentThread);
 
 	IDATA checkForCrash(J9VMThread* currentThread, bool hasClassSegmentMutex, bool canUnlockCache = true);
-	
+
 	void reportCorruptCache(J9VMThread* currentThread, SH_CompositeCacheImpl* _ccToUse);
 
 	void resetCorruptState(J9VMThread* currentThread, UDATA hasRefreshMutex);
@@ -379,18 +378,18 @@ private:
 
 	UDATA sanityWalkROMClassSegment(J9VMThread* currentThread, SH_CompositeCacheImpl* cache);
 
-	void updateBytesRead(UDATA numBytes); 
+	void updateBytesRead(UDATA numBytes);
 
 	const J9UTF8* getCachedUTFString(J9VMThread* currentThread, const char* local, U_16 localLen);
 
 	IDATA printAllCacheStats(J9VMThread* currentThread, UDATA showFlags, SH_CompositeCacheImpl* cache, U_32* staleBytes);
-	
+
 	IDATA resetAllManagers(J9VMThread* currentThread);
-	
+
 	void updateAllManagersWithNewCacheArea(J9VMThread* currentThread, SH_CompositeCacheImpl* newArea);
 
 	void updateAccessedShrCacheMetadataBounds(J9VMThread* currentThread, uintptr_t const  * result);
-	
+
 	bool isAddressInReleasedMetaDataBounds(J9VMThread* currentThread, UDATA address) const;
 
 	SH_CompositeCacheImpl* getCacheAreaForDataType(J9VMThread* currentThread, UDATA dataType, UDATA dataLength);
@@ -404,13 +403,13 @@ private:
 	SH_ByteDataManager* getByteDataManager(J9VMThread* currentThread);
 
 	SH_CompiledMethodManager* getCompiledMethodManager(J9VMThread* currentThread);
-	
+
 	SH_AttachedDataManager* getAttachedDataManager(J9VMThread* currentThread);
 
 	void updateAverageWriteHashTime(UDATA actualTimeMicros);
 
 	J9SharedClassCacheDescriptor* appendCacheDescriptorList(J9VMThread* currentThread, J9SharedClassConfig* sharedClassConfig, SH_CompositeCacheImpl* ccToUse);
-	
+
 	void resetCacheDescriptorList(J9VMThread* currentThread, J9SharedClassConfig* sharedClassConfig);
 
 	const J9ROMClass* allocateROMClassOnly(J9VMThread* currentThread, U_32 sizeToAlloc, U_16 classnameLength, const char* classnameData, ClasspathWrapper* cpw, const J9UTF8* partitionInCache, const J9UTF8* modContextInCache, IDATA callerHelperID, bool modifiedNoContext, void * &newItemInCache, void * &cacheAreaForAllocate);
@@ -426,7 +425,7 @@ private:
 	void tokenStoreStaleCheckAndMark(J9VMThread* currentThread, U_16 classnameLength, const char* classnameData, ClasspathWrapper* cpw, const J9UTF8* partitionInCache, const J9UTF8* modContextInCache, UDATA callerHelperID);
 
 	J9SharedClassConfig* getSharedClassConfig();
-	
+
 	void updateLineNumberContentInfo(J9VMThread* currentThread);
 
 	const IDATA aotMethodOperationHelper(J9VMThread* currentThread, MethodSpecTable* specTable, IDATA numSpecs, UDATA action);
@@ -444,21 +443,20 @@ private:
 	IDATA storeCacheUniqueID(J9VMThread* currentThread, const char* cacheDir, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes, const char** prereqCacheID, UDATA* idLen);
 
 	void handleStartupError(J9VMThread* currentThread, SH_CompositeCacheImpl* ccToUse, IDATA errorCode, U_64 runtimeFlags, UDATA verboseFlags, bool *doRetry, IDATA *deleteRC);
-	
+
 	void setCacheAddressRangeArray(void);
-	
+
 	void getJ9ShrOffsetFromAddress(const void* address, J9ShrOffset* offset);
-	
+
 	UDATA getJavacoreData(J9JavaVM *vm, J9SharedClassJavacoreDataDescriptor* descriptor, bool topLayerOnly);
-	
+
 	void printCacheStatsTopLayerStatsHelper(J9VMThread* currentThread, UDATA showFlags, U_64 runtimeFlags, J9SharedClassJavacoreDataDescriptor *javacoreData, bool multiLayerStats);
-	
+
 	void printCacheStatsTopLayerSummaryStatsHelper(J9VMThread* currentThread, UDATA showFlags, U_64 runtimeFlags, J9SharedClassJavacoreDataDescriptor *javacoreData);
-	
+
 	void printCacheStatsAllLayersStatsHelper(J9VMThread* currentThread, UDATA showFlags, U_64 runtimeFlags, J9SharedClassJavacoreDataDescriptor *javacoreData, U_32 staleBytes);
 
 	IDATA startupLowerLayerForStats(J9VMThread* currentThread, const char* ctrlDirName, UDATA groupPerm, SH_OSCache *oscache, J9Pool** lowerLayerList);
 };
 
 #endif /* !defined(CACHEMAP_H_INCLUDED) */
-

--- a/runtime/shared_common/OSCache.hpp
+++ b/runtime/shared_common/OSCache.hpp
@@ -35,7 +35,7 @@
 #define J9SH_OSCACHE_OPEXIST_DO_NOT_CREATE	0x8
 #define J9SH_OSCACHE_UNKNOWN (~(UDATA)0)
 
-/* 
+/*
  * The different results from attempting to open/create a cache are
  * defined below. Failure cases MUST all be less than zero.
  */
@@ -115,7 +115,7 @@ typedef struct SH_OSCache_Info {
 } SH_OSCache_Info;
 
 /* DO NOT use UDATA/IDATA in the cache headers so that 32-bit/64-bit JVMs can read each others headers
- * 
+ *
  * Versioning is achieved by using the typedef aliases below
  */
 
@@ -163,7 +163,7 @@ typedef struct LastErrorInfo {
 
 /**
  * A class to manage Shared Classes on Operating System level
- * 
+ *
  * This class provides and abstraction of a shared memory region and its control
  * mutex.
  *
@@ -176,7 +176,7 @@ public:
 		public:
 		virtual void init(char* data, U_32 len, I_32 minAOT, I_32 maxAOT, I_32 minJIT, I_32 maxJIT, U_32 readWriteLen, U_32 softMaxBytes) = 0;
 	};
-  
+
 	/**
 	 * Override new operator
 	 * @param [in] size  The size of the object
@@ -189,9 +189,9 @@ public:
 	static SH_OSCache* newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor, const char* cacheName, UDATA generation, J9PortShcVersion* versionData, I_8 layer);
 
 	static UDATA getRequiredConstrBytes(void);
-	
+
 	static IDATA getCacheDir(J9JavaVM* vm, const char* ctrlDirName, char* buffer, UDATA bufferSize, U_32 cacheType, bool allowVerbose = true);
-	
+
 	static IDATA createCacheDir(J9PortLibrary* portLibrary, char* cacheDirName, UDATA cacheDirPerm, bool cleanMemorySegments);
 
 	static void getCacheVersionAndGen(J9PortLibrary* portlib, J9JavaVM* vm, char* buffer, UDATA bufferSize, const char* cacheName,
@@ -204,23 +204,23 @@ public:
 	static J9Pool* getAllCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, bool includeOldGenerations, bool ignoreCompatible, UDATA reason, bool isCache);
 
 	static IDATA getCacheStatistics(J9JavaVM* vm, const char* ctrlDirName, const char* cacheNameWithVGen, UDATA groupPerm, UDATA localVerboseFlags, UDATA j2seVersion, SH_OSCache_Info* result, UDATA reason, bool getLowerLayerStats, bool isTopLayer, J9Pool** lowerLayerList, SH_OSCache* oscache);
-	
+
 	static bool isTopLayerCache(J9JavaVM* vm, const char* ctrlDirName, char* nameWithVGen);
-	
+
 	static IDATA getCachePathName(J9PortLibrary* portLibrary, const char* cacheDirName, char* buffer, UDATA bufferSize, const char* cacheNameWithVGen);
-	
+
 	static void getCacheNameAndLayerFromUnqiueID(J9JavaVM* vm, const char* uniqueID, UDATA idLen, char* nameBuf, UDATA nameBuffLen, I_8* layer);
-	
+
 	static UDATA generateCacheUniqueID(J9VMThread* currentThread, const char* cacheDir, const char* cacheName, I_8 layer, U_32 cacheType, char* buf, UDATA bufLen, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes);
-	
+
 	const char* getCacheUniqueID(J9VMThread* currentThread, U_64 createtime, UDATA metadataBytes, UDATA classesBytes, UDATA lineNumTabBytes, UDATA varTabBytes);
 
 	I_8 getLayer();
-	
+
 	const char* getCacheNameWithVGen();
 
 	bool isRunningReadOnly();
-	
+
 	U_32 getCacheType();
 
 	virtual bool startup(J9JavaVM* vm, const char* cacheDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig_, IDATA numLocks,
@@ -235,21 +235,21 @@ public:
 	virtual IDATA acquireWriteLock(UDATA lockid) = 0;
 	virtual IDATA releaseWriteLock(UDATA lockid) = 0;
 	virtual U_64 getCreateTime(void) = 0;
-  	
+
 	virtual void *attach(J9VMThread* currentThread, J9PortShcVersion* expectedVersionData) = 0;
 
 #if defined(J9VM_OPT_SHR_MSYNC_SUPPORT)
 	virtual IDATA syncUpdates(void* start, UDATA length, U_32 flags) = 0;
 #endif /* defined(J9VM_OPT_SHR_MSYNC_SUPPORT) */
-	
+
 	virtual IDATA getError(void) = 0;
-	
+
 	virtual void runExitCode(void) = 0;
-	
+
 	virtual IDATA getLockCapabilities(void) = 0;
-	
+
 	virtual IDATA setRegionPermissions(struct J9PortLibrary* portLibrary, void *address, UDATA length, UDATA flags) = 0;
-	
+
 	virtual UDATA getPermissionsRegionGranularity(struct J9PortLibrary* portLibrary) = 0;
 
 	virtual U_32 getDataSize();
@@ -265,14 +265,14 @@ public:
 	virtual void getCorruptionContext(IDATA *corruptionCode, UDATA *corruptValue);
 
 	virtual void setCorruptionContext(IDATA corruptionCode, UDATA corruptValue);
-	
+
 	virtual SH_CacheAccess isCacheAccessible(void) const { return J9SH_CACHE_ACCESS_ALLOWED; }
 
 	virtual void  dontNeedMetadata(J9VMThread* currentThread, const void* startAddress, size_t length);
-	
+
 	virtual IDATA detach(void) = 0;
 
-protected:	
+protected:
 	/*This constructor should only be used by this class*/
 	SH_OSCache() {};
 
@@ -281,23 +281,23 @@ protected:
 	virtual void errorHandler(U_32 moduleName, U_32 id, LastErrorInfo *lastErrorInfo) = 0;
 
 	static IDATA removeCacheVersionAndGen(char* buffer, UDATA bufferSize, UDATA versionLen, const char* cacheNameWithVGen);
-	
+
 	IDATA commonStartup(J9JavaVM* vm, const char* ctrlDirName, UDATA cacheDirPerm, const char* cacheName, J9SharedClassPreinitConfig* piconfig_, UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData);
 
 	void commonInit(J9PortLibrary* portLibrary, UDATA generation, I_8 layer = 0);
 
 	void commonCleanup();
-	
+
 	void initOSCacheHeader(OSCache_header_version_current* header, J9PortShcVersion* versionData, UDATA headerLen);
-	
+
 	IDATA checkOSCacheHeader(OSCache_header_version_current* header, J9PortShcVersion* versionData, UDATA headerLen);
 
 	static void* getHeaderFieldAddressForGen(void* header, UDATA headerGen, UDATA fieldID);
 
 	static IDATA getHeaderFieldOffsetForGen(UDATA headerGen, UDATA fieldID);
-	
+
 	static UDATA getGenerationFromName(const char* cacheNameWithVGen);
-	
+
 	static U_64 getCacheVersionToU64(U_32 major, U_32 minor);
 
 	static bool getCacheStatsCommon(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, SH_OSCache *cache, SH_OSCache_Info *cacheInfo, J9Pool **lowerLayerList);
@@ -320,7 +320,7 @@ protected:
 	UDATA _createFlags;
 	UDATA _verboseFlags;
 	IDATA _errorCode;
-	const J9SharedClassPreinitConfig* _config;	
+	const J9SharedClassPreinitConfig* _config;
 	I_32 _openMode;
 	bool _runningReadOnly;
 	J9PortLibrary* _portLibrary;
@@ -330,7 +330,7 @@ protected:
 	IDATA _corruptionCode;
 	UDATA _corruptValue;
 	bool _isUserSpecifiedCacheDir;
-	
+
 private:
 	void setEnableVerbose(J9PortLibrary* portLib, J9JavaVM* vm, J9PortShcVersion* versionData, char* cacheNameWithVGen);
 

--- a/runtime/shared_common/OSCachemmap.hpp
+++ b/runtime/shared_common/OSCachemmap.hpp
@@ -33,16 +33,16 @@
 
 /**
  * A class to manage Shared Classes on Operating System level
- * 
+ *
  * This class provides an abstraction of a shared memory mapped file
  */
 class SH_OSCachemmap : public SH_OSCacheFile
 {
 public:
 	static IDATA getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char *cacheNameWithVGen, SH_OSCache_Info *cacheInfo, UDATA reason, J9Pool** lowerLayerList);
-	
+
 	static IDATA getNonTopLayerCacheInfo(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char *cacheNameWithVGen, SH_OSCache_Info *cacheInfo, UDATA reason, SH_OSCachemmap* oscache);
-	  
+
 	SH_OSCachemmap(J9PortLibrary* portlib, J9JavaVM* vm, const char* cacheDirName, const char* cacheName, J9SharedClassPreinitConfig* piconfig, IDATA numLocks,
 			UDATA createFlag, UDATA verboseFlags, U_64 runtimeFlags, I_32 openMode, J9PortShcVersion* versionData, SH_OSCacheInitializer* initializer);
 	/*This constructor should only be used by this class or its parent*/
@@ -63,29 +63,29 @@ public:
 	virtual IDATA destroy(bool suppressVerbose, bool isReset = false);
 
 	virtual void cleanup();
-	
+
 	virtual void* attach(J9VMThread *currentThread, J9PortShcVersion* expectedVersionData);
 
 	virtual IDATA detach(void);
-	
+
 #if defined(J9VM_OPT_SHR_MSYNC_SUPPORT)
 	virtual IDATA syncUpdates(void* start, UDATA length, U_32 flags);
 #endif /* defined(J9VM_OPT_SHR_MSYNC_SUPPORT) */
-	
+
 	virtual IDATA getWriteLockID(void);
 	virtual IDATA getReadWriteLockID(void);
 	virtual IDATA acquireWriteLock(UDATA lockID);
 	virtual IDATA releaseWriteLock(UDATA lockID);
 	virtual U_64 getCreateTime(void);
-  	
+
 	virtual void runExitCode();
-	
+
 	virtual IDATA getLockCapabilities();
-	
+
 	virtual void initialize(J9PortLibrary* portLibrary, char* memForConstructor, UDATA generation, I_8 layer);
-	
+
 	virtual IDATA setRegionPermissions(J9PortLibrary* portLibrary, void *address, UDATA length, UDATA flags);
-	
+
 	virtual UDATA getPermissionsRegionGranularity(J9PortLibrary* portLibrary);
 
 	virtual U_32 getTotalSize();
@@ -101,11 +101,11 @@ protected:
 private:
 	I_64 _actualFileLength;
 	J9MmapHandle *_mapFileHandle;
-	
+
 	UDATA _finalised;
-	
+
 	omrthread_monitor_t _lockMutex[J9SH_OSCACHE_MMAP_LOCK_COUNT];
-	
+
 	SH_CacheFileAccess _cacheFileAccess;
 
 	IDATA acquireAttachReadLock(UDATA generation, LastErrorInfo *lastErrorInfo);
@@ -113,15 +113,15 @@ private:
 
 	IDATA internalAttach(bool isNewCache, UDATA generation);
 	void internalDetach(UDATA generation);
-	
+
 	I_32 updateLastAttachedTime(OSCachemmap_header_version_current *cacheHeader);
 	I_32 updateLastDetachedTime();
 	I_32 createCacheHeader(OSCachemmap_header_version_current *cacheHeader, J9PortShcVersion* versionData);
 	bool setCacheLength(U_32 cacheSize, LastErrorInfo *lastErrorInfo);
 	I_32 initializeDataHeader(SH_OSCacheInitializer *initializer);
-	
+
 	bool deleteCacheFile(LastErrorInfo *lastErrorInfo);
-	
+
 	void finalise();
 };
 

--- a/runtime/shared_common/OSCachesysv.hpp
+++ b/runtime/shared_common/OSCachesysv.hpp
@@ -29,8 +29,8 @@
 #include "pool_api.h"
 
 /* DO NOT use UDATA/IDATA in the cache headers so that 32-bit/64-bit JVMs can read each others headers
- * This is why OSCache_sysv_header3 was added.  
- * 
+ * This is why OSCache_sysv_header3 was added.
+ *
  * Versioning is achieved by using the typedef aliases below
  */
 
@@ -96,7 +96,7 @@ typedef enum SH_SysvShmAccess {
 
 /**
  * A class to manage Shared Classes on Operating System level
- * 
+ *
  * This class provides and abstraction of a shared memory region and its control
  * mutex.
  *
@@ -122,7 +122,7 @@ public:
 	static SH_OSCache* newInstance(J9PortLibrary* portlib, SH_OSCache* memForConstructor);
 
 	static UDATA getRequiredConstrBytes(void);
-	
+
 	IDATA destroy(bool suppressVerbose, bool isReset = false);
 
 	void cleanup(void);
@@ -132,27 +132,27 @@ public:
 	IDATA acquireWriteLock(UDATA lockID);
 	IDATA releaseWriteLock(UDATA lockID);
 	U_64 getCreateTime(void);
-  	
+
 	static IDATA getCacheStats(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char* cacheNameWithVGen, SH_OSCache_Info* cacheInfo, UDATA reason, J9Pool** lowerLayerList);
-	
+
 	static IDATA getNonTopLayerCacheInfo(J9JavaVM* vm, const char* ctrlDirName, UDATA groupPerm, const char *cacheNameWithVGen, SH_OSCache_Info *cacheInfo, UDATA reason, SH_OSCachesysv* oscache);
-	
+
 	void *attach(J9VMThread *currentThread, J9PortShcVersion* expectedVersionData);
-	
+
 	virtual IDATA detach(void);
-	
+
 #if defined(J9VM_OPT_SHR_MSYNC_SUPPORT)
-	IDATA syncUpdates(void* start, UDATA length, U_32 flags); 
+	IDATA syncUpdates(void* start, UDATA length, U_32 flags);
 #endif /* defined(J9VM_OPT_SHR_MSYNC_SUPPORT) */
-	
+
 	IDATA getError(void);
-	
+
 	void runExitCode(void);
-	
+
 	IDATA getLockCapabilities(void);
-	
+
 	IDATA setRegionPermissions(struct J9PortLibrary* portLibrary, void *address, UDATA length, UDATA flags);
-	
+
 	UDATA getPermissionsRegionGranularity(struct J9PortLibrary* portLibrary);
 
 	virtual U_32 getTotalSize();
@@ -162,9 +162,9 @@ public:
 	static IDATA findAllKnownCaches(struct J9PortLibrary* portlib, UDATA j2seVersion, struct J9Pool* cacheList);
 
 	static UDATA findfirst(struct J9PortLibrary *portLibrary, char *cacheDir, char *resultbuf);
-	
+
 	static I_32 findnext(struct J9PortLibrary *portLibrary, UDATA findHandle, char *resultbuf);
-	
+
 	static void findclose(struct J9PortLibrary *portLibrary, UDATA findhandle);
 
 	static IDATA getSysvHeaderFieldOffsetForGen(UDATA headerGen, UDATA fieldID);
@@ -181,10 +181,10 @@ public:
 	virtual void initialize(J9PortLibrary* portLib_, char* memForConstructor, UDATA generation, I_8 layer);
 
 protected :
-	
+
 	virtual void errorHandler(U_32 moduleName, U_32 id, LastErrorInfo *lastErrorInfo);
 	virtual void * getAttachedMemory();
-  
+
 private:
 	j9shmem_handle* _shmhandle;
 	j9shsem_handle* _semhandle;
@@ -197,7 +197,7 @@ private:
 	char* _shmFileName;
 	char* _semFileName;
 	bool _openSharedMemory;
-	
+
 	UDATA _storageKeyTesting;
 
 	const J9SharedClassPreinitConfig* config;
@@ -236,7 +236,7 @@ private:
 	static void* getSysvHeaderFieldAddressForGen(void* header, UDATA headerGen, UDATA fieldID);
 
 	IDATA getNewWriteLockID(void);
-	
+
 	SH_SysvSemAccess checkSemaphoreAccess(LastErrorInfo *lastErrorInfo);
 	SH_SysvShmAccess checkSharedMemoryAccess(LastErrorInfo *lastErrorInfo);
 
@@ -258,6 +258,3 @@ private:
 };
 
 #endif /* !defined(OSCACHESYSV_HPP_INCLUDED) */
-
-
-

--- a/runtime/vm/OutOfLineINL.hpp
+++ b/runtime/vm/OutOfLineINL.hpp
@@ -97,48 +97,48 @@ public:
 	static VMINLINE UDATA*
 	buildSpecialStackFrame(J9VMThread *currentThread, UDATA type, UDATA flags, bool visible)
 	{
- 		*--currentThread->sp = (UDATA)currentThread->arg0EA | (visible ? 0 : J9SF_A0_INVISIBLE_TAG);
- 		UDATA *bp = currentThread->sp;
- 		*--currentThread->sp = (UDATA)currentThread->pc;
- 		*--currentThread->sp = (UDATA)currentThread->literals;
- 		*--currentThread->sp = (flags);
- 		currentThread->pc = (U_8*)(type);
- 		currentThread->literals = NULL;
- 		return bp;
- 	}
- 	
- 	static VMINLINE UDATA
- 	jitStackFrameFlags(J9VMThread *currentThread, UDATA constantFlags)
- 	{
- 		UDATA flags = currentThread->jitStackFrameFlags;
- 		currentThread->jitStackFrameFlags = 0;
- 		return flags | constantFlags;
- 	}
- 	
- 	static VMINLINE void
- 	restoreSpecialStackFrameLeavingArgs(J9VMThread *currentThread, UDATA *bp)
- 	{
- 		currentThread->sp = bp + 1;
- 		currentThread->literals = (J9Method*)(bp[-2]);
- 		currentThread->pc = (U_8*)(bp[-1]);
- 		currentThread->arg0EA = (UDATA*)(bp[0] & ~(UDATA)J9SF_A0_INVISIBLE_TAG);
- 	}
- 	
- 	static VMINLINE UDATA*
- 	buildInternalNativeStackFrame(J9VMThread *currentThread, J9Method *method)
- 	{
- 		UDATA *bp = buildSpecialStackFrame(currentThread, J9SF_FRAME_TYPE_NATIVE_METHOD, jitStackFrameFlags(currentThread, 0), true);
- 		*--currentThread->sp = (UDATA)method;
- 		currentThread->arg0EA = bp + J9_ROM_METHOD_FROM_RAM_METHOD(method)->argCount;
- 		return bp;
- 	}
- 
- 	static VMINLINE void
- 	restoreInternalNativeStackFrame(J9VMThread *currentThread)
- 	{
- 		J9SFNativeMethodFrame *nativeMethodFrame = (J9SFNativeMethodFrame*)currentThread->sp;
- 		restoreSpecialStackFrameLeavingArgs(currentThread, ((UDATA*)(nativeMethodFrame + 1)) - 1);
- 	}
+		*--currentThread->sp = (UDATA)currentThread->arg0EA | (visible ? 0 : J9SF_A0_INVISIBLE_TAG);
+		UDATA *bp = currentThread->sp;
+		*--currentThread->sp = (UDATA)currentThread->pc;
+		*--currentThread->sp = (UDATA)currentThread->literals;
+		*--currentThread->sp = (flags);
+		currentThread->pc = (U_8*)(type);
+		currentThread->literals = NULL;
+		return bp;
+	}
+
+	static VMINLINE UDATA
+	jitStackFrameFlags(J9VMThread *currentThread, UDATA constantFlags)
+	{
+		UDATA flags = currentThread->jitStackFrameFlags;
+		currentThread->jitStackFrameFlags = 0;
+		return flags | constantFlags;
+	}
+
+	static VMINLINE void
+	restoreSpecialStackFrameLeavingArgs(J9VMThread *currentThread, UDATA *bp)
+	{
+		currentThread->sp = bp + 1;
+		currentThread->literals = (J9Method*)(bp[-2]);
+		currentThread->pc = (U_8*)(bp[-1]);
+		currentThread->arg0EA = (UDATA*)(bp[0] & ~(UDATA)J9SF_A0_INVISIBLE_TAG);
+	}
+
+	static VMINLINE UDATA *
+	buildInternalNativeStackFrame(J9VMThread *currentThread, J9Method *method)
+	{
+		UDATA *bp = buildSpecialStackFrame(currentThread, J9SF_FRAME_TYPE_NATIVE_METHOD, jitStackFrameFlags(currentThread, 0), true);
+		*--currentThread->sp = (UDATA)method;
+		currentThread->arg0EA = bp + J9_ROM_METHOD_FROM_RAM_METHOD(method)->argCount;
+		return bp;
+	}
+
+	static VMINLINE void
+	restoreInternalNativeStackFrame(J9VMThread *currentThread)
+	{
+		J9SFNativeMethodFrame *nativeMethodFrame = (J9SFNativeMethodFrame*)currentThread->sp;
+		restoreSpecialStackFrameLeavingArgs(currentThread, ((UDATA*)(nativeMethodFrame + 1)) - 1);
+	}
 };
 
 #include "objectreferencesmacros_define.inc"


### PR DESCRIPTION
Indentation should be consistent: zero or more tabs, then zero or more spaces, never with a tab following a space.

Trim trailing whitespace.

Fold one overly wide comment.