### PR TITLE
Valhalla removes JavaLangAccess.classFileVersion()

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -967,12 +967,12 @@ final class Access implements JavaLangAccess {
 	/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
 	/*[ENDIF] JAVA_SPEC_VERSION >= 9 */
 
-	/*[IF JAVA_SPEC_VERSION >= 25]*/
+	/*[IF (JAVA_SPEC_VERSION >= 25) & !INLINE-TYPES]*/
 	@Override
 	public int classFileVersion(Class<?> clazz) {
 		return clazz.getClassFileVersion();
 	}
-	/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
+	/*[ENDIF] (JAVA_SPEC_VERSION >= 25) & !INLINE-TYPES */
 
 	/*[IF JAVA_SPEC_VERSION >= 26]*/
 	@Override


### PR DESCRIPTION
Valhalla removes `JavaLangAccess.classFileVersion()`

Interdependent on
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/36

Passed [a personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/2628)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>