### PR TITLE
JIT preparations to remove x87 support

### DIFF
--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1031,23 +1031,6 @@ TR::Register *J9::X86::PrivateLinkage::buildDirectDispatch(TR::Node *callNode, b
     //
     stopUsingKilledRegisters(site.getPostConditionsUnderConstruction(), returnRegister);
 
-    if (callNode->getType().isFloatingPoint()) {
-        static char *forceX87LinkageForSSE = feGetEnv("TR_ForceX87LinkageForSSE");
-        if (callNode->getReferenceCount() == 1 && returnRegister->getKind() == TR_X87) {
-            // If the method returns a floating-point value that is not used, insert a
-            // dummy store to eventually pop the value from the floating-point stack.
-            //
-            generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, callNode, returnRegister, returnRegister,
-                cg());
-        } else if (forceX87LinkageForSSE && returnRegister->getKind() == TR_FPR) {
-            // If the caller expects the return value in an XMMR, insert a
-            // transfer from the floating-point stack to the XMMR via memory.
-            //
-            coerceFPReturnValueToXMMR(callNode, site.getPostConditionsUnderConstruction(), site.getMethodSymbol(),
-                returnRegister);
-        }
-    }
-
     if (cg()->enableRegisterAssociations() && !callNode->getSymbol()->castToMethodSymbol()->preservesAllRegisters())
         associatePreservedRegisters(site.getPostConditionsUnderConstruction(), returnRegister);
 
@@ -1696,23 +1679,6 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
     // Stop using the killed registers that are not going to persist
     //
     stopUsingKilledRegisters(site.getPostConditionsUnderConstruction(), returnRegister);
-
-    if (callNode->getType().isFloatingPoint()) {
-        static char *forceX87LinkageForSSE = feGetEnv("TR_ForceX87LinkageForSSE");
-        if (callNode->getReferenceCount() == 1 && returnRegister->getKind() == TR_X87) {
-            // If the method returns a floating-point value that is not used, insert a
-            // dummy store to eventually pop the value from the floating-point stack.
-            //
-            generateFPSTiST0RegRegInstruction(TR::InstOpCode::FSTRegReg, callNode, returnRegister, returnRegister,
-                cg());
-        } else if (forceX87LinkageForSSE && returnRegister->getKind() == TR_FPR) {
-            // If the caller expects the return value in an XMMR, insert a
-            // transfer from the floating-point stack to the XMMR via memory.
-            //
-            coerceFPReturnValueToXMMR(callNode, site.getPostConditionsUnderConstruction(), site.getMethodSymbol(),
-                returnRegister);
-        }
-    }
 
     if (cg()->enableRegisterAssociations())
         associatePreservedRegisters(site.getPostConditionsUnderConstruction(), returnRegister);

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -122,20 +122,10 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
     if (deps)
         stopUsingKilledRegisters(deps, returnReg);
 
-    if (callNode->getOpCode().isFloat()) {
-        TR::MemoryReference *tempMR = machine()->getDummyLocalMR(TR::Float);
-        generateFPMemRegInstruction(TR::InstOpCode::FSTPMemReg, callNode, tempMR, returnReg, cg());
-        cg()->stopUsingRegister(returnReg); // zhxingl: this is added by me
-        returnReg = cg()->allocateSinglePrecisionRegister(TR_FPR);
-        generateRegMemInstruction(TR::InstOpCode::MOVSSRegMem, callNode, returnReg,
-            generateX86MemoryReference(*tempMR, 0, cg()), cg());
-    } else if (callNode->getOpCode().isDouble()) {
-        TR::MemoryReference *tempMR = machine()->getDummyLocalMR(TR::Double);
-        generateFPMemRegInstruction(TR::InstOpCode::DSTPMemReg, callNode, tempMR, returnReg, cg());
-        cg()->stopUsingRegister(returnReg); // zhxingl: this is added by me
-        returnReg = cg()->allocateRegister(TR_FPR);
-        generateRegMemInstruction(cg()->getXMMDoubleLoadOpCode(), callNode, returnReg,
-            generateX86MemoryReference(*tempMR, 0, cg()), cg());
+    if (callNode->getOpCode().isFloat() || callNode->getOpCode().isDouble()) {
+        TR_ASSERT_FATAL(returnReg, "Expecting FPR returnReg to be set by linkage");
+        TR_ASSERT_FATAL((returnReg->getKind() == TR_FPR), "Unexpected returnReg kind: %d", returnReg->getKind());
+        returnReg = TR::TreeEvaluator::coerceST0ToFPR(callNode, callNode->getDataType(), cg(), returnReg);
     }
 
     if (cg()->enableRegisterAssociations())

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -456,18 +456,8 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
      * For floating point return types, transfer (and pop from the x87 stack)
      * the return value from st0 into a newly allocated XMM register.
      */
-    if (callNode->getOpCode().isFloat()) {
-        TR::MemoryReference *tempMR = cg()->machine()->getDummyLocalMR(TR::Float);
-        generateFPMemRegInstruction(TR::InstOpCode::FSTPMemReg, callNode, tempMR, returnRegister, cg());
-        returnRegister = cg()->allocateSinglePrecisionRegister(TR_FPR);
-        generateRegMemInstruction(TR::InstOpCode::MOVSSRegMem, callNode, returnRegister,
-            generateX86MemoryReference(*tempMR, 0, cg()), cg());
-    } else if (callNode->getOpCode().isDouble()) {
-        TR::MemoryReference *tempMR = cg()->machine()->getDummyLocalMR(TR::Double);
-        generateFPMemRegInstruction(TR::InstOpCode::DSTPMemReg, callNode, tempMR, returnRegister, cg());
-        returnRegister = cg()->allocateRegister(TR_FPR);
-        generateRegMemInstruction(cg()->getXMMDoubleLoadOpCode(), callNode, returnRegister,
-            generateX86MemoryReference(*tempMR, 0, cg()), cg());
+    if (callNode->getOpCode().isFloat() || callNode->getOpCode().isDouble()) {
+        returnRegister = TR::TreeEvaluator::coerceST0ToFPR(callNode, callNode->getDataType(), cg());
     }
 
     if (cg()->enableRegisterAssociations())


### PR DESCRIPTION
OpenJ9 JIT changes required to enable further x87 removal work in OMR.

* Remove x87 st0 from JNI linkage register dependencies
* Clean up x87 return value handling