### PR TITLE
Add ConstRefPrivatization.cpp to UMA makefile

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -176,6 +176,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/CatchBlockRemover.cpp \
     omr/compiler/optimizer/OMRCFGSimplifier.cpp \
     omr/compiler/optimizer/CompactLocals.cpp \
+    omr/compiler/optimizer/ConstRefPrivatization.cpp \
     omr/compiler/optimizer/CopyPropagation.cpp \
     omr/compiler/optimizer/DataFlowAnalysis.cpp \
     omr/compiler/optimizer/DeadStoreElimination.cpp \


### PR DESCRIPTION
Addresses build failures in platforms using UMA makefiles.

@jdmpapin FYI

Issue: https://github.com/eclipse-openj9/openj9/issues/16616