### PR TITLE
Enable validation of IEATDUMP dataset names on z/OS for Java 11+

### DIFF
--- a/runtime/CMakeLists.txt
+++ b/runtime/CMakeLists.txt
@@ -107,6 +107,12 @@ endif()
 # we also want to set the RPATH properly
 set(CMAKE_BUILD_WITH_INSTALL_RPATH TRUE)
 
+if(OMR_OS_ZOS AND (NOT JAVA_SPEC_VERSION LESS 11))
+	# Enable OMR support for IEATDUMP filename validation.
+	# Note: This requires a build system running z/OS 2.4 or newer.
+	set(OMR_TDUMP_VALIDATION ON CACHE BOOL "Recognize dump type 'IEATDUMP_VALIDATE'")
+endif()
+
 if(OPENJ9_BUILD)
 	add_definitions(-DOPENJ9_BUILD)
 endif()

--- a/runtime/nls/j9vm/j9vm.nls
+++ b/runtime/nls/j9vm/j9vm.nls
@@ -2577,3 +2577,29 @@ J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION.explanation=The JDWP option c
 J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION.system_action=The JVM will throw a JVMRestoreException.
 J9NLS_VM_CRIU_FAILED_TO_ENABLE_JDWP_RESTORE_OPTION.user_response=Enable -XX:+DebugOnRestore pre-checkpoint.
 # END NON-TRANSLATABLE
+
+# printDumpAgent is the name of an API: It should not be translated.
+J9NLS_VM_MISSING_DUMP_DLL_PRINT_DUMP_AGENT=printDumpAgent requires %s
+# START NON-TRANSLATABLE
+J9NLS_VM_MISSING_DUMP_DLL_PRINT_DUMP_AGENT.sample_input_1=j9dmp29
+J9NLS_VM_MISSING_DUMP_DLL_PRINT_DUMP_AGENT.explanation=A call to internal VM function printDumpAgent() has failed because the required DLL has not been loaded.
+J9NLS_VM_MISSING_DUMP_DLL_PRINT_DUMP_AGENT.system_action=The dump agent is not printed.
+J9NLS_VM_MISSING_DUMP_DLL_PRINT_DUMP_AGENT.user_response=Check whether the JVM dump functions have been disabled via the -Xdump:none option.
+# END NON-TRANSLATABLE
+
+# validateDumpAgent is the name of an API: It should not be translated.
+J9NLS_VM_MISSING_DUMP_DLL_VALIDATE_DUMP_AGENT=validateDumpAgent requires %s
+# START NON-TRANSLATABLE
+J9NLS_VM_MISSING_DUMP_DLL_VALIDATE_DUMP_AGENT.sample_input_1=j9dmp29
+J9NLS_VM_MISSING_DUMP_DLL_VALIDATE_DUMP_AGENT.explanation=A call to internal VM function validateDumpAgent() has failed because the required DLL has not been loaded.
+J9NLS_VM_MISSING_DUMP_DLL_VALIDATE_DUMP_AGENT.system_action=Dump agent validation is not performed.
+J9NLS_VM_MISSING_DUMP_DLL_VALIDATE_DUMP_AGENT.user_response=Check whether the JVM dump functions have been disabled via the -Xdump:none option.
+# END NON-TRANSLATABLE
+
+# -Xdump:system and dsn are parts of options: They should not be translated.
+J9NLS_VM_INVALID_DUMP_AGENTS=The following -Xdump:system options contain invalid dsn specifications:
+# START NON-TRANSLATABLE
+J9NLS_VM_INVALID_DUMP_AGENTS.explanation=One or more -Xdump:system options contain invalid dsn specifications.
+J9NLS_VM_INVALID_DUMP_AGENTS.system_action=The JVM will fail to start.
+J9NLS_VM_INVALID_DUMP_AGENTS.user_response=Check and correct the listed -Xdump:system options.
+# END NON-TRANSLATABLE

