### PR TITLE
Revert #23443 partially

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3169,6 +3169,10 @@ TR::TreeTop *TR_J9VMBase::lowerMultiANewArray(TR::Compilation *comp, TR::Node *r
     } else
         TR_ASSERT(false, "Number of dims in multianewarray is not constant");
 
+#if defined(TR_HOST_ARM64)
+    bool secondDimConstNonZero = (root->getChild(2)->getOpCode().isLoadConst() && (root->getChild(2)->getInt() != 0));
+#endif /* defined(TR_HOST_ARM64) */
+
     // Allocate a temp to hold the array of dimensions
     //
     TR::AutomaticSymbol *temp = TR::AutomaticSymbol::create(comp->trHeapMemory(), TR::Int32, sizeof(int32_t) * dims);
@@ -3201,7 +3205,11 @@ TR::TreeTop *TR_J9VMBase::lowerMultiANewArray(TR::Compilation *comp, TR::Node *r
     root->setNumChildren(3);
 
     static bool recreateRoot = feGetEnv("TR_LowerMultiANewArrayRecreateRoot") ? true : false;
-    if (!comp->target().is64Bit() || recreateRoot || dims > 2)
+    if (!comp->target().is64Bit() || recreateRoot || dims > 2
+#if defined(TR_HOST_ARM64)
+        || secondDimConstNonZero
+#endif /* defined(TR_HOST_ARM64) */
+    )
         TR::Node::recreate(root, TR::acall);
 
     return treeTop;


### PR DESCRIPTION
This commit reverts the change by #23443 partially. AArch64 to lower multianewarray nodes to helper calls again.

Fixes: #23482