### PR TITLE
Prepend VM startup options from java.base/jdk.internal.vm.options

### DIFF
--- a/runtime/bcutil/bcutil.c
+++ b/runtime/bcutil/bcutil.c
@@ -120,9 +120,8 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 {
 	IDATA returnVal = J9VMDLLMAIN_OK;
 	I_32 rc = J9JIMAGE_NO_ERROR;
-	J9VMDllLoadInfo* loadInfo;
-	J9JImageIntf *jimageIntf = NULL;
-	J9TranslationBufferSet* translationBuffers;
+	J9VMDllLoadInfo *loadInfo = NULL;
+	J9TranslationBufferSet *translationBuffers = NULL;
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	VMI_ACCESS_FROM_JAVAVM((JavaVM*)vm);
@@ -134,14 +133,6 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 		/* Note that verbose support should have already been initialized in an earlier stage */
 		case BUFFERS_ALLOC_STAGE :
 			loadInfo = FIND_DLL_TABLE_ENTRY( THIS_DLL_NAME );
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
-				rc = initJImageIntf(&jimageIntf, vm, PORTLIB);
-				if (J9JIMAGE_NO_ERROR != rc) {
-					vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "failed to initialize JImage interface", FALSE);
-					returnVal = J9VMDLLMAIN_FAILED;
-					break;
-				}
-			}
 			translationBuffers = j9bcutil_allocTranslationBuffers(vm->portLibrary);
 			if (translationBuffers == NULL) {
 				vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, "j9bcutil_allocTranslationBuffers failed", FALSE);
@@ -157,7 +148,6 @@ bcutil_J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 				vm->verboseStruct->hookDynamicLoadReporting(translationBuffers);
 			}
 #endif
-			vm->jimageIntf = jimageIntf;
 			vm->dynamicLoadBuffers = translationBuffers;
 			vm->mapMemoryBufferSize = MAP_MEMORY_DEFAULT + MAP_MEMORY_RESULTS_BUFFER_SIZE;
 			vm->mapMemoryResultsBuffer = j9mem_allocate_memory(vm->mapMemoryBufferSize, J9MEM_CATEGORY_CLASSES);

--- a/runtime/bcutil/j9bcu.tdf
+++ b/runtime/bcutil/j9bcu.tdf
@@ -356,9 +356,9 @@ TraceException=Trc_BCU_getJImageResource_MemoryAllocationFailed NoEnv Overhead=1
 TraceException=Trc_BCU_getJImageResource_JImageInvalidDecompressor NoEnv Overhead=1 Level=1 Template="BCU getJImageResource(file=%s) decompressor header is invalid"
 TraceException=Trc_BCU_getJImageResource_JImageDecompressorNotSupported NoEnv Overhead=1 Level=1 Template="BCU getJImageResource(file=%s) decompressor %s is not supported"
 
-TraceEvent=Trc_BCU_initJImageIntf_usingLibJImage NoEnv Overhead=1 Level=1 Template="JImage interface is using jimage library"
-TraceEvent=Trc_BCU_initJImageIntf_usingJ9JImageReader NoEnv Overhead=1 Level=1 Template="JImage interface is using internal implementation of jimage reader"
-TraceException=Trc_BCU_initJImageIntf_libJImageFailed NoEnv Overhead=1 Level=1 Template="JImage interface failed to use jimage library" 
+TraceEvent=Trc_BCU_initJImageIntf_usingLibJImage NoEnv Obsolete Overhead=1 Level=1 Template="JImage interface is using jimage library"
+TraceEvent=Trc_BCU_initJImageIntf_usingJ9JImageReader NoEnv Obsolete Overhead=1 Level=1 Template="JImage interface is using internal implementation of jimage reader"
+TraceException=Trc_BCU_initJImageIntf_libJImageFailed NoEnv Obsolete Overhead=1 Level=1 Template="JImage interface failed to use jimage library"
 TraceException=Trc_BCU_MalformedParameterAnnotation NoEnv Overhead=1 Level=1 Template="BCU readAttributes bad parameter_annotation attribute at %u"
 TraceException=Trc_BCU_MalformedAnnotation NoEnv Overhead=1 Level=1 Template="BCU readAttributes bad annotation attribute at %d"
 TraceException=Trc_BCU_BadAttributeLength NoEnv Obsolete Overhead=1 Level=1 Template="BCU readAttributes attribute length = %d  data length = %d"

--- a/runtime/bcutil/jimageintf.c
+++ b/runtime/bcutil/jimageintf.c
@@ -187,16 +187,13 @@ initJImageIntfCommon(J9JImageIntf **jimageIntf, J9JavaVM *vm, J9PortLibrary *por
 }
 
 I_32
