### PR TITLE
Prevent JITServer buffer overrun

### DIFF
--- a/runtime/compiler/net/MessageBuffer.cpp
+++ b/runtime/compiler/net/MessageBuffer.cpp
@@ -20,11 +20,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-#include "net/MessageBuffer.hpp"
-#include "infra/CriticalSection.hpp"
-#include "env/VerboseLog.hpp"
-#include "control/Options.hpp"
 #include <cstring>
+#include "control/Options.hpp"
+#include "env/VerboseLog.hpp"
+#include "infra/CriticalSection.hpp"
+#include "net/MessageBuffer.hpp"
+#include "net/StreamExceptions.hpp"
 
 namespace JITServer {
 
@@ -106,6 +107,15 @@ uint32_t MessageBuffer::writeData(const void *dataStart, uint32_t dataSize, uint
     memcpy(_curPtr, dataStart, dataSize);
     _curPtr += dataSize + paddingSize;
     return offset(data);
+}
+
+uint32_t MessageBuffer::readData(uint32_t dataSize)
+{
+    if (_curPtr + dataSize > _storage + _capacity)
+        throw JITServer::StreamFailure("readData exceeds buffer bounds");
+    char *data = _curPtr;
+    _curPtr += dataSize; // Advance cursor
+    return offset(data); // Return offset before the advance
 }
 
 uint8_t MessageBuffer::alignCurrentPositionOn64Bit()

--- a/runtime/compiler/net/MessageBuffer.hpp
+++ b/runtime/compiler/net/MessageBuffer.hpp
@@ -151,12 +151,7 @@ public:
 
        @return offset to the beginning of data
     */
-    uint32_t readData(uint32_t dataSize)
-    {
-        char *data = _curPtr;
-        _curPtr += dataSize; // Advance cursor
-        return offset(data); // Return offset before the advance
-    }
+    uint32_t readData(uint32_t dataSize);
 
     void clear() { _curPtr = _storage; }
 


### PR DESCRIPTION
When JITServer does not use TLS encryption for
communication an attacker may craft a TCP message
that could cause the JITServer to crash.
Link to description of the problem:
https://github.com/eclipse-openj9/openj9/security/advisories/GHSA-q393-vr4c-969r

This PR adds a buffer bounds check to prevent the crash.