### PR TITLE
Eliminate the VM_getObjectClassFromKnownObjectIndex message

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -549,11 +549,6 @@ static bool handleResponse(JITServer::MessageType response, JITServer::ClientStr
             uintptr_t objectAddress = std::get<0>(client->getRecvData<uintptr_t>());
             client->write(response, fe->getObjectClassAt(objectAddress));
         } break;
-        case MessageType::VM_getObjectClassFromKnownObjectIndex: {
-            auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
-            auto idx = std::get<0>(recv);
-            client->write(response, fe->getObjectClassFromKnownObjectIndex(comp, idx));
-        } break;
         case MessageType::VM_getObjectClassInfoFromKnotIndex: {
             auto recv = client->getRecvData<TR::KnownObjectTable::Index>();
             TR::KnownObjectTable::Index knotIndex = std::get<0>(recv);

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1140,13 +1140,12 @@ TR_OpaqueClassBlock *TR_J9VMBase::getObjectClassAt(uintptr_t objectAddress)
 TR_OpaqueClassBlock *TR_J9VMBase::getObjectClassFromKnownObjectIndex(TR::Compilation *comp,
     TR::KnownObjectTable::Index idx)
 {
-    TR::VMAccessCriticalSection getObjectClassFromKnownObjectIndex(comp);
-    TR_OpaqueClassBlock *clazz = getObjectClass(comp->getKnownObjectTable()->getPointer(idx));
+    // Get and cache the desired information
+    TR::KnownObjectTable::ObjectInfo objInfo = getObjClassInfoFromKnotIndex(comp, idx);
+    return objInfo._isFixedJavaLangClass ? objInfo._jlClass : objInfo._clazz;
 
-    J9::ConstProvenanceGraph *cpg = comp->constProvenanceGraph();
-    cpg->addEdge(cpg->knownObject(idx), clazz);
-
-    return clazz;
+    // Note: We don't need to add an edge to comp->constProvenanceGraph() because
+    // this is done in getObjClassInfoFromKnotIndexNoCaching()
 }
 
 TR_OpaqueClassBlock *TR_J9VMBase::getObjectClassFromKnownObjectIndex(TR::Compilation *comp,
@@ -1159,10 +1158,9 @@ TR_OpaqueClassBlock *TR_J9VMBase::getObjectClassFromKnownObjectIndex(TR::Compila
     TR::KnownObjectTable::ObjectInfo objInfo = getObjClassInfoFromKnotIndex(comp, idx);
     *isJavaLangClass = objInfo._isFixedJavaLangClass;
 
-    // Don't nedd to add an edge to comp->constProvenanceGraph() because this
-    // is done in getObjClassInfoFromKnotIndex() frontend query
-    // J9::ConstProvenanceGraph *cpg = comp->constProvenanceGraph();
-    // cpg->addEdge(cpg->knownObject(idx), clazz);
+    // Note: We don't need to add an edge to comp->constProvenanceGraph() because
+    // this is done in getObjClassInfoFromKnotIndexNoCaching()
+
     return objInfo._clazz;
 }
 
@@ -1172,6 +1170,8 @@ uintptr_t TR_J9VMBase::getStaticReferenceFieldAtAddress(uintptr_t fieldAddress)
     return (uintptr_t)J9STATIC_OBJECT_LOAD(vmThread(), NULL, fieldAddress);
 }
 
+// This function assumes that we have a knot entry that has only the _jniReference
+// field populated and we want to retrieve the rest of the fields.
 TR::KnownObjectTable::ObjectInfo TR_J9VMBase::getObjClassInfoFromKnotIndexNoCaching(TR::Compilation *comp,
     TR::KnownObjectTable::Index knotIndex)
 {
@@ -1195,6 +1195,8 @@ TR::KnownObjectTable::ObjectInfo TR_J9VMBase::getObjClassInfoFromKnotIndexNoCach
         // the java/lang/Class object represents.
         retrievedObjInfo._clazz = getClassFromJavaLangClass(objectReference);
     }
+    J9::ConstProvenanceGraph *cpg = comp->constProvenanceGraph();
+    cpg->addEdge(cpg->knownObject(knotIndex), retrievedObjInfo._clazz);
     return retrievedObjInfo;
 }
 
