### PR TITLE
(0.59) Avoid recursive Throwable cloning during StackOverflowError handling

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -320,6 +320,10 @@ final class J9VMInternals {
 	 * @return a copy of the Throwable
 	 */
 	private static Throwable copyThrowable(Throwable throwable) {
+		/* Avoid copying StackOverflowError to prevent additional stack use during an already exhausted stack condition. */
+		if (throwable instanceof StackOverflowError) {
+			return throwable;
+		}
 		HashMap hashMapThrowable = new HashMap();
 		/*[PR CMVC 199629] Exception During Class Initialization Not Handled Correctly */
 		return copyThrowable(throwable, hashMapThrowable);
@@ -335,6 +339,10 @@ final class J9VMInternals {
 	 * @return a copy of the Throwable or itself if it has been cloned already
 	 */
 	private static Throwable copyThrowable(Throwable throwable, HashMap hashMapThrowable) {
+		/* Avoid copying StackOverflowError to prevent additional stack use during an already exhausted stack condition. */
+		if (throwable instanceof StackOverflowError) {
+			return throwable;
+		}
 		if (hashMapThrowable.get(throwable) != null) {
 			//	stop recursive call here when the throwable has been cloned
 			return	throwable;


### PR DESCRIPTION
Fixes #23298

The fix prevents copyThrowable() from cloning a StackOverflowError.
Cloning a Throwable requires dynamically inspecting and
copying its internal fields, along with recursively copying.
Under stack exhaustion, this additional work can trigger further stack
usage during error processing.
The fix returns the original StackOverflowError immediately to avoid
additional stack consumption.

Backport of https://github.com/eclipse-openj9/openj9/pull/23365