### PR TITLE
Mark NullRestricted annotated fields with ACC_STRICT_INIT

### DIFF
--- a/runtime/bcutil/ClassFileOracle.cpp
+++ b/runtime/bcutil/ClassFileOracle.cpp
@@ -428,6 +428,8 @@ ClassFileOracle::walkFields()
 							}
 						}
 						_fieldsInfo[fieldIndex].isNullRestricted = true;
+						/* The NullRestricted annotation should always mark fields with ACC_STRICT_INIT. */
+						_fieldsInfo[fieldIndex].isStrictByNullRestrictedAnnotation = true;
 					}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 				}

--- a/runtime/bcutil/ClassFileOracle.hpp
+++ b/runtime/bcutil/ClassFileOracle.hpp
@@ -67,6 +67,7 @@ public:
 		bool isFieldContended;
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		bool isNullRestricted;
+		bool isStrictByNullRestrictedAnnotation;
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 	};
 
@@ -376,6 +377,7 @@ class FieldIterator
 		bool isFieldContended() const { return _fieldsInfo[_index].isFieldContended; }
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		bool isNullRestricted() const { return _fieldsInfo[_index].isNullRestricted; }
+		bool isStrictByNullRestrictedAnnotation() const { return _fieldsInfo[_index].isStrictByNullRestrictedAnnotation; }
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 		U_32 getConstantValueSlot1() const { return _classFile->constantPool[getConstantValueConstantPoolIndex()].slot1; }

--- a/runtime/bcutil/ROMClassWriter.cpp
+++ b/runtime/bcutil/ROMClassWriter.cpp
@@ -655,6 +655,9 @@ ROMClassWriter::writeFields(Cursor *cursor, bool markAndCountOnly)
 			if (iterator.isNullRestricted()) {
 				modifiers |= J9FieldFlagIsNullRestricted;
 			}
+			if (iterator.isStrictByNullRestrictedAnnotation()) {
+				modifiers |= J9AccStrictInit;
+			}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 			cursor->writeU32(modifiers, Cursor::GENERIC);

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTestClasses.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTestClasses.java
@@ -62,7 +62,10 @@ public class ValueTypeTestClasses {
 	}
 
 	static class IntWrapper {
-		IntWrapper(int i) { this.vti = new ValueTypeInt(i); }
+		IntWrapper(int i) {
+			this.vti = new ValueTypeInt(i);
+			super();
+		}
 		@NullRestricted
 		final ValueTypeInt vti;
 	}


### PR DESCRIPTION
Recent upstream Valhalla changes remove the @Strict annotation. The NullRestricted annotation should
add the ACC_STRICT_INIT flag to fields during runtime.

This is causing errors in FlatVarHandleTest OpenJDK test.