@@ -1231,9 +1233,8 @@ TR::KnownObjectTable::ObjectInfo TR_J9VMBase::getObjClassInfoFromKnotIndex(TR::C
             answerObjInfo = existingObjInfo;
         }
     }
-
-    J9::ConstProvenanceGraph *cpg = comp->constProvenanceGraph();
-    cpg->addEdge(cpg->knownObject(knotIndex), answerObjInfo._clazz);
+    // Note: We don't need to add an edge to comp->constProvenanceGraph() because
+    // this is done in getObjClassInfoFromKnotIndexNoCaching()
     return answerObjInfo;
 }
 

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -858,14 +858,6 @@ TR_OpaqueClassBlock *TR_J9ServerVM::getObjectClassAt(uintptr_t objectAddress)
     return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
 }
 
-TR_OpaqueClassBlock *TR_J9ServerVM::getObjectClassFromKnownObjectIndex(TR::Compilation *comp,
-    TR::KnownObjectTable::Index idx)
-{
-    JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
-    stream->write(JITServer::MessageType::VM_getObjectClassFromKnownObjectIndex, idx);
-    return std::get<0>(stream->read<TR_OpaqueClassBlock *>());
-}
-
 uintptr_t TR_J9ServerVM::getStaticReferenceFieldAtAddress(uintptr_t fieldAddress)
 {
     TR_ASSERT_FATAL(false, "getStaticReferenceFieldAtAddress() should not be called by JITServer");

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -137,8 +137,6 @@ public:
     virtual uint32_t getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock *clazz) override;
     virtual TR_OpaqueClassBlock *getObjectClass(uintptr_t objectPointer) override;
     virtual TR_OpaqueClassBlock *getObjectClassAt(uintptr_t objectAddress) override;
-    virtual TR_OpaqueClassBlock *getObjectClassFromKnownObjectIndex(TR::Compilation *comp,
-        TR::KnownObjectTable::Index idx) override;
     virtual uintptr_t getStaticReferenceFieldAtAddress(uintptr_t fieldAddress) override;
     virtual TR::KnownObjectTable::ObjectInfo getObjClassInfoFromKnotIndexNoCaching(TR::Compilation *comp,
         TR::KnownObjectTable::Index knotIndex) override;

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
     // likely to lose an increment when merging/rebasing/etc.
     //
     static const uint8_t MAJOR_NUMBER = 1;
-    static const uint16_t MINOR_NUMBER = 99; // ID: Ux5WzqSxujCchhi+IAqz
+    static const uint16_t MINOR_NUMBER = 100; // ID: fd7QYgAKTKgrQL6Fxs+7
     static const uint8_t PATCH_NUMBER = 0;
     static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -115,7 +115,6 @@ const char *messageNames[] = {
     "VM_getMethods",
     "VM_getObjectClass",
     "VM_getObjectClassAt",
-    "VM_getObjectClassFromKnownObjectIndex",
     "VM_stackWalkerMaySkipFrames",
     "VM_classInitIsFinished",
     "VM_getClassFromNewArrayType",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -127,7 +127,6 @@ enum MessageType : uint16_t {
     VM_getMethods,
     VM_getObjectClass,
     VM_getObjectClassAt,
-    VM_getObjectClassFromKnownObjectIndex,
     VM_stackWalkerMaySkipFrames,
     VM_classInitIsFinished,
     VM_getClassFromNewArrayType,


### PR DESCRIPTION
The message `VM_getObjectClassFromKnownObjectIndex` is sent by the server from the `getObjectClassFromKnownObjectIndex(comp, knot_index)` frontend call to retrieve the class of the object stored in the known object table at the given index. In many cases the known object table has this information already cached.
This commit reimplements the frontend query
`getObjectClassFromKnownObjectIndex(TR::Compilation *, TR::KnownObjectTable::Index)` so that it calls `getObjClassInfoFromKnotIndex()` which in turn takes advantage of the existing cache in the known object table.