### PR TITLE
Improve constant handling for Atomic Ops on Power

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -9388,8 +9388,7 @@ static TR::Register *inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8
         if (delta <= UPPER_IMMED && delta >= LOWER_IMMED) {
             // avoid evaluating immediates for add operations
             isArgImmediate = true;
-        } else if (delta & 0xFFFF == 0 && (delta & 0xFFFF0000) >> 16 <= UPPER_IMMED
-            && (delta & 0xFFFF0000) >> 16 >= LOWER_IMMED) {
+        } else if ((delta & 0xFFFF) == 0) {
             // avoid evaluating shifted immediates for add operations
             isArgImmediate = true;
             isArgImmediateShifted = true;
@@ -9577,7 +9576,7 @@ static TR::Register *inlineAtomicOps(TR::Node *node, TR::CodeGenerator *cg, int8
     if (isAddOp) {
         if (isArgImmediateShifted)
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addis, node, deltaReg, resultReg,
-                ((delta & 0xFFFF0000) >> 16));
+                static_cast<int16_t>(delta >> 16));
         else if (isArgImmediate)
             generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::addi, node, deltaReg, resultReg, delta);
         else


### PR DESCRIPTION
Due to a typo, worse code was generated for Atomic operations with a constant int parameter. An optimization checks to see if the lower 16 bits of the constant are 0 to skip filling them in. But, this check previously always returned false. This meant the safer, but less performant, codegen path was taken to generate the constant.

The typo is fixed and also some redundant checks are removed since they are always true.

Furthermore, changes are made to reduce reliance on particular behavior of shifting a negative number right. Prior to C++20 it was implementation defined.