### PR TITLE
Remove unused `j9gc_objaccess_*Split()` functions

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -140,9 +140,6 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_indexableStoreU32,
 	j9gc_objaccess_indexableStoreI64,
 	j9gc_objaccess_indexableStoreU64,
-#if !defined(J9VM_ENV_DATA64)
-	j9gc_objaccess_indexableStoreU64Split,
-#endif /* !J9VM_ENV_DATA64 */
 	j9gc_objaccess_indexableStoreObject,
 	j9gc_objaccess_indexableStoreAddress,
 	j9gc_objaccess_indexableDataDisplacement,
@@ -170,9 +167,6 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_mixedObjectStoreU64,
 	j9gc_objaccess_mixedObjectStoreObject,
 	j9gc_objaccess_mixedObjectStoreAddress,
-#if !defined(J9VM_ENV_DATA64)
-	j9gc_objaccess_mixedObjectStoreU64Split,
-#endif /* !J9VM_ENV_DATA64 */
 	j9gc_objaccess_mixedObjectCompareAndSwapInt,
 	j9gc_objaccess_mixedObjectCompareAndSwapLong,
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
@@ -193,9 +187,6 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_staticStoreU64,
 	j9gc_objaccess_staticStoreObject,
 	j9gc_objaccess_staticStoreAddress,
-#if !defined(J9VM_ENV_DATA64)
-	j9gc_objaccess_staticStoreU64Split,
-#endif /* !J9VM_ENV_DATA64 */
 	j9gc_objaccess_storeObjectToInternalVMSlot,
 	j9gc_objaccess_readObjectFromInternalVMSlot,
 	j9gc_objaccess_getArrayObjectDataAddress,
@@ -273,15 +264,9 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 #if defined(J9VM_GC_OBJECT_ACCESS_BARRIER)
 	j9gc_objaccess_staticCompareAndSwapInt,
 	j9gc_objaccess_staticCompareAndExchangeInt,
-#if !defined(J9VM_ENV_DATA64)
-	j9gc_objaccess_mixedObjectCompareAndSwapLongSplit,
-#endif /* !J9VM_ENV_DATA64 */
 	j9gc_objaccess_staticCompareAndSwapLong,
 	j9gc_objaccess_staticCompareAndExchangeLong,
-#if !defined(J9VM_ENV_DATA64)
-	j9gc_objaccess_staticCompareAndSwapLongSplit,
-#endif /* !J9VM_ENV_DATA64 */
-#endif /* J9VM_GC_OBJECT_ACCESS_BARRIER */
+#endif /* defined(J9VM_GC_OBJECT_ACCESS_BARRIER) */
 	j9gc_get_bytes_allocated_by_thread,
 	j9gc_get_cumulative_bytes_allocated_by_thread,
 	j9gc_get_cumulative_class_unloading_stats,

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -160,19 +160,6 @@ j9gc_objaccess_mixedObjectStoreI64(J9VMThread *vmThread, J9Object *destObject, U
 	barrier->mixedObjectStoreI64(vmThread, destObject, offset, value, 0 != isVolatile);
 }
 
