### PR TITLE
(0.59) Build p, x, z linux on CentOS/RHEL 7 with gcc14

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -226,10 +226,10 @@ ppc64le_linux:
     11: 'linux-ppc64le-normal-server-release'
   node_labels:
     build: 'ci.role.build && hw.arch.ppc64le && sw.tool.docker'
-    docker_image: 'adoptopenjdk/centos7_build_image:latest'
+    docker_image: 'ghcr.io/adoptium/adoptium_build_image:centos7'
   build_env:
     vars:
-      default: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
+      default: 'CC=/usr/local/gcc14/bin/gcc-14.2 CXX=/usr/local/gcc14/bin/g++-14.2'
 #========================================#
 # Linux PPCLE 64bits /w JITSERVER
 #========================================#
@@ -251,7 +251,7 @@ s390x_linux:
     build: 'ci.role.build && hw.arch.s390x && sw.os.rhel.7'
   build_env:
     cmd:
-      default: 'source /home/jenkins/set_gcc_11.2.0_env'
+      default: 'source /home/jenkins/set_gcc_14.2.0_env'
 #========================================#
 # Linux S390 64bits /w JITSERVER
 #========================================#
@@ -315,20 +315,12 @@ x86-64_linux:
   node_labels:
     build:
       default: 'ci.role.build && hw.arch.x86 && sw.tool.docker'
-    docker_image:
-      8: 'adoptopenjdk/centos6_build_image:latest'
-      11: 'adoptopenjdk/centos6_build_image:latest'
-      default: 'adoptopenjdk/centos7_build_image:latest'
+    docker_image: 'ghcr.io/adoptium/adoptium_build_image:centos7'
   build_env:
     vars:
-      default: 'CC=/usr/local/gcc11/bin/gcc-11.2 CXX=/usr/local/gcc11/bin/g++-11.2'
+      default: 'CC=/usr/local/gcc14/bin/gcc-14.2 CXX=/usr/local/gcc14/bin/g++-14.2'
   extra_test_labels:
-    11: '!sw.os.cent.6'
-    17: '!sw.os.cent.6'
-    21: '!sw.os.cent.6'
-    25: '!sw.os.cent.6'
-    26: '!sw.os.cent.6'
-    next: '!sw.os.cent.6'
+    default: '!sw.os.cent.6'
 #========================================#
 # Linux x86 64bits /w JITSERVER
 #========================================#


### PR DESCRIPTION
For x and p use the adoptium image. For z gcc14 is installed on the build machines.

Cherry pick https://github.com/eclipse-openj9/openj9/pull/23532