### PR TITLE
Fix potential malformed VECTOR data for JITServer

### DIFF
--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -82,6 +82,9 @@ void CommunicationStream::readMessage(Message &msg)
     if (bytesRead > serializedSize) {
         throw JITServer::StreamFailure("JITServer I/O error: read more than the message size");
     }
+    // A malicious actor could craft a message with a very large size
+    if (serializedSize > MAX_MSG_SIZE)
+        throw JITServer::StreamFailure("JITServer I/O error: message size to receive is too big");
 
     // serializedSize >= bytesRead
     uint32_t bytesLeftToRead = serializedSize - bytesRead;
@@ -89,6 +92,7 @@ void CommunicationStream::readMessage(Message &msg)
     if (bytesLeftToRead > 0) {
         if (serializedSize > bufferCapacity) {
             // bytesRead could be less than the buffer capacity.
+            // Buffer expansion may throw bad_alloc.
             msg.expandBuffer(serializedSize, bytesRead);
 
             // The buffer storage will change after the buffer is expanded.
@@ -114,6 +118,10 @@ void CommunicationStream::readMessage(Message &msg)
 void CommunicationStream::writeMessage(Message &msg)
 {
     char *serialMsg = msg.serialize();
+    // Some sanity check
+    if (msg.serializedSize() > MAX_MSG_SIZE)
+        throw JITServer::StreamFailure("JITServer I/O error: message size to send is too big");
+
     // write serialized message to the socket
     writeBlocking(serialMsg, msg.serializedSize());
     msg.clearForWrite();

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -48,6 +48,7 @@ public:
     static uint64_t _totalMsgSize;
     static uint32_t _lastReadError;
     static uint32_t _numConsecutiveReadErrorsOfSameType;
+    static constexpr uint32_t MAX_MSG_SIZE = 128 * 1024 * 1024; // 128 MB
     // The max read retry should be 1 less than the max compile attempt so we do
     // local compilations in the last attempt
     static const uint32_t MAX_READ_RETRY = MAX_COMPILE_ATTEMPTS - 1;
@@ -128,7 +129,7 @@ protected:
     // likely to lose an increment when merging/rebasing/etc.
     //
     static const uint8_t MAJOR_NUMBER = 1;
-    static const uint16_t MINOR_NUMBER = 102; // ID: pZ74UIsffkVgvUgGWXhc
+    static const uint16_t MINOR_NUMBER = 103; // ID: 4Gl+x5RWgtmgiwMonK0j
     static const uint8_t PATCH_NUMBER = 0;
     static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/net/Message.hpp
+++ b/runtime/compiler/net/Message.hpp
@@ -123,7 +123,8 @@ public:
             , _vectorElementSize(0)
         {
             // Round the _size up to a 4-byte multiple to ensure that the
-            // descriptor coming after this data point is 4-byte aligned
+            // descriptor coming after this data point is 4-byte aligned.
+            // The padding comes after the payload.
             _size = OMR::alignNoCheck(payloadSize, sizeof(uint32_t));
             _paddingSize = static_cast<uint8_t>(_size - payloadSize);
         }
@@ -201,15 +202,34 @@ public:
         }
 
         /**
+           @brief Get the pointer to the ending of data attached to this descriptor.
+
+           This could be used for bounds checks
+
+           @return A pointer to the end of the data defined by this descriptor
+        */
+        void *getDataEnd() { return static_cast<void *>(static_cast<char *>(static_cast<void *>(this + 1)) + _size); }
+
+        /**
+           @brief Check that the data defined by this descriptor is within the range [start, end).
+
+           @return Return true if the data is within the range [start, end), false otherwise.
+        */
+        bool isWithin(const void *start, const void *end)
+        {
+            if (static_cast<void *>(this) < start || static_cast<void *>(this + 1) > end)
+                return false;
+            if (getDataEnd() > end)
+                return false;
+            return true;
+        }
+
+        /**
             @brief Get a pointer to the beginning of the next descriptor in the MessageBuffer.
 
             @return Returns a pointer to the following descriptor in the MessageBuffer
         */
-        DataDescriptor *getNextDescriptor()
-        {
-            return static_cast<DataDescriptor *>(
-                static_cast<void *>(static_cast<char *>(static_cast<void *>(this + 1)) + _size));
-        }
+        DataDescriptor *getNextDescriptor() { return static_cast<DataDescriptor *>(static_cast<void *>(getDataEnd())); }
 
         uint32_t print(uint32_t nestingLevel);
 

--- a/runtime/compiler/net/RawTypeConvert.hpp
+++ b/runtime/compiler/net/RawTypeConvert.hpp
@@ -158,30 +158,55 @@ template<typename T> struct RawTypeConvert<T, typename std::enable_if<std::is_tr
 // For vectors
 template<typename T>
 struct RawTypeConvert<T, typename std::enable_if<std::is_same<T, std::vector<typename T::value_type> >::value>::type> {
+    static constexpr uint32_t MAX_VECTOR_ELEMENTS = 100000;
+
     static inline T onRecv(Message::DataDescriptor *desc)
     {
         if (desc->getDataType() == Message::DataDescriptor::DataType::EMPTY_VECTOR) {
             return std::vector<typename T::value_type>();
         }
         if (desc->getDataType() == Message::DataDescriptor::DataType::SIMPLE_VECTOR) {
-            TR_ASSERT(desc->getVectorElementSize() == sizeof(typename T::value_type), "Vector element size missmatch");
+            if (desc->getVectorElementSize() != sizeof(typename T::value_type))
+                throw StreamFailure("Malformed VECTOR payload: element type does not match descriptor");
             typename T::value_type *dataStart = static_cast<typename T::value_type *>(desc->getDataStart());
             typename T::value_type *dataEnd = reinterpret_cast<typename T::value_type *>(
                 reinterpret_cast<uintptr_t>(dataStart) + desc->getPayloadSize());
             return T(dataStart, dataEnd);
         }
 
-        TR_ASSERT(desc->getDataType() == Message::DataDescriptor::DataType::VECTOR, "onRecv type missmatch VECTOR");
-        // The first element is another descriptor to represent the number of elements in the vector
+        if (desc->getDataType() != Message::DataDescriptor::DataType::VECTOR)
+            throw StreamFailure("onRecv type missmatch VECTOR");
+
+        // Compute bounds for the data to be read
+        void *parentStart = desc->getDataStart();
+        void *parentEnd = desc->getDataEnd();
+
+        // The first element is a UINT32 descriptor to represent the number of elements in the vector.
         Message::DataDescriptor *sizeDesc = static_cast<Message::DataDescriptor *>(desc->getDataStart());
-        uint32_t size = RawTypeConvert<uint32_t>::onRecv(sizeDesc);
+        // Validate this descriptor
+        if (!sizeDesc->isWithin(parentStart, parentEnd))
+            throw StreamFailure("Malformed VECTOR payload: element descriptor for number of elements is out of bounds");
 
+        uint32_t numElem = RawTypeConvert<uint32_t>::onRecv(sizeDesc);
+        if (numElem > MAX_VECTOR_ELEMENTS)
+            throw StreamFailure("VECTOR size exceeds maximum allowed elements");
+
+        // Allocate memory for a vector with specified number of elements.
         std::vector<typename T::value_type> values;
-        values.reserve(size);
+        try {
+            values.reserve(numElem);
+        } catch (const std::bad_alloc &) {
+            throw StreamFailure("Failed to allocate memory for VECTOR elements");
+        }
 
-        // Find the descriptor of the first element in the array
+        // Find the descriptor of the first element in the array.
         auto curDesc = sizeDesc->getNextDescriptor();
-        for (uint32_t i = 0; i < size; ++i) {
+        // Iterate through all the remaining descriptors.
+        for (uint32_t i = 0; i < numElem; ++i) {
+            // Validate descriptor.
+            if (!curDesc->isWithin(parentStart, parentEnd))
+                throw StreamFailure("Malformed VECTOR payload: element descriptor/payload out of bounds");
+
             values.push_back(RawTypeConvert<typename T::value_type>::onRecv(curDesc));
             curDesc = curDesc->getNextDescriptor();
         }
@@ -210,6 +235,9 @@ struct RawTypeConvert<T, typename std::enable_if<std::is_same<T, std::vector<typ
         // Complex vectors here
         uint32_t descIndex = msg.getNumDescriptors();
         uint32_t descOffset = msg.reserveDescriptor();
+
+        if (value.size() > MAX_VECTOR_ELEMENTS)
+            throw StreamFailure("VECTOR size exceeds maximum allowed elements");
 
         // Write the size of the vector as a data point
         uint32_t totalSize = (value.size() + 1) * sizeof(Message::DataDescriptor);


### PR DESCRIPTION
Reading malformed nested vector data in
`RawTypeConvert<std::vector<...>>::onRecv()` may cause a JITServer crash. A malicious actor can claim a large vector length and cause descriptor walking past the received buffer. This commit changes the code to check that each nested descriptor remains within the parent descriptor’s bounds.
The commit also imposes a maximum number of elements for vectors and a maximum message size.
