### PR TITLE
Add GC is older JNI api

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -227,6 +227,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_modron_global_collect,
 	j9gc_modron_global_collect_with_overrides,
 	j9gc_modron_local_collect,
+	j9gc_is_older,
 	j9gc_all_object_and_vm_slots_do,
 	j9mm_iterate_heaps,
 	j9mm_iterate_spaces,

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -188,6 +188,7 @@ extern J9_CFUNC UDATA j9gc_modron_global_collect(J9VMThread *vmThread);
 extern J9_CFUNC UDATA j9gc_modron_global_collect_with_overrides(J9VMThread *vmThread, U_32 overrideFlags);
 extern J9_CFUNC UDATA j9gc_get_initial_heap_size(J9JavaVM *javaVM);
 extern J9_CFUNC UDATA j9gc_modron_local_collect(J9VMThread *vmThread);
+extern J9_CFUNC IDATA j9gc_is_older(J9VMThread *vmThread, j9object_t object1Ptr, j9object_t object2Ptr);
 extern J9_CFUNC I_32 referenceArrayCopy(J9VMThread *vmThread, J9IndexableObject *srcObject, J9IndexableObject *destObject, fj9object_t *srcAddress, fj9object_t *destAddress, I_32 lengthInSlots);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreI64(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, I_64 value, UDATA isVolatile);
 extern J9_CFUNC void J9WriteBarrierPostClass(J9VMThread *vmThread, J9Class *destinationClazz, j9object_t storedObject);

--- a/runtime/gc_base/modronapi.cpp
+++ b/runtime/gc_base/modronapi.cpp
@@ -35,7 +35,7 @@
 #include "GCExtensions.hpp"
 #include "HeapMemorySnapshot.hpp"
 #include "Heap.hpp"
-#include "HeapRegionDescriptor.hpp"
+#include "HeapRegionDescriptorVLHGC.hpp"
 #include "HeapRegionIterator.hpp"
 #include "HeapRegionManager.hpp"
 #include "GlobalCollector.hpp"
@@ -454,6 +454,38 @@ j9gc_is_local_collector(J9JavaVM *javaVM, UDATA gcID)
 	}
 
 	return local;