-void 
-j9gc_objaccess_mixedObjectStoreU64Split(J9VMThread *vmThread, J9Object *destObject, UDATA delta, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile)
-{
-	U_64 value64;
-	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
-
-	/* This is endian-independent. valueSlot0 is always the low 4 bytes in memory */
-	*(U_32 *)&value64 = valueSlot0;
-	*(((U_32 *)&value64) + 1) = valueSlot1;
-
-	barrier->mixedObjectStoreU64(vmThread, destObject, delta, value64, 0 != isVolatile);
-}
-
 J9Object *
 j9gc_objaccess_indexableReadObject(J9VMThread *vmThread, J9IndexableObject *srcObject, I_32 index, UDATA isVolatile) {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
@@ -293,19 +280,6 @@ j9gc_objaccess_indexableStoreI64(J9VMThread *vmThread, J9IndexableObject *destOb
 	barrier->indexableStoreI64(vmThread, destObject, index, value, 0 != isVolatile);
 }
 
-void 
-j9gc_objaccess_indexableStoreU64Split(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile)
-{
-	U_64 value64;
-	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
-
-	/* This is endian-independent. valueSlot0 is always the low 4 bytes in memory */
-	*(U_32 *)&value64 = valueSlot0;
-	*(((U_32 *)&value64) + 1) = valueSlot1;
-
-	barrier->indexableStoreU64(vmThread, destObject, index, value64, 0 != isVolatile);
-}
-
 J9Object *
 j9gc_objaccess_staticReadObject(J9VMThread *vmThread, J9Class *clazz, J9Object **srcSlot, UDATA isVolatile) {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
@@ -378,19 +352,6 @@ j9gc_objaccess_staticStoreI64(J9VMThread *vmThread, J9Class *clazz, I_64 *destSl
 	barrier->staticStoreI64(vmThread, clazz, destSlot, value, 0 != isVolatile);
 }
 
-void 
-j9gc_objaccess_staticStoreU64Split(J9VMThread *vmThread, J9Class *clazz, U_64 *destSlot, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile)
-{
-	U_64 value64;
-	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
-
-	/* This is endian-independent. valueSlot0 is always the low 4 bytes in memory */
-	*(U_32 *)&value64 = valueSlot0;
-	*(((U_32 *)&value64) + 1) = valueSlot1;
-
-	barrier->staticStoreU64(vmThread, clazz, destSlot, value64, 0 != isVolatile);
-}
-
 /**
  * Returns the displacement for the data of moved array object.
  * Used by the JIT, should only be called for off heap enabled cases,
@@ -415,8 +376,8 @@ j9gc_objaccess_indexableDataDisplacement(J9StackWalkState *walkState, J9Indexabl
 	return displacement;
 }
 
-/* TODO: After all array accesses in the VM have been made arraylet safe, 
- * it should be possible to delete this method + its associated ENVY and 
+/* TODO: After all array accesses in the VM have been made arraylet safe,
+ * it should be possible to delete this method + its associated ENVY and
  * ObjectAccessBarrier methods
  */
 U_8 *
@@ -434,7 +395,7 @@ j9gc_objaccess_getLockwordAddress(J9VMThread *vmThread, J9Object *object)
 }
 
 void
-j9gc_objaccess_storeObjectToInternalVMSlot(J9VMThread *vmThread, J9Object** destSlot, J9Object *value) 
+j9gc_objaccess_storeObjectToInternalVMSlot(J9VMThread *vmThread, J9Object** destSlot, J9Object *value)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
 	barrier->storeObjectToInternalVMSlot(vmThread, destSlot, value);
@@ -500,49 +461,11 @@ j9gc_objaccess_mixedObjectCompareAndSwapLong(J9VMThread *vmThread, J9Object *des
 	return 0;
 }
 
-UDATA 
-j9gc_objaccess_mixedObjectCompareAndSwapLongSplit(J9VMThread *vmThread, J9Object *destObject, UDATA offset, U_32 compareValueSlot0, U_32 compareValueSlot1, U_32 swapValueSlot0, U_32 swapValueSlot1)
-{
-	U_64 compareValue64 = 0;
-	U_64 swapValue64 = 0;
-	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
-
-	/* This is endian-independent. valueSlot0 is always the low 4 bytes in memory */
-	*(U_32 *)&compareValue64 = compareValueSlot0;
-	*(((U_32 *)&compareValue64) + 1) = compareValueSlot1;
-	*(U_32 *)&swapValue64 = swapValueSlot0;
-	*(((U_32 *)&swapValue64) + 1) = swapValueSlot1;
-
-	if (barrier->mixedObjectCompareAndSwapLong(vmThread, destObject, offset, compareValue64, swapValue64)) {
-		return 1;
-	}
-	return 0;
-}
-
 UDATA
 j9gc_objaccess_staticCompareAndSwapLong(J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_64 compareValue, U_64 swapValue)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
 	if (barrier->staticCompareAndSwapLong(vmThread, destClass, destAddress, compareValue, swapValue)) {
-		return 1;
-	}
-	return 0;
-}
-
-UDATA 
-j9gc_objaccess_staticCompareAndSwapLongSplit(J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_32 compareValueSlot0, U_32 compareValueSlot1, U_32 swapValueSlot0, U_32 swapValueSlot1)
-{
-	U_64 compareValue64 = 0;
-	U_64 swapValue64 = 0;
-	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
-
-	/* This is endian-independent. valueSlot0 is always the low 4 bytes in memory */
-	*(U_32 *)&compareValue64 = compareValueSlot0;
-	*(((U_32 *)&compareValue64) + 1) = compareValueSlot1;
-	*(U_32 *)&swapValue64 = swapValueSlot0;
-	*(((U_32 *)&swapValue64) + 1) = swapValueSlot1;
-
-	if (barrier->staticCompareAndSwapLong(vmThread, destClass, destAddress, compareValue64, swapValue64)) {
 		return 1;
 	}
 	return 0;
@@ -828,9 +751,8 @@ j9gc_weakRoot_readObjectVM(J9JavaVM *vm, j9object_t *srcAddress)
 	return *srcAddress;
 }
 
