### PR TITLE
Clean up memcpy calls to use direct member access

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -10232,11 +10232,11 @@ TR::CompilationInfoPerThreadBase::compile(
          // Put a metaData pointer into the Code Cache Header(s).
          //
          uint8_t *warmMethodHeader = compiler->cg()->getBinaryBufferStart() - sizeof(OMR::CodeCacheMethodHeader);
-         memcpy( warmMethodHeader + offsetof(OMR::CodeCacheMethodHeader, _metaData), &metaData, sizeof(metaData) );
+         reinterpret_cast<OMR::CodeCacheMethodHeader *>(warmMethodHeader)->_metaData = metaData;
          if ( metaData->startColdPC )
             {
             uint8_t *coldMethodHeader = reinterpret_cast<uint8_t *>(metaData->startColdPC) - sizeof(OMR::CodeCacheMethodHeader);
-            memcpy( coldMethodHeader + offsetof(OMR::CodeCacheMethodHeader, _metaData), &metaData, sizeof(metaData) );
+            reinterpret_cast<OMR::CodeCacheMethodHeader *>(coldMethodHeader)->_metaData = metaData;
             }
 
          // FAR: should we do postpone this copying until after CHTable commit?


### PR DESCRIPTION
Fixes #14981

replaced `memcpy` calls that use pointer arithmetic and `offsetof` with direct member access using `reinterpret_cast`.


