### PR TITLE
x86: Use general multianewarray implementation

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -1490,6 +1490,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     bool needsAlignLeaf = (OMR::align(leafArrayElementSize, alignmentInBytes) != leafArrayElementSize);
     bool needsAlignHeader = (contiguousArrayHeaderSize != OMR::align(contiguousArrayHeaderSize, alignmentInBytes));
     uintptr_t referenceSize = TR::Compiler->om.sizeofReferenceField();
+    bool needsAlignSpine = (OMR::align(referenceSize, alignmentInBytes) != referenceSize) || needsAlignHeader;
 
     bool use64BitClasses = !TR::Compiler->om.generateCompressedObjectHeaders();
 
@@ -1557,7 +1558,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         generateX86MemoryReference(spineSizeReg, firstDimReg, trailingZeroes((int32_t)referenceSize), 0, cg), cg);
 
     // pad spine size so leaf arrays will be aligned
-    if (needsAlignHeader) {
+    if (needsAlignSpine) {
         generateRegImmInstruction(TR::InstOpCode::ADD8RegImm4, node, spineSizeReg, alignmentInBytes - 1, cg);
         generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, spineSizeReg, -alignmentInBytes, cg);
     }
@@ -1832,7 +1833,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
  *
  * NB Must only be used for arrays of at least two dimensions
  */
-static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, TR::CodeGenerator *cg)
+static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
 
@@ -1884,6 +1885,10 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
     // Generate the heap allocation, and the snippet that will handle heap overflow.
     TR_OutlinedInstructions *outlinedHelperCall
         = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::acall, targetReg, oolFailLabel, doneLabel, cg);
+    cg->generateDebugCounter(outlinedHelperCall->getFirstInstruction(),
+        TR::DebugCounter::debugCounterName(comp, "multianewarray/dynamic/zero-dim/helper/(%s)/%d/%d", comp->signature(),
+            node->getByteCodeInfo().getCallerIndex(), node->getByteCodeInfo().getByteCodeIndex()),
+        1, TR::DebugCounter::Cheap);
     cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
 
     dimReg = cg->evaluate(secondChild);
@@ -2135,7 +2140,7 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
  * Generate code for multianewarray
  *
  * Checks the number of dimensions. For 1 dimensional arrays call the helper, for >1 call
- * generateMultianewArrayWithInlineAllocators.
+ * generate2DArrayWithInlineAllocators or generate2DZeroLengthArrayWithInlineAllocators.
  */
 TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
@@ -2148,10 +2153,21 @@ TR::Register *J9::X86::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, TR
     // The number of dimensions should always be an iconst
     TR_ASSERT_FATAL(secondChild->getOpCodeValue() == TR::iconst, "dims of multianewarray must be iconst");
 
-    // Only generate inline code if nDims > 1
+    // Anything with more than 2 dimensions will be replaced by a direct call when lowering trees.
     uint32_t nDims = secondChild->get32bitIntegralValue();
-    if (nDims > 1) {
-        return generateMultianewArrayWithInlineAllocators(node, cg);
+    TR_ASSERT_FATAL(nDims <= 2,
+        "multianewarray with dimension >2 should have been lowered to direct call before instruction selection");
+
+    TR::Node *classNode = node->getThirdChild(); // class of the outermost dimension
+
+    if (nDims == 2) {
+        static const bool disable = feGetEnv("TR_Disable2DArrayWithInlineAllocators") != NULL;
+        int32_t leafArrayElementSize = TR::Compiler->om.getTwoDimensionalArrayComponentSize(classNode);
+        if (!disable && (leafArrayElementSize != -1) && !comp->getOptions()->realTimeGC()) {
+            return generate2DArrayWithInlineAllocators(node, cg, leafArrayElementSize);
+        } else {
+            return generate2DZeroLengthArrayWithInlineAllocators(node, cg);
+        }
     } else {
         logprintf(comp->getOption(TR_TraceCG), comp->log(),
             "Disabling inline allocations for multianewarray of dim %d\n", nDims);


### PR DESCRIPTION
Another piece of https://github.com/eclipse-openj9/openj9/pull/22562 that got missed when reopened as https://github.com/eclipse-openj9/openj9/pull/23390. With the formatting change and the rush to fix https://github.com/eclipse-openj9/openj9/issues/23385, the call to `generate2DArrayWithInlineAllocators` was dropped.

Internal testing: http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=113831.
Showing that this passes the failing tests from https://github.com/eclipse-openj9/openj9/issues/23385: http://vmfarm.rtp.raleigh.ibm.com/build_diff_by_status.php?build_id_old=112671&from_state=FAILED&build_id_new=113831&to_state=PASSED