### PR TITLE
Test for aliased array stores before transforming to arrayset in Idiom Recognition

### DIFF
--- a/runtime/compiler/optimizer/IdiomTransformations.cpp
+++ b/runtime/compiler/optimizer/IdiomTransformations.cpp
@@ -8606,7 +8606,7 @@ bool CISCTransform2ArraySet(TR_CISCTransformer *trans)
 
     if (disptrace)
         logprintf(disptrace, log,
-            "Examining exit comparison CICS node %d, and determined required length modifier to be: %d\n",
+            "Examining exit comparison CISC node %d, and determined required length modifier to be: %d\n",
             cmpIfAllCISCNode->getID(), lengthMod);
 
     TR_ScratchList<TR::Node> listStores(comp->trMemory());
@@ -8674,9 +8674,10 @@ bool CISCTransform2ArraySet(TR_CISCTransformer *trans)
     //
     ListIterator<TR::Node> iteratorStores(&listStores);
     TR::Node *indexNode = createLoad(indexRepNode);
+    bool sawPreviousStore = false;
 
-    // check if the induction variable
-    // is being stored into the array
+    // Determine whether the induction variable is being stored into the array
+    // or if there are multiple array stores, whether the arrays might overlap
     for (inStoreNode = iteratorStores.getFirst(); inStoreNode; inStoreNode = iteratorStores.getNext()) {
         TR::Node *valueNode = inStoreNode->getChild(1);
         if (valueNode->getOpCode().isLoadDirect() && valueNode->getOpCode().hasSymbolReference()) {
@@ -8688,6 +8689,29 @@ bool CISCTransform2ArraySet(TR_CISCTransformer *trans)
                 return false;
             }
         }
+
+        if (sawPreviousStore) {
+            TR::SymbolReference *inStoreSymRef = inStoreNode->getSymbolReference();
+            TR_UseDefAliasSetInterface useDefAliases = inStoreSymRef->getUseDefAliases();
+
+            ListIterator<TR::Node> otherStoresIt(&listStores);
+
+            // Look at array stores found in loop pairwise to check for aliases - they prevent use of arrayset
+            for (TR::Node *otherStoreNode = otherStoresIt.getFirst();
+                 (otherStoreNode != inStoreNode) && (otherStoreNode != NULL);
+                 otherStoreNode = otherStoresIt.getNext()) {
+                TR::SymbolReference *otherStoreSymRef = otherStoreNode->getSymbolReference();
+
+                if ((inStoreSymRef == otherStoreSymRef) || useDefAliases.contains(otherStoreSymRef, comp)) {
+                    dumpOptDetails(comp,
+                        "Array store n%dn [%p] could overlap array store n%dn [%p] - cannot transform to arraysets\n",
+                        inStoreNode->getGlobalIndex(), inStoreNode, otherStoreNode->getGlobalIndex(), otherStoreNode);
+                    return false;
+                }
+            }
+        }
+
+        sawPreviousStore = true;
     }
 
     List<TR::Node> listArraySet(comp->trMemory());

--- a/test/functional/JIT_Test/src/jit/test/loopReduction/arrayset.java
+++ b/test/functional/JIT_Test/src/jit/test/loopReduction/arrayset.java
@@ -40,6 +40,8 @@ public class arrayset {
 
    public static int[] intArr = new int[18097];
 
+   public static int[] overlapIntArr = intArr;
+
    public static long[] longArr = new long[18097];
 
    public static short[] shortArr = new short[18097];
@@ -932,6 +934,48 @@ public class arrayset {
          java.util.Arrays.fill(byteArrB, (byte) -1);
          if (!java.util.Arrays.equals(byteArrB, byteArrBBase)) {
             c.printerr("arrB/arrBBase compares equal - wrong - on iter" + iters);
+         }
+      }
+   }
+
+   public void testOverlappingArrayset(Context c) {
+      int initVal1 = 0x1;
+      int initVal2 = 0x2;
+      int initVal3 = 0x3;
+      int initVal4 = 0x4;
+
+      java.util.Arrays.fill(intArr, 0);
+
+      for (int i = 0; i < 256; i++) {
+          intArr[i] = initVal1;
+          overlapIntArr[i+64] = initVal2;
+      }
+
+      for (int i = 256+64; i < 512; i++) {
+          intArr[i+64] = initVal3;
+          overlapIntArr[i] = initVal4;
+      }
+
+      if (c.verify()) {
+         for (int i = 0; i < 256; i++) {
+             if (intArr[i] != initVal1) {
+                 c.printerr("intArr["+i+"] expected "+initVal1+", but found "+intArr[i]);
+             }
+         }
+         for (int i = 256; i < 256+64; i++) {
+             if (intArr[i] != initVal2) {
+                 c.printerr("intArr["+i+"] expected "+initVal2+", but found "+intArr[i]);
+             }
+         }
+         for (int i = 256+64; i < 512; i++) {
+             if (intArr[i] != initVal4) {
+                 c.printerr("intArr["+i+"] expected "+initVal4+", but found "+intArr[i]);
+             }
+         }
+         for (int i = 512; i < 512+64; i++) {
+             if (intArr[i] != initVal3) {
+                 c.printerr("intArr["+i+"] expected "+initVal3+", but found "+intArr[i]);
+             }
          }
       }
    }