-initJImageIntf(J9JImageIntf **jimageIntf, J9JavaVM *vm, J9PortLibrary *portLibrary)
+initJImageIntf(J9JImageIntf **jimageIntf, J9JavaVM *vm, J9PortLibrary *portLibrary, BOOLEAN verbose)
 {
-	J9JImageIntf *intf = NULL;
 	UDATA libJImageHandle = 0;
 	IDATA argIndex1 = -1;
 	IDATA argIndex2 = -1;
 	I_32 rc = J9JIMAGE_NO_ERROR;
 	PORT_ACCESS_FROM_PORT(portLibrary);
-
-	Trc_BCU_Assert_True(NULL != jimageIntf);
 
 	/* Check for -XX:+UseJ9JImageReader and -XX:-UseJ9JImageReader; whichever comes later wins. */
 	argIndex1 = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_XXUSEJ9JIMAGEREADER, NULL);
@@ -210,46 +207,24 @@ initJImageIntf(J9JImageIntf **jimageIntf, J9JavaVM *vm, J9PortLibrary *portLibra
 		libJImageHandle = loadJImageLib(vm);
 		if (0 == libJImageHandle) {
 			rc = J9JIMAGE_LIBJIMAGE_LOAD_FAILED;
-			Trc_BCU_initJImageIntf_libJImageFailed();
+			if (verbose) {
+				j9tty_printf(PORTLIB, "JImage interface failed to load jimage library.\n");
+			}
 			goto _end;
 		} else {
-			if (0 != (vm->verboseLevel & VERBOSE_DYNLOAD)) {
-				j9tty_printf(PORTLIB, "JImage interface is using jimage library\n");
+			if (verbose) {
+				j9tty_printf(PORTLIB, "JImage interface is using jimage library.\n");
 			}
-			Trc_BCU_initJImageIntf_usingLibJImage();
 		}
 	} else {
-		if (0 != (vm->verboseLevel & VERBOSE_DYNLOAD)) {
-			j9tty_printf(PORTLIB, "JImage interface is using internal implementation of jimage reader\n");
+		if (verbose) {
+			j9tty_printf(PORTLIB, "JImage interface is using internal implementation of jimage reader.\n");
 		}
-		Trc_BCU_initJImageIntf_usingJ9JImageReader();
 	}
 
 	rc = initJImageIntfCommon(jimageIntf, vm, portLibrary, libJImageHandle);
 
 _end:
-	return rc;
-}
-
-I_32
-initJImageIntfWithLibrary(J9JImageIntf **jimageIntf, J9PortLibrary *portLibrary, const char *libjimage)
-{
-	UDATA libJImageHandle = 0;
-	I_32 rc = J9JIMAGE_NO_ERROR;
-	PORT_ACCESS_FROM_PORT(portLibrary);
-
-	Trc_BCU_Assert_True(NULL != jimageIntf);
-
-	if (0 != j9sl_open_shared_library((char *)libjimage, &libJImageHandle, 0)) {
-		rc = J9JIMAGE_LIBJIMAGE_LOAD_FAILED;
-	} else if (0 != lookupSymbolsInJImageLib(PORTLIB, libJImageHandle)) {
-		j9sl_close_shared_library(libJImageHandle);
-		libJImageHandle = 0;
-		rc = J9JIMAGE_LIBJIMAGE_LOAD_FAILED;
-	} else {
-		rc = initJImageIntfCommon(jimageIntf, NULL /* vm */, portLibrary, libJImageHandle);
-	}
-
 	return rc;
 }
 

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -2241,7 +2241,7 @@ JNI_CreateJavaVM_impl(JavaVM **pvm, void **penv, void *vm_args, BOOLEAN isJITSer
 		if (NULL != ldLibraryPathValue) {
 			free((void *)ldLibraryPathValue);
 		}
-		j9ArgList = createJvmInitArgs(&j9portLibrary, args, &vmArgumentsList, &argEncoding);
+		j9ArgList = createJvmInitArgs(&j9portLibrary, args, NULL, FALSE, &vmArgumentsList, &argEncoding);
 		if (ARG_ENCODING_LATIN == argEncoding) {
 			createParams.flags |= J9_CREATEJAVAVM_ARGENCODING_LATIN;
 		} else if (ARG_ENCODING_UTF == argEncoding) {

--- a/runtime/oti/bcutil_api.h
+++ b/runtime/oti/bcutil_api.h
@@ -279,29 +279,17 @@ findLocallyDefinedClass(J9VMThread * vmThread, J9Module *j9module, U_8 * classNa
 
 /**
  * Creates and initializes J9JImageIntf and returns its pointer in *jimageIntf.
+ * This is to be invoked at VM early bootstrap phase when the trace engine hasn't been initialized
+ * and the verbose module hasn't been loaded.
  *
  * @param [out] jimageIntf on success points to J9JImageIntf; should not be NULL
  * @param [in] vm pointer to J9JavaVM; may be NULL for unit testing
  * @param [in] portLibrary pointer to J9PortLibrary
- *
+ * @param [in] verbose output if -verbose:dynload is specified
  * @return J9JIMAGE_NO_ERROR on success, negative error code on failure
  */
 I_32
-initJImageIntf(J9JImageIntf **jimageIntf, J9JavaVM *vm, J9PortLibrary *portLibrary);
-
-/**
- * Loads the library specified by libjimage.
- * If the library is successfully loaded, then it creates and initializes J9JImageIntf
- * and returns its pointer in *jimageIntf.
- *
- * @param [out] jimageIntf on success points to J9JImageIntf; should not be NULL
- * @param [in] portLibrary pointer to J9PortLibrary
- * @param [in] libjimage name of jimage library to use for reading jimage files
- *
- * @return J9JIMAGE_NO_ERROR on success, negative error code on failure
- */
-I_32
-initJImageIntfWithLibrary(J9JImageIntf **jimageIntf, J9PortLibrary *portLibrary, const char *libjimage);
+initJImageIntf(J9JImageIntf **jimageIntf, J9JavaVM *vm, J9PortLibrary *portLibrary, BOOLEAN verbose);
 
 /**
  * Cleans up jimageIntf and frees up any resources held by it.

--- a/runtime/oti/vmargs_api.h
+++ b/runtime/oti/vmargs_api.h
@@ -258,18 +258,23 @@ IDATA
 addXserviceArgs(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, char *xServiceBuffer, UDATA verboseFlags);
 
 /**
- * Create the JavaVMInitArgs array and the J9VMInitArgs wrapper from a pool of J9JavaVMArgInfo structs.
+ * Create the JavaVMInitArgs array and the J9VMInitArgs wrapper from a pool of J9JavaVMArgInfo structs,
+ * or prepend those entries to the current J9VMInitArgs structure.
  * This allocates memory for the JavaVMInitArgs and J9VMInitArgs arrays,
  * plus the array of JavaVMOption and parallel J9CmdLineOption structs, but not the options strings themselves.
  * The caller is responsible for freeing the vmArgumentsList pool.
  * @param [in] portLib port library
  * @param [in] launcherArgs JavaVMInitArgs passed in from the launcher
- * @param [inout] vmArgumentsList current list of arguments
+ * @param [in] currentJ9VMArgs current J9VMInitArgs
+ * @param [in] prependFlag if prepend the options in vmArgumentsList
+ * @param [in/out] vmArgumentsList current list of arguments
  * @param [out] argEncoding update the encoding
- * @return J9VMInitArgs struct on success, NULL value on failure, e.g. memory allocate failed.
+ * @return J9VMInitArgs struct on success, NULL value on failure, e.g. memory allocation failed
  */
-J9VMInitArgs*
-createJvmInitArgs(J9PortLibrary * portLib, JavaVMInitArgs *launcherArgs, J9JavaVMArgInfoList *vmArgumentsList, UDATA* argEncoding);
+J9VMInitArgs *
+createJvmInitArgs(
+		J9PortLibrary *portLib, JavaVMInitArgs *launcherArgs, J9VMInitArgs *currentJ9VMArgs,
+		BOOLEAN prependFlag, J9JavaVMArgInfoList *vmArgumentsList, UDATA* argEncoding);
 
 /**
  * Free the space for the J9VMInitArgs and JavaVMInitArgs structs, plus the arrays of JavaVMOption and J9CmdLineOption structs.

--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -1537,50 +1537,59 @@ addXserviceArgs(J9PortLibrary * portLib, J9JavaVMArgInfoList *vmArgumentsList, c
 	return 0;
 }
 
-J9VMInitArgs*
-createJvmInitArgs(J9PortLibrary * portLib, JavaVMInitArgs *launcherArgs, J9JavaVMArgInfoList *vmArgumentsList, UDATA* argEncoding)
+J9VMInitArgs *
+createJvmInitArgs(
+		J9PortLibrary *portLib, JavaVMInitArgs *launcherArgs, J9VMInitArgs *currentJ9VMArgs,
+		BOOLEAN prependFlag, J9JavaVMArgInfoList *vmArgumentsList, UDATA *argEncoding)
 {
-	jint numArgs = 0;
+	UDATA numArgs = 0;
 	UDATA memoryRequired = 0;
 	JavaVMOption *javaVMOptionCursor = NULL;
 	J9CmdLineOption *cmdLineOptionCursor = NULL;
 	J9VMInitArgs *result = NULL;
-	JavaVMInitArgs *initArgs;
-	void *argsBuffer = NULL;
-	J9JavaVMArgInfo *current;
+	JavaVMInitArgs *initArgs = NULL;
+	J9JavaVMArgInfo *current = NULL;
 	const size_t ARGENCODING_LENGTH = strlen(VMOPT_XARGENCODING);
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	if (NULL != vmArgumentsList) {
-		numArgs = (jint) pool_numElements(vmArgumentsList->pool);
+		numArgs = pool_numElements(vmArgumentsList->pool);
+	}
+	if (prependFlag) {
+		numArgs += currentJ9VMArgs->nOptions;
 	}
 
-	memoryRequired = sizeof(J9VMInitArgs) + sizeof(JavaVMInitArgs) + numArgs*(sizeof(JavaVMInitArgs) + numArgs*sizeof(J9CmdLineOption));
-	argsBuffer = j9mem_allocate_memory(memoryRequired, OMRMEM_CATEGORY_VM);
-	if (NULL == argsBuffer) {
+	memoryRequired = sizeof(J9VMInitArgs) + sizeof(JavaVMInitArgs)
+			+ numArgs * (sizeof(JavaVMInitArgs) + (numArgs * sizeof(J9CmdLineOption)));
+	result = (J9VMInitArgs *)j9mem_allocate_memory(memoryRequired, OMRMEM_CATEGORY_VM);
+	if (NULL == result) {
 		return NULL;
 	}
 
-	/* create pointers into the buffer for the various datastructures and arrays */
-	result = (J9VMInitArgs *) argsBuffer;
-	initArgs = (JavaVMInitArgs *) (((U_8 *) result) + sizeof(*result));
-	javaVMOptionCursor = (JavaVMOption *) (((U_8 *) initArgs) + sizeof(*initArgs));
-	cmdLineOptionCursor = (J9CmdLineOption *) (((U_8 *) javaVMOptionCursor) + (numArgs * sizeof(*javaVMOptionCursor)));
+	/* Create pointers into the buffer for the various datastructures and arrays. */
+	initArgs = (JavaVMInitArgs *)(((U_8 *)result) + sizeof(*result));
+	javaVMOptionCursor = (JavaVMOption *)(((U_8 *)initArgs) + sizeof(*initArgs));
+	cmdLineOptionCursor = (J9CmdLineOption *)(((U_8 *)javaVMOptionCursor) + (numArgs * sizeof(*javaVMOptionCursor)));
 	result->actualVMArgs = initArgs;
 	result->nOptions = numArgs;
 	result->j9Options = cmdLineOptionCursor;
 	initArgs->nOptions = numArgs;
-	initArgs->version = launcherArgs->version;
 	initArgs->options = javaVMOptionCursor;
-	initArgs->ignoreUnrecognized = launcherArgs->ignoreUnrecognized;
+	if (prependFlag) {
+		initArgs->version = currentJ9VMArgs->actualVMArgs->version;
+		initArgs->ignoreUnrecognized = currentJ9VMArgs->actualVMArgs->ignoreUnrecognized;
+	} else {
+		initArgs->version = launcherArgs->version;
+		initArgs->ignoreUnrecognized = launcherArgs->ignoreUnrecognized;
+	}
 	if (NULL == vmArgumentsList) {
 		return result;
 	}
 	current = vmArgumentsList->head;
-	while (current) {
+	while (NULL != current) {
 		JavaVMOption currOpt = current->vmOpt;
 		if (NULL != currOpt.optionString) {
-			/* CMVC 201804 - need to parse all sources for argument encoding so we can transcode system properties */
+			/* CMVC 201804 - need to parse all sources for argument encoding so we can transcode system properties. */
 			const char *optString = currOpt.optionString;
 			UDATA consumableFlagMask = 0;
 
@@ -1612,6 +1621,17 @@ createJvmInitArgs(J9PortLibrary * portLib, JavaVMInitArgs *launcherArgs, J9JavaV
 		cmdLineOptionCursor += 1;
 		current = current->next;
 	}
+
+	if (prependFlag) {
+		UDATA i = 0;
+		for (i = 0; i < currentJ9VMArgs->nOptions; ++i) {
+			*javaVMOptionCursor = currentJ9VMArgs->actualVMArgs->options[i];
+			javaVMOptionCursor += 1;
+			*cmdLineOptionCursor = currentJ9VMArgs->j9Options[i];
+			cmdLineOptionCursor += 1;
+		}
+	}
+
 	return result;
 }
 

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -1578,7 +1578,8 @@ loadRestoreArguments(J9VMThread *currentThread, const char *optionsFile, char *e
 		}
 	}
 
-	vm->checkpointState.restoreArgsList = createJvmInitArgs(vm->portLibrary, vm->vmArgsArray->actualVMArgs, &vmArgumentsList, &ignored);
+	vm->checkpointState.restoreArgsList = createJvmInitArgs(
+			vm->portLibrary, vm->vmArgsArray->actualVMArgs, NULL, FALSE, &vmArgumentsList, &ignored);
 	vm->checkpointState.restoreArgsList->previousArgs = previousArgs;
 
 	if (TrcEnabled_Trc_VM_criu_restoreArg) {

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -823,7 +823,7 @@ TraceEvent=Trc_VM_ConvertMethodSignature_Malformed_Signature Overhead=1 Level=1 
 TraceEvent=Trc_VM_ConvertMethodSignature_Signature_BufferSize Overhead=1 Level=4 Template="ConvertMethodSignature - signature %.*s has bufferSize %d"
 TraceEvent=Trc_VM_ConvertMethodSignature_Signature_Result Overhead=1 Level=4 Template="ConvertMethodSignature - result (%s) with resultLength %zu"
 
-TraceEvent=Trc_VM_initializeModulesPathEntry_loadJImageFailed NoEnv Overhead=1 Level=1 Template="initializeModulesPathEntry - attempt to load %.*s as jimage file failed with error=%d"
+TraceEvent=Trc_VM_initializeModulesPathEntry_loadJImageFailed NoEnv Obsolete Overhead=1 Level=1 Template="initializeModulesPathEntry - attempt to load %.*s as jimage file failed with error=%d"
 
 TraceEvent=Trc_VM_GetCompleteNPEMessage_Not_Required Overhead=1 Level=3 Template="GetCompleteNPEMessage - No message generated for new NullPointerException().getMessage()"
 TraceEntry=Trc_VM_ComputeNPEMsgAtPC_Entry Obsolete Overhead=1 Level=3 Template="ComputeNPEMsgAtPC : romClass (%p) romMethod (%p) temps (%p) bytecodeOffset (%p) bcCurrent (0x%x) npePC (%u) npeFlag (%d) isMethodFlag (%d) npeMsg (%s)"

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -85,7 +85,10 @@
 #include "jvmstackusage.h"
 #include "omrsig.h"
 #include "bcnames.h"
+#if JAVA_SPEC_VERSION >= 11
+#include "bcutil_api.h"
 #include "jimagereader.h"
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #include "vendor_version.h"
 #include "omrlinkedlist.h"
 
@@ -338,6 +341,12 @@ UDATA debugBytecodeLoopCompressed(J9VMThread *currentThread);
 #if (defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)) || (defined(LINUX) && defined(J9VM_GC_REALTIME))
 static BOOLEAN isGCPolicyMetronome(J9JavaVM *javaVM);
 #endif /* (defined(OMR_GC_COMPRESSED_POINTERS) && defined(OMR_GC_FULL_POINTERS)) || (defined(LINUX) && defined(J9VM_GC_REALTIME)) */
+
+#if JAVA_SPEC_VERSION >= 11
+static IDATA initializeModulesPath(J9JavaVM *vm, const char *javaHomeValue, BOOLEAN verbose);
+static IDATA initializeModulesPathEntry(J9JavaVM *javaVM, J9ClassPathEntry *cpEntry, BOOLEAN verbose);
+static jint prependJimageVMOptions(J9JavaVM *vm);
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 #if defined(COUNT_BYTECODE_PAIRS)
 static jint
@@ -1705,8 +1714,17 @@ initializeClassPathEntry (J9JavaVM * javaVM, J9ClassPathEntry *cpEntry)
 	return CPE_TYPE_UNUSABLE;
 }
 
-IDATA
-initializeModulesPathEntry(J9JavaVM * javaVM, J9ClassPathEntry *cpEntry)
+#if JAVA_SPEC_VERSION >= 11
+/**
+ * Open modules jimage file and save the handle.
+ *
+ * @param [in] javaVM A pointer to the J9JavaVM.
+ * @param [in] cpEntry An entry storing modules file path, type and handle.
+ * @param [in] verbose The flag for verbose output.
+ * @return CPE_TYPE_DIRECTORY, CPE_TYPE_JIMAGE or CPE_TYPE_UNUSABLE
+ */
+static IDATA
+initializeModulesPathEntry(J9JavaVM *javaVM, J9ClassPathEntry *cpEntry, BOOLEAN verbose)
 {
 	PORT_ACCESS_FROM_JAVAVM(javaVM);
 	int32_t attr = 0;
@@ -1738,12 +1756,27 @@ initializeModulesPathEntry(J9JavaVM * javaVM, J9ClassPathEntry *cpEntry)
 						convertedModulesPath[convertedModulesPathLen] = '\0';
 						modulesPath = convertedModulesPath;
 					} else {
+						if (verbose) {
+							j9tty_printf(
+									PORTLIB, "InitializeModulesPathEntry() j9str_convert(%s) returns"
+									" convertedModulesPathLen(%zd).\n", modulesPath, convertedModulesPathLen);
+						}
 						goto _error;
 					}
 				} else {
+					if (verbose) {
+						j9tty_printf(
+								PORTLIB, "InitializeModulesPathEntry() j9mem_allocate_memory"
+								" failed for convertedModulesPath.\n");
+					}
 					goto _error;
 				}
 			} else {
+				if (verbose) {
+					j9tty_printf(
+							PORTLIB, "InitializeModulesPathEntry() j9str_convert(%s) failed to determine"
+							" convertedModulesPathLen(%zd).\n", modulesPath, convertedModulesPathLen);
+				}
 				goto _error;
 			}
 #endif /* defined(WIN32) */
@@ -1759,8 +1792,10 @@ initializeModulesPathEntry(J9JavaVM * javaVM, J9ClassPathEntry *cpEntry)
 				cpEntry->type = CPE_TYPE_JIMAGE;
 				cpEntry->extraInfo = (void *)jimageHandle;
 				return CPE_TYPE_JIMAGE;
-			} else {
-				Trc_VM_initializeModulesPathEntry_loadJImageFailed(cpEntry->pathLength, cpEntry->path, rc);
+			} else if (verbose) {
+				j9tty_printf(
+						PORTLIB, "InitializeModulesPathEntry() attempts to load %.*s as jimage file"
+						" failed with error=%d.\n", cpEntry->pathLength, cpEntry->path, rc);
 			}
 		}
 	}