-
 void
-j9gc_objaccess_recentlyAllocatedObject(J9VMThread *vmThread, J9Object *dstObject) 
+j9gc_objaccess_recentlyAllocatedObject(J9VMThread *vmThread, J9Object *dstObject)
 {
 	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vmThread)->accessBarrier;
 	return barrier->recentlyAllocatedObject(vmThread, dstObject);
@@ -946,4 +868,3 @@ postUnmountContinuation(J9VMThread *vmThread, j9object_t object)
 }
 
 } /* extern "C" */
-

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -33,10 +33,10 @@
 /*
  * This file defines extern "C" prototypes for C functions defined and used internally
  * in the GC module.
- * 
+ *
  * These are mostly used in the J9MemoryManagerFunctions function table definition
- * in gctable.c 
- * 
+ * in gctable.c
+ *
  * These prototypes were all moved here from j9protos.h as a first step in cleaning them up.
  * Many of these are still duplicated in other header files, and further clean up of this
  * file is required.
@@ -57,7 +57,6 @@ extern J9_CFUNC UDATA j9gc_incrementalUpdate_getCardSize(OMR_VM *omrVM);
 extern J9_CFUNC UDATA j9gc_incrementalUpdate_getCardTableShiftValue(OMR_VM *omrVM);
 extern J9_CFUNC UDATA j9gc_incrementalUpdate_getHeapBase(OMR_VM *omrVM);
 extern J9_CFUNC UDATA j9gc_incrementalUpdate_getCardTableVirtualStart(OMR_VM *omrVM);
-
 
 /* J9VMGCModronHLLPrototypeHolder */
 extern J9_CFUNC UDATA j9gc_objaccess_indexableReadU16(J9VMThread *vmThread, J9IndexableObject *srcObject, I_32 index, UDATA isVolatile);
