### PR TITLE
Compact layout: shrink small primitive types and flattened objects

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/AuxFieldInfo29.dat
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/AuxFieldInfo29.dat
@@ -84,6 +84,7 @@ J9Class.classLoader = required
 J9Class.classObject = required
 J9Class.eyecatcher = required
 J9Class.finalizeLinkOffset = required
+J9Class.flatFieldSize = UDATA
 J9Class.iTable = required
 J9Class.initializeStatus = required
 J9Class.instanceDescription = required

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/CompatibilityConstants29.dat
@@ -82,7 +82,9 @@ J9JavaAccessFlags.J9StaticFieldRefTypeShort = 0
 J9JavaClassFlags.J9ClassIsFlattened = 0
 J9JavaClassFlags.J9ClassIsValueType = 0
 J9JavaClassFlags.J9ClassLargestAlignmentConstraintDouble = 0
+J9JavaClassFlags.J9ClassLargestAlignmentConstraintInteger = 0
 J9JavaClassFlags.J9ClassLargestAlignmentConstraintReference = 0
+J9JavaClassFlags.J9ClassLargestAlignmentConstraintShort = 0
 J9JavaClassFlags.J9ClassRequiresPrePadding = 0
 
 J9NonbuilderConstants.J9_ROMCLASS_OPTINFO_INJECTED_INTERFACE_INFO = 0

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -97,9 +97,13 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	private UDATA firstFlatDoubleOffset = new UDATA(0);
 	private UDATA firstFlatObjectOffset = new UDATA(0);
 	private UDATA firstFlatSingleOffset = new UDATA(0);
+	private UDATA firstFlatShortOffset = new UDATA(0);
+	private UDATA firstFlatByteOffset = new UDATA(0);
 	private UDATA currentFlatDoubleOffset = new UDATA(0);
 	private UDATA currentFlatObjectOffset = new UDATA(0);
 	private UDATA currentFlatSingleOffset = new UDATA(0);
+	private UDATA currentFlatShortOffset = new UDATA(0);
+	private UDATA currentFlatByteOffset = new UDATA(0);
 	private UDATA flatBackFillSize = new UDATA(0);
 
 	private U32 doubleSeen = new U32(0);
@@ -140,12 +144,12 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		// Can't call init or set romClass in the constructor because they can throw a CorruptDataException
 	}
 
-	private void init() throws CorruptDataException {
+	private void init() throws CorruptDataException, NoSuchFieldException {
 		calculateInstanceSize(romClass, superClazz); //initInstanceSize(romClass, superClazz);
 		romFieldsShapeIterator = new J9ROMFieldShapeIterator(romClass.romFields(), romClass.romFieldCount());
 	}
 
-	private void nextField() throws CorruptDataException {
+	private void nextField() throws CorruptDataException, NoSuchFieldException {
 		boolean walkHiddenFields = false;
 		isHidden = false;
 		field = null;
@@ -189,8 +193,8 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		}
 	}
 
-	// Based on fieldOffsetsFindNext from resolvefield.cpp
-	private void fieldOffsetsFindNext() throws CorruptDataException {
+	// Based on fieldOffsetsFindNext from resolvefield.cpp.
+	private void fieldOffsetsFindNext() throws CorruptDataException, NoSuchFieldException {
 		/* start walking the fields to find the first one to return */
 		/* loop in case we have been told to only consider instance or static fields - we may have to skip past a few of the wrong kind */
 
@@ -239,9 +243,13 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 								UDATA size = null;
 								boolean forceDoubleAlignment;
 								if (fj9object_t_SizeOf == U32.SIZEOF) {
-									UDATA instanceSize = fieldClass.totalInstanceSize();
+									UDATA instanceSize = J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+										? fieldClass.flatFieldSize()
+										: fieldClass.totalInstanceSize();
 									UDATA doubleSize = new UDATA(U64.SIZEOF);
-									if (valueTypeHelper.classRequires4BytePrePadding(fieldClass)) {
+									if (!J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+										&& valueTypeHelper.classRequires4BytePrePadding(fieldClass)
+									) {
 										instanceSize = instanceSize.sub(U32.SIZEOF);
 									}
 									forceDoubleAlignment = (modifiers.allBitsIn(J9JavaAccessFlags.J9AccVolatile) && instanceSize.eq(doubleSize));
@@ -251,14 +259,20 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 								if (forceDoubleAlignment
 									|| valueTypeHelper.isJ9ClassLargestAlignmentConstraintDouble(fieldClass)
 								) {
-									size = fieldClass.totalInstanceSize();
-									if (valueTypeHelper.classRequires4BytePrePadding(fieldClass)) {
+									size = J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+										? fieldClass.flatFieldSize()
+										: fieldClass.totalInstanceSize();
+									if (!J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+										&& valueTypeHelper.classRequires4BytePrePadding(fieldClass)) {
 										size = size.sub(U32.SIZEOF);
 									}
 									offset = firstFlatDoubleOffset.add(currentFlatDoubleOffset);
 									currentFlatDoubleOffset = currentFlatDoubleOffset.add(Scalar.roundToSizeofU64(size));
 								} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintReference(fieldClass)) {
-									size = Scalar.roundToSizeToFJ9object(fieldClass.totalInstanceSize());
+									size = Scalar.roundToSizeToFJ9object(
+											J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+												? fieldClass.flatFieldSize()
+												: fieldClass.totalInstanceSize());
 									if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_BACKFILL_FLAT_OBJECT_FIELD) && size.eq(flatBackFillSize)) {
 										offset = new UDATA(backfillOffsetToUse);
 										walkFlags = walkFlags.bitAnd(new U32(new UDATA(J9VM_FIELD_OFFSET_WALK_BACKFILL_FLAT_OBJECT_FIELD).bitNot()));
@@ -266,16 +280,28 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 										offset = firstFlatObjectOffset.add(currentFlatObjectOffset);
 										currentFlatObjectOffset = currentFlatObjectOffset.add(size);
 									}
-								} else {
-									size = fieldClass.totalInstanceSize();
+								} else if (!J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+									|| valueTypeHelper.isJ9ClassLargestAlignmentConstraintInteger(fieldClass)
+								) {
+									size = Scalar.roundToSizeofU32(
+											J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+												? fieldClass.flatFieldSize()
+												: fieldClass.totalInstanceSize());
 									if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_BACKFILL_FLAT_SINGLE_FIELD) && size.eq(flatBackFillSize)) {
-										// Assert_VM_true(state->backfillOffsetToUse >= 0);
 										offset = new UDATA(backfillOffsetToUse);
 										walkFlags = walkFlags.bitAnd(new U32(new UDATA(J9VM_FIELD_OFFSET_WALK_BACKFILL_FLAT_SINGLE_FIELD).bitNot()));
 									} else {
 										offset = firstFlatSingleOffset.add(currentFlatSingleOffset);
 										currentFlatSingleOffset = currentFlatSingleOffset.add(size);
 									}
+								} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintShort(fieldClass)) {
+									size = Scalar.roundToSizeofU16(fieldClass.flatFieldSize());
+									offset = firstFlatShortOffset.add(currentFlatShortOffset);
+									currentFlatShortOffset = currentFlatShortOffset.add(size);
+								} else {
+									size = fieldClass.flatFieldSize();
+									offset = firstFlatByteOffset.add(currentFlatByteOffset);
+									currentFlatByteOffset = currentFlatByteOffset.add(size);
 								}
 							} else {
 								if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_BACKFILL_OBJECT_FIELD)) {
@@ -347,7 +373,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		return list;
 	}
 
-	private void calculateInstanceSize(J9ROMClassPointer romClass, J9ClassPointer superClazz) throws CorruptDataException {
+	private void calculateInstanceSize(J9ROMClassPointer romClass, J9ClassPointer superClazz) throws CorruptDataException, NoSuchFieldException {
 		lockwordNeeded = NO_LOCKWORD_NEEDED;
 
 		/* if we only care about statics we can skip all work related to instance size calculations */
@@ -448,8 +474,10 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 			firstFlatSingleOffset = new UDATA(fieldInfo.addObjectsArea(firstObjectOffset.intValue()));
 			firstSingleOffset = new UDATA(fieldInfo.addFlatSinglesArea(firstFlatSingleOffset.intValue()));
 			if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
-				firstShortOffset = new UDATA(fieldInfo.addSinglesArea(firstSingleOffset.intValue()));
-				firstByteOffset = new UDATA(fieldInfo.addShortsArea(firstShortOffset.intValue()));
+				firstFlatShortOffset = new UDATA(fieldInfo.addSinglesArea(firstSingleOffset.intValue()));
+				firstShortOffset = new UDATA(fieldInfo.addFlatShortsArea(firstFlatShortOffset.intValue()));
+				firstFlatByteOffset = new UDATA(fieldInfo.addShortsArea(firstShortOffset.intValue()));
+				firstByteOffset = new UDATA(fieldInfo.addFlatBytesArea(firstFlatByteOffset.intValue()));
 			}
 		} else {
 			firstDoubleOffset = new UDATA(fieldInfo.calculateFieldDataStart());
@@ -614,7 +642,16 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 				init();
 			} catch (CorruptDataException e) {
 				// Tell anyone listening there was corrupt data.
-				raiseCorruptDataEvent("CorruptDataException in com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator_V1.init()", e, false);
+				raiseCorruptDataEvent(
+					"CorruptDataException in com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator_V1.init()",
+					e,
+					false);
+				return null;
+			} catch (NoSuchFieldException nsfe) {
+				raiseCorruptDataEvent(
+					"NoSuchFieldException signals corrupt data in com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator_V1.init()",
+					new CorruptDataException(nsfe.getMessage()),
+					false);
 				return null;
 			}
 		}
@@ -633,6 +670,12 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		} catch (CorruptDataException e) {
 			// Returning null will stop the iteration.
 			raiseCorruptDataEvent("CorruptDataException getting next field offset.", e, false);
+			return null;
+		} catch (NoSuchFieldException nsfe) {
+			raiseCorruptDataEvent(
+				"NoSuchFieldException signals corrupt data getting next field offset.",
+				new CorruptDataException(nsfe.getMessage()),
+				false);
 			return null;
 		}
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -396,9 +396,9 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 			 * Note that in the J9Class, we do not store -1 to indicate no back fill,
 			 * we store the total instance size (including the header) instead.
 			 */
