### PR TITLE
Enable StringLatin1.inflate(byte->byte) acceleration on Z

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5463,8 +5463,10 @@ bool TR_J9InlinerPolicy::suppressInliningRecognizedInitialCallee(TR_CallSite *ca
             if (cg->getSupportsInlineStringLatin1Inflate()) {
                 return true;
             }
+            break;
         case TR::java_lang_StringLatin1_inflate_BIBII:
-            if (cg->getSupportsArrayTranslateTROTNoBreak() && !comp->target().cpu.isPower()) {
+            if ((!comp->target().cpu.isPower())
+                && (cg->getSupportsArrayTranslateTROTNoBreak() || cg->getSupportsInlineStringLatin1Inflate())) {
                 return true;
             }
             break;

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3600,6 +3600,8 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
 
     static const char *enableTRTRE = feGetEnv("TR_enableTRTRE");
     static const bool enableOSW = feGetEnv("TR_noPauseOnSpinWait") == NULL;
+    static const bool disableStringInflateByteToByte = feGetEnv("TR_DisableStringInflateByteToByte") != NULL;
+    static const bool disableStringInflateByteToChar = feGetEnv("TR_DisableStringInflateByteToChar") != NULL;
 
     bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
     bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
@@ -3799,9 +3801,14 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
             }
             break;
         }
-
+        case TR::java_lang_StringLatin1_inflate_BIBII:
+            if (cg->getSupportsInlineStringLatin1Inflate() && !disableStringInflateByteToByte) {
+                resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
+                return resultReg != NULL;
+            }
+            break;
         case TR::java_lang_StringLatin1_inflate_BICII:
-            if (cg->getSupportsInlineStringLatin1Inflate()) {
+            if (cg->getSupportsInlineStringLatin1Inflate() && !disableStringInflateByteToChar) {
                 resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
                 return resultReg != NULL;
             }

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -293,10 +293,6 @@ void J9::Z::TreeEvaluator::inlineEncodeASCII(TR::Node *node, TR::CodeGenerator *
 
 TR::Register *J9::Z::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, TR::CodeGenerator *cg)
 {
-    static bool disableStringInflate = feGetEnv("TR_DisableStringInflate") != NULL;
-    if (disableStringInflate) {
-        return NULL;
-    }
     TR_ASSERT_FATAL(cg->getSupportsInlineStringLatin1Inflate(),
         "This evaluator should only be triggered when inlining StringLatin1.inflate([BI[CII)V is enabled on Java 11 "
         "onwards!\n");


### PR DESCRIPTION
This commit uses the existing StringLatin1.inflate(byte->char) evaluator to accelerate StringLatin1.inflate(byte->byte) Java API as well. Both APIs perform similar work underneath the hood and can leverage the same evaluator.