### PR TITLE
Remove Double Mapping

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.cpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.cpp
@@ -25,12 +25,12 @@
 #include "IndexableObjectAllocationModel.hpp"
 #include "Math.hpp"
 #include "MemorySpace.hpp"
-#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) || defined(J9VM_GC_ENABLE_DOUBLE_MAP)
+#if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 #include "ArrayletLeafIterator.hpp"
 #include "HeapRegionDescriptorVLHGC.hpp"
 #include "Heap.hpp"
 #include "SparseVirtualMemory.hpp"
-#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) || defined(J9VM_GC_ENABLE_DOUBLE_MAP)*/
+#endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)*/
 
 /**
  * Allocation description and layout initialization. This is called before OMR allocates
@@ -286,28 +286,11 @@ MM_IndexableObjectAllocationModel::layoutDiscontiguousArraylet(MM_EnvironmentBas
 			indexableObjectModel->AssertArrayletIsDiscontiguous(spine);
 			Assert_MM_true(arrayoidIndex == _numberOfArraylets);
 			Assert_MM_false(isVirtualLargeObjectHeapEnabled);
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-			if (indexableObjectModel->isDoubleMappingEnabled()) {
-				/**
-				 * There are some special cases where double mapping an arraylet is
-				 * not necessary; isArrayletDataDiscontiguous() details those cases.
-				 */
-				if (indexableObjectModel->isArrayletDataDiscontiguous(spine)) {
-					doubleMapArraylets(env, (J9Object *)spine, NULL);
-				}
-			}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 			break;
 
 		case GC_ArrayletObjectModel::Hybrid:
 			/* Unreachable if off-heap is enabled. */
 			Assert_MM_false(isVirtualLargeObjectHeapEnabled);
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-			/* Unreachable if double map is enabled */
-			if (indexableObjectModel->isDoubleMappingEnabled()) {
-				Assert_MM_double_map_unreachable();
-			}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 			/* Last arrayoid points to end of arrayoid array in spine header (object-aligned if
 			   required). (data size % leaf size) bytes of data are stored here (may be empty). */
 			Assert_MM_true(arrayoidIndex == (_numberOfArraylets - 1));
@@ -457,83 +440,3 @@ MM_IndexableObjectAllocationModel::getSparseAddressAndDecommitLeaves(MM_Environm
 	return spine;
 }
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-#if !((defined(LINUX) || defined(OSX)) && defined(J9VM_ENV_DATA64))
-/* Double map is only supported on LINUX 64 bit Systems for now */
-#error "Platform not supported by Double Map API"
-#endif /* !((defined(LINUX) || defined(OSX)) && defined(J9VM_ENV_DATA64)) */
-void *
-MM_IndexableObjectAllocationModel::doubleMapArraylets(MM_EnvironmentBase *env, J9Object *objectPtr, void *preferredAddress)
-{
-	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-	J9JavaVM *javaVM = extensions->getJavaVM();
-
-	GC_ArrayletLeafIterator arrayletLeafIterator(javaVM, (J9IndexableObject *)objectPtr);
-	MM_Heap *heap = extensions->getHeap();
-	UDATA arrayletLeafSize = env->getOmrVM()->_arrayletLeafSize;
-	UDATA arrayletLeafCount = MM_Math::roundToCeiling(arrayletLeafSize, _dataSize) / arrayletLeafSize;
-	Trc_MM_double_map_Entry(env->getLanguageVMThread(), (void *)objectPtr, arrayletLeafSize, arrayletLeafCount);
-
-	void *result = NULL;
-
-#define ARRAYLET_ALLOC_THRESHOLD 64
-	void *leaves[ARRAYLET_ALLOC_THRESHOLD];
-	void **arrayletLeaveAddrs = leaves;
-	if (arrayletLeafCount > ARRAYLET_ALLOC_THRESHOLD) {
-		arrayletLeaveAddrs = (void **)env->getForge()->allocate(arrayletLeafCount * sizeof(uintptr_t), MM_AllocationCategory::GC_HEAP, J9_GET_CALLSITE());
-	}
-
-	if (NULL == arrayletLeaveAddrs) {
-		return NULL;
-	}
-
-	GC_SlotObject *slotObject = NULL;
-	uintptr_t count = 0;
-
-	while (NULL != (slotObject = arrayletLeafIterator.nextLeafPointer())) {
-		void *currentLeaf = slotObject->readReferenceFromSlot();
-		arrayletLeaveAddrs[count] = currentLeaf;
-		count++;
-	}
-
-	/* Number of arraylet leaves in the iterator must match the number of leaves calculated */
-	Assert_MM_true(arrayletLeafCount == count);
-
-	GC_SlotObject objectSlot(env->getOmrVM(), extensions->indexableObjectModel.getArrayoidPointer((J9IndexableObject *)objectPtr));
-	J9Object *firstLeafSlot = objectSlot.readReferenceFromSlot();
-
-	MM_HeapRegionDescriptorVLHGC *firstLeafRegionDescriptor = (MM_HeapRegionDescriptorVLHGC *)heap->getHeapRegionManager()->tableDescriptorForAddress(firstLeafSlot);
-
-	/* Retrieve actual page size */
-	UDATA pageSize = heap->getPageSize();
-
-	/* For now we double map the entire region of all arraylet leaves. This might change in the future if hybrid regions are introduced. */
-	uintptr_t byteAmount = arrayletLeafSize * arrayletLeafCount;
-
-	/* Get heap and from there call an OMR API that will doble map everything */
-	result = heap->doubleMapRegions(env, arrayletLeaveAddrs, count, arrayletLeafSize, byteAmount,
-				&firstLeafRegionDescriptor->_arrayletDoublemapID,
-				pageSize,
-				preferredAddress);
-
-	if (arrayletLeafCount > ARRAYLET_ALLOC_THRESHOLD) {
-		env->getForge()->free((void *)arrayletLeaveAddrs);
-	}
-
-	/*
-	 * Double map failed.
-	 * If doublemap fails the caller must handle it appropriately. The only case being
-	 * JNI critical, where it will fall back to copying each element of the array to
-	 * a temporary array (logic handled by JNI Critical). It might hurt performance
-	 * but execution won't halt.
-	 */
-	if (NULL == firstLeafRegionDescriptor->_arrayletDoublemapID.address) {
-		Trc_MM_double_map_Failed(env->getLanguageVMThread());
-		result = NULL;
-	}
-
-	Trc_MM_double_map_Exit(env->getLanguageVMThread(), result);
-	return result;
-}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */

