### PR TITLE
Add missing primordial handler for criuReloadXDumpAgents

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -75,7 +75,7 @@ J9NLS_VM_MALFORMED_XSERVICE_ERROR_STR.user_response=Examine -Xservice option and
 J9NLS_VM_OPTIONS_FILE_NOT_FOUND_STR=Options file not found
 # START NON-TRANSLATABLE
 J9NLS_VM_OPTIONS_FILE_NOT_FOUND_STR.explanation=The JVM could not open a file that contained extra command line options.
-J9NLS_VM_OPTIONS_FILE_NOT_FOUND_STR.system_action=The JVM will ignore the failure continue.
+J9NLS_VM_OPTIONS_FILE_NOT_FOUND_STR.system_action=The JVM will ignore the failure and continue.
 J9NLS_VM_OPTIONS_FILE_NOT_FOUND_STR.user_response=Correct the issue with the options file, either location or permissions, or remove the reference to the options file from the command line.
 # END NON-TRANSLATABLE
 
@@ -2551,4 +2551,13 @@ J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_STRICT=A static field with a NullRestrict
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_STRICT.explanation=Please consult the Java Virtual Machine Specification for a detailed explanation.
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_STRICT.system_action=The JVM will throw a java.lang.IncompatibleClassChangeError.
 J9NLS_VM_STATIC_NULLRESTRICTED_MUST_BE_STRICT.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE
+
+# criuReloadXDumpAgents is the name of an API. It should not be translated.
+J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS=criuReloadXDumpAgents requires %s
+# START NON-TRANSLATABLE
+J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS.sample_input_1=j9dmp29
+J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS.explanation=A call to internal VM function criuReloadXDumpAgents() has failed because the required DLL has not been loaded.
+J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS.system_action=The JVM will ignore the failure and continue.
+J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS.user_response=Check whether the JVM dump functions have been disabled via the -Xdump:none option.
 # END NON-TRANSLATABLE

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -442,7 +442,7 @@ static IDATA
 criuReloadXDumpAgents(J9JavaVM *vm, J9VMInitArgs *vmArgs)
 {
 	/* similar with startup except at CRIU restore */
-	IDATA result = 0;
+	IDATA result = J9VMDLLMAIN_OK;
 	J9VMThread *vmThread = vm->mainThread;
 
 	Trc_trcengine_criu_criuReloadXDumpAgents_Entry(vmThread);

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -55,6 +55,9 @@ static omr_error_t primordialSetDumpOption (struct J9JavaVM *vm, char *optionStr
 static omr_error_t primordialResetDumpOption (struct J9JavaVM *vm);
 static omr_error_t primordialRemoveDumpAgent (struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
 static omr_error_t primordialQueryVmDump(struct J9JavaVM *vm, int buffer_size, void* options_buffer, int* data_size);
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static IDATA primordialCriuReloadXDumpAgents(struct J9JavaVM *vm, struct J9VMInitArgs *j9vm_args);
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 void J9RASInitialize (J9JavaVM* javaVM);
 void J9RASShutdown (J9JavaVM* javaVM);
@@ -85,7 +88,10 @@ primordialDumpFacade = {
 	primordialTriggerDumpAgents,
 	primordialSetDumpOption,
 	primordialResetDumpOption,
-	primordialQueryVmDump
+	primordialQueryVmDump,
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+	primordialCriuReloadXDumpAgents,
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 };
 
 static omr_error_t
@@ -197,6 +203,18 @@ primordialQueryVmDump(struct J9JavaVM *vm, int buffer_size, void* options_buffer
 
 	return OMR_ERROR_NONE;
 }
+
+#if defined(J9VM_OPT_CRIU_SUPPORT)
+static IDATA
+primordialCriuReloadXDumpAgents(struct J9JavaVM *vm, struct J9VMInitArgs *j9vm_args)
+{
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS, J9_RAS_DUMP_DLL_NAME);
+
+	return 0;
+}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 IDATA 
 gpThreadDump(struct J9JavaVM *vm, struct J9VMThread *currentThread)


### PR DESCRIPTION
A snapshot taken with `-Xdump:none` in effect might crash on restart if `OPENJ9_RESTORE_JAVA_OPTIONS` contains `-Xdump` options.