### PR DESCRIPTION
 If a loop contains two or more array element store operations that each assign a loop invariant value to their respective arrays, Idiom Recognition will attempt to replace the loop with multiple `arrayset` operations, one for each array element store operation.
    
However, that transformation did not take into account that any two of the distinct store operations might refer to the same array.  If two of the array element store operations in a loop might reference the same array, Idiom Recognition must not transform the loop to use `arrayset` operations as that transformation would not in general take into account that the ranges of array elements involved might overlap.
    
Test the symbol references for the array element stores pairwise for aliasing and for use of the same shadow symbol reference, and if any aliasing or duplicate symbol references are found, abort the transformation of the loop to `arrayset` operations.

<details>
<Summary>The problem can be seen with a test like the following</Summary>

```
public class Sub {
    public static final void sub1(int[] c) {
        for (int i = 0; i < 3; i++) {
            c[i] = 17;
            c[i+1] = 19;
        }
    }

    public static final void sub2(int[] c, int[] d) {
        for (int i = 0; i < 3; i++) {
            c[i] = 17;
            d[i+1] = 19;
        }
    }

    public static final void main(String[] args) {
        int[] c = new int[4];
        sub1(c);
        sub1(c);
        for (int i = 0; i < c.length; i++) {
            System.out.print(c[i]+" ");
        }
        System.out.println();
        c = new int[4];
        sub2(c, c);
        sub2(c, c);
        for (int i = 0; i < c.length; i++) {
            System.out.print(c[i]+" ");
        }
        System.out.println();
    }
}
```

run with

```
java -Xjit:count=1,disableAsyncCompilation,{Sub.sub*}\(log=sub.log,traceIdiomRecognition,traceFull,optLevel=hot\) Sub
```

Expected output:

```
17 17 17 19 
17 17 17 19 
```

Actual output:

```
17 19 19 19
17 19 19 19
```

Prior to this change, the IL before Idiom Recognition for `Sub.sub1` looked like this in part:

```
n11n      BBStart <block_4> (freq 10000) (in loop 4)                                          [0x7f568f004ad0] bci=[-1,2,3] rc=0 vc=578 vn=54 li=- udi=- nc=0
n26n      istorei  <array-shadow>[#225  Shadow] [flags 0x80000603 0x0 ]                       [0x7f568f004f80] bci=[-1,11,4] rc=0 vc=578 vn=7 li=- udi=- nc=2
n25n        aladd (X>=0 internalPtr )                                                         [0x7f568f004f30] bci=[-1,11,4] rc=1 vc=578 vn=16 li=- udi=- nc=2 flg=0x8100
n14n          aload  <parm 0 [I>[#418  Parm] [flags 0x40000107 0x0 ] (X!=0 )                  [0x7f568f004bc0] bci=[-1,7,4] rc=2 vc=578 vn=1 li=- udi=8 nc=0 flg=0x4
n24n          lsub (highWordZero X>=0 cannotOverflow )                                        [0x7f568f004ee0] bci=[-1,11,4] rc=1 vc=578 vn=15 li=- udi=- nc=2 flg=0x5100
n22n            lmul (X>=0 cannotOverflow )                                                   [0x7f568f004e40] bci=[-1,11,4] rc=2 vc=578 vn=14 li=- udi=- nc=2 flg=0x1100
n21n              i2l (highWordZero X>=0 )                                                    [0x7f568f004df0] bci=[-1,11,4] rc=1 vc=578 vn=13 li=- udi=- nc=1 flg=0x4100
n15n                iload  <auto slot 1>[#419  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f004c10] bci=[-1,8,4] rc=2 vc=578 vn=12 li=- udi=9 nc=0 flg=0x1100
n20n              lconst 4 (highWordZero X!=0 X>=0 )                                          [0x7f568f004da0] bci=[-1,11,4] rc=1 vc=578 vn=9 li=- udi=- nc=0 flg=0x4104
n23n            lconst -8 (X!=0 X<=0 )                                                        [0x7f568f004e90] bci=[-1,11,4] rc=1 vc=578 vn=8 li=- udi=- nc=0 flg=0x204
n16n        iconst 17 (X!=0 X>=0 )                                                            [0x7f568f004c60] bci=[-1,9,4] rc=1 vc=578 vn=7 li=- udi=- nc=0 flg=0x104
n41n      istorei  <array-shadow>[#225  Shadow] [flags 0x80000603 0x0 ]                       [0x7f568f005430] bci=[-1,18,5] rc=0 vc=578 vn=17 li=- udi=- nc=2
n40n        aladd (X>=0 internalPtr )                                                         [0x7f568f0053e0] bci=[-1,18,5] rc=1 vc=578 vn=20 li=- udi=- nc=2 flg=0x8100
n14n          ==>aload
n39n          lsub (highWordZero X>=0 cannotOverflow )                                        [0x7f568f005390] bci=[-1,18,5] rc=1 vc=578 vn=19 li=- udi=- nc=2 flg=0x5100
n22n            ==>lmul
n38n            lconst -12 (X!=0 X<=0 )                                                       [0x7f568f005340] bci=[-1,18,5] rc=1 vc=578 vn=18 li=- udi=- nc=0 flg=0x204
n31n        iconst 19 (X!=0 X>=0 )                                                            [0x7f568f005110] bci=[-1,16,5] rc=1 vc=578 vn=17 li=- udi=- nc=0 flg=0x104
```

and after Idiom Recognition it looked like

