### PR TITLE
Abort inlining of caller class when frame skipping is ambiguous

### DIFF
--- a/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
+++ b/runtime/compiler/codegen/J9AheadOfTimeCompile.cpp
@@ -1870,9 +1870,9 @@ uint8_t *J9::AheadOfTimeCompile::dumpRelocationHeaderData(uint8_t *cursor, bool 
 
             self()->traceRelocationOffsets(startOfOffsets, offsetSize, endOfCurrentRecord, orderedPair);
             logprintf(isVerbose, log,
-                "\n Validate Stack Walker May Skip Frames: methodID=%d, methodClassID=%d, skipFrames=%s ",
+                "\n Validate Stack Walker May Skip Frames: methodID=%d, methodClassID=%d, skipFrames=%d ",
                 (uint32_t)swmsfRecord->methodID(reloTarget), (uint32_t)swmsfRecord->methodClassID(reloTarget),
-                swmsfRecord->skipFrames(reloTarget) ? "true" : "false");
+                swmsfRecord->skipFrames(reloTarget));
         } break;
 
         case TR_ValidateClassInfoIsInitialized: {

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -212,38 +212,51 @@ int32_t TR_J9VMBase::getCompThreadIDForVMThread(void *vmThread)
     return id;
 }
 
-bool TR_J9VM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
+TR_YesNoMaybe TR_J9VM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
 {
     if (!method)
-        return false;
+        return TR_no;
 
     TR::VMAccessCriticalSection stackWalkerMaySkipFrames(this);
 
     // Maybe I should be using isSameMethod ?
     if (vmThread()->javaVM->jlrMethodInvoke == NULL || ((J9Method *)method) == vmThread()->javaVM->jlrMethodInvoke) {
-        return true;
+        return TR_yes;
     }
 
     if (!methodClass) {
-        return false;
+        return TR_no;
     }
 
 #if defined(J9VM_OPT_SIDECAR)
-    if ((vmThread()->javaVM->srMethodAccessor != NULL)
-        && TR_J9VM::isInstanceOf(methodClass,
-            (TR_OpaqueClassBlock *)J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srMethodAccessor), false)) {
-        return true;
+    /*
+     * We assume here that no methods:
+     *  - defined in interfaces (default or static methods)
+     *  - where the interface is not implemented by 'srMethodAccessor'
+     *  - appear as frames in a reflective call path
+     */
+    bool callerTypeIsFixed = isInterfaceClass(methodClass);
+
+    if (vmThread()->javaVM->srMethodAccessor != NULL) {
+        TR_YesNoMaybe isMethodAccessor = TR_J9VM::isInstanceOf(methodClass,
+            (TR_OpaqueClassBlock *)J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srMethodAccessor),
+            callerTypeIsFixed);
+        if (isMethodAccessor != TR_no) {
+            return isMethodAccessor;
+        }
     }
 
-    if ((vmThread()->javaVM->srConstructorAccessor != NULL)
-        && TR_J9VM::isInstanceOf(methodClass,
+    if (vmThread()->javaVM->srConstructorAccessor != NULL) {
+        TR_YesNoMaybe isConstructorAccessor = TR_J9VM::isInstanceOf(methodClass,
             (TR_OpaqueClassBlock *)J9VM_J9CLASS_FROM_JCLASS(vmThread(), vmThread()->javaVM->srConstructorAccessor),
-            false)) {
-        return true;
+            callerTypeIsFixed);
+        if (isConstructorAccessor != TR_no) {
+            return isConstructorAccessor;
+        }
     }
 #endif // J9VM_OPT_SIDECAR
 
-    return false;
+    return TR_no;
 }
 
 bool TR_J9VMBase::isMethodBreakpointed(TR_OpaqueMethodBlock *method)
