### PR TITLE
Use GC assertion with message with variable number of parameters

### DIFF
--- a/runtime/gc_base/ClassLoaderManager.cpp
+++ b/runtime/gc_base/ClassLoaderManager.cpp
@@ -391,7 +391,7 @@ MM_ClassLoaderManager::addDyingClassesToList(MM_EnvironmentBase *env, J9ClassLoa
 				if (setAll || !markMap->isBitSet(classObject)) {
 
 					/* with setAll all classes must be unmarked */
-					Assert_GC_true_with_message3(
+					Assert_GC_true_with_message(
 							env, !markMap->isBitSet(classObject),
 							"Class %p class object %p is discovered marked during unloading classloader %p\n",
 							clazz, classObject, classLoader);

--- a/runtime/gc_base/GCExtensions.cpp
+++ b/runtime/gc_base/GCExtensions.cpp
@@ -315,7 +315,7 @@ MM_GCExtensions::releaseNativesForContinuationObject(MM_EnvironmentBase* env, j9
 		 * last unmounted continuation Object is marked as "dead", but the related J9VMContinuation has not been freed up.
 		 */
 		if (!VM_ContinuationHelpers::isFinished(continuationState)) {
-			Assert_GC_true_with_message2(env, (NULL == continuation), "Continuation expected to be NULL, but it is %p, from Continuation object %p\n", continuation, objectPtr);
+			Assert_GC_true_with_message(env, (NULL == continuation), "Continuation expected to be NULL, but it is %p, from Continuation object %p\n", continuation, objectPtr);
 		}
 	} else {
 		getJavaVM()->internalVMFunctions->freeContinuation(vmThread, objectPtr, TRUE);

--- a/runtime/gc_base/StringTable.cpp
+++ b/runtime/gc_base/StringTable.cpp
@@ -529,7 +529,7 @@ storeLatin1ByteArrayhelper(J9VMThread *vmThread, U_8 *data, UDATA length, j9obje
 		U_16 unicode = 0;
 		UDATA consumed = VM_VMHelpers::decodeUTF8CharN(data, &unicode, length);
 
-		Assert_GC_true_with_message3(
+		Assert_GC_true_with_message(
 				MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread), 0 != consumed,
 				"Invalid UTF8 character <%zx> at address %p, remaining length %zu\n",
 				(UDATA) *data, data, length);
@@ -678,7 +678,7 @@ j9gc_createJavaLangString(J9VMThread *vmThread, U_8 *data, UDATA length, UDATA s
 					U_16 unicode = 0;
 					UDATA consumed = VM_VMHelpers::decodeUTF8CharN(tempData, &unicode, tempLength);
 
-					Assert_GC_true_with_message4(
+					Assert_GC_true_with_message(
 							MM_EnvironmentBase::getEnvironment(vmThread->omrVMThread), 0 != consumed,
 							"Invalid UTF8 character <%zx> at address %p, remaining length %zu, string start address %p\n",
 							(UDATA) *tempData, tempData, tempLength, data);

--- a/runtime/gc_glue_java/ScavengerRootScanner.hpp
+++ b/runtime/gc_glue_java/ScavengerRootScanner.hpp
@@ -135,7 +135,7 @@ public:
 		if (_scavenger->isHeapObject(*slotPtr) && !_extensions->heap->objectIsInGap(*slotPtr)) {
 			_scavenger->copyAndForwardThreadSlot(envStandard, slotPtr);
 		} else if (NULL != *slotPtr) {
-			Assert_GC_true_with_message4(envStandard, (vmthreaditerator_state_monitor_records == vmThreadIterator->getState()),
+			Assert_GC_true_with_message(envStandard, (vmthreaditerator_state_monitor_records == vmThreadIterator->getState()),
 					"Thread %p structures scan: slot %p has bad value %p, iterator state %d\n", vmThreadIterator->getVMThread(), slotPtr, *slotPtr, vmThreadIterator->getState());
 		}
 	}

--- a/runtime/gc_modron_standard/StandardAccessBarrier.cpp
+++ b/runtime/gc_modron_standard/StandardAccessBarrier.cpp
@@ -798,7 +798,7 @@ MM_StandardAccessBarrier::preObjectRead(J9VMThread *vmThread, J9Object *srcObjec
 		MM_EnvironmentStandard *env = MM_EnvironmentStandard::getEnvironment(vmThread->omrVMThread);
 		Assert_GC_true_with_message(env, !_scavenger->isObjectInEvacuateMemory((omrobjectptr_t)srcAddress) || _extensions->isScavengerBackOutFlagRaised(), "readObject %llx in Evacuate\n", srcAddress);
 		if (_scavenger->isObjectInEvacuateMemory(object)) {
-			Assert_GC_true_with_message2(env, _scavenger->isConcurrentCycleInProgress(),
+			Assert_GC_true_with_message(env, _scavenger->isConcurrentCycleInProgress(),
 					"CS not in progress, found a object in Survivor: slot %llx object %llx\n", srcAddress, object);
 			Assert_MM_true(_scavenger->isMutatorThreadInSyncWithCycle(env));
 			/* since object is still in evacuate, srcObject has not been scanned yet => we cannot assert

--- a/runtime/gc_modron_startup/mgcalloc.cpp
+++ b/runtime/gc_modron_startup/mgcalloc.cpp
@@ -117,7 +117,7 @@ J9AllocateObjectNoGC(J9VMThread *vmThread, J9Class *clazz, uintptr_t allocateFla
 
 				/* Do sanity check: size of actually allocated Mixed object should match requested */
 				uintptr_t requestedBytes = mixedOAM.getAllocateDescription()->getContiguousBytes();
-				Assert_GC_true_with_message4(env, allocatedBytes == requestedBytes,
+				Assert_GC_true_with_message(env, allocatedBytes == requestedBytes,
 						"J9AllocateObjectNoGC: Object %p, requested %zu bytes, but read %zu, MM_MixedObjectAllocationModel %p\n",
 						objectPtr, requestedBytes, allocatedBytes, &mixedOAM);
 
@@ -359,7 +359,7 @@ J9AllocateIndexableObjectNoGC(J9VMThread *vmThread, J9Class *clazz, uint32_t num
 
 				/* Do sanity check: size of actually allocated Indexable object should match requested */
 				uintptr_t requestedBytes = indexableOAM.getAllocateDescription()->getContiguousBytes();
-				Assert_GC_true_with_message4(env, allocatedBytes == requestedBytes,
+				Assert_GC_true_with_message(env, allocatedBytes == requestedBytes,
 						"J9AllocateIndexableObjectNoGC: Object %p, requested %zu bytes, but read %zu, MM_IndexableObjectAllocationModel %p\n",
 						objectPtr, requestedBytes, allocatedBytes, &indexableOAM);
 			}
@@ -415,7 +415,7 @@ J9AllocateObject(J9VMThread *vmThread, J9Class *clazz, uintptr_t allocateFlags)
 
 			/* Do sanity check: size of actually allocated Mixed object should match requested */
 			uintptr_t requestedBytes = mixedOAM.getAllocateDescription()->getContiguousBytes();
-			Assert_GC_true_with_message4(env, allocatedBytes == requestedBytes,
+			Assert_GC_true_with_message(env, allocatedBytes == requestedBytes,
 					"J9AllocateObject: Object %p, requested %zu bytes, but read %zu, MM_MixedObjectAllocationModel %p\n",
 					objectPtr, requestedBytes, allocatedBytes, &mixedOAM);
 
@@ -579,7 +579,7 @@ J9AllocateIndexableObject(J9VMThread *vmThread, J9Class *clazz, uint32_t numberO
 
 			/* Do sanity check: size of actually allocated Indexable object should match requested */
 			uintptr_t requestedBytes = indexableOAM.getAllocateDescription()->getContiguousBytes();
-			Assert_GC_true_with_message4(env, allocatedBytes == requestedBytes,
+			Assert_GC_true_with_message(env, allocatedBytes == requestedBytes,
 					"J9AllocateIndexableObject: Object %p, requested %zu bytes, but read %zu, MM_IndexableObjectAllocationModel %p\n",
 					objectPtr, requestedBytes, allocatedBytes, &indexableOAM);
 		}

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -2276,19 +2276,19 @@ MM_CopyForwardScheme::updateMarkMapAndCardTableOnCopy(MM_EnvironmentVLHGC *env, 
 
 			/* Unexpected states */
 			case CARD_REMEMBERED:
-				Assert_GC_true_with_message4(env, false, "Unexpected Card state CARD_REMEMBERED %u for Card %p, srcObject %p, dstObject %p\n", CARD_REMEMBERED, card, srcObject, dstObject);
+				Assert_GC_true_with_message(env, false, "Unexpected Card state CARD_REMEMBERED %u for Card %p, srcObject %p, dstObject %p\n", CARD_REMEMBERED, card, srcObject, dstObject);
 				break;
 			case CARD_REMEMBERED_AND_GMP_SCAN:
-				Assert_GC_true_with_message4(env, false, "Unexpected Card state CARD_REMEMBERED_AND_GMP_SCAN %u for Card %p, srcObject %p, dstObject %p\n", CARD_REMEMBERED_AND_GMP_SCAN, card, srcObject, dstObject);
+				Assert_GC_true_with_message(env, false, "Unexpected Card state CARD_REMEMBERED_AND_GMP_SCAN %u for Card %p, srcObject %p, dstObject %p\n", CARD_REMEMBERED_AND_GMP_SCAN, card, srcObject, dstObject);
 				break;
 			case CARD_MARK_COMPACT_TRANSITION:
-				Assert_GC_true_with_message4(env, false, "Unexpected Card state CARD_MARK_COMPACT_TRANSITION %u for Card %p, srcObject %p, dstObject %p\n", CARD_MARK_COMPACT_TRANSITION, card, srcObject, dstObject);
+				Assert_GC_true_with_message(env, false, "Unexpected Card state CARD_MARK_COMPACT_TRANSITION %u for Card %p, srcObject %p, dstObject %p\n", CARD_MARK_COMPACT_TRANSITION, card, srcObject, dstObject);
 				break;
 			case CARD_INVALID:
-				Assert_GC_true_with_message4(env, false, "Unexpected Card state CARD_INVALID %u for Card %p, srcObject %p, dstObject %p\n", CARD_INVALID, card, srcObject, dstObject);
+				Assert_GC_true_with_message(env, false, "Unexpected Card state CARD_INVALID %u for Card %p, srcObject %p, dstObject %p\n", CARD_INVALID, card, srcObject, dstObject);
 				break;
 			default:
-				Assert_GC_true_with_message4(env, false, "Unexpected Card state UNKNOWN %u for Card %p, srcObject %p, dstObject %p\n", srcCardState, card, srcObject, dstObject);
+				Assert_GC_true_with_message(env, false, "Unexpected Card state UNKNOWN %u for Card %p, srcObject %p, dstObject %p\n", srcCardState, card, srcObject, dstObject);
 			}
 		}
 	}

--- a/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
+++ b/runtime/gc_vlhgc/GlobalMarkingScheme.cpp
@@ -920,7 +920,7 @@ MM_GlobalMarkingScheme::scanClassLoaderObject(MM_EnvironmentVLHGC *env, J9Object
 		while (NULL != (clazz = iterator.nextClass())) {
 			J9Object * classObject = J9VM_J9CLASS_TO_HEAPCLASS(clazz);
 
-			Assert_GC_true_with_message3(
+			Assert_GC_true_with_message(
 					env, NULL != classObject,
 					"During scan classloader object %p, classloader %p, j9class %p has classObject set to NULL\n",
 					classLoaderObject, classLoader, clazz);

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1826,7 +1826,7 @@ MM_IncrementalGenerationalGC::assertTableClean(MM_EnvironmentVLHGC *env, Card ad
 			Card *highCard = _extensions->cardTable->heapAddrToCardAddr(env, region->getHighAddress());
 			for (Card *thisCard = lowCard; thisCard < highCard; thisCard++) {
 				Card cardValue = *thisCard;
-				Assert_GC_true_with_message2(env, ((additionalCleanState == cardValue) || (CARD_CLEAN == cardValue)), "The card %p is not clean, value %u\n", thisCard, cardValue);
+				Assert_GC_true_with_message(env, ((additionalCleanState == cardValue) || (CARD_CLEAN == cardValue)), "The card %p is not clean, value %u\n", thisCard, cardValue);
 			}
 		}
 	}

--- a/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
+++ b/runtime/gc_vlhgc/VLHGCAccessBarrier.cpp
@@ -287,14 +287,14 @@ MM_VLHGCAccessBarrier::indexableDataDisplacement(J9StackWalkState *walkState, J9
 	J9IndexableObject *objectToCheckAdjacency = NULL;
 
 	if (srcRegion->_compactData._shouldCompact) {
-		Assert_GC_true_with_message3(env, !srcRegion->_copyForwardData._evacuateSet, "Evac set for compact src region %p src obj %p dst obj%p\n", srcRegion, src, dst);
+		Assert_GC_true_with_message(env, !srcRegion->_copyForwardData._evacuateSet, "Evac set for compact src region %p src obj %p dst obj%p\n", srcRegion, src, dst);
 		/* Moved by sliding compact - source may be overwritten. */
 		objectToCheckAdjacency = dst;
 	} else if (srcRegion->_copyForwardData._evacuateSet) {
 		/* Moved (or still being moved) by copy-forward - destination may not be fully copied yet. */
 		objectToCheckAdjacency = src;
 	} else {
-		Assert_GC_true_with_message3(env, false, "Neither evac nor compact set src region %p src obj %p dst obj%p\n", srcRegion, src, dst);
+		Assert_GC_true_with_message(env, false, "Neither evac nor compact set src region %p src obj %p dst obj%p\n", srcRegion, src, dst);
 	}
 
 	if (_extensions->indexableObjectModel.isDataAdjacentToHeader(objectToCheckAdjacency))


### PR DESCRIPTION
Current code uses GC assertions with message macro definitions with fixed number of parameters. Relpace them to use macro with variable number of parameters.

Depends https://github.com/eclipse-omr/omr/pull/8226