### PR TITLE
AArch64: Fix multianewarray inlining

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3915,7 +3915,7 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
     if (isOffHeapAllocationEnabled) {
         // the dataAddr field of the 2nd dimension subarray, which is non-zero and hence contiguous,
         // should point to where the first element should start, i.e. over the header
-        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmw, node, firstDimLenReg, temp2Reg,
+        generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addimmx, node, firstDimLenReg, temp2Reg,
             TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
         generateMemSrc1Instruction(cg, storeAddrOp, node,
             TR::MemoryReference::createWithDisplacement(cg, temp2Reg, fej9->getOffsetOfContiguousDataAddrField()),

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -3112,10 +3112,6 @@ TR::TreeTop *TR_J9VMBase::lowerMultiANewArray(TR::Compilation *comp, TR::Node *r
     } else
         TR_ASSERT(false, "Number of dims in multianewarray is not constant");
 
-#if defined(TR_HOST_ARM64)
-    bool secondDimConstNonZero = (root->getChild(2)->getOpCode().isLoadConst() && (root->getChild(2)->getInt() != 0));
-#endif /* defined(TR_HOST_ARM64) */
-
     // Allocate a temp to hold the array of dimensions
     //
     TR::AutomaticSymbol *temp = TR::AutomaticSymbol::create(comp->trHeapMemory(), TR::Int32, sizeof(int32_t) * dims);
@@ -3148,11 +3144,7 @@ TR::TreeTop *TR_J9VMBase::lowerMultiANewArray(TR::Compilation *comp, TR::Node *r
     root->setNumChildren(3);
 
     static bool recreateRoot = feGetEnv("TR_LowerMultiANewArrayRecreateRoot") ? true : false;
-    if (!comp->target().is64Bit() || recreateRoot || dims > 2
-#if defined(TR_HOST_ARM64)
-        || secondDimConstNonZero
-#endif /* defined(TR_HOST_ARM64) */
-    )
+    if (!comp->target().is64Bit() || recreateRoot || dims > 2)
         TR::Node::recreate(root, TR::acall);
 
     return treeTop;


### PR DESCRIPTION
This commit fixes the generated code of inlined 2-dimensional multianewarray with balanced GC for AArch64.
Address calculation of the array bodies of the second dimension arrays must be done in 64-bits in multianewarray with balanced GC.

Fixes: #23482