@@ -7196,10 +7209,13 @@ TR::Node *TR_J9VM::inlineNativeCall(TR::Compilation *comp, TR::TreeTop *callNode
                     if (targetInlineDepth == 0) {
                         // Logic for whether we should skip an inlined frame should match up with what the VM is doing.
                         // See the VM implementation of `getCallerClassIterator` for details.
-                        skipFrameAtDepth0 = transformJlrMethodInvoke(callerMethod, callerClass);
-                        if (skipFrameAtDepth0) {
+                        TR_YesNoMaybe skipFrame = transformJlrMethodInvoke(callerMethod, callerClass);
+                        if (skipFrame == TR_yes) {
+                            skipFrameAtDepth0 = true;
                             callerIndex = comp->getInlinedCallSite(callerIndex)._byteCodeInfo.getCallerIndex();
                             continue;
+                        } else if (skipFrame == TR_maybe) {
+                            return 0;
                         }
 
                         break;
@@ -7754,13 +7770,13 @@ TR::Node *TR_J9VM::inlineNativeCall(TR::Compilation *comp, TR::TreeTop *callNode
     return 0;
 }
 
-bool TR_J9VM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass)
+TR_YesNoMaybe TR_J9VM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass)
 {
     {
         TR::VMAccessCriticalSection jlrMethodInvoke(this);
 
         if (vmThread()->javaVM->jlrMethodInvoke == NULL)
-            return false;
+            return TR_no;
     }
 
     return stackWalkerMaySkipFrames((TR_OpaqueMethodBlock *)callerMethod, (TR_OpaqueClassBlock *)callerClass);
@@ -7982,9 +7998,10 @@ bool TR_J9SharedCacheVM::isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_Opa
     return (validated ? isVisible : false);
 }
 
-bool TR_J9SharedCacheVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
+TR_YesNoMaybe TR_J9SharedCacheVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method,
+    TR_OpaqueClassBlock *methodClass)
 {
-    bool skipFrames = TR_J9VM::stackWalkerMaySkipFrames(method, methodClass);
+    TR_YesNoMaybe skipFrames = TR_J9VM::stackWalkerMaySkipFrames(method, methodClass);
     TR::Compilation *comp = TR::comp();
     if (comp && comp->getOption(TR_UseSymbolValidationManager)) {
         bool recordCreated

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -361,7 +361,7 @@ public:
     // Not implemented
     virtual TR_ResolvedMethod *getObjectNewInstanceImplMethod(TR_Memory *) { return 0; }
 
-    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) = 0;
+    virtual TR_YesNoMaybe stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) = 0;
 
     virtual bool supportsEmbeddedHeapBounds() { return true; }
 
@@ -1748,7 +1748,7 @@ public:
      *         - otherwise, \c callNode is returned.
      */
     virtual TR::Node *inlineNativeCall(TR::Compilation *comp, TR::TreeTop *callNodeTreeTop, TR::Node *callNode);
-    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass);
+    virtual TR_YesNoMaybe transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass);
     virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method);
     virtual int32_t getObjectAlignmentInBytes();
 
@@ -1794,7 +1794,7 @@ public:
     virtual TR_YesNoMaybe isInstanceOf(TR_OpaqueClassBlock *instanceClass, TR_OpaqueClassBlock *castClass,
         bool instanceIsFixed, bool castIsFixed = true, bool optimizeForAOT = false);
 
-    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
+    virtual TR_YesNoMaybe stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
 
     virtual TR_OpaqueClassBlock *getSuperClass(TR_OpaqueClassBlock *classPointer);
     virtual bool isSameOrSuperClass(J9Class *superClass, J9Class *subClass);
@@ -1900,7 +1900,7 @@ public:
 
     virtual bool isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT = false);
 
-    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
+    virtual TR_YesNoMaybe stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass);
 
     virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method);
     virtual bool traceableMethodsCanBeInlined();

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -890,10 +890,10 @@ TR::KnownObjectTable::ObjectInfo TR_J9ServerVM::getObjClassInfoFromKnotIndexNoCa
     return retrievedObjInfo;
 }
 