```
n11n      BBStart <block_4> (freq 10000)                                                      [0x7f568f004ad0] bci=[-1,2,3] rc=0 vc=581 vn=54 li=- udi=- nc=0
n495n     treetop                                                                             [0x7f568f0a8a70] bci=[-1,11,4] rc=0 vc=0 vn=103 li=- udi=- nc=1
n494n       arrayset  <arrayset>[#215  helper Method] [flags 0x400 0x0 ] ()                   [0x7f568f0a8a20] bci=[-1,11,4] rc=1 vc=0 vn=102 li=- udi=- nc=3 flg=0x20
n479n         aladd (X>=0 internalPtr )                                                       [0x7f568f0a8570] bci=[-1,11,4] rc=1 vc=581 vn=87 li=- udi=- nc=2 flg=0x8100
n480n           aload  <parm 0 [I>[#418  Parm] [flags 0x40000107 0x0 ] (X!=0 )                [0x7f568f0a85c0] bci=[-1,7,4] rc=1 vc=581 vn=88 li=- udi=8 nc=0 flg=0x4
n481n           lsub (highWordZero X>=0 cannotOverflow )                                      [0x7f568f0a8610] bci=[-1,11,4] rc=1 vc=581 vn=89 li=- udi=- nc=2 flg=0x5100
n482n             lmul (X>=0 cannotOverflow )                                                 [0x7f568f0a8660] bci=[-1,11,4] rc=1 vc=581 vn=90 li=- udi=- nc=2 flg=0x1100
n483n               i2l (highWordZero X>=0 )                                                  [0x7f568f0a86b0] bci=[-1,11,4] rc=1 vc=581 vn=91 li=- udi=- nc=1 flg=0x4100
n484n                 iload  <auto slot 1>[#419  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f0a8700] bci=[-1,8,4] rc=1 vc=581 vn=92 li=- udi=9 nc=0 flg=0x1100
n485n               lconst 4 (highWordZero X!=0 X>=0 )                                        [0x7f568f0a8750] bci=[-1,11,4] rc=1 vc=581 vn=93 li=- udi=- nc=0 flg=0x4104
n486n             lconst -8 (X!=0 X<=0 )                                                      [0x7f568f0a87a0] bci=[-1,11,4] rc=1 vc=581 vn=94 li=- udi=- nc=0 flg=0x204
n487n         iconst 17 (X!=0 X>=0 )                                                          [0x7f568f0a87f0] bci=[-1,9,4] rc=1 vc=581 vn=95 li=- udi=- nc=0 flg=0x104
n493n         lmul                                                                            [0x7f568f0a89d0] bci=[-1,3,3] rc=1 vc=0 vn=101 li=- udi=- nc=2
n491n           i2l                                                                           [0x7f568f0a8930] bci=[-1,3,3] rc=1 vc=0 vn=99 li=- udi=- nc=1
n490n             isub                                                                        [0x7f568f0a88e0] bci=[-1,3,3] rc=1 vc=0 vn=98 li=- udi=- nc=2
n488n               iconst 3 (X!=0 X>=0 )                                                     [0x7f568f0a8840] bci=[-1,3,3] rc=2 vc=581 vn=96 li=- udi=- nc=0 flg=0x104
n461n               iload  <auto slot 1>[#419  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f0a7fd0] bci=[-1,8,4] rc=2 vc=581 vn=69 li=- udi=9 nc=0 flg=0x1100
n492n           lconst 4 (highWordZero X!=0 X>=0 )                                            [0x7f568f0a8980] bci=[-1,11,4] rc=1 vc=0 vn=100 li=- udi=- nc=0 flg=0x4104
n478n     treetop                                                                             [0x7f568f0a8520] bci=[-1,18,5] rc=0 vc=0 vn=86 li=- udi=- nc=1
n477n       arrayset  <arrayset>[#215  helper Method] [flags 0x400 0x0 ] ()                   [0x7f568f0a84d0] bci=[-1,18,5] rc=1 vc=0 vn=85 li=- udi=- nc=3 flg=0x20
n462n         aladd (X>=0 internalPtr )                                                       [0x7f568f0a8020] bci=[-1,18,5] rc=1 vc=581 vn=70 li=- udi=- nc=2 flg=0x8100
n463n           aload  <parm 0 [I>[#418  Parm] [flags 0x40000107 0x0 ] (X!=0 )                [0x7f568f0a8070] bci=[-1,7,4] rc=1 vc=581 vn=71 li=- udi=8 nc=0 flg=0x4
n464n           lsub (highWordZero X>=0 cannotOverflow )                                      [0x7f568f0a80c0] bci=[-1,18,5] rc=1 vc=581 vn=72 li=- udi=- nc=2 flg=0x5100
n465n             lmul (X>=0 cannotOverflow )                                                 [0x7f568f0a8110] bci=[-1,11,4] rc=1 vc=581 vn=73 li=- udi=- nc=2 flg=0x1100
n466n               i2l (highWordZero X>=0 )                                                  [0x7f568f0a8160] bci=[-1,11,4] rc=1 vc=581 vn=74 li=- udi=- nc=1 flg=0x4100
n467n                 iload  <auto slot 1>[#419  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f0a81b0] bci=[-1,8,4] rc=1 vc=581 vn=75 li=- udi=9 nc=0 flg=0x1100
n468n               lconst 4 (highWordZero X!=0 X>=0 )                                        [0x7f568f0a8200] bci=[-1,11,4] rc=1 vc=581 vn=76 li=- udi=- nc=0 flg=0x4104
n469n             lconst -12 (X!=0 X<=0 )                                                     [0x7f568f0a8250] bci=[-1,18,5] rc=1 vc=581 vn=77 li=- udi=- nc=0 flg=0x204
n470n         iconst 19 (X!=0 X>=0 )                                                          [0x7f568f0a82a0] bci=[-1,16,5] rc=1 vc=581 vn=78 li=- udi=- nc=0 flg=0x104
n476n         lmul                                                                            [0x7f568f0a8480] bci=[-1,3,3] rc=1 vc=0 vn=84 li=- udi=- nc=2
n474n           i2l                                                                           [0x7f568f0a83e0] bci=[-1,3,3] rc=1 vc=0 vn=82 li=- udi=- nc=1
n473n             isub                                                                        [0x7f568f0a8390] bci=[-1,3,3] rc=1 vc=0 vn=81 li=- udi=- nc=2
n471n               iconst 3 (X!=0 X>=0 )                                                     [0x7f568f0a82f0] bci=[-1,3,3] rc=1 vc=581 vn=79 li=- udi=- nc=0 flg=0x104
n461n               ==>iload
n475n           lconst 4 (highWordZero X!=0 X>=0 )                                            [0x7f568f0a8430] bci=[-1,18,5] rc=1 vc=0 vn=83 li=- udi=- nc=0 flg=0x4104
n496n     istore  <auto slot 1>[#419  Auto] [flags 0x3 0x0 ]                                  [0x7f568f0a8ac0] bci=[-1,3,3] rc=0 vc=0 vn=104 li=- udi=- nc=1
n488n       ==>iconst 3
n503n     goto --> block_5 BBStart at n1n                                                     [0x7f568f0a8cf0] bci=[-1,3,3] rc=0 vc=0 vn=111 li=- udi=- nc=0
n4n       BBEnd </block_4> =====                                                              [0x7f568f0048a0] bci=[-1,4,3] rc=0 vc=581 vn=56 li=- udi=- nc=0

n1n       BBStart <block_5> (freq 680)                                                        [0x7f568f0047b0] bci=[-1,25,7] rc=0 vc=578 vn=57 li=- udi=- nc=0
n48n      return                                                                              [0x7f568f005660] bci=[-1,25,7] rc=0 vc=578 vn=58 li=- udi=- nc=0
n2n       BBEnd </block_5> =====                                                              [0x7f568f004800] bci=[-1,25,7] rc=0 vc=578 vn=59 li=- udi=- nc=0

```

