### PR TITLE
Create -XX:DisclaimDir= command line option

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2917,7 +2917,8 @@ bool J9::Options::fePostProcessJIT(void *base)
 }
 
 // This function returns false if the running enviroment is suitable for
-// memory disclaim (Linux kernel >= 5.4 and default page size == 4KB).
+// memory disclaim (Linux kernel >= 5.4, default page size == 4KB, enough
+// free space on the file-backing media).
 // If the running environment is not suitable, it disables memory disclaim,
 // it issues a message to the verbose log (if enabled) and returns true.
 // The function must be called relatively late, when the cmdLineOptions
@@ -2946,9 +2947,8 @@ bool J9::Options::disableMemoryDisclaimIfNeeded(J9JITConfig *jitConfig)
     }
     if (!shouldDisableMemoryDisclaim) {
         // If the default page size if larger than 4K, the disclaim may not be effective
-        // because touching a page will make a large amount of memory to become resident
-        UDATA *pageSizes
-            = j9vmem_supported_page_sizes(); // // Default page size is always the first element of this array
+        // because touching a page will make a large amount of memory to become resident.
+        UDATA *pageSizes = j9vmem_supported_page_sizes(); // Default page size is always the first element of this array
         if (pageSizes[0] > 4096) {
             shouldDisableMemoryDisclaim = true;
             if (TR::Options::getVerboseOption(TR_VerbosePerformance)) {
@@ -2957,44 +2957,65 @@ bool J9::Options::disableMemoryDisclaimIfNeeded(J9JITConfig *jitConfig)
             }
         }
     }
+
+    // Note: if the user hasn't specified anything, the omr code will
+    // use /tmp as the default destination for disclaim backing-files.
+    const char *userSpecifiedDir = omrvmem_disclaim_dir();
+    const char *disclaimDir = userSpecifiedDir ? userSpecifiedDir : "/tmp";
+
     if (!shouldDisableMemoryDisclaim) {
-        // Check whether disclaiming on swap is possible
-        if (!TR::Options::getCmdLineOptions()->getOption(TR_DontDisclaimMemoryOnSwap)
-            && !compInfo->isSwapMemoryDisabled()) {
-            // Do we have enough free space?
+        // Pick the destination for disclaim files.
+        // If the user has specified a directory for disclaim with
+        // "-XX:DisclaimDir=" and the filesystem "is suitable", use that.
+        // Else, if swap space "is suitable", use that.
+        // Else, if /tmp "is suitable", use that.
+        // Else, disable disclaim.
+        if (!userSpecifiedDir) {
+            // Determine if swap is a suitable destination for disclaim backing-files.
             J9MemoryInfo memInfo;
-            if ((omrsysinfo_get_memory_info(&memInfo) == 0)
-                && (memInfo.availSwap >= ((uint64_t)J9::Options::_minDiskSpaceForDisclaimMB << 20))) {
-                compInfo->setCanDisclaimOnSwap(true);
-            }
+            bool isSuitable =
+                // User allows us to use swap
+                !TR::Options::getCmdLineOptions()->getOption(TR_DontDisclaimMemoryOnSwap) &&
+                // System is configured to use swap
+                !compInfo->isSwapMemoryDisabled() &&
+                // At least 1 GB of free space on swap
+                (omrsysinfo_get_memory_info(&memInfo) == 0)
+                && (memInfo.availSwap >= ((uint64_t)J9::Options::_minDiskSpaceForDisclaimMB << 20));
+            compInfo->setCanDisclaimOnSwap(isSuitable);
         }
-        // Check whether disclaiming on a file is possible.
-        // Do not disclaim if the filesystem for /tmp is tmpfs or ramfs because they use RAM memory.
-        // Also, do not disclaim if /tmp is on nfs because the latency is unpredictable.
-        // Also, do not disclaim if there is little available space.
-        // TODO: enhance the omr portlib (omrfile_stat/updateJ9FileStat/J9FileStat) to give us the desired information
+        // Determine if the directory selected for disclaim backing-files is suitable.
+        // The directory is not suitable if the supporting filesystem
+        // satisfies any of the following conditions:
+        // 1. Is tmpfs or ramfs, because they use RAM memory
+        // 2. Is remote (e.g. nfs), because the latency is unpredictable
+        // 3. Less than 1 GB available (configurable)
+        // TODO: enhance the omr portlib (omrfile_stat/updateJ9FileStat/J9FileStat) to
+        // give us the desired information
         struct statfs statfsbuf;
-        int retVal = statfs("/tmp", &statfsbuf);
+        int retVal = statfs(disclaimDir, &statfsbuf);
         if (retVal == 0 && statfsbuf.f_type != TMPFS_MAGIC && statfsbuf.f_type != RAMFS_MAGIC
             && statfsbuf.f_type != NFS_SUPER_MAGIC
             && ((uint64_t)statfsbuf.f_bavail * statfsbuf.f_bsize)
                 >= ((uint64_t)J9::Options::_minDiskSpaceForDisclaimMB << 20)) {
             compInfo->setCanDisclaimOnFile(true);
-            if (!compInfo->canDisclaimOnSwap() && TR::Options::getVerboseOption(TR_VerbosePerformance)) {
-                TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,
-                    "Memory disclaim will be done on /tmp because swap is not suitable");
-            }
-        } else {
-            if (TR::Options::getVerboseOption(TR_VerbosePerformance)) {
-                TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,
-                    "WARNING: Disclaim feature disabled because swap and /tmp are not suitable");
-            }
         }
     }
     if (!compInfo->canDisclaimOnSwap() && !compInfo->canDisclaimOnFile()) {
         TR::Options::getCmdLineOptions()->setOption(TR_DisableDataCacheDisclaiming);
         TR::Options::getCmdLineOptions()->setOption(TR_DisableIProfilerDataDisclaiming);
         TR::Options::getCmdLineOptions()->setOption(TR_EnableCodeCacheDisclaiming, false);
+        if (TR::Options::getVerboseOption(TR_VerbosePerformance)) {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,
+                "WARNING: Disclaim feature disabled because swap and %s are not suitable", disclaimDir);
+        }
+    } else {
+        // Disclaim is possible. Print the destination for the backing files.
+        if (TR::Options::getVerboseOption(TR_VerbosePerformance)) {
+            if (compInfo->canDisclaimOnSwap())
+                TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Memory disclaim will be done on swap");
+            else
+                TR_VerboseLog::writeLineLocked(TR_Vlog_PERF, "Memory disclaim will be done on %s", disclaimDir);
+        }
     }
     // SCC disclaiming does not need swap or additional files
     if (shouldDisableMemoryDisclaim) {

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -693,6 +693,7 @@ enum INIT_STAGE {
 #define VMOPT_XXCLASSMEMORYDISCLAIM_NONE "none"
 #define VMOPT_XXCLASSMEMORYDISCLAIM_RAM "ram"
 #define VMOPT_XXCLASSMEMORYDISCLAIM_ROM "rom"
+#define VMOPT_XXDISCLAIMDIRECTORY "-XX:DisclaimDir="
 
 /* Modularity command line options */
 #define VMOPT_MODULE_UPGRADE_PATH "--upgrade-module-path"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -4122,6 +4122,43 @@ processVMArgsFromFirstToLast(J9JavaVM * vm)
 		}
 	}
 