--- a/runtime/oti/j9dump.h
+++ b/runtime/oti/j9dump.h
@@ -143,6 +143,10 @@ typedef struct J9RASdumpFunctions {
 	omr_error_t  (*setDumpOption)(struct J9JavaVM *vm, char *optionString) ;
 	omr_error_t  (*resetDumpOptions)(struct J9JavaVM *vm) ;
 	omr_error_t  (*queryVmDump)(struct J9JavaVM *vm, int buffer_size, void* options_buffer, int* data_size) ;
+	omr_error_t (*printDumpAgent)(struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
+#if defined(OMR_TDUMP_VALIDATION)
+	omr_error_t (*validateDumpAgent)(struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
+#endif /* defined(OMR_TDUMP_VALIDATION) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	IDATA  (*criuReloadXDumpAgents)(struct J9JavaVM *vm, struct J9VMInitArgs *j9vm_args) ;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/oti/rasdump_api.h
+++ b/runtime/oti/rasdump_api.h
@@ -415,6 +415,27 @@ triggerOneOffDump(struct J9JavaVM *vm, char *optionString, char *caller, char *f
 omr_error_t
 queryVmDump(struct J9JavaVM *vm, int buffer_size, void* options_buffer, int* data_size);
 
+/**
+ * Print the specified dump agent.
+ *
+ * @param *vm VM pointer
+ * @param *agent the agent to be printed
+ * @return omr_error_t
+ */
+omr_error_t
+printDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
+
+#if defined(OMR_TDUMP_VALIDATION)
+/**
+ * Validate a dump agent.
+ *
+ * @param *vm VM pointer
+ * @param *agent the agent to be validated
+ * @return omr_error_t
+ */
+omr_error_t
+validateDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
+#endif /* defined(OMR_TDUMP_VALIDATION) */
 
 /**
 * @brief
@@ -425,11 +446,11 @@ queryVmDump(struct J9JavaVM *vm, int buffer_size, void* options_buffer, int* dat
 * @param len
 * @param *reqLen
 * @param now
+* @param incrSeqNum
 * @return omr_error_t
 */
 omr_error_t
-dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context, char *buf, size_t len, UDATA *reqLen, I_64 now);
-
+dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context, char *buf, size_t len, UDATA *reqLen, I_64 now, BOOLEAN incrSeqNum);
 
 /**
 * @brief
@@ -468,7 +489,7 @@ void
 j9rasSetServiceLevel(J9JavaVM *vm, const char *runtimeVersion);
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
 #endif /* rasdump_api_h */

--- a/runtime/rasdump/dmpagent.c
+++ b/runtime/rasdump/dmpagent.c
@@ -2715,18 +2715,18 @@ runDumpAgent(struct J9JavaVM *vm, J9RASdumpAgent * agent, J9RASdumpContext * con
 {
 	char localLabel[J9_MAX_DUMP_PATH];
 	char *label = localLabel;
-	UDATA reqLen;
+	UDATA reqLen = 0;
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	omr_error_t retVal = OMR_ERROR_INTERNAL;
 
 	/* Convert the dump label template into an actual label, by expanding any tokens */
-	retVal = dumpLabel(vm, agent, context, label, J9_MAX_DUMP_PATH, &reqLen, timeNow);
+	retVal = dumpLabel(vm, agent, context, label, sizeof(localLabel), &reqLen, timeNow, TRUE);
 	if ((OMR_ERROR_OUT_OF_NATIVE_MEMORY == retVal) && (agent->dumpFn == doToolDump)) {
 		/* For tool agent only, support longer labels, as it's actually a complete tool command line */
 		label = j9mem_allocate_memory(reqLen, OMRMEM_CATEGORY_VM);
 		if (label) {
 			/* retry label template expansion with increased (allocated) memory */
-			retVal = dumpLabel(vm, agent, context, label, reqLen, &reqLen, timeNow);
+			retVal = dumpLabel(vm, agent, context, label, reqLen, &reqLen, timeNow, TRUE);
 		} else {
 			return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
 		}
@@ -2958,6 +2958,37 @@ reportDumpRequest(struct J9PortLibrary* portLibrary, J9RASdumpContext * context,
 		}
 	}
 }
+
+#if defined(OMR_TDUMP_VALIDATION)
+omr_error_t
+validateDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent)
+{
+	omr_error_t retVal = OMR_ERROR_NONE;
+
+	/* validation currently only applies to "system" dump agents */
+	if (doSystemDump == agent->dumpFn) {
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		UDATA reqLen = 0;
+		U_64 timeNow = j9time_current_time_millis();
+		J9RASdumpContext context;
+		char label[J9_MAX_DUMP_PATH];
+
+		memset(&context, 0, sizeof(context));
+		context.javaVM = vm;
+
+		/* convert the dump label template into an actual label, by expanding any tokens */
+		retVal = dumpLabel(vm, agent, &context, label, sizeof(label), &reqLen, timeNow, FALSE);
+
+		if (OMR_ERROR_NONE == retVal) {
+			if (0 != j9dump_create(label, "IEATDUMP_VALIDATE", NULL)) {
+				retVal = OMR_ERROR_ILLEGAL_ARGUMENT;
+			}
+		}
+	}
+
+	return retVal;
+}
+#endif /* defined(OMR_TDUMP_VALIDATION) */
 
 static char *
 scanSubFilter(J9JavaVM *vm, const J9RASdumpSettings *settings, const char **cursor, UDATA *actionPtr)

--- a/runtime/rasdump/dmpsup.c
+++ b/runtime/rasdump/dmpsup.c
@@ -1166,6 +1166,10 @@ pushDumpFacade(J9JavaVM *vm)
 		queue->facade.setDumpOption		= setDumpOption;
 		queue->facade.resetDumpOptions	= resetDumpOptions;
 		queue->facade.queryVmDump		= queryVmDump;
+		queue->facade.printDumpAgent = printDumpAgent;
+#if defined(OMR_TDUMP_VALIDATION)
+		queue->facade.validateDumpAgent = validateDumpAgent;
+#endif /* defined(OMR_TDUMP_VALIDATION) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 		queue->facade.criuReloadXDumpAgents = criuReloadXDumpAgents;
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */

--- a/runtime/rasdump/trigger.c
+++ b/runtime/rasdump/trigger.c
@@ -789,21 +789,23 @@ unwindAfterDump(struct J9JavaVM *vm, struct J9RASdumpContext *context, UDATA sta
  * Convert a dump label template into an actual dump label by expanding all the tokens.
  *
  * Parameters:
- *  vm [in] 	 - VM structure pointer
- *  agent		 - dump agent pointer
- *  context		 - dump context pointer
- *  buf [in/out] - memory buffer for expanded label
- *  len [in]	 - length of supplied buffer
- *  reqLen [out] - length of buffer required, if expansion would have overflowed buf
- *  now [in]	 - current time
+ *  vm [in]         - VM structure pointer
+ *  agent [in]      - dump agent pointer
+ *  context [in]    - dump context pointer
+ *  buf [in/out]    - memory buffer for expanded label
+ *  len [in]        - length of supplied buffer
+ *  reqLen [out]    - length of buffer required, if expansion would have overflowed buf
+ *  now [in]        - current time
+ *  incrSeqNum [in] - should the global sequence number be incremented?
  *
  * Returns: OMR_ERROR_NONE, OMR_ERROR_INTERNAL, OMR_ERROR_OUT_OF_NATIVE_MEMORY
  */
 omr_error_t
-dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context, char *buf, size_t len, UDATA *reqLen, I_64 now)
+dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context, char *buf, size_t len, UDATA *reqLen, I_64 now, BOOLEAN incrSeqNum)
 {
 	/* monotonic counter */
 	static UDATA seqNum = 0;
+	omr_error_t result = OMR_ERROR_INTERNAL;
 	struct J9StringTokens *stringTokens = NULL;
 	RasDumpGlobalStorage *dump_storage = (RasDumpGlobalStorage *)vm->j9rasdumpGlobalStorage;
 
@@ -821,32 +823,29 @@ dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context,
 
 	j9str_set_time_tokens(stringTokens, now);
 
-	seqNum += 1; /* Atomicity guaranteed as we are inside the dumpLabelTokensMutex. */
+	if (incrSeqNum) {
+		seqNum += 1; /* Atomicity guaranteed as we are inside the dumpLabelTokensMutex. */
+	}
 
 	if (0 != j9str_set_token(stringTokens, "seq", "%04u", seqNum)) {
-		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-		return OMR_ERROR_INTERNAL;
+		goto done;
 	}
 
 	if (0 != j9str_set_token(stringTokens, "home", "%s", (vm->javaHome == NULL) ? "" : (const char *)vm->javaHome)) {
-		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-		return OMR_ERROR_INTERNAL;
+		goto done;
 	}
 
 	if (0 != j9str_set_token(stringTokens, "event", "%s", mapDumpEvent(context->eventFlags))) {
-		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-		return OMR_ERROR_INTERNAL;
+		goto done;
 	}
 
 	if (0 != j9str_set_token(stringTokens, "list", "%s", (context->dumpList == NULL) ? "" : context->dumpList)) {
-		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-		return OMR_ERROR_INTERNAL;
+		goto done;
 	}
 
 	/* %vmbin is not listed in printLabelSpec as it is only useful for loading internal tools that live in the vm directory. */
 	if (0 != j9str_set_token(stringTokens, "vmbin", "%s", (vm->j2seRootDirectory == NULL) ? "" : (const char *)vm->j2seRootDirectory)) {
-		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-		return OMR_ERROR_INTERNAL;
+		goto done;
 	}
 
 	/* Default label is "-", ie. stderr */
@@ -857,22 +856,24 @@ dumpLabel(struct J9JavaVM *vm, J9RASdumpAgent *agent, J9RASdumpContext *context,
 	/* Check the return value here to see if token expansion fitted in the buffer */
 	*reqLen = j9str_subst_tokens(buf, len, agent->labelTemplate, stringTokens);
 	if (*reqLen > len) {
-		omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-		return OMR_ERROR_OUT_OF_NATIVE_MEMORY;
+		result = OMR_ERROR_OUT_OF_NATIVE_MEMORY;
+		goto done;
 	}
 
 	if (agent->dumpFn != doToolDump) {
 		/* Cache last dump label (but not for tool dumps!) */
 		if (0 != j9str_set_token(stringTokens, "last", "%s", buf)) {
-			omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
-			return OMR_ERROR_INTERNAL;
+			goto done;
 		}
 	}
 
+	result = OMR_ERROR_NONE;
+
+done:
 	/* release access to the tokens */
 	omrthread_monitor_exit(dump_storage->dumpLabelTokensMutex);
 
-	return OMR_ERROR_NONE;
+	return result;
 }
 
 omr_error_t

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3557,7 +3557,6 @@ consumeVMArgs(J9JavaVM* vm, J9VMInitArgs* j9vm_args)
 static jint
 modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 {
-	jint rc = 0;
 	J9VMDllLoadInfo* entry = NULL;
 	JavaVMInitArgs* vm_args = j9vm_args->actualVMArgs;
 	BOOLEAN xsnw = FALSE;
@@ -3958,9 +3957,8 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 	JVMINIT_VERBOSE_INIT_VM_TRACE(vm, "IFA support required... whacking table\n");
 #endif /* defined(J9VM_OPT_JAVA_OFFLOAD_SUPPORT) */
 
-	rc = processXCheckOptions(vm, loadTable, j9vm_args);
 	JVMINIT_VERBOSE_INIT_TRACE_WORKING_SET(vm);
-	return rc;
+	return JNI_OK;
 }
 
 /* Process VM args that are order-dependent */
@@ -8033,6 +8031,10 @@ protectedInitializeJavaVM(J9PortLibrary* portLibrary, void * userData)
 	}
 
 	if (JNI_OK != (stageRC = runInitializationStage(vm, PORT_LIBRARY_GUARANTEED))) {
+		goto error;
+	}
+
+	if (JNI_OK != processXCheckOptions(vm, vm->dllLoadTable, vm->vmArgsArray)) {
 		goto error;
 	}
 

--- a/runtime/vm/rasdump.c
+++ b/runtime/vm/rasdump.c
@@ -55,13 +55,17 @@ static omr_error_t primordialSetDumpOption (struct J9JavaVM *vm, char *optionStr
 static omr_error_t primordialResetDumpOption (struct J9JavaVM *vm);
 static omr_error_t primordialRemoveDumpAgent (struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
 static omr_error_t primordialQueryVmDump(struct J9JavaVM *vm, int buffer_size, void* options_buffer, int* data_size);
+static omr_error_t primordialPrintDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
+#if defined(OMR_TDUMP_VALIDATION)
+static omr_error_t primordialValidateDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent);
+#endif /* defined(OMR_TDUMP_VALIDATION) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 static IDATA primordialCriuReloadXDumpAgents(struct J9JavaVM *vm, struct J9VMInitArgs *j9vm_args);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
 void J9RASInitialize (J9JavaVM* javaVM);
 void J9RASShutdown (J9JavaVM* javaVM);
-void J9RASCheckDump(J9JavaVM* javaVM);
+IDATA J9RASCheckDump(J9JavaVM *javaVM);
 void populateRASNetData (J9JavaVM *javaVM, J9RAS *rasStruct);
 static J9RAS* allocateRASStruct(J9JavaVM *javaVM);
 
@@ -89,6 +93,10 @@ primordialDumpFacade = {
 	primordialSetDumpOption,
 	primordialResetDumpOption,
 	primordialQueryVmDump,
+	primordialPrintDumpAgent,
+#if defined(OMR_TDUMP_VALIDATION)
+	primordialValidateDumpAgent,
+#endif /* defined(OMR_TDUMP_VALIDATION) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 	primordialCriuReloadXDumpAgents,
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
@@ -203,6 +211,28 @@ primordialQueryVmDump(struct J9JavaVM *vm, int buffer_size, void* options_buffer
 
 	return OMR_ERROR_NONE;
 }
+
+static omr_error_t
+primordialPrintDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent)
+{
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_VM_MISSING_DUMP_DLL_PRINT_DUMP_AGENT, J9_RAS_DUMP_DLL_NAME);
+
+	return OMR_ERROR_NONE;
+}
+
+#if defined(OMR_TDUMP_VALIDATION)
+static omr_error_t
+primordialValidateDumpAgent(struct J9JavaVM *vm, struct J9RASdumpAgent *agent)
+{
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_VM_MISSING_DUMP_DLL_VALIDATE_DUMP_AGENT, J9_RAS_DUMP_DLL_NAME);
+
+	return OMR_ERROR_NONE;
+}
+#endif /* defined(OMR_TDUMP_VALIDATION) */
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 static IDATA
@@ -656,84 +686,107 @@ populateRASNetData(J9JavaVM *javaVM, J9RAS *rasStruct)
 }
 
 /**
- * Function J9RASCheckDump(), implementation for -Xcheck:dump support
- * 
+ * Function J9RASCheckDump(), implementation for -Xcheck:dump support.
+ *
  * @param J9JavaVM* javaVM, JVM top-level structure pointer
- * @returns void
+ * @return 0 on success, non-zero if the VM should not continue
  */
