### PR TITLE
JVMTI: return JVMTI_ERROR_INVALID_CLASS for invalidated jclass (-1)

### DIFF
--- a/runtime/jvmti/jvmtiClass.c
+++ b/runtime/jvmti/jvmtiClass.c
@@ -338,7 +338,7 @@ jvmtiGetClassSignature(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
 
@@ -469,7 +469,7 @@ jvmtiGetClassStatus(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(status_ptr);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
@@ -508,7 +508,7 @@ jvmtiGetSourceFileName(jvmtiEnv* env,
 		ENSURE_PHASE_START_OR_LIVE(env);
 		ENSURE_CAPABILITY(env, can_get_source_file_name);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(source_name_ptr);
 
 		/* Assume that having the capability means that the debug info server is active */
@@ -553,7 +553,7 @@ jvmtiGetClassModifiers(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(modifiers_ptr);
 
 		/* Primitive classes have the correct modifiers, so no special processing needs to be done */
@@ -619,7 +619,7 @@ jvmtiGetClassMethods(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(method_count_ptr);
 		ENSURE_NON_NULL(methods_ptr);
 
@@ -691,7 +691,7 @@ jvmtiGetClassFields(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(field_count_ptr);
 		ENSURE_NON_NULL(fields_ptr);
 
@@ -771,7 +771,7 @@ jvmtiGetImplementedInterfaces(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(interface_count_ptr);
 		ENSURE_NON_NULL(interfaces_ptr);
 
@@ -842,7 +842,7 @@ jvmtiIsInterface(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(is_interface_ptr);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
@@ -879,7 +879,7 @@ jvmtiIsArrayClass(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(is_array_class_ptr);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
@@ -917,7 +917,7 @@ jvmtiGetClassLoader(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(classloader_ptr);
 
 		clazz = J9VM_J9CLASS_FROM_JCLASS(currentThread, klass);
@@ -962,7 +962,7 @@ jvmtiGetSourceDebugExtension(jvmtiEnv* env,
 		ENSURE_PHASE_START_OR_LIVE(env);
 		ENSURE_CAPABILITY(env, can_get_source_debug_extension);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(source_debug_extension_ptr);
 
 		/* Assume that having the capability means that the debug info server is active */
@@ -1699,7 +1699,7 @@ jvmtiIsModifiableClass(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JCLASS(currentThread, klass);
 		ENSURE_NON_NULL(is_modifiable_class_ptr);
 
@@ -1752,7 +1752,7 @@ jvmtiGetClassVersionNumbers(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_NON_NULL(minor_version_ptr);
 		ENSURE_NON_NULL(major_version_ptr);
 		ENSURE_JCLASS(currentThread, klass);
@@ -1878,7 +1878,7 @@ jvmtiGetConstantPool(jvmtiEnv* env,
 		ENSURE_PHASE_START_OR_LIVE(env);
 		ENSURE_CAPABILITY(env, can_get_constant_pool);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JCLASS(currentThread, klass);
 		ENSURE_NON_NULL(constant_pool_count_ptr);
 		ENSURE_NON_NULL(constant_pool_byte_count_ptr);

--- a/runtime/jvmti/jvmtiField.c
+++ b/runtime/jvmti/jvmtiField.c
@@ -52,7 +52,7 @@ jvmtiGetFieldName(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JFIELDID_VALID(field);
 
 		romFieldShape = ((J9JNIFieldID *) field)->field;
@@ -148,7 +148,7 @@ jvmtiGetFieldDeclaringClass(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JFIELDID_VALID(field);
 		ENSURE_NON_NULL(declaring_class_ptr);
 
@@ -187,7 +187,7 @@ jvmtiGetFieldModifiers(jvmtiEnv* env,
 
 		ENSURE_PHASE_START_OR_LIVE(env);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JFIELDID_VALID(field);
 		ENSURE_NON_NULL(modifiers_ptr);
 
@@ -229,7 +229,7 @@ jvmtiIsFieldSynthetic(jvmtiEnv* env,
 		ENSURE_PHASE_START_OR_LIVE(env);
 		ENSURE_CAPABILITY(env, can_get_synthetic_attribute);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JFIELDID_VALID(field);
 		ENSURE_NON_NULL(is_synthetic_ptr);
 

--- a/runtime/jvmti/jvmtiHeap10.c
+++ b/runtime/jvmti/jvmtiHeap10.c
@@ -133,7 +133,7 @@ jvmtiIterateOverInstancesOfClass(jvmtiEnv* env,
 		ENSURE_PHASE_LIVE(env);
 		ENSURE_CAPABILITY(env, can_tag_objects);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_VALID_HEAP_OBJECT_FILTER(object_filter);
 		ENSURE_NON_NULL(heap_object_callback);
 

--- a/runtime/jvmti/jvmtiWatchedField.c
+++ b/runtime/jvmti/jvmtiWatchedField.c
@@ -126,7 +126,7 @@ setFieldWatch(jvmtiEnv* env,
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JFIELDID_VALID(field);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);
@@ -230,7 +230,7 @@ clearFieldWatch(jvmtiEnv* env,
 
 		vm->internalVMFunctions->internalEnterVMFromJNI(currentThread);
 
-		ENSURE_JCLASS_NON_NULL(klass);
+		ENSURE_JCLASS_VALID(klass);
 		ENSURE_JFIELDID_VALID(field);
 
 		vm->internalVMFunctions->acquireExclusiveVMAccess(currentThread);

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -448,6 +448,13 @@ typedef struct jvmtiGcp_translation {
 		} \
 	} while (0)
 
+#define ENSURE_JCLASS_VALID(var) \
+	do { \
+		if (((var) == NULL) || (NULL == *((j9object_t *)(var))) || (UDATA_MAX == *((UDATA *)(var)))) { \
+			JVMTI_ERROR(JVMTI_ERROR_INVALID_CLASS); \
+		} \
+	} while (0)
+
 #define ENSURE_JNI_OBJECT_NON_NULL(var, err) \
 	do { \
 		if (((var) == NULL) || (*((j9object_t *)(var)) == NULL)) { \
@@ -456,7 +463,6 @@ typedef struct jvmtiGcp_translation {
 	} while (0)
 
 #define ENSURE_JOBJECT_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_OBJECT)
-#define ENSURE_JCLASS_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_CLASS)
 #define ENSURE_JTHREADGROUP_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_THREAD_GROUP)
 #define ENSURE_JOBJECT_NON_NULL(var) ENSURE_JNI_OBJECT_NON_NULL((var), JVMTI_ERROR_INVALID_OBJECT)
 
@@ -516,7 +522,7 @@ typedef struct jvmtiGcp_translation {
 #define ENSURE_JMETHODID_VALID(var)
 #define ENSURE_JFIELDID_VALID(var)
 #define ENSURE_JOBJECT_NON_NULL(var)
-#define ENSURE_JCLASS_NON_NULL(var)
+#define ENSURE_JCLASS_VALID(var)
 #define ENSURE_JTHREADGROUP_NON_NULL(var)
 #define ENSURE_VALID_HEAP_OBJECT_FILTER(var)
 #define ENSURE_MONITOR_NON_NULL(var)


### PR DESCRIPTION
Update JVMTI error handling to return JVMTI_ERROR_INVALID_CLASS
when an invalidated jclass that points to -1 is detected.

Related: https://github.ibm.com/runtimes/service-squad/issues/295