### PR TITLE
Fix Windows compilation error conversion from UDATA to jint

### DIFF
--- a/runtime/util/vmargs.c
+++ b/runtime/util/vmargs.c
@@ -1573,7 +1573,7 @@ createJvmInitArgs(
 	result->actualVMArgs = initArgs;
 	result->nOptions = numArgs;
 	result->j9Options = cmdLineOptionCursor;
-	initArgs->nOptions = numArgs;
+	initArgs->nOptions = (jint)numArgs;
 	initArgs->options = javaVMOptionCursor;
 	if (prependFlag) {
 		initArgs->version = currentJ9VMArgs->actualVMArgs->version;


### PR DESCRIPTION
Fix Windows compilation error conversion from `UDATA` to `jint`

```
vmargs.c(1600): error C2220: the following warning is treated as an error
vmargs.c(1600): warning C4244: '=': conversion from 'UDATA' to 'jint', possible loss of data
gmake[3]: *** [vmargs.obj] Error 2
```

Related to
* https://github.com/eclipse-openj9/openj9/pull/23508

Signed-off-by: Jason Feng <fengj@ca.ibm.com>