### PR TITLE
(0.59) Disable simultaneous usage of jcmd and cmd jfr ops

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -516,6 +516,10 @@ public class DiagnosticUtils {
 	}
 
 	private static DiagnosticProperties doJFR(String diagnosticCommand) {
+		if (VM.isStartFlightRecordingSpecified()) {
+			return DiagnosticProperties.makeStringResult("Cannot use jcmd JFR options at the same time as -XX:startFlightRecording.");
+		}
+
 		DiagnosticProperties result = null;
 		// split the command and arguments
 		String[] parts = diagnosticCommand.split(DIAGNOSTICS_OPTION_SEPARATOR);


### PR DESCRIPTION
Disallow the simultaneous usage of jcmd and cmdline JFR operations. Currently, we only supoort one JFR record at a time so allowing both jcmd and cmdline options may be confusing as both support duration recording.

Backport https://github.com/eclipse-openj9/openj9/pull/23427