-bool TR_J9ServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz)
+TR_YesNoMaybe TR_J9ServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz)
 {
     if (!method) {
-        return false;
+        return TR_no;
     }
 
     JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
@@ -909,15 +909,23 @@ bool TR_J9ServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_Op
         vmInfo->_srConstructorAccessorClass = std::get<2>(recv);
         freshInfo = true;
         if (vmInfo->_jlrMethodInvoke == NULL)
-            return true;
+            return TR_yes;
     }
     if (vmInfo->_jlrMethodInvoke == ((J9Method *)method)) {
-        return true;
+        return TR_yes;
     }
     if (!clazz) {
-        return false;
+        return TR_no;
     }
 #if defined(J9VM_OPT_SIDECAR)
+    /*
+     * We assume here that no methods:
+     *  - defined in interfaces (default or static methods)
+     *  - where the interface is not implemented by '_srMethodAccessorClass'
+     *  - appear as frames in a reflective call path
+     */
+    bool callerTypeIsFixed = isInterfaceClass(clazz);
+
     if (vmInfo->_srMethodAccessorClass == NULL && !freshInfo) {
         // Cached information could be outdated. Ask the client again.
         stream->write(JITServer::MessageType::VM_stackWalkerMaySkipFrames, JITServer::Void());
@@ -927,9 +935,12 @@ bool TR_J9ServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_Op
         vmInfo->_srConstructorAccessorClass = std::get<2>(recv);
         freshInfo = true;
     }
-    if (vmInfo->_srMethodAccessorClass != NULL
-        && TR_J9ServerVM::isInstanceOf(clazz, vmInfo->_srMethodAccessorClass, false)) {
-        return true;
+    if (vmInfo->_srMethodAccessorClass != NULL) {
+        TR_YesNoMaybe isMethodAccessor
+            = TR_J9ServerVM::isInstanceOf(clazz, vmInfo->_srMethodAccessorClass, callerTypeIsFixed);
+        if (isMethodAccessor != TR_no) {
+            return isMethodAccessor;
+        }
     }
     if (vmInfo->_srConstructorAccessorClass == NULL && !freshInfo) {
         // Cached information could be outdated. Ask the client again.
@@ -940,13 +951,16 @@ bool TR_J9ServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_Op
         vmInfo->_srConstructorAccessorClass = std::get<2>(recv);
         freshInfo = true;
     }
-    if (vmInfo->_srConstructorAccessorClass != NULL
-        && TR_J9ServerVM::isInstanceOf(clazz, vmInfo->_srConstructorAccessorClass, false)) {
-        return true;
+    if (vmInfo->_srConstructorAccessorClass != NULL) {
+        TR_YesNoMaybe isConstructorAccessor
+            = TR_J9ServerVM::isInstanceOf(clazz, vmInfo->_srConstructorAccessorClass, callerTypeIsFixed);
+        if (isConstructorAccessor != TR_no) {
+            return isConstructorAccessor;
+        }
     }
 #endif // J9VM_OPT_SIDECAR
 
-    return false;
+    return TR_no;
 }
 
 bool TR_J9ServerVM::hasFinalFieldsInClass(TR_OpaqueClassBlock *clazz)
@@ -1917,11 +1931,11 @@ bool TR_J9ServerVM::instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J
     return instanceOfOrCheckCastHelper(instanceClass, castClass, false);
 }
 
-bool TR_J9ServerVM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass)
+TR_YesNoMaybe TR_J9ServerVM::transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass)
 {
     JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
     stream->write(JITServer::MessageType::VM_transformJlrMethodInvoke, callerMethod, callerClass);
-    return std::get<0>(stream->read<bool>());
+    return std::get<0>(stream->read<TR_YesNoMaybe>());
 }
 
 bool TR_J9ServerVM::isAnonymousClass(TR_OpaqueClassBlock *j9clazz)
@@ -2821,9 +2835,10 @@ bool TR_J9SharedCacheServerVM::isPrimitiveClass(TR_OpaqueClassBlock *classPointe
     return validated ? isPrimClass : false;
 }
 
