### PR TITLE
[0.59.0] Share deriveCallingLinkage across all code generators

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -9163,23 +9163,10 @@ J9::ARM64::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node, TR::CodeGe
 TR::Register *J9::ARM64::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
    {
    TR::Register *returnRegister;
-
    if (!cg->inlineDirectCall(node, returnRegister))
       {
-      TR::SymbolReference *symRef = node->getSymbolReference();
-      TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
-      TR::Linkage *linkage;
-
-      if (callee->isJNI() && (node->isPreparedForDirectJNI() || callee->getResolvedMethodSymbol()->canDirectNativeCall()))
-         {
-         linkage = cg->getLinkage(TR_J9JNILinkage);
-         }
-      else
-         {
-         linkage = cg->getLinkage(callee->getLinkageConvention());
-         }
+      TR::Linkage *linkage = cg->deriveCallingLinkage(node, false /* isIndirect */);
       returnRegister = linkage->buildDirectDispatch(node);
       }
-
    return returnRegister;
    }

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -6382,3 +6382,20 @@ J9::CodeGenerator::setConstRefInfoOnClient(
    }
 
 #endif // defined(J9VM_OPT_OPENJDK_METHODHANDLE) && defined(J9VM_OPT_JITSERVER)
+
+TR::Linkage *J9::CodeGenerator::deriveCallingLinkage(TR::Node *node, bool isIndirect)
+   {
+   TR::SymbolReference *symRef = node->getSymbolReference();
+   TR::MethodSymbol *callee = symRef->getSymbol()->castToMethodSymbol();
+
+   static char *disableDirectNativeCall = feGetEnv("TR_DisableDirectNativeCall");
+
+   if (!isIndirect && callee->isJNI()
+       && (node->isPreparedForDirectJNI()
+           || (disableDirectNativeCall == NULL && callee->getResolvedMethodSymbol()->canDirectNativeCall())))
+      {
+      return self()->getLinkage(TR_J9JNILinkage);
+      }
+
+   return self()->getLinkage(callee->getLinkageConvention());
+   }

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -779,6 +779,11 @@ public:
    void setConstRefInfoOnClient(const std::vector<ConstRefInfo> &info, uint8_t *startPC);
 #endif
 
+   /**
+    * \copydoc OMR::CodeGenerator::deriveCallingLinkage
+    */
+   TR::Linkage *deriveCallingLinkage(TR::Node *node, bool isIndirect);
+
 private:
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -814,21 +814,3 @@ J9::Power::CodeGenerator::insertPrefetchIfNecessary(TR::Node *node, TR::Register
          }
       }
    }
-
-TR::Linkage *
-J9::Power::CodeGenerator::deriveCallingLinkage(TR::Node *node, bool isIndirect)
-   {
-   TR::SymbolReference *symRef    = node->getSymbolReference();
-   TR::MethodSymbol    *callee    = symRef->getSymbol()->castToMethodSymbol();
-   TR_J9VMBase         *fej9      = (TR_J9VMBase *)(self()->fe());
-
-   static char * disableDirectNativeCall = feGetEnv("TR_DisableDirectNativeCall");
-
-   // Clean-up: the fej9 checking seemed unnecessary
-   if (!isIndirect && callee->isJNI() &&
-       (node->isPreparedForDirectJNI() ||
-        (disableDirectNativeCall == NULL && callee->getResolvedMethodSymbol()->canDirectNativeCall())))
-      return self()->getLinkage(TR_J9JNILinkage);
-
-   return self()->getLinkage(callee->getLinkageConvention());
-   }

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -90,8 +90,6 @@ public:
 
    bool inlineDirectCall(TR::Node *node, TR::Register *&resultReg);
 
-   TR::Linkage *deriveCallingLinkage(TR::Node *node, bool isIndirect);
-
    bool suppressInliningOfRecognizedMethod(TR::RecognizedMethod method);
 
    bool enableAESInHardwareTransformations();


### PR DESCRIPTION
The `TR::CodeGenerator::deriveCallingLinkage` method provides a means for a downstream project like OpenJ9 to use linkage that's appropriate for a particular call site &mdash; in particular, direct calls to JNI native methods.  Otherwise, the call defaults to the linkage that's associated with the symbol that was specified on the call node.

Although `deriveCallingLinkage` is not called currently on any platform except Power, the intention is that OMR will provide a default implementation of that method and call `deriveCallingLinkage` to select the linkage to use for any particular call.

Reuse the Power implementation of `deriveCallingLinkage` as the default implementation for all platforms in OpenJ9.  Similar code that was part of `J9::ARM64::TreeEvaluator::directCallEvaluator` is replaced with a call to `deriveCallingLinkage`.

This pull request depends on OpenJ9-OMR pull request eclipse-openj9/openj9-omr#272 to introduce calls to `TR::CodeGenerator::deriveCallingLinkage`, and must be delivered before that OpenJ9-OMR pull request can be merged.  Together the two pull requests will resolve issue #23399.

This pull request is a port of pull request #23423 to the v0.59.0-release branch.  Some formatting changes were required due to the recent changes to formatting of the compiler component.