### PR TITLE
Saturate walking iTable list

### DIFF
--- a/runtime/compiler/p/runtime/PicBuilder.spp
+++ b/runtime/compiler/p/runtime/PicBuilder.spp
@@ -2629,6 +2629,7 @@ FUNC_LABEL(_interfaceSlotsUnavailable):
 #else
 _interfaceSlotsUnavailable:
 #endif
+        .align  4
 	startproc._interfaceSlotsUnavailable:
 	mfspr	r11, LR						! Preserve LR content
 	staddr	r10, -8*ALen(J9SP)				! Replaced staddru r10, -8*ALen(J9SP) for P6 perf
@@ -2644,39 +2645,21 @@ _interfaceSlotsUnavailable:
         cmpl    cr0, CmpAddr, r12, r0
 #ifndef NO_ITABLEWALK_CHECK
         beq     .L.hitITable
-        ! Before going to the VM helper do iTable walk N times
-        ! check iTable[0]
+        ! Before going to the VM helper, we will saturate iTable walking here
         laddr   r9, J9TR_J9Class_iTable(r10)                    ! Load the iTable pointer
+        nop                                                     ! Align the loop entry
+.L.iTableLoop:
         cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
         beq     .L.callHelper
         laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
         cmpl    cr0, CmpAddr, r12, r0
         beq     .L.hitITable
-        ! check iTable[1]
         laddr   r9, J9TR_J9ITable_next(r9)                      ! Load the next iTable pointer
-        cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
-        beq     .L.callHelper
-        laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
-        cmpl    cr0, CmpAddr, r12, r0
-        beq     .L.hitITable
-        ! check iTable[2]
-        laddr   r9, J9TR_J9ITable_next(r9)                      ! Load the next iTable pointer
-        cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
-        beq     .L.callHelper
-        laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
-        cmpl    cr0, CmpAddr, r12, r0
-        beq     .L.hitITable
-        ! check iTable[3]
-        laddr   r9, J9TR_J9ITable_next(r9)                      ! Load the next iTable pointer
-        cmpi	cr0, CmpAddr, r9, 0                             ! check iTable != null
-        beq     .L.callHelper
-        laddr	r0, J9TR_J9ITable_interfaceClass(r9)            ! Load iTable class
-        cmpl    cr0, CmpAddr, r12, r0
-        bne     .L.callHelper
+        b       .L.iTableLoop
 #else
         bne     .L.callHelper
 #endif /* ~NO_ITABLEWALK_CHECK */
-        ! lastITable is a match
+        ! ITable entry is a match
 .L.hitITable:
         laddr   r12, 4*ALen(r11)                                ! Load the itable offset from the snippet
         andi.   r0, r12, J9TR_J9_ITABLE_OFFSET_TAG_BITS         ! Call the helper if the itable offset is tagged


### PR DESCRIPTION
Before calling to the VM helper, now we always walk the receiver
class' iTable list completely. In reality, only exception-throwing
situations need to call the VM helper.

Dacapo pmd benchmark was tested for this change. Limiting to walk
up to 4 entries, ~1% runtime was still seen in the VM helper. With
this change, it was not seen anymore.