-bool TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass)
+TR_YesNoMaybe TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method,
+    TR_OpaqueClassBlock *methodClass)
 {
-    bool skipFrames = false;
+    TR_YesNoMaybe skipFrames = TR_no;
     TR::Compilation *comp = _compInfoPT->getCompilation();
     // For AOT with SVM do not optimize the messages by calling TR_J9ServerVM::stackWalkerMaySkipFrames
     // because this will call isInstanceOf() and then isSuperClass() which will fail the
@@ -2831,7 +2846,7 @@ bool TR_J9SharedCacheServerVM::stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *me
     if (comp && comp->getOption(TR_UseSymbolValidationManager)) {
         JITServer::ServerStream *stream = _compInfoPT->getMethodBeingCompiled()->_stream;
         stream->write(JITServer::MessageType::VM_stackWalkerMaySkipFramesSVM, method, methodClass);
-        skipFrames = std::get<0>(stream->read<bool>());
+        skipFrames = std::get<0>(stream->read<TR_YesNoMaybe>());
         bool recordCreated
             = comp->getSymbolValidationManager()->addStackWalkerMaySkipFramesRecord(method, methodClass, skipFrames);
         SVM_ASSERT(recordCreated, "Failed to validate addStackWalkerMaySkipFramesRecord");

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -141,7 +141,7 @@ public:
     virtual uintptr_t getStaticReferenceFieldAtAddress(uintptr_t fieldAddress) override;
     virtual TR::KnownObjectTable::ObjectInfo getObjClassInfoFromKnotIndexNoCaching(TR::Compilation *comp,
         TR::KnownObjectTable::Index knotIndex) override;
-    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz) override;
+    virtual TR_YesNoMaybe stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *clazz) override;
     virtual bool hasFinalFieldsInClass(TR_OpaqueClassBlock *clazz) override;
     virtual const char *sampleSignature(TR_OpaqueMethodBlock *aMethod, char *buf, int32_t bufLen,
         TR_Memory *memory) override;
@@ -255,7 +255,7 @@ public:
     //   safe answer, might change in the future
     virtual bool instanceOfOrCheckCast(J9Class *instanceClass, J9Class *castClass) override;
     virtual bool instanceOfOrCheckCastNoCacheUpdate(J9Class *instanceClass, J9Class *castClass) override;
-    virtual bool transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
+    virtual TR_YesNoMaybe transformJlrMethodInvoke(J9Method *callerMethod, J9Class *callerClass) override;
     using TR_J9VM ::isAnonymousClass;
     virtual bool isAnonymousClass(TR_OpaqueClassBlock *j9clazz) override;
     virtual bool isHiddenClass(TR_OpaqueClassBlock *j9clazz) override;
@@ -423,7 +423,8 @@ public:
     virtual bool isStable(J9Class *fieldClass, int32_t cpIndex) override { return false; }
 
     virtual bool isClassVisible(TR_OpaqueClassBlock *sourceClass, TR_OpaqueClassBlock *destClass) override;
-    virtual bool stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass) override;
+    virtual TR_YesNoMaybe stackWalkerMaySkipFrames(TR_OpaqueMethodBlock *method,
+        TR_OpaqueClassBlock *methodClass) override;
     virtual bool isMethodTracingEnabled(TR_OpaqueMethodBlock *method) override;
     virtual bool traceableMethodsCanBeInlined() override;
     virtual bool canMethodEnterEventBeHooked() override;

--- a/runtime/compiler/ilgen/IlGenerator.cpp
+++ b/runtime/compiler/ilgen/IlGenerator.cpp
@@ -329,8 +329,8 @@ bool TR_J9ByteCodeIlGenerator::internalGenIL()
                 TR_OpaqueClassBlock *callerClass = caller ? caller->classOfMethod() : 0;
                 TR_OpaqueClassBlock *callerClass1 = caller1 ? caller1->classOfMethod() : 0;
 
