### PR TITLE
Fold Invokers.checkVarHandleGenericType using const refs

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -4903,8 +4903,26 @@ TR::KnownObjectTable::Index TR_J9VMBase::getMethodHandleTableEntryIndex(TR::Comp
     uintptr_t methodTypeObj = getReferenceField(methodHandleObj, "type", "Ljava/lang/invoke/MethodType;");
     uintptr_t symbolicMTInvokerObj
         = getReferenceField(accessDescriptorObj, "symbolicMethodTypeInvoker", "Ljava/lang/invoke/MethodType;");
-    if (methodTypeObj != symbolicMTInvokerObj)
+
+    // the cached methodhandle will not be in the table; MethodHandleTransformer's processing of
+    // checkVarHandleGenericType may not work properly if TR_ALLOW_NON_CONST_KNOWN_OBJECTS is defined.
+#ifdef TR_ALLOW_NON_CONST_KNOWN_OBJECTS
+    if (methodTypeObj != symbolicMTInvokerObj) {
         return result;
+    }
+#else // TR_ALLOW_NON_CONST_KNOWN_OBJECTS
+    if (methodTypeObj != symbolicMTInvokerObj) {
+        uintptr_t cachedMT = 0;
+        uintptr_t cachedMH = getReferenceField(methodHandleObj, "asTypeCache", "Ljava/lang/invoke/MethodHandle;");
+        if (cachedMH != 0)
+            cachedMT = getReferenceField(cachedMH, "type", "Ljava/lang/invoke/MethodType;");
+
+        if (cachedMT != 0 && symbolicMTInvokerObj == cachedMT)
+            methodHandleObj = cachedMH;
+        else
+            return result;
+    }
+#endif // TR_ALLOW_NON_CONST_KNOWN_OBJECTS
 
     result = knot->getOrCreateIndex(methodHandleObj);
 

--- a/runtime/compiler/optimizer/MethodHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/MethodHandleTransformer.cpp
@@ -837,11 +837,11 @@ VarHandle$TypesAndInvokers field as the MethodHandle table exists as a field of 
 void TR_MethodHandleTransformer::process_java_lang_invoke_Invokers_checkVarHandleGenericType(TR::TreeTop *tt,
     TR::Node *node)
 {
-#ifdef TR_ALLOW_NON_CONST_KNOWN_OBJECTS
     static const bool disableFoldingVHGenType = feGetEnv("TR_disableFoldingVHGenType") != NULL;
     if (disableFoldingVHGenType) {
         return;
     }
+#ifdef TR_ALLOW_NON_CONST_KNOWN_OBJECTS
 
     auto vhIndex = getObjectInfoOfNode(node->getFirstArgument());
     auto adIndex = getObjectInfoOfNode(node->getLastChild());
@@ -950,6 +950,30 @@ void TR_MethodHandleTransformer::process_java_lang_invoke_Invokers_checkVarHandl
     if (comp()->useCompressedPointers()) {
         tt->insertBefore(TR::TreeTop::create(comp(), TR::Node::createCompressedRefsAnchor(node)));
     }
+#else // TR_ALLOW_NON_CONST_KNOWN_OBJECTS
+    auto vhIndex = getObjectInfoOfNode(node->getFirstArgument());
+    auto adIndex = getObjectInfoOfNode(node->getLastChild());
+    auto knot = comp()->getKnownObjectTable();
+    if (knot == NULL || !isKnownObject(adIndex) || !isKnownObject(vhIndex) || knot->isNull(vhIndex)
+        || knot->isNull(adIndex)) {
+        return;
+    }
+
+    auto mhIndex = comp()->fej9()->getMethodHandleTableEntryIndex(comp(), vhIndex, adIndex);
+    if (TR::KnownObjectTable::UNKNOWN == mhIndex)
+        return;
+
+    if (!performTransformation(comp(), "%sReplacing VarHandle access node n%un [%p] with MethodHandle known obj %d\n",
+            optDetailString(), node->getGlobalIndex(), node, mhIndex))
+        return;
+
+    J9::ConstProvenanceGraph *cpg = comp()->constProvenanceGraph();
+    cpg->addEdge(cpg->knownObject(vhIndex), cpg->knownObject(mhIndex));
+
+    anchorAllChildren(node, tt);
+    node->removeAllChildren();
+    TR::Node::recreateWithSymRef(node, TR::aload, knot->constSymRef(mhIndex));
+    return;
 #endif // TR_ALLOW_NON_CONST_KNOWN_OBJECTS
 }
 


### PR DESCRIPTION
- Modifies getMethodHandleTableEntryIndex to use the asTypeCache when there is no exact MethodType match and the cache is non-null.
- folds the call to a const ref load when the KOI is not UNKNOWN