### PR TITLE
Use JNIEXPORT consistently

### DIFF
--- a/runtime/j9vm/asgct.cpp
+++ b/runtime/j9vm/asgct.cpp
@@ -22,6 +22,7 @@
 
 #include "j9.h"
 #include "j9protos.h"
+#include "jvm.h"
 #include "ut_j9scar.h"
 #include "rommeth.h"
 #include "vmhook.h"
@@ -36,17 +37,17 @@ extern "C" {
 #define AGCT_LINE_NUMBER_NATIVE_METHOD -3
 
 enum {
-ticks_no_Java_frame         =  0, // new thread
-ticks_no_class_load         = -1, // jmethodIds are not available
-ticks_GC_active             = -2, // GC action
-ticks_unknown_not_Java      = -3,
-ticks_not_walkable_not_Java = -4,
-ticks_unknown_Java          = -5,
-ticks_not_walkable_Java     = -6,
-ticks_unknown_state         = -7,
-ticks_thread_exit           = -8, // dying thread
-ticks_deopt                 = -9, // mid-deopting code
-ticks_safepoint             = -10
+	ticks_no_Java_frame         =  0, // new thread
+	ticks_no_class_load         = -1, // jmethodIds are not available
+	ticks_GC_active             = -2, // GC action
+	ticks_unknown_not_Java      = -3,
+	ticks_not_walkable_not_Java = -4,
+	ticks_unknown_Java          = -5,
+	ticks_not_walkable_Java     = -6,
+	ticks_unknown_state         = -7,
+	ticks_thread_exit           = -8, // dying thread
+	ticks_deopt                 = -9, // mid-deopting code
+	ticks_safepoint             = -10
 };
 
 typedef struct {
@@ -79,7 +80,6 @@ typedef struct {
 #define J9VM_GET_SP(ucontext) ((ucontext_t*)(ucontext))->uc_mcontext.sp
 #define REGISTER greg_t
 #endif /* defined(J9VM_ARCH_AARCH64) */
-
 
 extern J9JavaVM *BFUjavaVM;
 
@@ -130,7 +130,7 @@ asyncFrameIterator(J9VMThread * currentThread, J9StackWalkState * walkState)
 static UDATA
 emptySignalHandler(J9PortLibrary *portLibrary, U_32 gpType, void *gpInfo, void *handler_arg)
 {
-   return J9PORT_SIG_EXCEPTION_RETURN;
+	return J9PORT_SIG_EXCEPTION_RETURN;
 }
 
 typedef struct {
@@ -217,8 +217,10 @@ protectedASGCT(J9PortLibrary *portLib, void *arg)
 
 #endif /* ASGCT_SUPPORTED */
 
-void AsyncGetCallTrace(ASGCT_CallTrace *trace, jint depth, void *ucontext)
+JNIEXPORT void JNICALL
+AsyncGetCallTrace(void *traceIn, jint depth, void *ucontext)
 {
+	ASGCT_CallTrace *trace = (ASGCT_CallTrace *)traceIn;
 	J9VMThread *currentThread = NULL;
 	jint num_frames = ticks_unknown_not_Java;
 #if defined(ASGCT_SUPPORTED)

--- a/runtime/j9vm/generated.h.m4
+++ b/runtime/j9vm/generated.h.m4
@@ -45,7 +45,7 @@ extern "C" {
 include([helpers.m4])
 dnl (1-name, 2-cc, 3-decorate, 4-ret, 5-args...)
 define([_X],
-[$4 ifelse($2,,,$2 )$1(join([, ],mshift(4,$@)));])
+[JNIEXPORT $4 ifelse($2,,,$2 )$1(join([, ],mshift(4,$@)));])
 
 include([forwarders.m4])dnl
 

--- a/runtime/j9vm/j7verify.c
+++ b/runtime/j9vm/j7verify.c
@@ -28,277 +28,215 @@
 #include <stdlib.h>
 #include <assert.h>
 #include "j9.h"
+#include "jvm.h"
 #include "sunvmi_api.h"
 
-
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxLocalsCount(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxLocalsCount() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPMethodNameUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetCPMethodNameUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxExceptionTableEntry(jint arg0, jint arg1, jint arg2, jint arg3, jint arg4)
 {
 	assert(!"JVM_GetMethodIxExceptionTableEntry() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxExceptionTableLength(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxExceptionTableLength() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxMaxStack(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxMaxStack() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxExceptionIndexes(jint arg0, jint arg1, jint arg2, jint arg3)
 {
 	assert(!"JVM_GetMethodIxExceptionIndexes() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPFieldSignatureUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetCPFieldSignatureUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetClassMethodsCount(jint arg0, jint arg1)
 {
 	assert(!"JVM_GetClassMethodsCount() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetClassFieldsCount(jint arg0, jint arg1)
 {
 	assert(!"JVM_GetClassFieldsCount() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetClassCPTypes(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetClassCPTypes() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetClassCPEntriesCount(jint arg0, jint arg1)
 {
 	assert(!"JVM_GetClassCPEntriesCount() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPMethodSignatureUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetCPMethodSignatureUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPFieldModifiers(jint arg0, jint arg1, jint arg2, jint arg3)
 {
 	assert(!"JVM_GetCPFieldModifiers() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPMethodModifiers(jint arg0, jint arg1, jint arg2, jint arg3)
 {
 	assert(!"JVM_GetCPMethodModifiers() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_IsSameClassPackage(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_IsSameClassPackage() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPMethodClassNameUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetCPMethodClassNameUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPFieldClassNameUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetCPFieldClassNameUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetCPClassNameUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetCPClassNameUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxArgsSize(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxArgsSize() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxModifiers(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxModifiers() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_IsConstructorIx(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_IsConstructorIx() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxByteCodeLength(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxByteCodeLength() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxByteCode(jint arg0, jint arg1, jint arg2, jint arg3)
 {
 	assert(!"JVM_GetMethodIxByteCode() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetFieldIxModifiers(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetFieldIxModifiers() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_FindClassFromClass(jint arg0, jint arg1, jint arg2, jint arg3)
 {
 	assert(!"JVM_FindClassFromClass() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetClassNameUTF(jint arg0, jint arg1)
 {
 	assert(!"JVM_GetClassNameUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxNameUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxNameUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxSignatureUTF(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxSignatureUTF() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetMethodIxExceptionsCount(jint arg0, jint arg1, jint arg2)
 {
 	assert(!"JVM_GetMethodIxExceptionsCount() stubbed!");
 	return NULL;
 }
 
-
-
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_ReleaseUTF(jint arg0)
 {
 	assert(!"JVM_ReleaseUTF() stubbed!");
 	return NULL;
 }
-
-

--- a/runtime/j9vm/j8vmi.c
+++ b/runtime/j9vm/j8vmi.c
@@ -32,6 +32,7 @@
 #include "j9.h"
 #include "omrgcconsts.h"
 #include "j9modifiers_api.h"
+#include "jvm.h"
 #include "j9vm_internal.h"
 #include "j9vmconstantpool.h"
 #include "rommeth.h"
@@ -40,32 +41,37 @@
 #include "ut_j9scar.h"
 #include "j9vmnls.h"
 
-jbyteArray JNICALL
-JVM_GetClassTypeAnnotations(JNIEnv *env, jclass jlClass) {
+JNIEXPORT jbyteArray JNICALL
+JVM_GetClassTypeAnnotations(JNIEnv *env, jclass jlClass)
+{
 	ENSURE_VMI();
 	return g_VMI->JVM_GetClassTypeAnnotations(env, jlClass);
 }
 
-jbyteArray JNICALL
-JVM_GetFieldTypeAnnotations(JNIEnv *env, jobject jlrField) {
+JNIEXPORT jbyteArray JNICALL
+JVM_GetFieldTypeAnnotations(JNIEnv *env, jobject jlrField)
+{
 	ENSURE_VMI();
 	return g_VMI->JVM_GetFieldTypeAnnotations(env, jlrField);
 }
 
-jobjectArray JNICALL
-JVM_GetMethodParameters(JNIEnv *env, jobject jlrExecutable) {
+JNIEXPORT jobjectArray JNICALL
+JVM_GetMethodParameters(JNIEnv *env, jobject jlrExecutable)
+{
 	ENSURE_VMI();
 	return g_VMI->JVM_GetMethodParameters(env, jlrExecutable);
 }
 
-jbyteArray JNICALL
-JVM_GetMethodTypeAnnotations(JNIEnv *env, jobject jlrMethod) {
+JNIEXPORT jbyteArray JNICALL
+JVM_GetMethodTypeAnnotations(JNIEnv *env, jobject jlrMethod)
+{
 	ENSURE_VMI();
 	return g_VMI->JVM_GetMethodTypeAnnotations(env, jlrMethod);
 }
 
-jboolean JNICALL
-JVM_IsVMGeneratedMethodIx(JNIEnv *env, jclass cb, jint index) {
+JNIEXPORT jboolean JNICALL
+JVM_IsVMGeneratedMethodIx(JNIEnv *env, jclass cb, jint index)
+{
 	assert(!"JVM_IsVMGeneratedMethodIx unimplemented"); /* Jazz 63527: Stub in APIs for Java 8 */
 	return FALSE;
 }
@@ -77,7 +83,7 @@ JVM_IsVMGeneratedMethodIx(JNIEnv *env, jclass cb, jint index) {
  *
  * @return String object representing the platform specific temporary directory.
  */
-jstring JNICALL
+JNIEXPORT jstring JNICALL
 JVM_GetTemporaryDirectory(JNIEnv *env)
 {
 	PORT_ACCESS_FROM_ENV(env);
@@ -87,7 +93,6 @@ JVM_GetTemporaryDirectory(JNIEnv *env)
 	j9mem_free_memory(tempBuf);
 	return result;
 }
-
 
 /**
  * Copies memory from one place to another, endian flipping the data.
@@ -107,7 +112,7 @@ JVM_GetTemporaryDirectory(JNIEnv *env)
  * elemSize = 4 means byte order 1,2,3,4 becomes 4,3,2,1
  * elemSize = 8 means byte order 1,2,3,4,5,6,7,8 becomes 8,7,6,5,4,3,2,1
  */
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_CopySwapMemory(JNIEnv *env, jobject srcObj, jlong srcOffset, jobject dstObj, jlong dstOffset, jlong size, jlong elemSize)
 {
 	U_8 *srcBytes = NULL;
@@ -132,7 +137,7 @@ JVM_CopySwapMemory(JNIEnv *env, jobject srcObj, jlong srcOffset, jobject dstObj,
 	/* First copy the bytes unmodified to the new location (memmove handles the overlap case) */
 	memmove(dstAddr, srcBytes + (UDATA)srcOffset, (size_t)size);
 	/* Now flip each element in the destination */
-	switch(elemSize) {
+	switch (elemSize) {
 	case 2: {
 		jlong elemCount = size / 2;
 		while (0 != elemCount) {

--- a/runtime/j9vm/java11vmi.c
+++ b/runtime/j9vm/java11vmi.c
@@ -24,6 +24,7 @@
 #include "vm_api.h"
 #include "j2sever.h"
 #include "j9.h"
+#include "jvm.h"
 #include "hashtable_api.h"
 #include "../util/ut_module.h"
 #undef UT_MODULE_LOADED
@@ -869,7 +870,7 @@ allowReadAccessToModule(J9VMThread * currentThread, J9Module * fromModule, J9Mod
  *
  * @return If successful, returns a java.lang.reflect.Module object. Otherwise, returns NULL.
  */
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 #if JAVA_SPEC_VERSION >= 15
 JVM_DefineModule(JNIEnv * env, jobject module, jboolean isOpen, jstring version, jstring location, jobjectArray packageArray)
 #else
@@ -1114,11 +1115,10 @@ done:
  * 4) Package is not defined for fromModule's class loader
  * 5) Package is not in module fromModule.
  */
+JNIEXPORT void JNICALL
 #if JAVA_SPEC_VERSION >= 15
-void JNICALL
 JVM_AddModuleExports(JNIEnv * env, jobject fromModule, jstring packageObj, jobject toModule)
 #else
-void JNICALL
 JVM_AddModuleExports(JNIEnv * env, jobject fromModule, const char *package, jobject toModule)
 #endif /* JAVA_SPEC_VERSION >= 15 */
 {
@@ -1194,11 +1194,10 @@ done:
  * 3) Package is not defined for fromModule's class loader
  * 4) Package is not in module fromModule.
  */
+JNIEXPORT void JNICALL
 #if JAVA_SPEC_VERSION >= 15
-void JNICALL
 JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, jstring packageObj)
 #else
-void JNICALL
 JVM_AddModuleExportsToAll(JNIEnv * env, jobject fromModule, const char *package)
 #endif /* JAVA_SPEC_VERSION >= 15 */
 {
@@ -1294,8 +1293,8 @@ trcModulesAddReadsModule(J9VMThread *currentThread, jobject toModule, J9Module *
  * @throws IllegalArgumentExceptions if
  * 1) if fromModule is null or if modules do not exist.
  */
-void JNICALL
-JVM_AddReadsModule(JNIEnv * env, jobject fromModule, jobject toModule)
+JNIEXPORT void JNICALL
+JVM_AddReadsModule(JNIEnv *env, jobject fromModule, jobject toModule)
 {
 	if (fromModule != toModule) {
 		J9VMThread * const currentThread = (J9VMThread*)env;
@@ -1336,7 +1335,7 @@ JVM_AddReadsModule(JNIEnv * env, jobject fromModule, jobject toModule)
  * @throws IllegalArgumentExceptions if
  * 1) either askModule or srcModule is not a java.lang.reflect.Module
  */
-jboolean JNICALL
+JNIEXPORT jboolean JNICALL
 JVM_CanReadModule(JNIEnv * env, jobject askModule, jobject srcModule)
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
@@ -1387,7 +1386,7 @@ trcModulesAddModulePackage(J9VMThread *currentThread, J9Module *j9mod, const cha
  * 3) Package is not syntactically correct
  * 4) Package is already defined for module's class loader.
  */
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_AddModulePackage(JNIEnv * env, jobject module, const char *package)
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
@@ -1419,12 +1418,11 @@ JVM_AddModulePackage(JNIEnv * env, jobject module, const char *package)
  * 2) module is unnamed or
  * 3) package is not in module
  */
+JNIEXPORT void JNICALL
 #if JAVA_SPEC_VERSION >= 15
-void JNICALL
-JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, jstring packageObj)
+JVM_AddModuleExportsToAllUnnamed(JNIEnv *env, jobject fromModule, jstring packageObj)
 #else
-void JNICALL
-JVM_AddModuleExportsToAllUnnamed(JNIEnv * env, jobject fromModule, const char *package)
+JVM_AddModuleExportsToAllUnnamed(JNIEnv *env, jobject fromModule, const char *package)
 #endif /* JAVA_SPEC_VERSION >= 15 */
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
@@ -1484,20 +1482,20 @@ done:
 	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
-jstring JNICALL
+JNIEXPORT jstring JNICALL
 JVM_GetSimpleBinaryName(JNIEnv *env, jclass arg1)
 {
 	assert(!"JVM_GetSimpleBinaryName unimplemented"); /* Jazz 108925: Revive J9JCL raw pConfig build */
 	return NULL;
 }
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_SetMethodInfo(JNIEnv *env, jobject arg1)
 {
 	assert(!"JVM_SetMethodInfo unimplemented"); /* Jazz 108925: Revive J9JCL raw pConfig build */
 }
 
-jint JNICALL
+JNIEXPORT jint JNICALL
 #if JAVA_SPEC_VERSION < 26
 JVM_ConstantPoolGetNameAndTypeRefIndexAt(JNIEnv *env, jobject arg1, jobject arg2, jint arg3)
 #else /* JAVA_SPEC_VERSION < 26 */
@@ -1508,7 +1506,7 @@ JVM_ConstantPoolGetNameAndTypeRefIndexAt(JNIEnv *env, jobject arg1, jint arg2)
 	return -1;
 }
 
-jint JNICALL
+JNIEXPORT jint JNICALL
 #if JAVA_SPEC_VERSION >= 22
 JVM_MoreStackWalk(JNIEnv *env, jobject arg1, jint arg2, jlong arg3, jint arg4, jint arg5, jint arg6, jobjectArray arg7, jobjectArray arg8)
 #else /* JAVA_SPEC_VERSION >= 22 */
@@ -1519,7 +1517,7 @@ JVM_MoreStackWalk(JNIEnv *env, jobject arg1, jlong arg2, jlong arg3, jint arg4, 
 	return -1;
 }
 
-jint JNICALL
+JNIEXPORT jint JNICALL
 #if JAVA_SPEC_VERSION < 26
 JVM_ConstantPoolGetClassRefIndexAt(JNIEnv *env, jobject arg1, jobject arg2, jint arg3)
 #else /* JAVA_SPEC_VERSION < 26 */
@@ -1530,7 +1528,7 @@ JVM_ConstantPoolGetClassRefIndexAt(JNIEnv *env, jobject arg1, jint arg2)
 	return -1;
 }
 
-jobjectArray JNICALL
+JNIEXPORT jobjectArray JNICALL
 JVM_GetVmArguments(JNIEnv *env)
 {
 	J9VMThread* currentThread = (J9VMThread*)env;
@@ -1573,20 +1571,20 @@ success:
 	return result;
 }
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_FillStackFrames(JNIEnv *env, jclass arg1, jint arg2, jobjectArray arg3, jint arg4, jint arg5)
 {
 	assert(!"JVM_FillStackFrames unimplemented"); /* Jazz 108925: Revive J9JCL raw pConfig build */
 }
 
-jclass JNICALL
+JNIEXPORT jclass JNICALL
 JVM_FindClassFromCaller(JNIEnv* env, const char* arg1, jboolean arg2, jobject arg3, jclass arg4)
 {
 	assert(!"JVM_FindClassFromCaller unimplemented"); /* Jazz 108925: Revive J9JCL raw pConfig build */
 	return NULL;
 }
 
-jobjectArray JNICALL
+JNIEXPORT jobjectArray JNICALL
 #if JAVA_SPEC_VERSION < 26
 JVM_ConstantPoolGetNameAndTypeRefInfoAt(JNIEnv *env, jobject arg1, jobject arg2, jint arg3)
 #else /* JAVA_SPEC_VERSION < 26 */
@@ -1597,7 +1595,7 @@ JVM_ConstantPoolGetNameAndTypeRefInfoAt(JNIEnv *env, jobject arg1, jint arg2)
 	return NULL;
 }
 
-jbyte JNICALL
+JNIEXPORT jbyte JNICALL
 #if JAVA_SPEC_VERSION < 26
 JVM_ConstantPoolGetTagAt(JNIEnv *env, jobject arg1, jobject arg2, jint arg3)
 #else /* JAVA_SPEC_VERSION < 26 */
@@ -1608,7 +1606,7 @@ JVM_ConstantPoolGetTagAt(JNIEnv *env, jobject arg1, jint arg2)
 	return 0;
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 #if JAVA_SPEC_VERSION >= 22
 JVM_CallStackWalk(JNIEnv *env, jobject arg1, jint arg2, jint arg3, jint arg4, jint arg5, jobjectArray arg6, jobjectArray arg7)
 #else /* JAVA_SPEC_VERSION >= 22 */
@@ -1654,7 +1652,7 @@ JVM_WaitForReferencePendingList(JNIEnv *env)
  *
  * @throws NullPointerException if module is NULL
  */
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_SetBootLoaderUnnamedModule(JNIEnv *env, jobject module)
 {
 	J9VMThread * const currentThread = (J9VMThread*)env;
@@ -1726,26 +1724,26 @@ JVM_SetBootLoaderUnnamedModule(JNIEnv *env, jobject module)
 	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_ToStackTraceElement(JNIEnv* env, jobject arg1, jobject arg2)
 {
 	assert(!"JVM_ToStackTraceElement unimplemented");
 }
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_GetStackTraceElements(JNIEnv *env, jobject throwable, jobjectArray elements)
 {
 	assert(!"JVM_GetStackTraceElements unimplemented");
 }
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_InitStackTraceElementArray(JNIEnv *env, jobjectArray elements, jobject throwable)
 {
 	assert(!"JVM_InitStackTraceElementArray unimplemented");
 }
 
-void JNICALL
-JVM_InitStackTraceElement(JNIEnv* env, jobject element, jobject stackFrameInfo)
+JNIEXPORT void JNICALL
+JVM_InitStackTraceElement(JNIEnv *env, jobject element, jobject stackFrameInfo)
 {
 	assert(!"JVM_InitStackTraceElement unimplemented");
 }
@@ -1759,7 +1757,7 @@ JVM_InitStackTraceElement(JNIEnv* env, jobject element, jobject stackFrameInfo)
  *
  * @return nanoSeconds, -1 on failure
  */
-jlong JNICALL
+JNIEXPORT jlong JNICALL
 JVM_GetNanoTimeAdjustment(JNIEnv *env, jclass clazz, jlong offsetSeconds)
 {
 	PORT_ACCESS_FROM_ENV(env);
@@ -1857,6 +1855,7 @@ done:
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
 #if JAVA_SPEC_VERSION >= 15
+
 JNIEXPORT void JNICALL
 JVM_RegisterLambdaProxyClassForArchiving(JNIEnv *env, jclass arg1, jstring arg2, jobject arg3, jobject arg4, jobject arg5, jobject arg6, jclass arg7)
 {
@@ -1878,6 +1877,7 @@ JVM_IsCDSDumpingEnabled(JNIEnv *env)
 	return JNI_FALSE;
 }
 #endif /* JAVA_SPEC_VERSION < 23 */
+
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
 #if JAVA_SPEC_VERSION >= 16
@@ -1890,6 +1890,7 @@ JVM_GetRandomSeedForDumping()
 }
 
 #if JAVA_SPEC_VERSION < 23
+
 JNIEXPORT jboolean JNICALL
 JVM_IsDumpingClassList(JNIEnv *env)
 {
@@ -1902,7 +1903,9 @@ JVM_IsSharingEnabled(JNIEnv *env)
 	/* OpenJ9 does not support CDS, so we return false unconditionally. */
 	return JNI_FALSE;
 }
+
 #endif /* JAVA_SPEC_VERSION < 23 */
+
 #endif /* JAVA_SPEC_VERSION >= 16 */
 
 /**

--- a/runtime/j9vm/javanextvmi.cpp
+++ b/runtime/j9vm/javanextvmi.cpp
@@ -26,6 +26,7 @@
 #include "bcverify_api.h"
 #include "j9.h"
 #include "j9cfg.h"
+#include "jvm.h"
 #include "jvminit.h"
 #include "rommeth.h"
 #include "ut_j9scar.h"

--- a/runtime/j9vm/jvm.c
+++ b/runtime/j9vm/jvm.c
@@ -51,6 +51,7 @@
 #include "j9cp.h"
 #include "j2sever.h"
 #include "j2senls.h"
+#include "jvm.h"
 #include "hashtable_api.h"
 #include "rommeth.h"
 #include "util_api.h"

--- a/runtime/j9vm/valhallavmi.cpp
+++ b/runtime/j9vm/valhallavmi.cpp
@@ -23,6 +23,7 @@
 #include <assert.h>
 #include <jni.h>
 #include "j9.h"
+#include "jvm.h"
 #include "VMHelpers.hpp"
 
 extern "C" {

--- a/runtime/j9vm/vmi.c
+++ b/runtime/j9vm/vmi.c
@@ -28,6 +28,7 @@
 
 #include <stdlib.h>
 #include "j9.h"
+#include "jvm.h"
 #include "sunvmi_api.h"
 
 #include "../util/ut_module.h"
@@ -58,14 +59,14 @@ initializeVMI(void)
 	}
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_LatestUserDefinedLoader(JNIEnv *env)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_LatestUserDefinedLoader(env);
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 #if JAVA_SPEC_VERSION >= 11
 JVM_GetCallerClass(JNIEnv *env)
 #else /* JAVA_SPEC_VERSION >= 11 */
@@ -80,14 +81,14 @@ JVM_GetCallerClass(JNIEnv *env, jint depth)
 #endif /* JAVA_SPEC_VERSION >= 11 */
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_NewInstanceFromConstructor(JNIEnv *env, jobject c, jobjectArray args)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_NewInstanceFromConstructor(env, c, args);
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_InvokeMethod(JNIEnv *env, jobject method, jobject obj, jobjectArray args)
 {
 	ENSURE_VMI();
@@ -95,7 +96,7 @@ JVM_InvokeMethod(JNIEnv *env, jobject method, jobject obj, jobjectArray args)
 }
 
 #if JAVA_SPEC_VERSION < 26
-jint JNICALL
+JNIEXPORT jint JNICALL
 JVM_GetClassAccessFlags(JNIEnv *env, jclass clazzRef)
 {
 	ENSURE_VMI();
@@ -104,7 +105,7 @@ JVM_GetClassAccessFlags(JNIEnv *env, jclass clazzRef)
 #endif /* JAVA_SPEC_VERSION < 26 */
 
 #if JAVA_SPEC_VERSION < 24
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetClassContext(JNIEnv *env)
 {
 	ENSURE_VMI();
@@ -112,21 +113,21 @@ JVM_GetClassContext(JNIEnv *env)
 }
 #endif /* JAVA_SPEC_VERSION < 24 */
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_Halt(jint exitCode)
 {
 	ENSURE_VMI();
 	g_VMI->JVM_Halt(exitCode);
 }
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_GCNoCompact(void)
 {
 	ENSURE_VMI();
 	g_VMI->JVM_GCNoCompact();
 }
 
-void JNICALL
+JNIEXPORT void JNICALL
 JVM_GC(void)
 {
 	ENSURE_VMI();
@@ -136,21 +137,21 @@ JVM_GC(void)
 /**
  * JVM_TotalMemory
  */
-jlong JNICALL
+JNIEXPORT jlong JNICALL
 JVM_TotalMemory(void)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_TotalMemory();
 }
 
-jlong JNICALL
+JNIEXPORT jlong JNICALL
 JVM_FreeMemory(void)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_FreeMemory();
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetSystemPackages(JNIEnv *env)
 {
 	ENSURE_VMI();
@@ -172,50 +173,51 @@ JVM_GetSystemPackages(JNIEnv *env)
  *
  * @note see CMVC defects 81175 and 92979
  */
-jstring JNICALL
+JNIEXPORT jstring JNICALL
 JVM_GetSystemPackage(JNIEnv *env, jstring pkgName)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetSystemPackage(env, pkgName);
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_AllocateNewObject(JNIEnv *env, jclass caller, jclass current, jclass init)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_AllocateNewObject(env, caller, current, init);
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_AllocateNewArray(JNIEnv *env, jclass caller, jclass current, jint length)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_AllocateNewArray(env, caller, current, length);
 }
 
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_GetClassLoader(JNIEnv *env, jobject obj)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetClassLoader(env, obj);
 }
 
-void * JNICALL
+JNIEXPORT void * JNICALL
 JVM_GetThreadInterruptEvent(void)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_GetThreadInterruptEvent();
 }
 
-jlong JNICALL
+JNIEXPORT jlong JNICALL
 JVM_MaxObjectInspectionAge(void)
 {
 	ENSURE_VMI();
 	return g_VMI->JVM_MaxObjectInspectionAge();
 }
 
-jlong JNICALL
-JVM_MaxMemory(void) {
+JNIEXPORT jlong JNICALL
+JVM_MaxMemory(void)
+{
 	ENSURE_VMI();
 	return g_VMI->JVM_MaxMemory();
 }

--- a/runtime/redirector/generated.c.m4
+++ b/runtime/redirector/generated.c.m4
@@ -113,7 +113,7 @@ JVM_OnExit(void (*func)(void))
 dnl (1-name, 2-cc, 3-decorate, 4-ret, 5-args...)
 define([_X],
 [dnl
-$4 $2
+JNIEXPORT ifelse($2,,$4,$4 $2)
 $1(join([, ],mshift(4,$@)))
 {
 	while (NULL == global_$1) {
@@ -171,7 +171,7 @@ include([forwarders.m4])dnl
 #endif /* defined(AIXPPC) */
 }
 
-void * JNICALL
+JNIEXPORT void * JNICALL
 JVM_LoadSystemLibrary(const char *libName)
 {
 	int count = 0;
@@ -232,7 +232,7 @@ retry:
  *  sun.jvm.flags = vm arguments passed to the launcher
  *  sun.jvm.args =
  */
-jobject JNICALL
+JNIEXPORT jobject JNICALL
 JVM_InitAgentProperties(JNIEnv *env, jobject agent_props)
 {
 	/* CMVC 150259 : Assert in JDWP Agent


### PR DESCRIPTION
Include `jvm.h` so compilers can verify signatures are consistent.

Addresses build failures for https://github.com/eclipse-openj9/openj9/pull/23664.