### PR TITLE
Share deriveCallingLinkage across all code generators

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -8838,20 +8838,9 @@ TR::Register *J9::ARM64::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *no
 TR::Register *J9::ARM64::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Register *returnRegister;
-
     if (!cg->inlineDirectCall(node, returnRegister)) {
-        TR::SymbolReference *symRef = node->getSymbolReference();
-        TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
-        TR::Linkage *linkage;
-
-        if (callee->isJNI()
-            && (node->isPreparedForDirectJNI() || callee->getResolvedMethodSymbol()->canDirectNativeCall())) {
-            linkage = cg->getLinkage(TR_J9JNILinkage);
-        } else {
-            linkage = cg->getLinkage(callee->getLinkageConvention());
-        }
+        TR::Linkage *linkage = cg->deriveCallingLinkage(node, false /* isIndirect */);
         returnRegister = linkage->buildDirectDispatch(node);
     }
-
     return returnRegister;
 }

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5600,3 +5600,19 @@ void J9::CodeGenerator::setConstRefInfoOnClient(const std::vector<ConstRefInfo> 
 }
 
 #endif // defined(J9VM_OPT_OPENJDK_METHODHANDLE) && defined(J9VM_OPT_JITSERVER)
+
+TR::Linkage *J9::CodeGenerator::deriveCallingLinkage(TR::Node *node, bool isIndirect)
+{
+    TR::SymbolReference *symRef = node->getSymbolReference();
+    TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
+
+    static char *disableDirectNativeCall = feGetEnv("TR_DisableDirectNativeCall");
+
+    if (!isIndirect && callee->isJNI()
+        && (node->isPreparedForDirectJNI()
+            || (disableDirectNativeCall == NULL && callee->getResolvedMethodSymbol()->canDirectNativeCall()))) {
+        return self()->getLinkage(TR_J9JNILinkage);
+    }
+
+    return self()->getLinkage(callee->getLinkageConvention());
+}

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -815,6 +815,11 @@ public:
     void setConstRefInfoOnClient(const std::vector<ConstRefInfo> &info, uint8_t *startPC);
 #endif
 
+    /**
+     * \copydoc OMR::CodeGenerator::deriveCallingLinkage
+     */
+    TR::Linkage *deriveCallingLinkage(TR::Node *node, bool isIndirect);
+
 private:
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
     void addInvokeBasicCallSiteImpl(TR::Node *callNode, TR::Instruction *instr, uint8_t *retAddr);

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -718,20 +718,3 @@ void J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Reg
         }
     }
 }
-
-TR::Linkage *J9::Power::CodeGenerator::deriveCallingLinkage(TR::Node *node, bool isIndirect)
-{
-    TR::SymbolReference *symRef = node->getSymbolReference();
-    TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
-    TR_J9VMBase *fej9 = (TR_J9VMBase *)(self()->fe());
-
-    static char *disableDirectNativeCall = feGetEnv("TR_DisableDirectNativeCall");
-
-    // Clean-up: the fej9 checking seemed unnecessary
-    if (!isIndirect && callee->isJNI()
-        && (node->isPreparedForDirectJNI()
-            || (disableDirectNativeCall == NULL && callee->getResolvedMethodSymbol()->canDirectNativeCall())))
-        return self()->getLinkage(TR_J9JNILinkage);
-
-    return self()->getLinkage(callee->getLinkageConvention());
-}

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -80,8 +80,6 @@ public:
 
     bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
 
-    TR::Linkage *deriveCallingLinkage(TR::Node *node, bool isIndirect);
-
     bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
 
     bool enableAESInHardwareTransformations();


### PR DESCRIPTION
The `TR::CodeGenerator::deriveCallingLinkage` method provides a means for a downstream project like OpenJ9 to use linkage that's appropriate for a particular call site &mdash; in particular, direct calls to JNI native methods.  Otherwise, the call defaults to the linkage that's associated with the symbol that was specified on the call node.

Although `deriveCallingLinkage` is not called currently on any platform except Power, the intention is that OMR will provide a default implementation of that method and call `deriveCallingLinkage` to select the linkage to use for any particular call.

Reuse the Power implementation of `deriveCallingLinkage` as the default implementation for all platforms in OpenJ9.  Similar code that was part of `J9::ARM64::TreeEvaluator::directCallEvaluator` is replaced with a call to `deriveCallingLinkage`.

This pull request depends on OMR pull request eclipse-omr/omr#8144 to introduce calls to `TR::CodeGenerator::deriveCallingLinkage`, and must be delivered before that OMR pull request can be merged.  Together the two pull requests will resolve issue #23399.
   