@@ -1778,38 +1813,41 @@ _error:
 	cpEntry->extraInfo = NULL;
 	return CPE_TYPE_UNUSABLE;
 }
+#endif /* JAVA_SPEC_VERSION >= 11 */
 #endif /* J9VM_OPT_DYNAMIC_LOAD_SUPPORT */
 
+#if JAVA_SPEC_VERSION >= 11
 /**
  * Create and initialize modules path entries.
  * Currently JVM searches system modules at following locations:
  * 	<JAVA_HOME>/lib/modules - should be a jimage file
  * 	<JAVA-HOME>/modules - should be a directory containing modules in exploded form
+ *
+ * @param [in] javaVM A pointer to the J9JavaVM.
+ * @param [in] javaHomeValue The java.home path.
+ * @param [in] verbose The flag for verbose output.
+ * @return CPE_TYPE_DIRECTORY, CPE_TYPE_JIMAGE or CPE_TYPE_UNUSABLE
  */
-IDATA
-initializeModulesPath(J9JavaVM *vm)
+static IDATA
+initializeModulesPath(J9JavaVM *vm, const char *javaHomeValue, BOOLEAN verbose)
 {
 	UDATA rc = 0;
-	IDATA modulesPathLen = 0;
 	U_8 *modulesPath = NULL;
-	J9VMSystemProperty *javaHome = NULL;
-	char *javaHomeValue = NULL;
-	IDATA javaHomeValueLen = 0;
+	IDATA javaHomeValueLen = strlen(javaHomeValue);
 	PORT_ACCESS_FROM_JAVAVM(vm);
-
-	rc = getSystemProperty(vm, "java.home", &javaHome);
-	if (J9SYSPROP_ERROR_NOT_FOUND == rc) {
-		goto _error;
-	}
-	javaHomeValue = javaHome->value;
-	javaHomeValueLen = strlen(javaHome->value);
 
 	/* If <JAVA_HOME>/lib/modules is a jimage file, it is used for searching system modules.
 	 * If it is not present, then <JAVA_HOME>/modules is searched for modules in exploded form.
 	 */
-	modulesPathLen = javaHomeValueLen + LITERAL_STRLEN(DIR_SEPARATOR_STR) + LITERAL_STRLEN("lib") + LITERAL_STRLEN(DIR_SEPARATOR_STR) + LITERAL_STRLEN("modules");
+	IDATA modulesPathLen = javaHomeValueLen
+			+ LITERAL_STRLEN(DIR_SEPARATOR_STR) + LITERAL_STRLEN("lib")
+			+ LITERAL_STRLEN(DIR_SEPARATOR_STR) + LITERAL_STRLEN("modules");
 	vm->modulesPathEntry = j9mem_allocate_memory(sizeof(J9ClassPathEntry) + modulesPathLen + 1, OMRMEM_CATEGORY_VM);
 	if (NULL == vm->modulesPathEntry) {
+		if (verbose) {
+			j9tty_printf(
+					PORTLIB, "InitializeModulesPath() j9mem_allocate_memory failed for vm->modulesPathEntry.\n");
+		}
 		goto _error;
 	}
 	memset(vm->modulesPathEntry, 0, sizeof(J9ClassPathEntry));
@@ -1818,15 +1856,20 @@ initializeModulesPath(J9JavaVM *vm)
 
 	vm->modulesPathEntry->path = modulesPath;
 	vm->modulesPathEntry->pathLength = (U_32)modulesPathLen;
-	rc = initializeModulesPathEntry(vm, vm->modulesPathEntry);
+	rc = initializeModulesPathEntry(vm, vm->modulesPathEntry, verbose);
 	if (CPE_TYPE_UNUSABLE == rc) {
 		vm->modulesPathEntry->type = CPE_TYPE_UNKNOWN;
 		/* If <JAVA_HOME>/lib/modules is not usable, try to use <JAVA_HOME>/modules dir */
 		modulesPathLen = javaHomeValueLen + LITERAL_STRLEN(DIR_SEPARATOR_STR) + LITERAL_STRLEN("modules");
 		j9str_printf((char *)modulesPath, (U_32)modulesPathLen + 1, "%s" DIR_SEPARATOR_STR "modules", javaHomeValue);
 		vm->modulesPathEntry->pathLength = (U_32)modulesPathLen;
-		rc = initializeModulesPathEntry(vm, vm->modulesPathEntry);
+		rc = initializeModulesPathEntry(vm, vm->modulesPathEntry, verbose);
 		if (CPE_TYPE_UNUSABLE == rc) {
+			if (verbose) {
+				j9tty_printf(
+						PORTLIB, "InitializeModulesPath() initializeModulesPathEntry(%s) returns CPE_TYPE_UNUSABLE.\n",
+						modulesPath);
+			}
 			goto _error;
 		}
 	}
@@ -1836,6 +1879,136 @@ initializeModulesPath(J9JavaVM *vm)
 _error:
 	return -1;
 }
