### PR TITLE
Do not share preview classes

### DIFF
--- a/runtime/bcutil/ROMClassBuilder.cpp
+++ b/runtime/bcutil/ROMClassBuilder.cpp
@@ -52,6 +52,14 @@
 #include "j9protos.h"
 #include "ut_j9bcu.h"
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#define J9ROM_BUILDER_SHARE_PREVIEW_CLASS true
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#define J9ROM_BUILDER_SHARE_PREVIEW_CLASS false
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
+#define J9ROM_BUILDER_SHARE_ENABLED_FOR_CLASS_VERSION(classfile) (J9_IS_CLASSFILE_OR_ROMCLASS_PREVIEW_VERSION(classfile) ? J9ROM_BUILDER_SHARE_PREVIEW_CLASS : true)
+
 static const UDATA INITIAL_CLASS_FILE_BUFFER_SIZE = 4096;
 static const UDATA INITIAL_BUFFER_MANAGER_SIZE = 32768 * 10;
 
@@ -661,7 +669,9 @@ ROMClassBuilder::prepareAndLaydown( BufferManager *bufferManager, ClassFileParse
 			sizeInformation.rawClassDataSize;
 
 #if defined(J9VM_OPT_SHARED_CLASSES)
-	if (context->isROMClassShareable()) {
+	if (context->isROMClassShareable()
+		&& J9ROM_BUILDER_SHARE_ENABLED_FOR_CLASS_VERSION(classFileParser->getParsedClassFile())
+	) {
 		UDATA loadType = J9SHR_LOADTYPE_NORMAL;
 		if (context->isRedefining()) {
 			loadType = J9SHR_LOADTYPE_REDEFINED;

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -992,6 +992,7 @@ extern "C" {
 #define PREVIEW_MINOR_VERSION 65535
 #define J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(classfileOrRomClass) (((classfileOrRomClass)->majorVersion >= VALUE_TYPES_MAJOR_VERSION) && (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion))
 #define J9_CLASSFILE_OR_ROMCLASS_SUPPORTS_STRICT_FIELDS(classfileOrRomClass) (((classfileOrRomClass)->majorVersion >= STRICT_FIELDS_MAJOR_VERSION) && (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion))
+#define J9_IS_CLASSFILE_OR_ROMCLASS_PREVIEW_VERSION(classfileOrRomClass) (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion)
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 /* Constants for java.lang.reflect.Field flags. */

--- a/runtime/shared_common/j9shr.tdf
+++ b/runtime/shared_common/j9shr.tdf
@@ -3008,3 +3008,5 @@ TraceException=Trc_SHR_OSC_Mmap_startup_jitserverlayerbaddelete NoEnv Overhead=1
 TraceEvent=Trc_SHR_CC_OSPAGE_SIZE_MISMATCH_V1 Overhead=1 Level=1 Template="Mismatch in layer %d composite cache osPageSize value. CompositeCache = %p, _theca->osPageSize = %zu, _osPageSize = %zu, _theca->roundedPagesFlag is %u, _readOnlyOSCache is %d"
 TraceEvent=Trc_SHR_CC_setExtraStartupHints_Event Overhead=1 Level=6 Template="CC setExtraStartupHints: set extraStartupHints in the header to %u"
 TraceEvent=Trc_SHR_CM_storeSharedData_NoMoreStartupHintsAllowed Overhead=1 Level=1 Template="CM storeSharedData: No more startup hints are allowed to be stored"
+
+TraceEvent=Trc_SHR_INIT_hookFindSharedClass_previewClassFoundButPreviewTurnedOff Overhead=1 Level=3 Template="INIT hookFindSharedClass: Class (classname=%.*s) is a preview version but current JVM does not enable preview. Returning NULL."

--- a/runtime/shared_common/shrinit.cpp
+++ b/runtime/shared_common/shrinit.cpp
@@ -1634,6 +1634,17 @@ hookFindSharedClass(J9HookInterface** hookInterface, UDATA eventNum, void* voidD
 		}
 	}
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	if ((NULL != eventData->result)
+		&& (J9_IS_CLASSFILE_OR_ROMCLASS_PREVIEW_VERSION(eventData->result))
+		&& J9_ARE_NO_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW)
+	) {
+		Trc_SHR_INIT_hookFindSharedClass_previewClassFoundButPreviewTurnedOff(currentThread, fixedNameSize, fixedName);
+		eventData->result = NULL;
+		goto _donePostFixedClassname;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 	if (eventData->doPreventStore && (NULL == eventData->result)) {
 		omrthread_monitor_enter(classSegmentMutex);
 		registerStoreFilter(vm, classloader, fixedName, strlen(fixedName), &(sharedClassConfig->classnameFilterPool));


### PR DESCRIPTION
Turn off SCC for preview classes in normal builds. 
For testing purposes, turn on SCC for preview classes in Valhalla only.

closes #23504