### PR TITLE
Move KeyHashTableClassEntry typedef to a dedicated header

### DIFF
--- a/runtime/ddr/vmddrstructs.properties
+++ b/runtime/ddr/vmddrstructs.properties
@@ -52,6 +52,7 @@ omrhashtable.h,\
 omrhookable.h,\
 j9modifiers_api.h,\
 j9nonbuilder.h,\
+KeyHashTable.h,\
 j9javaaccessflags.h,\
 j9nongenerated.h,\
 omrthread_generated.h,\

--- a/runtime/vm/KeyHashTable.c
+++ b/runtime/vm/KeyHashTable.c
@@ -27,6 +27,7 @@
 #include "j9port_generated.h"
 #endif /* defined(J9VM_OPT_SNAPSHOTS) */
 #include "j9protos.h"
+#include "KeyHashTable.h"
 #include "vm_internal.h"
 #include "ut_j9vm.h"
 
@@ -36,13 +37,6 @@
 
 #define ROUNDING_GRANULARITY    4
 #define ROUNDED_BYTE_AMOUNT(number)  (((number) + (ROUNDING_GRANULARITY - 1)) & ~(UDATA)(ROUNDING_GRANULARITY - 1))
-
-typedef union KeyHashTableClassEntry {
-	UDATA tag;
-	J9Class *ramClass;
-	J9PackageIDTableEntry packageID;
-	J9UTF8 *className;
-} KeyHashTableClassEntry;
 
 typedef struct KeyHashTableClassQueryEntry {
 	KeyHashTableClassEntry entry;

--- a/runtime/vm/KeyHashTable.h
+++ b/runtime/vm/KeyHashTable.h
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#ifndef KEYHHASHTABLE_H_
+#define KEYHHASHTABLE_H_
+
+#include "j9nonbuilder.h"
+
+typedef union KeyHashTableClassEntry {
+	UDATA tag;
+	struct J9Class *ramClass;
+	J9PackageIDTableEntry packageID;
+	struct J9UTF8 *className;
+} KeyHashTableClassEntry;
+
+#endif /* KEYHHASHTABLE_H_ */


### PR DESCRIPTION
The type was defined only in KeyHashTable.c, making it invisible to the legacy DDR toolchain. This caused !walkj9hashtable called with type KeyHashTableClassEntry to fail with:

  DDRInteractiveCommandException: Unrecognized type 'KeyHashTableClassEntry'

Move the typedef to keyhhashtableclassentry.h and add it to vmddrstructs.properties so the type is visible to the legacy DDR toolchain.

Fixes: #23766