--- a/runtime/gc_base/IndexableObjectAllocationModel.hpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.hpp
@@ -151,25 +151,6 @@ public:
 	 */
 	bool initializeAllocateDescription(MM_EnvironmentBase *env);
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	/**
-	 * For non-contiguous arraylets (discontiguous arraylets, hybrid not allowed
-	 * when double map is enabled), double maps the arraylet leaves to a contiguous
-	 * region outside the heap, making a discontiguous arraylet look contiguous.
-	 * Double map is enabled by default, if one wants to disable it, manually pass
-	 * command line option -Xgc:disableArrayletDoubleMapping; however, if the
-	 * system supports huge pages then double map will be disabled. That's because
-	 * double map does support huge pages yet. If one still wants to enable double
-	 * map in such systems, one must manually force the application to use the
-	 * small system page size
-	 *
-	 * @param env thread GC Environment
-	 * @param objectPtr indexable object spine
-	 * @return the contiguous address pointer
-	 */
-	void *doubleMapArraylets(MM_EnvironmentBase *env, J9Object *objectPtr, void *preferredAddress);
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 	/**
 	 * Initializer.
 	 */

--- a/runtime/gc_base/RootScanner.cpp
+++ b/runtime/gc_base/RootScanner.cpp
@@ -252,14 +252,6 @@ MM_RootScanner::doObjectInVirtualLargeObjectHeap(J9Object *objectPtr, GC_HashTab
 }
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-void
-MM_RootScanner::doDoubleMappedObjectSlot(J9Object *objectPtr, struct J9PortVmemIdentifier *identifier)
-{
-	/* No need to call doSlot() here since there's nothing to update */
-}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 /**
  * @Perform operation on the given string cache table slot.
  * @String table cache contains cached entries of string table, it's
@@ -969,30 +961,6 @@ MM_RootScanner::scanObjectsInVirtualLargeObjectHeap(MM_EnvironmentBase *env)
 }
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-void
-MM_RootScanner::scanDoubleMappedObjects(MM_EnvironmentBase *env)
-{
-	if (_singleThread || J9MODRON_HANDLE_NEXT_WORK_UNIT(env)) {
-		GC_HeapRegionIteratorVLHGC regionIterator(_extensions->heap->getHeapRegionManager());
-		MM_HeapRegionDescriptorVLHGC *region = NULL;
-
-		reportScanningStarted(RootScannerEntity_DoubleMappedObjects);
-		while (NULL != (region = regionIterator.nextRegion())) {
-			if (region->isArrayletLeaf()) {
-				J9Object *spineObject = (J9Object *)region->_allocateData.getSpine();
-				Assert_MM_true(NULL != spineObject);
-				J9PortVmemIdentifier *arrayletDoublemapID = &region->_arrayletDoublemapID;
-				if (NULL != arrayletDoublemapID->address) {
-					doDoubleMappedObjectSlot(spineObject, arrayletDoublemapID);
-				}
-			}
-		}
-		reportScanningEnded(RootScannerEntity_DoubleMappedObjects);
-	}
-}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 /**
  * Scan all root set references from the VM into the heap.
  * For all slots that are hard root references into the heap, the appropriate slot handler will be called.
@@ -1136,11 +1104,6 @@ MM_RootScanner::scanClearable(MM_EnvironmentBase *env)
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	if (_includeDoubleMap) {
-		scanDoubleMappedObjects(env);
-	}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 }
 
 /**
@@ -1195,12 +1158,6 @@ MM_RootScanner::scanAllSlots(MM_EnvironmentBase *env)
 		scanObjectsInVirtualLargeObjectHeap(env);
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-        if (_includeDoubleMap) {
-                scanDoubleMappedObjects(env);
-        }
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 	scanOwnableSynchronizerObjects(env);
 	scanContinuationObjects(env);

--- a/runtime/gc_base/RootScanner.hpp
+++ b/runtime/gc_base/RootScanner.hpp
@@ -97,9 +97,6 @@ protected:
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	bool _includeVirtualLargeObjectHeap; /**< Enables scanning of objects that has been allocated at sparse heap. Default is false */
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	bool _includeDoubleMap; /**< Enables doublemap should the GC policy be balanced. Default is false. */
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	bool _trackVisibleStackFrameDepth; /**< Should the stack walker be told to track the visible frame depth. Default false, should set to true when doing JVMTI walks that report stack slots */
 
 	U_64 _entityStartScanTime; /**< The start time of the scan of the current scanning entity, or 0 if no entity is being scanned.  Defaults to 0. */
