### PR TITLE
Add !walkj9hashtable DDR interactive command

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/GetCommandsTask.java
@@ -104,6 +104,7 @@ import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.TraceConfigCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.VMConstantPoolCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.VmCheckCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.WalkInternTableCommand;
+import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.WalkJ9HashTableCommand;
 import com.ibm.j9ddr.vm29.tools.ddrinteractive.commands.WalkJ9PoolCommand;
 
 /**
@@ -177,6 +178,7 @@ public class GetCommandsTask extends BaseJVMCommands implements IBootstrapRunnab
 		toPassBack.add(new SetVMCommand());
 		toPassBack.add(new TraceConfigCommand());
 		toPassBack.add(new WalkJ9PoolCommand());
+		toPassBack.add(new WalkJ9HashTableCommand());
 		toPassBack.add(new CoreInfoCommand());
 		toPassBack.add(new GCCheckCommand());
 		toPassBack.add(new DumpStringTableCommand());

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/WalkJ9HashTableCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/WalkJ9HashTableCommand.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package com.ibm.j9ddr.vm29.tools.ddrinteractive.commands;
+
+import java.io.PrintStream;
+
+import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.tools.ddrinteractive.Command;
+import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
+import com.ibm.j9ddr.tools.ddrinteractive.Context;
+import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
+import com.ibm.j9ddr.vm29.j9.HashTable;
+import com.ibm.j9ddr.vm29.j9.SlotIterator;
+import com.ibm.j9ddr.vm29.pointer.VoidPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
+import com.ibm.j9ddr.vm29.pointer.generated.J9HashTablePointer;
+import com.ibm.j9ddr.vm29.types.UDATA;
+
+/**
+ * Implementation of DDR extension !walkj9hashtable.
+ *
+ * This extension takes a J9HashTable address and an optional type argument,
+ * and prints the address of each element in the hashtable as a runnable DDR command.
+ * The type argument is used to derive the DDR command prefix to prepend to each element's address.
+ * If not provided, the default DDR command prefix is "!j9x".
+ */
+public class WalkJ9HashTableCommand extends Command
+{
+	private static final String POINTER_MARKER = "*";
+
+	/**
+	 * Constructor
+	 */
+	public WalkJ9HashTableCommand()
+	{
+		addCommand("walkj9hashtable", "<address> [<type>]", "Walks the elements of a J9HashTable");
+	}
+
+	/**
+	 * Prints the usage for the walkj9hashtable command.
+	 *
+	 * @param out  the PrintStream the usage statement prints to
+	 */
+	private void printUsage(PrintStream out)
+	{
+		out.println("walkj9hashtable <address> [<type>] - Walks the elements of a J9HashTable");
+	}
+
+	/**
+	 * Run method for !walkj9hashtable extension.
+	 *
+	 * @param command  !walkj9hashtable
+	 * @param args     args passed by !walkj9hashtable extension
+	 * @param context  Context
+	 * @param out      PrintStream
+	 * @throws DDRInteractiveCommandException
+	 */
+	@Override
+	public void run(String command, String[] args, Context context, PrintStream out) throws DDRInteractiveCommandException
+	{
+		if ((0 == args.length) || (2 < args.length)) {
+			printUsage(out);
+			return;
+		}
+
+		long address = CommandUtils.parsePointer(args[0], J9BuildFlags.J9VM_ENV_DATA64);
+
+		/* Parse the optional type argument. */
+		String typeName = (2 == args.length) ? args[1].trim() : null;
+
+		/* Set the default values. */
+		boolean isInline = true;
+		String ddrCommand = "!j9x";
+
+		if (null != typeName) {
+			String baseTypeName;
+			if (typeName.endsWith(POINTER_MARKER)) {
+				isInline = false;
+				baseTypeName = typeName.substring(0, typeName.length() - POINTER_MARKER.length());
+			} else {
+				baseTypeName = typeName;
+			}
+
+			baseTypeName = baseTypeName.toLowerCase();
+
+			/*
+			 * Validate: check that the derived DDR command is actually registered in
+			 * this context. This catches typos (e.g. "j9claas*") early with a clear
+			 * error message.
+			 */
+			if (!context.getCommandNames().contains(baseTypeName)) {
+				throw new DDRInteractiveCommandException(
+						"Unrecognized type '" + typeName + "'");
+			}
+
+			ddrCommand = "!" + baseTypeName;
+		}
+
+		out.format("J9HashTable at 0x%s%n{%n",
+				CommandUtils.longToBigInteger(address).toString(CommandUtils.RADIX_HEXADECIMAL));
+
+		walkJ9HashTable(address, isInline, ddrCommand, out);
+		out.println("}");
+	}
+
+	/**
+	 * Iterates all entries in the hashtable and prints each entry's address
+	 * as a runnable DDR command.
+	 *
+	 * @param address     address of the J9HashTable
+	 * @param isInline    true if entries are stored inline in the slot;
+	 *                    false if the slot holds a pointer to the entry
+	 * @param ddrCommand  DDR command prefix to prepend
+	 * @param out         print stream
+	 * @throws DDRInteractiveCommandException
+	 */
+	private void walkJ9HashTable(long address, boolean isInline, String ddrCommand, PrintStream out)
+			throws DDRInteractiveCommandException
+	{
+		try {
+			J9HashTablePointer j9hashtable = J9HashTablePointer.cast(address);
+
+			HashTable.HashEqualFunction<VoidPointer> equalFn = (e1, e2) -> e1.eq(e2);
+			HashTable.HashFunction<VoidPointer> hashFn = entry -> UDATA.cast(entry);
+
+			HashTable<VoidPointer> hashTable = HashTable.fromJ9HashTable(
+					j9hashtable, isInline, VoidPointer.class, equalFn, hashFn);
+
+			for (SlotIterator<VoidPointer> iterator = hashTable.iterator(); iterator.hasNext();) {
+				VoidPointer currentElement = iterator.next();
+				out.format("  %s %s%n", ddrCommand, currentElement.getHexAddress());
+			}
+		} catch (CorruptDataException e) {
+			throw new DDRInteractiveCommandException("Either address is not a valid J9HashTable address or J9HashTable is corrupted.");
+		}
+	}
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/Constants.java
@@ -112,6 +112,17 @@ public class Constants {
 	public static final String WALKJ9POOL_SUCCESS_KEYS = "J9Pool at";
 	public static final String WALKJ9POOL_FAILURE_KEY = "Either address is not a valid pool address or pool itself is corrupted";
 
+	public static final String J9HASHTABLE_CMD = "j9hashtable";
+
+	public static final String WALKJ9HASHTABLE_CMD = "walkj9hashtable";
+	public static final String WALKJ9HASHTABLE_SUCCESS_KEY = "J9HashTable at";
+	public static final String WALKJ9HASHTABLE_FAILURE_KEY = "Either address is not a valid J9HashTable address or J9HashTable is corrupted";
+
+	public static final String KEYHASHTABLECLASSENTRY_CMD = "keyhashtableclassentry";
+
+	public static final String J9CLASS_CMD = "j9class";
+	public static final String J9CLASSLOADER_CMD = "j9classloader";
+	public static final String J9MODULE_CMD = "j9module";
 
 	public static final String J9THREAD_CMD = "j9thread";
 	public static final String J9THREAD_SUCCESS_KEYS = "J9ThreadTracing,J9ThreadMonitor";

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestDDRExtensionGeneral.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestDDRExtensionGeneral.java
@@ -27,15 +27,22 @@ import j9vm.test.ddrext.DDRExtTesterBase;
 import j9vm.test.ddrext.SetupConfig;
 import j9vm.test.ddrext.util.parser.ClassForNameOutputParser;
 import j9vm.test.ddrext.util.parser.FindVMOutputParser;
+import j9vm.test.ddrext.util.parser.J9ClassLoaderOutputParser;
+import j9vm.test.ddrext.util.parser.J9ClassOutputParser;
 import j9vm.test.ddrext.util.parser.J9JavaVmOutputParser;
 import j9vm.test.ddrext.util.parser.J9MethodOutputParser;
+import j9vm.test.ddrext.util.parser.J9ModuleOutputParser;
 import j9vm.test.ddrext.util.parser.J9PoolOutputParser;
 import j9vm.test.ddrext.util.parser.J9PoolPuddleListOutputParser;
+import j9vm.test.ddrext.util.parser.KeyHashTableClassEntryOutputParser;
 import j9vm.test.ddrext.util.parser.MethodForNameOutputParser;
 import j9vm.test.ddrext.util.parser.ParserUtil;
 
 import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
 
+import org.openj9.test.util.VersionCheck;
 import org.testng.log4testng.Logger;
 
 import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
@@ -593,4 +600,215 @@ public class TestDDRExtensionGeneral extends DDRExtTesterBase {
 			assertTrue(validate(versionInfoOutput, Constants.COREINFO_VERSION_IBM_SUCCESS_KEYS, Constants.COREINFO_VERSION_FAILURE_KEYS));
 		}
 	}
+
+	/**
+	 * Tests the !walkj9hashtable DDR extension by covering both the inline entry
+	 * path (class names via KeyHashTableClassEntry) and the pointer-based path
+	 * (module names via J9Module*).
+	 */
+	public void testWalkJ9HashTable()
+	{
+		/* Get the vm address from core file by using !findvm extension. */
+		String findVMOutput = exec(Constants.FINDVM_CMD, new String[] {});
+		String j9javavmAddr = FindVMOutputParser.getJ9JavaVMAddress(findVMOutput);
+		if (null == j9javavmAddr) {
+			fail("j9javavm address could not be found in the !findvm output");
+			return;
+		}
+
+		testWalkJ9HashTablesForCLHashTables(j9javavmAddr);
+	}
+
+	/**
+	 * Tests !walkj9hashtable for the classHashTable and moduleHashTable
+	 * of each J9ClassLoader found in the J9JavaVM's classLoaderBlocks pool.
+	 *
+	 * @param j9javavmAddr hex address of the J9JavaVM struct
+	 */
+	private void testWalkJ9HashTablesForCLHashTables(String j9javavmAddr)
+	{
+		String j9javavmOutput = exec(Constants.J9JAVAVM_CMD, new String[] {j9javavmAddr});
+
+		String classLoaderBlocksAddr = J9JavaVmOutputParser.getClassLoaderBlocksAddress(j9javavmOutput);
+		if (null == classLoaderBlocksAddr) {
+			fail("Failed to get classLoaderBlocks address from !j9javavm output:\n" + j9javavmOutput);
+			return;
+		}
+
+		String walkJ9PoolOutputforClassLoaderBlocks = exec(Constants.WALKJ9POOL_CMD, new String[] {classLoaderBlocksAddr});
+		validate(walkJ9PoolOutputforClassLoaderBlocks, Constants.WALKJ9POOL_SUCCESS_KEYS, Constants.WALKJ9POOL_FAILURE_KEY);
+
+		List<String> classLoaderAddrs = parseAddressesFromWalkJ9PoolOutput(walkJ9PoolOutputforClassLoaderBlocks);
+		if (classLoaderAddrs.isEmpty()) {
+			fail("Failed to find classLoader addresses in !walkj9pool output for " + classLoaderBlocksAddr);
+			return;
+		}
+
+		testWalkJ9HashTableforClassHashTable(classLoaderAddrs);
+
+		/* moduleHashTable is only allocated for JAVA_SPEC_VERSION > 8. */
+		if (VersionCheck.major() > 8) {
+			testWalkJ9HashTableforModuleHashTable(classLoaderAddrs);
+		}
+	}
+
+	/**
+	 * This method walks every classLoader's classHashTable using !walkj9hashtable
+	 * with KeyHashTableClassEntry (inline=true) and asserts that known
+	 * class names are present.
+	 * @param classLoaderAddrs list of J9ClassLoader hex addresses to walk
+	 */
+	private void testWalkJ9HashTableforClassHashTable(List<String> classLoaderAddrs)
+	{
+		/* For each classLoader, walk its classHashTable and collect class names. */
+		List<String> allClassNames = new ArrayList<>();
+
+		for (String classLoaderAddr : classLoaderAddrs) {
+			/* Get the classHashTable address for the classLoader from the !j9classloader output. */
+			String j9ClassLoaderOutput = exec(Constants.J9CLASSLOADER_CMD, new String[] {classLoaderAddr});
+			String classHashTableAddr = J9ClassLoaderOutputParser.getClassHashTableAddress(j9ClassLoaderOutput);
+			if (null == classHashTableAddr) {
+				continue;
+			}
+
+			String walkJ9HashTableOutputForClassHashTable = exec(Constants.WALKJ9HASHTABLE_CMD, new String[] {classHashTableAddr, "KeyHashTableClassEntry"});
+			validate(walkJ9HashTableOutputForClassHashTable, Constants.WALKJ9HASHTABLE_SUCCESS_KEY, Constants.WALKJ9HASHTABLE_FAILURE_KEY);
+
+			List<String> classEntryAddrs = parseAddressesFromWalkJ9HashTableOutput(walkJ9HashTableOutputForClassHashTable);
+
+			for (String classEntryAddr : classEntryAddrs) {
+				String classEntryOutput = exec(Constants.KEYHASHTABLECLASSENTRY_CMD, new String[] {classEntryAddr.trim()});
+				String ramClassAddr = KeyHashTableClassEntryOutputParser.getRamClassAddress(classEntryOutput);
+				if (null == ramClassAddr) {
+					continue;
+				}
+
+				String j9classOutput = exec(Constants.J9CLASS_CMD, new String[] {ramClassAddr});
+				String className = J9ClassOutputParser.getClassName(j9classOutput);
+				if (null != className) {
+					allClassNames.add(className);
+				}
+			}
+		}
+
+		if (allClassNames.isEmpty()) {
+			fail("No class names found when walking classHashTables across all classLoaders");
+			return;
+		}
+
+		assertTrue(allClassNames.contains("com/ibm/jvm/Dump"));
+		assertTrue(allClassNames.contains("j9vm/test/corehelper/CoreGen"));
+		assertTrue(allClassNames.contains("j9vm/test/corehelper/SimpleThread"));
+		assertTrue(allClassNames.contains("j9vm/test/corehelper/SimpleThread$DumperThread"));
+		assertTrue(allClassNames.contains("j9vm/test/corehelper/TestJITExtHelperThread"));
+		assertTrue(allClassNames.contains("java/lang/Thread"));
+		assertTrue(allClassNames.contains("org/openj9/test/util/CompilerAccess"));
+	}
+
+	/**
+	 * Walks every classLoader's moduleHashTable using !walkj9hashtable with
+	 * J9Module* (inline=false) and asserts that known standard module names are present.
+	 *
+	 * @param classLoaderAddrs list of J9ClassLoader hex addresses to walk
+	 */
+	private void testWalkJ9HashTableforModuleHashTable(List<String> classLoaderAddrs)
+	{
+		/* For each classLoader, walk its moduleHashTable and collect module names. */
+		List<String> allModuleNames = new ArrayList<>();
+
+		for (String classLoaderAddr : classLoaderAddrs) {
+			/* Get the moduleHashTable address for the classLoader from the !j9classloader output. */
+			String j9classloaderOutput = exec(Constants.J9CLASSLOADER_CMD, new String[] {classLoaderAddr});
+			String moduleHashTableAddr = J9ClassLoaderOutputParser.getModuleHashTableAddress(j9classloaderOutput);
+			if (null == moduleHashTableAddr) {
+				continue;
+			}
+
+			/*
+			 * moduleHashTable stores J9Module* pointers (inline=false), so the walk
+			 * type argument is "J9Module*". Each output line is directly "!j9module 0x<addr>".
+			 */
+			String walkJ9HashTableOutputForModuleHashTable = exec(Constants.WALKJ9HASHTABLE_CMD, new String[] {moduleHashTableAddr, "J9Module*"});
+			validate(walkJ9HashTableOutputForModuleHashTable, Constants.WALKJ9HASHTABLE_SUCCESS_KEY, Constants.WALKJ9HASHTABLE_FAILURE_KEY);
+
+			List<String> moduleAddrs = parseAddressesFromWalkJ9HashTableOutput(walkJ9HashTableOutputForModuleHashTable);
+
+			for (String moduleAddr : moduleAddrs) {
+				String j9ModuleOutput = exec(Constants.J9MODULE_CMD, new String[] {moduleAddr.trim()});
+				String moduleName = J9ModuleOutputParser.getModuleName(j9ModuleOutput);
+				if (null != moduleName) {
+					allModuleNames.add(moduleName);
+				}
+			}
+		}
+
+		if (allModuleNames.isEmpty()) {
+			fail("No module names found when walking moduleHashTables across all classLoaders");
+			return;
+		}
+
+		assertTrue(allModuleNames.contains("java.base"));
+		assertTrue(allModuleNames.contains("java.logging"));
+		assertTrue(allModuleNames.contains("openj9.jvm"));
+	}
+
+	/**
+	 * Parses entry addresses from !walkj9pool output.
+	 *
+	 * @param walkPoolOutput output of !walkj9pool <address>
+	 * @return list of hex address strings, one per pool element
+	 */
+	private List<String> parseAddressesFromWalkJ9PoolOutput(String walkJ9PoolOutput)
+	{
+		ArrayList<String> addresses = new ArrayList<>();
+		String [] lines = walkJ9PoolOutput.split("\n");
+		for (int i = 0; i < lines.length; i++) {
+			String currentLine = lines[i].trim();
+			if (currentLine.startsWith("[")) {
+				/* Line format: [N]  =  0x<address> */
+				String[] parts = currentLine.split("=");
+				if (1 < parts.length) {
+					String addr = parts[parts.length - 1].trim();
+					if (0 < addr.length()) {
+						addresses.add(addr);
+					}
+				}
+			} else if (currentLine.equals("}")) {
+				/* Closing parenthesis in !walkj9pool output is encountered, stop parsing. */
+				break;
+			}
+		}
+		return addresses;
+	}
+
+	/**
+	 * Parses the entry addresses from !walkj9hashtable output.
+	 *
+	 * @param walkOutput output of !walkj9hashtable
+	 * @return list of hex address strings, one per table entry
+	 */
+	private List<String> parseAddressesFromWalkJ9HashTableOutput(String walkJ9HashTableOutput)
+	{
+		ArrayList<String> addresses = new ArrayList<>();
+		boolean insideBraces = false;
+		String [] lines = walkJ9HashTableOutput.split("\n");
+		for (int i = 0; i < lines.length; i++) {
+			String currentLine = lines[i].trim();
+			if (currentLine.equals("}")) {
+				/* Closing parenthesis in !walkj9hashtable output is encountered, stop parsing. */
+				break;
+			} else if (currentLine.startsWith("!")) {
+				/* Line format: !<command> 0x<address> */
+				String[] parts = currentLine.split("\\s+");
+				if (1 < parts.length) {
+					String addr = parts[parts.length - 1].trim();
+					if (0 < addr.length()) {
+						addresses.add(addr);
+					}
+				}
+			}
+		}
+		return addresses;
+	}
+
 }

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ClassLoaderOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ClassLoaderOutputParser.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+/**
+ * This class is used to extract info from !j9classloader <address> DDR extension output.
+ */
+public class J9ClassLoaderOutputParser {
+	private static final String FIELDSIGNATURE_CLASSHASHTABLE = "* classHashTable";
+	private static final String FIELDSIGNATURE_MODULEHASHTABLE = "* moduleHashTable";
+
+	/**
+	 * This method finds the address of the classHashTable field from !j9classloader output.
+	 *
+	 * Sample output:
+	 *   0x28: struct J9HashTable * classHashTable = !j9hashtable 0x00007F9DE00F6EC0
+	 *
+	 * @param j9ClassLoaderOutput output of !j9classloader <address>
+	 * @return hex address of the J9HashTable, or null if not found
+	 */
+	public static String getClassHashTableAddress(String j9ClassLoaderOutput)
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_CLASSHASHTABLE, Constants.J9HASHTABLE_CMD, j9ClassLoaderOutput);
+	}
+
+	/**
+	 * This method finds the address of the moduleHashTable field from !j9classloader output.
+	 *
+	 * Sample output:
+	 *   0x38: struct J9HashTable * moduleHashTable = !j9hashtable 0x00007F4E880F84E0
+	 *
+	 * @param j9ClassLoaderOutput output of !j9classloader <address>
+	 * @return hex address of the J9HashTable, or null if not found
+	 */
+	public static String getModuleHashTableAddress(String j9ClassLoaderOutput)
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_MODULEHASHTABLE, Constants.J9HASHTABLE_CMD, j9ClassLoaderOutput);
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ClassOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ClassOutputParser.java
@@ -93,6 +93,27 @@ public class J9ClassOutputParser {
 	}
 	
 	/**
+	 * This method extracts the internal class name from !j9class output.
+	 *
+	 * @param j9ClassOutput output of !j9class <address>
+	 * @return class name (e.g. "java/lang/String"), or null if not found
+	 */
+	public static String getClassName(String j9ClassOutput) {
+		if (null == j9ClassOutput) {
+			log.error("!j9class output is null");
+		} else {
+			String[] outputLines = j9ClassOutput.split(Constants.NL);
+			for (String aLine : outputLines) {
+				int index = aLine.indexOf("Class name:");
+				if (index != -1) {
+					return aLine.substring(index + "Class name:".length()).trim();
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
 	 * This method finds the address of replacedClass from !j9class output.
 	 * 
 	 * Sample output:

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ModuleOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/J9ModuleOutputParser.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+import org.testng.log4testng.Logger;
+
+/**
+ * This class is used to extract info from !j9module <address> DDR extension output.
+ */
+public class J9ModuleOutputParser {
+	private static final Logger log = Logger.getLogger(J9ModuleOutputParser.class);
+
+	/**
+	 * This method extracts the module name from !j9module output.
+	 *
+	 * Sample output:
+	 *   Module name: java.base
+	 *
+	 * @param j9ModuleOutput output of !j9module <address>
+	 * @return module name (e.g. "java.base"), or null if not found
+	 */
+	public static String getModuleName(String j9ModuleOutput)
+	{
+		if (null == j9ModuleOutput) {
+			log.error("!j9module output is null");
+		} else {
+			String[] outputLines = j9ModuleOutput.split(Constants.NL);
+			for (String aLine : outputLines) {
+				int index = aLine.indexOf("Module name:");
+				if (index != -1) {
+					return aLine.substring(index + "Module name:".length()).trim();
+				}
+			}
+		}
+		return null;
+	}
+
+}

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/KeyHashTableClassEntryOutputParser.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/parser/KeyHashTableClassEntryOutputParser.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package j9vm.test.ddrext.util.parser;
+
+import j9vm.test.ddrext.Constants;
+
+/**
+ * This class is used to extract info from !keyhashtableclassentry <address> DDR extension output.
+ */
+public class KeyHashTableClassEntryOutputParser {
+	private static final String FIELDSIGNATURE_RAMCLASS = "* ramClass";
+
+	/**
+	 * This method finds the address of the ramClass field from !keyhashtableclassentry output.
+	 *
+	 * @param keyHashTableClassEntryOutput output of !keyhashtableclassentry <address>
+	 * @return hex address of the J9Class, or null if not found
+	 */
+	public static String getRamClassAddress(String keyHashTableClassEntryOutput)
+	{
+		return ParserUtil.getFieldAddressOrValue(FIELDSIGNATURE_RAMCLASS, Constants.J9CLASS_CMD, keyHashTableClassEntryOutput);
+	}
+
+}


### PR DESCRIPTION
## Add !walkj9hashtable DDR command

Adds a new DDR extension command that walks all entries of a
J9HashTable and prints each entry as a runnable DDR command.

The command accepts a single hex address and an optional type
argument:

` !walkj9hashtable <address> [type]`


Issue: #23452