### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,27 @@
+# Copyright IBM Corp. and others 2026
+#
+# This program and the accompanying materials are made available under
+# the terms of the Eclipse Public License 2.0 which accompanies this
+# distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+# or the Apache License, Version 2.0 which accompanies this distribution and
+# is available at https://www.apache.org/licenses/LICENSE-2.0.
+#
+# This Source Code may also be made available under the following
+# Secondary Licenses when the conditions for such availability set
+# forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+# General Public License, version 2 with the GNU Classpath
+# Exception [1] and GNU General Public License, version 2 with the
+# OpenJDK Assembly Exception [2].
+#
+# [1] https://www.gnu.org/software/classpath/license.html
+# [2] https://openjdk.org/legal/assembly-exception.html
+#
+# SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+
+# .git-blame-ignore-revs
+
+# Merge namespace declaration in class forward declaration
+1d3403249a91cf8945f938c4931930859f1ea02e
+
+# Format Compiler component
+4e42110765c5b90fea977298555881417ceae882


### PR DESCRIPTION
Add a git blame ignore-revs file; this file can be used by git blame via the `--ignore-revs-file option`, and it is also used by GitHub to ignore revisions when blaming.

This file contains the SHAs of the two commits introduced by the Compiler Code Formatting PR, specifically:

Merge namespace declaration in class forward declaration 
1d3403249a91cf8945f938c4931930859f1ea02e

Format Compiler component
4e42110765c5b90fea977298555881417ceae882