### PR TITLE
Fix assertion failure due to sparse heap address overflow

### DIFF
--- a/runtime/gc_base/IndexableObjectAllocationModel.cpp
+++ b/runtime/gc_base/IndexableObjectAllocationModel.cpp
@@ -403,11 +403,11 @@ MM_IndexableObjectAllocationModel::getSparseAddressAndDecommitLeaves(MM_Environm
 		byteAmount = _dataSize;
 		void *virtualLargeObjectHeapAddress = extensions->largeObjectVirtualMemory->allocateSparseFreeEntryAndMapToHeapObject(spine, byteAmount);
 
-		for (uintptr_t idx = 0; idx < arrayReservedRegionCount; idx++) {
-			extensions->largeObjectVirtualMemory->setAllocationContextForAddress(virtualLargeObjectHeapAddress, reservedRegionAllocationContexts[idx], idx);
-		}
-
 		if (NULL != virtualLargeObjectHeapAddress) {
+			for (uintptr_t idx = 0; idx < arrayReservedRegionCount; idx++) {
+				extensions->largeObjectVirtualMemory->setAllocationContextForAddress(virtualLargeObjectHeapAddress, reservedRegionAllocationContexts[idx], idx);
+			}
+
 			indexableObjectModel->setDataAddrForContiguous((J9IndexableObject *)spine, virtualLargeObjectHeapAddress);
 		} else {
 			Trc_MM_getSparseAddressAndDecommitLeaves_allocFailed(env->getLanguageVMThread(), byteAmount);


### PR DESCRIPTION
The assertion failure occurs when virtualLargeObjectHeapAddress overflows during sparse heap allocation. This fix adds a NULL check after allocateSparseFreeEntryAndMapToHeapObject() returns and before setAllocationContextForAddress() is called, preventing the assertion from triggering on overflow conditions.