### PR TITLE
Improve cpu awareness on zos

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -102,6 +102,7 @@
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 #include "runtime/CRRuntime.hpp"
 #endif /* if defined(J9VM_OPT_CRIU_SUPPORT) */
+#include "omrport.h"
 
 extern "C" {
 struct J9JavaVM;
@@ -6278,6 +6279,10 @@ static int32_t J9THREAD_PROC samplerThreadProc(void *entryarg)
     compInfo->setSamplingThreadLifetimeState(TR::CompilationInfo::SAMPLE_THR_ATTACHED);
     j9thread_monitor_notify_all(jitConfig->samplerMonitor);
     j9thread_monitor_exit(jitConfig->samplerMonitor);
+#if defined(J9ZOS390)
+    uint64_t processStartTime = 0;
+    uint64_t lastSecondCPUUsageCheck = 0;
+#endif /* defined(J9ZOS390) */
 
     // Read some stats about SCC. This code could have stayed in aboutToBootstrap,
     // but here we execute it on a separate thread and hide its overhead
@@ -6352,6 +6357,41 @@ static int32_t J9THREAD_PROC samplerThreadProc(void *entryarg)
         } else {
             TR_VerboseLog::writeLine(TR_Vlog_INFO, "CPU entitlement = %3.2f", compInfo->getJvmCpuEntitlement());
         }
+#if defined(J9ZOS390)
+        if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCPUStats)) {
+            OMRPORT_ACCESS_FROM_J9VMTHREAD(vm);
+
+            // Print CPU usage metrics
+            struct CpuUsageStats usageStats = { 0 };
+            int rc = omrsysinfo_get_CPU_usage_stats(&usageStats);
+            if (rc == 0) {
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "zIIP count= %ld", usageStats.onlineZiipCount);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "ziipCapacity= %f", usageStats.ziipCapacity);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "GCP count= %ld", usageStats.onlineGcpCount);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "CPU count= %ld", usageStats.onlineCpuCount);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "CPU capacity= %f", usageStats.cpuCapacity);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "SVT normalization= %f", usageStats.svtNormalizationFactor);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "Threads per zIIP core= %d", usageStats.threadsPerZiipCore);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "Is IIPHonorPriority set= %d", usageStats.isIipHonorPrioritySet);
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "svtIFAFlags= %x", usageStats.svtIFAFlags);
+            } else {
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "call to omrsysinfo_get_CPU_usage_stats FAILED with %d", rc);
+            }
+
+            // Get current process PID
+            uintptr_t pid = omrsysinfo_get_pid();
+            // Get process start time
+            int rc = omrsysinfo_get_process_start_time(pid, &processStartTime);
+            if (rc == 0) {
+                // Convert nanosecond timestamps to milliseconds for easier
+                // readability
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "process start timestamp (ms)= %llu",
+                    processStartTime / 1000000LL);
+            } else {
+                TR_VerboseLog::writeLine(TR_Vlog_INFO, "call to omrsysinfo_get_process_start_time FAILED with %d", rc);
+            }
+        }
+#endif /* defined(J9ZOS390) */
     } // if (TR::Options::isAnyVerboseOptionSet())
 
     if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableScorchingSampleThresholdScalingBasedOnNumProc)) {
@@ -6800,6 +6840,59 @@ static int32_t J9THREAD_PROC samplerThreadProc(void *entryarg)
 
             // Determine the CPU load factor based on number of active threads and CPU utilization of the machine/JVM
             uint32_t cpuLoadFactor = computeCpuLoadFactor(numActiveThreads, compInfo);
+
+#if defined(J9ZOS390)
+            // Print CPU stats every second
+            if (TR::Options::isAnyVerboseOptionSet(TR_VerboseCPUStats)
+                && (crtTime - lastSecondCPUUsageCheck >= TR::Options::_cpuStatsPrintInterval)) {
+                lastSecondCPUUsageCheck = crtTime;
+                OMRPORT_ACCESS_FROM_J9VMTHREAD(vm);
+
+                // Calculate total elapsed time for current process (in nanoseconds)
+                uint64_t currentTimestamp = omrtime_nano_time();
+                uint64_t elapsedTime = currentTimestamp - processStartTime;
+                if (elapsedTime > 0) {
+                    TR_VerboseLog::CriticalSection vlogLock;
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "t (us)= %llu",
+                        elapsedTime / 1000LL); // print elapsed time in micro seconds
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "current timestamp (ms)= %llu",
+                        currentTimestamp / 1000000LL);
+                } else {
+                    TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "Invalid elapsedTime, %llu", elapsedTime);
+                }
+
+                // Print CPU usage metrics
+                struct CpuUsageStats usageStats = { 0 };
+                int rc = omrsysinfo_get_CPU_usage_stats(&usageStats);
+                if (rc == 0) {
+                    TR_VerboseLog::CriticalSection vlogLock;
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "number of active threads= %lu", numActiveThreads);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "gcp-utilization(ccvutilp)= %3.2f%%",
+                        usageStats.gcpLoad * 100);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "ziip-utilization(ccvutils)= %3.2f%%",
+                        usageStats.ziipLoad * 100);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "average-combined-utilization(ccvutila)= %3.2f%%",
+                        usageStats.combinedLoad * 100);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "calculatedCombinedCpuLoad= %3.2f%%",
+                        usageStats.calculatedCombinedCpuLoad * 100);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "process-cpu-utilization= %3.2f%%",
+                        usageStats.perProcessUtilization * 100);
+
+                    // Convert nanosecond timestamps to milliseconds for easier readability
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "oldestCpuTime->timestamp (ms)= %llu",
+                        usageStats.oldestCpuTime.timestamp / 1000000LL);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "oldestCpuTime->cpuTime (ms)= %llu",
+                        usageStats.oldestCpuTime.cpuTime / 1000000LL);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "latestCpuTime->timestamp (ms)= %llu",
+                        usageStats.latestCpuTime.timestamp / 1000000LL);
+                    TR_VerboseLog::writeLine(TR_Vlog_INFO, "latestCpuTime->cpuTime (ms)= %llu",
+                        usageStats.latestCpuTime.cpuTime / 1000000LL);
+                } else {
+                    TR_VerboseLog::writeLineLocked(TR_Vlog_INFO,
+                        "call to omrsysinfo_get_CPU_usage_stats FAILED with %d", rc);
+                }
+            }
+#endif /* defined(J9ZOS390) */
 
             UDATA samplingFreq = jitConfig->samplingFrequency;
             // TODO: Should the sampling frequency types in TR::Options be changed to more closely match the J9JITConfig

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -338,6 +338,7 @@ bool J9::Options::_aggressiveLockReservation = false;
 bool J9::Options::_xrsSync = false;
 
 int32_t J9::Options::_jvmStarvationThreshold = 40; // 40% CPU utilization. Use 10 (or lower) to disable the feature
