### PR TITLE
JITServer: handle non-null compilation

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -9426,6 +9426,20 @@ TR_MethodMetaData *TR::CompilationInfoPerThreadBase::compile(J9VMThread *vmThrea
             optimizationPlan);
 
         TRIGGER_J9HOOK_JIT_COMPILING_END(_jitConfig->hookInterface, vmThread, method);
+
+        if (_compiler && _methodBeingCompiled->isOutOfProcessCompReq()) {
+            // In JITServer mode preemtively call _compiler->retainedMethods() to
+            // create the retainedMethod set if it doesn't exist. If this operation
+            // is not done now, it will be done later during:
+            // postCompilationTasks
+            //   - compilationEnd
+            //     - outOfProcessCompilationEnd
+            //       - computeDataForCHTableCommit
+            //         - getDataForClient
+            // The server will send a message to the client, which could cause an
+            // exception and exceptions are not allowed to be triggerred from postCompilationTasks()
+            _compiler->retainedMethods();
+        }
     } catch (const std::exception &e) {
         const char *exceptionName;
 

--- a/runtime/compiler/env/J9RetainedMethodSet.cpp
+++ b/runtime/compiler/env/J9RetainedMethodSet.cpp
@@ -583,6 +583,8 @@ void J9::RepeatRetainedMethodsAnalysis::getDataForClient(TR::Compilation *comp,
     }
 
     TR_ResolvedMethod *keepaliveMethod = NULL;
+    // retainedMethods is guaranteed to exist, so no messages
+    // will be sent to the server. See issue #23845
     auto keepaliveMethodsIter = comp->retainedMethods()->keepaliveMethods();
     while (keepaliveMethodsIter.next(&keepaliveMethod)) {
         keepaliveMethods.push_back(static_cast<TR_ResolvedJ9JITServerMethod *>(keepaliveMethod)->getRemoteMirror());


### PR DESCRIPTION
When a JITServer stream failure is thrown, sometimes setting
the compilation object to NULL can be skiped to head straight
into exception handling. This causes an assert to be tripped.

In this particular case, there is a front-end call in
postCompilationTasks which can cause a stream error. Since it
isn't guarded by a global try-catch, it results in the given
assert being tripped.

Addresses this issue:
https://github.com/eclipse-openj9/openj9/issues/23845