### PR TITLE
Use new leadingZeros() and trailingZeros() functions

### DIFF
--- a/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.cpp
+++ b/runtime/gc_vlhgc/ParallelSweepSchemeVLHGC.cpp
@@ -1,5 +1,3 @@
-
-
 /*******************************************************************************
  * Copyright IBM Corp. and others 1991
  *
@@ -425,13 +423,10 @@ MM_ParallelSweepSchemeVLHGC::sweepMarkMapHead(
 	UDATA * &heapSlotFreeHead,
 	UDATA &heapSlotFreeCount )
 {
-	UDATA markMapHeadValue;
-	UDATA markMapFreeBitIndexHead;
-
-	if(markMapFreeHead > markMapChunkBase) {
-		markMapHeadValue = *(markMapFreeHead - 1);
-		markMapFreeBitIndexHead = J9MODRON_HEAP_SLOTS_PER_MARK_BIT * MM_Bits::trailingZeroes(markMapHeadValue);
-		if(markMapFreeBitIndexHead) {
+	if (markMapFreeHead > markMapChunkBase) {
+		UDATA markMapHeadValue = *(markMapFreeHead - 1);
+		UDATA markMapFreeBitIndexHead = J9MODRON_HEAP_SLOTS_PER_MARK_BIT * MM_Bits::leadingZeros(markMapHeadValue);
+		if (0 != markMapFreeBitIndexHead) {
 			heapSlotFreeHead -= markMapFreeBitIndexHead;
 			heapSlotFreeCount += markMapFreeBitIndexHead;
 		}
@@ -444,14 +439,10 @@ MM_ParallelSweepSchemeVLHGC::sweepMarkMapTail(
 	UDATA *markMapChunkTop,
 	UDATA &heapSlotFreeCount )
 {
-	UDATA markMapTailValue;
-	UDATA markMapFreeBitIndexTail;
-
-	if(markMapCurrent < markMapChunkTop) {
-		markMapTailValue = *markMapCurrent;
-		markMapFreeBitIndexTail = J9MODRON_HEAP_SLOTS_PER_MARK_BIT * MM_Bits::leadingZeroes(markMapTailValue);
-
-		if(markMapFreeBitIndexTail) {
+	if (markMapCurrent < markMapChunkTop) {
+		UDATA markMapTailValue = *markMapCurrent;
+		UDATA markMapFreeBitIndexTail = J9MODRON_HEAP_SLOTS_PER_MARK_BIT * MM_Bits::trailingZeros(markMapTailValue);
+		if (0 != markMapFreeBitIndexTail) {
 			heapSlotFreeCount += markMapFreeBitIndexTail;
 		}
 	}

--- a/runtime/gc_vlhgc/WriteOnceCompactor.cpp
+++ b/runtime/gc_vlhgc/WriteOnceCompactor.cpp
@@ -2763,8 +2763,8 @@ MM_WriteOnceCompactor::removeTailMarksInPage(MM_EnvironmentVLHGC *env, MM_MarkMa
 		UDATA markMapWord = markMap->getSlot(slotIndex);
 		UDATA newWord = 0;
 		while (0 != markMapWord) {
-			UDATA leadingZeroes = MM_Bits::leadingZeroes(markMapWord);
-			UDATA bit = ((UDATA)1 << leadingZeroes);
+			UDATA trailingZeros = MM_Bits::trailingZeros(markMapWord);
+			UDATA bit = ((UDATA)1 << trailingZeros);
 			markMapWord &= ~bit;
 			if (isHead) {
 				newWord |= bit;


### PR DESCRIPTION
The new functions introduced in https://github.com/eclipse-omr/omr/pull/8126 can be used now that the openj9 branch of https://github.com/eclipse-openj9/openj9-omr includes that change.