### PR TITLE
Remove -Xdump:none from re001 JVMTI test

### DIFF
--- a/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
+++ b/test/functional/cmdLineTests/jvmtitests/jvmtitests.xml
@@ -158,7 +158,7 @@
 	</test>
 
 	<test id="re001">
-		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:re001 -Xdisableexcessivegc -Dcom.ibm.tools.attach.enable=no -Dcom.ibm.tools.attach.enable=no -Xdump:none -Xmx128M -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
+		<command>$EXE$ $JVM_OPTS$ $AGENTLIB$=test:re001 -Xdisableexcessivegc -Dcom.ibm.tools.attach.enable=no -Dcom.ibm.tools.attach.enable=no -Xmx128M -cp $Q$$JAR$$Q$ $TESTRUNNER$</command>
 		<return type="success" value="0"/>
 	</test>
 


### PR DESCRIPTION
Currently JVMTI test re001 has -Xdump:none option set. This option prevents core generation in the case of failure. Removing.

Issue https://github.com/eclipse-openj9/openj9/issues/23444