-			fieldInfo.setSuperclassFieldsSize( superClazz.totalInstanceSize().intValue());
+			fieldInfo.setSuperclassFieldsSize(superClazz.totalInstanceSize().longValue());
 			if (!superClazz.backfillOffset().eq(superClazz.totalInstanceSize().add(J9ObjectHelper.headerSize()))) {
-				fieldInfo.setSuperclassBackfillOffset(superClazz.backfillOffset().sub(J9ObjectHelper.headerSize()).intValue());
+				fieldInfo.setSuperclassBackfillOffset(superClazz.backfillOffset().sub(J9ObjectHelper.headerSize()).longValue());
 			}
 		} else {
 			fieldInfo.setSuperclassFieldsSize(0);
@@ -411,7 +411,7 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		 */
 		if ((LOCKWORD_NEEDED.equals(lockwordNeeded))||(NO_LOCKWORD_NEEDED .equals(lockwordNeeded))) {
 			if (superClazz.notNull() && !superClazz.lockOffset().eq(new UDATA(-1)) && J9ClassHelper.classDepth(superClazz).isZero()) {
-				int newSuperSize = fieldInfo.getSuperclassFieldsSize() - LOCKWORD_SIZE;
+				long newSuperSize = fieldInfo.getSuperclassFieldsSize() - LOCKWORD_SIZE;
 				/*
 				 * superClazz is java.lang.Object: subtract off non-inherited monitor field.
 				 * Note that java.lang.Object's backfill slot can be only at the end.
@@ -468,21 +468,21 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 		if (valueTypeHelper.areValueTypesSupported()) {
 			flatBackFillSize = new UDATA(fieldInfo.getBackfillSize());
 			firstFlatDoubleOffset = new UDATA(fieldInfo.calculateFieldDataStart());
-			firstDoubleOffset = new UDATA(fieldInfo.addFlatDoublesArea(firstFlatDoubleOffset.intValue()));
-			firstFlatObjectOffset = new UDATA(fieldInfo.addDoublesArea(firstDoubleOffset.intValue()));
-			firstObjectOffset = new UDATA(fieldInfo.addFlatObjectsArea(firstFlatObjectOffset.intValue()));
-			firstFlatSingleOffset = new UDATA(fieldInfo.addObjectsArea(firstObjectOffset.intValue()));
-			firstSingleOffset = new UDATA(fieldInfo.addFlatSinglesArea(firstFlatSingleOffset.intValue()));
+			firstDoubleOffset = new UDATA(fieldInfo.addFlatDoublesArea(firstFlatDoubleOffset.longValue()));
+			firstFlatObjectOffset = new UDATA(fieldInfo.addDoublesArea(firstDoubleOffset.longValue()));
+			firstObjectOffset = new UDATA(fieldInfo.addFlatObjectsArea(firstFlatObjectOffset.longValue()));
+			firstFlatSingleOffset = new UDATA(fieldInfo.addObjectsArea(firstObjectOffset.longValue()));
+			firstSingleOffset = new UDATA(fieldInfo.addFlatSinglesArea(firstFlatSingleOffset.longValue()));
 			if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
-				firstFlatShortOffset = new UDATA(fieldInfo.addSinglesArea(firstSingleOffset.intValue()));
-				firstShortOffset = new UDATA(fieldInfo.addFlatShortsArea(firstFlatShortOffset.intValue()));
-				firstFlatByteOffset = new UDATA(fieldInfo.addShortsArea(firstShortOffset.intValue()));
-				firstByteOffset = new UDATA(fieldInfo.addFlatBytesArea(firstFlatByteOffset.intValue()));
+				firstFlatShortOffset = new UDATA(fieldInfo.addSinglesArea(firstSingleOffset.longValue()));
+				firstShortOffset = new UDATA(fieldInfo.addFlatShortsArea(firstFlatShortOffset.longValue()));
+				firstFlatByteOffset = new UDATA(fieldInfo.addShortsArea(firstShortOffset.longValue()));
+				firstByteOffset = new UDATA(fieldInfo.addFlatBytesArea(firstFlatByteOffset.longValue()));
 			}
 		} else {
 			firstDoubleOffset = new UDATA(fieldInfo.calculateFieldDataStart());
-			firstObjectOffset = new UDATA(fieldInfo.addDoublesArea(firstDoubleOffset.intValue()));
-			firstSingleOffset = new UDATA(fieldInfo.addObjectsArea(firstObjectOffset.intValue()));
+			firstObjectOffset = new UDATA(fieldInfo.addDoublesArea(firstDoubleOffset.longValue()));
+			firstSingleOffset = new UDATA(fieldInfo.addObjectsArea(firstObjectOffset.longValue()));
 		}
 
 		if (fieldInfo.isMyBackfillSlotAvailable() && fieldInfo.isBackfillSuitableFieldAvailable() ) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/J9ObjectFieldOffsetIterator_V1.java
@@ -29,6 +29,11 @@ import static com.ibm.j9ddr.vm29.j9.ObjectFieldInfo.fj9object_t_SizeOf;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagIsNullRestricted;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagObject;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldSizeDouble;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeBoolean;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeByte;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeChar;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeMask;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeShort;
 import static com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags.J9AccStatic;
 import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_BACKFILL_OBJECT_FIELD;
 import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_BACKFILL_SINGLE_FIELD;
@@ -62,6 +67,8 @@ import com.ibm.j9ddr.vm29.pointer.helper.ValueTypeHelper;
 import com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags;
 import com.ibm.j9ddr.vm29.types.IDATA;
 import com.ibm.j9ddr.vm29.types.Scalar;
+import com.ibm.j9ddr.vm29.types.U8;
+import com.ibm.j9ddr.vm29.types.U16;
 import com.ibm.j9ddr.vm29.types.U32;
 import com.ibm.j9ddr.vm29.types.U64;
 import com.ibm.j9ddr.vm29.types.UDATA;
@@ -81,11 +88,11 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	private Iterator romFieldsShapeIterator;
 	private J9ClassPointer instanceClass;
 
-	private U32 doubleSeen = new U32(0);
-	private U32 doubleStaticsSeen = new U32(0);
 	private UDATA firstDoubleOffset = new UDATA(0);
 	private UDATA firstSingleOffset = new UDATA(0);
 	private UDATA firstObjectOffset = new UDATA(0);
+	private UDATA firstShortOffset = new UDATA(0);
+	private UDATA firstByteOffset = new UDATA(0);
 
 	private UDATA firstFlatDoubleOffset = new UDATA(0);
 	private UDATA firstFlatObjectOffset = new UDATA(0);
@@ -95,10 +102,14 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 	private UDATA currentFlatSingleOffset = new UDATA(0);
 	private UDATA flatBackFillSize = new UDATA(0);
 
+	private U32 doubleSeen = new U32(0);
+	private U32 doubleStaticsSeen = new U32(0);
 	private U32 objectsSeen = new U32(0);
 	private U32 objectStaticsSeen = new U32(0);
 	private U32 singlesSeen = new U32(0);
 	private U32 singleStaticsSeen = new U32(0);
+	private U32 shortsSeen = new U32(0);
+	private U32 bytesSeen = new U32(0);
 	private U32 walkFlags = new U32(0);
 
 	private J9ROMFieldShapePointer field;
@@ -292,6 +303,18 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 						if (modifiers.anyBitsIn(J9FieldSizeDouble)) {
 							offset = firstDoubleOffset.add(doubleSeen.mult(U64.SIZEOF));
 							doubleSeen = doubleSeen.add(1);
+						} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+							&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeChar)
+								|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeShort))
+						) {
+							offset = firstShortOffset.add(shortsSeen.mult(U16.SIZEOF));
+							shortsSeen = shortsSeen.add(1);
+						} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+							&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeBoolean)
+								|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeByte))
+						) {
+							offset = firstByteOffset.add(bytesSeen.mult(U8.SIZEOF));
+							bytesSeen = bytesSeen.add(1);
 						} else {
 							if (walkFlags.anyBitsIn(J9VM_FIELD_OFFSET_WALK_BACKFILL_SINGLE_FIELD)) {
 								// Assert_VM_true(state->backfillOffsetToUse >= 0);
@@ -424,6 +447,10 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 			firstObjectOffset = new UDATA(fieldInfo.addFlatObjectsArea(firstFlatObjectOffset.intValue()));
 			firstFlatSingleOffset = new UDATA(fieldInfo.addObjectsArea(firstObjectOffset.intValue()));
 			firstSingleOffset = new UDATA(fieldInfo.addFlatSinglesArea(firstFlatSingleOffset.intValue()));
+			if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
+				firstShortOffset = new UDATA(fieldInfo.addSinglesArea(firstSingleOffset.intValue()));
+				firstByteOffset = new UDATA(fieldInfo.addShortsArea(firstShortOffset.intValue()));
+			}
 		} else {
 			firstDoubleOffset = new UDATA(fieldInfo.calculateFieldDataStart());
 			firstObjectOffset = new UDATA(fieldInfo.addDoublesArea(firstDoubleOffset.intValue()));
@@ -464,6 +491,12 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 			UDATA hiddenSingleOffset = firstSingleOffset.add(J9ObjectHelper.headerSize() + (fieldInfo.getNonBackfilledInstanceSingleCount() * U32.SIZEOF));
 			UDATA hiddenDoubleOffset = firstDoubleOffset.add(J9ObjectHelper.headerSize() + (fieldInfo.getInstanceDoubleCount() * U64.SIZEOF));
 			UDATA hiddenObjectOffset = firstObjectOffset.add(J9ObjectHelper.headerSize() + (fieldInfo.getNonBackfilledInstanceObjectCount() * fj9object_t_SizeOf));
+			UDATA hiddenShortOffset = new UDATA(0);
+			UDATA hiddenByteOffset = new UDATA(0);
+			if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
+				hiddenShortOffset = firstShortOffset.add(J9ObjectHelper.headerSize() + (fieldInfo.getInstanceShortCount() * U16.SIZEOF));
+				hiddenByteOffset = firstByteOffset.add(J9ObjectHelper.headerSize() + (fieldInfo.getInstanceByteCount() * U8.SIZEOF));
+			}
 			boolean useBackfillForObject = false;
 			boolean useBackfillForSingle = false;
 
@@ -490,6 +523,18 @@ public class J9ObjectFieldOffsetIterator_V1 extends J9ObjectFieldOffsetIterator 
 				} else if (modifiers.allBitsIn(J9FieldSizeDouble)) {
 					hiddenField.setFieldOffset(hiddenDoubleOffset);
 					hiddenDoubleOffset = hiddenDoubleOffset.add(U64.SIZEOF);
+				} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+					&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeChar)
+						|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeShort))
+				) {
+					hiddenField.setFieldOffset(hiddenShortOffset);
+					hiddenShortOffset = hiddenShortOffset.add(U16.SIZEOF);
+				} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+					&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeBoolean)
+						|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeByte))
+				) {
+					hiddenField.setFieldOffset(hiddenByteOffset);
+					hiddenByteOffset = hiddenByteOffset.add(U8.SIZEOF);
 				} else {
 					if (useBackfillForSingle) {
 						hiddenField.setFieldOffset(fieldInfo.getMyBackfillOffsetForHiddenField());

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -24,12 +24,18 @@ package com.ibm.j9ddr.vm29.j9;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagIsNullRestricted;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagObject;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldSizeDouble;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeBoolean;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeByte;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeChar;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeMask;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeShort;
 import static com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags.J9AccStatic;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 
 import com.ibm.j9ddr.CorruptDataException;
+import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ROMClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ROMFieldShapePointer;
@@ -39,6 +45,8 @@ import com.ibm.j9ddr.vm29.pointer.helper.J9UTF8Helper;
 import com.ibm.j9ddr.vm29.pointer.helper.ValueTypeHelper;
 import com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags;
 import com.ibm.j9ddr.vm29.types.Scalar;
+import com.ibm.j9ddr.vm29.types.U8;
+import com.ibm.j9ddr.vm29.types.U16;
 import com.ibm.j9ddr.vm29.types.U32;
 import com.ibm.j9ddr.vm29.types.U64;
 import com.ibm.j9ddr.vm29.types.UDATA;
@@ -57,9 +65,13 @@ public class ObjectFieldInfo {
 	int instanceObjectCount;
 	int instanceSingleCount;
 	int instanceDoubleCount;
+	int instanceShortCount;
+	int instanceByteCount;
 	int totalObjectCount;
 	int totalSingleCount;
 	int totalDoubleCount;
+	int totalShortCount;
+	int totalByteCount;
 	int hiddenFieldCount;
 	int superclassBackfillOffset; /* inherited backfill */
 	int myBackfillOffset; /* backfill available for this class's fields */
@@ -86,9 +98,13 @@ public class ObjectFieldInfo {
 		instanceObjectCount = 0;
 		instanceSingleCount = 0;
 		instanceDoubleCount = 0;
+		instanceShortCount = 0;
+		instanceByteCount = 0;
 		totalObjectCount = 0;
 		totalSingleCount = 0;
 		totalDoubleCount = 0;
+		totalShortCount = 0;
+		totalByteCount = 0;
 		hiddenFieldCount = 0;
 		this.romClass = romClass;
 		superclassFieldsSize = -1;
@@ -179,6 +195,14 @@ public class ObjectFieldInfo {
 
 	int getInstanceDoubleCount() {
 		return instanceDoubleCount;
+	}
+
+	int getInstanceShortCount() {
+		return instanceShortCount;
+	}
+
+	int getInstanceByteCount() {
+		return instanceByteCount;
 	}
 
 	int getInstanceObjectCount() {
@@ -319,6 +343,23 @@ public class ObjectFieldInfo {
 	}
 
 	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the singles area
+	 * @note takes into account singles which will go in the backfill
+	 */
+	int addSinglesArea(int start) {
+		return start + (getNonBackfilledInstanceSingleCount() * U32.SIZEOF);
+	}
+
+	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the shorts area
+	 */
+	int addShortsArea(int start) {
+		return start + (totalShortCount * U16.SIZEOF);
+	}
+
+	/**
 	 * @note This is used for instance fields.
 	 * The backfill slot can either be embedded within the superclass,
 	 * or it can be the result of padding the superclass.
@@ -434,6 +475,18 @@ public class ObjectFieldInfo {
 				} else if (modifiers.anyBitsIn(J9FieldSizeDouble)) {
 					instanceDoubleCount += 1;
 					totalDoubleCount += 1;
+				} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+					&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeChar)
+						|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeShort))
+				) {
+					instanceShortCount += 1;
+					totalShortCount += 1;
+				} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+					&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeBoolean)
+						|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeByte))
+				) {
+					instanceByteCount += 1;
+					totalByteCount += 1;
 				} else {
 					instanceSingleCount += 1;
 					totalSingleCount += 1;
@@ -454,6 +507,16 @@ public class ObjectFieldInfo {
 					totalObjectCount += 1;
 				} else if (modifiers.anyBitsIn(J9FieldSizeDouble)) {
 					totalDoubleCount += 1;
+				} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+					&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeChar)
+						|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeShort))
+				) {
+					totalShortCount += 1;
+				} else if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+					&& (modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeBoolean)
+						|| modifiers.maskAndCompare(J9FieldTypeMask, J9FieldTypeByte))
+				) {
+					totalByteCount += 1;
 				} else {
 					totalSingleCount += 1;
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -81,6 +81,8 @@ public class ObjectFieldInfo {
 	int totalFlatFieldDoubleBytes = 0;
 	int totalFlatFieldRefBytes = 0;
 	int totalFlatFieldSingleBytes = 0;
+	int totalFlatFieldShortBytes = 0;
+	int totalFlatFieldByteBytes = 0;
 	int flatAlignedObjectInstanceBackfill = 0;
 	int flatAlignedSingleInstanceBackfill = 0;
 	int flatUnAlignedObjectInstanceBackfill = 0;
@@ -121,6 +123,8 @@ public class ObjectFieldInfo {
 		totalFlatFieldDoubleBytes = 0;
 		totalFlatFieldRefBytes = 0;
 		totalFlatFieldSingleBytes = 0;
+		totalFlatFieldShortBytes = 0;
+		totalFlatFieldByteBytes = 0;
 	}
 
 	int getTotalDoubleCount() {
@@ -420,7 +424,7 @@ public class ObjectFieldInfo {
 	}
 
 	void
-	countInstanceFields() throws CorruptDataException
+	countInstanceFields() throws CorruptDataException, NoSuchFieldException
 	{
 		/* iterate over fields to count instance fields by size */
 
@@ -440,9 +444,13 @@ public class ObjectFieldInfo {
 						} else {
 							boolean forceDoubleAlignment;
 							if (fj9object_t_SizeOf == U32.SIZEOF) {
-								UDATA instanceSize = fieldClass.totalInstanceSize();
+								UDATA instanceSize = J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+									? fieldClass.flatFieldSize()
+									: fieldClass.totalInstanceSize();
 								UDATA doubleSize = new UDATA(U64.SIZEOF);
-								if (valueTypeHelper.classRequires4BytePrePadding(fieldClass)) {
+								if (!J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+									&& valueTypeHelper.classRequires4BytePrePadding(fieldClass)
+								) {
 									instanceSize = instanceSize.sub(U32.SIZEOF);
 								}
 								forceDoubleAlignment = (modifiers.allBitsIn(J9JavaAccessFlags.J9AccVolatile) && instanceSize.eq(doubleSize));
@@ -452,20 +460,40 @@ public class ObjectFieldInfo {
 							if (forceDoubleAlignment
 								|| valueTypeHelper.isJ9ClassLargestAlignmentConstraintDouble(fieldClass)
 							) {
-								UDATA doubleSize = fieldClass.totalInstanceSize();
-								if (valueTypeHelper.classRequires4BytePrePadding(fieldClass)) {
-									doubleSize = doubleSize.sub(U32.SIZEOF);
+								UDATA flatFieldSize = J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+									? fieldClass.flatFieldSize()
+									: fieldClass.totalInstanceSize();
+								if (!J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+									&& valueTypeHelper.classRequires4BytePrePadding(fieldClass)
+								) {
+									flatFieldSize = flatFieldSize.sub(U32.SIZEOF);
 								}
-								size = Scalar.roundToSizeofU64(doubleSize).intValue();
+								size = Scalar.roundToSizeofU64(flatFieldSize).intValue();
 								totalFlatFieldDoubleBytes += size;
 							} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintReference(fieldClass)) {
-								size = Scalar.roundToSizeToFJ9object(fieldClass.totalInstanceSize()).intValue();
+								size = Scalar.roundToSizeToFJ9object(
+										J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+											? fieldClass.flatFieldSize()
+											: fieldClass.totalInstanceSize()
+										).intValue();
 								totalFlatFieldRefBytes += size;
 								setPotentialFlatObjectInstanceBackfill(size);
-							} else {
-								size = fieldClass.totalInstanceSize().intValue();
+							} else if (!J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+								|| valueTypeHelper.isJ9ClassLargestAlignmentConstraintInteger(fieldClass)
+							) {
+								size = Scalar.roundToSizeofU32(
+									J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+										? fieldClass.flatFieldSize()
+										: fieldClass.totalInstanceSize()
+									).intValue();
 								totalFlatFieldSingleBytes += size;
 								setPotentialFlatSingleInstanceBackfill(size);
+							} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintShort(fieldClass)) {
+								size = Scalar.roundToSizeofU16(fieldClass.flatFieldSize()).intValue();
+								totalFlatFieldShortBytes += size;
+							} else {
+								size = fieldClass.flatFieldSize().intValue();
+								totalFlatFieldByteBytes += size;
 							}
 						}
 					} else {
@@ -531,7 +559,14 @@ public class ObjectFieldInfo {
 		long accumulator = superclassFieldsSize + (totalObjectCount * J9ObjectHelper.headerSize()) + (totalSingleCount * U32.SIZEOF)
 				+ (totalDoubleCount * U64.SIZEOF);
 
+		if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
+			accumulator += (totalShortCount * U16.SIZEOF) + (totalByteCount * U8.SIZEOF);
+		}
+
 		accumulator += totalFlatFieldDoubleBytes + totalFlatFieldRefBytes + totalFlatFieldSingleBytes;
+		if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
+			accumulator += totalFlatFieldShortBytes + totalFlatFieldByteBytes;
+		}
 
 		/* ValueTypes cannot be subtyped and their superClass contains no fields */
 		if (isValue) {
@@ -613,6 +648,26 @@ public class ObjectFieldInfo {
 	addFlatSinglesArea(int start)
 	{
 		return start + getNonBackfilledFlatInstanceSingleSize();
+	}
+
+	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the flat shorts area
+	 */
+	int
+	addFlatShortsArea(int start)
+	{
+		return start + totalFlatFieldShortBytes;
+	}
+
+	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the flat bytes area
+	 */
+	int
+	addFlatBytesArea(int start)
+	{
+		return start + totalFlatFieldByteBytes;
 	}
 	
 	int

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/ObjectFieldInfo.java
@@ -54,7 +54,7 @@ import com.ibm.j9ddr.vm29.types.UDATA;
 public class ObjectFieldInfo {
 	ValueTypeHelper valueTypeHelper = ValueTypeHelper.getValueTypeHelper();
 	J9ROMClassPointer romClass;
-	int superclassFieldsSize;
+	long superclassFieldsSize;
 	boolean objectCanUseBackfill; /* true if an object reference is the same size as a backfill slot */
 	// Sizeof constants
 	public static final int fj9object_t_SizeOf =
@@ -73,20 +73,20 @@ public class ObjectFieldInfo {
 	int totalShortCount;
 	int totalByteCount;
 	int hiddenFieldCount;
-	int superclassBackfillOffset; /* inherited backfill */
-	int myBackfillOffset; /* backfill available for this class's fields */
-	int subclassBackfillOffset; /* backfill available to subclasses */
+	long superclassBackfillOffset; /* inherited backfill */
+	long myBackfillOffset; /* backfill available for this class's fields */
+	long subclassBackfillOffset; /* backfill available to subclasses */
 	boolean isValue = false;
 	J9ClassPointer containerClazz = J9ClassPointer.NULL;
-	int totalFlatFieldDoubleBytes = 0;
-	int totalFlatFieldRefBytes = 0;
-	int totalFlatFieldSingleBytes = 0;
-	int totalFlatFieldShortBytes = 0;
-	int totalFlatFieldByteBytes = 0;
-	int flatAlignedObjectInstanceBackfill = 0;
-	int flatAlignedSingleInstanceBackfill = 0;
-	int flatUnAlignedObjectInstanceBackfill = 0;
-	int flatUnAlignedSingleInstanceBackfill = 0;
+	long totalFlatFieldDoubleBytes = 0;
+	long totalFlatFieldRefBytes = 0;
+	long totalFlatFieldSingleBytes = 0;
+	long totalFlatFieldShortBytes = 0;
+	long totalFlatFieldByteBytes = 0;
+	long flatAlignedObjectInstanceBackfill = 0;
+	long flatAlignedSingleInstanceBackfill = 0;
+	long flatUnAlignedObjectInstanceBackfill = 0;
+	long flatUnAlignedSingleInstanceBackfill = 0;
 	boolean classRequiresPrePadding = false;
 	boolean isBackFillPostPadded = false;
 
@@ -271,7 +271,7 @@ public class ObjectFieldInfo {
 		return new UDATA(myBackfillOffset + J9ObjectHelper.headerSize());
 	}
 
-	int getSuperclassFieldsSize() {
+	long getSuperclassFieldsSize() {
 		return superclassFieldsSize;
 	}
 
@@ -280,7 +280,7 @@ public class ObjectFieldInfo {
 	}
 
 	void
-	setSuperclassFieldsSize(int i)
+	setSuperclassFieldsSize(long i)
 	{
 		this.superclassFieldsSize = i;
 	}
@@ -300,8 +300,8 @@ public class ObjectFieldInfo {
 	 * Since the superclass is not end-aligned it must have no embedded backfill.
 	 * @return offset to the first (non-backfilled) field.
 	 */
-	int calculateFieldDataStart() {
-		int fieldDataStart = getSuperclassFieldsSize();
+	long calculateFieldDataStart() {
+		long fieldDataStart = getSuperclassFieldsSize();
 		
 		/* If the type has double field the doubles need to start on an 8-byte boundary. In the case of valuetypes
 		 * there is no lockword so the super class field size will be zero. This means that valueTypes in compressedrefs
@@ -332,7 +332,7 @@ public class ObjectFieldInfo {
 	 * @param start end of previous field area
 	 * @return offset to end of the doubles area
 	 */
-	int addDoublesArea(int start) {
+	long addDoublesArea(long start) {
 		return start + (totalDoubleCount * U64.SIZEOF);
 	}
 
@@ -341,7 +341,7 @@ public class ObjectFieldInfo {
 	 * @return offset to end of the objects area
 	 * @note takes into account objects which will go in the backfill
 	 */
-	int addObjectsArea(int start) {
+	long addObjectsArea(long start) {
 		int nonBackfilledObjects = getNonBackfilledObjectCount();
 		return start + (nonBackfilledObjects * fj9object_t_SizeOf);
 	}
@@ -351,7 +351,7 @@ public class ObjectFieldInfo {
 	 * @return offset to end of the singles area
 	 * @note takes into account singles which will go in the backfill
 	 */
-	int addSinglesArea(int start) {
+	long addSinglesArea(long start) {
 		return start + (getNonBackfilledInstanceSingleCount() * U32.SIZEOF);
 	}
 
@@ -359,7 +359,7 @@ public class ObjectFieldInfo {
 	 * @param start end of previous field area
 	 * @return offset to end of the shorts area
 	 */
-	int addShortsArea(int start) {
+	long addShortsArea(long start) {
 		return start + (totalShortCount * U16.SIZEOF);
 	}
 
@@ -371,7 +371,7 @@ public class ObjectFieldInfo {
 	 * at the end of the superclass.
 	 * @return backfill offset from the first field
 	 */
-	int getMyBackfillOffset() {
+	long getMyBackfillOffset() {
 		return myBackfillOffset;
 	}
 	
@@ -389,10 +389,10 @@ public class ObjectFieldInfo {
 	 *
 	 * @return size of backfill
 	 */
-	int
+	long
 	getBackfillSize()
 	{
-		int backFillSize = BACKFILL_SIZE;
+		long backFillSize = BACKFILL_SIZE;
 
 		if ((0 != getInstanceSingleCount()) || (0 != getInstanceObjectCount())) {
 			/* BACKFILL_SIZE */
@@ -409,17 +409,17 @@ public class ObjectFieldInfo {
 		return backFillSize;
 	}
 
-	int getSubclassBackfillOffset() {
+	long getSubclassBackfillOffset() {
 		return subclassBackfillOffset;
 	}
 
 	void
-	setSuperclassBackfillOffset(int superclassBackfillOffset)
+	setSuperclassBackfillOffset(long superclassBackfillOffset)
 	{
 		this.superclassBackfillOffset = superclassBackfillOffset;
 	}
 
-	int getSuperclassBackfillOffset() {
+	long getSuperclassBackfillOffset() {
 		return superclassBackfillOffset;
 	}
 
@@ -436,7 +436,7 @@ public class ObjectFieldInfo {
 					if (valueTypeHelper.isFlattenableFieldSignature(J9ROMFieldShapeHelper.getSignature(f))
 						|| modifiers.anyBitsIn(J9FieldFlagIsNullRestricted)
 					) {
-						int size = 0;
+						long size = 0;
 						J9ClassPointer fieldClass = valueTypeHelper.findJ9ClassInFlattenedClassCacheWithFieldName(containerClazz, J9ROMFieldShapeHelper.getName(f));
 						if (!valueTypeHelper.isJ9FieldIsFlattened(fieldClass, f)) {
 							instanceObjectCount += 1;
@@ -468,14 +468,14 @@ public class ObjectFieldInfo {
 								) {
 									flatFieldSize = flatFieldSize.sub(U32.SIZEOF);
 								}
-								size = Scalar.roundToSizeofU64(flatFieldSize).intValue();
+								size = Scalar.roundToSizeofU64(flatFieldSize).longValue();
 								totalFlatFieldDoubleBytes += size;
 							} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintReference(fieldClass)) {
 								size = Scalar.roundToSizeToFJ9object(
-										J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
-											? fieldClass.flatFieldSize()
-											: fieldClass.totalInstanceSize()
-										).intValue();
+									J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
+										? fieldClass.flatFieldSize()
+										: fieldClass.totalInstanceSize()
+									).longValue();
 								totalFlatFieldRefBytes += size;
 								setPotentialFlatObjectInstanceBackfill(size);
 							} else if (!J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
@@ -485,14 +485,14 @@ public class ObjectFieldInfo {
 									J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
 										? fieldClass.flatFieldSize()
 										: fieldClass.totalInstanceSize()
-									).intValue();
+									).longValue();
 								totalFlatFieldSingleBytes += size;
 								setPotentialFlatSingleInstanceBackfill(size);
 							} else if (valueTypeHelper.isJ9ClassLargestAlignmentConstraintShort(fieldClass)) {
-								size = Scalar.roundToSizeofU16(fieldClass.flatFieldSize()).intValue();
+								size = Scalar.roundToSizeofU16(fieldClass.flatFieldSize()).longValue();
 								totalFlatFieldShortBytes += size;
 							} else {
-								size = fieldClass.flatFieldSize().intValue();
+								size = fieldClass.flatFieldSize().longValue();
 								totalFlatFieldByteBytes += size;
 							}
 						}
@@ -555,7 +555,7 @@ public class ObjectFieldInfo {
 		return hiddenFieldCount;
 	}
 
-	int calculateTotalFieldsSizeAndBackfill() { /* TODO update to handle contended fields */
+	long calculateTotalFieldsSizeAndBackfill() { /* TODO update to handle contended fields */
 		long accumulator = superclassFieldsSize + (totalObjectCount * J9ObjectHelper.headerSize()) + (totalSingleCount * U32.SIZEOF)
 				+ (totalDoubleCount * U64.SIZEOF);
 
@@ -574,7 +574,7 @@ public class ObjectFieldInfo {
 			 * alignment requirements of double slot fields. We will use the J9ClassHasPrePadding flag
 			 * to denote this.
 			 */
-			int firstFieldOffset = calculateFieldDataStart();
+			long firstFieldOffset = calculateFieldDataStart();
 			if (0 < firstFieldOffset) {
 				if (isBackfillSuitableFieldAvailable()) {
 					/*
@@ -611,21 +611,21 @@ public class ObjectFieldInfo {
 			}
 			if (((accumulator + J9ObjectHelper.headerSize()) % OBJECT_SIZE_INCREMENT_IN_BYTES) != 0) {
 				/* we have consumed the superclass's backfill (if any), so let our subclass use the residue at the end of this class. */
-				subclassBackfillOffset = (int)accumulator;
+				subclassBackfillOffset = accumulator;
 				accumulator += BACKFILL_SIZE;
 			} else {
 				subclassBackfillOffset = superclassBackfillOffset;
 			}
 		}
-		return (int) accumulator;
+		return accumulator;
 	}
 
 	/**
 	 * @param start end of previous field area, which should be the first field area
 	 * @return offset to end of the flat doubles area
 	 */
-	int
-	addFlatDoublesArea(int start)
+	long
+	addFlatDoublesArea(long start)
 	{
 		return start + totalFlatFieldDoubleBytes;
 	}
@@ -634,8 +634,8 @@ public class ObjectFieldInfo {
 	 * @param start end of previous field area, which should be after doubles
 	 * @return offset to end of the flat doubles area
 	 */
-	int
-	addFlatObjectsArea(int start)
+	long
+	addFlatObjectsArea(long start)
 	{
 		return start + getNonBackfilledFlatInstanceObjectSize();
 	}
@@ -644,8 +644,8 @@ public class ObjectFieldInfo {
 	 * @param start end of previous field area, which should be after objects
 	 * @return offset to end of the flat doubles area
 	 */
-	int
-	addFlatSinglesArea(int start)
+	long
+	addFlatSinglesArea(long start)
 	{
 		return start + getNonBackfilledFlatInstanceSingleSize();
 	}
@@ -654,8 +654,8 @@ public class ObjectFieldInfo {
 	 * @param start end of previous field area
 	 * @return offset to end of the flat shorts area
 	 */
-	int
-	addFlatShortsArea(int start)
+	long
+	addFlatShortsArea(long start)
 	{
 		return start + totalFlatFieldShortBytes;
 	}
@@ -664,62 +664,62 @@ public class ObjectFieldInfo {
 	 * @param start end of previous field area
 	 * @return offset to end of the flat bytes area
 	 */
-	int
-	addFlatBytesArea(int start)
+	long
+	addFlatBytesArea(long start)
 	{
 		return start + totalFlatFieldByteBytes;
 	}
 	
-	int
+	long
 	getFlatAlignedSingleInstanceBackfillSize()
 	{
 		return flatAlignedSingleInstanceBackfill;
 	}
 
-	int
+	long
 	getFlatUnAlignedSingleInstanceBackfillSize()
 	{
 		return flatUnAlignedSingleInstanceBackfill;
 	}
 
-	int
+	long
 	getFlatAlignedObjectInstanceBackfillSize()
 	{
 		return flatAlignedObjectInstanceBackfill;
 	}
 
-	int
+	long
 	getFlatUnAlignedObjectInstanceBackfillSize()
 	{
 		return flatUnAlignedObjectInstanceBackfill;
 	}
 
 	void
-	setFlatAlignedSingleInstanceBackfill(int size)
+	setFlatAlignedSingleInstanceBackfill(long size)
 	{
 		flatAlignedSingleInstanceBackfill = size;
 	}
 
 	void
-	setFlatUnAlignedSingleInstanceBackfill(int size)
+	setFlatUnAlignedSingleInstanceBackfill(long size)
 	{
 		flatUnAlignedSingleInstanceBackfill = size;
 	}
 
 	void
-	setFlatAlignedObjectInstanceBackfill(int size)
+	setFlatAlignedObjectInstanceBackfill(long size)
 	{
 		flatAlignedObjectInstanceBackfill = size;
 	}
 
 	void
-	setFlatUnAlignedObjectInstanceBackfill(int size)
+	setFlatUnAlignedObjectInstanceBackfill(long size)
 	{
 		flatUnAlignedObjectInstanceBackfill = size;
 	}
 
 	void
-	setPotentialFlatObjectInstanceBackfill(int size)
+	setPotentialFlatObjectInstanceBackfill(long size)
 	{
 		if (isValue) {
 			if (U32.SIZEOF == (size % U64.SIZEOF)) {
@@ -735,7 +735,7 @@ public class ObjectFieldInfo {
 	}
 
 	void
-	setPotentialFlatSingleInstanceBackfill(int size)
+	setPotentialFlatSingleInstanceBackfill(long size)
 	{
 		if (isValue) {
 			if (U32.SIZEOF == (size % U64.SIZEOF)) {
@@ -750,17 +750,18 @@ public class ObjectFieldInfo {
 		}
 	}
 
-	int
+	long
 	getNonBackfilledFlatInstanceObjectSize()
 	{
-		int nonBackfilledFlatObjectsSize = totalFlatFieldRefBytes;
+		long nonBackfilledFlatObjectsSize = totalFlatFieldRefBytes;
 		if (isBackfillSuitableInstanceObjectAvailable()
 			&& isMyBackfillSlotAvailable()
 			&& (0 == getInstanceSingleCount())
-			&& (objectCanUseBackfill && (0 == getInstanceObjectCount()))
+			&& objectCanUseBackfill
+			&& (0 == getInstanceObjectCount())
 			&& (0 == getFlatAlignedSingleInstanceBackfillSize())
 		) {
-			int backfillSize = getFlatAlignedObjectInstanceBackfillSize();
+			long backfillSize = getFlatAlignedObjectInstanceBackfillSize();
 			if (0 == backfillSize) {
 				if (0 == getFlatUnAlignedSingleInstanceBackfillSize()) {
 					backfillSize = getFlatUnAlignedObjectInstanceBackfillSize();
@@ -771,16 +772,17 @@ public class ObjectFieldInfo {
 		return nonBackfilledFlatObjectsSize;
 	}
 
-	int
+	long
 	getNonBackfilledFlatInstanceSingleSize()
 	{
-		int nonBackfilledFlatSinglesSize = totalFlatFieldSingleBytes;
+		long nonBackfilledFlatSinglesSize = totalFlatFieldSingleBytes;
 		if (isBackfillSuitableFlatInstanceSingleAvailable()
 			&& isMyBackfillSlotAvailable()
 			&& (0 == getInstanceSingleCount())
-			&& (objectCanUseBackfill && (0 == getInstanceObjectCount()))
+			&& objectCanUseBackfill
+			&& (0 == getInstanceObjectCount())
 		) {
-			int backfillSize = getFlatAlignedSingleInstanceBackfillSize();
+			long backfillSize = getFlatAlignedSingleInstanceBackfillSize();
 			if (0 == backfillSize) {
 				if (0 == getFlatAlignedObjectInstanceBackfillSize()) {
 					backfillSize = getFlatUnAlignedSingleInstanceBackfillSize();
@@ -804,7 +806,7 @@ public class ObjectFieldInfo {
 	}
 	
 	boolean
-	isBackfillTypeEndAligned(int fieldDataStart) {
+	isBackfillTypeEndAligned(long fieldDataStart) {
 		return BACKFILL_SIZE == (fieldDataStart % U64.SIZEOF);
 	}
 	

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCMixedObjectIterator_V1.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/gc/GCMixedObjectIterator_V1.java
@@ -80,14 +80,14 @@ class GCMixedObjectIterator_V1 extends GCObjectIterator
 
 	private void initialize(J9ClassPointer clazz, VoidPointer addr) throws CorruptDataException
 	{
-		int totalInstanceSize = clazz.totalInstanceSize().intValue();
+		long totalInstanceSize = clazz.totalInstanceSize().longValue();
 
 		data = ObjectReferencePointer.cast(addr);
 		scanIndex = 0;
-		scanLimit = totalInstanceSize / bytesInObjectSlot;
+		scanLimit = (int)(totalInstanceSize / bytesInObjectSlot);
 		descriptionArray = checkCache(clazz);
 		if (null == descriptionArray) {
-			descriptionArray = new boolean[(totalInstanceSize + bytesInObjectSlot - 1) / bytesInObjectSlot];
+			descriptionArray = new boolean[(int)((totalInstanceSize + bytesInObjectSlot - 1) / bytesInObjectSlot)];
 			if ((scanLimit > 0) && clazz.instanceDescription().notNull()) {
 				initializeDescriptionArray(clazz);
 				setCache(clazz, descriptionArray);

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
@@ -23,6 +23,11 @@ package com.ibm.j9ddr.vm29.pointer.helper;
 
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldFlagObject;
 import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldSizeDouble;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeBoolean;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeByte;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeChar;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeMask;
+import static com.ibm.j9ddr.vm29.structure.J9FieldFlags.J9FieldTypeShort;
 import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_INCLUDE_HIDDEN;
 import static com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE;
 
@@ -36,7 +41,11 @@ import com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffset;
 import com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator;
 import com.ibm.j9ddr.vm29.j9.ObjectModel;
 import com.ibm.j9ddr.vm29.pointer.AbstractPointer;
+import com.ibm.j9ddr.vm29.pointer.I8Pointer;
+import com.ibm.j9ddr.vm29.pointer.I16Pointer;
 import com.ibm.j9ddr.vm29.pointer.I32Pointer;
+import com.ibm.j9ddr.vm29.pointer.U8Pointer;
+import com.ibm.j9ddr.vm29.pointer.U16Pointer;
 import com.ibm.j9ddr.vm29.pointer.U32Pointer;
 import com.ibm.j9ddr.vm29.pointer.U64Pointer;
 import com.ibm.j9ddr.vm29.pointer.U8Pointer;
@@ -275,7 +284,22 @@ public class PrintObjectFieldsHelper {
 				out.format("!fj9object 0x%x", ptr.at(0).longValue());
 			}
 		} else {
-			out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+			if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
+				long fieldType = fieldShape.modifiers().longValue() & J9FieldTypeMask;
+				if (fieldType == J9FieldTypeByte) {
+					out.print(I8Pointer.cast(valuePtr).at(0).getHexValue());
+				} else if (fieldType == J9FieldTypeBoolean) {
+					out.print(U8Pointer.cast(valuePtr).at(0).getHexValue());
+				} else if (fieldType == J9FieldTypeShort) {
+					out.print(I16Pointer.cast(valuePtr).at(0).getHexValue());
+				} else if (fieldType == J9FieldTypeChar) {
+					out.print(U16Pointer.cast(valuePtr).at(0).getHexValue());
+				} else {
+					out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+				}
+			} else {
+				out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+			}
 		}
 		if (fieldIsFlattened) {
 			out.format(" (offset = %d) (%s)", fieldOffset.longValue(), fieldSignature.substring(1, fieldSignature.length() - 1));
@@ -337,7 +361,18 @@ public class PrintObjectFieldsHelper {
 				out.format("!fj9object 0x%x%n", ptr.at(0).longValue());
 			}
 		} else {
-			out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+			if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
+				long fieldType = fieldShape.modifiers().longValue() & J9FieldTypeMask;
+				if ((fieldType == J9FieldTypeByte) || (fieldType == J9FieldTypeBoolean)) {
+					out.print(I8Pointer.cast(valuePtr).at(0).getHexValue());
+				} else if ((fieldType == J9FieldTypeShort) || (fieldType == J9FieldTypeChar)) {
+					out.print(I16Pointer.cast(valuePtr).at(0).getHexValue());
+				} else {
+					out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+				}
+			} else {
+				out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
+			}
 		}
 
 		if (fieldIsFlattened) {

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/PrintObjectFieldsHelper.java
@@ -363,10 +363,14 @@ public class PrintObjectFieldsHelper {
 		} else {
 			if (J9BuildFlags.J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) {
 				long fieldType = fieldShape.modifiers().longValue() & J9FieldTypeMask;
-				if ((fieldType == J9FieldTypeByte) || (fieldType == J9FieldTypeBoolean)) {
+				if (fieldType == J9FieldTypeByte) {
 					out.print(I8Pointer.cast(valuePtr).at(0).getHexValue());
-				} else if ((fieldType == J9FieldTypeShort) || (fieldType == J9FieldTypeChar)) {
+				} else if (fieldType == J9FieldTypeBoolean) {
+					out.print(U8Pointer.cast(valuePtr).at(0).getHexValue());
+				} else if (fieldType == J9FieldTypeShort) {
 					out.print(I16Pointer.cast(valuePtr).at(0).getHexValue());
+				} else if (fieldType == J9FieldTypeChar) {
+					out.print(U16Pointer.cast(valuePtr).at(0).getHexValue());
 				} else {
 					out.print(I32Pointer.cast(valuePtr).at(0).getHexValue());
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
@@ -279,8 +279,8 @@ public class ValueTypeHelper {
 		}
 
 		@Override
-		public int getFlatFieldSize(J9ClassPointer clazz) throws CorruptDataException, NoSuchFieldException {
-			return clazz.flatFieldSize().intValue();
+		public long getFlatFieldSize(J9ClassPointer clazz) throws CorruptDataException, NoSuchFieldException {
+			return clazz.flatFieldSize().longValue();
 		}
 
 		@Override
@@ -479,7 +479,7 @@ public class ValueTypeHelper {
 	 * @param clazz J9Class
 	 * @return flat field size in bytes
 	 */
-	public int getFlatFieldSize(J9ClassPointer clazz) throws CorruptDataException, NoSuchFieldException {
+	public long getFlatFieldSize(J9ClassPointer clazz) throws CorruptDataException, NoSuchFieldException {
 		return 0;
 	}
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/pointer/helper/ValueTypeHelper.java
@@ -269,6 +269,21 @@ public class ValueTypeHelper {
 		}
 
 		@Override
+		public boolean isJ9ClassLargestAlignmentConstraintInteger(J9ClassPointer clazz) throws CorruptDataException {
+			return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassLargestAlignmentConstraintInteger);
+		}
+
+		@Override
+		public boolean isJ9ClassLargestAlignmentConstraintShort(J9ClassPointer clazz) throws CorruptDataException {
+			return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassLargestAlignmentConstraintShort);
+		}
+
+		@Override
+		public int getFlatFieldSize(J9ClassPointer clazz) throws CorruptDataException, NoSuchFieldException {
+			return clazz.flatFieldSize().intValue();
+		}
+
+		@Override
 		public boolean isJ9ClassIsFlattened(J9ClassPointer clazz) throws CorruptDataException {
 			return J9ClassHelper.extendedClassFlags(clazz).allBitsIn(J9JavaClassFlags.J9ClassIsFlattened);
 		}
@@ -424,7 +439,7 @@ public class ValueTypeHelper {
 	}
 
 	/**
-	 * Queries if class contains a field with a double (64 bit) alignment constraint
+	 * Queries if clazz contains a field with a double (64-bit) alignment constraint.
 	 * @param clazz J9Class
 	 * @return true if clazz has double alignment constraint, false otherwise
 	 */
@@ -433,12 +448,39 @@ public class ValueTypeHelper {
 	}
 
 	/**
-	 * Queries if class contains a field with a reference alignment constraint
+	 * Queries if clazz contains a field with a reference alignment constraint.
 	 * @param clazz J9Class
 	 * @return true if clazz has reference alignment constraint, false otherwise
 	 */
 	public boolean isJ9ClassLargestAlignmentConstraintReference(J9ClassPointer clazz) throws CorruptDataException {
 		return false;
+	}
+
+	/**
+	 * Queries if clazz contains a field with an int (32-bit) alignment constraint.
+	 * @param clazz J9Class
+	 * @return true if clazz has int alignment constraint, false otherwise
+	 */
+	public boolean isJ9ClassLargestAlignmentConstraintInteger(J9ClassPointer clazz) throws CorruptDataException {
+		return false;
+	}
+
+	/**
+	 * Queries if clazz contains a field with a short (16-bit) alignment constraint.
+	 * @param clazz J9Class
+	 * @return true if clazz has short alignment constraint, false otherwise
+	 */
+	public boolean isJ9ClassLargestAlignmentConstraintShort(J9ClassPointer clazz) throws CorruptDataException {
+		return false;
+	}
+
+	/**
+	 * Gets the flat field size for a value type class
+	 * @param clazz J9Class
+	 * @return flat field size in bytes
+	 */
+	public int getFlatFieldSize(J9ClassPointer clazz) throws CorruptDataException, NoSuchFieldException {
+		return 0;
 	}
 
 	/**

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RamClassWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/RamClassWalker.java
@@ -253,7 +253,7 @@ public class RamClassWalker extends ClassWalker {
 		 * then this section will display the array of instanceDescription bits.
 		 */
 		if (!ramClass.instanceDescription().allBitsIn(1)) {
-			final int totalInstanceSize = ramClass.totalInstanceSize().intValue();
+			final long totalInstanceSize = ramClass.totalInstanceSize().longValue();
 			final int fj9object_t_SizeOf = J9ObjectHelper.compressObjectReferences ? U32.SIZEOF : UDATA.SIZEOF;
 			final long totalSize = totalInstanceSize / fj9object_t_SizeOf;
 

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/ObjectSizeInfo.java
@@ -313,7 +313,7 @@ public class ObjectSizeInfo extends Command
 			
 			long accum = 0;
 			if (!superclass.isNull()) {
-				accum = superclass.totalInstanceSize().intValue();
+				accum = superclass.totalInstanceSize().longValue();
 				if (superclass.backfillOffset().gt(0)) {
 					accum -= ObjectFieldInfo.BACKFILL_SIZE;
 				}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/Scalar.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/types/Scalar.java
@@ -195,6 +195,11 @@ public abstract class Scalar extends DataType {
 		return roundTo(value, ObjectReferencePointer.SIZEOF);
 	}
 
+	public static UDATA roundToSizeofU16(UDATA value)
+	{
+		return roundTo(value, U16.SIZEOF);
+	}
+
 	public static UDATA roundToSizeofU32(UDATA value)
 	{
 		return roundTo(value, U32.SIZEOF);

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1651,7 +1651,11 @@ MM_ObjectAccessBarrier::structuralCompareFlattenedObjects(J9VMThread *vmThread, 
 	UDATA const referenceSize = J9VMTHREAD_REFERENCE_SIZE(vmThread);
 	bool hasReferences = J9CLASS_HAS_REFERENCES(valueClass);
 	/* for non value-types this is just the instance size */
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 	UDATA limit = J9CLASS_UNPADDED_INSTANCE_SIZE(valueClass);
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+	UDATA limit = J9_VALUETYPE_FLATTENED_SIZE(valueClass);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	UDATA offset = 0;
 
 	Assert_MM_true(J9_IS_J9CLASS_VALUETYPE(valueClass));
@@ -1739,7 +1743,7 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 	bool isValueType = J9_IS_J9CLASS_VALUETYPE(objectClass);
 
 	j9objectmonitor_t *lockwordAddress = NULL;
-	I_32 hashCode = 0;
+	int32_t hashCode = 0;
 	bool isDestObjectPreHashed = false;
 
 	isDestObjectPreHashed = _extensions->objectModel.hasBeenHashed(destObject);
@@ -1747,22 +1751,27 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 		hashCode = _extensions->objectModel.getObjectHashCode(vmThread->javaVM, destObject);
 	}
 
-	UDATA offset = 0;
+	uintptr_t offset = 0;
 	/* for non value-types this is just the instance size */
-	UDATA limit = J9CLASS_UNPADDED_INSTANCE_SIZE(objectClass);
-	UDATA const referenceSize = J9VMTHREAD_REFERENCE_SIZE(vmThread);
+	uintptr_t limit = J9CLASS_UNPADDED_INSTANCE_SIZE(objectClass);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	if (isValueType) {
+		limit = J9_VALUETYPE_FLATTENED_SIZE(objectClass);
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+	uintptr_t const referenceSize = J9VMTHREAD_REFERENCE_SIZE(vmThread);
 	bool hasReferences = J9CLASS_HAS_REFERENCES(objectClass);
 
 	if (hasReferences) {
-		const UDATA *descriptionPtr = (UDATA *) objectClass->instanceDescription;
-		UDATA descriptionBits = 0;
-		if (((UDATA)descriptionPtr) & 1) {
-			descriptionBits = ((UDATA)descriptionPtr) >> 1;
+		const uintptr_t *descriptionPtr = (uintptr_t *)objectClass->instanceDescription;
+		uintptr_t descriptionBits = 0;
+		if (((uintptr_t)descriptionPtr) & 1) {
+			descriptionBits = ((uintptr_t)descriptionPtr) >> 1;
 		} else {
 			descriptionBits = *descriptionPtr++;
 		}
 
-		UDATA descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
+		uintptr_t descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 
 		while (offset < limit) {
 			/* Determine if the slot contains an object pointer or not */
@@ -1772,17 +1781,22 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 					objectPtr = objectMapFunction(vmThread, objectPtr, objectMapData);
 				}
 				mixedObjectStoreObject(vmThread, destObject, destOffset + offset, objectPtr, false);
+				offset += referenceSize;
 			} else {
-				UDATA srcAddress = (UDATA)srcObject + srcOffset + offset;
-				UDATA destAddress = (UDATA)destObject + destOffset + offset;
+				uintptr_t srcAddress = (uintptr_t)srcObject + srcOffset + offset;
+				uintptr_t destAddress = (uintptr_t)destObject + destOffset + offset;
 				bool copy64Bits = false;
-				UDATA descriptionBitsNext = descriptionBits;
-				const UDATA *descriptionPtrNext = descriptionPtr;
-				UDATA descriptionIndexNext = descriptionIndex;
+				uintptr_t descriptionBitsNext = descriptionBits;
+				const uintptr_t *descriptionPtrNext = descriptionPtr;
+				uintptr_t descriptionIndexNext = descriptionIndex;
 				if (isValueType
 					&& (sizeof(uint32_t) == referenceSize)
 					&& (0 == (srcAddress & 7))
-					&& ((offset + referenceSize) < limit)
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+					&& ((offset + sizeof(uint64_t)) <= limit)
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+					&& ((offset + sizeof(uint64_t)) <= limit)
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 				) {
 					descriptionBitsNext >>= 1;
 					if (descriptionIndexNext-- == 0) {
@@ -1798,15 +1812,30 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 					descriptionBits = descriptionBitsNext;
 					descriptionPtr = descriptionPtrNext;
 					descriptionIndex = descriptionIndexNext;
-					/**
-					 * When doing 64-bit copy, offset needs to be advanced 8 bytes. referenceSize is 4 bytes here.
-					 * Advance offset 4 bytes here. Another 4 bytes are advanced at the end of the while loop below.
-					 */
+					offset += sizeof(uint64_t);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+				} else if ((sizeof(uint32_t) == referenceSize)
+					&& ((offset + sizeof(uint32_t)) <= limit)
+				) {
+					*(uint32_t *)destAddress = *(uint32_t *)srcAddress;
+					offset += sizeof(uint32_t);
+				} else if ((offset + sizeof(uintptr_t)) <= limit) {
+					*(uintptr_t *)destAddress = *(uintptr_t *)srcAddress;
 					offset += referenceSize;
+				} else if ((offset + sizeof(uint16_t)) <= limit) {
+					*(uint16_t *)destAddress = *(uint16_t *)srcAddress;
+					offset += sizeof(uint16_t);
+				} else {
+					*(uint8_t *)destAddress = *(uint8_t *)srcAddress;
+					offset += sizeof(uint8_t);
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 				} else if (sizeof(uint32_t) == referenceSize) {
 					*(uint32_t *)destAddress = *(uint32_t *)srcAddress;
+					offset += sizeof(uint32_t);
 				} else {
 					*(uintptr_t *)destAddress = *(uintptr_t *)srcAddress;
+					offset += referenceSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 				}
 			}
 			descriptionBits >>= 1;
@@ -1814,22 +1843,33 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 				descriptionBits = *descriptionPtr++;
 				descriptionIndex = J9_OBJECT_DESCRIPTION_SIZE - 1;
 			}
-			offset += referenceSize;
 		}
 	} else {
 		/* no instanceDescription bits needed on this path */
 		while (offset < limit) {
-			UDATA srcAddress = (UDATA)srcObject + srcOffset + offset;
-			UDATA destAddress = (UDATA)destObject + destOffset + offset;
+			uintptr_t srcAddress = (uintptr_t)srcObject + srcOffset + offset;
+			uintptr_t destAddress = (uintptr_t)destObject + destOffset + offset;
 			/* prefer to copy 64 bits at a time if possible */
 			if ((sizeof(uint64_t) == referenceSize)
 				|| (isValueType && (0 == (srcAddress & 7)) && ((offset + referenceSize) < limit))
 			) {
 				*(uint64_t *)destAddress = *(uint64_t *)srcAddress;
 				offset += sizeof(uint64_t);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			} else if ((offset + sizeof(uint32_t)) <= limit) {
+				*(uint32_t *)destAddress = *(uint32_t *)srcAddress;
+				offset += sizeof(uint32_t);
+			} else if ((offset + sizeof(uint16_t)) <= limit) {
+				*(uint16_t *)destAddress = *(uint16_t *)srcAddress;
+				offset += sizeof(uint16_t);
+			} else {
+				*(uint8_t *)destAddress = *(uint8_t *)srcAddress;
+				offset += sizeof(uint8_t);
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			} else {
 				*(uint32_t *)destAddress = *(uint32_t *)srcAddress;
 				offset += sizeof(uint32_t);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			}
 		}
 	}
@@ -1843,7 +1883,7 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 			hashcodeOffset = _extensions->mixedObjectModel.getHashcodeOffset(destObject);
 		}
 		if (hashcodeOffset <= limit) {
-			I_32 *hashcodePointer = (I_32*)((U_8*)destObject + hashcodeOffset);
+			int32_t *hashcodePointer = (int32_t *)((uint8_t *)destObject + hashcodeOffset);
 			*hashcodePointer = hashCode;
 		}
 	}

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -1792,11 +1792,7 @@ MM_ObjectAccessBarrier::copyObjectFields(J9VMThread *vmThread, J9Class *objectCl
 				if (isValueType
 					&& (sizeof(uint32_t) == referenceSize)
 					&& (0 == (srcAddress & 7))
-#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 					&& ((offset + sizeof(uint64_t)) <= limit)
-#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
-					&& ((offset + sizeof(uint64_t)) <= limit)
-#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 				) {
 					descriptionBitsNext >>= 1;
 					if (descriptionIndexNext-- == 0) {

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -369,6 +369,11 @@ public:
 	VMINLINE UDATA
 	mixedObjectGetDataSize(J9Class *objectClass)
 	{
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+		if (J9_IS_J9CLASS_VALUETYPE(objectClass)) {
+			return objectClass->flatFieldSize;
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 		return J9CLASS_UNPADDED_INSTANCE_SIZE(objectClass);
 	}
 
@@ -433,22 +438,33 @@ public:
 		vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyObjectFields(vmThread, objectClass, srcObject, srcOffset, destObject, destOffset, objectMapFunction, objectMapData, initializeLockWord);
 #else /* defined(J9VM_GC_ALWAYS_CALL_OBJECT_ACCESS_BARRIER) */
 		bool hasReferences = J9CLASS_HAS_REFERENCES(objectClass);
-		if (hasReferences && ((NULL != objectMapFunction) || (j9gc_modron_readbar_none != _readBarrierType) || (j9gc_modron_wrtbar_always == _writeBarrierType))) {
+		UDATA limit = mixedObjectGetDataSize(objectClass);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		bool is32BitAligned = (0 != limit) && (0 == (limit % sizeof(U_32)));
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+		if ((hasReferences
+				&& ((NULL != objectMapFunction)
+					|| (j9gc_modron_readbar_none != _readBarrierType)
+					|| (j9gc_modron_wrtbar_always == _writeBarrierType)))
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			|| !is32BitAligned
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+		) {
 			vmThread->javaVM->memoryManagerFunctions->j9gc_objaccess_copyObjectFields(vmThread, objectClass, srcObject, srcOffset, destObject, destOffset, objectMapFunction, objectMapData, initializeLockWord);
 		} else {
 			UDATA offset = 0;
-			UDATA limit = mixedObjectGetDataSize(objectClass);
 
-			if (J9VMTHREAD_COMPRESS_OBJECT_REFERENCES(vmThread)) {
-				while (offset < limit) {
-					*(uint32_t*)((UDATA)destObject + offset + destOffset) = *(uint32_t*)((UDATA)srcObject + offset + srcOffset);
-					offset += sizeof(uint32_t);
-				}
-			} else {
-				while (offset < limit) {
-					*(uintptr_t*)((UDATA)destObject + offset + destOffset) = *(uintptr_t*)((UDATA)srcObject + offset + srcOffset);
-					offset += sizeof(uintptr_t);
-				}
+			/* At this point, limit is 32-bit aligned.
+			 * First copy as many 64-bit segments as possible, then copy 32 bits if needed.
+			 */
+			UDATA limitRounded = ROUND_DOWN_TO_POWEROF2(limit, sizeof(U_64));
+			while (offset < limitRounded) {
+				*(U_64 *)((UDATA)destObject + offset + destOffset) = *(U_64 *)((UDATA)srcObject + offset + srcOffset);
+				offset += sizeof(U_64);
+			}
+			if ((offset + sizeof(U_32)) <= limit) {
+				*(U_32 *)((UDATA)destObject + offset + destOffset) = *(U_32 *)((UDATA)srcObject + offset + srcOffset);
+				offset += sizeof(U_32);
 			}
 			if (!J9_IS_J9CLASS_VALUETYPE(objectClass)) {
 				if (initializeLockWord) {

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -338,7 +338,7 @@ static const struct { \
 #endif /* J9VM_OPT_VALHALLA_VALUE_TYPES */
 
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-#define J9CLASS_UNPADDED_INSTANCE_SIZE(clazz) J9_VALUETYPE_FLATTENED_SIZE(clazz)
+#define J9CLASS_UNPADDED_INSTANCE_SIZE(clazz) (J9CLASS_HAS_4BYTE_PREPADDING((clazz)) ? ((clazz)->totalInstanceSize - sizeof(U_32)) : (clazz)->totalInstanceSize)
 #define J9_IS_J9CLASS_PRIMITIVE_VALUETYPE(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassIsPrimitiveValueType)
 /**
  * This macro can only be used to determine vm flattening for a J9ArrayClass.
@@ -354,7 +354,11 @@ static const struct { \
 		(J9ROMFIELD_IS_NULL_RESTRICTED(romFieldShape) && \
 		J9_IS_J9CLASS_FLATTENED(fieldClazz) && \
 		(J9_ARE_NO_BITS_SET((romFieldShape)->modifiers, J9AccVolatile) || (J9CLASS_UNPADDED_INSTANCE_SIZE(fieldClazz) <= sizeof(U_64))))
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+#define J9_VALUETYPE_FLATTENED_SIZE(clazz) ((clazz)->flatFieldSize)
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #define J9_VALUETYPE_FLATTENED_SIZE(clazz) (J9CLASS_HAS_4BYTE_PREPADDING((clazz)) ? ((clazz)->totalInstanceSize - sizeof(U_32)) : (clazz)->totalInstanceSize)
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #define J9_IS_J9ARRAYCLASS_NULL_RESTRICTED(clazz) J9_ARE_ALL_BITS_SET((clazz)->classFlags, J9ClassArrayIsNullRestricted)
 #define J9CLASS_GET_NULLRESTRICTED_ARRAY(clazz) (J9_IS_J9CLASS_VALUETYPE(clazz) ? (clazz)->nullRestrictedArrayClass : NULL)
 #else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -1996,10 +1996,18 @@ typedef struct J9ROMFieldOffsetWalkState {
 	UDATA firstSingleOffset;
 	UDATA firstObjectOffset;
 	UDATA firstDoubleOffset;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	UDATA firstShortOffset;
+	UDATA firstByteOffset;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	IDATA backfillOffsetToUse;
 	U_32 singlesSeen;
 	U_32 objectsSeen;
 	U_32 doublesSeen;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	U_32 shortsSeen;
+	U_32 bytesSeen;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	U_32 singleStaticsSeen;
 	U_32 objectStaticsSeen;
 	U_32 doubleStaticsSeen;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -83,6 +83,7 @@
 #define J9ClassLargestAlignmentConstraintReference 0x800
 #define J9ClassLargestAlignmentConstraintDouble 0x1000
 #define J9ClassIsExemptFromValidation 0x2000
+#define J9ClassLargestAlignmentConstraintInteger 0x4000
 #define J9ClassCanSupportFastSubstitutability 0x8000
 #define J9ClassHasReferences 0x10000
 #define J9ClassRequiresPrePadding 0x20000
@@ -91,6 +92,7 @@
 #define J9ClassEnsureHashed 0x100000
 #define J9ClassHasOffloadAllowSubtasksNatives 0x200000
 #define J9ClassIsPrimitiveValueType 0x400000
+#define J9ClassLargestAlignmentConstraintShort 0x800000
 #define J9ClassNeedToPruneMemberNames 0x1000000
 #define J9ClassArrayIsNullRestricted 0x2000000
 #define J9ClassIsLoadedFromSnapshot 0x4000000
@@ -1975,6 +1977,9 @@ typedef struct J9ROMFieldOffsetWalkResult {
 	IDATA backfillOffset;
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 	struct J9Class* flattenedClass;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	UDATA flatFieldSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 } J9ROMFieldOffsetWalkResult;
 
@@ -2024,9 +2029,17 @@ typedef struct J9ROMFieldOffsetWalkState {
 	UDATA firstFlatSingleOffset;
 	UDATA firstFlatObjectOffset;
 	UDATA firstFlatDoubleOffset;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	UDATA firstFlatShortOffset;
+	UDATA firstFlatByteOffset;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	UDATA currentFlatSingleOffset;
 	UDATA currentFlatObjectOffset;
 	UDATA currentFlatDoubleOffset;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	UDATA currentFlatShortOffset;
+	UDATA currentFlatByteOffset;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	BOOLEAN classRequiresPrePadding;
 	UDATA flatBackFillSize;
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
@@ -3743,6 +3756,9 @@ typedef struct J9Class {
 #endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 	struct J9Class *nullRestrictedArrayClass;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	UDATA flatFieldSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 } J9Class;
 
@@ -3848,6 +3864,9 @@ typedef struct J9ArrayClass {
 	 * A null-restricted J9ArrayClass points to its nullable companion, if one exists.
 	 */
 	struct J9Class *companionArray;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	UDATA flatFieldSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 } J9ArrayClass;
 

--- a/runtime/vm/ObjectFieldInfo.cpp
+++ b/runtime/vm/ObjectFieldInfo.cpp
@@ -90,6 +90,14 @@ ObjectFieldInfo::countInstanceFields(void)
 			} else if (modifiers & J9FieldSizeDouble) {
 				_instanceDoubleCount += 1;
 				_totalDoubleCount += 1;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeChar) || ((modifiers & J9FieldTypeMask) == J9FieldTypeShort)) {
+				_instanceShortCount += 1;
+				_totalShortCount += 1;
+			} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeBoolean) || ((modifiers & J9FieldTypeMask) == J9FieldTypeByte)) {
+				_instanceByteCount += 1;
+				_totalByteCount += 1;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			} else {
 				_instanceSingleCount += 1;
 				_totalSingleCount += 1;
@@ -107,6 +115,14 @@ ObjectFieldInfo::countInstanceFields(void)
 		_contendedSingleCount = _instanceSingleCount;
 		_totalSingleCount -= _instanceSingleCount;
 		_instanceSingleCount = 0;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		_contendedShortCount = _instanceShortCount;
+		_totalShortCount -= _instanceShortCount;
+		_instanceShortCount = 0;
+		_contendedByteCount = _instanceByteCount;
+		_totalByteCount -= _instanceByteCount;
+		_instanceByteCount = 0;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	}
 }
 
@@ -126,6 +142,12 @@ ObjectFieldInfo::countAndCopyHiddenFields(J9HiddenInstanceField *hiddenFieldList
 				_totalObjectCount += 1;
 			} else if (J9_ARE_ANY_BITS_SET(modifiers, J9FieldSizeDouble)) {
 				_totalDoubleCount += 1;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeChar) || ((modifiers & J9FieldTypeMask) == J9FieldTypeShort)) {
+				_totalShortCount += 1;
+			} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeBoolean) || ((modifiers & J9FieldTypeMask) == J9FieldTypeByte)) {
+				_totalByteCount += 1;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			} else {
 				_totalSingleCount += 1;
 			}
@@ -147,9 +169,18 @@ ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 
 		accumulator = getPaddedTrueNonContendedSize(); /* this includes the header */
 		accumulator += (_contendedObjectCount * _referenceSize) + (_contendedSingleCount * sizeof(U_32)) + (_contendedDoubleCount * sizeof(U_64)); /* add the contended fields */
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		accumulator += (_contendedShortCount * sizeof(U_16)) + (_contendedByteCount * sizeof(U_8));
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 		accumulator = ROUND_UP_TO_POWEROF2((UDATA)accumulator, (UDATA)_cacheLineSize) - _objectHeaderSize; /* Rounding takes care of the odd number of 4-byte fields. Remove the header */
 	} else {
 		accumulator = _superclassFieldsSize + (_totalObjectCount * _referenceSize) + (_totalSingleCount * sizeof(U_32)) + (_totalDoubleCount * sizeof(U_64));
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		U_32 smallTypeSize = (_totalShortCount * sizeof(U_16)) + (_totalByteCount * sizeof(U_8));
+		/* 16 and 8-bit fields must be aligned to 32 bits. */
+		U_32 smallTypeSizeRounded = ROUND_UP_TO_POWEROF2((UDATA)smallTypeSize, sizeof(U_32));
+		accumulator += smallTypeSizeRounded;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		accumulator += _totalFlatFieldDoubleBytes + _totalFlatFieldRefBytes + _totalFlatFieldSingleBytes;
 

--- a/runtime/vm/ObjectFieldInfo.cpp
+++ b/runtime/vm/ObjectFieldInfo.cpp
@@ -50,11 +50,15 @@ ObjectFieldInfo::countInstanceFields(void)
 					J9UTF8 *fieldSig = J9ROMFIELDSHAPE_SIGNATURE(field);
 					U_8 *fieldSigBytes = J9UTF8_DATA(J9ROMFIELDSHAPE_SIGNATURE(field));
 					J9Class *fieldClass = findJ9ClassInFlattenedClassCache(_flattenedClassCache, fieldSigBytes + 1, J9UTF8_LENGTH(fieldSig) - 2);
-					U_32 size = (U_32)fieldClass->totalInstanceSize;
 					if (!J9_IS_FIELD_FLATTENED(fieldClass, field)) {
 						_instanceObjectCount += 1;
 						_totalObjectCount += 1;
 					} else {
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+						U_32 size = (U_32)fieldClass->flatFieldSize;
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+						U_32 size = (U_32)fieldClass->totalInstanceSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 						bool forceDoubleAlignment = false;
 						if (sizeof(U_32) == _referenceSize) {
 							/* Flattened volatile valueType that is 8 bytes should be put at 8-byte aligned address. Currently flattening is disabled
@@ -68,17 +72,31 @@ ObjectFieldInfo::countInstanceFields(void)
 						if (forceDoubleAlignment
 							|| J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintDouble)
 						) {
+#if !defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 							if (J9CLASS_HAS_4BYTE_PREPADDING(fieldClass)) {
 								size -= sizeof(U_32);
 							}
+#endif /* !defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 							_totalFlatFieldDoubleBytes += (U_32) ROUND_UP_TO_POWEROF2(size, sizeof(U_64));
 						} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {
 							size = (U_32) ROUND_UP_TO_POWEROF2(size, (UDATA)_referenceSize);
 							_totalFlatFieldRefBytes += size;
 							setPotentialFlatObjectInstanceBackfill(size);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+						} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintInteger)) {
+							size = (U_32) ROUND_UP_TO_POWEROF2(size, sizeof(U_32));
+							_totalFlatFieldSingleBytes += size;
+							setPotentialFlatSingleInstanceBackfill(size);
+						} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintShort)) {
+							size = (U_32) ROUND_UP_TO_POWEROF2(size, sizeof(U_16));
+							_totalFlatFieldShortBytes += size;
+						} else {
+							_totalFlatFieldByteBytes += size;
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 						} else {
 							_totalFlatFieldSingleBytes += size;
 							setPotentialFlatSingleInstanceBackfill(size);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 						}
 					}
 				} else
@@ -177,6 +195,9 @@ ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 		accumulator = _superclassFieldsSize + (_totalObjectCount * _referenceSize) + (_totalSingleCount * sizeof(U_32)) + (_totalDoubleCount * sizeof(U_64));
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 		U_32 smallTypeSize = (_totalShortCount * sizeof(U_16)) + (_totalByteCount * sizeof(U_8));
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+		smallTypeSize += _totalFlatFieldShortBytes + _totalFlatFieldByteBytes;
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 		/* 16 and 8-bit fields must be aligned to 32 bits. */
 		U_32 smallTypeSizeRounded = ROUND_UP_TO_POWEROF2((UDATA)smallTypeSize, sizeof(U_32));
 		accumulator += smallTypeSizeRounded;
@@ -241,3 +262,25 @@ ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 	}
 	return accumulator;
 }
+
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+U_32
+ObjectFieldInfo::calculateFlatFieldSize()
+{
+	U_32 accumulator = 0;
+	if (isValue()) {
+		accumulator = _superclassFieldsSize
+				+ (_totalObjectCount * _referenceSize)
+				+ (_totalDoubleCount * sizeof(U_64))
+				+ (_totalSingleCount * sizeof(U_32))
+				+ (_totalShortCount * sizeof(U_16))
+				+ (_totalByteCount * sizeof(U_8))
+				+ _totalFlatFieldDoubleBytes
+				+ _totalFlatFieldRefBytes
+				+ _totalFlatFieldSingleBytes
+				+ _totalFlatFieldShortBytes
+				+ _totalFlatFieldByteBytes;
+	}
+	return accumulator;
+}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */

--- a/runtime/vm/ObjectFieldInfo.cpp
+++ b/runtime/vm/ObjectFieldInfo.cpp
@@ -55,9 +55,9 @@ ObjectFieldInfo::countInstanceFields(void)
 						_totalObjectCount += 1;
 					} else {
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
-						U_32 size = (U_32)fieldClass->flatFieldSize;
+						UDATA size = fieldClass->flatFieldSize;
 #else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
-						U_32 size = (U_32)fieldClass->totalInstanceSize;
+						UDATA size = fieldClass->totalInstanceSize;
 #endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 						bool forceDoubleAlignment = false;
 						if (sizeof(U_32) == _referenceSize) {
@@ -77,18 +77,18 @@ ObjectFieldInfo::countInstanceFields(void)
 								size -= sizeof(U_32);
 							}
 #endif /* !defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
-							_totalFlatFieldDoubleBytes += (U_32) ROUND_UP_TO_POWEROF2(size, sizeof(U_64));
+							_totalFlatFieldDoubleBytes += ROUND_UP_TO_POWEROF2(size, sizeof(U_64));
 						} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {
-							size = (U_32) ROUND_UP_TO_POWEROF2(size, (UDATA)_referenceSize);
+							size = ROUND_UP_TO_POWEROF2(size, _referenceSize);
 							_totalFlatFieldRefBytes += size;
 							setPotentialFlatObjectInstanceBackfill(size);
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 						} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintInteger)) {
-							size = (U_32) ROUND_UP_TO_POWEROF2(size, sizeof(U_32));
+							size = ROUND_UP_TO_POWEROF2(size, sizeof(U_32));
 							_totalFlatFieldSingleBytes += size;
 							setPotentialFlatSingleInstanceBackfill(size);
 						} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintShort)) {
-							size = (U_32) ROUND_UP_TO_POWEROF2(size, sizeof(U_16));
+							size = ROUND_UP_TO_POWEROF2(size, sizeof(U_16));
 							_totalFlatFieldShortBytes += size;
 						} else {
 							_totalFlatFieldByteBytes += size;
@@ -176,10 +176,10 @@ ObjectFieldInfo::countAndCopyHiddenFields(J9HiddenInstanceField *hiddenFieldList
 	return _hiddenFieldCount;
 }
 
-U_32
+UDATA
 ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 {
-	U_32 accumulator = 0;
+	UDATA accumulator = 0;
 	if (isContendedClassLayout()) {
 		_superclassBackfillOffset = NO_BACKFILL_AVAILABLE;
 		_myBackfillOffset = NO_BACKFILL_AVAILABLE;
@@ -190,16 +190,16 @@ ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 		accumulator += (_contendedShortCount * sizeof(U_16)) + (_contendedByteCount * sizeof(U_8));
 #endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
-		accumulator = ROUND_UP_TO_POWEROF2((UDATA)accumulator, (UDATA)_cacheLineSize) - _objectHeaderSize; /* Rounding takes care of the odd number of 4-byte fields. Remove the header */
+		accumulator = ROUND_UP_TO_POWEROF2(accumulator, _cacheLineSize) - _objectHeaderSize; /* Rounding takes care of the odd number of 4-byte fields. Remove the header */
 	} else {
 		accumulator = _superclassFieldsSize + (_totalObjectCount * _referenceSize) + (_totalSingleCount * sizeof(U_32)) + (_totalDoubleCount * sizeof(U_64));
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
-		U_32 smallTypeSize = (_totalShortCount * sizeof(U_16)) + (_totalByteCount * sizeof(U_8));
+		UDATA smallTypeSize = (_totalShortCount * sizeof(U_16)) + (_totalByteCount * sizeof(U_8));
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		smallTypeSize += _totalFlatFieldShortBytes + _totalFlatFieldByteBytes;
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 		/* 16 and 8-bit fields must be aligned to 32 bits. */
-		U_32 smallTypeSizeRounded = ROUND_UP_TO_POWEROF2((UDATA)smallTypeSize, sizeof(U_32));
+		UDATA smallTypeSizeRounded = ROUND_UP_TO_POWEROF2(smallTypeSize, sizeof(U_32));
 		accumulator += smallTypeSizeRounded;
 #endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
@@ -235,7 +235,7 @@ ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 			 * alignment requirements of double slot fields. We will use the J9ClassHasPrePadding flag
 			 * to denote this.
 			 */
-			U_32 firstFieldOffset = calculateFieldDataStart();
+			UDATA firstFieldOffset = calculateFieldDataStart();
 			if (0 < firstFieldOffset) {
 				if (isBackfillSuitableFieldAvailable()) {
 					/*
@@ -264,10 +264,10 @@ ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 }
 
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-U_32
+UDATA
 ObjectFieldInfo::calculateFlatFieldSize()
 {
-	U_32 accumulator = 0;
+	UDATA accumulator = 0;
 	if (isValue()) {
 		accumulator = _superclassFieldsSize
 				+ (_totalObjectCount * _referenceSize)

--- a/runtime/vm/ObjectFieldInfo.hpp
+++ b/runtime/vm/ObjectFieldInfo.hpp
@@ -36,12 +36,12 @@
 
 class ObjectFieldInfo {
 private:
-	U_32 _objectHeaderSize;
-	U_32 _referenceSize;
-	U_32 _cacheLineSize;
+	UDATA _objectHeaderSize;
+	UDATA _referenceSize;
+	UDATA _cacheLineSize;
 	bool _useContendedClassLayout; /* check this in constructor. Forced to false if we can't get the line size */
 	J9ROMClass *_romClass;
-	U_32 _superclassFieldsSize;
+	UDATA _superclassFieldsSize;
 	bool _objectCanUseBackfill; /* true if an object reference is the same size as a backfill slot */
 
 	/* These count uncontended instance and hidden fields */
@@ -72,17 +72,17 @@ private:
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 	bool _isValue;
 	J9FlattenedClassCache *_flattenedClassCache;
-	U_32 _totalFlatFieldDoubleBytes;
-	U_32 _totalFlatFieldRefBytes;
-	U_32 _totalFlatFieldSingleBytes;
+	UDATA _totalFlatFieldDoubleBytes;
+	UDATA _totalFlatFieldRefBytes;
+	UDATA _totalFlatFieldSingleBytes;
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
-	U_32 _totalFlatFieldShortBytes;
-	U_32 _totalFlatFieldByteBytes;
+	UDATA _totalFlatFieldShortBytes;
+	UDATA _totalFlatFieldByteBytes;
 #endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
-	U_32 _flatAlignedObjectInstanceBackfill;
-	U_32 _flatAlignedSingleInstanceBackfill;
-	U_32 _flatUnAlignedObjectInstanceBackfill;
-	U_32 _flatUnAlignedSingleInstanceBackfill;
+	UDATA _flatAlignedObjectInstanceBackfill;
+	UDATA _flatAlignedSingleInstanceBackfill;
+	UDATA _flatUnAlignedObjectInstanceBackfill;
+	UDATA _flatUnAlignedSingleInstanceBackfill;
 	bool _classRequiresPrePadding;
 	bool _isBackFillPostPadded;
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
@@ -97,15 +97,15 @@ private:
 	 * Calculate a position guaranteed to be on a different cache line from the header, superclass fields, and hidden fields.
 	 * @return offset from the start of the header
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getPaddedTrueNonContendedSize(void) const
 	{
-		U_32 accumulator = _superclassFieldsSize +  _objectHeaderSize; /* get the true size with header */
+		UDATA accumulator = _superclassFieldsSize +  _objectHeaderSize; /* get the true size with header */
 		accumulator += (_totalObjectCount * _objectHeaderSize) + (_totalSingleCount * sizeof(U_32)) + (_totalDoubleCount * sizeof(U_64)); /* add the non-contended and hidden fields */
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
-		U_32 smallTypeSize = (_totalShortCount * sizeof(U_16)) + (_totalByteCount * sizeof(U_8));
+		UDATA smallTypeSize = (_totalShortCount * sizeof(U_16)) + (_totalByteCount * sizeof(U_8));
 		/* 16 and 8-bit fields must be aligned to 32 bits. */
-		U_32 smallTypeSizeRounded = ROUND_UP_TO_POWEROF2((UDATA)smallTypeSize, sizeof(U_32));
+		UDATA smallTypeSizeRounded = ROUND_UP_TO_POWEROF2((UDATA)smallTypeSize, sizeof(U_32));
 		accumulator += smallTypeSizeRounded;
 #endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 		accumulator = ROUND_DOWN_TO_POWEROF2(accumulator, OBJECT_SIZE_INCREMENT_IN_BYTES) + _cacheLineSize; /* get the worst-case cache line boundary and add a cache size */
@@ -130,7 +130,7 @@ public:
 		_cacheLineSize(0),
 		_useContendedClassLayout(false),
 		_romClass(romClass),
-		_superclassFieldsSize((U_32) -1),
+		_superclassFieldsSize((UDATA) -1),
 		_objectCanUseBackfill(J9JAVAVM_REFERENCE_SIZE(vm) == BACKFILL_SIZE),
 		_instanceObjectCount(0),
 		_instanceSingleCount(0),
@@ -179,7 +179,7 @@ public:
 		if (J9ROMCLASS_IS_CONTENDED(romClass)) {
 			UDATA dCacheLineSize = vm->dCacheLineSize;
 			if (dCacheLineSize > 0) {
-				_cacheLineSize = (U_32) dCacheLineSize;
+				_cacheLineSize = dCacheLineSize;
 				_useContendedClassLayout = true;
 			}
 		}
@@ -413,10 +413,10 @@ public:
 	 *
 	 * @return size of backfill
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getBackfillSize()
 	{
-		U_32 backFillSize = BACKFILL_SIZE;
+		UDATA backFillSize = BACKFILL_SIZE;
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		if ((0 != getInstanceSingleCount()) || (_objectCanUseBackfill && (0 != getInstanceObjectCount()))) {
 			/* BACKFILL_SIZE */
@@ -445,20 +445,20 @@ public:
 		return _myBackfillOffset + _objectHeaderSize;
 	}
 
-	VMINLINE U_32
+	VMINLINE UDATA
 	getSuperclassFieldsSize(void) const
 	{
 		return _superclassFieldsSize;
 	}
 
-	VMINLINE U_32
+	VMINLINE UDATA
 	getSuperclassObjectSize(void) const
 	{
 		return _superclassFieldsSize + _objectHeaderSize;
 	}
 
 	VMINLINE void
-	setSuperclassFieldsSize(U_32 superTotalSize)
+	setSuperclassFieldsSize(UDATA superTotalSize)
 	{
 		this->_superclassFieldsSize = superTotalSize;
 	}
@@ -480,7 +480,7 @@ public:
 	 * Update the backfill values to use for this class's fields and those of subclasses
 	 * @return size of the object in bytes, not including the header
 	 */
-	U_32
+	UDATA
 	calculateTotalFieldsSizeAndBackfill(void);
 
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
@@ -495,7 +495,7 @@ public:
 	 *
 	 * @return the flat field size for value classes
 	 */
-	U_32
+	UDATA
 	calculateFlatFieldSize(void);
 #endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
@@ -505,10 +505,10 @@ public:
 	 * Since the superclass is not end-aligned it must have no embedded backfill.
 	 * @return offset to the first (non-backfilled) field.
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	calculateFieldDataStart(void)
 	{
-		U_32 fieldDataStart = 0;
+		UDATA fieldDataStart = 0;
 		if (!isContendedClassLayout()) {
 			bool doubleAlignment = (_totalDoubleCount > 0);
 			bool hasObjects = _totalObjectCount > 0;
@@ -681,7 +681,7 @@ public:
 	 *
 	 * @return size of flat single slot end-aligned backfill
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getFlatAlignedSingleInstanceBackfillSize() const
 	{
 		return _flatAlignedSingleInstanceBackfill;
@@ -693,7 +693,7 @@ public:
 	 *
 	 * @return size of flat single slot non end-aligned backfill
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getFlatUnAlignedSingleInstanceBackfillSize() const
 	{
 		return _flatUnAlignedSingleInstanceBackfill;
@@ -705,7 +705,7 @@ public:
 	 *
 	 * @return size of flat object slot end-aligned backfill
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getFlatAlignedObjectInstanceBackfillSize() const
 	{
 		return _flatAlignedObjectInstanceBackfill;
@@ -717,7 +717,7 @@ public:
 	 *
 	 * @return size of flat object slot end-aligned backfill
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getFlatUnAlignedObjectInstanceBackfillSize() const
 	{
 		return _flatUnAlignedObjectInstanceBackfill;
@@ -730,7 +730,7 @@ public:
 	 * @param size of flat single slot end-aligned backfill
 	 */
 	VMINLINE void
-	setFlatAlignedSingleInstanceBackfill(U_32 size)
+	setFlatAlignedSingleInstanceBackfill(UDATA size)
 	{
 		_flatAlignedSingleInstanceBackfill = size;
 	}
@@ -742,7 +742,7 @@ public:
 	 * @param size of flat single slot non end-aligned backfill
 	 */
 	VMINLINE void
-	setFlatUnAlignedSingleInstanceBackfill(U_32 size)
+	setFlatUnAlignedSingleInstanceBackfill(UDATA size)
 	{
 		_flatUnAlignedSingleInstanceBackfill = size;
 	}
@@ -754,7 +754,7 @@ public:
 	 * @param size of flat object slot end-aligned backfill
 	 */
 	VMINLINE void
-	setFlatAlignedObjectInstanceBackfill(U_32 size)
+	setFlatAlignedObjectInstanceBackfill(UDATA size)
 	{
 		_flatAlignedObjectInstanceBackfill = size;
 	}
@@ -766,7 +766,7 @@ public:
 	 * @param size of flat object slot non end-aligned backfill
 	 */
 	VMINLINE void
-	setFlatUnAlignedObjectInstanceBackfill(U_32 size)
+	setFlatUnAlignedObjectInstanceBackfill(UDATA size)
 	{
 		_flatUnAlignedObjectInstanceBackfill = size;
 	}
@@ -783,7 +783,7 @@ public:
 	 * @param size of flat object slot end-aligned backfill
 	 */
 	VMINLINE void
-	setPotentialFlatObjectInstanceBackfill(U_32 size)
+	setPotentialFlatObjectInstanceBackfill(UDATA size)
 	{
 		if (_isValue) {
 			if (isBackfillTypeEndAligned(size)) {
@@ -810,7 +810,7 @@ public:
 	 * @param size of flat single slot end-aligned backfill
 	 */
 	VMINLINE void
-	setPotentialFlatSingleInstanceBackfill(U_32 size)
+	setPotentialFlatSingleInstanceBackfill(UDATA size)
 	{
 		if (_isValue) {
 			if (isBackfillTypeEndAligned(size)) {
@@ -830,17 +830,18 @@ public:
 	 *
 	 * @return size of flat object instance bytes
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getNonBackfilledFlatInstanceObjectSize(void) const
 	{
-		U_32 nonBackfilledFlatObjectsSize = _totalFlatFieldRefBytes;
+		UDATA nonBackfilledFlatObjectsSize = _totalFlatFieldRefBytes;
 		if (isBackfillSuitableInstanceObjectAvailable()
 			&& isMyBackfillSlotAvailable()
 			&& (0 == getInstanceSingleCount())
-			&& (_objectCanUseBackfill && (0 == getInstanceObjectCount()))
+			&& _objectCanUseBackfill
+			&& (0 == getInstanceObjectCount())
 			&& (0 == getFlatAlignedSingleInstanceBackfillSize())
 		) {
-			U_32 backfillSize = getFlatAlignedObjectInstanceBackfillSize();
+			UDATA backfillSize = getFlatAlignedObjectInstanceBackfillSize();
 			if (0 == backfillSize) {
 				if (0 == getFlatUnAlignedSingleInstanceBackfillSize()) {
 					backfillSize = getFlatUnAlignedObjectInstanceBackfillSize();
@@ -856,16 +857,17 @@ public:
 	 *
 	 * @return size of flat single instance bytes
 	 */
-	VMINLINE U_32
+	VMINLINE UDATA
 	getNonBackfilledFlatInstanceSingleSize(void) const
 	{
-		U_32 nonBackfilledFlatSinglesSize = _totalFlatFieldSingleBytes;
+		UDATA nonBackfilledFlatSinglesSize = _totalFlatFieldSingleBytes;
 		if (isBackfillSuitableFlatInstanceSingleAvailable()
 			&& isMyBackfillSlotAvailable()
 			&& (0 == getInstanceSingleCount())
-			&& (_objectCanUseBackfill && (0 == getInstanceObjectCount()))
+			&& _objectCanUseBackfill
+			&& (0 == getInstanceObjectCount())
 		) {
-			U_32 backfillSize = getFlatAlignedSingleInstanceBackfillSize();
+			UDATA backfillSize = getFlatAlignedSingleInstanceBackfillSize();
 			if (0 == backfillSize) {
 				if (0 == getFlatAlignedObjectInstanceBackfillSize()) {
 					backfillSize = getFlatUnAlignedSingleInstanceBackfillSize();

--- a/runtime/vm/ObjectFieldInfo.hpp
+++ b/runtime/vm/ObjectFieldInfo.hpp
@@ -75,6 +75,10 @@ private:
 	U_32 _totalFlatFieldDoubleBytes;
 	U_32 _totalFlatFieldRefBytes;
 	U_32 _totalFlatFieldSingleBytes;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	U_32 _totalFlatFieldShortBytes;
+	U_32 _totalFlatFieldByteBytes;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	U_32 _flatAlignedObjectInstanceBackfill;
 	U_32 _flatAlignedSingleInstanceBackfill;
 	U_32 _flatUnAlignedObjectInstanceBackfill;
@@ -155,6 +159,10 @@ public:
 		_totalFlatFieldDoubleBytes(0),
 		_totalFlatFieldRefBytes(0),
 		_totalFlatFieldSingleBytes(0),
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		_totalFlatFieldShortBytes(0),
+		_totalFlatFieldByteBytes(0),
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 		_flatAlignedObjectInstanceBackfill(0),
 		_flatAlignedSingleInstanceBackfill(0),
 		_flatUnAlignedObjectInstanceBackfill(0),
@@ -422,9 +430,9 @@ public:
 			backFillSize = getFlatUnAlignedObjectInstanceBackfillSize();
 		}
 		return backFillSize;
-#else /* if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 		return backFillSize;
-#endif /* if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 	}
 
 	/**
@@ -474,6 +482,22 @@ public:
 	 */
 	U_32
 	calculateTotalFieldsSizeAndBackfill(void);
+
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+	/**
+	 * Calculate the flat field size.
+	 *
+	 * The flat field size is the size if this class were flattened
+	 * as a field. It does not include alignment padding which
+	 * should be calculated depending on the largest field size in the class.
+	 *
+	 * For identity classes return 0, this value will not be used.
+	 *
+	 * @return the flat field size for value classes
+	 */
+	U_32
+	calculateFlatFieldSize(void);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 	/**
 	 * Fields can start on the first 8-byte boundary after the end of the superclass.
@@ -585,7 +609,7 @@ public:
 
 	/**
 	 * @param start end of previous field area, which should be after doubles
-	 * @return offset to end of the flat doubles area
+	 * @return offset to end of the flat objects area
 	 */
 	VMINLINE UDATA
 	addFlatObjectsArea(UDATA start) const
@@ -595,13 +619,35 @@ public:
 
 	/**
 	 * @param start end of previous field area, which should be after objects
-	 * @return offset to end of the flat doubles area
+	 * @return offset to end of the flat singles area
 	 */
 	VMINLINE UDATA
 	addFlatSinglesArea(UDATA start) const
 	{
 		return start + getNonBackfilledFlatInstanceSingleSize();
 	}
+
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the flat shorts area
+	 */
+	VMINLINE UDATA
+	addFlatShortsArea(UDATA start) const
+	{
+		return start + _totalFlatFieldShortBytes;
+	}
+
+	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the flat bytes area
+	 */
+	VMINLINE UDATA
+	addFlatBytesArea(UDATA start) const
+	{
+		return start + _totalFlatFieldByteBytes;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 
 	/**
 	 * Determines if a double field can be placed contiguously after the

--- a/runtime/vm/ObjectFieldInfo.hpp
+++ b/runtime/vm/ObjectFieldInfo.hpp
@@ -48,14 +48,26 @@ private:
 	U_32 _instanceObjectCount;
 	U_32 _instanceSingleCount;
 	U_32 _instanceDoubleCount;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	U_32 _instanceShortCount;
+	U_32 _instanceByteCount;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 	U_32 _totalObjectCount;
 	U_32 _totalSingleCount;
 	U_32 _totalDoubleCount;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	U_32 _totalShortCount;
+	U_32 _totalByteCount;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 
 	/* the following count fields annotated with @Contended, including regular fields in classes annotated with @Contended. */
 	U_32 _contendedObjectCount;
 	U_32 _contendedSingleCount;
 	U_32 _contendedDoubleCount;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	U_32 _contendedShortCount;
+	U_32 _contendedByteCount;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 	bool _isValue;
@@ -86,6 +98,12 @@ private:
 	{
 		U_32 accumulator = _superclassFieldsSize +  _objectHeaderSize; /* get the true size with header */
 		accumulator += (_totalObjectCount * _objectHeaderSize) + (_totalSingleCount * sizeof(U_32)) + (_totalDoubleCount * sizeof(U_64)); /* add the non-contended and hidden fields */
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		U_32 smallTypeSize = (_totalShortCount * sizeof(U_16)) + (_totalByteCount * sizeof(U_8));
+		/* 16 and 8-bit fields must be aligned to 32 bits. */
+		U_32 smallTypeSizeRounded = ROUND_UP_TO_POWEROF2((UDATA)smallTypeSize, sizeof(U_32));
+		accumulator += smallTypeSizeRounded;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 		accumulator = ROUND_DOWN_TO_POWEROF2(accumulator, OBJECT_SIZE_INCREMENT_IN_BYTES) + _cacheLineSize; /* get the worst-case cache line boundary and add a cache size */
 		return accumulator;
 	}
@@ -113,12 +131,24 @@ public:
 		_instanceObjectCount(0),
 		_instanceSingleCount(0),
 		_instanceDoubleCount(0),
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		_instanceShortCount(0),
+		_instanceByteCount(0),
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 		_totalObjectCount(0),
 		_totalSingleCount(0),
 		_totalDoubleCount(0),
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		_totalShortCount(0),
+		_totalByteCount(0),
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 		_contendedObjectCount(0),
 		_contendedSingleCount(0),
 		_contendedDoubleCount(0),
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		_contendedShortCount(0),
+		_contendedByteCount(0),
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		_isValue(J9ROMCLASS_IS_VALUE(romClass)),
 		_flattenedClassCache(flattenedClassCache),
@@ -182,6 +212,14 @@ public:
 		return _totalSingleCount;
 	}
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	VMINLINE U_32
+	getTotalShortCount(void) const
+	{
+		return _totalShortCount;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+
 	/**
 	 * Priorities for slots are:
 	 * 1. instance singles
@@ -211,11 +249,12 @@ public:
 		return nonBackfilledObjects;
 	}
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 	VMINLINE U_32
 	getNonBackfilledSingleCount(void) const
 	{
 		U_32 nonBackfilledSingle = _totalSingleCount;
-		if (isBackfillSuitableSingleAvailable()
+		if ((isBackfillSuitableInstanceSingleAvailable() || (isBackfillSuitableSingleAvailable() && !isBackfillSuitableObjectAvailable()))
 			&& isMyBackfillSlotAvailable()
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 			&& (0 != nonBackfilledSingle)
@@ -225,6 +264,7 @@ public:
 		}
 		return nonBackfilledSingle;
 	}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 
 	VMINLINE U_32
 	getNonBackfilledInstanceObjectCount(void) const
@@ -274,6 +314,20 @@ public:
 	{
 		return _instanceSingleCount;
 	}
+
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	VMINLINE U_32
+	getInstanceShortCount(void) const
+	{
+		return _instanceShortCount;
+	}
+
+	VMINLINE U_32
+	getInstanceByteCount(void) const
+	{
+		return _instanceByteCount;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 
 	VMINLINE U_32
 	getHiddenFieldCount(void) const
@@ -496,6 +550,28 @@ public:
 		return start + (isContendedClassLayout() ? _contendedObjectCount: getNonBackfilledObjectCount()) * _referenceSize;
 	}
 
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the shorts area
+	 * @note takes into account singles which will go in the backfill
+	 */
+	VMINLINE UDATA
+	addSinglesArea(UDATA start) const
+	{
+		return start + ((isContendedClassLayout() ? _contendedSingleCount : getNonBackfilledSingleCount()) * sizeof(U_32));
+	}
+
+	/**
+	 * @param start end of previous field area
+	 * @return offset to end of the shorts area
+	 */
+	VMINLINE UDATA
+	addShortsArea(UDATA start) const
+	{
+		return start + ((isContendedClassLayout() ? _contendedShortCount : _totalShortCount) * sizeof(U_16));
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 	/**
 	 * @param start end of previous field area, which should be the first field area

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -1983,10 +1983,11 @@ checkSuperClassAndInterfaces(J9VMThread *vmThread, J9ClassLoader *classLoader, J
  * static fields in the flattenedClassCache.
  *
  * 3. Sets the J9ClassLargestAlignmentConstraintDouble flag if any
- * of the fields are double-aligned. Similarily, it sets the
+ * of the fields are double-aligned. Similarly, it sets the
  * J9ClassLargestAlignmentConstraintReference flag given there is at least one
- * reference field. For single-aligned fields, nothing else is done. Eventually,
- * only the highest prioritized flag (Double > Reference > Single) will be used.
+ * reference field, J9ClassLargestAlignmentConstraintInteger for 4-byte aligned fields,
+ * and J9ClassLargestAlignmentConstraintShort for 2-byte aligned fields. Eventually,
+ * only the highest prioritized flag (Double > Reference > Integer > Short) will be used.
  *
  * 4. Sets the J9ClassCanSupportFastSubstitutability flag in
  * valuetypeFlags given that the class does not contain any field of
@@ -2028,10 +2029,19 @@ loadFlattenableFieldClasses(J9VMThread *currentThread, J9ClassLoader *classLoade
 			UDATA signatureLength = J9UTF8_LENGTH(signature);
 			switch (signatureChars[0]) {
 			case 'D':
-				/* Fall through */
 			case 'J':
 				*valueTypeFlags |= J9ClassLargestAlignmentConstraintDouble;
 				break;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			case 'I':
+			case 'F':
+				*valueTypeFlags |= J9ClassLargestAlignmentConstraintInteger;
+				break;
+			case 'S':
+			case 'C':
+				*valueTypeFlags |= J9ClassLargestAlignmentConstraintShort;
+				break;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			case 'L':
 			{
 				if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldFlagIsNullRestricted)) {
@@ -2063,7 +2073,11 @@ loadFlattenableFieldClasses(J9VMThread *currentThread, J9ClassLoader *classLoade
 						entry->offset = UDATA_MAX;
 						numberOfCacheEntries += 1;
 					}
-					*valueTypeFlags |= (valueClass->classFlags & (J9ClassLargestAlignmentConstraintDouble | J9ClassLargestAlignmentConstraintReference | J9ClassHasReferences));
+					*valueTypeFlags |= (valueClass->classFlags & (J9ClassLargestAlignmentConstraintDouble | J9ClassLargestAlignmentConstraintReference
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+						| J9ClassLargestAlignmentConstraintShort | J9ClassLargestAlignmentConstraintInteger
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+						| J9ClassHasReferences));
 				} else {
 					*valueTypeFlags |= (J9ClassLargestAlignmentConstraintReference | J9ClassHasReferences);
 					eligibleForFastSubstitutability = false;
@@ -2074,9 +2088,13 @@ loadFlattenableFieldClasses(J9VMThread *currentThread, J9ClassLoader *classLoade
 				*valueTypeFlags |= (J9ClassLargestAlignmentConstraintReference | J9ClassHasReferences);
 				break;
 			default:
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+				/* byte and boolean aligned fields are not marked with a flag. */
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 				/* Do nothing for now. If we eventually decide to pack fields smaller than 32 bits we'll
 				 * need to modify this code.
 				 */
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 				break;
 			}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
@@ -2430,6 +2448,9 @@ nativeOOM:
 				}
 			}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+			/* totalInstanceSize reflects the unflattened value size. Use this to be consistent
+			 * with the information given to the user through Unsafe.getObjectSize().
+			 */
 			if ((state->ramClass->totalInstanceSize <= javaVM->valueFlatteningThreshold)
 					&& !J9ROMCLASS_IS_CONTENDED(romClass)
 			) {
@@ -2443,6 +2464,12 @@ nativeOOM:
 				classFlags |= J9ClassLargestAlignmentConstraintDouble;
 			} else if (J9_ARE_ALL_BITS_SET(state->valueTypeFlags, J9ClassLargestAlignmentConstraintReference)) {
 				classFlags |= J9ClassLargestAlignmentConstraintReference;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			} else if (J9_ARE_ALL_BITS_SET(state->valueTypeFlags, J9ClassLargestAlignmentConstraintInteger)) {
+				classFlags |= J9ClassLargestAlignmentConstraintInteger;
+			} else if (J9_ARE_ALL_BITS_SET(state->valueTypeFlags, J9ClassLargestAlignmentConstraintShort)) {
+				classFlags |= J9ClassLargestAlignmentConstraintShort;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			}
 			if (J9_ARE_ALL_BITS_SET(state->valueTypeFlags, J9ClassRequiresPrePadding)) {
 				classFlags |= J9ClassRequiresPrePadding;
@@ -3299,6 +3326,9 @@ fail:
 					ramClass->backfillOffset = classBeingRedefined->backfillOffset;
 					ramClass->finalizeLinkOffset = classBeingRedefined->finalizeLinkOffset;
 					ramClass->lockOffset = classBeingRedefined->lockOffset;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+					ramClass->flatFieldSize = classBeingRedefined->flatFieldSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 				} else {
 					instanceDescription = allocationRequests[RAM_INSTANCE_DESCRIPTION_FRAGMENT].address;
 					iTable = allocationRequests[RAM_ITABLE_FRAGMENT].address;
@@ -3479,7 +3509,7 @@ fail:
 			 *
 			 *                        + J9ClassLargestAlignmentConstraintDouble
 			 *                       + J9ClassIsExemptFromValidation (inherited)
-			 *                      + Unused
+			 *                      + J9ClassLargestAlignmentConstraintInteger
 			 *                     + J9ClassCanSupportFastSubstitutability
 			 *
 			 *                   + J9ClassHasReferences
@@ -3490,7 +3520,7 @@ fail:
 			 *              + J9ClassEnsureHashed (inherited)
 			 *             + J9ClassHasOffloadAllowSubtasksNatives
 			 *            + J9ClassIsPrimitiveValueType
-			 *           + Unused
+			 *           + J9ClassLargestAlignmentConstraintShort
 			 *
 			 *         + J9ClassNeedToPruneMemberNames
 			 *        + J9ClassArrayIsNullRestricted
@@ -3739,7 +3769,11 @@ fail:
 					 * properties from the leafComponentType. A 2D array is an array of references so it can never be flattened, however, its
 					 * elements may be flattened arrays.
 					 */
-					U_32 arrayFlags = J9ClassLargestAlignmentConstraintReference | J9ClassLargestAlignmentConstraintDouble;
+					U_32 arrayFlags = J9ClassLargestAlignmentConstraintReference | J9ClassLargestAlignmentConstraintDouble
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+						| J9ClassLargestAlignmentConstraintShort | J9ClassLargestAlignmentConstraintInteger
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+						;
 					if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_CLASS_OPTION_NULL_RESTRICTED_ARRAY)) {
 						if (J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_VT_ARRAY_FLATTENING)) {
 							arrayFlags |= J9ClassIsFlattened;
@@ -3769,7 +3803,16 @@ fail:
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_64)));
 					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintReference)) {
 						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), referenceSize));
-					} else { /* VT only contains singles (int, short, etc) at this point */
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintInteger)) {
+						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_32)));
+					} else if (J9_ARE_ALL_BITS_SET(elementClass->classFlags, J9ClassLargestAlignmentConstraintShort)) {
+						J9ARRAYCLASS_SET_STRIDE(ramClass, ROUND_UP_TO_POWEROF2(J9_VALUETYPE_FLATTENED_SIZE(elementClass), sizeof(U_16)));
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+					} else {
+						/* VT only contains singles (int, short, etc.) at this point.
+						 * If compact layouts are enabled this case covers byte aligned objects.
+						 */
 						J9ARRAYCLASS_SET_STRIDE(ramClass, J9_VALUETYPE_FLATTENED_SIZE(elementClass));
 					}
 				} else {

--- a/runtime/vm/description.c
+++ b/runtime/vm/description.c
@@ -93,6 +93,9 @@ calculateInstanceDescription( J9VMThread *vmThread, J9Class *ramClass, J9Class *
 		 */
 		ramClass->totalInstanceSize = walkResult->totalInstanceSize;
 		ramClass->backfillOffset = objectHeaderSize + ((walkResult->backfillOffset == -1) ?	walkResult->totalInstanceSize : walkResult->backfillOffset);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+		ramClass->flatFieldSize = walkResult->flatFieldSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) && defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 		/* write lockword offset into ramClass */
 		ramClass->lockOffset =	walkState->lockOffset;

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -969,10 +969,18 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 		state->firstObjectOffset = fieldInfo.addFlatObjectsArea(state->firstFlatObjectOffset);
 		state->firstFlatSingleOffset = fieldInfo.addObjectsArea(state->firstObjectOffset);
 		state->firstSingleOffset = fieldInfo.addFlatSinglesArea(state->firstFlatSingleOffset);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		state->firstShortOffset = fieldInfo.addSinglesArea(state->firstSingleOffset);
+		state->firstByteOffset = fieldInfo.addShortsArea(state->firstShortOffset);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 		state->firstDoubleOffset = fieldInfo.calculateFieldDataStart();
 		state->firstObjectOffset = fieldInfo.addDoublesArea(state->firstDoubleOffset);
 		state->firstSingleOffset = fieldInfo.addObjectsArea(state->firstObjectOffset);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		state->firstShortOffset = fieldInfo.addSinglesArea(state->firstSingleOffset);
+		state->firstByteOffset = fieldInfo.addShortsArea(state->firstShortOffset);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
 
@@ -1010,14 +1018,26 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 			UDATA hiddenSingleOffset = objectHeaderSize;
 			UDATA hiddenDoubleOffset = objectHeaderSize;
 			UDATA hiddenObjectOffset = objectHeaderSize;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			UDATA hiddenShortOffset = objectHeaderSize;
+			UDATA hiddenByteOffset = objectHeaderSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			if (fieldInfo.isContendedClassLayout()) { /* hidden fields go immediately after the superclass fields and the instance fields which are placed on the following cache line */
 				/* hidden doubles go right at the start.  No adjustment required */
 				hiddenObjectOffset = hiddenDoubleOffset + (fieldInfo.getTotalDoubleCount() * sizeof(U_64));
 				hiddenSingleOffset = hiddenObjectOffset + (fieldInfo.getTotalObjectCount() * referenceSize);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+				hiddenShortOffset = hiddenSingleOffset + (fieldInfo.getTotalSingleCount() * sizeof(U_32));
+				hiddenByteOffset = hiddenShortOffset + (fieldInfo.getTotalShortCount() * sizeof(U_16));
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			} else {
 				hiddenSingleOffset += state->firstSingleOffset + (fieldInfo.getNonBackfilledInstanceSingleCount() * sizeof(U_32));
 				hiddenDoubleOffset += state->firstDoubleOffset + (fieldInfo.getInstanceDoubleCount() * sizeof(U_64));
 				hiddenObjectOffset += state->firstObjectOffset + (fieldInfo.getNonBackfilledInstanceObjectCount() * referenceSize);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+				hiddenShortOffset += state->firstShortOffset + (fieldInfo.getInstanceShortCount() * sizeof(U_16));
+				hiddenByteOffset += state->firstByteOffset + (fieldInfo.getInstanceByteCount() * sizeof(U_8));
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			}
 			bool useBackfillForObject = false;
 			bool useBackfillForSingle = false;
@@ -1046,6 +1066,14 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 				} else if (J9_ARE_ALL_BITS_SET(modifiers, J9FieldSizeDouble)) {
 					hiddenField->fieldOffset = hiddenDoubleOffset;
 					hiddenDoubleOffset += sizeof(U_64);
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+				} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeChar) || ((modifiers & J9FieldTypeMask) == J9FieldTypeShort)) {
+					hiddenField->fieldOffset = hiddenShortOffset;
+					hiddenShortOffset += sizeof(U_16);
+				} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeBoolean) || ((modifiers & J9FieldTypeMask) == J9FieldTypeByte)) {
+					hiddenField->fieldOffset = hiddenByteOffset;
+					hiddenByteOffset += sizeof(U_8);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 				} else {
 					if (useBackfillForSingle) {
 						hiddenField->fieldOffset = fieldInfo.getMyBackfillOffsetForHiddenField();
@@ -1280,6 +1308,14 @@ fieldOffsetsFindNext(J9ROMFieldOffsetWalkState *state, J9ROMFieldShape *field)
 					if (modifiers & J9FieldSizeDouble) {
 						state->result.offset = state->firstDoubleOffset + state->doublesSeen * sizeof(U_64);
 						state->doublesSeen++;
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+					} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeChar) || ((modifiers & J9FieldTypeMask) == J9FieldTypeShort)) {
+						state->result.offset = state->firstShortOffset + state->shortsSeen * sizeof(U_16);
+						state->shortsSeen++;
+					} else if (((modifiers & J9FieldTypeMask) == J9FieldTypeBoolean) || ((modifiers & J9FieldTypeMask) == J9FieldTypeByte)) {
+						state->result.offset = state->firstByteOffset + state->bytesSeen * sizeof(U_8);
+						state->bytesSeen++;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 					} else {
 						if (state->walkFlags & J9VM_FIELD_OFFSET_WALK_BACKFILL_SINGLE_FIELD) {
 							Assert_VM_true(state->backfillOffsetToUse >= 0);

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -882,7 +882,7 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 			 * Note that in the J9Class, we do not store -1 to indicate no back fill,
 			 * we store the total instance size (including the header) instead.
 			 */
-			fieldInfo.setSuperclassFieldsSize((U_32) superClazz->totalInstanceSize);
+			fieldInfo.setSuperclassFieldsSize(superClazz->totalInstanceSize);
 			if ((superClazz->totalInstanceSize + objectHeaderSize) != (UDATA)superClazz->backfillOffset) {
 				fieldInfo.setSuperclassBackfillOffset(superClazz->backfillOffset - objectHeaderSize);
 			}
@@ -898,7 +898,7 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 		 */
 		if ((LOCKWORD_NEEDED == lockwordNeeded) || (NO_LOCKWORD_NEEDED == lockwordNeeded)) {
 			if ((NULL != superClazz) && ((UDATA)-1 != superClazz->lockOffset) && (0 == J9CLASS_DEPTH(superClazz))) {
-				U_32 newSuperSize = fieldInfo.getSuperclassFieldsSize() - referenceSize;
+				UDATA newSuperSize = fieldInfo.getSuperclassFieldsSize() - referenceSize;
 				/*
 				 * superClazz is java.lang.Object: subtract off non-inherited monitor field.
 				 * Note that java.lang.Object's backfill slot can be only at the end.

--- a/runtime/vm/resolvefield.cpp
+++ b/runtime/vm/resolvefield.cpp
@@ -961,6 +961,9 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 
 		state->result.totalInstanceSize = fieldInfo.calculateTotalFieldsSizeAndBackfill();
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+		state->result.flatFieldSize = fieldInfo.calculateFlatFieldSize();
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 		state->flatBackFillSize = fieldInfo.getBackfillSize();
 		state->classRequiresPrePadding = fieldInfo.doesClassRequiresPrePadding();
 		state->firstFlatDoubleOffset = fieldInfo.calculateFieldDataStart();
@@ -970,8 +973,10 @@ fieldOffsetsStartDo(J9JavaVM *vm, J9ROMClass *romClass, J9Class *superClazz, J9R
 		state->firstFlatSingleOffset = fieldInfo.addObjectsArea(state->firstObjectOffset);
 		state->firstSingleOffset = fieldInfo.addFlatSinglesArea(state->firstFlatSingleOffset);
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
-		state->firstShortOffset = fieldInfo.addSinglesArea(state->firstSingleOffset);
-		state->firstByteOffset = fieldInfo.addShortsArea(state->firstShortOffset);
+		state->firstFlatShortOffset = fieldInfo.addSinglesArea(state->firstSingleOffset);
+		state->firstShortOffset = fieldInfo.addFlatShortsArea(state->firstFlatShortOffset);
+		state->firstFlatByteOffset = fieldInfo.addShortsArea(state->firstShortOffset);
+		state->firstByteOffset = fieldInfo.addFlatBytesArea(state->firstFlatByteOffset);
 #endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 #else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 		state->firstDoubleOffset = fieldInfo.calculateFieldDataStart();
@@ -1236,7 +1241,11 @@ fieldOffsetsFindNext(J9ROMFieldOffsetWalkState *state, J9ROMFieldShape *field)
 								state->objectsSeen++;
 							}
 						} else {
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+							U_32 size = (U_32)fieldClass->flatFieldSize;
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 							U_32 size = (U_32)fieldClass->totalInstanceSize;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 							bool forceDoubleAlignment = false;
 							if (sizeof(U_32) == referenceSize) {
 								/**
@@ -1252,9 +1261,11 @@ fieldOffsetsFindNext(J9ROMFieldOffsetWalkState *state, J9ROMFieldShape *field)
 							if (forceDoubleAlignment
 								|| J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintDouble)
 							) {
+#if !defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
 								if (J9CLASS_HAS_4BYTE_PREPADDING(fieldClass)) {
 									size -= sizeof(U_32);
 								}
+#endif /* !defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 								state->result.offset = state->firstFlatDoubleOffset + state->currentFlatDoubleOffset;
 								Assert_VM_true((state->result.offset + referenceSize) % sizeof(U_64) == 0);
 								state->currentFlatDoubleOffset += ROUND_UP_TO_POWEROF2(size, sizeof(U_64));
@@ -1270,7 +1281,12 @@ fieldOffsetsFindNext(J9ROMFieldOffsetWalkState *state, J9ROMFieldShape *field)
 									state->result.offset = state->firstFlatObjectOffset + state->currentFlatObjectOffset;
 									state->currentFlatObjectOffset += size;
 								}
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+							} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintInteger)) {
+								size = (U_32)ROUND_UP_TO_POWEROF2(size, sizeof(U_32));
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 							} else {
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 								if (J9_ARE_ALL_BITS_SET(state->walkFlags, J9VM_FIELD_OFFSET_WALK_BACKFILL_FLAT_SINGLE_FIELD)
 									&& (state->flatBackFillSize == size)
 								) {
@@ -1281,6 +1297,15 @@ fieldOffsetsFindNext(J9ROMFieldOffsetWalkState *state, J9ROMFieldShape *field)
 									state->result.offset = state->firstFlatSingleOffset + state->currentFlatSingleOffset;
 									state->currentFlatSingleOffset += size;
 								}
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+							} else if (J9_ARE_ALL_BITS_SET(fieldClass->classFlags, J9ClassLargestAlignmentConstraintShort)) {
+								size = (U_32)ROUND_UP_TO_POWEROF2(size, sizeof(U_16));
+								state->result.offset = state->firstFlatShortOffset + state->currentFlatShortOffset;
+								state->currentFlatShortOffset += size;
+							} else { /* 8-bit case. */
+								state->result.offset = state->firstFlatByteOffset + state->currentFlatByteOffset;
+								state->currentFlatByteOffset += size;
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 							}
 						}
 					} else {
@@ -1448,7 +1473,7 @@ fullTraversalFieldOffsetsNextDo(J9ROMFullTraversalFieldOffsetWalkState *state)
 		state->clazz = NULL;
 	}
 
-	while(state->currentClass) {
+	while (NULL != state->currentClass) {
 		
 		if ((state->walkFlags & J9VM_FIELD_OFFSET_WALK_PREINDEX_INTERFACE_FIELDS) == 0) { 
 			/* add the slots for the interfaces to the index */

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/DDRValueTypeTest.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/DDRValueTypeTest.java
@@ -42,20 +42,30 @@ public class DDRValueTypeTest {
 		ValueTypeTests.testCreatePoint2D();
 		ValueTypeTests.testCreateFlattenedLine2D();
 		ValueTypeTests.testCreateTriangle2D();
+		ValueTypeTests.testCreateValueBoolean();
+		ValueTypeTests.testCreateValueByte();
+		ValueTypeTests.testCreateValueChar();
+		ValueTypeTests.testCreateValueShort();
+		ValueTypeTests.testCreateLayoutsWithPrimitivesAndSmallTypes();
 		
 		// Create value types and check object
 		Class assortedValueWithSingleAlignmentClass = ValueTypeGenerator.generateValueClass("AssortedValueWithSingleAlignment", ValueTypeTests.typeWithSingleAlignmentFields);
 		
 		MethodHandle makeAssortedValueWithSingleAlignment = MethodHandles.lookup().findStatic(assortedValueWithSingleAlignmentClass,
 			"makeObjectGeneric", MethodType.methodType(Object.class, Object.class,
-						Object.class, Object.class, Object.class, Object.class, Object.class));
+						Object.class, Object.class, Object.class, Object.class, Object.class,
+						Object.class, Object.class, Object.class, Object.class));
 		
 		Object[] altFields = {
 			ValueTypeTests.defaultTrianglePositionsNew, 
 			ValueTypeTests.defaultPointPositions2, 
 			ValueTypeTests.defaultLinePositions2, 
-			ValueTypeTests.defaultIntNew, 
-			ValueTypeTests.defaultFloatNew, 
+			ValueTypeTests.defaultIntNew,
+			ValueTypeTests.defaultFloatNew,
+			ValueTypeTests.defaultByteNew,
+			ValueTypeTests.defaultShortNew,
+			ValueTypeTests.defaultCharNew,
+			ValueTypeTests.defaultBooleanNew,
 			ValueTypeTests.defaultTrianglePositionsNew
 		};
 		Object assortedValueWithSingleAlignment = ValueTypeTests.createAssorted(makeAssortedValueWithSingleAlignment, ValueTypeTests.typeWithSingleAlignmentFields);
@@ -65,10 +75,20 @@ public class DDRValueTypeTest {
 		Object[] valArray = ValueClass.newNullRestrictedAtomicArray(assortedValueWithSingleAlignmentClass, 2, assortedValueWithSingleAlignment);
 		valArray[1] = assortedValueWithSingleAlignmentAlt;
 
+		/* Compact layout offset tests */
+		Object compactBytes = ValueTypeTests.makeCompactByte.invoke(ValueTypeTests.defaultByte, ValueTypeTests.defaultByteNew, ValueTypeTests.defaultByte, ValueTypeTests.defaultByteNew);
+		Object compactShorts = ValueTypeTests.makeCompactShort.invoke(ValueTypeTests.defaultShort, ValueTypeTests.defaultShortNew, ValueTypeTests.defaultShort, ValueTypeTests.defaultShortNew);
+		Object compactByteShort = ValueTypeTests.makeCompactByteShort.invoke(ValueTypeTests.defaultByte, ValueTypeTests.defaultShort, ValueTypeTests.defaultByteNew, ValueTypeTests.defaultShortNew);
+		Object compactAssorted = ValueTypeTests.makeCompactAssorted.invoke(ValueTypeTests.defaultInt, ValueTypeTests.defaultIntNew, ValueTypeTests.defaultShort, ValueTypeTests.defaultByte);
+
+		MethodHandle make = ValueTypeTests.createObjectOfCompactLayoutScenarios();
+		Object compactLayoutScenarios = make.invoke(compactBytes, compactShorts, compactByteShort, compactAssorted);
+
 		ValueTypeTests.checkObject(assortedValueWithSingleAlignment, 
 				assortedValueWithSingleAlignmentAlt, 
 				valArray, 
-				referenceTypeWithVolatileValueTypeFields
+				referenceTypeWithVolatileValueTypeFields,
+				compactLayoutScenarios
 				);
 	}
 }

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -108,6 +108,22 @@ public class ValueTypeTests {
 	static Class<?> valueObjectClass = null;
 	static MethodHandle makeValueObject = null;
 	static MethodHandle getObject = null;
+	/* valueByte */
+	static Class<?> valueByteClass = null;
+	static MethodHandle makeValueByte = null;
+	static MethodHandle getByte = null;
+	/* valueShort */
+	static Class<?> valueShortClass = null;
+	static MethodHandle makeValueShort = null;
+	static MethodHandle getShort = null;
+	/* valueChar */
+	static Class<?> valueCharClass = null;
+	static MethodHandle makeValueChar = null;
+	static MethodHandle getChar = null;
+	/* valueBoolean */
+	static Class<?> valueBooleanClass = null;
+	static MethodHandle makeValueBoolean = null;
+	static MethodHandle getBoolean = null;
 	/* largeObject */
 	static Class<?> largeObjectValueClass = null;
 	static MethodHandle makeLargeObjectValue = null;
@@ -155,6 +171,33 @@ public class ValueTypeTests {
 	static MethodHandle makeObjectBackfillClass = null;
 	static MethodHandle getObjectO = null;
 	static MethodHandle getObjectL = null;
+	/* LayoutsWithPrimitivesAndSmallTypes classes */
+	static Class<?> compactSingleBackfillClass = null;
+	static MethodHandle makeCompactSingleBackfill = null;
+	static MethodHandle getCompactSingleI = null;
+	static MethodHandle getCompactSingleO = null;
+	static MethodHandle getCompactSingleL = null;
+	static MethodHandle getCompactSingleB = null;
+	static MethodHandle getCompactSingleS = null;
+	static Class<?> compactObjectBackfillClass = null;
+	static MethodHandle makeCompactObjectBackfill = null;
+	static MethodHandle getCompactObjectO = null;
+	static MethodHandle getCompactObjectL = null;
+	static MethodHandle getCompactObjectC = null;
+	static MethodHandle getCompactObjectZ = null;
+	/* Compact layout test classes for the four new scenarios */
+	static Class<?> compactByteClass = null;
+	static MethodHandle makeCompactByte = null;
+	static MethodHandle[] getCompactBytes = null;
+	static Class<?> compactShortClass = null;
+	static MethodHandle makeCompactShort = null;
+	static MethodHandle[] getCompactShorts = null;
+	static Class<?> compactByteShortClass = null;
+	static MethodHandle makeCompactByteShort = null;
+	static MethodHandle[] getCompactByteShortFields = null;
+	static Class<?> compactAssortedClass = null;
+	static MethodHandle makeCompactAssorted = null;
+	static MethodHandle[] getCompactAssortedFields = null;
 	/* LayoutsWithValueTypes classes */
 	static Class<?> flatSingleBackfillClass = null;
 	static MethodHandle makeFlatSingleBackfillClass = null;
@@ -201,6 +244,10 @@ public class ValueTypeTests {
 		"line:LFlattenedLine2D;:NR",
 		"i:LValueInt;:NR",
 		"f:LValueFloat;:NR",
+		"b:LValueByte;:NR",
+		"s:LValueShort;:NR",
+		"c:LValueChar;:NR",
+		"z:LValueBoolean;:NR",
 		"tri2:LTriangle2D;:NR"
 	};
 	static String[] typeWithObjectAlignmentFields = {
@@ -210,6 +257,10 @@ public class ValueTypeTests {
 		"o:LValueObject;:NR",
 		"i:LValueInt;:NR",
 		"f:LValueFloat;:NR",
+		"b:LValueByte;:NR",
+		"s:LValueShort;:NR",
+		"c:LValueChar;:NR",
+		"z:LValueBoolean;:NR",
 		"tri2:LTriangle2D;:NR"
 	};
 	static String[] typeWithLongAlignmentFields = {
@@ -219,6 +270,10 @@ public class ValueTypeTests {
 		"l:LValueLong;:NR",
 		"d:LValueDouble;:NR",
 		"i:LValueInt;:NR",
+		"b:LValueByte;:NR",
+		"s:LValueShort;:NR",
+		"c:LValueChar;:NR",
+		"z:LValueBoolean;:NR",
 		"tri:LTriangle2D;:NR"
 	};
 	
@@ -250,6 +305,15 @@ public class ValueTypeTests {
 	static double defaultDoubleNew = -123412341.21341234d;
 	static float defaultFloatNew = -123423.12341234f;
 	static Object defaultObjectNew = (Object)0xFFEEFFEE;
+	/* compact layout default values */
+	static byte defaultByte = (byte)0x7F;
+	static short defaultShort = (short)0x7FFF;
+	static char defaultChar = 'Z';
+	static boolean defaultBoolean = true;
+	static byte defaultByteNew = (byte)0x42;
+	static short defaultShortNew = (short)0x1234;
+	static char defaultCharNew = 'A';
+	static boolean defaultBooleanNew = false;
 	/* miscellaneous constants */
 	static final int genericArraySize = 10;
 	static final int objectGCScanningIterationCount = 1000;
@@ -853,6 +917,10 @@ public class ValueTypeTests {
 			defaultLongNew,
 			defaultDoubleNew,
 			defaultIntNew,
+			defaultByteNew,
+			defaultShortNew,
+			defaultCharNew,
+			defaultBooleanNew,
 			defaultTrianglePositionsNew
 		};
 		Object[] newObjectFields = {
@@ -862,6 +930,10 @@ public class ValueTypeTests {
 			defaultObjectNew,
 			defaultIntNew,
 			defaultFloatNew,
+			defaultByteNew,
+			defaultShortNew,
+			defaultCharNew,
+			defaultBooleanNew,
 			defaultTrianglePositionsNew
 		};
 
@@ -1216,6 +1288,98 @@ public class ValueTypeTests {
 
 		assertEquals(getObject.invoke(valueObject), val);
 	}
+
+	/*
+	 * Create a value type with a byte primitive member
+	 *
+	 * value ValueByte {
+	 * 	byte b;
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testCreateValueByte() throws Throwable {
+		String[] fields = {"b:B"};
+		valueByteClass = ValueTypeGenerator.generateValueClass("ValueByte", fields);
+
+		makeValueByte = lookup.findStatic(valueByteClass, "makeObjectGeneric",
+				MethodType.methodType(Object.class, Object.class));
+
+		getByte = generateGenericGetter(valueByteClass, "b");
+
+		byte b = Byte.MAX_VALUE;
+		Object valueByte = makeValueByte.invoke(b);
+
+		assertEquals(getByte.invoke(valueByte), b);
+	}
+
+	/*
+	 * Create a value type with a short primitive member
+	 *
+	 * value ValueShort {
+	 * 	short s;
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testCreateValueShort() throws Throwable {
+		String[] fields = {"s:S"};
+		valueShortClass = ValueTypeGenerator.generateValueClass("ValueShort", fields);
+
+		makeValueShort = lookup.findStatic(valueShortClass, "makeObjectGeneric",
+				MethodType.methodType(Object.class, Object.class));
+
+		getShort = generateGenericGetter(valueShortClass, "s");
+
+		short s = Short.MAX_VALUE;
+		Object valueShort = makeValueShort.invoke(s);
+
+		assertEquals(getShort.invoke(valueShort), s);
+	}
+
+	/*
+	 * Create a value type with a char primitive member
+	 *
+	 * value ValueChar {
+	 * 	char c;
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testCreateValueChar() throws Throwable {
+		String[] fields = {"c:C"};
+		valueCharClass = ValueTypeGenerator.generateValueClass("ValueChar", fields);
+
+		makeValueChar = lookup.findStatic(valueCharClass, "makeObjectGeneric",
+				MethodType.methodType(Object.class, Object.class));
+
+		getChar = generateGenericGetter(valueCharClass, "c");
+
+		char c = Character.MAX_VALUE;
+		Object valueChar = makeValueChar.invoke(c);
+
+		assertEquals(getChar.invoke(valueChar), c);
+	}
+
+	/*
+	 * Create a value type with a boolean primitive member
+	 *
+	 * value ValueBoolean {
+	 * 	boolean z;
+	 * }
+	 */
+	@Test(priority=1)
+	static public void testCreateValueBoolean() throws Throwable {
+		String[] fields = {"z:Z"};
+		valueBooleanClass = ValueTypeGenerator.generateValueClass("ValueBoolean", fields);
+
+		makeValueBoolean = lookup.findStatic(valueBooleanClass, "makeObjectGeneric",
+				MethodType.methodType(Object.class, Object.class));
+
+		getBoolean = generateGenericGetter(valueBooleanClass, "z");
+
+		boolean z = true;
+		Object valueBoolean = makeValueBoolean.invoke(z);
+
+		assertEquals(getBoolean.invoke(valueBoolean), z);
+	}
 	
 	/*	
 	 * Create a class with four valueType members including 2 volatile.
@@ -1252,6 +1416,10 @@ public class ValueTypeTests {
 	 *	flattened ValueLong l;
 	 *	flattened ValueDouble d;
 	 *	flattened ValueInt i;
+	 *	flattened ValueByte b;
+	 *	flattened ValueShort s;
+	 *	flattened ValueChar c;
+	 *	flattened ValueBoolean z;
 	 *	flattened Triangle2D tri;
 	 * }
 	 */
@@ -1261,7 +1429,8 @@ public class ValueTypeTests {
 
 		makeAssortedValueWithLongAlignment = lookup.findStatic(assortedValueWithLongAlignmentClass,
 				"makeObjectGeneric", MethodType.methodType(Object.class, Object.class,
-						Object.class, Object.class, Object.class, Object.class, Object.class, Object.class));
+						Object.class, Object.class, Object.class, Object.class, Object.class, Object.class,
+						Object.class, Object.class, Object.class, Object.class));
 		/*
 		 * Getters are created in array getterList[i][0] according to the order of fields i
 		 */
@@ -1277,13 +1446,17 @@ public class ValueTypeTests {
 	/*
 	 * Create an assorted refType with long alignment
 	 *
-	 * class AssortedReftWithLongAlignment {
+	 * class AssortedRefWithLongAlignment {
 	 *	flattened Point2D point;
 	 *	flattened Line2D line;
 	 *	flattened ValueObject o;
 	 *	flattened ValueLong l;
 	 *	flattened ValueDouble d;
 	 *	flattened ValueInt i;
+	 *	flattened ValueByte b;
+	 *	flattened ValueShort s;
+	 *	flattened ValueChar c;
+	 *	flattened ValueBoolean z;
 	 *	flattened Triangle2D tri;
 	 * }
 	 */
@@ -1292,9 +1465,9 @@ public class ValueTypeTests {
 		assortedRefWithLongAlignmentClass = ValueTypeGenerator.generateRefClass("AssortedRefWithLongAlignment", typeWithLongAlignmentFields);
 
 		makeAssortedRefWithLongAlignment = lookup.findStatic(assortedRefWithLongAlignmentClass,
-				"makeObjectGeneric", MethodType.methodType(Object.class, Object.class, Object.class,
-						Object.class, Object.class, Object.class, Object.class, Object.class));
-
+				"makeObjectGeneric", MethodType.methodType(Object.class, Object.class,
+						Object.class, Object.class, Object.class, Object.class, Object.class, Object.class,
+						Object.class, Object.class, Object.class, Object.class));
 		/*
 		 * Getters are created in array getterAndSetter[i][0] according to the order of fields i
 		 * Setters are created in array getterAndSetter[i][1] according to the order of fields i
@@ -1336,6 +1509,129 @@ public class ValueTypeTests {
 		Object objectBackfillInstance = makeObjectBackfillClass.invoke(defaultLong, defaultObject);
 		assertEquals(getObjectO.invoke(objectBackfillInstance), defaultObject);
 		assertEquals(getObjectL.invoke(objectBackfillInstance), defaultLong);
+	}
+
+	static public MethodHandle createObjectOfCompactLayoutScenarios() throws Throwable {
+		String[] fields = {"compactByte:LCompactByte;:NR", "compactShort:LCompactShort;:NR",
+		"compactByteShort:LCompactByteShort;:NR", "compactAssorted:LCompactAssorted;:NR"};
+
+		Class<?> clazz = ValueTypeGenerator.generateValueClass("CompactLayoutScenarios", fields);
+		MethodHandle make = lookup.findStatic(clazz, "makeObjectGeneric",
+			MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		return make;
+	}
+
+	@Test(priority=2)
+	static public void testCreateLayoutsWithPrimitivesAndSmallTypes() throws Throwable {
+		String[] compactByteFields = {"b0:B", "b1:B", "b2:B", "b3:B"};
+		String[] compactShortFields = {"s0:S", "s1:S", "s2:S", "s3:S"};
+		String[] compactByteShortFields = {"b0:B", "s0:S", "b1:B", "s1:S"};
+		String[] compactAssortedFields = {"i0:I", "i1:I", "s:S", "b:B"};
+
+		compactByteClass = ValueTypeGenerator.generateValueClass("CompactByte", compactByteFields);
+		makeCompactByte = lookup.findStatic(compactByteClass, "makeObjectGeneric",
+			MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		getCompactBytes = new MethodHandle[4];
+		for (int i = 0; i < 4; i++) {
+			getCompactBytes[i] = generateGenericGetter(compactByteClass, "b" + i);
+		}
+
+		compactShortClass = ValueTypeGenerator.generateValueClass("CompactShort", compactShortFields);
+		makeCompactShort = lookup.findStatic(compactShortClass, "makeObjectGeneric",
+			MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		getCompactShorts = new MethodHandle[4];
+		for (int i = 0; i < 4; i++) {
+			getCompactShorts[i] = generateGenericGetter(compactShortClass, "s" + i);
+		}
+
+		compactByteShortClass = ValueTypeGenerator.generateValueClass("CompactByteShort", compactByteShortFields);
+		makeCompactByteShort = lookup.findStatic(compactByteShortClass, "makeObjectGeneric",
+			MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		getCompactByteShortFields = new MethodHandle[4];
+		getCompactByteShortFields[0] = generateGenericGetter(compactByteShortClass, "b0");
+		getCompactByteShortFields[1] = generateGenericGetter(compactByteShortClass, "s0");
+		getCompactByteShortFields[2] = generateGenericGetter(compactByteShortClass, "b1");
+		getCompactByteShortFields[3] = generateGenericGetter(compactByteShortClass, "s1");
+
+		compactAssortedClass = ValueTypeGenerator.generateValueClass("CompactAssorted", compactAssortedFields);
+		makeCompactAssorted = lookup.findStatic(compactAssortedClass, "makeObjectGeneric",
+			MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		getCompactAssortedFields = new MethodHandle[4];
+		getCompactAssortedFields[0] = generateGenericGetter(compactAssortedClass, "i0");
+		getCompactAssortedFields[1] = generateGenericGetter(compactAssortedClass, "i1");
+		getCompactAssortedFields[2] = generateGenericGetter(compactAssortedClass, "s");
+		getCompactAssortedFields[3] = generateGenericGetter(compactAssortedClass, "b");
+
+		/* 8-bit and 16-bit fields are not eligible for backfill. */
+		String[] compactSingleBackfill = {"l:J", "o:Ljava/lang/Object;", "i:I", "b:B", "s:S"};
+		compactSingleBackfillClass = ValueTypeGenerator.generateValueClass("CompactSingleBackfill", compactSingleBackfill);
+		makeCompactSingleBackfill = lookup.findStatic(compactSingleBackfillClass, "makeObjectGeneric",
+			MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class, Object.class));
+		getCompactSingleI = generateGenericGetter(compactSingleBackfillClass, "i");
+		getCompactSingleO = generateGenericGetter(compactSingleBackfillClass, "o");
+		getCompactSingleL = generateGenericGetter(compactSingleBackfillClass, "l");
+		getCompactSingleB = generateGenericGetter(compactSingleBackfillClass, "b");
+		getCompactSingleS = generateGenericGetter(compactSingleBackfillClass, "s");
+
+		String[] compactObjectBackfill = {"l:J", "o:Ljava/lang/Object;", "c:C", "z:Z"};
+		compactObjectBackfillClass = ValueTypeGenerator.generateValueClass("CompactObjectBackfill", compactObjectBackfill);
+		makeCompactObjectBackfill = lookup.findStatic(compactObjectBackfillClass, "makeObjectGeneric",
+			MethodType.methodType(Object.class, Object.class, Object.class, Object.class, Object.class));
+		getCompactObjectO = generateGenericGetter(compactObjectBackfillClass, "o");
+		getCompactObjectL = generateGenericGetter(compactObjectBackfillClass, "l");
+		getCompactObjectC = generateGenericGetter(compactObjectBackfillClass, "c");
+		getCompactObjectZ = generateGenericGetter(compactObjectBackfillClass, "z");
+	}
+
+	@Test(priority=3, invocationCount=2)
+	static public void testCompactLayoutScenarios() throws Throwable {
+		/* Test Scenario 1: Four byte fields */
+		byte b1 = (byte)0x11, b2 = (byte)0x22, b3 = (byte)0x33, b4 = (byte)0x44;
+		Object compactByteInstance = makeCompactByte.invoke(b1, b2, b3, b4);
+		assertEquals(getCompactBytes[0].invoke(compactByteInstance), b1);
+		assertEquals(getCompactBytes[1].invoke(compactByteInstance), b2);
+		assertEquals(getCompactBytes[2].invoke(compactByteInstance), b3);
+		assertEquals(getCompactBytes[3].invoke(compactByteInstance), b4);
+
+		/* Test Scenario 2: Four short fields */
+		short s1 = (short)0x1111, s2 = (short)0x2222, s3 = (short)0x3333, s4 = (short)0x4444;
+		Object compactShortInstance = makeCompactShort.invoke(s1, s2, s3, s4);
+		assertEquals(getCompactShorts[0].invoke(compactShortInstance), s1);
+		assertEquals(getCompactShorts[1].invoke(compactShortInstance), s2);
+		assertEquals(getCompactShorts[2].invoke(compactShortInstance), s3);
+		assertEquals(getCompactShorts[3].invoke(compactShortInstance), s4);
+
+		/* Test Scenario 3: Mixed byte and short fields */
+		byte bs1 = (byte)0x55, bs2 = (byte)0x66;
+		short ss1 = (short)0x5555, ss2 = (short)0x6666;
+		Object compactByteShortInstance = makeCompactByteShort.invoke(bs1, ss1, bs2, ss2);
+		assertEquals(getCompactByteShortFields[0].invoke(compactByteShortInstance), bs1);
+		assertEquals(getCompactByteShortFields[1].invoke(compactByteShortInstance), ss1);
+		assertEquals(getCompactByteShortFields[2].invoke(compactByteShortInstance), bs2);
+		assertEquals(getCompactByteShortFields[3].invoke(compactByteShortInstance), ss2);
+
+		/* Test Scenario 4: Assorted fields (int, int, short, byte) */
+		int i1 = 0x11111111, i2 = 0x22222222;
+		short as = (short)0x7777;
+		byte ab = (byte)0x88;
+		Object compactAssortedInstance = makeCompactAssorted.invoke(i1, i2, as, ab);
+		assertEquals(getCompactAssortedFields[0].invoke(compactAssortedInstance), i1);
+		assertEquals(getCompactAssortedFields[1].invoke(compactAssortedInstance), i2);
+		assertEquals(getCompactAssortedFields[2].invoke(compactAssortedInstance), as);
+		assertEquals(getCompactAssortedFields[3].invoke(compactAssortedInstance), ab);
+
+		Object compactSingleBackfillInstance = makeCompactSingleBackfill.invoke(defaultLong, defaultObject, defaultInt, defaultByte, defaultShort);
+		assertEquals(getCompactSingleI.invoke(compactSingleBackfillInstance), defaultInt);
+		assertEquals(getCompactSingleO.invoke(compactSingleBackfillInstance), defaultObject);
+		assertEquals(getCompactSingleL.invoke(compactSingleBackfillInstance), defaultLong);
+		assertEquals(getCompactSingleB.invoke(compactSingleBackfillInstance), defaultByte);
+		assertEquals(getCompactSingleS.invoke(compactSingleBackfillInstance), defaultShort);
+
+		Object compactObjectBackfillInstance = makeCompactObjectBackfill.invoke(defaultLong, defaultObject, defaultChar, defaultBoolean);
+		assertEquals(getCompactObjectO.invoke(compactObjectBackfillInstance), defaultObject);
+		assertEquals(getCompactObjectL.invoke(compactObjectBackfillInstance), defaultLong);
+		assertEquals(getCompactObjectC.invoke(compactObjectBackfillInstance), defaultChar);
+		assertEquals(getCompactObjectZ.invoke(compactObjectBackfillInstance), defaultBoolean);
 	}
 	
 	@Test(priority=4)
@@ -1466,6 +1762,10 @@ public class ValueTypeTests {
 	 * 	flattened ValueObject o;
 	 * 	flattened ValueInt i;
 	 * 	flattened ValueFloat f;
+	 * 	flattened ValueByte b;
+	 * 	flattened ValueShort s;
+	 * 	flattened ValueChar c;
+	 * 	flattened ValueBoolean z;
 	 * 	flattened Triangle2D tri2;
 	 * }
 	 */
@@ -1476,7 +1776,8 @@ public class ValueTypeTests {
 
 		makeAssortedValueWithObjectAlignment = lookup.findStatic(assortedValueWithObjectAlignmentClass,
 			"makeObjectGeneric", MethodType.methodType(Object.class, Object.class,
-					Object.class, Object.class, Object.class, Object.class, Object.class, Object.class));
+					Object.class, Object.class, Object.class, Object.class, Object.class, Object.class,
+					Object.class, Object.class, Object.class, Object.class));
 		/*
 		 * Getters are created in array getterAndSetter[i][0] according to the order of fields i
 		 * Setters are created in array getterAndSetter[i][1] according to the order of fields i
@@ -1500,6 +1801,10 @@ public class ValueTypeTests {
 	 * 	flattened ValueObject o;
 	 * 	flattened ValueInt i;
 	 * 	flattened ValueFloat f;
+	 * 	flattened ValueByte b;
+	 * 	flattened ValueShort s;
+	 * 	flattened ValueChar c;
+	 * 	flattened ValueBoolean z;
 	 * 	flattened Triangle2D tri2;
 	 * }
 	 */
@@ -1509,7 +1814,8 @@ public class ValueTypeTests {
 
 		makeAssortedRefWithObjectAlignment = lookup.findStatic(assortedRefWithObjectAlignmentClass,
 				"makeObjectGeneric", MethodType.methodType(Object.class, Object.class, Object.class,
-						Object.class, Object.class, Object.class, Object.class, Object.class));
+						Object.class, Object.class, Object.class, Object.class, Object.class,
+						Object.class, Object.class, Object.class, Object.class));
 		/*
 		 * Getters are created in array getterAndSetter[i][0] according to the order of fields i
 		 * Setters are created in array getterAndSetter[i][1] according to the order of fields i
@@ -1532,6 +1838,10 @@ public class ValueTypeTests {
 	 * 	flattened Line2D line;
 	 * 	flattened ValueInt i;
 	 * 	flattened ValueFloat f;
+	 * 	flattened ValueByte b;
+	 * 	flattened ValueShort s;
+	 * 	flattened ValueChar c;
+	 * 	flattened ValueBoolean z;
 	 * 	flattened Triangle2D tri2;
 	 * }
 	 */
@@ -1541,7 +1851,8 @@ public class ValueTypeTests {
 
 		makeAssortedValueWithSingleAlignment = lookup.findStatic(assortedValueWithSingleAlignmentClass,
 			"makeObjectGeneric", MethodType.methodType(Object.class, Object.class,
-					Object.class, Object.class, Object.class, Object.class, Object.class));
+					Object.class, Object.class, Object.class, Object.class, Object.class,
+					Object.class, Object.class, Object.class, Object.class));
 		/*
 		 * Getters are created in array getterAndSetter[i][0] according to the order of fields i
 		 * Setters are created in array getterAndSetter[i][1] according to the order of fields i
@@ -1564,6 +1875,10 @@ public class ValueTypeTests {
 	 * 	flattened Line2D line;
 	 * 	flattened ValueInt i;
 	 * 	flattened ValueFloat f;
+	 * 	flattened ValueByte b;
+	 * 	flattened ValueShort s;
+	 * 	flattened ValueChar c;
+	 * 	flattened ValueBoolean z;
 	 * 	flattened Triangle2D tri2;
 	 * }
 	 */
@@ -1573,7 +1888,8 @@ public class ValueTypeTests {
 
 		makeAssortedRefWithSingleAlignment = lookup.findStatic(assortedRefWithSingleAlignmentClass,
 				"makeObjectGeneric", MethodType.methodType(Object.class, Object.class, Object.class,
-						Object.class, Object.class, Object.class, Object.class));
+						Object.class, Object.class, Object.class, Object.class, Object.class,
+						Object.class, Object.class, Object.class));
 		/*
 		 * Getters are created in array getterAndSetter[i][0] according to the order of fields i
 		 * Setters are created in array getterAndSetter[i][1] according to the order of fields i
@@ -2940,6 +3256,18 @@ public class ValueTypeTests {
 			case "LValueLong;":
 				args[i] = makeValueLong.invoke(useInitFields ? (long)initFields[i] : defaultLong);
 				break;
+			case "LValueByte;":
+				args[i] = makeValueByte.invoke(useInitFields ? (byte)initFields[i] : defaultByte);
+				break;
+			case "LValueShort;":
+				args[i] = makeValueShort.invoke(useInitFields ? (short)initFields[i] : defaultShort);
+				break;
+			case "LValueChar;":
+				args[i] = makeValueChar.invoke(useInitFields ? (char)initFields[i] : defaultChar);
+				break;
+			case "LValueBoolean;":
+				args[i] = makeValueBoolean.invoke(useInitFields ? (boolean)initFields[i] : defaultBoolean);
+				break;
 			case "LLargeObject;":
 				args[i] = createLargeObject(useInitFields ? (Object)initFields[i] : defaultObject);
 				break;
@@ -3066,6 +3394,38 @@ public class ValueTypeTests {
 				if (!isValue) {
 					fieldAccessMHs[i][1].invoke(instance, lNew);
 					assertEquals(getLong.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultLongNew);
+				}
+				break;
+			case "LValueByte;":
+				assertEquals(getByte.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultByte);
+				Object bNew = makeValueByte.invoke(defaultByteNew);
+				if (!isValue) {
+					fieldAccessMHs[i][1].invoke(instance, bNew);
+					assertEquals(getByte.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultByteNew);
+				}
+				break;
+			case "LValueShort;":
+				assertEquals(getShort.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultShort);
+				Object sNew = makeValueShort.invoke(defaultShortNew);
+				if (!isValue) {
+					fieldAccessMHs[i][1].invoke(instance, sNew);
+					assertEquals(getShort.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultShortNew);
+				}
+				break;
+			case "LValueChar;":
+				assertEquals(getChar.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultChar);
+				Object cNew = makeValueChar.invoke(defaultCharNew);
+				if (!isValue) {
+					fieldAccessMHs[i][1].invoke(instance, cNew);
+					assertEquals(getChar.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultCharNew);
+				}
+				break;
+			case "LValueBoolean;":
+				assertEquals(getBoolean.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultBoolean);
+				Object zNew = makeValueBoolean.invoke(defaultBooleanNew);
+				if (!isValue) {
+					fieldAccessMHs[i][1].invoke(instance, zNew);
+					assertEquals(getBoolean.invoke(fieldAccessMHs[i][0].invoke(instance)), defaultBooleanNew);
 				}
 				break;
 			case "LLargeObject;":

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -371,6 +371,66 @@ public class ValueTypeTests {
 		assertEquals(getY.invoke(point2D_2_check), getY.invoke(point2D_2));
 	}
 
+	@Test(priority=2)
+	static public void testCreateArrayCompactByte() throws Throwable {
+		byte b1_1 = (byte)0x11;
+		byte b1_2 = (byte)0x22;
+		byte b1_3 = (byte)0x33;
+		byte b1_4 = (byte)0x44;
+		byte b2_1 = (byte)0x55;
+		byte b2_2 = (byte)0x66;
+		byte b2_3 = (byte)0x77;
+		byte b2_4 = (byte)0x88;
+
+		Object compactByte_1 = makeCompactByte.invoke(b1_1, b1_2, b1_3, b1_4);
+		Object compactByte_2 = makeCompactByte.invoke(b2_1, b2_2, b2_3, b2_4);
+
+		Object arrayObject = Array.newInstance(compactByteClass, 3);
+		Array.set(arrayObject, 1, compactByte_1);
+		Array.set(arrayObject, 2, compactByte_2);
+
+		Object compactByte_1_check = Array.get(arrayObject, 1);
+		Object compactByte_2_check = Array.get(arrayObject, 2);
+		assertEquals(getCompactBytes[0].invoke(compactByte_1_check), getCompactBytes[0].invoke(compactByte_1));
+		assertEquals(getCompactBytes[1].invoke(compactByte_1_check), getCompactBytes[1].invoke(compactByte_1));
+		assertEquals(getCompactBytes[2].invoke(compactByte_1_check), getCompactBytes[2].invoke(compactByte_1));
+		assertEquals(getCompactBytes[3].invoke(compactByte_1_check), getCompactBytes[3].invoke(compactByte_1));
+		assertEquals(getCompactBytes[0].invoke(compactByte_2_check), getCompactBytes[0].invoke(compactByte_2));
+		assertEquals(getCompactBytes[1].invoke(compactByte_2_check), getCompactBytes[1].invoke(compactByte_2));
+		assertEquals(getCompactBytes[2].invoke(compactByte_2_check), getCompactBytes[2].invoke(compactByte_2));
+		assertEquals(getCompactBytes[3].invoke(compactByte_2_check), getCompactBytes[3].invoke(compactByte_2));
+	}
+
+	@Test(priority=2)
+	static public void testCreateArrayCompactShort() throws Throwable {
+		short s1_1 = (short)0x1111;
+		short s1_2 = (short)0x2222;
+		short s1_3 = (short)0x3333;
+		short s1_4 = (short)0x4444;
+		short s2_1 = (short)0x5555;
+		short s2_2 = (short)0x6666;
+		short s2_3 = (short)0x7777;
+		short s2_4 = (short)0x8888;
+
+		Object compactShort_1 = makeCompactShort.invoke(s1_1, s1_2, s1_3, s1_4);
+		Object compactShort_2 = makeCompactShort.invoke(s2_1, s2_2, s2_3, s2_4);
+
+		Object arrayObject = Array.newInstance(compactShortClass, 3);
+		Array.set(arrayObject, 1, compactShort_1);
+		Array.set(arrayObject, 2, compactShort_2);
+
+		Object compactShort_1_check = Array.get(arrayObject, 1);
+		Object compactShort_2_check = Array.get(arrayObject, 2);
+		assertEquals(getCompactShorts[0].invoke(compactShort_1_check), getCompactShorts[0].invoke(compactShort_1));
+		assertEquals(getCompactShorts[1].invoke(compactShort_1_check), getCompactShorts[1].invoke(compactShort_1));
+		assertEquals(getCompactShorts[2].invoke(compactShort_1_check), getCompactShorts[2].invoke(compactShort_1));
+		assertEquals(getCompactShorts[3].invoke(compactShort_1_check), getCompactShorts[3].invoke(compactShort_1));
+		assertEquals(getCompactShorts[0].invoke(compactShort_2_check), getCompactShorts[0].invoke(compactShort_2));
+		assertEquals(getCompactShorts[1].invoke(compactShort_2_check), getCompactShorts[1].invoke(compactShort_2));
+		assertEquals(getCompactShorts[2].invoke(compactShort_2_check), getCompactShorts[2].invoke(compactShort_2));
+		assertEquals(getCompactShorts[3].invoke(compactShort_2_check), getCompactShorts[3].invoke(compactShort_2));
+	}
+
 	@Test(priority=5)
 	static public void testGCFlattenedPoint2DArray() throws Throwable {
 		int x1 = 0xFFEEFFEE;
@@ -1521,7 +1581,7 @@ public class ValueTypeTests {
 		return make;
 	}
 
-	@Test(priority=2)
+	@Test(priority=1)
 	static public void testCreateLayoutsWithPrimitivesAndSmallTypes() throws Throwable {
 		String[] compactByteFields = {"b0:B", "b1:B", "b2:B", "b3:B"};
 		String[] compactShortFields = {"s0:S", "s1:S", "s2:S", "s3:S"};

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -164,7 +164,7 @@
 		<output regex="no" type="required" showMatch="yes"> point (offset = 24) (Point2D)</output>
 		<output regex="no" type="required" showMatch="yes"> vpoint (offset = 4) (Point2D)</output>
 		<output regex="no" type="required" showMatch="yes"> line (offset = 32) (FlattenedLine2D)</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x[\w]+ \(offset = 12\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x\p{XDigit}+ \(offset = 12\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -204,10 +204,10 @@
 			<input>quit</input>
 		</command>
 		<output regex="no" type="success" showMatch="yes">CompactLayoutScenarios</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactByte = !j9object 0x[\w]+ compactByte \(offset = 0\) \(CompactByte\)</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactShort = !j9object 0x[\w]+ compactShort \(offset = 4\) \(CompactShort\)</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactByteShort = !j9object 0x[\w]+ compactByteShort \(offset = 12\) \(CompactByteShort\)</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactAssorted = !j9object 0x[\w]+ compactAssorted \(offset = 20\) \(CompactAssorted\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactAssorted = !j9object 0x\p{XDigit}+ compactAssorted \(offset = 0\) \(CompactAssorted\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactShort = !j9object 0x\p{XDigit}+ compactShort \(offset = 12\) \(CompactShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactByteShort = !j9object 0x\p{XDigit}+ compactByteShort \(offset = 20\) \(CompactByteShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactByte = !j9object 0x\p{XDigit}+ compactByte \(offset = 26\) \(CompactByte\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -74,6 +74,7 @@
 		<saveoutput regex="no" type="required" saveName="valueAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
 		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
 		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="compactLayoutAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[4] = !fj9object 0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -193,6 +194,50 @@
 		<output regex="no" type="success" showMatch="yes"> FlattenedLine2D</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !j9object $compactLayoutAddr$ to verify compact layout field offsets">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $compactLayoutAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">CompactLayoutScenarios</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactByte = !j9object 0x[\w]+ compactByte \(offset = 0\) \(CompactByte\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactShort = !j9object 0x[\w]+ compactShort \(offset = 4\) \(CompactShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactByteShort = !j9object 0x[\w]+ compactByteShort \(offset = 12\) \(CompactByteShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">compactAssorted = !j9object 0x[\w]+ compactAssorted \(offset = 20\) \(CompactAssorted\)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !flatobject $compactLayoutAddr$ to verify all compact layout field offsets and values">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!flatobject $compactLayoutAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">CompactLayoutScenarios</output>
+		<output regex="no" type="required" showMatch="yes">CompactByte compactByte</output>
+		<output regex="no" type="required" showMatch="yes">B b0 = 0x7F</output>
+		<output regex="no" type="required" showMatch="yes">B b1 = 0x42</output>
+		<output regex="no" type="required" showMatch="yes">B b2 = 0x7F</output>
+		<output regex="no" type="required" showMatch="yes">B b3 = 0x42</output>
+		<output regex="no" type="required" showMatch="yes">CompactShort compactShort</output>
+		<output regex="no" type="required" showMatch="yes">S s0 = 0x7FFF</output>
+		<output regex="no" type="required" showMatch="yes">S s1 = 0x1234</output>
+		<output regex="no" type="required" showMatch="yes">S s2 = 0x7FFF</output>
+		<output regex="no" type="required" showMatch="yes">S s3 = 0x1234</output>
+		<output regex="no" type="required" showMatch="yes">CompactByteShort compactByteShort</output>
+		<output regex="no" type="required" showMatch="yes">B b0 = 0x7F</output>
+		<output regex="no" type="required" showMatch="yes">S s0 = 0x7FFF</output>
+		<output regex="no" type="required" showMatch="yes">B b1 = 0x42</output>
+		<output regex="no" type="required" showMatch="yes">S s1 = 0x1234</output>
+		<output regex="no" type="required" showMatch="yes">CompactAssorted compactAssorted</output>
+		<output regex="no" type="required" showMatch="yes">I i0 = 0x12123434</output>
+		<output regex="no" type="required" showMatch="yes">I i1 = 0x45456767</output>
+		<output regex="no" type="required" showMatch="yes">S s = 0x7FFF</output>
+		<output regex="no" type="required" showMatch="yes">B b = 0x7F</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -73,6 +73,7 @@
 		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[0] = !fj9object 0x</saveoutput>
 		<saveoutput regex="no" type="required" saveName="valueAddr2" splitIndex="1" splitBy="= !j9object " showMatch="yes">[1] = !fj9object 0x</saveoutput>
 		<saveoutput regex="no" type="required" saveName="arrayAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[2] = !fj9object 0x</saveoutput>
+		<saveoutput regex="no" type="required" saveName="compactLayoutAddr" splitIndex="1" splitBy="= !j9object " showMatch="yes">[4] = !fj9object 0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
@@ -138,6 +139,76 @@
 		<output regex="no" type="success" showMatch="yes">Triangle2D; tri = !fj9object</output>
 		<output regex="no" type="success" showMatch="yes">ValueInt; i = !fj9object</output>
 		<output regex="no" type="success" showMatch="yes">Triangle2D; tri2 = !fj9object</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<!-- Compact Layout Scenarios Tests -->
+	<test id="Run !j9object $compactLayoutAddr$ to show compact layout scenarios container">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!j9object $compactLayoutAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="no" type="success" showMatch="yes">CompactByte; compactByte = !fj9object 0x</output>
+		<saveoutput regex="no" type="required" saveName="compactByteAddr" splitIndex="4" splitBy=" " showMatch="yes">CompactByte; compactByte = !fj9object 0x</saveoutput>
+		<output regex="no" type="success" showMatch="yes">CompactShort; compactShort = !fj9object 0x</output>
+		<saveoutput regex="no" type="required" saveName="compactShortAddr" splitIndex="4" splitBy=" " showMatch="yes">CompactShort; compactShort = !fj9object 0x</saveoutput>
+		<output regex="no" type="success" showMatch="yes">CompactByteShort; compactByteShort = !fj9object 0x</output>
+		<saveoutput regex="no" type="required" saveName="compactByteShortAddr" splitIndex="4" splitBy=" " showMatch="yes">CompactByteShort; compactByteShort = !fj9object 0x</saveoutput>
+		<output regex="no" type="success" showMatch="yes">CompactAssorted; compactAssorted = !fj9object 0x</output>
+		<saveoutput regex="no" type="required" saveName="compactAssortedAddr" splitIndex="4" splitBy=" " showMatch="yes">CompactAssorted; compactAssorted = !fj9object 0x</saveoutput>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !fj9object $compactByteAddr$ to verify byte field offsets">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!fj9object $compactByteAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">B b0 = 0x7f \(offset = 0\) \(.*CompactByte\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">B b1 = 0x42 \(offset = 1\) \(.*CompactByte\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">B b2 = 0x7f \(offset = 2\) \(.*CompactByte\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">B b3 = 0x42 \(offset = 3\) \(.*CompactByte\)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !fj9object $compactShortAddr$ to verify short field offsets">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!fj9object $compactShortAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">S s0 = 0x7fff \(offset = 0\) \(.*CompactShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">S s1 = 0x1234 \(offset = 2\) \(.*CompactShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">S s2 = 0x7fff \(offset = 4\) \(.*CompactShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">S s3 = 0x1234 \(offset = 6\) \(.*CompactShort\)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !fj9object $compactByteShortAddr$ to verify mixed byte/short field offsets">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!fj9object $compactByteShortAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">B b0 = 0x7f \(offset = 4\) \(.*CompactByteShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">S s0 = 0x7fff \(offset = 0\) \(.*CompactByteShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">B b1 = 0x42 \(offset = 5\) \(.*CompactByteShort\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">S s1 = 0x1234 \(offset = 2\) \(.*CompactByteShort\)</output>
+		<output regex="no" type="failure">Problem running command</output>
+	</test>
+
+	<test id="Run !fj9object $compactAssortedAddr$ to verify assorted field offsets">
+		<command command="$JDMPVIEW_EXE$">
+			<arg>-core $DUMPFILE$</arg>
+			<input>!fj9object $compactAssortedAddr$</input>
+			<input>quit</input>
+		</command>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i0 = 0x12123434 \(offset = 0\) \(.*CompactAssorted\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">I i1 = 0x45456767 \(offset = 4\) \(.*CompactAssorted\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">S s = 0x7fff \(offset = 8\) \(.*CompactAssorted\)</output>
+		<output regex="yes" javaUtilPattern="yes" type="success" showMatch="yes">B b = 0x7f \(offset = 10\) \(.*CompactAssorted\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 </suite>


### PR DESCRIPTION
## Compact layout: shrink small primitive types in object

Allocate 1 byte of memory for byte and boolean types, 2 bytes
for short and char types. Previously these fields were treated
as 4 byte singles that were eligible for backfills.

byte/boolean/short/char are no longer eligible to be used
in backfill slots.

16-bit values are placed after 32-bit singles, 8-bit values
are placed after that. Extra space may follow to
round the size to 32-bits. For example an object with one short
and one boolean will use 24 bits for those fields, there will
be 8 bits of empty space that the end that is unusable to
ensure reasonable alignment.

## Compact Layout: shrink flattened object sizes
Shrink flattened fields to be as close to their data size as possible.
Now that small primitive types are allocated as only 1 or 2 bytes of
memory, flattened objects can also shrink in size depending on the
alignment of the largest field.

This change introduces new value type alignment flags
J9ClassLargestAlignmentConstraintInteger and
J9ClassLargestAlignmentConstraintShort to track alignment
constraints of value types that contain small primitives.
Previously single (32-bit) alignment was implied by setting
no flags, now byte (8-bit) alignment is implied.

For example:
value class V1 {
	byte b;
}

value class V2 {
	int i;
	byte b;
}

A flattened V1 would take up 1 byte of space when flattened. A flattened V2
would take up 5 bytes of space when flattened however since it contains an
integer the field would need to be 32-bit aligned making it 8 bytes.

This change also introduces J9Class.flatFieldSize. This value is only calculated
for value types and is the size the object would be when flattened, not accounting
for alignment. The only difference between this field and totalInstanceSize is that
totalInstanceSize represents the standalone object size so may include padding for
compressed refs and is always aligned to 32 bits.

---

This code compiles with COMPACT_LAYOUT and J9VM_OPT_VALHALLA_COMPACT_LAYOUTS
enabled on x86-64 with the jit disabled (IBM_JAVA_OPTIONS="-Xint").

Related: https://github.com/eclipse-openj9/openj9/issues/21251