### PR TITLE
(0.59) Stabilize ExceptionMeta profiling by using preserved copy

### DIFF
--- a/runtime/compiler/optimizer/JProfilingValue.cpp
+++ b/runtime/compiler/optimizer/JProfilingValue.cpp
@@ -320,6 +320,111 @@ TR_JProfilingValue::performOnNode(TR::Node *node, TR::TreeTop *cursor, TR_BitVec
       performOnNode(node->getChild(i), cursor, alreadyProfiledValues, checklist);
    }
 
+// Identify a direct-load of the MethodMetaData symbol named "ExceptionMeta"
+static bool isExceptionMetaLoad(TR::Node *node)
+   {
+   const char *exceptionMetaName = "ExceptionMeta";
+   return (node && node->getOpCode().isLoadDirect() && node->getOpCode().hasSymbolReference()
+      && node->getSymbolReference() && node->getSymbolReference()->getSymbol()
+      && node->getSymbolReference()->getSymbol()->isMethodMetaData()
+      && node->getSymbolReference()->getSymbol()->getName()
+      && !strcmp(node->getSymbolReference()->getSymbol()->getName(), exceptionMetaName));
+   }
+
+/*
+ * Strip away trivial wrappers so we can compare the underlying value.
+ * PassThrough nodes commonly appear after various transforms and can otherwise
+ * prevent us from recognizing equivalent values.
+ */
+static TR::Node *skipPassThrough(TR::Node *n)
+   {
+   while (n && n->getOpCodeValue() == TR::PassThrough)
+      n = n->getFirstChild();
+   return n;
+   }
+
+/*
+ * Return true if 'candidate' represents the same value as 'value' for purposes
+ * of locating a "preserving store".
+ */
+static bool isSameValueForPreservingStore(TR::Node *candidate, TR::Node *value)
+   {
+   if (candidate == value)
+      return true;
+
+   candidate = skipPassThrough(candidate);
+   value = skipPassThrough(value);
+
+   if (!candidate || !value)
+      return false;
+
+   // If both are direct loads with symbol references, compare by symref.
+   if (candidate->getOpCode().isLoadDirect() && value->getOpCode().isLoadDirect()
+      && candidate->getOpCode().hasSymbolReference() && value->getOpCode().hasSymbolReference()
+      && candidate->getSymbolReference() && value->getSymbolReference()
+      && candidate->getSymbolReference() == value->getSymbolReference())
+      return true;
+
+   // Treat distinct ExceptionMeta load nodes as equivalent even if node identity differs.
+   if (isExceptionMetaLoad(candidate) && isExceptionMetaLoad(value))
+      return true;
+
+   return false;
+   }
+
+/*
+ * Scan backwards from 'cursor' within the current extended basic block and
+ * return the nearest store (direct or register) whose stored value is 'value'.
+ */
+static TR::Node *findNearestStoreForValue(TR::TreeTop *cursor, TR::Node *value)
+   {
+   for (TR::TreeTop *tt = cursor->getPrevTreeTop(); tt
+      && (tt->getNode()->getOpCodeValue() != TR::BBStart || tt->getNode()->getBlock()->isExtensionOfPreviousBlock());
+      tt = tt->getPrevTreeTop())
+      {
+      TR::Node *ttNode = tt->getNode();
+      if (ttNode->getOpCode().isStoreDirectOrReg() && ttNode->getNumChildren() >= 1
+         && isSameValueForPreservingStore(ttNode->getFirstChild(), value))
+         {
+         return ttNode;
+         }
+      }
+   return NULL;
+   }
+
+/*
+ * Return true if 'store' is a direct store to a stable symbol suitable for profiling.
+ * We explicitly exclude MethodMetaData symbols because ExceptionMeta (MethodMetaData)
+ * may be cleared to NULL after being copied.
+ */
+static bool isStableNonMetaDataStoreDirect(TR::Node *store)
+   {
+   return store && store->getOpCode().isStoreDirect() && store->getOpCode().hasSymbolReference()
+      && store->getSymbolReference() && store->getSymbolReference()->getSymbol()
+      && !store->getSymbolReference()->getSymbol()->isMethodMetaData();
+   }
+
+// Materialize a loadReg that corresponds to a storeReg preservingStore.
+static TR::Node *createRegLoadFromStoreReg(TR::Compilation *comp, TR::Node *example, TR::Node *storeReg)
+   {
+   TR_ASSERT_FATAL(storeReg && storeReg->getOpCode().isStoreReg(), "Expected storeReg preserving store");
+
+   TR::Node *regLoad = TR::Node::create(example, comp->il.opCodeForRegisterLoad(example->getDataType()));
+   regLoad->setRegLoadStoreSymbolReference(storeReg->getRegLoadStoreSymbolReference());
+
+   if (example->requiresRegisterPair(comp))
+      {
+      regLoad->setLowGlobalRegisterNumber(storeReg->getLowGlobalRegisterNumber());
+      regLoad->setHighGlobalRegisterNumber(storeReg->getHighGlobalRegisterNumber());
+      }
+   else
+      {
+      regLoad->setGlobalRegisterNumber(storeReg->getGlobalRegisterNumber());
+      }
+
+   return regLoad;
+   }
+
 void
 TR_JProfilingValue::lowerCalls()
    {
@@ -381,6 +486,58 @@ TR_JProfilingValue::lowerCalls()
                optDetailString(), child->getGlobalIndex());
             // Extract the arguments and add the profiling trees
             TR::Node *value = child->getFirstChild();
