### PR TITLE
Add test to verify static field flattening

### DIFF
--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTestClasses.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTestClasses.java
@@ -70,6 +70,11 @@ public class ValueTypeTestClasses {
 		final ValueTypeInt vti;
 	}
 
+	static value class StaticIntWrapper {
+		@NullRestricted
+		static final ValueTypeInt siw = new ValueTypeInt(10);
+	}
+
 	static class Point2D {
 		final int x, y;
 

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeUnsafeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeUnsafeTests.java
@@ -152,6 +152,12 @@ public class ValueTypeUnsafeTests {
 	}
 
 	@Test
+	static public void testStaticFieldIsNeverFlattened() throws Throwable {
+		boolean isFlattened = myUnsafe.isFlatField(StaticIntWrapper.class.getDeclaredField("siw"));
+		assertFalse(isFlattened);
+	}
+
+	@Test
 	static public void testFlattenedArrayIsFlattened() throws Throwable {
 		boolean isArrayFlattened = myUnsafe.isFlatArray(vtPointAry.getClass());
 		assertEquals(isArrayFlattened, isArrayFlatteningEnabled);


### PR DESCRIPTION
Add tests to verify that static fields are not flattened. 
Add a test for the isFlatField API to ensure it correctly validates static field flattening.


Signed-off-by: Aditi Srinivas M <Aditi.Srini@ibm.com>