### PR TITLE
Implement JVM.getPid() to return the JVM process ID as a String

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -111,8 +111,24 @@ Java_jdk_jfr_internal_JVM_getClassId(JNIEnv *env, jclass clazz, jclass targetCla
 jstring JNICALL
 Java_jdk_jfr_internal_JVM_getPid(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return NULL;
+	J9VMThread *currentThread = (J9VMThread*) env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	jstring result = NULL;
+	U_8 pidBuffer[32];
+	UDATA pidLen = 0;
+
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	pidLen = j9str_printf((char*) pidBuffer, sizeof(pidBuffer), "%zu", vm->j9ras->pid);
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	j9object_t stringObj = vm->memoryManagerFunctions->j9gc_createJavaLangString(
+		currentThread, pidBuffer, pidLen, 0);
+	result = (jstring) vmFuncs->j9jni_createLocalRef(env, stringObj);
+	vmFuncs->internalExitVMToJNI(currentThread);
+
+	return result;
 }
 
 jlong JNICALL


### PR DESCRIPTION
Implement JVM.getPid() to return the JVM process ID as a String
Java_jdk_jfr_internal_JVM_getPid was returning NULL, causing
TestPid.java to fail. This change retrieves the JVM process ID
from vm->j9ras->pid, formats it as a decimal and returns \
a Java String object.

Issue: https://github.com/eclipse-openj9/openj9/issues/23735 