### PR TITLE
Valhalla JVM method signature update

### DIFF
--- a/runtime/j9vm/valhallavmi.cpp
+++ b/runtime/j9vm/valhallavmi.cpp
@@ -87,14 +87,14 @@ done:
 }
 
 JNIEXPORT jboolean JNICALL
-JVM_IsAtomicArray(JNIEnv *env, jobject obj)
+JVM_IsAtomicArray(JNIEnv *env, jarray obj)
 {
 	/* J9 doesn't currently support non-atomic arrays. */
 	return JNI_TRUE;
 }
 
 JNIEXPORT jboolean JNICALL
-JVM_IsFlatArray(JNIEnv *env, jobject obj)
+JVM_IsFlatArray(JNIEnv *env, jarray obj)
 {
 	jboolean result = JNI_FALSE;
 	J9VMThread *currentThread = (J9VMThread *)env;
@@ -113,7 +113,7 @@ JVM_IsFlatArray(JNIEnv *env, jobject obj)
 }
 
 JNIEXPORT jboolean JNICALL
-JVM_IsNullRestrictedArray(JNIEnv *env, jobject obj)
+JVM_IsNullRestrictedArray(JNIEnv *env, jarray obj)
 {
 	jboolean result = JNI_FALSE;
 	J9VMThread *currentThread = (J9VMThread *)env;

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -466,11 +466,11 @@ _IF([(21 <= JAVA_SPEC_VERSION) && (JAVA_SPEC_VERSION < 26)],
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_CopyOfSpecialArray, JNICALL, false, jarray, JNIEnv *env, jarray orig, jint from, jint to)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
-	[_X(JVM_IsAtomicArray, JNICALL, false, jboolean, JNIEnv *env, jobject obj)])
+	[_X(JVM_IsAtomicArray, JNICALL, false, jboolean, JNIEnv *env, jarray obj)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
-	[_X(JVM_IsFlatArray, JNICALL, false, jboolean, JNIEnv *env, jclass cls)])
+	[_X(JVM_IsFlatArray, JNICALL, false, jboolean, JNIEnv *env, jarray obj)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
-	[_X(JVM_IsNullRestrictedArray, JNICALL, false, jboolean, JNIEnv *env, jobject obj)])
+	[_X(JVM_IsNullRestrictedArray, JNICALL, false, jboolean, JNIEnv *env, jarray obj)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],


### PR DESCRIPTION
Valhalla JVM method signature update

Match the `JNIEXPORT` signatures in `jvm.h` and also the upstream updates.

This addresses the [compilation failure](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Build_JDKnext_x86-64_linux_valhalla_Nightly/2225/consoleFull):
```
21:31:36  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/openj9/runtime/j9vm/valhallavmi.cpp:97:1: error: conflicting declaration of C function ‘jboolean JVM_IsFlatArray(JNIEnv*, jobject)’
21:31:36     97 | JVM_IsFlatArray(JNIEnv *env, jobject obj)
21:31:36        | ^~~~~~~~~~~~~~~
21:31:36  In file included from /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/openj9/runtime/j9vm/jvm.h:253,
21:31:36                   from /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/openj9/runtime/j9vm/valhallavmi.cpp:26:
21:31:36  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/build/linux-x86_64-server-release/vm/runtime/j9vm/generated.h:628:28: note: previous declaration ‘jboolean JVM_IsFlatArray(JNIEnv*, jclass)’
21:31:36    628 | JNIEXPORT jboolean JNICALL JVM_IsFlatArray(JNIEnv *env, jclass cls);
21:31:36        |                            ^~~~~~~~~~~~~~~
21:31:36  gmake[6]: *** [runtime/j9vm/CMakeFiles/jvm.dir/valhallavmi.cpp.o] Error 1
```

Verified via [a personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/2689/console)

Signed-off-by: Jason Feng <fengj@ca.ibm.com>