### PR TITLE
Fix JFR processing of carrier threads

### DIFF
--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -875,7 +875,11 @@ VM_JFRConstantPoolTypes::addThreadEntry(J9VMThread *vmThread)
 	entry->vmThread = vmThread;
 	_buildResult = OK;
 	osThread = vmThread->osThread;
+#if JAVA_SPEC_VERSION >= 19
+	threadObject = vmThread->carrierThreadObject;
+#else /* JAVA_SPEC_VERSION >= 19 */
 	threadObject = vmThread->threadObject;
+#endif /* JAVA_SPEC_VERSION >= 19 */
 
 	if ((NULL == osThread) || (NULL == threadObject)) {
 		/* this can happen if a thread dies during a monitor enter */
@@ -892,7 +896,7 @@ VM_JFRConstantPoolTypes::addThreadEntry(J9VMThread *vmThread)
 	}
 
 	entry->osTID = ((J9AbstractThread*)osThread)->tid;
-	if (NULL != threadObject) {
+	if ((NULL != threadObject) && J9VMJAVALANGTHREAD_STARTED(_currentThread, threadObject)) {
 		entry->javaTID = J9VMJAVALANGTHREAD_TID(_currentThread, threadObject);
 
 		entry->javaThreadName = copyStringToJ9UTF8WithMemAlloc(_currentThread, J9VMJAVALANGTHREAD_NAME(_currentThread, threadObject), J9_STR_NONE, "", 0, NULL, 0);

--- a/test/functional/cmdLineTests/jfr/jfr.xml
+++ b/test/functional/cmdLineTests/jfr/jfr.xml
@@ -27,69 +27,69 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <suite id="JFR Tests" timeout="3000">
 	<envvar name="OPENJ9_METADATA_BLOB_FILE_PATH" value="$METADATA_BLOB_PATH$" />
 	<test id="triggerExecutionSample">
-		<command>$EXE$ -XX:StartFlightRecording --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.TriggerExecutionSample</command>
+		<command>$EXE$ -XX:StartFlightRecording --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.TriggerExecutionSample</command>
 		<return type="success" value="0" />
 	</test>
 	<test id="runWorkload - approx 30seconds">
-		<command>$EXE$ -XX:StartFlightRecording --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
+		<command>$EXE$ -XX:StartFlightRecording --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception</output>
 	</test>
 	<test id="runWorkload 2 - approx 2mins">
-		<command>$EXE$ -XX:StartFlightRecording --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 200 20000 200</command>
+		<command>$EXE$ -XX:StartFlightRecording --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 200 20000 200</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
 		<output type="failure" caseSensitive="yes" regex="no">Exception</output>
 	</test>
 	<test id="VM API Test - approx 2mins">
-		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest</command>
+		<command>$EXE$ --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
 		<output type="failure" caseSensitive="yes" regex="no">Failed</output>
 	</test>
 	<test id="VM API Test aggressive start and stop - approx 2mins">
-		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest 1</command>
+		<command>$EXE$ --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest 1</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
 		<output type="failure" caseSensitive="yes" regex="no">Failed</output>
 	</test>
 	<test id="VM API Test2 - approx 2mins">
-		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest2</command>
+		<command>$EXE$ --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.VMAPITest2</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete.</output>
 		<output type="failure" caseSensitive="yes" regex="no">Failed</output>
 	</test>
 	<test id="Test JFR enablement 1">
-		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
+		<command>$EXE$ --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
 		<output type="required" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="failure" caseSensitive="yes" regex="no">JFR recording has started</output>
 		<output type="success" caseSensitive="yes" regex="no">JFR is enabled</output>
 	</test>
 	<test id="Test JFR enablement 2">
-		<command>$EXE$  -XX:+FlightRecorder --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
+		<command>$EXE$  -XX:+FlightRecorder --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
 		<output type="required" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="failure" caseSensitive="yes" regex="no">JFR recording has started</output>
 		<output type="success" caseSensitive="yes" regex="no">JFR is enabled</output>
 	</test>
 	<test id="Test JFR enablement 3">
-		<command>$EXE$  -XX:-FlightRecorder --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
+		<command>$EXE$  -XX:-FlightRecorder --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
 		<output type="required" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="failure" caseSensitive="yes" regex="no">JFR recording has started</output>
 		<output type="failure" caseSensitive="yes" regex="no">JFR is enabled</output>
 		<output type="success" caseSensitive="yes" regex="no">JFR is not enabled</output>
 	</test>
 	<test id="Test Start flight recording 1">
-		<command>$EXE$  -XX:-FlightRecorder -XX:StartFlightRecording --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
+		<command>$EXE$  -XX:-FlightRecorder -XX:StartFlightRecording --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
 		<output type="required" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="failure" caseSensitive="yes" regex="no">JFR recording has started</output>
 		<output type="failure" caseSensitive="yes" regex="no">JFR is enabled</output>
 		<output type="success" caseSensitive="yes" regex="no">JFR is not enabled</output>
 	</test>
 	<test id="Test Start flight recording 2">
-		<command>$EXE$ -XX:StartFlightRecording --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
+		<command>$EXE$ -XX:StartFlightRecording --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.JFRCMDLineTest</command>
 		<output type="required" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="success" caseSensitive="yes" regex="no">JFR recording has started</output>
 		<output type="success" caseSensitive="yes" regex="no">JFR is enabled</output>
 		<output type="failure" caseSensitive="yes" regex="no">JFR is not enabled</output>
 	</test>
 	<test id="JFR File name test - approx 5mins">
-		<command>$EXE$ --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -Xint -Xgcpolicy:nogc -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -cp $RESJAR$ org.openj9.test.JFRFileNameTest</command>
+		<command>$EXE$ --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -Xint -Xgcpolicy:nogc -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -cp $RESJAR$ org.openj9.test.JFRFileNameTest</command>
 		<output type="success" caseSensitive="yes" regex="no">All allocated blocks were freed</output>
 		<output type="failure" caseSensitive="yes" regex="no">unfreed blocks remaining at shutdown</output>
 	</test>

--- a/test/functional/cmdLineTests/jfr/jfrevents.xml
+++ b/test/functional/cmdLineTests/jfr/jfrevents.xml
@@ -26,7 +26,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 <suite id="JFR Tests" timeout="3000">
 	<test id="runWorkload - approx 300 seconds">
-		<command>$EXE$ -XX:StartFlightRecording -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Xcheck:memory --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 10 100 10</command>
+		<command>$EXE$ -XX:StartFlightRecording -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Xcheck:memory  --add-opens java.base/java.lang=ALL-UNNAMED --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 10 100 10 false</command>
 		<output type="required" caseSensitive="yes" regex="no">All runs complete.</output>
 		<output type="required" caseSensitive="yes" regex="no">Memory checker statistics:</output>
 		<output type="failure" caseSensitive="yes" regex="no">unfreed blocks remaining at shutdown!</output>

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCMDLineTest.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCMDLineTest.java
@@ -27,7 +27,7 @@ public class JFRCMDLineTest {
 
 	public static void main(String[] args) throws Throwable {
 
-		final WorkLoad workLoad = new WorkLoad(200, 20000, 200);
+		final WorkLoad workLoad = new WorkLoad(200, 20000, 200, false);
 
 		if (VM.isJFRRecordingStarted()) {
 			System.out.println("JFR recording has started");

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCmdLinePropertiesTest.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/JFRCmdLinePropertiesTest.java
@@ -38,7 +38,7 @@ public class JFRCmdLinePropertiesTest {
 
 		// Create WorkLoad with parameters tuned for ~2 minute execution
 		// numberOfThreads=10, sizeOfNumberList=5000, repeats=20
-		WorkLoad workload = new WorkLoad(10, 5000, 20);
+		WorkLoad workload = new WorkLoad(10, 5000, 20, false);
 		workload.runWork();
 
 		long totalTime = System.currentTimeMillis() - startTime;

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/VMAPITest.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/VMAPITest.java
@@ -25,7 +25,7 @@ import com.ibm.oti.vm.VM;
 
 public class VMAPITest {
 	public static void main(String[] args) throws Throwable {
-		final WorkLoad workLoad = new WorkLoad(200, 20000, 200);
+		final WorkLoad workLoad = new WorkLoad(200, 20000, 200, false);
 		int sleepDuration = 1000;
 
 		if (args.length > 1) {

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/VMAPITest2.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/VMAPITest2.java
@@ -25,7 +25,7 @@ import com.ibm.oti.vm.VM;
 
 public class VMAPITest2 {
 	public static void main(String[] args) throws Throwable {
-		final WorkLoad workLoad = new WorkLoad(200, 20000, 200);
+		final WorkLoad workLoad = new WorkLoad(200, 20000, 200, false);
 
 		Thread app = new Thread(() -> {
 			workLoad.runWork();

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
@@ -21,6 +21,7 @@
  */
 package org.openj9.test;
 
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Paths;
@@ -34,6 +35,7 @@ public class WorkLoad {
 	private int numberOfThreads;
 	private int sizeOfNumberList;
 	private int repeats;
+	private boolean vthreads;
 
 	public static double average;
 	public static double stdDev;
@@ -44,16 +46,18 @@ public class WorkLoad {
 	static interface GlobalLoack {}
 	private static Object globalLock = new GlobalLoack(){};
 
-	public WorkLoad(int numberOfThreads, int sizeOfNumberList, int repeats) {
+	public WorkLoad(int numberOfThreads, int sizeOfNumberList, int repeats, boolean vthreads) {
 		this.numberOfThreads = numberOfThreads;
 		this.sizeOfNumberList = sizeOfNumberList;
 		this.repeats = repeats;
+		this.vthreads = vthreads;
 	}
 
 	public static void main(String[] args) {
 		int numberOfThreads = 100;
 		int sizeOfNumberList = 10000;
 		int repeats = 50;
+		boolean vthreads = Integer.getInteger("java.vm.specification.version") >= 21;
 
 		if (args.length > 0) {
 			numberOfThreads = Integer.parseInt(args[0]);
@@ -67,7 +71,11 @@ public class WorkLoad {
 			repeats = Integer.parseInt(args[2]);
 		}
 
-		WorkLoad workload = new WorkLoad(numberOfThreads, sizeOfNumberList, repeats);
+		if (args.length > 3) {
+			vthreads = Boolean.parseBoolean(args[3]);
+		}
+
+		WorkLoad workload = new WorkLoad(numberOfThreads, sizeOfNumberList, repeats, vthreads);
 		workload.runWork();
 		System.gc();
 	}
@@ -96,6 +104,40 @@ public class WorkLoad {
 		System.out.println("All runs complete. " + average + " : " + stdDev);
 	}
 
+	public void runWorkWithVirtualThreads(int numVirtualThreads) {
+		try {
+			final AtomicLong completionCount = new AtomicLong(0);
+			Thread[] threads = new Thread[numVirtualThreads];
+
+			Class<?> threadClass = Thread.class;
+			Method ofVirtualMethod = threadClass.getMethod("ofVirtual");
+
+			Object virtualThreadBuilder = ofVirtualMethod.invoke(null);
+
+			Method unstartedMethod = virtualThreadBuilder.getClass()
+				.getMethod("unstarted", Runnable.class);
+
+
+			ofVirtualMethod.setAccessible(true);
+			unstartedMethod.setAccessible(true);
+			for (int i = 0; i < numVirtualThreads; i++) {
+				Runnable task = () -> {
+					burnCPU();
+					generateTimedPark();
+					burnCPU();
+					completionCount.incrementAndGet();
+				};
+
+				Thread vthread = (Thread) unstartedMethod.invoke(virtualThreadBuilder, task);
+				threads[i] = vthread;
+				vthread.start();
+			}
+		} catch (Exception e) {
+			e.printStackTrace();
+		}
+	}
+
+
 	private void workload() {
 		for (int i = 0; i < repeats; i++) {
 			generateAnonClasses();
@@ -106,6 +148,9 @@ public class WorkLoad {
 			contendOnLock();
 			burnCPU();
 			generateClassLoader();
+			if (vthreads) {
+				runWorkWithVirtualThreads(8);
+			}
 		}
 	}
 


### PR DESCRIPTION
Instead of using threadObject which may be a virtual thread in JDK19+
always use the carrier thread object which is guaranteed to be a
platform thread.

Additionaly, add a test to ensure that the carrier thread is always
started so the thread object fields are not NULL.

Fixes https://github.com/eclipse-openj9/openj9/issues/23534