+}
+
+/**
+ * check which of two objects is older in the heap
+ * returns 1 if object1 is older, -1 if object2 is older, 0 if no object or same age
+ */
+IDATA
+j9gc_is_older(J9VMThread *vmThread, j9object_t object1Ptr, j9object_t object2Ptr)
+{
+	if ((NULL == object1Ptr) || (NULL == object2Ptr)) {
+		return 0;
+	}
+
+	OMR_VM *omrVM = vmThread->javaVM->omrVM;
+
+	if ( OMR_GC_POLICY_BALANCED != omrVM->gcPolicy ) {
+		return 0;
+	}
+
+	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(vmThread);
+
+	MM_HeapRegionManager *regionManager = extensions->heapRegionManager;
+
+	MM_HeapRegionDescriptorVLHGC *vlhgcRegion1 = (MM_HeapRegionDescriptorVLHGC *)regionManager->tableDescriptorForAddress(object1Ptr);
+	MM_HeapRegionDescriptorVLHGC *vlhgcRegion2 = (MM_HeapRegionDescriptorVLHGC *)regionManager->tableDescriptorForAddress(object2Ptr);
+
+	uintptr_t age1 = vlhgcRegion1->getLogicalAge();
+	uintptr_t age2 = vlhgcRegion2->getLogicalAge();
+
+	if (age1 > age2) return 1;
+	if (age1 < age2) return -1;
+	return 0;
 }
 
 /**

--- a/runtime/gc_base/modronapi.hpp
+++ b/runtime/gc_base/modronapi.hpp
@@ -61,6 +61,7 @@ extern "C" {
 
 UDATA j9gc_modron_global_collect(J9VMThread *vmThread);
 UDATA j9gc_modron_local_collect(J9VMThread *vmThread);
+IDATA j9gc_is_older(J9VMThread *vmThread, j9object_t object1Ptr, j9object_t object2Ptr);
 UDATA j9gc_heap_total_memory(J9JavaVM *javaVM);
 UDATA j9gc_heap_free_memory(J9JavaVM *javaVM);
 UDATA j9gc_is_garbagecollection_disabled(J9JavaVM *javaVM);

--- a/runtime/jcl/common/jclvm.c
+++ b/runtime/jcl/common/jclvm.c
@@ -71,6 +71,24 @@ static UDATA printHeapStatistics(JNIEnv *env,J9HeapStatisticsTableEntry **statsA
 		UDATA numClasses, char *stringBuffer, UDATA bufferSize);
 static int compareByAggregateSize(const void *a, const void *b);
 
+jint JNICALL
+Java_com_ibm_oti_vm_VM_isOlder(JNIEnv *env, jclass unused, jobject jobject1, jobject jobject2)
+{
+	jint older = 0;
+
+	J9VMThread *currentThread = (J9VMThread*)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	j9object_t object1 = J9_JNI_UNWRAP_REFERENCE(jobject1);
+	j9object_t object2 = J9_JNI_UNWRAP_REFERENCE(jobject2);
+	older = (jint)vm->memoryManagerFunctions->j9gc_is_older(currentThread, object1, object2);
+	vmFuncs->internalExitVMToJNI(currentThread);
+
+	return older;
+}
+
 void JNICALL
 Java_com_ibm_oti_vm_VM_localGC(JNIEnv *env, jclass clazz)
 {

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -300,6 +300,7 @@ omr_add_exports(jclse
 	Java_com_ibm_oti_vm_VM_getVMArgsImpl
 	Java_com_ibm_oti_vm_VM_globalGC
 	Java_com_ibm_oti_vm_VM_localGC
+	Java_com_ibm_oti_vm_VM_isOlder
 	Java_com_ibm_oti_vm_VM_markCurrentThreadAsSystemImpl
 	Java_com_ibm_oti_vm_VM_setCommonData
 	Java_com_ibm_oti_vm_VM_getJ9ConstantPoolFromJ9Class

--- a/runtime/jcl/uma/se6_vm-side_natives_exports.xml
+++ b/runtime/jcl/uma/se6_vm-side_natives_exports.xml
@@ -27,6 +27,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<export name="Java_com_ibm_oti_vm_VM_getVMArgsImpl" />
 	<export name="Java_com_ibm_oti_vm_VM_globalGC" />
 	<export name="Java_com_ibm_oti_vm_VM_localGC" />
+	<export name="Java_com_ibm_oti_vm_VM_isOlder" />
 	<export name="J9VMDllMain" />
 	<export name="Java_com_ibm_jvm_Dump_HeapDumpImpl" />
 	<export name="Java_com_ibm_jvm_Dump_JavaDumpImpl" />

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5103,6 +5103,7 @@ typedef struct J9MemoryManagerFunctions {
 	UDATA  ( *j9gc_modron_global_collect)(struct J9VMThread *vmThread) ;
 	UDATA  ( *j9gc_modron_global_collect_with_overrides)(struct J9VMThread *vmThread, U_32 overrideFlags) ;
 	UDATA  ( *j9gc_modron_local_collect)(struct J9VMThread *vmThread) ;
+	IDATA  ( *j9gc_is_older)(struct J9VMThread *vmThread, j9object_t object1Ptr, j9object_t object2Ptr);
 	void  ( *j9gc_all_object_and_vm_slots_do)(struct J9JavaVM *javaVM, void *function, void *userData, UDATA walkFlags) ;
 	jvmtiIterationControl  ( *j9mm_iterate_heaps)(struct J9JavaVM *vm, J9PortLibrary *portLibrary, UDATA flags, jvmtiIterationControl (*func)(struct J9JavaVM *vm, struct J9MM_IterateHeapDescriptor *heapDesc, void *userData), void *userData) ;
 	jvmtiIterationControl  ( *j9mm_iterate_spaces)(struct J9JavaVM *javaVM, J9PortLibrary *portLibrary, struct J9MM_IterateHeapDescriptor *heap, UDATA flags, jvmtiIterationControl (*func)(struct J9JavaVM *vm, struct J9MM_IterateSpaceDescriptor *spaceDesc, void *userData), void *userData) ;


### PR DESCRIPTION
This change adds a JNI/native api into the GC heap descriptor to check which of two string objects is older.