+
+            // ExceptionMeta is normally copied to a temp and then it is cleared to NULL.
+            // If we build profiling trees from the raw ExceptionMeta load, later rematerialization
+            // may reload NULL. Prefer profiling a preserved copy when we can identify it.
+            //
+            // If we can find a preserving store to a stable (non-MethodMetaData) symbol,
+            // profile that preserved symbol instead of the MethodMetaData slot.
+            //
+            // Otherwise, materialize a stable value by spilling to a compiler temporary
+            // before lowering. When the only preserved form is a post-GRA register store,
+            // first create an explicit regLoad from that register and spill that value,
+            // so we do not re-read ExceptionMeta from metadata.
+            //
+            if (isExceptionMetaLoad(value))
+               {
+               TR::Node *preservingStore = findNearestStoreForValue(cursor, value);
+
+               if (isStableNonMetaDataStoreDirect(preservingStore))
+                  {
+                  // Profile the preserved variable instead of the MethodMetaData slot.
+                  value = TR::Node::createLoad(value, preservingStore->getSymbolReference());
+                  dumpOptDetails(comp(), "%s %s: ExceptionMeta preservingStore n%dn value n%dn\n",
+                     optDetailString(), __FUNCTION__, preservingStore->getGlobalIndex(),
+                     value->getGlobalIndex());
+                  }
+               else
+                  {
+                  // If the preserved copy is held only in a register store (post-GRA) or we could not
+                  // find a stable symbol, spill to a temporary before lowering and profile the temporary.
+                  TR::SymbolReference *tmpSymRef = NULL;
+                  // Default spill source is the original value
+                  TR::Node *spillSource = value;
+                  // If we found a preserving store in a register (post-GRA), spill from the register value
+                  // rather than reloading ExceptionMeta which may already be NULL.
+                  if (preservingStore && preservingStore->getOpCode().isStoreReg())
+                     {
+                     spillSource = createRegLoadFromStoreReg(comp(), value, preservingStore);
+                     dumpOptDetails(comp(),
+                        "%s %s: ExceptionMeta preservingStore n%dn value n%dn spillSource n%dn\n",
+                        optDetailString(), __FUNCTION__, preservingStore->getGlobalIndex(),
+                        value->getGlobalIndex(), spillSource->getGlobalIndex());
+                     }
+
+                  TR::TreeTop *storeTT = TR::TreeTop::create(comp(), storeNode(comp(), spillSource, tmpSymRef));
+                  cursor->insertBefore(storeTT);
+
+                  value = TR::Node::createLoad(value, tmpSymRef);
+                  dumpOptDetails(comp(), "%s %s: ExceptionMeta value n%dn symRef #%d\n", optDetailString(),
+                     __FUNCTION__, value->getGlobalIndex(), tmpSymRef ? tmpSymRef->getReferenceNumber() : -1);
+                  }
+               }
+
             TR_AbstractHashTableProfilerInfo *table = (TR_AbstractHashTableProfilerInfo*) child->getSecondChild()->getAddress();
             bool needNullTest =  comp()->getSymRefTab()->isNonHelper(child->getSymbolReference(), TR::SymbolReferenceTable::jProfileValueWithNullCHKSymbol);
             addProfilingTrees(comp(), cursor, value, table, needNullTest, true, trace());
@@ -576,6 +733,52 @@ TR_JProfilingValue::addProfilingTrees(
          break;
          }
       }