and for `Sub.sub2` looked like this, in part, before Idiom Recognition:

```
n436n     BBStart <block_35> (freq 2500) (in loop 35)                                         [0x7f568f0a7800] bci=[-1,2,10] rc=0 vc=676 vn=72 li=- udi=- nc=0
n438n     istorei  <array-shadow>[#225  Shadow] [flags 0x80000603 0x0 ]                       [0x7f568f0a78a0] bci=[-1,11,11] rc=0 vc=676 vn=9 li=- udi=- nc=2
n439n       aladd (X>=0 internalPtr )                                                         [0x7f568f0a78f0] bci=[-1,11,11] rc=1 vc=676 vn=18 li=- udi=- nc=2 flg=0x8100
n440n         aload  <parm 0 [I>[#418  Parm] [flags 0x40000107 0x0 ] (X!=0 )                  [0x7f568f0a7940] bci=[-1,7,11] rc=1 vc=676 vn=1 li=- udi=11 nc=0 flg=0x4
n441n         lsub (highWordZero X>=0 cannotOverflow )                                        [0x7f568f0a7990] bci=[-1,11,11] rc=1 vc=676 vn=17 li=- udi=- nc=2 flg=0x5100
n442n           lmul (X>=0 cannotOverflow )                                                   [0x7f568f0a79e0] bci=[-1,11,11] rc=2 vc=676 vn=16 li=- udi=- nc=2 flg=0x1100
n443n             i2l (highWordZero X>=0 )                                                    [0x7f568f0a7a30] bci=[-1,11,11] rc=1 vc=676 vn=15 li=- udi=- nc=1 flg=0x4100
n444n               iload  <auto slot 2>[#420  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f0a7a80] bci=[-1,8,11] rc=2 vc=676 vn=14 li=- udi=12 nc=0 flg=0x1100
n445n             lconst 4 (highWordZero X!=0 X>=0 )                                          [0x7f568f0a7ad0] bci=[-1,11,11] rc=1 vc=676 vn=11 li=- udi=- nc=0 flg=0x4104
n446n           lconst -8 (X!=0 X<=0 )                                                        [0x7f568f0a7b20] bci=[-1,11,11] rc=1 vc=676 vn=10 li=- udi=- nc=0 flg=0x204
n447n       iconst 17 (X!=0 X>=0 )                                                            [0x7f568f0a7b70] bci=[-1,9,11] rc=1 vc=676 vn=9 li=- udi=- nc=0 flg=0x104
n448n     istorei  <array-shadow>[#225  Shadow] [flags 0x80000603 0x0 ]                       [0x7f568f0a7bc0] bci=[-1,18,12] rc=0 vc=676 vn=19 li=- udi=- nc=2
n449n       aladd (X>=0 internalPtr )                                                         [0x7f568f0a7c10] bci=[-1,18,12] rc=1 vc=676 vn=22 li=- udi=- nc=2 flg=0x8100
n450n         aload  <parm 1 [I>[#419  Parm] [flags 0x40000107 0x0 ] (X!=0 )                  [0x7f568f0a7c60] bci=[-1,12,12] rc=1 vc=676 vn=2 li=- udi=13 nc=0 flg=0x4
n451n         lsub (highWordZero X>=0 cannotOverflow )                                        [0x7f568f0a7cb0] bci=[-1,18,12] rc=1 vc=676 vn=21 li=- udi=- nc=2 flg=0x5100
n442n           ==>lmul
n456n           lconst -12 (X!=0 X<=0 )                                                       [0x7f568f0a7e40] bci=[-1,18,12] rc=1 vc=676 vn=20 li=- udi=- nc=0 flg=0x204
n457n       iconst 19 (X!=0 X>=0 )                                                            [0x7f568f0a7e90] bci=[-1,16,12] rc=1 vc=676 vn=19 li=- udi=- nc=0 flg=0x104
```

