### PR TITLE
Remove migrated valueclass patching from tests

### DIFF
--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -40,7 +40,6 @@
 		-Xint --enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTests \
 		-groups $(TEST_GROUP) \
@@ -78,7 +77,6 @@
 		--enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeTests \
 		-groups $(TEST_GROUP) \
@@ -116,7 +114,6 @@
 		-Xint --enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeArrayTests \
 		-groups $(TEST_GROUP) \
@@ -169,7 +166,6 @@
 		--enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeArrayTests \
 		-groups $(TEST_GROUP) \
@@ -201,7 +197,6 @@
 		-Xint --enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeUnsafeTests \
 		-groups $(TEST_GROUP) \
@@ -243,7 +238,6 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeOptTests \
 		-groups $(TEST_GROUP) \
@@ -287,7 +281,6 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames NullRestrictedTypeOptTests \
 		-groups $(TEST_GROUP) \
@@ -321,7 +314,6 @@
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--enable-preview \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValhallaAttributeTests \
 		-groups $(TEST_GROUP) \
@@ -372,7 +364,6 @@
 		--enable-preview \
 		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
-		--patch-module java.base=$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar \
 		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
 		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeSystemArraycopyTests \
 		-groups $(TEST_GROUP) \

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
-	<variable name="ARGS" value="--enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED --patch-module java.base=$MIGRATEDVALUECLASSJAR$" />
+	<variable name="ARGS" value="--enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRBackfillLayoutTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -25,8 +25,8 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
-	<variable name="ARGS" value="-Xint --enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED --patch-module java.base=$MIGRATEDVALUECLASSJAR$" />
-	<variable name="ARGS_NOCR" value="-Xint --enable-preview -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED --patch-module java.base=$MIGRATEDVALUECLASSJAR$" />
+	<variable name="ARGS" value="-Xint --enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
+	<variable name="ARGS_NOCR" value="-Xint --enable-preview -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -39,7 +39,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
 			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
-			-DMIGRATEDVALUECLASSJAR=$(Q)$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
 			-config $(Q)$(TEST_RESROOT)$(D)flattenedvaluetypeddrtests.xml$(Q) \
@@ -79,7 +78,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
 			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
-			-DMIGRATEDVALUECLASSJAR=$(Q)$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
 			-config $(Q)$(TEST_RESROOT)$(D)unflattenedvaluetypeddrtests.xml$(Q) \
@@ -120,7 +118,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
 			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
-			-DMIGRATEDVALUECLASSJAR=$(Q)$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
 			-config $(Q)$(TEST_RESROOT)$(D)flattened32bitRefBackfillTest.xml$(Q) \
@@ -161,7 +158,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DJCOMMANDERJAR=$(Q)$(LIB_DIR)$(D)jcommander.jar$(Q) \
 			-DTESTNGJAR=$(Q)$(LIB_DIR)$(D)testng.jar$(Q) \
 			-DVALUETYPEJAR=$(Q)$(JVM_TEST_ROOT)$(D)functional$(D)Valhalla$(D)ValhallaTests.jar$(Q) \
-			-DMIGRATEDVALUECLASSJAR=$(Q)$(TEST_JDK_HOME)$(D)lib$(D)valueclasses$(D)java.base-valueclasses.jar$(Q) \
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
 			-config $(Q)$(TEST_RESROOT)$(D)flattened32bitRefBackfillTest.xml$(Q) \

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Value Type ddr test with flattening disabled" timeout="600">
-	<variable name="ARGS" value="--enable-preview -Xint -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED --patch-module java.base=$MIGRATEDVALUECLASSJAR$" />
+	<variable name="ARGS" value="--enable-preview -Xint -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/23479