### PR TITLE
Remove Vahalla Access.classFileFormatVersion()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -918,13 +918,6 @@ final class Access implements JavaLangAccess {
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 22 */
 
-	/*[IF INLINE-TYPES]*/
-	@Override
-	public int classFileFormatVersion(Class<?> c) {
-		return c.getClassFileVersion();
-	}
-	/*[ENDIF] INLINE-TYPES */
-
 	/*[IF JAVA_SPEC_VERSION >= 24]*/
 	@Override
 	/*[IF JAVA_SPEC_VERSION >= 25]*/


### PR DESCRIPTION
[Remove Vahalla Access.classFileFormatVersion()](https://github.com/eclipse-openj9/openj9/commit/75d20dbbb38ddbee493cf747da84797c558bf6ba) 

```
Valhalla removed JavaLangAccess.classFileFormatVersion().
```

Interdependent on
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/32

Passed [a personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/2608/)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>