### PR TITLE
Add ConstRefRematerialization.cpp in UMA Makefile

### DIFF
--- a/runtime/compiler/build/files/common.mk.ftl
+++ b/runtime/compiler/build/files/common.mk.ftl
@@ -177,6 +177,7 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/optimizer/OMRCFGSimplifier.cpp \
     omr/compiler/optimizer/CompactLocals.cpp \
     omr/compiler/optimizer/ConstRefPrivatization.cpp \
+    omr/compiler/optimizer/ConstRefRematerialization.cpp \
     omr/compiler/optimizer/CopyPropagation.cpp \
     omr/compiler/optimizer/DataFlowAnalysis.cpp \
     omr/compiler/optimizer/DeadStoreElimination.cpp \


### PR DESCRIPTION
Depends: https://github.com/eclipse-omr/omr/pull/8175 (requires coordinated merge)

Issue: https://github.com/eclipse-openj9/openj9/issues/16616