@@ -328,9 +325,6 @@ public:
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 		, _includeVirtualLargeObjectHeap(_extensions->indexableObjectModel.isVirtualLargeObjectHeapEnabled())
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		, _includeDoubleMap(_extensions->indexableObjectModel.isDoubleMappingEnabled())
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 		, _trackVisibleStackFrameDepth(false)
 		, _entityStartScanTime(0)
 		, _entityIncrementStartTime(0)
@@ -492,19 +486,6 @@ public:
 	void scanObjectsInVirtualLargeObjectHeap(MM_EnvironmentBase *env);
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	/**
-	 * Scans each heap region for arraylet leaves that contains a not NULL
-	 * contiguous address. This address points to a contiguous representation
-	 * of the arraylet associated with this leaf. Only arraylets that has been
-	 * double mapped will contain such contiguous address, otherwise the
-	 * address will be NULL
-	 *
-	 * @param env thread GC Environment
-	 */
-	void scanDoubleMappedObjects(MM_EnvironmentBase *env);
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 	virtual void doClassLoader(J9ClassLoader *classLoader);
 
 	virtual void scanWeakReferenceObjects(MM_EnvironmentBase *env);
@@ -575,18 +556,6 @@ public:
 	 */
 	virtual void doObjectInVirtualLargeObjectHeap(J9Object *objectPtr, GC_HashTableIterator *sparseDataEntryIterator);
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	/**
-	 * Frees double mapped region associated to objectPtr (arraylet spine) if objectPtr
-	 * is not live
-	 *
-	 * @param objectPtr[in] indexable object's spine
-	 * @param identifier[in/out] identifier associated with object's spine, which contains
-	 * doble mapped address and size
-	 */
-	virtual void doDoubleMappedObjectSlot(J9Object *objectPtr, struct J9PortVmemIdentifier *identifier);
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 #if JAVA_SPEC_VERSION >= 24
 	virtual void doContinuationSlot(J9Object **slotPtr, GC_ContinuationSlotIterator *continuationSlotIterator);

