### PR TITLE
(0.59.0) Enable bound checks on String related methods

### DIFF
--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -377,8 +377,10 @@ static TR::RecognizedMethod canSkipBoundChecks[] =
 
 static TR::RecognizedMethod stringCanSkipBoundChecks[] =
    {
+#if JAVA_SPEC_VERSION > 21
    TR::java_lang_AbstractStringBuilder_append_char,
    TR::java_lang_AbstractStringBuilder_appendChars,
+#endif /* JAVA_SPEC_VERSION > 21 */
    TR::java_lang_String_valueOf_C,
    TR::java_lang_StringLatin1_charAt,
    TR::java_lang_StringLatin1_lastIndexOf,
@@ -388,7 +390,9 @@ static TR::RecognizedMethod stringCanSkipBoundChecks[] =
    TR::java_lang_StringLatin1_toLowerCase,
    TR::java_lang_StringLatin1_toUpperCase,
    TR::java_lang_StringLatin1_trim,
+#if JAVA_SPEC_VERSION > 21
    TR::java_lang_StringUTF16_getChars_ByteArray,
+#endif /* JAVA_SPEC_VERSION > 21 */
    TR::java_lang_StringUTF16_replace_CharSequence,
    TR::unknownMethod
    };


### PR DESCRIPTION
For JDK21 and earlier, enables bound checks on array accesses for the following methods:
```
AbstractStringBuilder.append(C)Ljava/lang/AbstractStringBuilder;
AbstractStringBuilder.appendChars([CII)V
StringUTF16.getChars([BII[CI)V
```
Prior to JDK25, it was possible for these methods to attempt out of bounds array accesses.

Backport of https://github.com/eclipse-openj9/openj9/pull/23590
As of writing, the original PR has not yet been merged but is close to doing so. This PR is good to go when it is.