@@ -123,9 +122,7 @@ extern J9_CFUNC UDATA j9gc_objaccess_staticCompareAndSwapObject(J9VMThread *vmTh
 extern J9_CFUNC UDATA j9gc_objaccess_mixedObjectCompareAndSwapInt(J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_32 compareValue, U_32 swapValue);
 extern J9_CFUNC UDATA j9gc_objaccess_staticCompareAndSwapInt(J9VMThread *vmThread, J9Class *destClass, U_32 *destAddress, U_32 compareValue, U_32 swapValue);
 extern J9_CFUNC UDATA j9gc_objaccess_mixedObjectCompareAndSwapLong(J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_64 compareValue, U_64 swapValue);
-extern J9_CFUNC UDATA j9gc_objaccess_mixedObjectCompareAndSwapLongSplit(J9VMThread *vmThread, J9Object *destObject, UDATA offset, U_32 compareValueSlot0, U_32 compareValueSlot1, U_32 swapValueSlot0, U_32 swapValueSlot1);
 extern J9_CFUNC UDATA j9gc_objaccess_staticCompareAndSwapLong(J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_64 compareValue, U_64 swapValue);
-extern J9_CFUNC UDATA j9gc_objaccess_staticCompareAndSwapLongSplit(J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_32 compareValueSlot0, U_32 compareValueSlot1, U_32 swapValueSlot0, U_32 swapValueSlot1);
 extern J9_CFUNC j9object_t j9gc_objaccess_compareAndExchangeObject(J9VMThread *vmThread, j9object_t destObject, j9object_t *destAddress, j9object_t compareObject, j9object_t swapObject);
 extern J9_CFUNC j9object_t j9gc_objaccess_staticCompareAndExchangeObject(J9VMThread *vmThread, J9Class *destClass, j9object_t *destAddress, j9object_t compareObject, j9object_t swapObject);
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
@@ -163,7 +160,6 @@ extern J9_CFUNC void j9gc_objaccess_staticStoreObject(J9VMThread *vmThread, J9Cl
 extern J9_CFUNC void gcShutdownHeapManagement(J9JavaVM * vm);
 extern J9_CFUNC jvmtiIterationControl j9mm_iterate_regions(J9JavaVM *vm, J9PortLibrary *portLibrary, struct J9MM_IterateSpaceDescriptor *space, UDATA flags, jvmtiIterationControl(*func)(J9JavaVM *vm, struct J9MM_IterateRegionDescriptor *regionDesc, void *userData), void *userData);
 extern J9_CFUNC UDATA j9mm_find_region_for_pointer(J9JavaVM* javaVM, void *pointer, struct J9MM_IterateRegionDescriptor *regionDesc);
-extern J9_CFUNC void j9gc_objaccess_staticStoreU64Split(J9VMThread *vmThread, J9Class *clazz, U_64 *destSlot, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile);
 extern J9_CFUNC UDATA j9gc_objaccess_compressedPointersShadowHeapTop(J9VMThread *vmThread);
 extern J9_CFUNC U_64 j9gc_objaccess_staticReadU64(J9VMThread *vmThread, J9Class *clazz, U_64 *srcSlot, UDATA isVolatile);
 extern J9_CFUNC IDATA j9gc_objaccess_indexableReadI8(J9VMThread *vmThread, J9IndexableObject *srcObject, I_32 index, UDATA isVolatile);
@@ -187,7 +183,6 @@ extern J9_CFUNC U_64 j9gc_get_sum_of_pauses(J9VMThread *vmThread);
 extern J9_CFUNC jint j9gc_register_jfr_hooks(J9JavaVM *javaVM);
 extern J9_CFUNC void j9gc_deregister_jfr_hooks(J9JavaVM *javaVM);
 extern J9_CFUNC UDATA j9gc_objaccess_compressedPointersShift(J9VMThread *vmThread);
-extern J9_CFUNC void j9gc_objaccess_indexableStoreU64Split(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile);
 extern J9_CFUNC void cleanupMutatorModelJava(J9VMThread* vmThread);
 extern J9_CFUNC j9object_t j9gc_objaccess_mixedObjectReadObject(J9VMThread *vmThread, j9object_t srcObject, UDATA offset, UDATA isVolatile);
 extern J9_CFUNC UDATA j9gc_get_objects_pending_finalization_count(J9JavaVM* vm);
@@ -238,7 +233,6 @@ extern J9_CFUNC struct J9HookInterface** j9gc_get_hook_interface(J9JavaVM *javaV
 extern J9_CFUNC struct J9HookInterface** j9gc_get_omr_hook_interface(OMR_VM *omrVM);
 extern J9_CFUNC void j9gc_objaccess_staticStoreU32(J9VMThread *vmThread, J9Class *clazz, U_32 *destSlot, U_32 value, UDATA isVolatile);
 extern J9_CFUNC IDATA initializeMutatorModelJava(J9VMThread* vmThread);
-extern J9_CFUNC void j9gc_objaccess_mixedObjectStoreU64Split(J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile);
 extern J9_CFUNC IDATA j9gc_objaccess_staticReadI32(J9VMThread *vmThread, J9Class *clazz, I_32 *srcSlot, UDATA isVolatile);
 extern J9_CFUNC void j9gc_objaccess_indexableStoreObject(J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, j9object_t value, UDATA isVolatile);
 extern J9_CFUNC UDATA j9gc_objaccess_staticReadU32(J9VMThread *vmThread, J9Class *clazz, U_32 *srcSlot, UDATA isVolatile);
@@ -298,7 +292,7 @@ extern J9_CFUNC BOOLEAN j9gc_reinitialize_for_restore(J9VMThread *vmThread, cons
 extern J9_CFUNC BOOLEAN gcReinitializeDefaultsForRestore(J9VMThread *vmThread);
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
-/* J9VMFinalizeSupport*/
+/* J9VMFinalizeSupport */
 extern J9_CFUNC void runFinalization(J9VMThread *vmThread);
 extern J9_CFUNC UDATA finalizeObjectCreated(J9VMThread *vmThread, j9object_t object);
 extern J9_CFUNC UDATA forceClassLoaderUnload(J9VMThread *vmThread, J9ClassLoader *classLoader);
@@ -327,7 +321,7 @@ extern J9_CFUNC BOOLEAN j9gc_get_cumulative_bytes_allocated_by_thread(J9VMThread
 extern J9_CFUNC BOOLEAN j9gc_get_cumulative_class_unloading_stats(J9VMThread *vmThread, UDATA *anonymous, UDATA *classes, UDATA *classloaders);
 
 #ifdef __cplusplus
-}
+} /* extern "C" */
 #endif
 
-#endif /*GC_INTERNAL_H_*/
+#endif /* !defined(GC_INTERNAL_H_) */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5026,9 +5026,6 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9gc_objaccess_indexableStoreU32)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, U_32 value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_indexableStoreI64)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, I_64 value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_indexableStoreU64)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, U_64 value, UDATA isVolatile) ;
-#if !defined(J9VM_ENV_DATA64)
-	void  ( *j9gc_objaccess_indexableStoreU64Split)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile) ;
-#endif /* !defined(J9VM_ENV_DATA64) */
 	void  ( *j9gc_objaccess_indexableStoreObject)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, j9object_t value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_indexableStoreAddress)(struct J9VMThread *vmThread, J9IndexableObject *destObject, I_32 index, void *value, UDATA isVolatile) ;
 	IDATA  ( *j9gc_objaccess_indexableDataDisplacement)(struct J9StackWalkState *walkState, J9IndexableObject *src, J9IndexableObject *dst) ;
@@ -5056,9 +5053,6 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9gc_objaccess_mixedObjectStoreU64)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_64 value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_mixedObjectStoreObject)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, j9object_t value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_mixedObjectStoreAddress)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, void *value, UDATA isVolatile) ;
-#if !defined(J9VM_ENV_DATA64)
-	void  ( *j9gc_objaccess_mixedObjectStoreU64Split)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile) ;
-#endif /* !defined(J9VM_ENV_DATA64) */
 	UDATA  ( *j9gc_objaccess_mixedObjectCompareAndSwapInt)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_32 compareValue, U_32 swapValue) ;
 	UDATA  ( *j9gc_objaccess_mixedObjectCompareAndSwapLong)(struct J9VMThread *vmThread, j9object_t destObject, UDATA offset, U_64 compareValue, U_64 swapValue) ;
 #if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
