### PR TITLE
Set minimum region size 1M for Balanced for all platforms

### DIFF
--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.hpp
@@ -47,12 +47,7 @@ public:
 protected:
 private:
 
-#if defined(J9ZOS39064)
-	/* Set minimum region size to 1m for ZOS to match 1m pageable page */
-	static const uintptr_t _minimumRegionSizeInBytes = (1024 * 1024);
-#else /* defined(J9ZOS39064) */
-	static const uintptr_t _minimumRegionSizeInBytes = (512 * 1024);
-#endif /* defined(J9ZOS39064) */
+	static const uintptr_t _minimumRegionSizeInBytes = (uintptr_t)(1024 * 1024);
 
 /* Methods */
 public:


### PR DESCRIPTION
Currently minimum region size is set for 512k for all platforms except ZOS, where it is set to 1M to match 1M pageable physical page size. So, let's unify this and set 1M for all platforms.