### PR TITLE
JITServer: Prevent empty IP data being interpreted as valid data

### DIFF
--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -2401,9 +2401,9 @@ void TR_IPBCDataEightWords::serialize(uintptr_t methodStartAddress, TR_IPBCDataS
 {
     TR_IPBCDataEightWordsStorage *store = (TR_IPBCDataEightWordsStorage *)storage;
     storage->pc = _pc - methodStartAddress;
-    storage->ID = TR_IPBCD_EIGHT_WORDS;
     storage->left = 0;
     storage->right = 0;
+    storage->ID = TR_IPBCD_EIGHT_WORDS;
     for (int i = 0; i < SWITCH_DATA_COUNT; i++)
         store->data[i] = data[i];
 }
@@ -2658,9 +2658,9 @@ void TR_IPBCDataCallGraph::serialize(uintptr_t methodStartAddress, TR_IPBCDataSt
     TR_ASSERT(_pc >= methodStartAddress, "_pc=%p should be larger than methodStartAddress=%p\n", (void *)_pc,
         (void *)methodStartAddress);
     storage->pc = _pc - methodStartAddress;
-    storage->ID = TR_IPBCD_CALL_GRAPH;
     storage->left = 0;
     storage->right = 0;
+    storage->ID = TR_IPBCD_CALL_GRAPH;
     for (int32_t i = 0; i < NUM_CS_SLOTS; i++) {
         J9Class *clazz = (J9Class *)_csInfo.getClazz(i);
         if (clazz) {

--- a/runtime/compiler/runtime/JITServerIProfiler.cpp
+++ b/runtime/compiler/runtime/JITServerIProfiler.cpp
@@ -211,7 +211,7 @@ TR_IPBytecodeHashTableEntry *JITServerIProfiler::ipBytecodeHashTableEntryFactory
             TR_Memory::IPBCDataEightWords);
         entry = new (entry) TR_IPBCDataEightWords(pc);
     } else {
-        TR_ASSERT(false, "Unknown entry type %u", entryType);
+        TR_ASSERT_FATAL(false, "Unknown entry type %u", entryType);
     }
     return entry;
 }
@@ -288,6 +288,8 @@ bool JITServerIProfiler::cacheProfilingDataForMethod(TR_OpaqueMethodBlock *metho
     bool usePersistentCache, ClientSessionData *clientSessionData, TR::CompilationInfoPerThreadRemote *compInfoPT,
     bool isCompiled, TR::Compilation *comp)
 {
+    if (ipdata.empty())
+        return true;
     // TODO: this should also return the desired entry so that we don't have to search again
     bool cachingFailed = false;
     // Walk the data sent by the client and add new entries to our internal hashtable
@@ -561,6 +563,8 @@ TR_IPBytecodeHashTableEntry *JITServerIProfiler::profilingSample(TR_OpaqueMethod
             entry = compInfoPT->getCachedIProfilerInfo(method, byteCodeIndex, &methodInfoPresent);
     } else // No caching
     {
+        if (ipdata.empty())
+            return NULL;
         // Did the client send an entire method? Such a waste
         // This could happen if, through options, we disable the caching at the server
         uintptr_t methodStart = TR::Compiler->mtd.bytecodeStart(method);


### PR DESCRIPTION
The server may ask for interpreter profiling (IP) data from the client and sometimes the client may send back an empty string (no data).  On some path, the server was blindly interpreting the empty data as valid data leading to intermittent crashes.
See Issue https://github.com/eclipse-openj9/openj9/issues/23057 for more details.

Fixes: #23057