+
+/**
+ * Prepend the VM startup options from a resource file java.base/jdk.internal.vm.options
+ * in the jimage file modules created via jlink --add-options <options>.
+ *
+ * @param [in] javaVM A pointer to the J9JavaVM.
+ * @return JNI_OK on success, otherwise JNI_ERR.
+ */
+static jint
+prependJimageVMOptions(J9JavaVM *vm)
+{
+	J9JImageIntf *jimageIntf = NULL;
+	BOOLEAN verboseDynload = FALSE;
+
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	/* Find java.home property value and if -verbose:dynload was specified. */
+#define VMARG_JAVA_HOME "-Djava.home="
+#define VMARG_VERBOSE_DYNLOAD "-verbose:dynload"
+	const char *optionString = NULL;
+	const char *javaHomeValue = NULL;
+	UDATA vmArgJavaHomeLen = LITERAL_STRLEN(VMARG_JAVA_HOME);
+	JavaVMInitArgs *actualVMArgs = vm->vmArgsArray->actualVMArgs;
+	jint i = 0;
+
+	/* Search from last to first which could be overridden by later options. */
+	for (i = (actualVMArgs->nOptions - 1); i >= 0; --i) {
+		optionString = actualVMArgs->options[i].optionString;
+		if ((NULL == javaHomeValue)
+				&& (0 == strncmp(VMARG_JAVA_HOME, optionString, vmArgJavaHomeLen))
+		) {
+			javaHomeValue = optionString + vmArgJavaHomeLen;
+			if (verboseDynload) {
+				/* Both java.home and -verbose:dynload are found. */
+				break;
+			}
+		} else if (!verboseDynload
+				&& (0 == strncmp(VMARG_VERBOSE_DYNLOAD, optionString, sizeof(VMARG_VERBOSE_DYNLOAD)))
+		) {
+			verboseDynload = TRUE;
+			if (NULL != javaHomeValue) {
+				/* Both java.home and -verbose:dynload are found. */
+				break;
+			}
+		}
+	}
+#undef VMARG_VERBOSE_DYNLOAD
+#undef VMARG_JAVA_HOME
+	if (NULL == javaHomeValue) {
+		if (verboseDynload) {
+			j9tty_printf(PORTLIB, "PrependJimageVMOptions() java.home property wasn't found.\n");
+		}
+		return JNI_ERR;
+	}
+
+	/* Initialize J9JImageIntf only once. */
+	if (J9JIMAGE_NO_ERROR != initJImageIntf(&jimageIntf, vm, PORTLIB, verboseDynload)) {
+		return JNI_ERR;
+	}
+	vm->jimageIntf = jimageIntf;
+
+	if (0 != initializeModulesPath(vm, javaHomeValue, verboseDynload)) {
+		return JNI_ERR;
+	}
+
+	if (CPE_TYPE_JIMAGE == vm->modulesPathEntry->type) {
+		UDATA jimageHandle = (UDATA)vm->modulesPathEntry->extraInfo;
+		UDATA resourceLocation = 0;
+		I_64 size = 0;
+		/* Locate java.base/jdk/internal/vm/options created by jlink --add-options. */
+		if (J9JIMAGE_NO_ERROR == jimageIntf->jimageFindResource(
+				jimageIntf, jimageHandle, "java.base", "jdk/internal/vm/options", &resourceLocation, &size)
+		) {
+			UDATA argEncoding = ARG_ENCODING_DEFAULT;
+			J9JavaVMArgInfoList jimageVMOptionsList;
+			char *options = (char *)j9mem_allocate_memory(size + 1, OMRMEM_CATEGORY_VM);
+
+			if (NULL == options) {
+				if (verboseDynload) {
+					j9tty_printf(
+							PORTLIB, "PrependJimageVMOptions() j9mem_allocate_memory for options failed.\n");
+				}
+				goto cleanup;
+			}
+			if (J9JIMAGE_NO_ERROR != jimageIntf->jimageGetResource(
+					jimageIntf, jimageHandle, resourceLocation, options, size, NULL)
+			) {
+				if (verboseDynload) {
+					j9tty_printf(
+							PORTLIB, "PrependJimageVMOptions()"
+							" jimageGetResource(java.base/jdk.internal.vm.options) not successful.\n");
+				}
+				goto cleanup;
+			}
+			options[size] = '\0';
+			jimageVMOptionsList.pool = pool_new(
+					sizeof(J9JavaVMArgInfo), 0, 0, 0, J9_GET_CALLSITE(), OMRMEM_CATEGORY_VM, POOL_FOR_PORT(PORTLIB));
+			if (NULL == jimageVMOptionsList.pool) {
+				if (verboseDynload) {
+					j9tty_printf(PORTLIB, "PrependJimageVMOptions() pool_new for jimageVMOptionsList failed.\n");
+				}
+				goto cleanup;
+			}
+			jimageVMOptionsList.head = NULL;
+			jimageVMOptionsList.tail = NULL;
+			if (parseOptionsFileText(PORTLIB, options, &jimageVMOptionsList, 0) < 0) {
+				if (verboseDynload) {
+					j9tty_printf(PORTLIB, "PrependJimageVMOptions() parseOptionsFileText(%s) failed.\n", options);
+				}
+				goto cleanup;
+			}
+
+			/* Prepend the new options before current vmArgsArray entries. */
+			vm->vmArgsArray = createJvmInitArgs(
+					PORTLIB, NULL, vm->vmArgsArray, TRUE, &jimageVMOptionsList, &argEncoding);
+cleanup:
+			pool_kill(jimageVMOptionsList.pool);
+			j9mem_free_memory(options);
+		}
+	} else if (verboseDynload) {
+		j9tty_printf(PORTLIB,
+				"PrependJimageVMOptions() jimageFindResource(java.base/jdk.internal.vm.options) not successful.\n");
+	}
+
+	/* Initialization was successful,
+	 * ignore any error when reading java.base/jdk/internal/vm/options in the jimage file.
+	 */
+	return JNI_OK;
+}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 BOOLEAN
 setBootLoaderModulePatchPaths(J9JavaVM * javaVM, J9Module * j9module, const char * moduleName)
