### PR TITLE
Remove aarch64 directCallEvaluator

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -8827,13 +8827,3 @@ TR::Register *J9::ARM64::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *no
 
     return NULL;
 }
-
-TR::Register *J9::ARM64::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
-{
-    TR::Register *returnRegister;
-    if (!cg->inlineDirectCall(node, returnRegister)) {
-        TR::Linkage *linkage = cg->deriveCallingLinkage(node, false /* isIndirect */);
-        returnRegister = linkage->buildDirectDispatch(node);
-    }
-    return returnRegister;
-}

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.hpp
@@ -164,14 +164,6 @@ public:
     static TR::Register *BNDCHKwithSpineCHKEvaluator(TR::Node *node, TR::CodeGenerator *cg);
 
     /**
-     * @brief Handles direct call nodes
-     * @param[in] node : node
-     * @param[in] cg : CodeGenerator
-     * @return register containing result
-     */
-    static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
-
-    /**
      * @brief Generates the sequence to handle cases where the monitor object is value type
      * @param[in] node : the monitor enter/exit node
      * @param[in] mergeLabel : the label to return from OOL code


### PR DESCRIPTION
The implementation of [`J9::ARM64::TreeEvaluator::directCallEvaluator`](https://github.com/eclipse-openj9/openj9/blob/c3efe837c7cd58e8142d572025227937934a8f5a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp#L8831-L8839) is functionally identical to OMR's version,
[`OMR::ARM64::TreeEvaluator::directCallEvaluator`](https://github.com/eclipse-omr/omr/blob/22dcd7df88616647abd14cf19940ac5b1e9a5c74/compiler/aarch64/codegen/OMRTreeEvaluator.cpp#L7216-L7224).  This is due to changes delivered under OpenJ9 pull request #23423 and OMR pull request eclipse-omr/omr#8144.  Remove the OpenJ9 version as it is no longer needed.