### PR TITLE
Disable SVM (temporarily)

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2722,7 +2722,7 @@ bool J9::Options::fePreProcess(void *base)
 
 #if (defined(TR_HOST_X86) || defined(TR_HOST_S390) || defined(TR_HOST_POWER)) && defined(TR_TARGET_64BIT)
     self()->setOption(TR_EnableSymbolValidationManager);
-    self()->setOption(TR_EnableMHRelocatableCompile);
+    self()->setOption(TR_DisableSVMDuringStartup);
 #endif
 
     // Forcing inlining of unrecognized intrinsics needs more performance investigation


### PR DESCRIPTION
This is to help triage https://github.com/eclipse-openj9/openj9/issues/23649; enabling SVM cannot be the issue since https://github.com/eclipse-openj9/openj9/issues/23649 was opened a day before https://github.com/eclipse-openj9/openj9/pull/23648 was merged. However, this is to aid in triaging.