### PR TITLE
Remove stale comment

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -2422,7 +2422,6 @@ typedef struct J9BCTranslationData {
 #define BCT_Xfuture  0x800
 #define BCT_AlwaysSplitBytecodes 0x1000
 #define BCT_IntermediateDataIsClassfile  0x2000
-/* Bit 0x4000 is free to use. */
 #define BCT_SuperClassOnly 0x4000
 #define BCT_StripDebugLines  0x8000
 #define BCT_StripDebugSource  0x10000


### PR DESCRIPTION
Bit 0x4000 is no longer available; it is used by `BCT_SuperClassOnly`.
See #23535.