### PR TITLE
Show register number in JIT dumps

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8473,6 +8473,9 @@ TR_MethodMetaData *TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrar
                 options->setOption(TR_TraceAll);
                 options->setOption(TR_EnableParanoidOptCheck);
 
+                // Shows register number instead of register reference in JIT dumps
+                options->setAddressEnumerationOption(TR_EnumerateRegister);
+
                 // Tracing higher optimization level compilations may put us past the allocation limit and result in an
                 // std::bad_alloc exception being thrown. To maximize our chances of getting a trace log we artificially
                 // inflate the scratch space memory for JitDump compilations.


### PR DESCRIPTION
Sets TR_EnumerateRegister in the case of a JIT dump, letting us read register numbers instead of register references.

Issue: https://github.com/eclipse-omr/omr/issues/8163

Requires: https://github.com/eclipse-omr/omr/pull/8194