### PR TITLE
Move setupProfiledGuardRelocation to J9::X86::TreeEvaluator

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -14687,3 +14687,27 @@ TR::Register *J9::X86::TreeEvaluator::awrtbarEvaluator(TR::Node *node, TR::CodeG
    // counts of the children evaluated here and let this helper handle it.
    return TR::TreeEvaluator::writeBarrierEvaluator(node, cg);
    }
+
+void J9::X86::TreeEvaluator::setupProfiledGuardRelocation(TR::X86RegImmInstruction *cmpInstruction, TR::Node *node,
+    TR_ExternalRelocationTargetKind reloKind)
+{
+   // The following makes sure that the TR_ProfiledInlinedMethod relocation for this inlined site will be created
+   // later in TR::CodeGenerator::processRelocations()
+   TR::Compilation *comp = TR::comp();
+   TR_VirtualGuard *virtualGuard = comp->findVirtualGuardInfo(node);
+   TR_AOTGuardSite *site = comp->addAOTNOPSite();
+   site->setLocation(NULL);
+   site->setType(TR_ProfiledGuard);
+   site->setGuard(virtualGuard);
+   site->setNode(node);
+   site->setAconstNode(node->getSecondChild());
+
+   // If we've generated an instruction, then make sure it is marked to get the right kind of relocation
+   if (cmpInstruction) {
+      cmpInstruction->setReloKind(reloKind);
+      cmpInstruction->setNode(node->getSecondChild());
+   }
+
+   logprintf(comp->getOption(TR_TraceCG), comp->log(), "setupProfiledGuardRelocation: site %p type %d node %p\n", site,
+       site->getType(), node);
+}

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -177,6 +177,9 @@ class OMR_EXTENSIBLE TreeEvaluator: public J9::TreeEvaluator
    static TR::Register *d2lEvaluator(TR::Node *node, TR::CodeGenerator *cg);
    class CaseConversionManager;
    static TR::Register *stringCaseConversionHelper(TR::Node *node, TR::CodeGenerator *cg, CaseConversionManager& manager);
+  static void setupProfiledGuardRelocation(TR::X86RegImmInstruction *cmpInstruction, TR::Node *node,
+    TR_ExternalRelocationTargetKind reloKind);
+
 
    private:
    static TR::Register* performHeapLoadWithReadBarrier(TR::Node* node, TR::CodeGenerator* cg);


### PR DESCRIPTION
Part of eclipse-openj9/omr
Adds the `setupProfiledGuardRelocation` implementation to `J9::X86::TreeEvaluator`,
as moved from OMR per [eclipse/omr#6342](https://github.com/eclipse-omr/omr/issues/6342).

Note: This change must be merged together with the corresponding OMR PR:
- https://github.com/eclipse-omr/omr/pull/8129

Resolves https://github.com/eclipse-omr/omr/issues/6342.