### PR TITLE
Add missing null check for module version ver2

### DIFF
--- a/runtime/vm/exceptiondescribe.c
+++ b/runtime/vm/exceptiondescribe.c
@@ -145,7 +145,7 @@ printStackTraceEntry(J9VMThread * vmThread, void * voidUserData, UDATA bytecodeO
 					}
 
 					if (NULL != moduleNameUTF) {
-						if (NULL == module->version) {
+						if (NULL != module->version) {
 							moduleVersionUTF = copyStringToUTF8WithMemAlloc(
 								vmThread, module->version, J9_STR_NULL_TERMINATE_RESULT, "", 0, versionBuf, J9VM_PACKAGE_NAME_BUFFER_LENGTH, NULL);
 						}


### PR DESCRIPTION
When describing exceptions early in the bootstrapping phase, module version object may be null. Add a null check to avoid a crash.

This PR corrects the NULL check from https://github.com/eclipse-openj9/openj9/pull/23572