### PR TITLE
Fold MethodHandleImpl.isCompileConstant

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5731,6 +5731,7 @@ TR_InlinerFailureReason TR_J9InlinerPolicy::checkIfTargetInlineable(TR_CallTarge
         case TR::java_lang_invoke_MethodHandle_asType:
         case TR::java_lang_invoke_Invokers_checkVarHandleGenericType:
         case TR::java_lang_invoke_Invokers_checkGenericType:
+        case TR::java_lang_invoke_MethodHandleImpl_isCompileConstant:
             return DontInline_Callee;
         default:
             break;

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -2234,7 +2234,24 @@ void J9::ValuePropagation::constrainRecognizedMethod(TR::Node *node)
                 }
                 break;
             }
+            case TR::java_lang_invoke_MethodHandleImpl_isCompileConstant: {
+                TR::Node *mhNode = node->getFirstChild();
+                bool isGlobal;
+                logprintf(trace(), log, "Trying to fold MethodHandleImpl.isCompileConstant\n");
+                TR::VPConstraint *mhConstraint = getConstraint(mhNode, isGlobal);
+                if (mhConstraint && mhConstraint->getKnownObject() && mhConstraint->isNonNullObject()) {
+                    transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, 1, isGlobal, true, false);
+                    logprintf(trace(), log, "MethodHandleImpl.isCompileConstant folded to true\n");
+                    return;
+                }
 
+                if (!lastTimeThrough())
+                    return;
+
+                transformCallToIconstInPlaceOrInDelayedTransformations(_curTree, 0, isGlobal, true, false);
+                logprintf(trace(), log, "MethodHandleImpl.isCompileConstant folded to false\n");
+                break;
+            }
             default:
                 break;
         }


### PR DESCRIPTION
When we have the Known Object Info and the MH object is non-null, fold the call to true.
Wait until the last iteration of VP to fold to false.