### PR TITLE
Fix Class.getMethod() to reject non-public interface methods

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -2047,7 +2047,7 @@ Method getMethodHelper(
 	}
 	if (initialResultShouldBeReplaced) {
 		// The initial result is not a public method to be searched, and no other public methods found.
-		return null;
+		return throwExceptionOrReturnNull(throwException, name, parameterTypes);
 	} else {
 		return cacheMethod(bestCandidate);
 	}

--- a/test/functional/Java9andUp/playlist.xml
+++ b/test/functional/Java9andUp/playlist.xml
@@ -516,4 +516,26 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>GetMethodTests</testCaseName>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+	-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)GeneralTest.jar$(Q) \
+	org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames GetMethodTests \
+	-groups $(TEST_GROUP) \
+	-excludegroups $(DEFAULT_EXCLUDE); \
+	$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>9+</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/Java9andUp/src/org/openj9/test/reflect/GetMethodTests.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/reflect/GetMethodTests.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test.reflect;
+
+import org.testng.annotations.Test;
+import static org.testng.Assert.*;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+/*
+ * Tests for Class.getMethod() with interface methods (Java 9+ feature).
+ */
+@Test(groups = { "level.sanity" })
+public class GetMethodTests {
+
+	/*
+	 * Test that Class.getMethod() throws NoSuchMethodException for
+	 * private static methods in interfaces.
+	 */
+	@Test
+	public void testGetMethod_InterfacePrivateStatic() {
+		assertThrows(NoSuchMethodException.class,
+			() -> TestInterfaceForGetMethod.class.getMethod("privateStaticMethod"));
+	}
+
+	/*
+	 * Test that Class.getMethod() throws NoSuchMethodException for
+	 * private non-static methods in interfaces.
+	 */
+	@Test
+	public void testGetMethod_InterfacePrivateNonStatic() {
+		assertThrows(NoSuchMethodException.class,
+			() -> TestInterfaceForGetMethod.class.getMethod("privateNonStaticMethod"));
+	}
+
+	/*
+	 * Test that Class.getMethod() successfully returns a Method for
+	 * public static methods in interfaces.
+	 */
+	@Test
+	public void testGetMethod_InterfacePublicStatic() throws NoSuchMethodException {
+		Method method = TestInterfaceForGetMethod.class.getMethod("publicStaticMethod");
+		assertEquals("publicStaticMethod", method.getName());
+		assertEquals(TestInterfaceForGetMethod.class, method.getDeclaringClass());
+		assertEquals(void.class, method.getReturnType());
+		assertEquals(0, method.getParameterCount());
+		assertTrue(Modifier.isPublic(method.getModifiers()));
+		assertTrue(Modifier.isStatic(method.getModifiers()));
+	}
+
+	/*
+	 * Test that Class.getMethod() successfully returns a Method for
+	 * public non-static methods in interfaces.
+	 */
+	@Test
+	public void testGetMethod_InterfacePublicNonStatic() throws NoSuchMethodException {
+		Method method = TestInterfaceForGetMethod.class.getMethod("publicNonStaticMethod");
+		assertEquals("publicNonStaticMethod", method.getName());
+		assertEquals(TestInterfaceForGetMethod.class, method.getDeclaringClass());
+		assertEquals(void.class, method.getReturnType());
+		assertEquals(0, method.getParameterCount());
+		assertTrue(Modifier.isPublic(method.getModifiers()));
+		assertTrue(Modifier.isAbstract(method.getModifiers()));
+	}
+
+	/*
+	 * Test that Class.getMethod() successfully returns a Method for
+	 * default methods in interfaces.
+	 */
+	@Test
+	public void testGetMethod_InterfaceDefault() throws NoSuchMethodException {
+		Method method = TestInterfaceForGetMethod.class.getMethod("defaultMethod");
+		assertEquals("defaultMethod", method.getName());
+		assertEquals(TestInterfaceForGetMethod.class, method.getDeclaringClass());
+		assertEquals(void.class, method.getReturnType());
+		assertEquals(0, method.getParameterCount());
+		assertTrue(Modifier.isPublic(method.getModifiers()));
+	}
+
+}

--- a/test/functional/Java9andUp/src/org/openj9/test/reflect/TestInterfaceForGetMethod.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/reflect/TestInterfaceForGetMethod.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test.reflect;
+
+/*
+ * Test interface for Class.getMethod() tests.
+ * Contains private methods (Java 9+ feature) to test reflection behavior.
+ */
+public interface TestInterfaceForGetMethod {
+
+	private static void privateStaticMethod() {}
+	private void privateNonStaticMethod() {}
+	public static void publicStaticMethod() {}
+	public void publicNonStaticMethod();
+	default void defaultMethod() {}
+
+}

--- a/test/functional/Java9andUp/testng.xml
+++ b/test/functional/Java9andUp/testng.xml
@@ -95,17 +95,17 @@
 	<test name="Test_Class">
 		<classes>
 			<class name="org.openj9.test.java.lang.Test_Class" />
- 		</classes>
+		</classes>
 	</test>
 	<test name="Test_Math_Fma">
 		<classes>
 			<class name="org.openj9.test.java.lang.Test_Math_Fma" />
- 		</classes>
+		</classes>
 	</test>
 	<test name="Test_StrictMath_Fma">
 		<classes>
 			<class name="org.openj9.test.java.lang.Test_StrictMath_Fma" />
- 		</classes>
+		</classes>
 	</test>
 	<test name="TestJava9AttachAPI">
 		<classes>
@@ -121,10 +121,15 @@
 		<classes>
 			<class name="org.openj9.test.access.staticAccessChecks.DenyAccess" />
 		</classes>
-    </test>
+	</test>
 	<test name="TestClassLoaderFindResource">
 		<classes>
 			<class name="org.openj9.test.modularity.TestClassLoaderFindResource" />
 		</classes>
-    </test>
+	</test>
+	<test name="GetMethodTests">
+		<classes>
+			<class name="org.openj9.test.reflect.GetMethodTests" />
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
Fix Class.getMethod() to throw NoSuchMethodException for non-public interface methods

## Problem
`Class.getMethod()` must return only public methods or throw `NoSuchMethodException` as per Java specification. Previously, when invoked on interface types with non-public methods (private static or non-static), the method incorrectly returned `null` instead of throwing the required exception.

## Root Cause
The issue was in the `initialResultShouldBeReplaced` code path in `getMethodHelper()`. When `publicOnly` was true but the initial result was a non-public method, and no public alternatives were found, the method returned `null` instead of calling `throwExceptionOrReturnNull()`.

Test cases added in `Java9andUp/GetMethodTests` covering cases of Class.getMethod() call for both public and non-public interface methods.

## Test Results:
Local builds and Jenkins grinder tests were executed for aarch64 using JDK 11 and JDK 25.

- sanity.functional – PASS and stable
- extended.openjdk – PASS and stable
- sanity.openjdk – JDK11: fails on `jdk_lang_j9_0` and `jdk_lang_j9_1`. JDK25 fails on `java/util/StringJoiner/StringJoinerTest`

The sanity.openjdk failures are already tracked issues:
- `jdk_lang_j9_0` and `jdk_lang_j9_1` failures observed across multiple Java levels (JDK 11, 17) and platforms (linux64, x86-64_mac): #23389
- `StringJoinerTest OutOfMemoryError: Java heap space` has recently been seen in openjdk25 on ppc64le_linux: https://github.com/eclipse-openj9/openj9/issues/18708#issuecomment-3991693250

These failures are outside this change and appear to be existing issues.

Fixes: #22448