### PR TITLE
Ensure Security class is loaded when checking FIPS mode

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -1004,6 +1004,10 @@ public static String getProperty(String prop, String defaultValue) {
 		}
 		throw new Error("bootstrap error, system property access before init: " + prop); //$NON-NLS-1$
 	}
+	if (prop.equals("com.ibm.fips.mode")) { //$NON-NLS-1$
+		// Ensure the Security class is loaded and initialized.
+		J9VMInternals.initialize(Security.class);
+	}
 
 	return systemProperties.getProperty(prop, defaultValue);
 }


### PR DESCRIPTION
Initialize security class when accessing com.ibm.fips.mode property.

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)