--- a/runtime/gc_glue_java/ArrayletObjectModel.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.cpp
@@ -55,22 +55,14 @@ GC_ArrayletObjectModel::AssertContiguousArrayDataUnreachable()
 void
 GC_ArrayletObjectModel::AssertArrayletIsDiscontiguous(J9IndexableObject *objPtr)
 {
-	if (!isVirtualLargeObjectHeapEnabled()
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		&& !isDoubleMappingEnabled()
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-	) {
+	if (!isVirtualLargeObjectHeapEnabled()) {
 		uintptr_t arrayletLeafSize = _omrVM->_arrayletLeafSize;
 		uintptr_t remainderBytes = getDataSizeInBytes(objPtr) % arrayletLeafSize;
 		if (0 != remainderBytes) {
 			MM_GCExtensionsBase *extensions = MM_GCExtensionsBase::getExtensions(_omrVM);
 			Assert_MM_true((getSpineSize(objPtr) + remainderBytes + extensions->getObjectAlignmentInBytes()) > arrayletLeafSize);
 		}
-	} else if ((0 != getSizeInElements(objPtr))
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-			&& isVirtualLargeObjectHeapEnabled()
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-			) {
+	} else if (0 != getSizeInElements(objPtr)) {
 		Assert_MM_unreachable();
 	}
 }
@@ -132,20 +124,13 @@ GC_ArrayletObjectModel::getArrayletLayout(J9Class* clazz, uintptr_t numberOfElem
 			if (extensions->isVLHGC()) {
 				adjustedHybridSpineBytesAfterMove += objectAlignmentInBytes;
 			}
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-			if (extensions->indexableObjectModel.isDoubleMappingEnabled()) {
+			/* if remainder data can fit in spine, make it hybrid */
+			if (adjustedHybridSpineBytesAfterMove <= largestDesirableSpine) {
+				/* remainder data can fit in spine, last arrayoid pointer points to empty data section in spine */
+				layout = Hybrid;
+			} else {
+				/* remainder data will go into an arraylet, last arrayoid pointer points to it */
 				layout = Discontiguous;
-			} else
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-			{
-				/* if remainder data can fit in spine, make it hybrid */
-				if (adjustedHybridSpineBytesAfterMove <= largestDesirableSpine) {
-					/* remainder data can fit in spine, last arrayoid pointer points to empty data section in spine */
-					layout = Hybrid;
-				} else {
-					/* remainder data will go into an arraylet, last arrayoid pointer points to it */
-					layout = Discontiguous;
-				}
 			}
 		} else {
 			/* remainder is empty, so no arraylet allocated; last arrayoid pointer is set to MULL */

--- a/runtime/gc_glue_java/ArrayletObjectModel.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModel.hpp
@@ -254,59 +254,6 @@ public:
 		return getSpineSizeWithoutHeader(layout, numberArraylets, dataSize, alignData);
 	}
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	/**
-	 * Checks if arraylet falls into corner case of discontiguous data
-	 * Arraylet possible cases:
-	 * 0: Empty arraylets, in this case the array is represented as
-	 *		an arraylet however it does not contain any data, but it
-	 *		does contain an arrayoid (leaf pointer) that points to NULL.
-	 *		Even though this case is represented as a discontiguous arraylet
-	 *		internally due to its implementation, it is actually a contiguous
-	 *		array with length zero.
-	 * 1: The total data size in arraylet is between 0 and region
-	 *		size. Small enough to make the arraylet layout contiguous,
-	 *		in which case this function is unreachable.
-	 * 2: The total data size in arraylet is exacly the same size
-	 *		of a region. In this case we do not need to double
-	 *		map since we already have a contiguous representation of the
-	 *		data at first leaf.
-	 * 3: Similar to first case, the data portion is slightly smaller than
-	 *		a region size, however not small enough to include header and data
-	 *		at the same region to make it contiguous. In which case we would
-	 *		have one leaf, where we also do not need to double map.
-	 * 4: The total data size in arraylet is stricly greater than one region;
-	 *		however, not multiple of region size. Since with enabled double map
-	 *		layout is always discontiguous, we would have 2 or more arraylet leaves
-	 *		therefore we always double map.
-	 * 5: The total data size in arraylet is stricly greater than one region and
-	 *		multiple of region size. Here we would have 2 or more arraylet leaves
-	 *		containing data. We always double map in this case.
-	 *
-	 * @param spine Pointer to an array indexable object spine
-	 * @return false in case corner cases 0, 2 or 3 are valid. On the other hand,
-	 *		if cases 4 or 5 are true, the function returns true.
-	 */
-	MMINLINE bool
-	isArrayletDataDiscontiguous(J9IndexableObject *spine)
-	{
-		return numArraylets(spine) > 1;
-	}
-
-	/**
-	 * Checks if arraylet falls into corner case of contiguous data
-	 *
-	 * @param spine Pointer to an array indexable object spine
-	 * @return true in case corner cases 2 or 3 are valid. On the other hand,
-	 * 		if cases 0, 4 or 5 are true, the function returns false.
-	 */
-	MMINLINE bool
-	isArrayletDataContiguous(J9IndexableObject *spine)
-	{
-		return (1 == numArraylets(spine)) && (getSizeInElements(spine) > 0);
-	}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 	/**
 	 * We can't use memcpy because it may be not atomic for pointers, use this function instead
 	 * Copy data in uintptr_t words

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.cpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.cpp
@@ -33,9 +33,6 @@ GC_ArrayletObjectModelBase::initialize(MM_GCExtensionsBase *extensions)
 	_arrayletRangeBase = NULL;
 	_arrayletRangeTop = (void *)UDATA_MAX;
 	_arrayletSubSpace = NULL;
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	_enableDoubleMapping = false;
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	_largestDesirableArraySpineSize = UDATA_MAX;
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
 	_enableVirtualLargeObjectHeap = false;
@@ -113,15 +110,8 @@ GC_ArrayletObjectModelBase::getSpineSizeWithoutHeader(ArrayLayout layout, uintpt
 		if (isVirtualLargeObjectHeapEnabled) {
 			extensions->indexableObjectModel.AssertContiguousArrayDataUnreachable();
 		}
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		else if (extensions->indexableObjectModel.isDoubleMappingEnabled()) {
-			spineDataSize = 0;
-		} else
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-		{
-			/* Last arraylet in spine */
-			spineDataSize = (dataSize & (_omrVM->_arrayletLeafSize - 1));
-		}
+		/* Last arraylet in spine */
+		spineDataSize = (dataSize & (_omrVM->_arrayletLeafSize - 1));
 	}
 
 	return spinePaddingSize + spineArrayoidSize + spineDataSize;

--- a/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
@@ -41,9 +41,6 @@ class GC_ArrayletObjectModelBase
 * Data members
 */
 private:
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	bool _enableDoubleMapping; /** Allows arraylets to be double mapped */
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 protected:
 #if defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)
 	bool _compressObjectReferences;
@@ -164,27 +161,14 @@ public:
 
 #if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
 	/**
-	 * Sets enable double mapping status. Note that the double map
-	 * status value may differ from the requested one in certain
-	 * circuntances.
-	 *
-	 * @param enableDoubleMapping
-	 */
-	MMINLINE void
-	setEnableDoubleMapping(bool enableDoubleMapping)
-	{
-		_enableDoubleMapping = enableDoubleMapping;
-	}
-
-	/**
 	 * Returns enable double mapping status
-	 * 
+	 *
 	 * @return true if double mapping status is set to true, false otherwise.
 	 */
 	MMINLINE bool
 	isDoubleMappingEnabled()
 	{
-		return _enableDoubleMapping;
+		return false;
 	}
 #endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -1509,24 +1509,6 @@ gcParseXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