@@ -5079,9 +5073,6 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9gc_objaccess_staticStoreU64)(struct J9VMThread *vmThread, J9Class *clazz, U_64 *destSlot, U_64 value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_staticStoreObject)(struct J9VMThread *vmThread, J9Class *clazz, j9object_t *destSlot, j9object_t value, UDATA isVolatile) ;
 	void  ( *j9gc_objaccess_staticStoreAddress)(struct J9VMThread *vmThread, J9Class *clazz, void **destSlot, void *value, UDATA isVolatile) ;
-#if !defined(J9VM_ENV_DATA64)
-	void  ( *j9gc_objaccess_staticStoreU64Split)(struct J9VMThread *vmThread, J9Class *clazz, U_64 *destSlot, U_32 valueSlot0, U_32 valueSlot1, UDATA isVolatile) ;
-#endif /* !defined(J9VM_ENV_DATA64) */
 	void  ( *j9gc_objaccess_storeObjectToInternalVMSlot)(struct J9VMThread *vmThread, j9object_t *destSlot, j9object_t value) ;
 	j9object_t  ( *j9gc_objaccess_readObjectFromInternalVMSlot)(struct J9VMThread *vmThread, struct J9JavaVM *vm, j9object_t *srcSlot) ;
 	U_8*  ( *j9gc_objaccess_getArrayObjectDataAddress)(struct J9VMThread *vmThread, J9IndexableObject *arrayObject) ;
