### PR TITLE
Add stub implementation for getAllEventClasses

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
+++ b/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
@@ -25,6 +25,9 @@ package java.lang;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -309,6 +312,13 @@ final class JFRHelpers {
 	private static byte[] transformClassAndInvokebytesForEagerInstrumentation(long traceId, boolean forceInstrumentation, Class<?> superClass, byte[] oldBytes, boolean addMethods) throws ReflectiveOperationException {
 		oldBytes = JFRClassTransformer.transformClass(oldBytes, addMethods);
 		return (byte[])bytesForEagerInstrumentation.invoke(null, traceId, forceInstrumentation, superClass, oldBytes);
+	}
+
+	private static List<?> transformToList(Object[] array) {
+		if (array == null) {
+			return Collections.emptyList();
+		}
+		return Arrays.asList(array);
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION == 17 */
 

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -81,8 +81,16 @@ Java_jdk_jfr_internal_JVM_endRecording(JNIEnv *env, jobject obj)
 jobject JNICALL
 Java_jdk_jfr_internal_JVM_getAllEventClasses(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return NULL;
+	J9VMThread *currentThread = (J9VMThread*) env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	jobject result = NULL;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	result = vmFuncs->j9jni_createLocalRef(env, vmFuncs->jvmUpcallTransformArrayToList(currentThread, NULL));
+	vmFuncs->internalExitVMToJNI(currentThread);
+
+	return result;
 }
 
 jlong JNICALL

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5637,6 +5637,7 @@ typedef struct J9InternalVMFunctions {
 	jlong (*getTypeIdUTF8)(struct J9VMThread *currentThread, struct J9ClassLoader *classLoader, struct J9UTF8 *className, BOOLEAN freeName);
 	jlong (*getTypeId)(struct J9VMThread *currentThread, struct J9Class *clazz);
 	void (*jvmUpcallsEagerByteInstrumentation)(struct J9VMThread *currentThread, struct J9Class *superClass, U_8 *className, U_16 classNameLength, struct J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
+	j9object_t (*jvmUpcallTransformArrayToList)(struct J9VMThread *currentThread, j9object_t array);
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	void (*initializeSnapshotClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);
@@ -6164,6 +6165,7 @@ typedef struct JFRState {
 	jclass jfrInternalEventClassRef;
 	jclass jfrEventClassRef;
 	J9Method *onRetransformUpcallMethod;
+	J9Method *transformToListMethod;
 } JFRState;
 
 typedef struct J9ReflectFunctionTable {

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5913,6 +5913,18 @@ shutdownJFRIDs(J9JavaVM *vm);
 void
 jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClass, U_8 *className, U_16 classNameLength, J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 
+/**
+ * Call the JFR transform array to list method to transform an array to a list. Current exception will
+ * be set if there is a failure.
+ *
+ * @param currentThread[in] the current J9VMThread
+ * @param array[in] the array to transform
+ *
+ * @return the transformed list
+ */
+j9object_t
+jvmUpcallTransformArrayToList(J9VMThread *currentThread, j9object_t array);
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 #ifdef __cplusplus

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -483,6 +483,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	getTypeIdUTF8,
 	getTypeId,
 	jvmUpcallsEagerByteInstrumentation,
+	jvmUpcallTransformArrayToList,
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	initializeSnapshotClassLoaderObject,

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -44,6 +44,9 @@ J9_DECLARE_CONSTANT_UTF8(jfrHelpersUTF8, "java/lang/JFRHelpers");
 J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationUTF8, "transformClassAndInvokebytesForEagerInstrumentation");
 J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationSigUTF8, "(JZLjava/lang/Class;[BZ)[B");
 J9_DECLARE_CONSTANT_NAS(bytesForEagerInstrumentationNAS, bytesForEagerInstrumentationUTF8, bytesForEagerInstrumentationSigUTF8);
+J9_DECLARE_CONSTANT_UTF8(transformToListUTF8, "transformToList");
+J9_DECLARE_CONSTANT_UTF8(transformToListSigUTF8, "([Ljava/lang/Object;)Ljava/util/List;");
+J9_DECLARE_CONSTANT_NAS(transformToListNAS, transformToListUTF8, transformToListSigUTF8);
 
 // TODO: allow configureable values
 #define J9JFR_THREAD_BUFFER_SIZE (1024*1024)
@@ -1592,6 +1595,32 @@ done:
 popInputArrayAndDone:
 	inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
 	goto done;
+}
+
+j9object_t
+jvmUpcallTransformArrayToList(J9VMThread *currentThread, j9object_t array)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	j9object_t result = NULL;
+	UDATA args[1];
+
+	if (NULL == vm->jfrState.transformToListMethod) {
+		J9Class *jfrHelpersClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrHelpersUTF8), J9UTF8_LENGTH(&jfrHelpersUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+
+		vm->jfrState.transformToListMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrHelpersClass, (J9ROMNameAndSignature *)&transformToListNAS, jfrHelpersClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
+		if (NULL == vm->jfrState.transformToListMethod) {
+			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+			goto done;
+		}
+	}
+
+	args[0] = (UDATA)array;
+	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.transformToListMethod, TRUE, 1, args);
+	result = (j9object_t)currentThread->returnValue;
+
+done:
+	return result;
 }
 
 


### PR DESCRIPTION
JVM_getAllEventClasses returns all JFR event classes in the ssytem. This
is used by the JFR subsystem to determine which events are available. It
is also used during JFR subsystem initialization for event config.

This PR adds a stub implementation that returns an empty array to make
further progress in the JFR subsystem initialization while
https://github.com/eclipse-openj9/openj9/issues/23692 is being worked
on.