### PR TITLE
(v0.59) Enable checks on array copies for String.getBytes()

### DIFF
--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -769,8 +769,10 @@ static TR::RecognizedMethod extraCanSkipChecksOnArrayCopies[] =
 
 static TR::RecognizedMethod stringCanSkipChecksOnArrayCopies[] =
    {
+#if JAVA_SPEC_VERSION > 21
    TR::java_lang_String_getBytes,
    TR::java_lang_String_getBytes_subString,
+#endif /* JAVA_SPEC_VERSION > 21 */
    TR::java_lang_StringLatin1_toLowerCase,
    TR::java_lang_StringLatin1_toUpperCase,
    TR::java_lang_StringUTF16_toLowerCase,


### PR DESCRIPTION
Enable JIT checks on arraycopy operations for String.getBytes() in Java 21 and older.

Original PR in master: #23449