### PR TITLE
AArch64: Clean up unused variables in JIT

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64JNILinkage.cpp
@@ -87,8 +87,6 @@ void J9::ARM64::JNILinkage::releaseVMAccess(TR::Node *callNode, TR::Register *vm
     // releaseVMRestart:
     //
 
-    const int releaseVMAccessMask = fej9->constReleaseVMAccessMask();
-
     generateTrg1Src1ImmInstruction(cg(), TR::InstOpCode::addimmx, callNode, scratchReg0, vmThreadReg,
         fej9->thisThreadGetPublicFlagsOffset());
     loadConstant64(cg(), callNode, fej9->constReleaseVMAccessOutOfLineMask(), scratchReg1);
@@ -988,8 +986,6 @@ TR::Instruction *J9::ARM64::JNILinkage::generateMethodDispatch(TR::Node *callNod
 TR::Register *J9::ARM64::JNILinkage::buildDirectDispatch(TR::Node *callNode)
 {
     TR::LabelSymbol *returnLabel = generateLabelSymbol(cg());
-    TR::SymbolReference *callSymRef = callNode->getSymbolReference();
-    TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();
     TR::ResolvedMethodSymbol *resolvedMethodSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
     TR_ResolvedMethod *resolvedMethod = resolvedMethodSymbol->getResolvedMethod();
     uintptr_t targetAddress = reinterpret_cast<uintptr_t>(resolvedMethod->startAddressForJNIMethod(comp()));
@@ -1046,8 +1042,10 @@ TR::Register *J9::ARM64::JNILinkage::buildDirectDispatch(TR::Node *callNode)
     TR::RealRegister *javaStackReg = machine()->getRealRegister(getProperties().getStackPointerRegister()); // x20
     TR::Register *x9Reg = deps->searchPreConditionRegister(TR::RealRegister::x9);
     TR::Register *x10Reg = deps->searchPreConditionRegister(TR::RealRegister::x10);
+#ifndef J9VM_INTERP_ATOMIC_FREE_JNI
     TR::Register *x11Reg = deps->searchPreConditionRegister(TR::RealRegister::x11);
     TR::Register *x12Reg = deps->searchPreConditionRegister(TR::RealRegister::x12);
+#endif
 
     if (createJNIFrame) {
         buildJNICallOutFrame(callNode, (resolvedMethod == comp()->getCurrentMethod()), returnLabel, vmThreadReg,

--- a/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64PrivateLinkage.cpp
@@ -839,7 +839,6 @@ void J9::ARM64::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
     const TR::ARM64LinkageProperties &properties = getProperties();
     TR::Machine *machine = cg()->machine();
     TR::Node *lastNode = cursor->getNode();
-    TR::ResolvedMethodSymbol *bodySymbol = comp()->getJittedMethodSymbol();
     TR::RealRegister *javaSP = machine->getRealRegister(properties.getStackPointerRegister()); // x20
 
     // restore preserved GPRs
@@ -1859,7 +1858,6 @@ static TR::Register *evaluateUpToVftChild(TR::Node *callNode, TR::CodeGenerator 
 void J9::ARM64::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode, TR::RegisterDependencyConditions *dependencies,
     uint32_t argSize)
 {
-    TR::Register *x0 = dependencies->searchPreConditionRegister(TR::RealRegister::x0);
     TR::Register *x9 = dependencies->searchPreConditionRegister(TR::RealRegister::x9);
     TR::Register *x10 = dependencies->searchPreConditionRegister(TR::RealRegister::x10);
     TR::Register *x11 = dependencies->searchPreConditionRegister(TR::RealRegister::x11);
@@ -2225,7 +2223,6 @@ void J9::ARM64::PrivateLinkage::buildVirtualDispatch(TR::Node *callNode, TR::Reg
 TR::Register *J9::ARM64::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
 {
     const TR::ARM64LinkageProperties &pp = getProperties();
-    TR::RealRegister *sp = cg()->machine()->getRealRegister(pp.getStackPointerRegister());
 
     // Extra post dependency for killing vector registers (see KillVectorRegs)
     const int extraPostReg = killsVectorRegisters() ? 1 : 0;

--- a/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64Recompilation.cpp
@@ -51,8 +51,6 @@ TR_PersistentMethodInfo *TR_ARM64Recompilation::getExistingMethodInfo(TR_Resolve
 
 TR::Instruction *TR_ARM64Recompilation::generatePrePrologue()
 {
-    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
-
     // If in Full Speed Debug, allow to go through
     if (!couldBeCompiledAgain() && !_compilation->getOption(TR_FullSpeedDebug))
         return NULL;

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -184,7 +184,6 @@ TR_RuntimeHelper TR::ARM64CallSnippet::getHelper()
     TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
     TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
     TR_J9VMBase *fej9 = comp->fej9();
-    TR::SymbolReference *glueRef = NULL;
     bool isJitInduceOSRCall = false;
     if (methodSymbol->isHelper() && methodSymRef->isOSRInductionHelper()) {
         isJitInduceOSRCall = true;
@@ -234,7 +233,6 @@ uint8_t *TR::ARM64CallSnippet::emitSnippetBody()
     TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
     TR::SymbolReference *glueRef;
     TR::Compilation *comp = cg()->comp();
-    void *trmpln = NULL;
     TR_J9VMBase *fej9 = comp->fej9();
 
     getSnippetLabel()->setCodeLocation(cursor);
@@ -404,7 +402,6 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64CallSnippet *snippet)
     TR::Node *callNode = snippet->getNode();
     TR::SymbolReference *glueRef = _cg->getSymRef(snippet->getHelper());
     TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
-    TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
     printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(methodSymRef));
@@ -454,7 +451,6 @@ uint8_t *TR::ARM64UnresolvedCallSnippet::emitSnippetBody()
     uint8_t *cursor = TR::ARM64CallSnippet::emitSnippetBody();
 
     TR::SymbolReference *methodSymRef = getNode()->getSymbolReference();
-    TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
     intptr_t helperLookupOffset;
 
     TR::Compilation *comp = cg()->comp();
@@ -511,7 +507,6 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64UnresolvedCallSnippet *snippet)
     uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation() + snippet->getLength(0) - (sizeof(intptr_t) * 2);
 
     TR::SymbolReference *methodSymRef = snippet->getNode()->getSymbolReference();
-    TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();
 
     intptr_t helperLookupOffset;
     switch (snippet->getNode()->getDataType()) {

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -789,7 +789,6 @@ static void VMnonNullSrcWrtBarCardCheckEvaluator(TR::Node *node, TR::Register *d
     TR_ARM64ScratchRegisterManager *srm, TR::LabelSymbol *doneLabel, TR::SymbolReference *wbRef, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
-    TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
     auto gcMode = TR::Compiler->om.writeBarrierType();
     bool doWrtBar = (gcMode == gc_modron_wrtbar_oldcheck || gcMode == gc_modron_wrtbar_cardmark_and_oldcheck
         || gcMode == gc_modron_wrtbar_always);
@@ -838,7 +837,6 @@ static void VMnonNullSrcWrtBarCardCheckEvaluator(TR::Node *node, TR::Register *d
                                      "wrtbarEvaluator:010VMnonNullSrcWrtBarCardCheckEvaluator:01oldCheckDone"),
             *srm);
 
-        TR::LabelSymbol *noChkLabel = generateLabelSymbol(cg);
         if (doCrdMrk) {
             /*
              * Check if J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE flag is set.
@@ -1078,7 +1076,6 @@ static void wrtbarEvaluator(TR::Node *node, TR::Register *srcReg, TR::Register *
     TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
-    TR::Instruction *cursor;
     auto gcMode = TR::Compiler->om.writeBarrierType();
     bool doWrtBar = (gcMode == gc_modron_wrtbar_oldcheck || gcMode == gc_modron_wrtbar_cardmark_and_oldcheck
         || gcMode == gc_modron_wrtbar_always);
@@ -2014,7 +2011,6 @@ TR::Register *J9::ARM64::TreeEvaluator::VMinstanceofEvaluator(TR::Node *node, TR
     bool topClassWasCastClass = false;
     float topClassProbability = 0.0;
 
-    bool profiledClassIsInstanceOf;
     InstanceOfOrCheckCastProfiledClasses profiledClassesList[4];
     uint32_t numberOfProfiledClass;
     uint32_t numSequencesRemaining
@@ -2030,8 +2026,6 @@ TR::Register *J9::ARM64::TreeEvaluator::VMinstanceofEvaluator(TR::Node *node, TR
     TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *callHelperLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *nextSequenceLabel = generateLabelSymbol(cg);
-
-    TR::Instruction *gcPoint;
 
     TR_ARM64ScratchRegisterManager *srm = cg->generateScratchRegisterManager();
     TR::Register *objectClassReg = NULL;
@@ -2319,7 +2313,6 @@ TR::Register *J9::ARM64::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR:
     bool topClassWasCastClass = false;
     float topClassProbability = 0.0;
 
-    bool profiledClassIsInstanceOf;
     InstanceOfOrCheckCastProfiledClasses profiledClassesList[4];
     uint32_t numberOfProfiledClass;
     uint32_t numSequencesRemaining
@@ -2334,8 +2327,6 @@ TR::Register *J9::ARM64::TreeEvaluator::VMcheckcastEvaluator(TR::Node *node, TR:
     TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *callHelperLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *nextSequenceLabel = generateLabelSymbol(cg);
-
-    TR::Instruction *gcPoint;
 
     TR_ARM64ScratchRegisterManager *srm = cg->generateScratchRegisterManager();
     TR::Register *objectClassReg = NULL;
@@ -3600,10 +3591,6 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
     bool use64BitClasses = !TR::Compiler->om.generateCompressedObjectHeaders();
     TR::InstOpCode::Mnemonic storeClassOp = use64BitClasses ? TR::InstOpCode::strimmx : TR::InstOpCode::strimmw;
 
-    // Zero size arrays are considered "discontiguous", and the "mustBeZero" field
-    // of discontiguous arrays must be located where the "size" field of contiguous arrays is.
-    UDATA offsetOfMustBeZeroField = fej9->getOffsetOfContiguousArraySizeField();
-
     // the maximum number of elements we can handle without risking an overflow
     uintptr_t maxObjectSizeInElements = cg->getMaxObjectSizeGuaranteedNotToOverflow() / referenceFieldSize;
 
@@ -3627,8 +3614,6 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
 
     // ptr to array of sizes, with the highest dimension in the front
     TR::Register *dimsPtrReg = cg->evaluate(node->getFirstChild());
-    // number of dimensions - compile time constant
-    uint32_t nDims = node->getSecondChild()->get32bitIntegralValue();
     // class pointer of objects in the array - in the 2D case this is the class of the subarray
     TR::Register *classReg = cg->evaluate(node->getThirdChild());
 
@@ -4638,8 +4623,7 @@ TR::Register *J9::ARM64::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, T
             //
             TR_VirtualGuard *virtualGuard
                 = TR_VirtualGuard::createArrayStoreCheckGuard(comp, node, node->getArrayStoreClassInNode());
-            TR::Instruction *vgnopInstr
-                = generateVirtualGuardNOPInstruction(cg, node, virtualGuard->addNOPSite(), NULL, helperCallLabel);
+            generateVirtualGuardNOPInstruction(cg, node, virtualGuard->addNOPSite(), NULL, helperCallLabel);
         } else {
             // If source is null, we can skip array store check.
             auto cbzInstruction = generateCompareBranchInstruction(cg, TR::InstOpCode::cbzx, node, srcReg, wbLabel);
@@ -5384,7 +5368,6 @@ static TR::Register *VMinlineCompareAndSwap(TR::Node *node, TR::CodeGenerator *c
 static TR::Register *VMinlineCompareAndSwapObject(TR::Node *node, TR::CodeGenerator *cg, bool isExchange = false)
 {
     TR::Compilation *comp = cg->comp();
-    TR_J9VMBase *fej9 = reinterpret_cast<TR_J9VMBase *>(comp->fe());
     TR::Register *objReg, *offsetReg, *resultReg;
     TR::Node *firstChild, *objNode, *offsetNode, *oldVNode, *newVNode;
     TR::LabelSymbol *doneLabel;
@@ -7951,7 +7934,6 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
 TR::Instruction *J9::ARM64::TreeEvaluator::generateVFTMaskInstruction(TR::CodeGenerator *cg, TR::Node *node,
     TR::Register *dstReg, TR::Register *srcReg, TR::Instruction *preced)
 {
-    TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
     uintptr_t mask = TR::Compiler->om.maskOfObjectVftField();
     bool isCompressed = TR::Compiler->om.compressObjectReferences();
 
@@ -7977,7 +7959,6 @@ TR::Register *J9::ARM64::TreeEvaluator::loadaddrEvaluator(TR::Node *node, TR::Co
 {
     TR::Register *resultReg;
     TR::Symbol *sym = node->getSymbol();
-    TR::Compilation *comp = cg->comp();
     TR::MemoryReference *mref = TR::MemoryReference::createWithSymRef(cg, node, node->getSymbolReference());
 
     if (mref->getUnresolvedSnippet() != NULL) {
@@ -8398,7 +8379,6 @@ static void genArrayletAccessAddr(TR::CodeGenerator *cg, TR::Node *node, int32_t
     // Outputs:
     TR::Register *arrayletReg, TR::Register *offsetReg, int32_t &offsetVal)
 {
-    TR::Compilation *comp = cg->comp();
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
     TR_ASSERT(offsetReg || !indexReg, "Expecting valid offset reg when index reg is passed");
 

--- a/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
@@ -34,7 +34,6 @@
 uint8_t *TR::ARM64StackCheckFailureSnippet::emitSnippetBody()
 {
     TR::ResolvedMethodSymbol *bodySymbol = cg()->comp()->getJittedMethodSymbol();
-    TR::Machine *machine = cg()->machine();
     TR::SymbolReference *sofRef = cg()->comp()->getSymRefTab()->findOrCreateStackOverflowSymbolRef(bodySymbol);
     ListIterator<TR::ParameterSymbol> paramIterator(&(bodySymbol->getParameterList()));
     TR::ParameterSymbol *paramCursor = paramIterator.getFirst();

--- a/runtime/compiler/aarch64/runtime/ARM64RelocationTarget.cpp
+++ b/runtime/compiler/aarch64/runtime/ARM64RelocationTarget.cpp
@@ -52,7 +52,6 @@ uintptr_t TR_ARM64RelocationTarget::loadThunkCPIndex(uint8_t *reloLocation)
 
 void TR_ARM64RelocationTarget::performThunkRelocation(uint8_t *thunkBase, uintptr_t vmHelper)
 {
-    uintptr_t sendTarget = vmHelper;
     int32_t *thunkRelocationData = (int32_t *)(thunkBase - sizeof(int32_t));
 
     storeAddressSequence((uint8_t *)vmHelper, thunkBase + *thunkRelocationData, 1);

--- a/runtime/compiler/aarch64/runtime/Recomp.cpp
+++ b/runtime/compiler/aarch64/runtime/Recomp.cpp
@@ -50,8 +50,6 @@ static int32_t encodeDistanceInBranchInstruction(TR::InstOpCode::Mnemonic op, in
 TR_PersistentJittedBodyInfo *J9::Recompilation::getJittedBodyInfoFromPC(void *startPC)
 {
     J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
-    int32_t jitEntryOffset = getJitEntryOffset(linkageInfo);
-    int32_t *jitEntry = (int32_t *)((int8_t *)startPC + jitEntryOffset);
     TR_PersistentJittedBodyInfo *info = NULL;
 
     if (linkageInfo->isSamplingMethodBody()) {
@@ -200,7 +198,7 @@ void J9::Recompilation::methodCannotBeRecompiled(void *oldStartPC, TR_FrontEnd *
 {
     J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(oldStartPC);
     TR_J9VMBase *fej9 = (TR_J9VMBase *)fe;
-    int32_t *patchAddr, newInstr;
+    int32_t *patchAddr;
     intptr_t distance;
     TR_ASSERT(linkageInfo->isSamplingMethodBody() && !linkageInfo->isCountingMethodBody()
             || !linkageInfo->isSamplingMethodBody() && linkageInfo->isCountingMethodBody(),
@@ -272,8 +270,6 @@ void arm64IndirectCallPatching_unwrapper(void **argsPtr, void **resPtr)
 void fixupMethodInfoAddressInCodeCache(void *startPC, void *bodyInfo)
 {
     J9::PrivateLinkage::LinkageInfo *linkageInfo = J9::PrivateLinkage::LinkageInfo::get(startPC);
-    int32_t jitEntryOffset = getJitEntryOffset(linkageInfo);
-    int32_t *jitEntry = (int32_t *)((int8_t *)startPC + jitEntryOffset);
 
     if (linkageInfo->isSamplingMethodBody()) {
         *(void **)((int8_t *)startPC + OFFSET_SAMPLING_METHODINFO_FROM_STARTPC) = bodyInfo;


### PR DESCRIPTION
This PR removes unused variables from the JIT files for AArch64.