### PR TITLE
Fix SCC disableBCI mode with intermediate and modified classes

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -669,6 +669,8 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 			loadType = J9SHR_LOADTYPE_RETRANSFORMED;
 		} else if (context->isClassUnsafe()
 			|| context->isClassHidden()
+			|| context->isCreatingIntermediateROMClass()
+			|| (context->classFileBytesReplaced() && (NULL == _javaVM->sharedClassConfig->modContext))
 			|| (LOAD_LOCATION_UNKNOWN == context->loadLocation())
 		) {
 			/* For redefining/transforming, we still want loadType to be J9SHR_LOADTYPE_REDEFINED/J9SHR_LOADTYPE_RETRANSFORMED,


### PR DESCRIPTION
1. In disableBCI mode, intermediate and modified classes (with no modcontext) are always stored as orphan, which are not asscoated with any class paths. Set loadType to J9SHR_LOADTYPE_NOT_FROM_PATH so that we won't create classpath wraper in these cases.

2. Intermediate class and modified class are not cached in enableBCI mode. This change has no effect on SCC enableBCI mode, which is the default mode.

Fixes #23448