### PR TITLE
Correct error for putfield with static field before super()

### DIFF
--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -1505,6 +1505,13 @@ _illegalPrimitiveReturn:
 			if (BCV_ERR_INSUFFICIENT_MEMORY == reasonCode) {
 				goto _outOfMemoryError;
 			}
+#if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
+			if (BCV_ERR_INVALID_USE_STRICT_INSTANCE_FIELDS == reasonCode) {
+				errorType = J9NLS_BCV_ERR_UNKNOWN_STRICT_FIELD__ID;
+				verboseErrorCode = BCV_ERR_INVALID_USE_STRICT_INSTANCE_FIELDS;
+				goto _miscError;
+			}
+#endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 			inconsistentStack |= (FALSE == rc);
 			if (inconsistentStack) {
 				constantPool = (J9ROMConstantPoolItem *) (romClass + 1);

--- a/runtime/bcverify/vrfyhelp.c
+++ b/runtime/bcverify/vrfyhelp.c
@@ -893,8 +893,10 @@ j9bcv_createVerifyErrorString(J9PortLibrary * portLib, J9BytecodeVerificationDat
  *
  * returns TRUE if class are compatible
  * returns FALSE it not compatible
- * 		reasonCode (set by isClassCompatibleByName) is:
- *			BCV_ERR_INSUFFICIENT_MEMORY :in OOM error case
+ * 		reasonCode:
+ *			BCV_ERR_INSUFFICIENT_MEMORY in OOM error case (set by isClassCompatibleByName)
+ *			BCV_ERR_INVALID_USE_STRICT_INSTANCE_FIELDS if putfield tries to set a
+ * 				static field in early larval phase
  */
 IDATA 
 isFieldAccessCompatible(
@@ -934,10 +936,15 @@ isFieldAccessCompatible(
 			}
 
 			if (isInitMethod && liveStack->uninitializedThis) {
+				if (J9_ARE_ALL_BITS_SET(field->modifiers, J9AccStatic)) {
+					*reasonCode = BCV_ERR_INVALID_USE_STRICT_INSTANCE_FIELDS;
+					return (IDATA)FALSE;
+				}
 				J9StrictFieldEntry query = {0};
 				query.nas = J9ROMFIELDREF_NAMEANDSIGNATURE(fieldRef);
 				J9StrictFieldEntry *entry = hashTableFind(verifyData->strictFields, &query);
-				if ((NULL != entry) && !entry->isSet) {
+				Assert_RTV_true(NULL != entry);
+				if (!entry->isSet) {
 					Assert_RTV_true(verifyData->strictFieldsUnsetCount > 0);
 					entry->isSet = TRUE;
 					verifyData->strictFieldsUnsetCount--;
@@ -1276,8 +1283,7 @@ findFieldFromCurrentRomClass(J9ROMClass *romClass, J9ROMFieldRef *field)
 
 	currentField = romFieldsStartDo(romClass, &state);
 	while (NULL != currentField) {
-		if (J9_ARE_NO_BITS_SET(currentField->modifiers, J9AccStatic)
-			&& compareTwoUTF8s(searchName, J9ROMFIELDSHAPE_NAME(currentField))
+		if (compareTwoUTF8s(searchName, J9ROMFIELDSHAPE_NAME(currentField))
 			&& compareTwoUTF8s(searchSignature, J9ROMFIELDSHAPE_SIGNATURE(currentField))
 		) {
 			break;

--- a/runtime/nls/vrfy/j9bcv.nls
+++ b/runtime/nls/vrfy/j9bcv.nls
@@ -446,3 +446,11 @@ J9NLS_BCV_ERR_UNINITIALIZED_VALUE_OBJECT.system_action=The JVM will throw a veri
 J9NLS_BCV_ERR_UNINITIALIZED_VALUE_OBJECT.user_response=Contact the provider of the classfile for a corrected version.
 
 # END NON-TRANSLATABLE
+
+J9NLS_BCV_ERR_UNKNOWN_STRICT_FIELD=Initializing unknown strict field
+# START NON-TRANSLATABLE
+J9NLS_BCV_ERR_UNKNOWN_STRICT_FIELD.explanation=Verification failed because putfield bytecode is used with a strict static field in early larval.
+J9NLS_BCV_ERR_UNKNOWN_STRICT_FIELD.system_action=The JVM will throw a java.lang.VerifyError.
+J9NLS_BCV_ERR_UNKNOWN_STRICT_FIELD.user_response=Contact the provider of the classfile for a corrected version.
+
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -601,6 +601,7 @@ extern "C" {
 #define BCV_ERR_STRICT_FIELDS_UNASSIGNED                (-37)
 #define BCV_ERR_STRICT_FIELD_NOT_VALID                  (-38)
 #define BCV_ERR_STRICT_FIELD_STACK_MAP_INCONSISTENT     (-39)
+#define BCV_ERR_INVALID_USE_STRICT_INSTANCE_FIELDS      (-40)
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 
 #define J9_GC_OBJ_HEAP_HOLE 0x1

--- a/runtime/verbose/errormessageframeworkrtv.c
+++ b/runtime/verbose/errormessageframeworkrtv.c
@@ -957,6 +957,9 @@ generateJ9RtvExceptionDetails(J9BytecodeVerificationData* verifyData, U_8* initM
 	case BCV_ERR_STRICT_FIELD_STACK_MAP_INCONSISTENT:
 		printMessage(&msgBuf, "Inconsistent stackmap frames at branch target.");
 		break;
+	case BCV_ERR_INVALID_USE_STRICT_INSTANCE_FIELDS:
+		printMessage(&msgBuf, "Invalid use of strict instance fields, field is strict static.");
+		break;
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
 	default:
 		Assert_VRB_ShouldNeverHappen();


### PR DESCRIPTION
OpenJ9's behavior does not match the ri's error handling when trying to set a static field with the putfield bytecode before initializing the class's superclass. Example:

```
  public static int x;
    descriptor: I
    flags: (0x0009) ACC_PUBLIC, ACC_STATIC

  public BadExample();
    descriptor: ()V
    flags: (0x0001) ACC_PUBLIC
    Code:
      stack=2, locals=1, args_size=1
         0: aload_0
         1: iconst_5
         2: putfield      #10                 // Field x:I
         5: aload_0
         6: invokespecial #12                 // Method java/lang/Object."<init>":()V
         9: return
```

## Case 1: applicable from Java 8+

ri throws an `java.lang.IncompatibleClassChangeError`

OpenJ9 throws
```
Exception in thread "main" java.lang.VerifyError: JVMVRFY021 thrown object not throwable; class=BadExample, method=<init>()V, pc=2
Exception Details:
  Location:
    BadExample.<init>()V @2: JBputfield
  Reason:
    Type 'uninitializedThis' (current frame, stack[0]) is not assignable to 'BadExample'
  Current Frame:
    bci: @2
    flags: { flagThisUninit }
    locals: { 'uninitializedThis' }
    stack: { 'uninitializedThis' }
	at Test.main(Test.java:4)
```
## Case 2: strict static fields (Project Valhalla)

ri throws
```
Exception in thread "main" java.lang.VerifyError: Initializing unknown strict field: y:I
Exception Details:
  Location:
    StrictFieldNotSubset.<init>()V @2: putfield
  Reason:
    Invalid use of strict instance fields
  Current Frame:
    bci: @2
    flags: { flagThisUninit }
    locals: { uninitializedThis }
    stack: { uninitializedThis, integer }
  Bytecode:
    0000000: 2a04 b500 012a b700 02b1
```

OpenJ9 throws
```
Exception in thread "main" java.lang.VerifyError: JVMVRFY012 stack shape inconsistent; class=StrictFieldNotSubset, method=<init>()V, pc=2
Exception Details:
  Location:
    StrictFieldNotSubset.<init>()V @2: JBputfield
  Reason:
    Type 'uninitializedThis' (current frame, stack[0]) is not assignable to 'StrictFieldNotSubset'
  Current Frame:
    bci: @2
    flags: { flagThisUninit }
    locals: { 'uninitializedThis' }
    stack: { 'uninitializedThis' }
JavaTest Message: shutting down test
```

## Solution

In order to handle this correctly static fields must be returned from findFieldFromCurrentRomClass. In case 1 this would allow static fields to bypass the verifier and in case 2 the field will be handled specially if it is strict.

With this change OpenJ9 throws `java.lang.IncompatibleClassChangeError`
 for case 1 and the following for case 2:
```
JVMVRFY045 Initializing unknown strict field; class=StrictFieldNotSubset, method=<init>()V, pc=2
Exception Details:
  Location:
    StrictFieldNotSubset.<init>()V @2: JBputfield
  Reason:
    Invalid use of strict instance fields, field is static.
	at StrictInstanceFieldsTest.negativeTest(StrictInstanceFieldsTest.java:59)
	at StrictInstanceFieldsTest.main(StrictInstanceFieldsTest.java:110)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:571)
	at com.sun.javatest.regtest.agent.MainMethodHelper.executeModernMainClass(MainMethodHelper.java:55)
	at com.sun.javatest.regtest.agent.MainWrapper$MainTask.run(MainWrapper.java:138)
	at java.base/java.lang.Thread.run(Thread.java:1538)
```