### PR TITLE
Enable idiomRecognitionGroup for String.startsWith() at warm

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8393,7 +8393,7 @@ TR_MethodMetaData *TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrar
                             if (TR::Compiler->target.cpu.isX86()) {
                                 static char *enableIdiomRecognitionAtWarm = feGetEnv("TR_EnableIdiomRecognitionAtWarm");
                                 if (!enableIdiomRecognitionAtWarm)
-                                    options->setDisabled(OMR::idiomRecognition, true);
+                                    options->setDisabled(OMR::cheapIdiomRecognitionGroup, true);
                             }
                         }
                     }

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -374,6 +374,20 @@ bool TR_J9ByteCodeIlGenerator::genILFromByteCodes()
     if (comp()->isPeekingMethod() && _maxByteCodeIndex >= USHRT_MAX / 8)
         return false;
 
+    if (comp()->getOptLevel() == warm) {
+        static const char *disableIdiomRecognitionAtWarm = feGetEnv("TR_disableIdiomRecognitionAtWarm");
+        TR::RecognizedMethod recognizedMethod = _methodSymbol->getRecognizedMethod();
+        if (!disableIdiomRecognitionAtWarm) {
+            switch (recognizedMethod) {
+                case TR::java_lang_String_startsWith:
+                    _methodSymbol->setHasIdiomRecognitionOpportunities(true);
+                    break;
+                default:
+                    break; // do nothing
+            }
+        }
+    }
+
     // FSD sync object support
     //
     // Ideally, I'd like the sync object in FSD to work exactly as it does in the interpreter.

--- a/runtime/compiler/optimizer/J9Optimizer.cpp
+++ b/runtime/compiler/optimizer/J9Optimizer.cpp
@@ -366,8 +366,8 @@ static const OptimizationStrategy warmStrategyOpts[] = {
     { OMR::loopReduction },
     { OMR::blockShuffling },
 #endif
-    { OMR::localCSE, OMR::IfLoopsAndNotProfiling },
-    { OMR::idiomRecognition, OMR::IfLoopsAndNotProfiling },
+    { OMR::idiomRecognitionGroup, OMR::IfKnownIdiomRecognitionOpportunity },
+    { OMR::cheapIdiomRecognitionGroup, OMR::IfNotKnownIdiomRecognitionOpportunity },
     { OMR::treeSimplification },
     { OMR::redundantGotoElimination, OMR::IfEnabledAndNotJitProfiling },
     { OMR::blockSplitter },


### PR DESCRIPTION
This commit applies a new JIT optimization group, idiomRecognitionGroup, to String.startsWith() at the warm level.  When the flag for idiomRecognitionGroup is not set, cheapIdiomRecognitionGroup is executed instead.