### PR TITLE
Valhalla adds Access/Unsafe APIs and JVM_NewReferenceArray

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -645,16 +645,16 @@ final class Access implements JavaLangAccess {
 	/*[ENDIF] JAVA_SPEC_VERSION < 25 */
 
 	@Override
-	/*[IF (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION == 26) | INLINE-TYPES]*/
+	/*[IF (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION == 26)]*/
 	public int uncheckedEncodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ELSE] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION == 26) | INLINE-TYPES */
+	/*[ELSE] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION == 26) */
 	public int encodeASCII(char[] sa, int sp, byte[] da, int dp, int len) {
-	/*[ENDIF] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION == 26) | INLINE-TYPES */
-		/*[IF (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES]*/
+	/*[ENDIF] (JAVA_SPEC_VERSION == 25) | (JAVA_SPEC_VERSION == 26) */
+		/*[IF JAVA_SPEC_VERSION >= 27]*/
 		return StringCoding.encodeAsciiArray(sa, sp, da, dp, len);
-		/*[ELSE] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
+		/*[ELSE] JAVA_SPEC_VERSION >= 27 */
 		return StringCoding.implEncodeAsciiArray(sa, sp, da, dp, len);
-		/*[ENDIF] (JAVA_SPEC_VERSION >= 27) & !INLINE-TYPES */
+		/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
@@ -1039,7 +1039,6 @@ final class Access implements JavaLangAccess {
 		StackTraceElement.finishInit(stackTrace);
 	}
 
-	/*[IF !INLINE-TYPES]*/
 	@Override
 	public long nativeThreadID(Thread thread) {
 		return thread.nativeThreadID();
@@ -1049,6 +1048,5 @@ final class Access implements JavaLangAccess {
 	public void setThreadNativeID(long id) {
 		Thread.currentThread().setNativeThreadID(id);
 	}
-	/*[ENDIF] !INLINE-TYPES */
 	/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
 }

--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -7255,5 +7255,9 @@ public final class Unsafe {
 	public int arrayInstanceIndexScale(Object[] array) {
 		throw new Error("jdk.internal.misc.Unsafe.arrayInstanceIndexScale unimplemented"); //$NON-NLS-1$
 	}
+
+	public boolean isFlatPayloadBinary(Class<?> valueType) {
+		throw new Error("jdk.internal.misc.Unsafe.isFlatPayloadBinary unimplemented"); //$NON-NLS-1$
+	}
 	/*[ENDIF] INLINE-TYPES */
 }

--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -536,6 +536,7 @@ if(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		JVM_NewNullableAtomicArray
 		JVM_NewNullRestrictedAtomicArray
 		JVM_NewNullRestrictedNonAtomicArray
+		JVM_NewReferenceArray
 		JVM_VirtualThreadHideFrames
 	)
 endif()

--- a/runtime/j9vm/valhallavmi.cpp
+++ b/runtime/j9vm/valhallavmi.cpp
@@ -239,6 +239,12 @@ JVM_NewNullRestrictedNonAtomicArray(JNIEnv *env, jclass componentType, jint leng
 	return newArrayHelper(env, componentType, length, true, initialValue);
 }
 
+JNIEXPORT jarray JNICALL
+JVM_NewReferenceArray(JNIEnv *env, jclass componentType, jint length)
+{
+	assert(!"JVM_NewReferenceArray() stubbed!");
+	return NULL;
+}
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 } /* extern "C" */

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -479,6 +479,8 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_NewNullRestrictedAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length, jobject initialValue)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_NewNullRestrictedNonAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass elmClass, jint len, jobject initialValue)])
+_IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
+	[_X(JVM_NewReferenceArray, JNICALL, false, jarray, JNIEnv *env, jclass componentType, jint length)])
 _IF([JAVA_SPEC_VERSION >= 22],
 	[_X(JVM_ExpandStackFrameInfo, JNICALL, false, void, JNIEnv *env, jobject object)])
 _IF([JAVA_SPEC_VERSION == 22],


### PR DESCRIPTION
Valhalla adds `Access`/`Unsafe` APIs and `JVM_NewReferenceArray`

Updated `Access` APIs;
Stubbed `jdk.internal.misc.Unsafe.isFlatPayloadBinary(Class<?> valueType)`;
Stubbed `JVM_NewReferenceArray(JNIEnv *env, jclass componentType, jint length)`.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/29

and also depends on its change.

Passed [a personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/2602/)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>