### PR TITLE
Remove long deprecated XMMBinaryArithmeticAnalyser.cpp

### DIFF
--- a/runtime/compiler/build/files/target/x.mk
+++ b/runtime/compiler/build/files/target/x.mk
@@ -51,8 +51,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/x/codegen/X86BinaryEncoding.cpp \
     omr/compiler/x/codegen/X86Debug.cpp \
     omr/compiler/x/codegen/X86FPConversionSnippet.cpp \
-    omr/compiler/x/codegen/X86SystemLinkage.cpp \
-    omr/compiler/x/codegen/XMMBinaryArithmeticAnalyser.cpp
+    omr/compiler/x/codegen/X86SystemLinkage.cpp
 
 JIT_PRODUCT_SOURCE_FILES+=\
     compiler/x/codegen/AllocPrefetchSnippet.cpp \


### PR DESCRIPTION
The file exists but is empty in OMR.  Remove it from the OpenJ9 build.