-void
-J9RASCheckDump(J9JavaVM* javaVM)
+IDATA
+J9RASCheckDump(J9JavaVM *javaVM)
 {
-#if defined(LINUX) || defined(AIXPPC)
+	IDATA result = 0;
+#if defined(AIXPPC) || defined(LINUX) || defined(OMR_TDUMP_VALIDATION)
+	PORT_ACCESS_FROM_JAVAVM(javaVM);
+#endif /* defined(AIXPPC) || defined(LINUX) || defined(OMR_TDUMP_VALIDATION) */
+#if defined(AIXPPC) || defined(LINUX)
 	IDATA rc = 0;
 	U_64 limit = 0;
 #if defined(LINUX)
-	IDATA fd = -1;
+	IDATA fd = 0;
 #endif /* defined(LINUX) */
 
-	PORT_ACCESS_FROM_JAVAVM(javaVM);
-
-	/* Check the UNIX core-size hard ulimit */
+	/* Check the UNIX core-size hard ulimit. */
 	rc = j9sysinfo_get_limit(J9PORT_RESOURCE_CORE_FILE | J9PORT_LIMIT_HARD, &limit);
-	if (rc == J9PORT_LIMIT_LIMITED) {
-		/* Issue NLS message warning, with force routing to syslog as well */
+	if (J9PORT_LIMIT_LIMITED == rc) {
+		/* Issue NLS message warning, with force routing to syslog as well. */
 		j9nls_printf(PORTLIB, J9NLS_WARNING | J9NLS_VITAL, J9NLS_VM_CHECK_DUMP_ULIMIT, limit);
 	}
+#endif /* defined(AIXPPC) || defined(LINUX) */
 
 #if defined(LINUX)
 	/* Check if /proc/sys/kernel/core_pattern is set. */
 	fd = j9file_open("/proc/sys/kernel/core_pattern", EsOpenRead, 0);
-	if (fd != -1) {
+	if (-1 != fd) {
 		/* Files in /proc report length as 0 but we don't expect the contents to be more than 1 line. */
 		char buf[80];
-		char* read = NULL;
-		read = j9file_read_text(fd, &buf[0], 80);
-		if( read == &buf[0] ) {
+		char *read = j9file_read_text(fd, buf, sizeof(buf));
+		if (buf == read) {
 			size_t bufLen = 0;
-			char *cursor;
-			/* Make sure the string is only one line and null terminated. */
-			for( bufLen = 0; bufLen < 80; bufLen++) {
-				if( read[bufLen] == '\n') {
+			/* Make sure the string is only one line and NUL-terminated. */
+			for (bufLen = 0; bufLen < sizeof(buf); bufLen++) {
+				if (read[bufLen] == '\n') {
 					read[bufLen] = '\0';
 					break;
 				}
 			}
-			buf[79] = '\0';
-			if( buf[0] == '|') {
+			buf[sizeof(buf) - 1] = '\0';
+			if ('|' == buf[0]) {
 				/* Check for core dumps being piped to an external program. */
 				j9nls_printf(PORTLIB, J9NLS_WARNING | J9NLS_VITAL, J9NLS_VM_CHECK_DUMP_COREPATTERN_PIPE, buf);
-			} else if( buf[0] != '\0') {
+			} else if ('\0' != buf[0]) {
 				/* Check for core dumps being renamed via % format specifiers. */
-				cursor = &buf[0];
-				while( *cursor !='\0' ) {
+				char *cursor = buf;
+				while ('\0' != *cursor) {
 					/* % means a replacement char unless it's followed by another % */
-					if( *cursor == '%' ) {
-						/* Found a %, issue a warning if it's not followed by % or the end of the string.*/
-						cursor++;
-						if( *cursor != '\0' && *cursor != '%' ) {
+					if ('%' == *cursor) {
+						/* Found a %, issue a warning if it's not followed by % or the end of the string. */
+						cursor += 1;
+						if (('\0' != *cursor) && ('%' != *cursor)) {
 							j9nls_printf(PORTLIB, J9NLS_WARNING | J9NLS_VITAL, J9NLS_VM_CHECK_DUMP_COREPATTERN_FORMAT, buf);
 							break; /* Found one specifier, don't worry about any others. */
-						} else if( *cursor != '\0' ) {
-							cursor++; /* Skip over a %% */
+						} else if ('\0' != *cursor) {
+							cursor += 1; /* Skip over a %%. */
 						}
 					} else {
-						cursor++;
+						cursor += 1;
 					}
 				}
 			}
 		}
 		j9file_close(fd);
 	}
-#endif
-#if defined(AIXPPC)
+#endif /* defined(LINUX) */
 
-	/* Check the AIX fullcore setting */
+#if defined(AIXPPC)
+	/* Check the AIX fullcore setting. */
 	rc = j9sysinfo_get_limit(J9PORT_RESOURCE_CORE_FLAGS, &limit);
-	if (rc == J9PORT_LIMIT_LIMITED) {
-		/* Issue NLS message warning, with force routing to syslog as well */
+	if (J9PORT_LIMIT_LIMITED == rc) {
+		/* Issue NLS message warning, with force routing to syslog as well. */
 		j9nls_printf(PORTLIB, J9NLS_WARNING | J9NLS_VITAL, J9NLS_VM_CHECK_DUMP_FULLCORE);
 	}
+#endif /* defined(AIXPPC) */
 
-#endif
-#endif
+#if defined(OMR_TDUMP_VALIDATION)
+	{
+		J9RASdumpFunctions *dumpFunctions = javaVM->j9rasDumpFunctions;
+		J9RASdumpAgent *agent = NULL;
+		BOOLEAN anyInvalid = FALSE;
+
+		while (OMR_ERROR_NONE == dumpFunctions->seekDumpAgent(javaVM, &agent, NULL)) {
+			omr_error_t error = dumpFunctions->validateDumpAgent(javaVM, agent);
+
+			if (OMR_ERROR_NONE != error) {
+				if (!anyInvalid) {
+					j9nls_printf(PORTLIB, J9NLS_ERROR | J9NLS_STDERR, J9NLS_VM_INVALID_DUMP_AGENTS);
+					anyInvalid = TRUE;
+					result = -1;
+				}
+
+				dumpFunctions->printDumpAgent(javaVM, agent);
+			}
+		}
+	}
+#endif /* defined(OMR_TDUMP_VALIDATION) */
+
+	return result;
 }

--- a/runtime/vm/vm_internal.h
+++ b/runtime/vm/vm_internal.h
@@ -269,15 +269,15 @@ J9VMI_Initialize(J9JavaVM* vm);
 
 /* ---------------- xcheck.c ---------------- */
 /**
-* @brief
-* Modify the DLL load table for shared libraries used by -Xcheck: options.
-* @param vm
-* @param loadTable
-* @param j9vm_args
-* @return void
-*/
+ * @brief
+ * Modify the DLL load table for shared libraries used by -Xcheck: options.
+ * @param vm
+ * @param loadTable
+ * @param j9vm_args
+ * @return 0 on success, non-zero if options prevent the JVM from continuing
+ */
 jint
-processXCheckOptions(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args);
+processXCheckOptions(J9JavaVM *vm, J9Pool *loadTable, J9VMInitArgs *j9vm_args);
 
 /* ---------------- statistics.c ---------------- */
 /**

--- a/runtime/vm/xcheck.c
+++ b/runtime/vm/xcheck.c
@@ -28,10 +28,10 @@
 
 static UDATA isVerboseJni(J9PortLibrary *portLibrary, J9VMInitArgs* j9vm_args, IDATA *verboseIndexPtr);
 static IDATA printXcheckUsage(J9JavaVM *vm);
-extern void J9RASCheckDump(J9JavaVM* javaVM);
+extern IDATA J9RASCheckDump(J9JavaVM *vm);
 
-jint 
-processXCheckOptions(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args) 
+jint
+processXCheckOptions(J9JavaVM *vm, J9Pool *loadTable, J9VMInitArgs *j9vm_args)
 {
 	jint rc = 0;
 	J9VMDllLoadInfo* entry = NULL;
@@ -41,7 +41,7 @@ processXCheckOptions(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 	IDATA helpIndex, memoryHelpIndex, memoryNoneIndex;
 	IDATA dumpIndex, dumpHelpIndex, dumpNoneIndex;
 
-    PORT_ACCESS_FROM_JAVAVM(vm);
+	PORT_ACCESS_FROM_JAVAVM(vm);
 
 	/*
 	 * Global options
@@ -165,11 +165,11 @@ processXCheckOptions(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 	if (dumpHelpIndex > dumpNoneIndex) {
 		j9tty_err_printf("\nUsage: -Xcheck:dump\nRun JVM start-up checks for OS system dump settings\n\n");
 		rc = -1;
-	}
-
-	if (dumpIndex > dumpNoneIndex) {
+	} else if (dumpIndex > dumpNoneIndex) {
 		/* dump checking has been requested, do it now */
-		J9RASCheckDump(vm);
+		if (0 != J9RASCheckDump(vm)) {
+			rc = -1;
+		}
 	}
 
 	nohelpIndex = OMR_MAX(OMR_MAX(noneIndex, memoryHelpIndex), checkCPHelpIndex);


### PR DESCRIPTION
* add `printDumpAgent()` and `validateIEATDumpSettings()` to RAS functions
* change return type of `J9RASCheckDump()`
* delay `processXCheckOptions()` until Xdump support is available
* document return value of `processXCheckOptions()`
* add `incrSeqNum` parameter to `dumpLabel()` to avoid incrementing the label sequence number during validation