-                bool doIt = !(fej9()->stackWalkerMaySkipFrames(caller->getPersistentIdentifier(), callerClass)
-                    || fej9()->stackWalkerMaySkipFrames(caller1->getPersistentIdentifier(), callerClass1));
+                bool doIt = (fej9()->stackWalkerMaySkipFrames(caller->getPersistentIdentifier(), callerClass) == TR_no)
+                    && (fej9()->stackWalkerMaySkipFrames(caller1->getPersistentIdentifier(), callerClass1) == TR_no);
 
                 if (doIt && !comp()->compileRelocatableCode()) {
                     if (recognizedMethod == TR::java_lang_ClassLoader_callerClassLoader) {

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -128,7 +128,7 @@ protected:
     // likely to lose an increment when merging/rebasing/etc.
     //
     static const uint8_t MAJOR_NUMBER = 1;
-    static const uint16_t MINOR_NUMBER = 102; // ID: pZ74UIsffkVgvUgGWXhc
+    static const uint16_t MINOR_NUMBER = 103; // ID: SH6TaKIfBffpYX8of0Ch
     static const uint8_t PATCH_NUMBER = 0;
     static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/RelocationRecord.cpp
+++ b/runtime/compiler/runtime/RelocationRecord.cpp
@@ -4919,7 +4919,7 @@ TR_RelocationErrorCode TR_RelocationRecordValidateStackWalkerMaySkipFrames::appl
 {
     uint16_t methodID = this->methodID(reloTarget);
     uint16_t methodClassID = this->methodClassID(reloTarget);
-    bool skipFrames = this->skipFrames(reloTarget);
+    TR_YesNoMaybe skipFrames = this->skipFrames(reloTarget);
 
     if (reloRuntime->comp()->getSymbolValidationManager()->validateStackWalkerMaySkipFramesRecord(methodID,
             methodClassID, skipFrames))
@@ -4935,7 +4935,7 @@ void TR_RelocationRecordValidateStackWalkerMaySkipFrames::print(TR_RelocationRun
     TR_RelocationRecord::print(reloRuntime);
     reloLogger->printf("\tmethodID %d\n", methodID(reloTarget));
     reloLogger->printf("\tmethodClassID %d\n", methodClassID(reloTarget));
-    reloLogger->printf("\tskipFrames %s\n", skipFrames(reloTarget) ? "true" : "false");
+    reloLogger->printf("\tskipFrames %d\n", skipFrames(reloTarget));
 }
 
 void TR_RelocationRecordValidateStackWalkerMaySkipFrames::setMethodID(TR_RelocationTarget *reloTarget,
@@ -4965,15 +4965,15 @@ uint16_t TR_RelocationRecordValidateStackWalkerMaySkipFrames::methodClassID(TR_R
 }
 
 void TR_RelocationRecordValidateStackWalkerMaySkipFrames::setSkipFrames(TR_RelocationTarget *reloTarget,
-    bool skipFrames)
+    TR_YesNoMaybe skipFrames)
 {
     reloTarget->storeUnsigned8b((uint8_t)skipFrames,
         (uint8_t *)&((TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *)_record)->_skipFrames);
 }
 
-bool TR_RelocationRecordValidateStackWalkerMaySkipFrames::skipFrames(TR_RelocationTarget *reloTarget)
+TR_YesNoMaybe TR_RelocationRecordValidateStackWalkerMaySkipFrames::skipFrames(TR_RelocationTarget *reloTarget)
 {
-    return (bool)reloTarget->loadUnsigned8b(
+    return (TR_YesNoMaybe)reloTarget->loadUnsigned8b(
         (uint8_t *)&((TR_RelocationRecordValidateStackWalkerMaySkipFramesBinaryTemplate *)_record)->_skipFrames);
 }
 

--- a/runtime/compiler/runtime/RelocationRecord.hpp
+++ b/runtime/compiler/runtime/RelocationRecord.hpp
@@ -2081,8 +2081,8 @@ public:
     void setMethodClassID(TR_RelocationTarget *reloTarget, uint16_t methodClassID);
     uint16_t methodClassID(TR_RelocationTarget *reloTarget);
 
-    void setSkipFrames(TR_RelocationTarget *reloTarget, bool skipFrames);
-    bool skipFrames(TR_RelocationTarget *reloTarget);
+    void setSkipFrames(TR_RelocationTarget *reloTarget, TR_YesNoMaybe skipFrames);
+    TR_YesNoMaybe skipFrames(TR_RelocationTarget *reloTarget);
 };
 
 class TR_RelocationRecordValidateClassInfoIsInitialized : public TR_RelocationRecord {

--- a/runtime/compiler/runtime/SymbolValidationManager.cpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.cpp
@@ -985,7 +985,7 @@ bool TR::SymbolValidationManager::addHandleMethodFromCPIndex(TR_OpaqueMethodBloc
 }
 
 bool TR::SymbolValidationManager::addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method,
-    TR_OpaqueClassBlock *methodClass, bool skipFrames)
+    TR_OpaqueClassBlock *methodClass, TR_YesNoMaybe skipFrames)
 {
     if (!method || !methodClass)
         return false;
@@ -1565,12 +1565,12 @@ bool TR::SymbolValidationManager::validateHandleMethodFromCPIndex(uint16_t metho
 }
 
 bool TR::SymbolValidationManager::validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID,
-    bool couldSkipFrames)
+    TR_YesNoMaybe couldSkipFrames)
 {
     TR_OpaqueMethodBlock *method = getMethodFromID(methodID);
     TR_OpaqueClassBlock *methodClass = getClassFromID(methodClassID);
 
-    bool canSkipFrames = _fej9->stackWalkerMaySkipFrames(method, methodClass);
+    TR_YesNoMaybe canSkipFrames = _fej9->stackWalkerMaySkipFrames(method, methodClass);
 
     return (canSkipFrames == couldSkipFrames);
 }
@@ -2092,7 +2092,7 @@ void TR::StackWalkerMaySkipFramesRecord::printFields()
     log->printf("\t_method=0x%p\n", _method);
     log->printf("\t_methodClass=0x%p\n", _methodClass);
     printClass(_methodClass);
-    log->printf("\t_skipFrames=%sp\n", _skipFrames ? "true" : "false");
+    log->printf("\t_skipFrames=%d\n", _skipFrames);
 }
 
 bool TR::ClassInfoIsInitialized::isLessThanWithinKind(SymbolValidationRecord *other)

