### PR TITLE
AArch64: Improve awrtbari evaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -1248,11 +1248,34 @@ TR::Register *J9::ARM64::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Co
 {
     TR::Compilation *comp = cg->comp();
 
-    TR::Register *destinationRegister = cg->evaluate(node->getChild(2));
+    TR::Node *valueNode = NULL;
+    TR::TreeEvaluator::getIndirectWrtbarValueNode(cg, node, valueNode, false);
+    TR::Register *valueReg = cg->evaluate(valueNode);
     TR::Node *secondChild = node->getSecondChild();
     TR::Register *sourceRegister;
+    TR::Register *compressedRegister;
     bool killSource = false;
-    bool usingCompressedPointers = TR::TreeEvaluator::getIndirectWrtbarValueNode(cg, node, secondChild, true);
+    bool usingCompressedPointers = false;
+
+    // Handle fieldwatch side effect first if it's enabled.
+    if (comp->getOption(TR_EnableFieldWatch) && !node->getSymbolReference()->getSymbol()->isArrayShadowSymbol()) {
+        // The Third child (sideEffectNode) and valueReg's node is also used by the store evaluator below.
+        // The store evaluator will also evaluate+decrement it. In order to avoid double
+        // decrementing the node we skip doing it here and let the store evaluator do it.
+        TR::Register *sideEffectReg = cg->evaluate(node->getThirdChild());
+        TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, sideEffectReg, valueReg);
+    }
+
+    if (comp->useCompressedPointers() && (node->getSymbolReference()->getSymbol()->getDataType() == TR::Address)
+        && (secondChild->getDataType() != TR::Address)) {
+        usingCompressedPointers = true;
+        while (secondChild->getNumChildren() && secondChild->getOpCodeValue() != TR::a2l) {
+            secondChild = secondChild->getFirstChild();
+        }
+        if (secondChild->getNumChildren()) {
+            secondChild = secondChild->getFirstChild();
+        }
+    }
 
     if (secondChild->getReferenceCount() > 1 && secondChild->getRegister() != NULL) {
         if (!secondChild->getRegister()->containsInternalPointer())
@@ -1264,21 +1287,14 @@ TR::Register *J9::ARM64::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Co
         }
         generateMovInstruction(cg, node, sourceRegister, secondChild->getRegister());
         killSource = true;
+        compressedRegister = usingCompressedPointers ? cg->evaluate(node->getSecondChild()) : sourceRegister;
     } else {
         sourceRegister = cg->evaluate(secondChild);
-    }
-
-    // Handle fieldwatch side effect first if it's enabled.
-    if (comp->getOption(TR_EnableFieldWatch) && !node->getSymbolReference()->getSymbol()->isArrayShadowSymbol()) {
-        // The Third child (sideEffectNode) and valueReg's node is also used by the store evaluator below.
-        // The store evaluator will also evaluate+decrement it. In order to avoid double
-        // decrementing the node we skip doing it here and let the store evaluator do it.
-        TR::TreeEvaluator::rdWrtbarHelperForFieldWatch(node, cg, destinationRegister /* sideEffectRegister */,
-            sourceRegister /* valueReg */);
+        compressedRegister = usingCompressedPointers ? cg->evaluate(node->getSecondChild()) : sourceRegister;
     }
 
     TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? TR::InstOpCode::strimmw : TR::InstOpCode::strimmx;
-    TR::Register *translatedSrcReg = usingCompressedPointers ? cg->evaluate(node->getSecondChild()) : sourceRegister;
+    TR::Register *translatedSrcReg = usingCompressedPointers ? compressedRegister : sourceRegister;
 
     TR::MemoryReference *tempMR = TR::MemoryReference::createWithRootLoadOrStore(cg, node);
 
@@ -1293,17 +1309,14 @@ TR::Register *J9::ARM64::TreeEvaluator::awrtbariEvaluator(TR::Node *node, TR::Co
     if (node->getSymbolReference()->getSymbol()->isVolatile() && cg->comp()->target().isSMP())
         generateSynchronizationInstruction(cg, TR::InstOpCode::dmb, node, TR::InstOpCode::ish);
 
+    TR::Register *destinationRegister = cg->evaluate(node->getThirdChild());
     wrtbarEvaluator(node, sourceRegister, destinationRegister, secondChild->isNonNull(), cg);
 
     if (killSource)
         cg->stopUsingRegister(sourceRegister);
 
-    if (usingCompressedPointers) {
-        // The reference count of secondChild has been bumped up.
-        cg->decReferenceCount(secondChild);
-    }
     cg->decReferenceCount(node->getSecondChild());
-    cg->decReferenceCount(node->getChild(2));
+    cg->decReferenceCount(node->getThirdChild());
     tempMR->decNodeReferenceCounts(cg);
 
     if (comp->useCompressedPointers())


### PR DESCRIPTION
This PR modifies awrtbariEvaluator() for AArch64, based on the implementation of the same function for Power.
It makes the generated instruction sequence shorter by removing redundant register copies caused by bumped reference counts.