### PR TITLE
x86, AArch64: Don't lower non-zero multianewarray

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3169,8 +3169,6 @@ TR::TreeTop *TR_J9VMBase::lowerMultiANewArray(TR::Compilation *comp, TR::Node *r
     } else
         TR_ASSERT(false, "Number of dims in multianewarray is not constant");
 
-    bool secondDimConstNonZero = (root->getChild(2)->getOpCode().isLoadConst() && (root->getChild(2)->getInt() != 0));
-
     // Allocate a temp to hold the array of dimensions
     //
     TR::AutomaticSymbol *temp = TR::AutomaticSymbol::create(comp->trHeapMemory(), TR::Int32, sizeof(int32_t) * dims);
@@ -3203,11 +3201,7 @@ TR::TreeTop *TR_J9VMBase::lowerMultiANewArray(TR::Compilation *comp, TR::Node *r
     root->setNumChildren(3);
 
     static bool recreateRoot = feGetEnv("TR_LowerMultiANewArrayRecreateRoot") ? true : false;
-#if defined(TR_HOST_POWER) || defined(TR_HOST_S390)
     if (!comp->target().is64Bit() || recreateRoot || dims > 2)
-#else
-    if (!comp->target().is64Bit() || recreateRoot || dims > 2 || secondDimConstNonZero)
-#endif /* defined(TR_HOST_POWER) || defined(TR_HOST_S390) */
         TR::Node::recreate(root, TR::acall);
 
     return treeTop;


### PR DESCRIPTION
Remove the platform-specific guard for lowering multianewarray nodes to helper calls. As x86 and AArch64 code generators now support multianewarray for 2D arrays with non-zero dimensions, there is no longer any benefit to lowering the node to a helper call when we know the dimensions are non-zero.

This change was originally part of https://github.com/eclipse-openj9/openj9/pull/22562, but the changes to runtime/compiler/env/VMJ9.cpp got missed when the corrected multianewarray changes were re-submitted in https://github.com/eclipse-openj9/openj9/pull/23390.