### PR TITLE
Mirror only the OMR master branch

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
@@ -34,15 +34,14 @@ timestamps {
                         try {
                             //Clone/update
                             if (!fileExists('HEAD')) {
-                                sh "git clone --mirror ${HTTP}${SRC_REPO} ."
+                                sh "git clone --bare --no-tags --single-branch --branch master ${HTTP}${SRC_REPO} ."
                             } else {
                                 sh 'git remote update --prune'
                             }
 
                             // Push
                             withCredentials([usernamePassword(credentialsId: 'github-bot', usernameVariable: 'USERNAME', passwordVariable: 'PASSWORD')]) {
-                                sh "git push ${HTTP}${USERNAME}:${PASSWORD}@${TARGET_REPO} --all"
-                                sh "git push ${HTTP}${USERNAME}:${PASSWORD}@${TARGET_REPO} --tags"
+                                sh "git push ${HTTP}${USERNAME}:${PASSWORD}@${TARGET_REPO} master"
                             }
 
                             // Set the build description


### PR DESCRIPTION
OMR has been creating release branches, most recently `v0.9.0-release`. These branch names have exactly the same names as the branches created for openj9 releases in the openj9-omr repo. The omr `v0.9.0-release` branch conflicts with the openj9 `v0.9.0-release` branch, and the mirror jobs fails.

`! [rejected]            v0.9.0-release -> v0.9.0-release (fetch first)`

It's sufficient to mirror the master branch.