### PR TITLE
Implement JVM.isRecording

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
@@ -22,6 +22,7 @@
 
 #include "j9.h"
 #include "jni.h"
+#include "jclprots.h"
 
 extern "C" {
 
@@ -34,8 +35,7 @@ Java_jdk_jfr_internal_JVM_markChunkFinal(JNIEnv *env, jobject obj)
 jboolean JNICALL
 Java_jdk_jfr_internal_JVM_isRecording(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return JNI_FALSE;
+	return Java_com_ibm_oti_vm_VM_isJFRRecordingStarted(env, NULL);
 }
 
 void JNICALL


### PR DESCRIPTION
Use the existing VM.isRecordingStarted() to implement the equivalent OpenJDK JFR native.

Fixes https://github.com/eclipse-openj9/openj9/issues/23778