### PR TITLE
Increase SCC disclaim frequency if many AOT loads

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1520,6 +1520,10 @@ public:
 #endif /* defined(J9VM_OPT_JITSERVER) */
     static const uint32_t MAX_DIAGNOSTIC_COMP_THREADS = 1;
 
+    uint32_t getNumAotedMethods() const { return _statNumAotedMethods; }
+
+    uint32_t getNumMethodsFromSharedCache() const { return _statNumMethodsFromSharedCache; }
+
 private:
     enum {
         JITA2N_EXTENDED_DATA_EYE_CATCHER = 0xCCCCCCCC,

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4490,10 +4490,21 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
     TR_J9VMBase *fej9 = TR_J9VMBase::get(jitConfig, compInfo->getSamplerThread(), TR_J9VMBase::AOT_VM);
     TR_J9SharedCache *sharedCache = fej9->sharedCache();
     if (sharedCache && sharedCache->isDisclaimEnabled()) {
-        // Disclaim if there was a large time interval since the last disclaim
+        // Ensure we don't do it too often
         if (crtElapsedTime > lastSCCDisclaimTime + TR::Options::_minTimeBetweenSCCDisclaims) {
-            disclaimSharedClassCache(sharedCache, crtElapsedTime);
-            lastSCCDisclaimTime = crtElapsedTime;
+            // Disclaim if there were many AOT compilations/loads since the last disclaim
+            // or if there was a large time interval since the last disclaim
+            static uint32_t oldTotalAOT = 0;
+            uint32_t crtTotalAOT = compInfo->getNumAotedMethods() + compInfo->getNumMethodsFromSharedCache();
+            static const char *TR_AOTLoadThresholdForSCCDisclaim = feGetEnv("TR_AOTLoadThresholdForSCCDisclaim");
+            static int32_t aotLoadThresholdForSCCDisclaim
+                = TR_AOTLoadThresholdForSCCDisclaim ? atoi(TR_AOTLoadThresholdForSCCDisclaim) : 300;
+            if (crtTotalAOT > oldTotalAOT + aotLoadThresholdForSCCDisclaim
+                || crtElapsedTime > lastSCCDisclaimTime + 4 * (uint64_t)TR::Options::_minTimeBetweenSCCDisclaims) {
+                disclaimSharedClassCache(sharedCache, crtElapsedTime);
+                lastSCCDisclaimTime = crtElapsedTime;
+                oldTotalAOT = crtTotalAOT;
+            }
         }
     }
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && defined(LINUX)

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -237,7 +237,7 @@ int32_t J9::Options::_TLHPrefetchTLHEndLineCount = 0;
 
 uint32_t J9::Options::_minDiskSpaceForDisclaimMB = 1024; // 1 GB
 int32_t J9::Options::_minTimeBetweenMemoryDisclaims = 5000; // ms (for non-SCC memory areas)
-int32_t J9::Options::_minTimeBetweenSCCDisclaims = 10000; // ms (for Shared Class Cache)
+int32_t J9::Options::_minTimeBetweenSCCDisclaims = 3000; // ms (for Shared Class Cache)
 uint32_t J9::Options::_maxDeviceLatencyForDisclaimUs = 1500; // us (disable disclaiming to slow devices)
 int32_t J9::Options::_mallocTrimPeriod = 0; // seconds; 0 means disabled
 
@@ -1166,7 +1166,7 @@ TR::OptionTable OMR::Options::_feOptions[] = {
      TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_minTimeBetweenMemoryDisclaims, 500, "F%d",
      NOT_IN_SUBSET },
     { "minTimeBetweenSCCDisclaims=", "M<nnn>\tMinimum time (ms) between two consecutive SCC disclaim operations",
-     TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_minTimeBetweenSCCDisclaims, 10000, "F%d",
+     TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_minTimeBetweenSCCDisclaims, 3000, "F%d",
      NOT_IN_SUBSET },
     { "noregmap", 0, RESET_JITCONFIG_RUNTIME_FLAG(J9JIT_CG_REGISTER_MAPS) },
     { "numCodeCachesOnStartup=", "R<nnn>\tnumber of code caches to create at startup", TR::Options::setStaticNumeric,


### PR DESCRIPTION
If there are many AOT loads and AOT compilations, a large part of the SCC memory that was disclaimed may become resident again. In those cases, increase the frequency of the SCC memory disclaim from every 10 seconds to every 3 seconds.