and like this after Idiom Recognition:

```
n436n     BBStart <block_35> (freq 2500)                                                      [0x7f568f0a7800] bci=[-1,2,10] rc=0 vc=680 vn=72 li=- udi=- nc=0
n567n     treetop                                                                             [0x7f568f0aa0f0] bci=[-1,11,11] rc=0 vc=0 vn=129 li=- udi=- nc=1
n566n       arrayset  <arrayset>[#215  helper Method] [flags 0x400 0x0 ] ()                   [0x7f568f0aa0a0] bci=[-1,11,11] rc=1 vc=0 vn=128 li=- udi=- nc=3 flg=0x20
n551n         aladd (X>=0 internalPtr )                                                       [0x7f568f0a9bf0] bci=[-1,11,11] rc=1 vc=680 vn=113 li=- udi=- nc=2 flg=0x8100
n552n           aload  <parm 0 [I>[#418  Parm] [flags 0x40000107 0x0 ] (X!=0 )                [0x7f568f0a9c40] bci=[-1,7,11] rc=1 vc=680 vn=114 li=- udi=11 nc=0 flg=0x4
n553n           lsub (highWordZero X>=0 cannotOverflow )                                      [0x7f568f0a9c90] bci=[-1,11,11] rc=1 vc=680 vn=115 li=- udi=- nc=2 flg=0x5100
n554n             lmul (X>=0 cannotOverflow )                                                 [0x7f568f0a9ce0] bci=[-1,11,11] rc=1 vc=680 vn=116 li=- udi=- nc=2 flg=0x1100
n555n               i2l (highWordZero X>=0 )                                                  [0x7f568f0a9d30] bci=[-1,11,11] rc=1 vc=680 vn=117 li=- udi=- nc=1 flg=0x4100
n556n                 iload  <auto slot 2>[#420  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f0a9d80] bci=[-1,8,11] rc=1 vc=680 vn=118 li=- udi=12 nc=0 flg=0x1100
n557n               lconst 4 (highWordZero X!=0 X>=0 )                                        [0x7f568f0a9dd0] bci=[-1,11,11] rc=1 vc=680 vn=119 li=- udi=- nc=0 flg=0x4104
n558n             lconst -8 (X!=0 X<=0 )                                                      [0x7f568f0a9e20] bci=[-1,11,11] rc=1 vc=680 vn=120 li=- udi=- nc=0 flg=0x204
n559n         iconst 17 (X!=0 X>=0 )                                                          [0x7f568f0a9e70] bci=[-1,9,11] rc=1 vc=680 vn=121 li=- udi=- nc=0 flg=0x104
n565n         lmul                                                                            [0x7f568f0aa050] bci=[-1,3,10] rc=1 vc=0 vn=127 li=- udi=- nc=2
n563n           i2l                                                                           [0x7f568f0a9fb0] bci=[-1,3,10] rc=1 vc=0 vn=125 li=- udi=- nc=1
n562n             isub                                                                        [0x7f568f0a9f60] bci=[-1,3,10] rc=1 vc=0 vn=124 li=- udi=- nc=2
n560n               iconst 3 (X!=0 X>=0 )                                                     [0x7f568f0a9ec0] bci=[-1,3,10] rc=2 vc=680 vn=122 li=- udi=- nc=0 flg=0x104
n533n               iload  <auto slot 2>[#420  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f0a9650] bci=[-1,8,11] rc=2 vc=680 vn=95 li=- udi=12 nc=0 flg=0x1100
n564n           lconst 4 (highWordZero X!=0 X>=0 )                                            [0x7f568f0aa000] bci=[-1,11,11] rc=1 vc=0 vn=126 li=- udi=- nc=0 flg=0x4104
n550n     treetop                                                                             [0x7f568f0a9ba0] bci=[-1,18,12] rc=0 vc=0 vn=112 li=- udi=- nc=1
n549n       arrayset  <arrayset>[#215  helper Method] [flags 0x400 0x0 ] ()                   [0x7f568f0a9b50] bci=[-1,18,12] rc=1 vc=0 vn=111 li=- udi=- nc=3 flg=0x20
n534n         aladd (X>=0 internalPtr )                                                       [0x7f568f0a96a0] bci=[-1,18,12] rc=1 vc=680 vn=96 li=- udi=- nc=2 flg=0x8100
n535n           aload  <parm 1 [I>[#419  Parm] [flags 0x40000107 0x0 ] (X!=0 )                [0x7f568f0a96f0] bci=[-1,12,12] rc=1 vc=680 vn=97 li=- udi=13 nc=0 flg=0x4
n536n           lsub (highWordZero X>=0 cannotOverflow )                                      [0x7f568f0a9740] bci=[-1,18,12] rc=1 vc=680 vn=98 li=- udi=- nc=2 flg=0x5100
n537n             lmul (X>=0 cannotOverflow )                                                 [0x7f568f0a9790] bci=[-1,11,11] rc=1 vc=680 vn=99 li=- udi=- nc=2 flg=0x1100
n538n               i2l (highWordZero X>=0 )                                                  [0x7f568f0a97e0] bci=[-1,11,11] rc=1 vc=680 vn=100 li=- udi=- nc=1 flg=0x4100
n539n                 iload  <auto slot 2>[#420  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f0a9830] bci=[-1,8,11] rc=1 vc=680 vn=101 li=- udi=12 nc=0 flg=0x1100
n540n               lconst 4 (highWordZero X!=0 X>=0 )                                        [0x7f568f0a9880] bci=[-1,11,11] rc=1 vc=680 vn=102 li=- udi=- nc=0 flg=0x4104
n541n             lconst -12 (X!=0 X<=0 )                                                     [0x7f568f0a98d0] bci=[-1,18,12] rc=1 vc=680 vn=103 li=- udi=- nc=0 flg=0x204
n542n         iconst 19 (X!=0 X>=0 )                                                          [0x7f568f0a9920] bci=[-1,16,12] rc=1 vc=680 vn=104 li=- udi=- nc=0 flg=0x104
n548n         lmul                                                                            [0x7f568f0a9b00] bci=[-1,3,10] rc=1 vc=0 vn=110 li=- udi=- nc=2
n546n           i2l                                                                           [0x7f568f0a9a60] bci=[-1,3,10] rc=1 vc=0 vn=108 li=- udi=- nc=1
n545n             isub                                                                        [0x7f568f0a9a10] bci=[-1,3,10] rc=1 vc=0 vn=107 li=- udi=- nc=2
n543n               iconst 3 (X!=0 X>=0 )                                                     [0x7f568f0a9970] bci=[-1,3,10] rc=1 vc=680 vn=105 li=- udi=- nc=0 flg=0x104
n533n               ==>iload
n547n           lconst 4 (highWordZero X!=0 X>=0 )                                            [0x7f568f0a9ab0] bci=[-1,18,12] rc=1 vc=0 vn=109 li=- udi=- nc=0 flg=0x4104
n568n     istore  <auto slot 2>[#420  Auto] [flags 0x3 0x0 ]                                  [0x7f568f0aa140] bci=[-1,3,10] rc=0 vc=0 vn=130 li=- udi=- nc=1
n560n       ==>iconst 3
n575n     goto --> block_36 BBStart at n465n                                                  [0x7f568f0aa370] bci=[-1,3,10] rc=0 vc=0 vn=137 li=- udi=- nc=0
n437n     BBEnd </block_35> =====                                                             [0x7f568f0a7850] bci=[-1,2,10] rc=0 vc=680 vn=74 li=- udi=- nc=0

n465n     BBStart <block_36> (freq 680)                                                       [0x7f568f0a8110] bci=[-1,25,14] rc=0 vc=676 vn=75 li=- udi=- nc=0
n48n      return                                                                              [0x7f568f005660] bci=[-1,25,14] rc=0 vc=676 vn=76 li=- udi=- nc=0
n2n       BBEnd </block_36> =====                                                             [0x7f568f004800] bci=[-1,25,14] rc=0 vc=676 vn=77 li=- udi=- nc=0
```

