### PR TITLE
Build OpenSSL from the openssl-3.5 branch

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -138,7 +138,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-branch=openssl-3.5.5'
+  extra_getsource_options: '-openssl-branch=openssl-3.5'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
This includes CVE-2026-2673.

Temporary until 3.5.6 is released.