@@ -5159,14 +5150,8 @@ typedef struct J9MemoryManagerFunctions {
 #if defined(J9VM_GC_OBJECT_ACCESS_BARRIER)
 	UDATA  ( *j9gc_objaccess_staticCompareAndSwapInt)(struct J9VMThread *vmThread, J9Class *destClass, U_32 *destAddress, U_32 compareValue, U_32 swapValue) ;
 	U_32  ( *j9gc_objaccess_staticCompareAndExchangeInt)(struct J9VMThread *vmThread, J9Class *destClass, U_32 *destAddress, U_32 compareValue, U_32 swapValue) ;
-#if !defined(J9VM_ENV_DATA64)
-	UDATA  ( *j9gc_objaccess_mixedObjectCompareAndSwapLongSplit)(struct J9VMThread *vmThread, J9Object *destObject, UDATA offset, U_32 compareValueSlot0, U_32 compareValueSlot1, U_32 swapValueSlot0, U_32 swapValueSlot1) ;
-#endif /* !defined(J9VM_ENV_DATA64) */
 	UDATA  ( *j9gc_objaccess_staticCompareAndSwapLong)(struct J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_64 compareValue, U_64 swapValue) ;
 	U_64 ( *j9gc_objaccess_staticCompareAndExchangeLong)(struct J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_64 compareValue, U_64 swapValue) ;
-#if !defined(J9VM_ENV_DATA64)
-	UDATA  ( *j9gc_objaccess_staticCompareAndSwapLongSplit)(struct J9VMThread *vmThread, J9Class *destClass, U_64 *destAddress, U_32 compareValueSlot0, U_32 compareValueSlot1, U_32 swapValueSlot0, U_32 swapValueSlot1) ;
-#endif /* !defined(J9VM_ENV_DATA64) */
 #endif /* defined(J9VM_GC_OBJECT_ACCESS_BARRIER) */
 	UDATA  ( *j9gc_get_bytes_allocated_by_thread)(struct J9VMThread *vmThread) ;
 	BOOLEAN ( *j9gc_get_cumulative_bytes_allocated_by_thread)(struct J9VMThread *vmThread, UDATA *cumulativeValue) ;

--- a/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/FieldRef.java
+++ b/sourcetools/j9constantpool/com/ibm/oti/VMCPTool/FieldRef.java
@@ -141,7 +141,6 @@ public class FieldRef extends PrimaryItem implements Constants {
 		// j9gc_objaccess_mixedObjectStoreU64
 		// j9gc_objaccess_mixedObjectStoreObject
 		// j9gc_objaccess_mixedObjectStoreAddress
-		// j9gc_objaccess_mixedObjectStoreU64Split
 
 		// Arrays and objects take precedence over cast to support pointer compression
 		switch (((Alias) primary).nas.signature.data.charAt(0)) {
@@ -182,9 +181,6 @@ public class FieldRef extends PrimaryItem implements Constants {
 
 		// Otherwise just determine it from the signature
 		switch (((Alias) primary).nas.signature.data.charAt(0)) {
-		case '[':
-		case 'L':
-			return "OBJECT";
 		case 'J':
 			return "I64";
 		case 'D':


### PR DESCRIPTION
This removes these unused functions:
* j9gc_objaccess_indexableStoreU64Split
* j9gc_objaccess_mixedObjectCompareAndSwapLongSplit
* j9gc_objaccess_mixedObjectStoreU64Split
* j9gc_objaccess_staticCompareAndSwapLongSplit
* j9gc_objaccess_staticStoreU64Split

Also removes some dead code from `FieldRef.java`.