@@ -2051,7 +2224,6 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 	char *parseErrorOption = NULL;
 	IDATA parseError = 0;
 	BOOLEAN lockwordWhat = FALSE;
-	UDATA rc = 0;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
@@ -2964,18 +3136,6 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 
 			vm->checkpointState.requiredGhostFileLimit = 1024 * 1024; /* 1 MB is the default ghost limit set by the CRIU library*/
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
-
-			break;
-
-		case BYTECODE_TABLE_SET:
-			if (J2SE_VERSION(vm) >= J2SE_V11) {
-				rc = initializeModulesPath(vm);
-				if (0 != rc) {
-					loadInfo = FIND_DLL_TABLE_ENTRY( FUNCTION_VM_INIT );
-					setErrorJ9dll(PORTLIB, loadInfo, "cannot initialize modules path", FALSE);
-					goto _error;
-				}
-			}
 
 			break;
 
@@ -7640,6 +7800,12 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 		goto error;
 	}
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
+
+#if JAVA_SPEC_VERSION >= 11
+	if (JNI_OK != prependJimageVMOptions(vm)) {
+		goto error;
+	}
+#endif /* JAVA_SPEC_VERSION >= 11 */
 
 	/* Scans cmd-line arguments in order */
 	if (JNI_OK != processVMArgsFromFirstToLast(vm)) {


### PR DESCRIPTION
Prepend VM startup options from `java.base/jdk.internal.vm.options`

`java.base/jdk.internal.vm.options` is a resource file in the jimage file modules created via `jlink --add-options <options>`;
Insert these VM options into `vm->vmArgsArray` before `processVMArgsFromFirstToLast(vm)`;
Updated `initJImageIntf()`, `initializeModulesPath()` and `initializeModulesPathEntry()` to be invoked at VM early bootstrap phase when the trace engine hasn't been initialized and the verbose module hasn't been loaded;
Modified `createJvmInitArgs()` to allow insert VM option entries before current `J9VMInitArgs`;
Obsoleted a few trace points.

Issue: https://github.com/eclipse-openj9/openj9/issues/23031

Signed-off-by: Jason Feng <fengj@ca.ibm.com>