### PR TITLE
Extended HCR support updated to JDK 29

### DIFF
--- a/doc/release-notes/0.46/0.46.md
+++ b/doc/release-notes/0.46/0.46.md
@@ -74,7 +74,9 @@ Although this option is by default enabled at the server, it is still disabled f
 <td valign="top">All versions</td>
 <td valign="top">By default, the extended HCR capability in the VM is disabled for all OpenJDK versions. You can enable the HCR capability by using the <tt>-XX:+EnableExtendedHCR</tt> option.
 
-The extended HCR feature is deprecated in this release and will be removed in a future release. From OpenJDK 25 onwards, extended HCR will not be supported. Following that, the extended HCR support will be removed from other earlier OpenJDK versions also.
+The extended HCR feature is deprecated in this release and will be removed in a future release. From OpenJDK 29 onwards, extended HCR will not be supported. Following that, the extended HCR support will be removed from other earlier OpenJDK versions also.
+
+<!--At the time of 0.58 release, received information that extended HCR will not be supported from OpenJDK 29 instead of JDK 25. SK - 12 Mar 2026-->
 </td>
 </tr>
 <tr>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/issues/1671

Extended HCR will not be supported from OpenJDK 29 onwards and not from OpenJDK 25. Updated 0.46 release note.

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com