### PR TITLE
Compact layout type updates for JVMTI

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.cpp
+++ b/runtime/jvmti/jvmtiHelpers.cpp
@@ -868,16 +868,32 @@ fillInJValue(char signatureType, jvalue * jvaluePtr, void * valueAddress, j9obje
 
 	switch (signatureType) {
 		case 'Z':
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			jvaluePtr->z = (jboolean) *((U_8 *) valueAddress);
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			jvaluePtr->z = (jboolean) *((I_32 *) valueAddress);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			break;
 		case 'B':
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			jvaluePtr->b = (jbyte) *((I_8 *) valueAddress);
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			jvaluePtr->b = (jbyte) *((I_32 *) valueAddress);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			break;
 		case 'C':
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			jvaluePtr->c = (jchar) *((U_16 *) valueAddress);
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			jvaluePtr->c = (jchar) *((I_32 *) valueAddress);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			break;
 		case 'S':
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			jvaluePtr->s = (jshort) *((I_16 *) valueAddress);
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			jvaluePtr->s = (jshort) *((I_32 *) valueAddress);
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
 			break;
 		case 'I':
 			jvaluePtr->i = (jint) *((I_32 *) valueAddress);


### PR DESCRIPTION
Related: https://github.com/eclipse-openj9/openj9/issues/21251

I ran cmdLineTester_jvmtitests with these changes and compact layouts enabled. All tests that don't rely on the JIT are passing. Compact layout builds are not expected to work with the JIT yet.

```
---TEST RESULTS---
Number of PASSED tests: 54 out of 60
Number of FAILED tests: 6 out of 60

---SUMMARY OF FAILED TESTS---
gaste001
gaste001_multiple
gste001
gste001_multiple
gtlste001
gtlste001_multiple
-----------------------------
```