### PR TITLE
Selectively acquire parked class is event is hook

### DIFF
--- a/runtime/vm/threadpark.cpp
+++ b/runtime/vm/threadpark.cpp
@@ -92,9 +92,9 @@ threadParkImpl(J9VMThread *vmThread, BOOLEAN timeoutIsEpochRelative, I_64 timeou
 
 	if (J9THREAD_TIMED_OUT != rc) {
 		PORT_ACCESS_FROM_VMC(vmThread);
-		J9Class *parkedClass = getThreadParkClassObject(vmThread);
 		UDATA parkedAddress = (UDATA) vmThread->threadObject;
 		I_64 startTicks = j9time_nano_time();
+
 		/* vmThread->threadObject != NULL because vmThread must be the current thread */
 		J9VMTHREAD_SET_BLOCKINGENTEROBJECT(vmThread, vmThread, J9VMJAVALANGTHREAD_PARKBLOCKER(vmThread, vmThread->threadObject));
 		TRIGGER_J9HOOK_VM_PARK(vm->hookInterface, vmThread, millis, nanos);
@@ -120,7 +120,10 @@ threadParkImpl(J9VMThread *vmThread, BOOLEAN timeoutIsEpochRelative, I_64 timeou
 
 		internalAcquireVMAccessClearStatus(vmThread, thrstate);
 		VM_VMHelpers::setThreadState(vmThread, oldState);
-		TRIGGER_J9HOOK_VM_UNPARKED(vm->hookInterface, vmThread, millis, nanos, startTicks, (UDATA) parkedAddress, VM_VMHelpers::currentClass(parkedClass));
+		if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_UNPARKED)) {
+			J9Class *parkedClass = getThreadParkClassObject(vmThread);
+			ALWAYS_TRIGGER_J9HOOK_VM_UNPARKED(vm->hookInterface, vmThread, millis, nanos, startTicks, (UDATA) parkedAddress, VM_VMHelpers::currentClass(parkedClass));
+		}
 		J9VMTHREAD_SET_BLOCKINGENTEROBJECT(vmThread, vmThread, NULL);
 	}
 	/* Trc_JCL_park_Exit(vmThread, rc); */


### PR DESCRIPTION
In the park path, currently the pak class is looked up in all cases. This requires a stackwalk which may be expensive if park/unpark is done frequently. This PR modifies the behaviour such that park is only called if the unpark event is hooked.