### PR TITLE
Add WorkLoad execution to JFRCmdLinePropertiesTest to keep application alive for 2min

### DIFF
--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCmdLinePropertiesTest.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCmdLinePropertiesTest.java
@@ -31,5 +31,17 @@ public class JFRCmdLinePropertiesTest {
 		System.out.println("filename=" + (filename != null ? filename : "null"));
 		System.out.println("delay=" + (delayNanos != null ? delayNanos + " nanoseconds" : "null"));
 		System.out.println("duration=" + (durationNanos != null ? durationNanos + " nanoseconds" : "null"));
+
+		// Run workload to keep application alive for 2 minutes
+		System.out.println("Starting workload for 2 minutes...");
+		long startTime = System.currentTimeMillis();
+
+		// Create WorkLoad with parameters tuned for ~2 minute execution
+		// numberOfThreads=10, sizeOfNumberList=5000, repeats=20
+		WorkLoad workload = new WorkLoad(10, 5000, 20);
+		workload.runWork();
+
+		long totalTime = System.currentTimeMillis() - startTime;
+		System.out.println("Workload completed. Total time: " + (totalTime / 1000) + " seconds");
 	}
 }


### PR DESCRIPTION
# Summary

This PR enhances the JFRCmdLinePropertiesTest to run a comprehensive workload that keeps the application alive for approximately 2 minutes, allowing JFR (Java Flight Recorder) to capture meaningful runtime data during command-line property testing.

# Changes Made

- Integrated the existing WorkLoad class into JFRCmdLinePropertiesTest
- Configured WorkLoad with parameters (10 threads, 5000 number list size, 20 repeats) tuned for ~2 minute execution
- Added execution time reporting after workload completion
- Workload generates various JFR events including:
  - Thread operations (park, sleep, wait)
  - Class loading activities
  - Exception throwing
  - Lock contention
  - CPU-intensive calculations

# Testing

- The test now runs the WorkLoad which has been used in other JFR tests
- Application will remain active for approximately 2 minutes, providing sufficient time for JFR recording
- Existing test functionality (printing JFR command-line properties) is preserved

# Additional Notes

This change ensures that JFR has adequate time to capture runtime events and data during the test execution, making the test more effective for validating JFR command-line property handling.