### PR TITLE
CRIU improves the error message when enabling JDWP agent post-restore

### DIFF
--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2570,3 +2570,10 @@ J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.explanation=JNI NewWeakGlobalR
 J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.system_action=The JVM will throw an IdentityException.
 J9NLS_VM_JNI_WEAK_GLOBAL_REF_CANNOT_BE_VALUE_TYPE.user_response=Do not call NewWeakGlobalRef on value types.
 # END NON-TRANSLATABLE
+
+J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION=The JVM could not enable %s in the restore option file because -XX:+DebugOnRestore wasn't enabled pre-checkpoint.
+# START NON-TRANSLATABLE
+J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION.explanation=The JDWP option can't be enabled post-restore because -XX:+DebugOnRestore wasn't enabled pre-checkpoint.
+J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION.system_action=The JVM will throw a JVMRestoreException.
+J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION.user_response=Enable -XX:+DebugOnRestore pre-checkpoint.
+# END NON-TRANSLATABLE

--- a/runtime/vm/CRIUHelpers.cpp
+++ b/runtime/vm/CRIUHelpers.cpp
@@ -2141,8 +2141,31 @@ criuCheckpointJVMImpl(JNIEnv *env,
 			IDATA ignoreDisabled = FIND_AND_CONSUME_ARG(restoreArgsList, EXACT_MATCH, VMOPT_XXIGNOREUNRECOGNIZEDRESTOREOPTIONSDISABLE, NULL);
 
 			bool dontIgnoreUnsupportedRestoreOptions = (ignoreEnabled < 0) || (ignoreEnabled < ignoreDisabled);
+			bool jdwpFoundButIgnored = false;
 
-			if ((FALSE == checkArgsConsumed(vm, vm->portLibrary, restoreArgsList)) && dontIgnoreUnsupportedRestoreOptions) {
+			if (!isDebugOnRestoreEnabled(vm)) {
+				/* -XX:+DebugOnRestore wasn't enabled pre-checkpoint,
+				 * check if there is a JDWP option in the restore option file.
+				 * If so, print a message and consume it to avoid errors such as:
+				 * JVMJ9VM007E Command-line option unrecognised: -agentlib:jdwp=transport=dt_socket,server=y,suspend=n
+				 */
+				IDATA agentIndex = 0;
+				agentIndex = FIND_AND_CONSUME_ARG_FORWARD(restoreArgsList, STARTSWITH_MATCH, MAPOPT_XRUNJDWP, NULL);
+				if (agentIndex < 0) {
+					agentIndex = FIND_AND_CONSUME_ARG_FORWARD(restoreArgsList, STARTSWITH_MATCH, VMOPT_AGENTLIB_COLON, NULL);
+					if (agentIndex < 0) {
+						agentIndex = FIND_AND_CONSUME_ARG_FORWARD(restoreArgsList, STARTSWITH_MATCH, VMOPT_AGENTPATH_COLON, NULL);
+					}
+				}
+				if (agentIndex >= 0) {
+					JavaVMOption *options = restoreArgsList->actualVMArgs->options;
+					j9nls_printf(PORTLIB, J9NLS_ERROR, J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION, options[agentIndex].optionString);
+					jdwpFoundButIgnored = true;
+				}
+			}
+			if (jdwpFoundButIgnored
+					|| ((FALSE == checkArgsConsumed(vm, vm->portLibrary, restoreArgsList)) && dontIgnoreUnsupportedRestoreOptions)
+			) {
 				currentExceptionClass = vm->checkpointState.criuJVMRestoreExceptionClass;
 				systemReturnCode = 0;
 				nlsMsgFormat = j9nls_lookup_message(J9NLS_DO_NOT_PRINT_MESSAGE_TAG | J9NLS_DO_NOT_APPEND_NEWLINE,

--- a/test/functional/cmdLineTests/criu/criu_nonPortable.xml
+++ b/test/functional/cmdLineTests/criu/criu_nonPortable.xml
@@ -1321,6 +1321,44 @@
     <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
     <output type="failure" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore</output>
   </test>
+  <test id="Test errorMsgNoDebugOnRestoreAgenlibJDWP">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:-DebugOnRestore" $MAINCLASS_OPTIONSFILE_TEST$ errorMsgNoDebugOnRestoreAgenlibJDWP 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="required" caseSensitive="yes" regex="no">The JVM could not enable -agentlib:jdwp=transport=dt_socket,server=y,suspend=y in the restore option file because -XX:+DebugOnRestore wasn't enabled pre-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">java.lang.NullPointerException</output>
+    <output type="success" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+    <output type="failure" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore</output>
+  </test>
+  <test id="Test errorMsgNoDebugOnRestoreXrunjdwp">
+    <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ -XX:-DebugOnRestore" $MAINCLASS_OPTIONSFILE_TEST$ errorMsgNoDebugOnRestoreXrunjdwp 1 false false</command>
+    <output type="success" caseSensitive="no" regex="no">Killed</output>
+    <output type="failure" caseSensitive="yes" regex="no">failed properties test</output>
+    <output type="required" caseSensitive="yes" regex="no">Pre-checkpoint</output>
+    <output type="required" caseSensitive="yes" regex="no">The JVM could not enable -Xrunjdwp:transport=dt_socket,server=y,suspend=y in the restore option file because -XX:+DebugOnRestore wasn't enabled pre-checkpoint</output>
+    <output type="failure" caseSensitive="yes" regex="no">java.lang.NullPointerException</output>
+    <output type="success" caseSensitive="yes" regex="no">org.eclipse.openj9.criu.JVMRestoreException</output>
+    <output type="failure" caseSensitive="yes" regex="no">CRIU is not enabled</output>
+    <output type="failure" caseSensitive="yes" regex="no">Operation not permitted</output>
+    <!-- If CRIU can't acquire the original thread IDs, this test will fail. Nothing can be done about this failure. -->
+    <output type="success" caseSensitive="yes" regex="no">Thread pid mismatch</output>
+    <output type="success" caseSensitive="yes" regex="no">do not match expected</output>
+    <output type="success" caseSensitive="yes" regex="no">Unable to create a thread:</output>
+    <!-- In the past, the failure below was caused by an issue where CRIU can't be found on the PATH. -->
+    <output type="failure" caseSensitive="yes" regex="no">Could not dump the JVM processes, err=-70</output>
+    <output type="failure" caseSensitive="yes" regex="no">User requested Java dump using</output>
+    <output type="failure" caseSensitive="yes" regex="no">AOT load and compilation disabled post restore</output>
+  </test>
   <!--
   <test id="Test CRIU failure paths - - bad dir">
     <command>bash $SCRIPPATH$ $TEST_RESROOT$ $JAVA_COMMAND$ "$JVM_OPTIONS$ $STD_CMD_OPTS$" $MAINCLASS_FAILUREPATH_TEST$ badDir 1 false false</command>

--- a/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
+++ b/test/functional/cmdLineTests/criu/src/org/openj9/criu/OptionsFileTest.java
@@ -77,6 +77,12 @@ public class OptionsFileTest {
 		case "notExistOptionsFile":
 			notExistOptionsFile();
 			break;
+		case "errorMsgNoDebugOnRestoreAgenlibJDWP":
+			errorMsgNoDebugOnRestoreAgenlibJDWP();
+			break;
+		case "errorMsgNoDebugOnRestoreXrunjdwp":
+			errorMsgNoDebugOnRestoreXrunjdwp();
+			break;
 		default:
 			throw new RuntimeException("incorrect parameters");
 		}
@@ -361,6 +367,34 @@ public class OptionsFileTest {
 		System.out.println("Pre-checkpoint");
 		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
 		// Restore continues if the post-restore option file doesn't exist.
+		System.out.println("Post-checkpoint");
+	}
+
+	static void errorMsgNoDebugOnRestoreAgenlibJDWP() {
+		String optionsContents = "-agentlib:jdwp=transport=dt_socket,server=y,suspend=y";
+		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
+		System.out.println("Post-checkpoint");
+	}
+
+	static void errorMsgNoDebugOnRestoreXrunjdwp() {
+		String optionsContents = "-Xrunjdwp:transport=dt_socket,server=y,suspend=y";
+		Path optionsFilePath = CRIUTestUtils.createOptionsFile("options", optionsContents);
+
+		Path imagePath = Paths.get("cpData");
+		CRIUTestUtils.createCheckpointDirectory(imagePath);
+		CRIUSupport criuSupport = CRIUSupport.getCRIUSupport().setImageDir(imagePath)
+				.registerRestoreOptionsFile(optionsFilePath);
+
+		System.out.println("Pre-checkpoint");
+		CRIUTestUtils.checkPointJVM(criuSupport, imagePath, true);
 		System.out.println("Post-checkpoint");
 	}
 }


### PR DESCRIPTION
CRIU improves the error message when enabling JDWP agent post-restore

Provide the instruction that `-XX:+DebugOnRestore` is required pre-checkpoint to enable JDWP agent post-restore via the restore option file instead showing an error message "JVMJ9VM007E Command-line option unrecognised".


Signed-off-by: Jason Feng <fengj@ca.ibm.com>