### PR TITLE
Updated Release notes for 0.59.0 with `jcmd` change

### DIFF
--- a/doc/release-notes/0.59/0.59.md
+++ b/doc/release-notes/0.59/0.59.md
@@ -60,7 +60,7 @@ Now the root cause for these VM crashes has been identified and fixed. Therefore
 <td valign="top"><a href="https://github.com/eclipse-openj9/openj9/issues/19052">#19052</a></td>
 <td valign="top">The <tt>-XX:[+|-]UseMediumPageSize</tt> option is added to enable or disable the default setting of the <tt>LDR_CNTRL</tt> environment variable whereby medium page sizes (64 KB) are configured for text, data, stack, and shared memory segments.</td>
 <td valign="top">All versions (AIX&reg;)</td>
-<td valign="top">On AIX systems, by default the Java launcher sets the <tt>LDR_CNTRL</tt> environment variable as <tt>TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K</tt> to specify medium page sizes (64 KB) for the text, data, stack, and shared memory segments. This default setting is used to improve performance.<br>
+<td valign="top">From this release onwards, on AIX systems, by default the Java launcher sets the <tt>LDR_CNTRL</tt> environment variable as <tt>TEXTPSIZE=64K@DATAPSIZE=64K@STACKPSIZE=64K@SHMPSIZE=64K</tt> to specify medium page sizes (64 KB) for the text, data, stack, and shared memory segments. This default setting is used to improve performance.<br>
 You can use <tt>-XX:-UseMediumPageSize</tt> to disable the default setting of the <tt>LDR_CNTRL</tt> environment variable. When this option is used, the Java launcher uses the default AIX page sizes (4 KB for each segment).
 </td>
 </tr>
@@ -95,6 +95,12 @@ You can use <tt>-XX:-UseMediumPageSize</tt> to disable the default setting of th
 - YoungGarbageCollection</td>
 <td valign="top">OpenJDK 11 and later</td>
 <td valign="top"></td>
+</tr>
+<tr>
+<td valign="top"><a href="https://github.com/eclipse-openj9/openj9/pull/23477">#23477</a><</td>
+<td valign="top"><tt>compact</tt> is added by default to the <tt>request=<requests></tt> parameter for the <tt>jcmd Dump.heap</tt> command.</td>
+<td valign="top">All versions</td>
+<td valign="top">When <tt>jcmd Dump.heap</tt> is used to request a heap dump, the <tt>compact</tt> option is now added to the dump request by default. The default request for heap dumps is now: <tt>request=exclusive+compact+prepwalk</tt>.</td>
 </tr>
 </tbody>
 </table>


### PR DESCRIPTION
Updated Release note for 0.59.0 with `jcmd` change. Made changes to the medium page setting related content also

[skip ci]
Signed-off-by: Sreekala Gopakumar sreekala.gopakumar@ibm.com