+
+   /*
+    * In catch blocks the preserving store of ExceptionMeta may appear before
+    * the profiling placeholder. If the profiling value is still the raw ExceptionMeta
+    * load after the forward scan, scan backwards for a preserving store so helper
+    * call construction can use the preserved value instead of reloading metadata.
+    */
+   if (profilingValue == value && isExceptionMetaLoad(value))
+      {
+      TR::Node *preservingStore = findNearestStoreForValue(insertionPoint, value);
+      if (preservingStore)
+         {
+         /* Prefer profiling a preserved copy held in a stable symbol (not MethodMetaData). */
+         if (isStableNonMetaDataStoreDirect(preservingStore))
+            {
+            profilingValue = preservingStore;
+            logprintf(trace, log,
+               "\t\t\tExceptionMeta preservingStoreDirect n%dn chosen as profilingValue (value n%dn)\n",
+               preservingStore->getGlobalIndex(), value->getGlobalIndex());
+            }
+         /*
+          * If the preserved value is only available via a register store (post-GRA),
+          * do NOT use the storeReg as profilingValue. Using storeReg can later trigger
+          * the 'must be loadReg' assertion when we can't find it in GlRegDeps.
+          * Instead, materialize a corresponding loadReg and use that for subsequent
+          * spilling/temping logic.
+          */
+         else if (preservingStore->getOpCode().isStoreReg())
+            {
+            profilingValue = createRegLoadFromStoreReg(comp, value, preservingStore);
+            logprintf(trace, log,
+               "\t\t\tExceptionMeta preservingStoreReg n%dn -> n%dn chosen as profilingValue (value n%dn)\n",
+               preservingStore->getGlobalIndex(), profilingValue->getGlobalIndex(), value->getGlobalIndex());
+            }
+         else
+            {
+            /*
+             * If we found something unexpected (e.g., MethodMetaData storeDirect or other form),
+             * leave profilingValue unchanged and let the existing temp-slot logic handle it.
+             */
+            logprintf(trace, log, "\t\t\tExceptionMeta preservingStore n%dn ignored (unstable) (value n%dn)!\n",
+               preservingStore->getGlobalIndex(), value->getGlobalIndex());
+            }
+         }
+      }
+
    logprintf(trace, log, "\t\t\tProfiling value n%dn\n", profilingValue->getGlobalIndex());
 
    TR::Block *iter = originalBlock;
@@ -757,19 +960,37 @@ TR_JProfilingValue::addProfilingTrees(
             }
          }
       }
-   // In case we can not find value in register or temp slot, store the value to temp slot before going to helper block.
+
+   /*
+    * In case we can not find value in register or temp slot, store the value to temp slot before going to helper
+    * block.
+    *
+    * When selecting an existing symref to reuse for the helper call value, do not
+    * reuse the MethodMetaData symref for ExceptionMeta loads. ExceptionMeta may be
+    * cleared to NULL, so helper calls must not reload it from the metadata slot.
+    * Instead, store to a temp slot and load from that stable location.
+    */
    if (valueChildOfHelperCall == NULL)
       {
       TR::SymbolReference *storedValueSymRef = NULL;
-      if (profilingValue->getOpCode().isStoreDirect() || (profilingValue->getOpCode().isLoadDirect() && !profilingValue->getOpCode().isLoadConst()))
+      if (profilingValue->getOpCode().isStoreDirect()
+         || (profilingValue->getOpCode().isLoadDirect() && !profilingValue->getOpCode().isLoadConst()
+            && !isExceptionMetaLoad(profilingValue)))
          {
          storedValueSymRef = profilingValue->getSymbolReference();
+         logprintf(trace, log, "\t\t\tstoredValueSymRef #%d\n", storedValueSymRef->getReferenceNumber());
          }
       else
          {
-         logprintf(trace, log, "\t\t\tNode n%dn needs to be stored on temp slot\n", profilingValue->getGlobalIndex());
-         // profiledValue is normal Node which is not referenced further. Store value to temp slot at the beginning of quick test
-         TR::TreeTop *storeValue = TR::TreeTop::create(comp, quickTestBlock->getEntry(), storeNode(comp,  profilingValue, storedValueSymRef));
+         /*
+          * profiledValue is normal Node which is not referenced further. Store value to temp slot at the beginning
+          * of quick test
+          */
+         TR::TreeTop *storeValue = TR::TreeTop::create(comp, quickTestBlock->getEntry(),
+            storeNode(comp, profilingValue, storedValueSymRef));
+         logprintf(trace, log, "\t\t\tprofilingValue n%dn is stored on temp slot n%dn #%d\n",
+            profilingValue->getGlobalIndex(), storeValue->getNode()->getGlobalIndex(),
+            storedValueSymRef->getReferenceNumber());
          }
       valueChildOfHelperCall = TR::Node::createLoad(value, storedValueSymRef);
       }
@@ -781,7 +1002,7 @@ TR_JProfilingValue::addProfilingTrees(
                                        comp->getSymRefTab()->findOrCreateVftSymbolRef());
       }
 
-   // Add the call to the helper and return to the mainline
+   /* Add the call to the helper and return to the mainline */
    TR::TreeTop *helperCallTreeTop = TR::TreeTop::create(comp, helper->getEntry(), createHelperCall(comp,
       valueChildOfHelperCall,
       TR::Node::aconst(value, table->getBaseAddress())));


### PR DESCRIPTION
Port [PR #23447](https://github.com/eclipse-openj9/openj9/pull/23447) to 0.59

--------
Profiling placeholders can receive a direct load of MethodMetaData ExceptionMeta. ExceptionMeta is typically copied to a temporary and then cleared to NULL; later rematerialization of the profiling value may reload NULL, producing incorrect profiling data.

Detect direct ExceptionMeta loads when lowering profiling placeholders. Prefer profiling a preserved copy by finding the nearest store that saves ExceptionMeta into a non-MethodMetaData symbol. If a stable symbol cannot be identified (or the value is only preserved in a register post-GRA), spill the value into a temporary before constructing profiling trees.

Fixes: #23381