### PR TITLE
(0.59) Update JFRCmdLinePropertiesTest

### DIFF
--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCmdLinePropertiesTest.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCmdLinePropertiesTest.java
@@ -31,5 +31,17 @@ public class JFRCmdLinePropertiesTest {
 		System.out.println("filename=" + (filename != null ? filename : "null"));
 		System.out.println("delay=" + (delayNanos != null ? delayNanos + " nanoseconds" : "null"));
 		System.out.println("duration=" + (durationNanos != null ? durationNanos + " nanoseconds" : "null"));
+
+		// Run workload to keep application alive for 2 minutes
+		System.out.println("Starting workload for 2 minutes...");
+		long startTime = System.currentTimeMillis();
+
+		// Create WorkLoad with parameters tuned for ~2 minute execution
+		// numberOfThreads=10, sizeOfNumberList=5000, repeats=20
+		WorkLoad workload = new WorkLoad(10, 5000, 20);
+		workload.runWork();
+
+		long totalTime = System.currentTimeMillis() - startTime;
+		System.out.println("Workload completed. Total time: " + (totalTime / 1000) + " seconds");
 	}
 }


### PR DESCRIPTION
- Integrated existing WorkLoad class to run comprehensive workload
- Configured with 10 threads, 5000 number list size, and 20 repeats
- Workload generates various JFR events including thread operations, class loading, exceptions, and CPU activity
- Reports total execution time after workload completion

Backport of https://github.com/eclipse-openj9/openj9/pull/23461

Co-written by IBM-Bob