-		/*
-		 * This feature is not supported for all platforms.
-		 * Ignore options silently if feature is not supported
-		 * to allow to use the same Java command line across platforms.
-		 */
-		if (try_scan(&scan_start, "enableArrayletDoubleMapping")) {
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-			extensions->isArrayletDoubleMapRequested = true;
-#endif /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
-			continue;
-		}
-		if (try_scan(&scan_start, "disableArrayletDoubleMapping")) {
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-			extensions->isArrayletDoubleMapRequested = false;
-#endif /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
-			continue;
-		}
-
 #if defined (J9VM_GC_VLHGC)
 		if (try_scan(&scan_start, "fvtest_tarokForceNUMANode=")) {
 			if (!scan_udata_helper(vm, &scan_start, &extensions->fvtest_tarokForceNUMANode, "fvtest_tarokForceNUMANode=")) {

--- a/runtime/gc_stats/CopyForwardStats.hpp
+++ b/runtime/gc_stats/CopyForwardStats.hpp
@@ -74,10 +74,6 @@ public:
 	uintptr_t _offHeapRegionsCleared; /**< The number of sparse heap allocated regions that have been cleared during marking */
 	uintptr_t _offHeapRegionCandidates; /**< The number of sparse heap allocated regions that have been visited during marking */
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	uintptr_t _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
-	uintptr_t _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 	uint64_t _cycleStartTime; /**< The start time of a copy forward cycle */
 
@@ -115,10 +111,6 @@ public:
 		_offHeapRegionsCleared = 0;
 		_offHeapRegionCandidates = 0;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		_doubleMappedArrayletsCleared = 0;
-		_doubleMappedArrayletsCandidates = 0;
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	}
 	
 	/**
@@ -148,10 +140,6 @@ public:
 		_offHeapRegionsCleared += stats->_offHeapRegionsCleared;
 		_offHeapRegionCandidates += stats->_offHeapRegionCandidates;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		_doubleMappedArrayletsCleared += stats->_doubleMappedArrayletsCleared;
-		_doubleMappedArrayletsCandidates += stats->_doubleMappedArrayletsCandidates;
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	}
 
 	MM_CopyForwardStats() :
@@ -173,10 +161,6 @@ public:
 		, _offHeapRegionsCleared(0)
 		, _offHeapRegionCandidates(0)
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		, _doubleMappedArrayletsCleared(0)
-		, _doubleMappedArrayletsCandidates(0)
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	{}
 };
 

--- a/runtime/gc_stats/MarkVLHGCStats.hpp
+++ b/runtime/gc_stats/MarkVLHGCStats.hpp
@@ -78,10 +78,6 @@ public:
 	uintptr_t _offHeapRegionsCleared; /**< The number of or sparse heap allocated regions that have been cleared during marking */
 	uintptr_t _offHeapRegionCandidates; /**< The number of or sparse heap allocated regions that have been visited during marking */
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	uintptr_t _doubleMappedArrayletsCleared; /**< The number of double mapped arraylets that have been cleared durign marking */
-	uintptr_t _doubleMappedArrayletsCandidates; /**< The number of double mapped arraylets that have been visited during marking */
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 	uintptr_t _splitArraysProcessed; /**< The number of array chunks (not counting parts smaller than the split size) processed by this thread */
@@ -122,10 +118,6 @@ public:
 		_offHeapRegionsCleared = 0;
 		_offHeapRegionCandidates = 0;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		_doubleMappedArrayletsCleared = 0;
-		_doubleMappedArrayletsCandidates = 0;
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		_splitArraysProcessed = 0;
@@ -164,10 +156,6 @@ public:
 		_offHeapRegionsCleared += statsToMerge->_offHeapRegionsCleared;
 		_offHeapRegionCandidates += statsToMerge->_offHeapRegionCandidates;
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		_doubleMappedArrayletsCleared += statsToMerge->_doubleMappedArrayletsCleared;
-		_doubleMappedArrayletsCandidates += statsToMerge->_doubleMappedArrayletsCandidates;
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 
 		_concurrentGCThreadsCPUStartTimeSum += statsToMerge->_concurrentGCThreadsCPUStartTimeSum;
 		_concurrentGCThreadsCPUEndTimeSum += statsToMerge->_concurrentGCThreadsCPUEndTimeSum;
@@ -199,10 +187,6 @@ public:
 		,_offHeapRegionsCleared(0)
 		,_offHeapRegionCandidates(0)
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-		,_doubleMappedArrayletsCleared(0)
-		,_doubleMappedArrayletsCandidates(0)
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 #if defined(J9MODRON_TGC_PARALLEL_STATISTICS)
 		,_splitArraysProcessed(0)
 #endif /* J9MODRON_TGC_PARALLEL_STATISTICS */

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -107,28 +107,6 @@ MM_ConfigurationIncrementalGenerational::createHeapWithManager(MM_EnvironmentBas
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	/* Enable double mapping if glibc version 2.27 or newer is found. For double map to
-	 * work we need a file descriptor, to get one we use shm_open(3)  or memfd_create(2);
-	 * shm_open(3) has 2 drawbacks: [I] shared memory is used; [II] does not support
-	 * anonymous huge pages. [I] shared memory in Linux systems has a limit (half of
-	 * physical memory). [II] if we create a file descriptor using shm_open(3) and then
-	 * try to mmap with huge pages with the respective file descriptor the mmap call
-	 * fails. It would only succeed if MAP_ANON flag was provided, but doing so ignores
-	 * the file descriptor which is the opposite of what we want. In a newer glibc
-	 * version (glibc 2.27 onwards) there's a new function that does exactly what we
-	 * want, and that's memfd_create(2); however that's only supported in glibc 2.27. We
-	 * also need to check if region size is a bigger or equal to multiple of page size.
-	 *
-	 */
-	if (!extensions->isVirtualLargeObjectHeapEnabled && extensions->isArrayletDoubleMapRequested && extensions->isArrayletDoubleMapAvailable) {
-		uintptr_t pagesize = heap->getPageSize();
-		if (!extensions->memoryManager->isLargePage(env, pagesize) || (pagesize <= extensions->getOmrVM()->_arrayletLeafSize)) {
-			extensions->indexableObjectModel.setEnableDoubleMapping(true);
-		}
-	}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 	/* when we try to attach this heap to a region manager, we will need the card table since it needs to be NUMA-affinitized using the same logic as the heap so initialize it here */
 	extensions->cardTable = MM_IncrementalCardTable::newInstance(MM_EnvironmentVLHGC::getEnvironment(env), heap);
 	if (NULL == extensions->cardTable) {

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -4212,24 +4212,6 @@ private:
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	virtual void doDoubleMappedObjectSlot(J9Object *objectPtr, struct J9PortVmemIdentifier *identifier) {
-		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(_env);
-		env->_copyForwardStats._doubleMappedArrayletsCandidates += 1;
-		if (!_copyForwardScheme->isLiveObject(objectPtr)) {
-			Assert_MM_true(_copyForwardScheme->isObjectInEvacuateMemory(objectPtr));
-			MM_ForwardedHeader forwardedHeader(objectPtr, _extensions->compressObjectReferences());
-			objectPtr = forwardedHeader.getForwardedObject();
-			if (NULL == objectPtr) {
-				Assert_MM_mustBeClass(_extensions->objectModel.getPreservedClass(&forwardedHeader));
-				env->_copyForwardStats._doubleMappedArrayletsCleared += 1;
-				OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
-				omrvmem_release_double_mapped_region(identifier->address, identifier->size, identifier);
-			}
-		}
-	}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 	/**
 	 * @Clear the string table cache slot if the object is not marked
 	 */

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -1458,17 +1458,6 @@ private:
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	virtual void doDoubleMappedObjectSlot(J9Object *objectPtr, struct J9PortVmemIdentifier *identifier) {
-		MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCandidates += 1;
-		if (!_markingScheme->isMarked(objectPtr)) {
-			MM_EnvironmentVLHGC::getEnvironment(_env)->_markVLHGCStats._doubleMappedArrayletsCleared += 1;
-			OMRPORT_ACCESS_FROM_OMRVM(_javaVM->omrVM);
-			omrvmem_release_double_mapped_region(identifier->address, identifier->size, identifier);
-		}
-    }
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 	/**
 	 * @Clear the string table cache slot if the object is not marked
 	 */

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
@@ -85,9 +85,6 @@ public:
 	uintptr_t _projectedLiveBytesPreviousPGC;   /**< _projectedLiveBytes value from previous PGC; updated just before we apply decay for this PGC */
 	IDATA _projectedLiveBytesDeviation;	/**< difference between actual live bytes and projected live bytes. Note: not always update to date and can be negative. */
 	MM_HeapRegionDescriptorVLHGC *_compactDestinationQueueNext; /**< pointer to next compact destination region in the queue */
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	J9PortVmemIdentifier _arrayletDoublemapID;	/**< Contiguous address identifier associate with double mapped region of arraylet */
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	bool _defragmentationTarget;		/**< indicates whether this region should be considered for defragmentation, currently this means the region has been GMPed but not collected yet */
 
 protected:

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -32,9 +32,6 @@
 #include "j9protos.h"
 #include "ModronAssertions.h"
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-#include "ArrayletLeafIterator.hpp"
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 #include "VLHGCAccessBarrier.hpp"
 #include "AtomicOperations.hpp"
 #include "CardTable.hpp"
@@ -325,47 +322,9 @@ MM_VLHGCAccessBarrier::jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jarray
 		*isCopy = JNI_FALSE;
 	}
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	if (alwaysCopyInCritical) {
-#else /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
 	if (alwaysCopyInCritical || !indexableObjectModel->isInlineContiguousArraylet(arrayObject)) {
-#endif /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
 		/* alwaysCopyInCritical or discontiguous (including 0 size array) */
 		copyArrayCritical(vmThread, &data, arrayObject, isCopy);
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	} else if (!indexableObjectModel->isInlineContiguousArraylet(arrayObject)) {
-		/* an array having discontiguous extents is another reason to force the critical section to be a copy */
-		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(vmThread);
-		if (indexableObjectModel->isDoubleMappingEnabled()) {
-			fj9object_t *arrayoidPtr = indexableObjectModel->getArrayoidPointer(arrayObject);
-			if (indexableObjectModel->isArrayletDataDiscontiguous(arrayObject)) {
-				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
-				J9Object *firstLeafSlot = objectSlot.readReferenceFromSlot();
-				MM_HeapRegionDescriptorVLHGC *firstLeafRegionDescriptor = (MM_HeapRegionDescriptorVLHGC *)_extensions->heapRegionManager->tableDescriptorForAddress(firstLeafSlot);
-				data = firstLeafRegionDescriptor->_arrayletDoublemapID.address;
-
-				if (NULL == data) {
-					/* Doublemap failed, but we still need to continue execution; therefore fallback to previous approach */
-					copyArrayCritical(vmThread, &data, arrayObject, isCopy);
-				}
-			/* Corner case where there's only one arraylet leaf */
-			} else if (indexableObjectModel->isArrayletDataContiguous(arrayObject)) {
-				/* Solo arraylet leaf is contiguous so we can simply return the data associated with it */
-				MM_JNICriticalRegion::enterCriticalRegion(vmThread, true);
-				Assert_MM_true(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS);
-				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
-				data = objectSlot.readReferenceFromSlot();
-			} else {
-				/* Possible to reach here if arraylet has no leaves.
-				 * Even though there are no elements in it the caller expects a non NULL value
-				 * therefore we just return the address after the object header. */
-				data = (void *)arrayoidPtr;
-				Assert_MM_true((0 == indexableObjectModel->numArraylets(arrayObject)) && (0 == indexableObjectModel->getSizeInElements(arrayObject)));
-			}
-		} else {
-			copyArrayCritical(vmThread, &data, arrayObject, isCopy);
-		}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	} else if (indexableObjectModel->isVirtualLargeObjectHeapEnabled() && !indexableObjectModel->isDataAdjacentToHeader(arrayObject)) {
 		/* off heap enabled and not adjacent */
 		data = (void *)indexableObjectModel->getDataPointerForContiguous(arrayObject);
@@ -395,48 +354,9 @@ MM_VLHGCAccessBarrier::jniReleasePrimitiveArrayCritical(J9VMThread* vmThread, ja
 	J9IndexableObject *arrayObject = (J9IndexableObject *)J9_JNI_UNWRAP_REFERENCE(array);
 	bool alwaysCopyInCritical = (vmThread->javaVM->runtimeFlags & J9_RUNTIME_ALWAYS_COPY_JNI_CRITICAL) == J9_RUNTIME_ALWAYS_COPY_JNI_CRITICAL;
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	if (alwaysCopyInCritical) {
-#else /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
-		if (alwaysCopyInCritical || !indexableObjectModel->isInlineContiguousArraylet(arrayObject)) {
-#endif /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
+	if (alwaysCopyInCritical || !indexableObjectModel->isInlineContiguousArraylet(arrayObject)) {
 		/* alwaysCopyInCritical or discontiguous (including 0 size array) */
 		copyBackArrayCritical(vmThread, elems, &arrayObject, mode);
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	} else if (!indexableObjectModel->isInlineContiguousArraylet(arrayObject)) {
-		/* an array having discontiguous extents is another reason to force the critical section to be a copy */
-		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(vmThread);
-		if (indexableObjectModel->isDoubleMappingEnabled()) {
-			fj9object_t *arrayoidPtr = indexableObjectModel->getArrayoidPointer(arrayObject);
-			if (indexableObjectModel->isArrayletDataDiscontiguous(arrayObject)) {
-				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
-				J9Object *firstLeafSlot = objectSlot.readReferenceFromSlot();
-				MM_HeapRegionDescriptorVLHGC *firstLeafRegionDescriptor = (MM_HeapRegionDescriptorVLHGC *)_extensions->heapRegionManager->tableDescriptorForAddress(firstLeafSlot);
-
-				if (NULL == firstLeafRegionDescriptor->_arrayletDoublemapID.address) {
-					/* Doublemap failed, but we still need to continue execution; therefore fallback to previous approach */
-					copyBackArrayCritical(vmThread, elems, &arrayObject, mode);
-				}
-			} else if (indexableObjectModel->isArrayletDataContiguous(arrayObject)) {
-				/**
-				 * Objects can not be moved if critical section is active
-				 * This trace point will be generated if object has been moved or passed value of elems is corrupted
-				 */
-				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
-				void *data = objectSlot.readReferenceFromSlot();
-
-				if (elems != data) {
-					Trc_MM_JNIReleasePrimitiveArrayCritical_invalid(vmThread, arrayObject, elems, data);
-				}
-				MM_JNICriticalRegion::exitCriticalRegion(vmThread, true);
-			} else {
-				/* Possible to reach here if arraylet has no leaves */
-				Assert_MM_true((0 == indexableObjectModel->numArraylets(arrayObject)) && (0 == indexableObjectModel->getSizeInElements(arrayObject)));
-			}
-		} else {
-			copyBackArrayCritical(vmThread, elems, &arrayObject, mode);
-		}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	} else if (indexableObjectModel->isVirtualLargeObjectHeapEnabled() && !indexableObjectModel->isDataAdjacentToHeader(arrayObject)) {
 		/* off heap enabled and not adjacent */
 	} else {
@@ -477,46 +397,9 @@ MM_VLHGCAccessBarrier::jniGetStringCritical(J9VMThread* vmThread, jstring str, j
 	}
 
 	bool alwaysCopyInCritical = (javaVM->runtimeFlags & J9_RUNTIME_ALWAYS_COPY_JNI_CRITICAL) == J9_RUNTIME_ALWAYS_COPY_JNI_CRITICAL;
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	if (alwaysCopyInCritical || isCompressed) {
-#else /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
 	if (alwaysCopyInCritical || isCompressed || !indexableObjectModel->isInlineContiguousArraylet(valueObject)) {
-#endif /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
 		/*  alwaysCopyInCritical or isCompressed  or discontiguous (including 0 size array) */
 		copyStringCritical(vmThread, &data, valueObject, stringObject, isCopy, isCompressed);
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	} else if (!indexableObjectModel->isInlineContiguousArraylet(valueObject)) {
-		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(vmThread);
-		if (indexableObjectModel->isDoubleMappingEnabled()) {
-			fj9object_t *arrayoidPtr = indexableObjectModel->getArrayoidPointer(valueObject);
-			if (indexableObjectModel->isArrayletDataDiscontiguous(valueObject)) {
-				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
-				J9Object *firstLeafSlot = objectSlot.readReferenceFromSlot();
-				MM_HeapRegionDescriptorVLHGC *firstLeafRegionDescriptor = (MM_HeapRegionDescriptorVLHGC *)_extensions->heapRegionManager->tableDescriptorForAddress(firstLeafSlot);
-				data = (jchar *)firstLeafRegionDescriptor->_arrayletDoublemapID.address;
-
-				if (NULL == data) {
-					/* Doublemap failed, but we still need to continue execution; therefore fallback to previous approach */
-					copyStringCritical(vmThread, &data, valueObject, stringObject, isCopy, isCompressed);
-				}
-			/* Corner case where there's only one arraylet leaf */
-			} else if (indexableObjectModel->isArrayletDataContiguous(valueObject)) {
-				/* Solo arraylet leaf is contiguous so we can simply return the data associated with it */
-				MM_JNICriticalRegion::enterCriticalRegion(vmThread, true);
-				Assert_MM_true(vmThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS);
-				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
-				data = (jchar *)objectSlot.readReferenceFromSlot();
-			} else {
-				/* Possible to reach here if arraylet has no leaves.
-				 * Even though there are no elements in it the caller expects a non NULL value
-				 * therefore we just return the address after the object header. */
-				data = (jchar *)arrayoidPtr;
-				Assert_MM_true((0 == indexableObjectModel->numArraylets(valueObject)) && (0 == indexableObjectModel->getSizeInElements(valueObject)));
-			}
-		} else {
-			copyStringCritical(vmThread, &data, valueObject, stringObject, isCopy, isCompressed);
-		}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	} else if (indexableObjectModel->isVirtualLargeObjectHeapEnabled() && !indexableObjectModel->isDataAdjacentToHeader(valueObject)) {
 		/* off heap enabled and not adjacent */
 		data = (jchar *)indexableObjectModel->getDataPointerForContiguous(valueObject);
@@ -556,39 +439,9 @@ MM_VLHGCAccessBarrier::jniReleaseStringCritical(J9VMThread* vmThread, jstring st
 	bool alwaysCopyInCritical = (javaVM->runtimeFlags & J9_RUNTIME_ALWAYS_COPY_JNI_CRITICAL) == J9_RUNTIME_ALWAYS_COPY_JNI_CRITICAL;
 	bool isCompressed = IS_STRING_COMPRESSION_ENABLED_VM(javaVM) && IS_STRING_COMPRESSED(vmThread, stringObject);
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	if (alwaysCopyInCritical || isCompressed) {
-#else /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
-		if (alwaysCopyInCritical || isCompressed || !indexableObjectModel->isInlineContiguousArraylet(valueObject)) {
-#endif /* defined(J9VM_GC_ENABLE_DOUBLE_MAP) */
+	if (alwaysCopyInCritical || isCompressed || !indexableObjectModel->isInlineContiguousArraylet(valueObject)) {
 		/*  alwaysCopyInCritical or isCompressed  or discontiguous (including 0 size array) */
 		freeStringCritical(vmThread, elems);
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	} else if (!indexableObjectModel->isInlineContiguousArraylet(valueObject)) {
-		/* an array having discontiguous extents can use double mapping if enabled in the critical section */
-		MM_EnvironmentVLHGC *env = MM_EnvironmentVLHGC::getEnvironment(vmThread);
-		if (indexableObjectModel->isDoubleMappingEnabled()) {
-			fj9object_t *arrayoidPtr = indexableObjectModel->getArrayoidPointer(valueObject);
-			if (indexableObjectModel->isArrayletDataDiscontiguous(valueObject)) {
-				GC_SlotObject objectSlot(env->getOmrVM(), arrayoidPtr);
-				J9Object *firstLeafSlot = objectSlot.readReferenceFromSlot();
-				MM_HeapRegionDescriptorVLHGC *firstLeafRegionDescriptor = (MM_HeapRegionDescriptorVLHGC *)_extensions->heapRegionManager->tableDescriptorForAddress(firstLeafSlot);
-				if (NULL == firstLeafRegionDescriptor->_arrayletDoublemapID.address) {
-					/* Doublemap failed, but we still need to continue execution; therefore fallback to previous approach */
-					freeStringCritical(vmThread, elems);
-				}
-			} else if (indexableObjectModel->isArrayletDataContiguous(valueObject)) {
-				/* Solo arraylet leaf is contiguous so nothing to do besides exiting critical section */
-				MM_JNICriticalRegion::exitCriticalRegion(vmThread, true);
-			} else {
-				/* Possible to reach here if arraylet has no leaves */
-				Assert_MM_true((0 == indexableObjectModel->numArraylets(valueObject)) && (0 == indexableObjectModel->getSizeInElements(valueObject)));
-			}
-		} else {
-			/* an array having discontiguous extents is another reason to force the critical section to be a copy in case double mapping is desabled */
-			freeStringCritical(vmThread, elems);
-		}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
 	} else if (indexableObjectModel->isVirtualLargeObjectHeapEnabled() && !indexableObjectModel->isDataAdjacentToHeader(valueObject)) {
 		/* off heap enabled and not adjacent */
 	} else {


### PR DESCRIPTION
Balanced GC’s new off-heap feature (enabled by default) now covers all double-mapping use cases with better performance. Since the off-heap feature has proven stable, there is no longer a need to maintain double-mapping as a fallback mechanism. This change removes all double-mapping code to simplify the implementation.

- remove the code under preprocessor symbol "J9VM_GC_ENABLE_DOUBLE_MAP"
- except gc_glue_java isDoubleMappingEnabled(), which has dependance on omr OMR_GC_DOUBLE_MAP_ARRAYLETS.