### PR TITLE
Remove allocation-based aging system from VLHGC

### DIFF
--- a/runtime/gc_modron_startup/mmparseXXgc.cpp
+++ b/runtime/gc_modron_startup/mmparseXXgc.cpp
@@ -559,44 +559,6 @@ gcParseXXgcArguments(J9JavaVM *vm, char *optArg)
 			extensions->tarokEnableStableRegionDetection = false;
 			continue;
 		}
-		if (try_scan(&scan_start, "tarokAllocationAgeEnabled")) {
-			extensions->tarokAllocationAgeEnabled = true;
-			continue;
-		}
-		if (try_scan(&scan_start, "tarokAllocationAgeDisabled")) {
-			extensions->tarokAllocationAgeEnabled = false;
-			continue;
-		}
-		if (try_scan(&scan_start, "tarokAllocationAgeExponentBase=")) {
-			UDATA exponentBase = 0;
-			if(!scan_udata_helper(vm, &scan_start, &exponentBase, "tarokAllocationAgeExponentBase=")) {
-				returnValue = JNI_EINVAL;
-				break;
-			}
-			extensions->tarokAllocationAgeExponentBase = ((double)exponentBase) / 100.0;
-			continue ;
-		}
-		if (try_scan(&scan_start, "tarokAllocationAgeUnit=")) {
-			if(!scan_udata_memory_size_helper(vm, &scan_start, &(extensions->tarokAllocationAgeUnit), "tarokAllocationAgeUnit=")) {
-				returnValue = JNI_EINVAL;
-				break;
-			}
-			continue;
-		}
-		if (try_scan(&scan_start, "tarokMaximumAgeInBytes=")) {
-			if(!scan_u64_memory_size_helper(vm, &scan_start, &(extensions->tarokMaximumAgeInBytes), "tarokMaximumAgeInBytes=")) {
-				returnValue = JNI_EINVAL;
-				break;
-			}
-			continue;
-		}
-		if (try_scan(&scan_start, "tarokMaximumNurseryAgeInBytes=")) {
-			if(!scan_u64_memory_size_helper(vm, &scan_start, &(extensions->tarokMaximumNurseryAgeInBytes), "tarokMaximumNurseryAgeInBytes=")) {
-				returnValue = JNI_EINVAL;
-				break;
-			}
-			continue;
-		}
 		if (try_scan(&scan_start, "tarokEnableProjectedSurvivalCollectionSet")) {
 			extensions->tarokUseProjectedSurvivalCollectionSet = true;
 			continue;

--- a/runtime/gc_trace_vlhgc/TgcDynamicCollectionSet.cpp
+++ b/runtime/gc_trace_vlhgc/TgcDynamicCollectionSet.cpp
@@ -216,9 +216,9 @@ MM_TgcDynamicCollectionSetData::dumpDynamicCollectionSetStatistics(MM_Environmen
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	while (NULL != (region = regionIterator.nextRegion())) {
 		if (region->containsObjects()) {
-			UDATA ageIndex = region->getLogicalAge();
+			uintptr_t ageIndex = region->getAge();
 
-			Assert_MM_true(region->getLogicalAge() <= extensions->tarokRegionMaxAge);
+			Assert_MM_true(region->getAge() <= extensions->tarokRegionMaxAge);
 			currentHistoryTable[ageIndex].regionCount += 1;
 		}
 	}

--- a/runtime/gc_trace_vlhgc/TgcInterRegionRememberedSet.cpp
+++ b/runtime/gc_trace_vlhgc/TgcInterRegionRememberedSet.cpp
@@ -146,10 +146,10 @@ calculateAndPrintHistogram(J9VMThread *vmThread, MM_HeapRegionManager *regionMan
 		}
 		tgcExtensions->printf("      OF");
 
-		for (UDATA age = 0; age <= extensions->tarokRegionMaxAge; age++) {
+		for (uintptr_t age = 0; age <= extensions->tarokRegionMaxAge; age++) {
 			for (i = 0; i < regionCount; i++) {
 				MM_HeapRegionDescriptorVLHGC *region = (MM_HeapRegionDescriptorVLHGC *)regionManager->physicalTableDescriptorForIndex(i);
-				if (age == region->getLogicalAge()) {
+				if (age == region->getAge()) {
 					UDATA cardCount = region->getRememberedSetCardList()->getSize(env);
 					UDATA duplicates = getUpperBoundDuplicatesCount(env, region->getRememberedSetCardList());
 					UDATA bucketIndex;

--- a/runtime/gc_vlhgc/AllocationContextBalanced.cpp
+++ b/runtime/gc_vlhgc/AllocationContextBalanced.cpp
@@ -410,7 +410,7 @@ MM_AllocationContextBalanced::lockedAllocateArrayletLeaf(MM_EnvironmentBase *env
 	}
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
-	freeRegionForArrayletLeaf->resetAge(env, (U_64)_subspace->getBytesRemainingBeforeTaxation());
+	freeRegionForArrayletLeaf->setAge(0);
 	/* store the base address of the leaf for the memset and the return */
 	return freeRegionForArrayletLeaf->getLowAddress();
 }
@@ -780,7 +780,7 @@ MM_AllocationContextBalanced::acquireMPRegionFromContext(MM_EnvironmentBase *env
 		if (MM_HeapRegionDescriptor::FREE == region->getRegionType()) {
 			if (region->_allocateData.taskAsMemoryPool(env, requestingContext)) {
 				/* this is a new region. Initialize it for the given pool */
-				region->resetAge(env, (U_64)_subspace->getBytesRemainingBeforeTaxation());
+				region->setAge(0);
 				MM_MemoryPool *mpaol = region->getMemoryPool();
 				mpaol->setSubSpace(subSpace);
 				mpaol->expandWithRange(env, region->getSize(), region->getLowAddress(), region->getHighAddress(), false);
@@ -795,7 +795,7 @@ MM_AllocationContextBalanced::acquireMPRegionFromContext(MM_EnvironmentBase *env
 			/* we can't fail to convert an IDLE region to an active one */
 			Assert_MM_true(success);
 			/* also add this region into our owned region list */
-			region->resetAge(env, (U_64)_subspace->getBytesRemainingBeforeTaxation());
+			region->setAge(0);
 			region->_allocateData._owningContext = requestingContext;
 			MM_MemoryPool *pool = region->getMemoryPool();
 			Assert_MM_true(subSpace == pool->getSubSpace());

--- a/runtime/gc_vlhgc/AllocationContextTarok.cpp
+++ b/runtime/gc_vlhgc/AllocationContextTarok.cpp
@@ -35,5 +35,5 @@ bool
 MM_AllocationContextTarok::shouldMigrateRegionToCommonContext(MM_EnvironmentBase *env, MM_HeapRegionDescriptorVLHGC *region)
 {
 	Assert_MM_true(this == region->_allocateData._owningContext);
-	return region->getLogicalAge() == MM_GCExtensions::getExtensions(env)->tarokRegionMaxAge;
+	return region->getAge() == MM_GCExtensions::getExtensions(env)->tarokRegionMaxAge;
 }

--- a/runtime/gc_vlhgc/CompactGroupManager.hpp
+++ b/runtime/gc_vlhgc/CompactGroupManager.hpp
@@ -72,7 +72,7 @@ public:
 	 */
 	MMINLINE static UDATA getCompactGroupNumberInContext(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, MM_AllocationContextTarok *migrationDestination)
 	{
-		return getCompactGroupNumberForAge(env, region->getLogicalAge(), migrationDestination);
+		return getCompactGroupNumberForAge(env, region->getAge(), migrationDestination);
 	}
 
 	/**
@@ -124,87 +124,6 @@ public:
 	}
 
 	/**
-	 * Calculate Logical age for region based on Allocation age
-	 *
-	 * Each next ages interval growth exponentially (specified-based)
-	 * To avoid exponent/logarithm operations and as far as maximum logical age is a small constant (order of tens)
-	 * it is safe to do calculation incrementally.
-	 * Also it is easy to control possible overflow at each step of calculation and explicitly limit amount of work
-	 *
-	 * 	AgesIntervalSize(n+1) = AgesIntervalSize(n) * exponentBase;
-	 * 	ThresholdForAge(n+1) = ThresholdForAge(n) + AgesIntervalSize(n+1);
-	 *
-	 * @param env current thread environment
-	 * @param allocationAge for region
-	 * @return calculated logical region age
-	 */
-	MMINLINE static UDATA calculateLogicalAgeForRegion(MM_EnvironmentVLHGC *env, U_64 allocationAge)
-	{
-		MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-
-		U_64 unit = (U_64)extensions->tarokAllocationAgeUnit;
-		double exponentBase = extensions->tarokAllocationAgeExponentBase;
-
-		Assert_MM_true(unit > 0);
-		Assert_MM_true(allocationAge <= extensions->tarokMaximumAgeInBytes);
-
-		UDATA logicalAge = 0;
-		bool tooLarge = false;
-
-		U_64 threshold = unit;
-
-		while (!tooLarge && (threshold <= allocationAge)) {
-			unit = (U_64)(unit * exponentBase);
-			U_64 nextThreshold = threshold + unit;
-
-			tooLarge = (nextThreshold < threshold)									/* overflow */
-					|| (logicalAge >= extensions->tarokRegionMaxAge);				/* maximum logical age reached */
-
-			if (tooLarge) {
-				logicalAge = extensions->tarokRegionMaxAge;
-			} else {
-				threshold = nextThreshold;
-				logicalAge += 1;
-			}
-		}
-
-		return logicalAge;
-	}
-
-	/**
-	 * Calculate initial value for maximum allocation age in bytes based on maximumLogicalAge
-	 * @param env current thread environment
-	 * @param maximumLogicalAge maximum logical age allocation age calculated for
-	 */
-	MMINLINE static U_64 calculateMaximumAllocationAge(MM_EnvironmentVLHGC *env, UDATA maximumLogicalAge)
-	{
-		MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-		U_64 unit = (U_64)extensions->tarokAllocationAgeUnit;
-		double exponentBase = extensions->tarokAllocationAgeExponentBase;
-		Assert_MM_true(unit > 0);
-		Assert_MM_true(maximumLogicalAge > 0);
-		UDATA logicalAge = 1;
-		bool tooLarge = false;
-		U_64 allocationAge = unit;
-
-		while (!tooLarge && (logicalAge < maximumLogicalAge)) {
-			unit = (U_64)(unit * exponentBase);
-			U_64 nextThreshold = allocationAge + unit;
-
-			tooLarge = (nextThreshold < allocationAge);	/* overflow */
-
-			if (tooLarge) {
-				allocationAge = U_64_MAX;
-			} else {
-				allocationAge = nextThreshold;
-				logicalAge += 1;
-			}
-		}
-
-		return allocationAge;
-	}
-
-	/**
 	 * Check is given region is a member of Nursery Collection Set
 	 * Eden region is mandatory part of Nursery Collection Set regardless it's age
 	 * non-Eden region is part of Nursery Collection Set if it's age is lower or equal of nursery threshold
@@ -215,15 +134,7 @@ public:
 	MMINLINE static bool isRegionInNursery(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region)
 	{
 		MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-		bool result = false;
-
-		if (extensions->tarokAllocationAgeEnabled) {
-			result = region->isEden() || (region->getAllocationAge() <= extensions->tarokMaximumNurseryAgeInBytes);
-		} else {
-			result = region->isEden() || (region->getLogicalAge() <= extensions->tarokNurseryMaxAge._valueSpecified);
-		}
-
-		return result;
+		return region->isEden() || (region->getAge() <= extensions->tarokNurseryMaxAge._valueSpecified);
 	}
 
 	/**
@@ -235,16 +146,7 @@ public:
 	 */
 	MMINLINE static bool isRegionDCSSCandidate(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region)
 	{
-		MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-		bool result = false;
-
-		if (extensions->tarokAllocationAgeEnabled) {
-			result = !isRegionInNursery(env, region) && (region->getAllocationAge() < extensions->tarokMaximumAgeInBytes);
-		} else {
-			result = !isRegionInNursery(env, region) && (region->getLogicalAge() < extensions->tarokRegionMaxAge);
-		}
-
-		return result;
+		return !isRegionInNursery(env, region) && (region->getAge() < MM_GCExtensions::getExtensions(env)->tarokRegionMaxAge);
 	}
 
 	/**

--- a/runtime/gc_vlhgc/CompactGroupPersistentStats.cpp
+++ b/runtime/gc_vlhgc/CompactGroupPersistentStats.cpp
@@ -55,15 +55,6 @@ MM_CompactGroupPersistentStats::allocateCompactGroupPersistentStats(MM_Environme
 			result[i]._liveBytesAbsoluteDeviation = 0;
 			result[i]._regionCount = 0;
 			result[i]._statsHaveBeenUpdatedThisCycle = false;
-			/* this is not really stats, but a constant; calculate only if unit is set */
-			if (0 != extensions->tarokAllocationAgeUnit) {
-				UDATA ageGroup = MM_CompactGroupManager::getRegionAgeFromGroup(env, i);
-				if (ageGroup != extensions->tarokRegionMaxAge) {
-					result[i]._maxAllocationAge = MM_CompactGroupManager::calculateMaximumAllocationAge(env, ageGroup + 1);
-				} else {
-					result[i]._maxAllocationAge = UDATA_MAX;
-				}
-			}
 		}
 	}
 	return result;
@@ -224,7 +215,7 @@ MM_CompactGroupPersistentStats::updateProjectedSurvivalRate(MM_EnvironmentVLHGC 
 			thisSurvivalRate,
 			thisSurvivalRate,
 			thisSurvivalRate,
-			1.0, /* ageUnitsInThisAgeGroup - always 1 logical age unit */
+			1.0, /* ageUnitsInThisAgeGroup - always 1 */
 			thisSurvivalRate,
 			persistentStats->_projectedInstantaneousSurvivalRate,
 			persistentStats->_projectedInstantaneousSurvivalRate);
@@ -273,8 +264,6 @@ MM_CompactGroupPersistentStats::resetLiveBytesStats(MM_EnvironmentVLHGC *env, MM
 		persistentStats[compactGroup]._measuredLiveBytesAfterCollectInCollectedSet = 0;
 		persistentStats[compactGroup]._measuredBytesCopiedFromGroupDuringCopyForward = 0;
 		persistentStats[compactGroup]._measuredBytesCopiedToGroupDuringCopyForward = 0;
-		persistentStats[compactGroup]._measuredAllocationAgeToGroupDuringCopyForward = 0;
-		persistentStats[compactGroup]._averageAllocationAgeToGroup = 0;
 
 		/* TODO: lpnguyen move this or rename this function (not a live bytes stat */
 		persistentStats[compactGroup]._regionsInRegionCollectionSetForPGC = 0;
@@ -514,9 +503,9 @@ MM_CompactGroupPersistentStats::decayProjectedLiveBytesForRegions(MM_Environment
 			/* Save snapshot of projectedLiveBytes before applying decay */
 			region->_projectedLiveBytesPreviousPGC = region->_projectedLiveBytes;
 
-			/* Get the compact group for this region based on its logical age */
+			/* Get the compact group for this region based on its age */
 			UDATA compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
-			UDATA regionAge = region->getLogicalAge();
+			uintptr_t regionAge = region->getAge();
 
 			/* Apply survival rate for this region's compact group only. */
 			double survivalRate = persistentStats[compactGroup]._projectedInstantaneousSurvivalRate;
@@ -532,10 +521,10 @@ MM_CompactGroupPersistentStats::decayProjectedLiveBytesForRegions(MM_Environment
 				(double)region->_projectedLiveBytes / (1024 * 1024),
 				compactGroup,
 				0.0, /* bytesRemaining - no longer applicable */
-				(double)regionAge, /* currentAge - now logical age */
+				(double)regionAge, /* currentAge */
 				survivalRate,
 				survivalRate, /* baseSurvivalRate same as survivalRate */
-				1.0, /*  ageUnitsInThisGroup - 1 logical age unit */
+				1.0, /*  ageUnitsInThisGroup = 1 */
 				compactGroup);
 		}
 	}

--- a/runtime/gc_vlhgc/CompactGroupPersistentStats.hpp
+++ b/runtime/gc_vlhgc/CompactGroupPersistentStats.hpp
@@ -61,10 +61,6 @@ public:
 	UDATA _measuredLiveBytesAfterCollectInCollectedSet;	/**< The number of bytes allocated in the collection set subset in this group at the    */
 	volatile UDATA _measuredBytesCopiedFromGroupDuringCopyForward;	/**< The total number of bytes measured to be live during a copy-forward which were copied from this compact group (the destination could be this group or another) */
 	volatile UDATA _measuredBytesCopiedToGroupDuringCopyForward; /**< The total number of bytes measured to be copied to group during a copy-forward */
-	volatile U_64 _measuredAllocationAgeToGroupDuringCopyForward; /**< The total allocation age measured on objects to be copied to group during copy-forward */
-	U_64 _averageAllocationAgeToGroup;	/**< Average allocation age for group */
-	U_64 _maxAllocationAge;  /**< max allocation age (of an object or region) in this compact group) */
-	/* TODO: lpnguyen group everything into anonymous structs */
 
 	double _projectedInstantaneousSurvivalRate; /**< survivor rate between this and previous age group */
 	double _projectedInstantaneousSurvivalRateThisPGC; /**< same as _projectedInstantaneousSurvivalRate, but for this PGC (not an average over time) */
@@ -117,7 +113,6 @@ private:
 	 * Init projected live bytes of regions that have been allocated from since previous PGC.
 	 * The init value is set to current consumed space (according to memory pool).
 	 *
-	 * TODO: Create a new class for this as it's not really tied to compact groups
 	 * @param env[in] The Main GC thread
 	 */
 	static void initProjectedLiveBytes(MM_EnvironmentVLHGC *env);
@@ -125,7 +120,6 @@ private:
 	/*
 	 * Updates the projectedLiveBytes for all regions by multiplying by their compact group's instantaneous survivor rate
 	 *
-	 * TODO: Create a new class for this as it's not really tied to compact groups
 	 * @param env[in] The Main GC thread
 	 */
 	static void decayProjectedLiveBytesForRegions(MM_EnvironmentVLHGC *env);

--- a/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
+++ b/runtime/gc_vlhgc/ConfigurationIncrementalGenerational.cpp
@@ -306,11 +306,7 @@ MM_ConfigurationIncrementalGenerational::initialize(MM_EnvironmentBase *env)
 
 	/* set default region maximum age if it is not specified yet */
 	if (0 == extensions->tarokRegionMaxAge) {
-		if (extensions->tarokAllocationAgeEnabled) {
-			extensions->tarokRegionMaxAge = DEFAULT_MAX_AGE_FOR_ALLOCATION_BASED;
-		} else {
-			extensions->tarokRegionMaxAge = DEFAULT_MAX_AGE_FOR_PGC_COUNT_BASED;
-		}
+		extensions->tarokRegionMaxAge = DEFAULT_MAX_AGE_FOR_PGC_COUNT_BASED;
 	}
 
 	if (!extensions->tarokNurseryMaxAge._wasSpecified) {

--- a/runtime/gc_vlhgc/CopyForwardCompactGroup.hpp
+++ b/runtime/gc_vlhgc/CopyForwardCompactGroup.hpp
@@ -80,7 +80,6 @@ public:
 	UDATA _freeMemoryMeasured;	/**< The number of bytes which were wasted while this thread was working with the given _copyCache (due to alignment, etc) which is needs to save back into the pool when giving up the cache */
 	UDATA _discardedBytes; /**< The number of bytes discarded in survivor regions for this compact group by the owning thread due to incompletely filled copy caches and other inefficiencies */
 	UDATA _TLHRemainderCount; /**< number of TLHRemainders has been created for the compact group during the copyforward */
-	U_64 _allocationAge; /**< Average allocation age for this compact group */
 	
 	/* Mark map rebuilding cache values for the active MM_CopyScanCacheVLHGC associated with this group */
 	UDATA _markMapAtomicHeadSlotIndex;  /**< Slot index of head which requires atomic update into the mark map (if any) */
@@ -116,7 +115,6 @@ public:
 		_freeMemoryMeasured = 0;
 		_discardedBytes = 0;
 		_TLHRemainderCount = 0;
-		_allocationAge = 0;
 		_markMapAtomicHeadSlotIndex = 0;
 		_markMapAtomicTailSlotIndex = 0;
 		_markMapPGCSlotIndex = 0;

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -542,7 +542,7 @@ MM_CopyForwardScheme::postProcessRegions(MM_EnvironmentVLHGC *env)
 			}
 		} else if (region->isFreshSurvivorRegion()) {
 			/* check Eden Survivor Regions */
-			if (0 == region->getLogicalAge()) {
+			if (0 == region->getAge()) {
 				static_cast<MM_CycleStateVLHGC *>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats._edenSurvivorRegionCount += 1;
 			} else {
 				static_cast<MM_CycleStateVLHGC *>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats._nonEdenSurvivorRegionCount += 1;
@@ -571,9 +571,6 @@ MM_CopyForwardScheme::postProcessRegions(MM_EnvironmentVLHGC *env)
 				 */
 				pool->reset(MM_MemoryPool::any);
 				region->getSubSpace()->recycleRegion(env, region);
-			} else {
-				/* this is non-empty merged region - estimate its age based on compact group */
-				setAllocationAgeForMergedRegion(env, region);
 			}
 		}
 
@@ -708,11 +705,6 @@ MM_CopyForwardScheme::reinitCache(MM_EnvironmentVLHGC *env, MM_CopyScanCacheVLHG
 	
 	Assert_MM_true(compactGroup < _compactGroupMaxCount);
 	cache->_compactGroup = compactGroup;
-	Assert_MM_true(0.0 == cache->_allocationAgeSizeProduct);
-	
-	MM_HeapRegionDescriptorVLHGC * region = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(cache->cacheBase);
-	Trc_MM_CopyForwardScheme_reinitCache(env->getLanguageVMThread(), _regionManager->mapDescriptorToRegionTableIndex(region), cache,
-			region->getAllocationAgeSizeProduct() / (1024 * 1024) / (1024 * 1024), (double)((uintptr_t)cache->cacheAlloc - (uintptr_t)region->getLowAddress()) / (1024 * 1024));
 
 	/* store back the given flags */
 	cache->flags = OMR_COPYSCAN_CACHE_TYPE_COPY | (cache->flags & OMR_COPYSCAN_CACHE_MASK_PERSISTENT);
@@ -816,11 +808,11 @@ MM_CopyForwardScheme::acquireEmptyRegion(MM_EnvironmentVLHGC *env, MM_ReservedRe
 			newRegion->_reclaimData._shouldReclaim = false;
 
 			/*
-			 * set logical age here to have a compact groups working properly
+			 * set age here to have a compact groups working properly
 			 * real allocation age will be updated after PGC
 			 */
-			uintptr_t logicalRegionAge = MM_CompactGroupManager::getRegionAgeFromGroup(env, compactGroup);
-			newRegion->setAge(0, logicalRegionAge);
+			uintptr_t regionAge = MM_CompactGroupManager::getRegionAgeFromGroup(env, compactGroup);
+			newRegion->setAge(regionAge);
 
 			Assert_MM_true(newRegion->getReferenceObjectList()->isSoftListEmpty());
 			Assert_MM_true(newRegion->getReferenceObjectList()->isWeakListEmpty());
@@ -1558,7 +1550,6 @@ MM_CopyForwardScheme::mergeGCStats(MM_EnvironmentVLHGC *env)
 
 		if (0 != totalCopiedBytes) {
 			MM_AtomicOperations::add(&persistentStats[compactGroupNumber]._measuredBytesCopiedToGroupDuringCopyForward, totalCopiedBytes);
-			MM_AtomicOperations::addU64(&persistentStats[compactGroupNumber]._measuredAllocationAgeToGroupDuringCopyForward, compactGroup->_allocationAge);
 		}
 
 		if (0 != (totalCopiedBytes + compactGroup->_discardedBytes)) {
@@ -1856,23 +1847,10 @@ MM_CopyForwardScheme::stopCopyingIntoCache(MM_EnvironmentVLHGC *env, uintptr_t c
 		uintptr_t wastedMemory = env->_copyForwardCompactGroups[compactGroup]._freeMemoryMeasured;
 		env->_copyForwardCompactGroups[compactGroup]._freeMemoryMeasured = 0;
 		
-		MM_HeapRegionDescriptorVLHGC * region = (MM_HeapRegionDescriptorVLHGC *)_regionManager->tableDescriptorForAddress(copyCache->cacheBase);
-
-		/* atomically add (age * usedBytes) product from this cache to the regions product */
-		double newAllocationAgeSizeProduct = region->atomicIncrementAllocationAgeSizeProduct(copyCache->_allocationAgeSizeProduct);
-		region->updateAgeBounds(copyCache->_lowerAgeBound, copyCache->_upperAgeBound);
-
 		/* Return any remaining memory to the pool */
 		discardRemainingCache(env, copyCache, copyCacheLock, wastedMemory);
 
-		Trc_MM_CopyForwardScheme_stopCopyingIntoCache(env->getLanguageVMThread(), _regionManager->mapDescriptorToRegionTableIndex(region), copyCache,
-				(double)(newAllocationAgeSizeProduct - copyCache->_allocationAgeSizeProduct) / (1024 * 1024) / (1024 * 1024), (double)((uintptr_t)copyCache->cacheAlloc - (uintptr_t)region->getLowAddress()) / (1024 * 1024),
-				(double)copyCache->_allocationAgeSizeProduct / (1024 * 1024) / (1024 * 1024), (double)copyCache->_objectSize / (1024 * 1024), (double)newAllocationAgeSizeProduct / (1024 * 1024) / (1024 * 1024));
-
-		copyCache->_allocationAgeSizeProduct = 0.0;
 		copyCache->_objectSize = 0;
-		copyCache->_lowerAgeBound = U_64_MAX;
-		copyCache->_upperAgeBound = 0;
 
 		/* Push any cached mark map data out */
 		flushCacheMarkMap(env, copyCache);
@@ -2099,10 +2077,7 @@ MM_CopyForwardScheme::copy(MM_EnvironmentVLHGC *env, MM_AllocationContextTarok *
 					env->_copyForwardCompactGroups[destinationCompactGroup]._nonEdenStats._copiedObjects += 1;
 					env->_copyForwardCompactGroups[destinationCompactGroup]._nonEdenStats._copiedBytes += objectCopySizeInBytes;
 				}
-				copyCache->_allocationAgeSizeProduct += ((double)objectReserveSizeInBytes * (double)sourceRegion->getAllocationAge());
 				copyCache->_objectSize += objectReserveSizeInBytes;
-				copyCache->_lowerAgeBound = OMR_MIN(copyCache->_lowerAgeBound, sourceRegion->getLowerAgeBound());
-				copyCache->_upperAgeBound = OMR_MAX(copyCache->_upperAgeBound, sourceRegion->getUpperAgeBound());
 
 #if defined(J9VM_GC_LEAF_BITS)
 				if (_extensions->tarokEnableLeafFirstCopying) {
@@ -4566,7 +4541,7 @@ MM_CopyForwardScheme::verifyDumpObjectDetails(MM_EnvironmentVLHGC *env, const ch
 				region->_copyForwardData._initialLiveSet ? 'Y' : 'N',
 				region->isSurvivorRegion() ? 'Y' : 'N',
 				region->isFreshSurvivorRegion() ? 'Y' : 'N',
-				region->getLogicalAge()
+				region->getAge()
 		);
 	}
 }
@@ -5637,58 +5612,10 @@ MM_CopyForwardScheme::convertFreeMemoryCandidateToSurvivorRegion(MM_EnvironmentV
 void
 MM_CopyForwardScheme::setRegionAsSurvivor(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, bool freshSurvivor)
 {
-	uintptr_t usedBytes = region->getSize() - region->getMemoryPool()->getFreeMemoryAndDarkMatterBytes();
-
-	/* convert allocation age into (usedBytes * age) multiple. it will be converted back to pure age at the end of GC.
-	 * in the mean time as caches are allocated from the region, the age will be merged
-	 */
-	double allocationAgeSizeProduct = (double)usedBytes * (double)region->getAllocationAge();
-
-	Trc_MM_CopyForwardScheme_setRegionAsSurvivor(env->getLanguageVMThread(), _regionManager->mapDescriptorToRegionTableIndex(region), MM_CompactGroupManager::getCompactGroupNumber(env, region),
-	    (double)region->getAllocationAge() / (1024 * 1024), (double)usedBytes / (1024 * 1024), allocationAgeSizeProduct / (1024 * 1024) / (1024 * 1024));
-
-	Assert_MM_true(0.0 == region->getAllocationAgeSizeProduct());
-	region->setAllocationAgeSizeProduct(allocationAgeSizeProduct);
-	if (freshSurvivor) {
-		region->resetAgeBounds();
-	}
-
 	/* update the pool so it only knows about the free memory occurring before survivor base.  We will add whatever we don't use at the end of the copy-forward */
 	Assert_MM_false(region->_copyForwardData._requiresPhantomReferenceProcessing);
 	region->_copyForwardData._survivor = true;
 	region->_copyForwardData._freshSurvivor = freshSurvivor;
-}
-
-void
-MM_CopyForwardScheme::setAllocationAgeForMergedRegion(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region)
-{
-	uintptr_t compactGroup = MM_CompactGroupManager::getCompactGroupNumber(env, region);
-	uintptr_t usedBytes = region->getSize() - region->getMemoryPool()->getFreeMemoryAndDarkMatterBytes();
-
-	Assert_MM_true(0 != usedBytes);
-
-	/* convert allocation age product (usedBytes * age) back to pure age */
-	uint64_t newAllocationAge = (uint64_t)(region->getAllocationAgeSizeProduct() / (double)usedBytes);
-
-	Trc_MM_CopyForwardScheme_setAllocationAgeForMergedRegion(env->getLanguageVMThread(), _regionManager->mapDescriptorToRegionTableIndex(region), compactGroup,
-	    region->getAllocationAgeSizeProduct() / (1024 * 1024) / (1024 * 1024), (double)usedBytes / (1024 * 1024), (double)newAllocationAge / (1024 * 1024),
-	    (double)region->getLowerAgeBound() / (1024 * 1024), (double)region->getUpperAgeBound() / (1024 * 1024));
-
-	if (_extensions->tarokAllocationAgeEnabled) {
-		Assert_MM_true(newAllocationAge < _extensions->compactGroupPersistentStats[compactGroup]._maxAllocationAge);
-		Assert_MM_true((MM_CompactGroupManager::getRegionAgeFromGroup(env, compactGroup) == 0) || (newAllocationAge >= _extensions->compactGroupPersistentStats[compactGroup - 1]._maxAllocationAge));
-	}
-
-	uintptr_t logicalAge = 0;
-	if (_extensions->tarokAllocationAgeEnabled) {
-		logicalAge = MM_CompactGroupManager::calculateLogicalAgeForRegion(env, newAllocationAge);
-	} else {
-		logicalAge = MM_CompactGroupManager::getRegionAgeFromGroup(env, compactGroup);
-	}
-
-	region->setAge(newAllocationAge, logicalAge);
-	/* reset aging auxiliary datea for future usage */
-	region->setAllocationAgeSizeProduct(0.0);
 }
 
 bool

--- a/runtime/gc_vlhgc/CopyForwardScheme.hpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.hpp
@@ -944,13 +944,6 @@ private:
 #endif /* J9VM_GC_LEAF_BITS */
 
 	/**
-	 * Calculate estimation for allocation age based on compact group and set it to the merged region
-	 * @param[in] env The current thread
-	 * @param[in] region The region to adjust age to
-	 */
-	void setAllocationAgeForMergedRegion(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region);
-
-	/**
 	 * check if the Object in jni critical region
 	 */
 	bool isObjectInNoEvacuationRegions(MM_EnvironmentVLHGC *env, J9Object *objectPtr);

--- a/runtime/gc_vlhgc/CopyScanCacheVLHGC.hpp
+++ b/runtime/gc_vlhgc/CopyScanCacheVLHGC.hpp
@@ -48,10 +48,7 @@ protected:
 public:
 	GC_ObjectIteratorState _objectIteratorState; /**< the scan state of the partially scanned object */
 	uintptr_t _compactGroup; /**< The compact group this cache belongs to */
-	double _allocationAgeSizeProduct; /**< sum of (age * size) products for each object copied to this copy cache */
 	uintptr_t _objectSize;   /**< sum of objects sizes copied to this copy cache */
-	uint64_t _lowerAgeBound; /**< lowest possible age of any object in this copy cache */
-	uint64_t _upperAgeBound; /**< highest possible age of any object in this copy cache */
 	uintptr_t _arraySplitIndex; /**< The index within the array in scanCurrent to start scanning from (meaningful is OMR_COPYSCAN_CACHE_TYPE_SPLIT_ARRAY is set) */
 
 	/* Members Function */
@@ -83,10 +80,7 @@ public:
 	MM_CopyScanCacheVLHGC()
 		: MM_CopyScanCache()
 		, _compactGroup(UDATA_MAX)
-		, _allocationAgeSizeProduct(0.0)
 		, _objectSize(0)
-		, _lowerAgeBound(U_64_MAX)
-		, _upperAgeBound(0)
 		, _arraySplitIndex(0)
 	{}
 };

--- a/runtime/gc_vlhgc/HeapRegionDataForAllocate.cpp
+++ b/runtime/gc_vlhgc/HeapRegionDataForAllocate.cpp
@@ -126,8 +126,7 @@ MM_HeapRegionDataForAllocate::taskAsFreePool(MM_EnvironmentBase *env)
 	/* set _projectedLiveBytes to 'uninitialized' value. it will be initialized at the beginning of the first PGC */
 	_region->_projectedLiveBytes = UDATA_MAX;
 	_region->_projectedLiveBytesDeviation = 0;
-	_region->setAge(0,0);
-	_region->resetAgeBounds();
+	_region->setAge(0);
 	_region->_defragmentationTarget = false;
 }
 
@@ -147,8 +146,7 @@ MM_HeapRegionDataForAllocate::taskAsIdlePool(MM_EnvironmentVLHGC *env)
 	/* set _projectedLiveBytes to 'uninitialized' value. it will be initialized at the beginning of the first PGC */
 	_region->_projectedLiveBytes = UDATA_MAX;
 	_region->_projectedLiveBytesDeviation = 0;
-	_region->setAge(0,0);
-	_region->resetAgeBounds();
+	_region->setAge(0);
 	_region->_defragmentationTarget = false;
 
 	/* When a region becomes idle ensure that identity hash salt for this region gets updated */

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.cpp
@@ -48,8 +48,6 @@ MM_HeapRegionDescriptorVLHGC::MM_HeapRegionDescriptorVLHGC(MM_EnvironmentVLHGC *
 	,_compactDestinationQueueNext(NULL)
 	,_defragmentationTarget(false)
 	,_extensions(MM_GCExtensions::getExtensions(env))
-	,_allocationAge(0)
-	,_allocationAgeSizeProduct(0.0)
 	,_age(0)
 	,_rememberedSetCardList()
 	,_rsclBufferPool(NULL)
@@ -161,24 +159,3 @@ MM_HeapRegionDescriptorVLHGC::getProjectedReclaimableBytes()
 	uintptr_t projectedReclaimableBytes = consumedBytes - _projectedLiveBytes;
 	return projectedReclaimableBytes;
 }
-
-void 
-MM_HeapRegionDescriptorVLHGC::resetAge(MM_EnvironmentVLHGC *env, U_64 allocationAge)
-{
-	MM_GCExtensions *extensions = MM_GCExtensions::getExtensions(env);
-	uintptr_t logicalAge = 0;
-	if (extensions->tarokAllocationAgeEnabled) {
-		logicalAge = MM_CompactGroupManager::calculateLogicalAgeForRegion(env, allocationAge);
-	}
-	setAge(allocationAge, logicalAge);
-
-	U_64 maxAllocationAge = extensions->compactGroupPersistentStats[logicalAge]._maxAllocationAge;
-	U_64 minAllocationAge = 0;
-
-	if (logicalAge > 0) {
-		minAllocationAge = extensions->compactGroupPersistentStats[logicalAge - 1]._maxAllocationAge;
-	}
-
-	setAgeBounds(minAllocationAge, maxAllocationAge);
-}
-

--- a/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
+++ b/runtime/gc_vlhgc/HeapRegionDescriptorVLHGC.hpp
@@ -90,11 +90,7 @@ protected:
 	MM_GCExtensions * _extensions;
 
 private:
-	U_64 _allocationAge; /**< allocation age (number of bytes allocated since the last attempted allocation) */
-	U_64 _lowerAgeBound; /**< lowest possible age of any object in this region */
-	U_64 _upperAgeBound; /**< highest possible age of any object in this region */
-	double _allocationAgeSizeProduct; /**< sum of (age * size) products for each object in the region. used for age merging math in survivor regions */
-	uintptr_t _age; /**< logical allocation age (number of GC cycles since the last attempted allocation) */
+	uintptr_t _age; /**< number of GC cycles since the last attempted allocation */
 	MM_RememberedSetCardList _rememberedSetCardList; /**< remembered set card list */
 	MM_RememberedSetCard *_rsclBufferPool;			 /**< RSCL Buffer pool owned by this region (Buffers can still be shared among other regions) */
 	
@@ -111,100 +107,19 @@ public:
 	MM_HeapRegionDescriptorVLHGC(MM_EnvironmentVLHGC *env, void *lowAddress, void *highAddress);
 
 	/**
-	 * Get Allocation Age - return back allocation age
-	 * @return allocation age value
-	 */
-	MMINLINE U_64 getAllocationAge() { return _allocationAge; }
-
-	MMINLINE U_64 getLowerAgeBound() { return _lowerAgeBound; }
-	MMINLINE U_64 getUpperAgeBound() { return _upperAgeBound; }
-
-	/**
-	 * get current value of (age * size) product used for survivor regions
-	 * @return allocationAgeSizeProduct value
-	 */
-	MMINLINE double getAllocationAgeSizeProduct()
-	{
-		 return _allocationAgeSizeProduct;
-	}
-
-	/**
-	 * set current value of (age * size) product used for survivor regions (used for setting its initial value)
-	 */
-	MMINLINE void setAllocationAgeSizeProduct(double allocationAgeSizeProduct)
-	{
-		 _allocationAgeSizeProduct = allocationAgeSizeProduct;
-	}
-
-
-	/**
-	 * increment atomically allocation (age * size) product
-	 * @param allocationAgeSizeProduct age to increment with
-	 * @return new allocationAgeSizeProduct value
-	 */
-	MMINLINE double atomicIncrementAllocationAgeSizeProduct(double allocationAgeSizeProduct)
-	{
-		 return MM_AtomicOperations::addDouble(&_allocationAgeSizeProduct, allocationAgeSizeProduct);
-	}
-
-	/**
-	 *	Get Logical Age - return back logical age in range 0-tarokRegionMaxAge
+	 *	Get Age - return back age in range 0-tarokRegionMaxAge
 	 *	@return return age value
 	 */
-	MMINLINE uintptr_t getLogicalAge() { return _age; }
+	MMINLINE uintptr_t getAge() { return _age; }
 
 	/**
-	 * Set Age - set both allocation and logical age
-	 * @param allocationAge allocation age to set
-	 * @param logicalAge logical age to set
+	 * Set Age - set age
+	 * @param age age to set
 	 */
-	MMINLINE void setAge(U_64 allocationAge, uintptr_t logicalAge)
+	MMINLINE void setAge(uintptr_t age)
 	{
-		_allocationAge = allocationAge;
-		_age = logicalAge;
+		_age = age;
 	}
-
-	/**
-	 * Update lowest and higher object age bounds (propageted info from just filled-up copy cache)
-	 */
-	MMINLINE void updateAgeBounds(U_64 lowerAgeBound, U_64 upperAgeBound) {
-		/* ideally, these should be atomic updates, but bounds are anyway just an approximation */
-		_lowerAgeBound = OMR_MIN(_lowerAgeBound, lowerAgeBound);
-		_upperAgeBound = OMR_MAX(_upperAgeBound, upperAgeBound);
-	}
-
-	/**
-	 * Increment lowest and higher object age bounds (when doing region aging)
-	 */
-	MMINLINE void incrementAgeBounds(uintptr_t increment) {
-		_lowerAgeBound += increment;
-		_upperAgeBound += increment;
-	}
-
-	/**
-	 * Set age bounds from newly allocated region
-	 */
-	MMINLINE void setAgeBounds(U_64 lowerAgeBound, U_64 upperAgeBound) {
-		_lowerAgeBound = lowerAgeBound;
-		_upperAgeBound = upperAgeBound;
-	}
-
-	/**
-	 * Reset age bounds for IDLE/FREE regions
-	 */
-	MMINLINE void resetAgeBounds() {
-		_lowerAgeBound = U_64_MAX;
-		_upperAgeBound = 0;
-	}
-
-
-	/**
-	 * Reset Age
-	 * Supports both old and bytes-allocated-based aging systems
-	 * @param env[in] the current thread
-	 * @param allocationAge allocation age to set
-	 */
-	void resetAge(MM_EnvironmentVLHGC *env, U_64 allocationAge);
 
 	/**
 	 * Is Eden - return true if region is Eden

--- a/runtime/gc_vlhgc/HeapRegionManagerVLHGC.cpp
+++ b/runtime/gc_vlhgc/HeapRegionManagerVLHGC.cpp
@@ -195,7 +195,7 @@ MM_HeapRegionManagerVLHGC::getHeapMemorySnapshot(MM_GCExtensionsBase *extensions
 				Assert_MM_true(region->isArrayletLeaf());
 				free = 0;
 			}
-			age = region->getLogicalAge();
+			age = region->getAge();
 			if (0 == age) {
 				allocateEdenTotal += regionSize;
 				snapshot->_freeRegionEdenSize += free;

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -204,58 +204,12 @@ MM_IncrementalGenerationalGC::initialize(MM_EnvironmentVLHGC *env)
 		goto error_no_memory;
 	}
 
-	/*
-	 * Set base unit for allocation-based aging system here as an estimated "ideal" taxation interval
-	 * except it has not been hard coded in command line
-	 */
-	if (0 == extensions->tarokAllocationAgeUnit) {
-		extensions->tarokAllocationAgeUnit = extensions->tarokIdealEdenMaximumBytes;
-		extensions->tarokAllocationAgeExponentBase = 1.0;
-	}
-
 	/* The Tarok policy always compacts since it can't handle dark matter in scan-only regions */
 	extensions->compactOnGlobalGC = true;
-
-	/**
-	 * Set maximum allocation age based on logical maximum age
-	 * except it has not been hard coded in command line
-	 */
-	if (0 == extensions->tarokMaximumAgeInBytes) {
-		extensions->tarokMaximumAgeInBytes = MM_CompactGroupManager::calculateMaximumAllocationAge(env, extensions->tarokRegionMaxAge);
-	} else {
-		/*
-		 * Maximum allocation age is specified in command line
-		 * For Allocation-based aging system take is as a primary value and set logical maximum age
-		 */
-		if (extensions->tarokAllocationAgeEnabled) {
-			UDATA maxLogicalAge = MM_CompactGroupManager::calculateLogicalAgeForRegion(env, extensions->tarokMaximumAgeInBytes);
-			/*
-			 * There are a few data structures have been allocated already with size based on tarokRegionMaxAge(in TGC for example)
-			 * so new value can not be larger then old one
-			 */
-			Assert_MM_true(maxLogicalAge <= extensions->tarokRegionMaxAge);
-			extensions->tarokRegionMaxAge = maxLogicalAge;
-		}
-	}
 
 	extensions->compactGroupPersistentStats = MM_CompactGroupPersistentStats::allocateCompactGroupPersistentStats(env);
 	if (NULL == extensions->compactGroupPersistentStats) {
 		goto error_no_memory;
-	}
-
-	/*
-	 * Set threshold for Nursery collection set for allocation-based aging system here as a doubled estimated "ideal" taxation interval
-	 * except it has not been hard coded in command line
-	 */
-	if (0 == extensions->tarokMaximumNurseryAgeInBytes) {
-		extensions->tarokMaximumNurseryAgeInBytes = extensions->tarokIdealEdenMaximumBytes * 2;
-	}
-
-	/*
-	 * For Allocation-based aging system take tarokMaximumNurseryAgeInBytes as a primary value and set tarokNurseryMaxAge
-	 */
-	if (extensions->tarokAllocationAgeEnabled) {
-		extensions->tarokNurseryMaxAge._valueSpecified = MM_CompactGroupManager::calculateLogicalAgeForRegion(env, extensions->tarokMaximumNurseryAgeInBytes);
 	}
 
 	/* Attach to hooks required by the global collector's
@@ -652,7 +606,7 @@ MM_IncrementalGenerationalGC::initializeTaxationThreshold(MM_EnvironmentVLHGC *e
 	_configuredSubspace->setBytesRemainingBeforeTaxation(_taxationThreshold);
 	_allocatedSinceLastPGC = 0;
 	
-	initialRegionAgesSetup(env, _taxationThreshold);
+	initialRegionAgesSetup(env);
 }
 
 bool
@@ -1016,7 +970,7 @@ MM_IncrementalGenerationalGC::partialGarbageCollectPostWork(MM_EnvironmentVLHGC 
 
 	env->_cycleState->_externalCycleState = NULL;
 
-	incrementRegionAges(env, _taxationThreshold, true);
+	incrementRegionAges(env, true);
 
 	PORT_ACCESS_FROM_ENVIRONMENT(env);
 	env->_cycleState->_endTime = j9time_hires_clock();
@@ -1129,7 +1083,7 @@ MM_IncrementalGenerationalGC::runGlobalMarkPhaseIncrement(MM_EnvironmentVLHGC *e
 		env->_cycleState->_currentIncrement = 0;
 	}
 
-	incrementRegionAges(env, _taxationThreshold, false);
+	incrementRegionAges(env, false);
 
 	/* If the GMP is no longer running, then we have run the final increment of the cycle. */
 	Assert_MM_true(0 == static_cast<MM_CycleStateVLHGC*>(env->_cycleState)->_vlhgcIncrementStats._copyForwardStats.getStallTime());
@@ -1534,32 +1488,21 @@ MM_IncrementalGenerationalGC::setConfiguredSubspace(MM_EnvironmentBase *env, MM_
 }
 
 void 
-MM_IncrementalGenerationalGC::initialRegionAgesSetup(MM_EnvironmentVLHGC *env, UDATA givenAge)
+MM_IncrementalGenerationalGC::initialRegionAgesSetup(MM_EnvironmentVLHGC *env)
 {
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager, MM_HeapRegionDescriptor::MANAGED);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 
-	U_64 age = (U_64)givenAge;
-	if (age > _extensions->tarokMaximumAgeInBytes) {
-		age = _extensions->tarokMaximumAgeInBytes;
-	}
-
 	while (NULL != (region = regionIterator.nextRegion())) {
 		/* Adjust age for non-empty regions. */
-		if(region->containsObjects() || region->isArrayletLeaf()) {
-
-			/*
-			 * At the moment of creation taxation point was artificially set to tarokMaximumAgeInBytes
-			 * Correct age of regions allocated before initialization
-			 * Assume that all this regions are allocated _NOW_
-			 */
-			region->resetAge(env, age);
+		if (region->containsObjects() || region->isArrayletLeaf()) {
+			region->setAge(0);
 		}
 	}
 }
 
 void
-MM_IncrementalGenerationalGC::incrementRegionAges(MM_EnvironmentVLHGC *env, UDATA increment, bool isPGC)
+MM_IncrementalGenerationalGC::incrementRegionAges(MM_EnvironmentVLHGC *env, bool isPGC)
 {
 	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager, MM_HeapRegionDescriptor::MANAGED);
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
@@ -1568,11 +1511,11 @@ MM_IncrementalGenerationalGC::incrementRegionAges(MM_EnvironmentVLHGC *env, UDAT
 
 	while (NULL != (region = regionIterator.nextRegion())) {
 		/* Adjust age for non-empty regions. */
-		if(region->containsObjects() || region->isArrayletLeaf()) {
+		if (region->containsObjects() || region->isArrayletLeaf()) {
 
-			UDATA previousLogicalAge = region->getLogicalAge();
+			uintptr_t previousAge = region->getAge();
 			/* Increment ages up to the maximum allowable region age */
-			incrementRegionAge(env, region, increment, isPGC);
+			incrementRegionAge(env, region, isPGC);
 
 			MM_AllocationContextTarok *owner = region->_allocateData._owningContext;
 			if (owner->shouldMigrateRegionToCommonContext(env, region)) {
@@ -1586,13 +1529,13 @@ MM_IncrementalGenerationalGC::incrementRegionAges(MM_EnvironmentVLHGC *env, UDAT
 				}
 			}
 
-			if (region->containsObjects() && (region->getLogicalAge() == env->getExtensions()->tarokRegionMaxAge)) {
+			if (region->containsObjects() && (region->getAge() == env->getExtensions()->tarokRegionMaxAge)) {
 				/* regions that are full and age out are considered 'stable' */
 				_interRegionRememberedSet->overflowIfStableRegion(env, region);
 
 				/* regions that age out, but are not full (thus not stable => accurate), should merge with other old non-full regions (in same AC) */
 				if (region->getRememberedSetCardList()->isAccurate()) {
-					if (previousLogicalAge < _extensions->tarokRegionMaxAge) {
+					if (previousAge < _extensions->tarokRegionMaxAge) {
 						_schedulingDelegate.updateCurrentMacroDefragmentationWork(env, region);
 					}
 				}
@@ -1607,60 +1550,15 @@ MM_IncrementalGenerationalGC::incrementRegionAges(MM_EnvironmentVLHGC *env, UDAT
 }
 
 void 
-MM_IncrementalGenerationalGC::incrementRegionAge(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, UDATA increment, bool isPGC)
+MM_IncrementalGenerationalGC::incrementRegionAge(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, bool isPGC)
 {
-	/* Update age for bytes-allocated-based aging system */
-	U_64 allocationAge = region->getAllocationAge();
+	uintptr_t age = region->getAge();
 
-	U_64 allocationAgeBefore = allocationAge;
-	UDATA logicalAgeBefore = region->getLogicalAge();
-
-	U_64 maxAgeInBytes = _extensions->tarokMaximumAgeInBytes;
-	if (allocationAge < maxAgeInBytes) {
-		U_64 value = allocationAge + increment;
-		if (allocationAge <= value) {
-			/* no overflow */
-			if (value <= maxAgeInBytes) {
-				/* still be undo maximum age, increment it */
-				allocationAge = value;
-			} else {
-				/* Maximum age is exceeded, saturate */
-				allocationAge = maxAgeInBytes;
-			}
-		} else {
-			/* overflow, set to the maximum possible age */
-			allocationAge = maxAgeInBytes;
+	if (isPGC) {
+		if (age < _extensions->tarokRegionMaxAge) {
+			region->setAge(age + 1);
 		}
 	}
-
-	UDATA logicalAge = 0;
-	if (_extensions->tarokAllocationAgeEnabled) {
-		logicalAge = MM_CompactGroupManager::calculateLogicalAgeForRegion(env, allocationAge);
-	} else {
-		/* Calculate age for PGC-count-based (old) aging system */
-		logicalAge = region->getLogicalAge();
-		if (isPGC) {
-			if (logicalAge < _extensions->tarokRegionMaxAge) {
-				logicalAge += 1;
-			}
-		}
-	}
-	
-	region->incrementAgeBounds(increment);
-
-	Trc_MM_IncrementalGenerationalGC_incrementRegionAge(env->getLanguageVMThread(),
-			_regionManager->mapDescriptorToRegionTableIndex(region),
-			isPGC,
-			(double)increment/(1024*1024),
-			(double)allocationAgeBefore/(1024*1024),
-			(double)allocationAge/(1024*1024),
-			(double)region->getLowerAgeBound() / (1024 * 1024),
-			(double)region->getUpperAgeBound() / (1024 * 1024),
-			logicalAgeBefore,
-			logicalAge);
-
-	region->setAge(allocationAge, logicalAge);
-
 }
 
 void
@@ -1673,8 +1571,8 @@ MM_IncrementalGenerationalGC::setRegionAgesToMax(MM_EnvironmentVLHGC *env)
 		/* Adjust age for non-empty regions.  Note: Currently object artifact regions (e.g., arraylet leaves) won't
 		 * have their age adjusted.  The parent of the artifact will have its region age, which it implicitly inherits.
 		 */
-		if(region->containsObjects()) {
-			region->setAge(_extensions->tarokMaximumAgeInBytes, _extensions->tarokRegionMaxAge);
+		if (region->containsObjects()) {
+			region->setAge(_extensions->tarokRegionMaxAge);
 			/* migrate to common context */
 			MM_AllocationContextTarok *owner = region->_allocateData._owningContext;
 			if ( (owner != commonContext) && owner->shouldMigrateRegionToCommonContext(env, region) ) {
@@ -1686,7 +1584,7 @@ MM_IncrementalGenerationalGC::setRegionAgesToMax(MM_EnvironmentVLHGC *env)
 			}
 		} else if (region->isArrayletLeaf()) {
 			/* adjust age for arraylet leaves */
-			region->setAge(_extensions->tarokMaximumAgeInBytes, _extensions->tarokRegionMaxAge);
+			region->setAge(_extensions->tarokRegionMaxAge);
 		}
 	}
 }
@@ -2257,9 +2155,8 @@ MM_IncrementalGenerationalGC::exportStats(MM_EnvironmentVLHGC *env, MM_Collectio
 				if (region->containsObjects()) {
 					MM_MemoryPool *memoryPool = region->getMemoryPool();
 					Assert_MM_true(NULL != memoryPool);
-					/* Eden region containing objects, Allocation Age must be smaller then amount allocated since last PGC,
-					 * more accurately, its logical age must be equal to zero */
-					if (0 == region->getLogicalAge()) {
+					/* Eden region containing objects, its age must be equal to zero */
+					if (0 == region->getAge()) {
 						UDATA size = memoryPool->getActualFreeMemorySize();
 						stats->_edenFreeHeapSize += size;
 						usedMemory = regionSize - size;
@@ -2270,7 +2167,7 @@ MM_IncrementalGenerationalGC::exportStats(MM_EnvironmentVLHGC *env, MM_Collectio
 				} else {
 					Assert_MM_true(region->isArrayletLeaf());
 					usedMemory = regionSize;
-					if (0 == region->getLogicalAge()) {
+					if (0 == region->getAge()) {
 						allocateEdenTotal += regionSize;
 					}
 				}

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
@@ -271,10 +271,9 @@ public:
 	/**
 	 * Increment the nursery age of every region which contains objects, up to the maximum age.
 	 * @param env[in] The main GC thread
-	 * @param increment number of allocated bytes age should be incremented for
 	 * @param isPGC set to true if it is a PCG cycle - for compatibility with old aging system
 	 */
-	void incrementRegionAges(MM_EnvironmentVLHGC *env, UDATA increment, bool isPGC);
+	void incrementRegionAges(MM_EnvironmentVLHGC *env, bool isPGC);
 
 	/**
 	 * Initial increment of region ages
@@ -282,17 +281,15 @@ public:
 	 * all regions allocated at this time required to have their age corrected
 	 * Currently age just set up to time of Collector's start up
 	 * @param env[in] The main GC thread
-	 * @param increment number of allocated bytes age should be set up
 	 */
-	void initialRegionAgesSetup(MM_EnvironmentVLHGC *env, UDATA age);
+	void initialRegionAgesSetup(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Increment the nursery age of region.
 	 * @param env[in] The main GC thread
-	 * @param increment number of allocated bytes age should be incremented for
 	 * @param isPGC set to true if it is a PCG cycle - for compatibility with old aging system
 	 */
-	void incrementRegionAge(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, UDATA increment, bool isPGC);
+	void incrementRegionAge(MM_EnvironmentVLHGC *env, MM_HeapRegionDescriptorVLHGC *region, bool isPGC);
 
 	/**
 	 * Set the nursery age of every region which contains objects to the maximum age.

--- a/runtime/gc_vlhgc/ReclaimDelegate.cpp
+++ b/runtime/gc_vlhgc/ReclaimDelegate.cpp
@@ -230,7 +230,7 @@ MM_ReclaimDelegate::tagRegionsBeforeCompactWithWorkGoal(MM_EnvironmentVLHGC *env
 			expectedBytesToReclaimThroughCompaction += freeMemory;
 			regionCount += 1;
 			UDATA regionIndex = _regionManager->mapDescriptorToRegionTableIndex(region);
-			Trc_MM_ReclaimDelegate_tagRegionsBeforeCompactWithWorkGoal_addingToCompactSet(env->getLanguageVMThread(), regionIndex, compactGroup, region->getLogicalAge(), region->_compactData._compactScore, (100 * freeMemory)/regionSize, MM_GCExtensions::getExtensions(env)->compactGroupPersistentStats[compactGroup]._weightedSurvivalRate);
+			Trc_MM_ReclaimDelegate_tagRegionsBeforeCompactWithWorkGoal_addingToCompactSet(env->getLanguageVMThread(), regionIndex, compactGroup, region->getAge(), region->_compactData._compactScore, (100 * freeMemory)/regionSize, MM_GCExtensions::getExtensions(env)->compactGroupPersistentStats[compactGroup]._weightedSurvivalRate);
 
 			if (isCopyForward) {
 				region->_markData._shouldMark = true;


### PR DESCRIPTION
The allocation-based aging system is very complicated and never fully working. Simplify VLHGC region aging by removing the experimental allocation-based aging system and Keeping the simpler PGC-count-based(Logical age) aging system for improving PGC performance.

 - Disable tarokAllocationAgeEnabled flag and related command-line options in mmparseXXgc.cpp
 
 - Removed allocation age parameters (tarokAllocationAgeExponentBase, tarokAllocationAgeUnit, tarokMaximumAgeInBytes, tarokMaximumNurseryAgeInBytes)
 
 - Removed allocation age tracking fields: _allocationAge, _allocationAgeSizeProduct, _lowerAgeBound, _upperAgeBound
 
 - Removed age bounds management methods: updateAgeBounds(), incrementAgeBounds(), setAgeBounds(), resetAgeBounds()
 
 - Simplified resetAge() and setAge()
 
 - Remove copy-forward cache accounting for allocation-age products and
  related survivor-region age-bound propagation in MM_CopyForwardScheme::copy() and MM_CopyForwardScheme::stopCopyingIntoCache().

 #depends on https://github.com/eclipse-openj9/openj9/pull/24406
 
 
Signed-off-by: lhu <linhu@ca.ibm.com>