### PR TITLE
Clean up double mapping related code

### DIFF
--- a/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
+++ b/runtime/gc_glue_java/ArrayletObjectModelBase.hpp
@@ -159,19 +159,6 @@ public:
 	}
 #endif /* defined(J9VM_ENV_DATA64) */
 
-#if defined(J9VM_GC_ENABLE_DOUBLE_MAP)
-	/**
-	 * Returns enable double mapping status
-	 *
-	 * @return true if double mapping status is set to true, false otherwise.
-	 */
-	MMINLINE bool
-	isDoubleMappingEnabled()
-	{
-		return false;
-	}
-#endif /* J9VM_GC_ENABLE_DOUBLE_MAP */
-
 	/**
 	 * Sets size in elements of a discontiguous indexable object .
 	 * @param arrayPtr Pointer to the indexable object whose size is required

--- a/runtime/gc_modron_startup/mmparseXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXgc.cpp
@@ -1509,6 +1509,17 @@ gcParseXgcArguments(J9JavaVM *vm, char *optArg)
 			continue;
 		}
 
+		/*
+		 * This feature has been superseded by Off-heap.
+		 * The option is silently ignored for backward compatibility.
+		 */
+		if (try_scan(&scan_start, "enableArrayletDoubleMapping")) {
+			continue;
+		}
+		if (try_scan(&scan_start, "disableArrayletDoubleMapping")) {
+			continue;
+		}
+
 #if defined (J9VM_GC_VLHGC)
 		if (try_scan(&scan_start, "fvtest_tarokForceNUMANode=")) {
 			if (!scan_udata_helper(vm, &scan_start, &extensions->fvtest_tarokForceNUMANode, "fvtest_tarokForceNUMANode=")) {

--- a/runtime/gc_trace/TgcRootScanner.cpp
+++ b/runtime/gc_trace/TgcRootScanner.cpp
@@ -74,7 +74,7 @@ const static char *attributeNames[] = {
 	"monitorlookupcaches", /* RootScannerEntity_MonitorLookupCaches */
 	"monitorlookupcachescomplete", /* RootScannerEntity_MonitorLookupCachesComplete */
 	"monitorreferenceobjectscomplete", /* RootScannerEntity_MonitorReferenceObjectsComplete */
-	"doubleMappedObjects", /* RootScannerEntity_DoubleMappedObjects */
+	"Unused", /* Unused */
 	"virtualLargeObjectHeapObjects", /* RootScannerEntity_virtualLargeObjectHeapObjects */
 };
 


### PR DESCRIPTION
 - Remove gc_glue_java/GC_ArrayletObjectModelBase.isDoubleMappingEnabled()
 - Remove double mapping related XML attribute names from TGC

depends on #https://github.com/eclipse-omr/omr/pull/8165