+int32_t J9::Options::_cpuStatsPrintInterval = 1000; // Write CPU stats to JIT verbose log every second
 
 void J9::Options::findExternalOptions(J9JavaVM *vm, bool consume)
 {
@@ -931,6 +932,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
     { "cpuEntitlementForConservativeScorching=", "M<nnn>\tPercentage. 200 means two full cpus",
      TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_cpuEntitlementForConservativeScorching, 0, "F%d",
      NOT_IN_SUBSET },
+    { "cpuStatsPrintInterval=", "M<nnn>\tInterval in milliseconds at which cpu stats are printed",
+     TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_cpuStatsPrintInterval, 0, "F%d", NOT_IN_SUBSET },
     { "cpuUtilThresholdForStarvation=", "M<nnn>\tThreshold for deciding that a comp thread is not starved",
      TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_cpuUtilThresholdForStarvation, 0, "F%d",
      NOT_IN_SUBSET },
@@ -1368,11 +1371,9 @@ bool J9::Options::showPID()
 {
     static bool showedAlready = false;
 
-    if (!showedAlready) {
-        if (TR::Options::getVerboseOption(TR_VerboseMMap)) {
-            showedAlready = true;
-            return true;
-        }
+    if (!showedAlready && TR::Options::isAnyVerboseOptionSet(TR_VerboseMMap, TR_VerboseCPUStats)) {
+        showedAlready = true;
+        return true;
     }
     return false;
 }

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -541,6 +541,9 @@ public:
 
     static char *_logFileNameSuffix;
 
+    // Frequency (in ms) at which CPU stats are printed when -Xjit:verbose={CPUStats} is specified
+    static int32_t _cpuStatsPrintInterval;
+
     static ExternalOptionsMetadata _externalOptionsMetadata[ExternalOptions::TR_NumExternalOptions];
 
     /**

--- a/runtime/compiler/env/CpuUtilization.cpp
+++ b/runtime/compiler/env/CpuUtilization.cpp
@@ -103,17 +103,38 @@ int32_t CpuUtilization::getCpuUtil(J9JITConfig *jitConfig, J9SysinfoCPUTime *mac
 
     // get access to portlib
     PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+    portLibraryStatusVm = j9thread_get_process_times(vmCpuStats);
+#if defined(J9ZOS390)
+    /* On z/OS, CPU load is retrieved directly from system control structures
+     * (via j9sysinfo_get_CPU_load) rather than calculating it from
+     * user/system/idle times.
+     */
+    double cpuLoad = 0.0;
+    portLibraryStatusSys = j9sysinfo_get_CPU_load(&cpuLoad);
 
+    double cpuCapacity = 0.0;
+    if (0 == portLibraryStatusSys) {
+        portLibraryStatusSys = j9sysinfo_get_CPU_capacity(&cpuCapacity);
+        /* CPU capacity on z/OS is double but J9SysinfoCPUTime expects an integer
+         * CPU count, so we set numberOfCpus to -1 to indicate that it's not applicable.
+         * CPU capacity is queried in updateCpuUtil.
+         */
+        machineCpuStats->numberOfCpus = -1; // not used for z/OS, setting it to -1
+        machineCpuStats->timestamp = j9time_nano_time();
+    }
+#else
     // get CPU stats for the machine
     portLibraryStatusSys = j9sysinfo_get_CPU_utilization(machineCpuStats);
-    portLibraryStatusVm = j9thread_get_process_times(vmCpuStats);
+    if (machineCpuStats->numberOfCpus <= 0) {
+        portLibraryStatusSys = -1;
+    }
+#endif /* defined(J9ZOS390) */
 
     // if either call failed, disable self
-    if (portLibraryStatusSys < 0 || portLibraryStatusVm < 0 || machineCpuStats->numberOfCpus <= 0) {
+    if (portLibraryStatusSys < 0 || portLibraryStatusVm < 0) {
         disable();
         return (-1);
     }
-
     return 0;
 }
 
@@ -148,6 +169,28 @@ int CpuUtilization::updateCpuUtil(J9JITConfig *jitConfig)
     double cpuLoad = 0.0;
     double cpuIdle = 0.0;
 
+#if defined(J9ZOS390)
+    // get access to portlib
+    PORT_ACCESS_FROM_JITCONFIG(jitConfig);
+    /* On z/OS, we can retrieve CPU usage directly from control structures
+     * using j9sysinfo_get_CPU_load, eliminating the need to rely on
+     * user/system/idle time breakdowns.
+     */
+    IDATA portLibraryStatus = j9sysinfo_get_CPU_load(&cpuLoad);
+    if (portLibraryStatus < 0) { // error
+        return (-1);
+    }
+
+    double cpuCapacity = 0.0;
+    portLibraryStatus = j9sysinfo_get_CPU_capacity(&cpuCapacity);
+    if (portLibraryStatus < 0) {
+        return -1;
+    }
+
+    cpuIdle = 1.0 - cpuLoad;
+    _cpuUsage = 100.0 * cpuCapacity * cpuLoad;
+    _cpuIdle = 100.0 * cpuCapacity * cpuIdle;
+#else /* defined(J9ZOS390) */
     if ((-1 != _prevMachineUserTime) && (-1 != _prevMachineSystemTime) && (-1 != _prevMachineIdleTime)
         && (-1 != machineCpuStats.userTime) && (-1 != machineCpuStats.systemTime) && (-1 != machineCpuStats.idleTime)) {
         int64_t userDelta = machineCpuStats.userTime - _prevMachineUserTime;
@@ -162,13 +205,13 @@ int CpuUtilization::updateCpuUtil(J9JITConfig *jitConfig)
     } else {
         int64_t cpuTimeDelta = machineCpuStats.cpuTime - _prevMachineCpuTime;
         cpuLoad = cpuTimeDelta / ((double)machineCpuStats.numberOfCpus * elapsedTime);
-        cpuIdle = 1 - cpuLoad;
+        cpuIdle = 1.0 - cpuLoad;
     }
-
-    _avgCpuUsage = 100.0 * cpuLoad;
-    _avgCpuIdle = 100.0 * cpuIdle;
     _cpuUsage = 100.0 * machineCpuStats.numberOfCpus * cpuLoad;
     _cpuIdle = 100.0 * machineCpuStats.numberOfCpus * cpuIdle;
+#endif /* defined(J9ZOS390) */
+    _avgCpuUsage = 100.0 * cpuLoad;
+    _avgCpuIdle = 100.0 * cpuIdle;
     _vmCpuUsage = (100 * (newTotalTimeUsedByVm - prevTotalTimeUsedByVm)) / elapsedTime;
 
     // If _prevMachineUptime is different than 0 (initial value) it means that we already
@@ -178,10 +221,13 @@ int CpuUtilization::updateCpuUtil(J9JITConfig *jitConfig)
 
     // remember values for next time
     _prevMachineUptime = machineCpuStats.timestamp;
+#if !defined(J9ZOS390)
+    // z/OS doesn't support these fields, because it gets CPU load directly from control structures
     _prevMachineCpuTime = machineCpuStats.cpuTime;
     _prevMachineUserTime = machineCpuStats.userTime;
     _prevMachineSystemTime = machineCpuStats.systemTime;
     _prevMachineIdleTime = machineCpuStats.idleTime;
+#endif /* !defined(J9ZOS390) */
     _prevVmSysTime = vmCpuStats._systemTime;
     _prevVmUserTime = vmCpuStats._userTime;
 
@@ -203,10 +249,13 @@ int32_t CpuUtilization::updateCpuUsageCircularBuffer(J9JITConfig *jitConfig)
         return (-1);
 
     _cpuUsageCircularBuffer[_cpuUsageCircularBufferIndex]._timeStamp = machineCpuStats.timestamp;
+#if !defined(J9ZOS390)
+    // z/OS doesn't support these fields, because it gets CPU load directly from control structures
     _cpuUsageCircularBuffer[_cpuUsageCircularBufferIndex]._sampleSystemCpu = machineCpuStats.cpuTime;
     _cpuUsageCircularBuffer[_cpuUsageCircularBufferIndex]._sampleUserTime = machineCpuStats.userTime;
     _cpuUsageCircularBuffer[_cpuUsageCircularBufferIndex]._sampleSystemTime = machineCpuStats.systemTime;
     _cpuUsageCircularBuffer[_cpuUsageCircularBufferIndex]._sampleIdleTime = machineCpuStats.idleTime;
+#endif /* !defined(J9ZOS390) */
     _cpuUsageCircularBuffer[_cpuUsageCircularBufferIndex]._sampleJvmCpu = vmCpuStats._systemTime + vmCpuStats._userTime;
 
     _cpuUsageCircularBufferIndex = (_cpuUsageCircularBufferIndex + 1) % _cpuUsageCircularBufferSize;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -1463,7 +1463,7 @@ void TR_J9VMBase::printPID()
 
     pascb = ppsa->psaaold; // PSAAOLD -> ASCB
     TR_ASSERT(pascb->eye == 0xc1e2c3c2, "eye catcher not found");
-    TR_VerboseLog::write("ASID=%d, ", (int)pascb->ascbasid);
+    TR_VerboseLog::write("ASID=%x, ", (int)pascb->ascbasid);
 
 #endif /* z/OS specific ASID printing */
 

--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -755,6 +755,10 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sysinfo_get_open_file_count(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_open_file_count(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
 #define j9sysinfo_get_os_description(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_os_description(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
 #define j9sysinfo_os_has_feature(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_os_has_feature(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
+#define j9sysinfo_get_CPU_load(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_CPU_load(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
+#if defined(J9ZOS390)
+#define j9sysinfo_get_CPU_capacity(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_CPU_load(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
+#endif /* defined(J9ZOS390) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 #define j9sysinfo_get_process_start_time(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_process_start_time(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */


### PR DESCRIPTION
Enhance z/OS CPU monitoring by utilizing system control structures to
directly retrieve CPU load metrics. This provides more accurate CPU
utilization data for JIT compilation decisions and verbose logging.

Key changes:
- Add support for j9sysinfo_get_CPU_load() and j9sysinfo_get_CPU_capacity()
  port library APIs on z/OS to retrieve CPU metrics from control structures
- Implement detailed CPU statistics logging via -Xjit:verbose={cpuStats}
  including zIIP count, capacity, GCP count, utilization percentages,
  and process timing information
- Add cpuStatsPrintInterval option to control logging frequency (default: 1000ms)
- Enable isJVMStarved flag support on z/OS using the new CPU load helpers
- Print ASID in hexadecimal format for consistency with z/OS conventions
- Update CpuUtilization to use direct CPU load retrieval on z/OS

This implementation leverages z/OS-specific control structures (CVT, CSD)
to provide accurate CPU metrics that account for zIIP processors, SMT
configurations, and the SVT normalization factor.

Signed-off-by: Shubham Verma <shubhamv.sv@gmail.com>