### PR TITLE
Align zip data structures

### DIFF
--- a/runtime/include/vmizip.h
+++ b/runtime/include/vmizip.h
@@ -92,11 +92,10 @@ typedef struct VMIZipFile
   U_8 *filename;
   void *cache;
   void *cachePool;
-  I_32 fd;
-  I_32 pointer;
+  IDATA fd;
+  I_64 pointer;
   U_8 internalFilename[80];
   U_8 type;
-  char _vmipadding0065[3];  /* 3 bytes of automatic padding */
 } VMIZipFile;
 
 typedef struct VMIZipFunctionTable {

--- a/runtime/include/zipsup.h
+++ b/runtime/include/zipsup.h
@@ -132,7 +132,7 @@ typedef struct J9ZipFile {
     struct J9ZipCache* cache;
     void* cachePool;
     IDATA fd;
-    U_32 pointer;
+    I_64 pointer;
     U_8 internalFilename[80];
     U_8 type;
 } J9ZipFile;


### PR DESCRIPTION
The two data structures VMIZipFile and J9ZipFile used in the different layers of jvm, should have the same definitions for direct cast. 

Fixes: #23440