### PR TITLE
Update OMR mirror when local repo already exists

### DIFF
--- a/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
+++ b/buildenv/jenkins/jobs/infrastructure/omrMirror.groovy
@@ -34,7 +34,7 @@ timestamps {
                         try {
                             // Clone/update
                             if (fileExists('HEAD')) {
-                                sh 'git remote update --prune'
+                                sh 'git fetch origin master:master'
                             } else {
                                 sh "git clone --bare --no-tags --single-branch --branch master ${HTTP}${SRC_REPO} ."
                             }


### PR DESCRIPTION
When the repo already exists it's not being updated to the latest since https://github.com/eclipse-openj9/openj9/pull/23821 was merged.