In the case of `Sub.sub2`, Loop Alias Refiner also produces a second version of the loop using array element shadow symbols that are not aliased, and Idiom Recognition is still correctly able to transform that version of the loop into two `arrayset` operations with this change:

```
n11n      BBStart <block_4> (freq 10000) (in loop 4)                                          [0x7f568f004ad0] bci=[-1,2,10] rc=0 vc=676 vn=80 li=- udi=- nc=0
n26n      istorei  <refined-array-shadow>[#424  Shadow] [flags 0x80000603 0x0 ]               [0x7f568f004f80] bci=[-1,11,11] rc=0 vc=676 vn=9 li=- udi=- nc=2
n25n        aladd (X>=0 internalPtr )                                                         [0x7f568f004f30] bci=[-1,11,11] rc=1 vc=676 vn=28 li=- udi=- nc=2 flg=0x8100
n14n          aload  <parm 0 [I>[#418  Parm] [flags 0x40000107 0x0 ] (X!=0 )                  [0x7f568f004bc0] bci=[-1,7,11] rc=1 vc=676 vn=1 li=- udi=14 nc=0 flg=0x4
n24n          lsub (highWordZero X>=0 cannotOverflow )                                        [0x7f568f004ee0] bci=[-1,11,11] rc=1 vc=676 vn=27 li=- udi=- nc=2 flg=0x5100
n22n            lmul (X>=0 cannotOverflow )                                                   [0x7f568f004e40] bci=[-1,11,11] rc=2 vc=676 vn=26 li=- udi=- nc=2 flg=0x1100
n21n              i2l (highWordZero X>=0 )                                                    [0x7f568f004df0] bci=[-1,11,11] rc=1 vc=676 vn=25 li=- udi=- nc=1 flg=0x4100
n15n                iload  <auto slot 2>[#420  Auto] [flags 0x3 0x0 ] (X>=0 cannotOverflow )  [0x7f568f004c10] bci=[-1,8,11] rc=2 vc=676 vn=24 li=- udi=15 nc=0 flg=0x1100
n20n              lconst 4 (highWordZero X!=0 X>=0 )                                          [0x7f568f004da0] bci=[-1,11,11] rc=1 vc=676 vn=11 li=- udi=- nc=0 flg=0x4104
n23n            lconst -8 (X!=0 X<=0 )                                                        [0x7f568f004e90] bci=[-1,11,11] rc=1 vc=676 vn=10 li=- udi=- nc=0 flg=0x204
n16n        iconst 17 (X!=0 X>=0 )                                                            [0x7f568f004c60] bci=[-1,9,11] rc=1 vc=676 vn=9 li=- udi=- nc=0 flg=0x104
n41n      istorei  <refined-array-shadow>[#423  Shadow] [flags 0x80000603 0x0 ]               [0x7f568f005430] bci=[-1,18,12] rc=0 vc=676 vn=19 li=- udi=- nc=2
n40n        aladd (X>=0 internalPtr )                                                         [0x7f568f0053e0] bci=[-1,18,12] rc=1 vc=676 vn=30 li=- udi=- nc=2 flg=0x8100
n27n          aload  <parm 1 [I>[#419  Parm] [flags 0x40000107 0x0 ] (X!=0 )                  [0x7f568f004fd0] bci=[-1,12,12] rc=1 vc=676 vn=2 li=- udi=16 nc=0 flg=0x4
n39n          lsub (highWordZero X>=0 cannotOverflow )                                        [0x7f568f005390] bci=[-1,18,12] rc=1 vc=676 vn=29 li=- udi=- nc=2 flg=0x5100
n22n            ==>lmul
n38n            lconst -12 (X!=0 X<=0 )                                                       [0x7f568f005340] bci=[-1,18,12] rc=1 vc=676 vn=20 li=- udi=- nc=0 flg=0x204
n31n        iconst 19 (X!=0 X>=0 )                                                            [0x7f568f005110] bci=[-1,16,12] rc=1 vc=676 vn=19 li=- udi=- nc=0 flg=0x104
```

</details>

Also added a new ~~test~~ functional test case to test for this scenario.

Fixes:  #18955