### PR TITLE
Disallow weak references to value types

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2561,3 +2561,12 @@ J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS.explanation=A call to internal VM f
 J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS.system_action=The JVM will ignore the failure and continue.
 J9NLS_VM_MISSING_DUMP_DLL_CRIU_RELOAD_AGENTS.user_response=Check whether the JVM dump functions have been disabled via the -Xdump:none option.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE=%2$.*1$s is not an identity class. Weak reference can only be created on identity classes.
+# START NON-TRANSLATABLE
+J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.sample_input_1=3
+J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.sample_input_2=Foo
+J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.explanation=JNI NewWeakGlobalRef cannot be called on a value type.
+J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.system_action=The JVM will throw an IdentityException.
+J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.user_response=Do not call NewWeakGlobalRef on value types.
+# END NON-TRANSLATABLE

--- a/runtime/vm/jnicsup.cpp
+++ b/runtime/vm/jnicsup.cpp
@@ -1080,11 +1080,24 @@ allocateGlobalRef(JNIEnv *env, jobject localOrGlobalRef, jboolean isWeak)
 		VM_VMAccess::inlineEnterVMFromJNI(vmThread);
 		obj = *((j9object_t*) localOrGlobalRef);
 		if (obj != NULL) {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			if (isWeak) {
+				J9Class* objClass = J9OBJECT_CLAZZ(vmThread, obj);
+				if (J9_IS_J9CLASS_VALUETYPE(objClass)) {
+					J9UTF8* className = J9ROMCLASS_CLASSNAME(objClass->romClass);
+					setCurrentExceptionNLSWithArgs(vmThread, J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE,
+							J9VMCONSTANTPOOL_JAVALANGIDENTITYEXCEPTION, J9UTF8_LENGTH(className),
+							J9UTF8_DATA(className));
+					VM_VMAccess::inlineExitVMToJNI(vmThread);
+					goto done;
+				}
+			}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			result = j9jni_createGlobalRef(env, obj, isWeak);
 		}
 		VM_VMAccess::inlineExitVMToJNI(vmThread);
 	}
-
+done:
 	return result;
 }
 


### PR DESCRIPTION
Throw Identity Exception on creating weak
references to valuetypes.

With these changes `runtime/valhalla/inlinetypes/TestJNINewWeakGlobalRef.java` passes.