--- a/runtime/compiler/runtime/SymbolValidationManager.hpp
+++ b/runtime/compiler/runtime/SymbolValidationManager.hpp
@@ -1130,7 +1130,8 @@ struct StackWalkerMaySkipFramesRecord : public SymbolValidationRecord {
      * @param skipFrames Whether the stack walker may skip frames for this
      *                   method
      */
-    StackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass, bool skipFrames)
+    StackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass,
+        TR_YesNoMaybe skipFrames)
         : SymbolValidationRecord(TR_ValidateStackWalkerMaySkipFramesRecord)
         , _method(method)
         , _methodClass(methodClass)
@@ -1154,7 +1155,7 @@ struct StackWalkerMaySkipFramesRecord : public SymbolValidationRecord {
     /** The class containing the method */
     TR_OpaqueClassBlock *_methodClass;
     /** Whether the stack walker may skip frames for this method */
-    bool _skipFrames;
+    TR_YesNoMaybe _skipFrames;
 };
 
 /**
@@ -1948,7 +1949,7 @@ public:
      * @return true if record was added, false otherwise
      */
     bool addStackWalkerMaySkipFramesRecord(TR_OpaqueMethodBlock *method, TR_OpaqueClassBlock *methodClass,
-        bool skipFrames);
+        TR_YesNoMaybe skipFrames);
 
     /**
      * @brief Add a class-info-is-initialized validation record
@@ -2258,7 +2259,8 @@ public:
      * @param couldSkipFrames Whether the stack walker could skip frames
      * @return true if validation succeeds, false otherwise
      */
-    bool validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID, bool couldSkipFrames);
+    bool validateStackWalkerMaySkipFramesRecord(uint16_t methodID, uint16_t methodClassID,
+        TR_YesNoMaybe couldSkipFrames);
 
     /**
      * @brief Validate a class-info-is-initialized record


### PR DESCRIPTION
Type checks done to detect skippable frames associated with reflective calls are inherently ambiguous (they return TR_YesNoMaybe). This ambiguity needs to propagate through and cause the transformation to abort.

Fixes #23586