+	{
+		/* Parse -XX:DisclaimDir= option to set directory for temporary disclaim files. */
+		IDATA argIndex = FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_XXDISCLAIMDIRECTORY, NULL);
+		if (0 <= argIndex) {
+			PORT_ACCESS_FROM_JAVAVM(vm);
+#if defined(LINUX)
+			char *optionValue = NULL;
+			GET_OPTION_VALUE(argIndex, '=', &optionValue);
+			if (NULL != optionValue) {
+				OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+				/* Make sure the directory exists. */
+				struct J9FileStat statBuf = {0};
+				int32_t statRc = omrfile_stat(optionValue, 0, &statBuf);
+
+				/* Verify the directory exists and is actually a directory. */
+				if (0 != statRc) {
+					j9tty_printf(PORTLIB, "Error: Directory specified by -XX:DisclaimDir=%s does not exist\n", optionValue);
+					return JNI_ERR;
+				}
+				if (0 == statBuf.isDir) {
+					j9tty_printf(PORTLIB, "Error: Path specified by -XX:DisclaimDir=%s is not a directory\n", optionValue);
+					return JNI_ERR;
+				}
+				/* Set the temporary directory via port control. */
+				j9port_control(OMRPORT_CTLDATA_VMEM_TMPDIR_PATH, (uintptr_t)optionValue);
+				/* If the port_control fails, fall back on /tmp as tye default directory for disclaim files. */
+			} else {
+				j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_UNRECOGNISED_CMD_LINE_OPT, VMOPT_XXDISCLAIMDIRECTORY);
+				return JNI_ERR;
+			}
+#else /* defined(LINUX) */
+			j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_UNSUPPORTED_OPTION, VMOPT_XXDISCLAIMDIRECTORY);
+			return JNI_ERR;
+#endif /* defined(LINUX) */
+		}
+	}
+
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	{
 		IDATA enableCRIU = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXENABLECRIU, NULL);


### PR DESCRIPTION
This commit creates a new command line option called `-XX:DisclaimDir=` which can be used to set the desired directory for the backing files created by the memory disclaim mechanism.
If no such option is specified, the JVM will use either swap (if possible) or `/tmp` directory.
If the specified directory does not exist or it's not a directory, the JVM will terminate.
If the specified directory exists, but it is not writeable or it has less than 1 GB free space, the JVM will continue to run, but it will not use the disclaim mechanism.
The disclaim mechanism will also be disabled if the specified directory is remote (e.g. nfs) or it's using RAM under the covers (e.g. ramfs ot tmpfs).

Depends on: https://github.com/eclipse-omr/omr/pull/8125
Depends on: https://github.com/eclipse-omr/omr/pull/8137