### PR TITLE
Add missing instanceof validation for findSingleProfiledReceiver

### DIFF
--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -1134,8 +1134,15 @@ void TR_ProfileableCallSite::findSingleProfiledReceiver(ListIterator<TR_ExtraAdd
             // need to be able to store class chains for these methods
             if (comp()->compileRelocatableCode()) {
                 if (tempreceiverClass && comp()->getOption(TR_UseSymbolValidationManager)) {
+                    // Add Profiled Class Validation
                     if (!comp()->getSymbolValidationManager()->addProfiledClassRecord(tempreceiverClass))
                         continue;
+
+                    // Add instanceof relationship
+                    if (!comp()->getSymbolValidationManager()->addClassInstanceOfClassRecord(tempreceiverClass,
+                            callSiteClass, true, true, true))
+                        continue;
+
                     /* call getResolvedMethod again to generate the validation records */
                     TR_ResolvedMethod *target_method = getResolvedMethod(tempreceiverClass);
 


### PR DESCRIPTION
The code
```
                profiledClassIsNotInstanceOfCallSiteClass
                    = (fe()->isInstanceOf(tempreceiverClass, callSiteClass, true, true, true) != TR_yes);
```
in `TR_ProfileableCallSite::findSingleProfiledReceiver` is wrapped in a heuristic region, which prevents a SVM validation record from being generated. This is because at this point, it isn't clear whether the `tempreceiverClass` will be used. Once it is certain to be used, a validation record must be generated.