### PR TITLE
[0.59] Revert "Disable traps on 64-bit Windows"

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2656,14 +2656,9 @@ J9::Options::fePreProcess(void * base)
    * receive the 0C7 signal causing the product process to get killed
    *
    * Therefore, the recommendation is to disable traps on z/OS by default.
-   *
-   * On Windows the OS signal handlers may require a large amount of stack space, which causes
-   * stack overflow and corruption on the Java stack. As a temporary workaround until a better
-   * solution is found, traps are disabled by default on Windows as well.
-   *
    * Users can choose to enable traps using the "enableTraps" option.
    */
-   #if defined(J9ZOS390) || (defined(OMR_OS_WINDOWS) && defined(TR_TARGET_64BIT))
+   #if defined(J9ZOS390)
       self()->setOption(TR_DisableTraps);
    #endif
 


### PR DESCRIPTION
This reverts https://github.com/eclipse-openj9/openj9/pull/23123.

[#23472](https://github.com/eclipse-openj9/openj9/pull/23472) increased the Java stack size on Windows, circumventing the stack overflow error that was seen when trap handlers ran on the Java stack. With that change, the temporary workaround of disabling traps on Windows by default is no longer necessary.

Port of #23517 to v0.59.0-release branch.