### PR TITLE
Refactor Thread identification in JFR buffers

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -389,12 +389,18 @@ typedef struct J9JFRBuffer {
 	U_8 *bufferCurrent;
 } J9JFRBuffer;
 
+typedef struct J9JFRThreadObject {
+	jobject threadObject;
+	I_64 nativeTID;
+	I_64 javaTID;
+} J9JFRThreadObject;
+
 /* JFR event structures */
 
 #define J9JFR_EVENT_COMMON_FIELDS \
 	I_64 startTicks; \
 	UDATA eventType; \
-	struct J9VMThread *vmThread;
+	I_64 currentThreadTID;
 
 #define J9JFR_EVENT_WITH_STACKTRACE_FIELDS \
 	J9JFR_EVENT_COMMON_FIELDS \
@@ -419,8 +425,8 @@ typedef struct J9JFRExecutionSample {
 /* Variable-size structure - stackTraceSize worth of UDATA follow the fixed portion */
 typedef struct J9JFRThreadStart {
 	J9JFR_EVENT_WITH_STACKTRACE_FIELDS
-	struct J9VMThread *thread;
-	struct J9VMThread *parentThread;
+	I_64 threadTID;
+	I_64 parentThreadTID;
 } J9JFRThreadStart;
 
 #define J9JFRTHREADSTART_STACKTRACE(jfrEvent) ((UDATA *)(((J9JFRThreadStart *)(jfrEvent)) + 1))
@@ -440,7 +446,7 @@ typedef struct J9JFRMonitorWaited {
 	I_64 time;
 	I_64 duration;
 	struct J9Class *monitorClass;
-	struct J9VMThread *notifierThread;
+	I_64 notifierThreadTID;
 	BOOLEAN timedOut;
 	UDATA monitorAddress;
 } J9JFRMonitorWaited;
@@ -450,7 +456,6 @@ typedef struct J9JFRMonitorWaited {
 typedef struct J9JFRThreadParked {
 	J9JFR_EVENT_WITH_STACKTRACE_FIELDS
 	I_64 duration;
-	struct J9VMThread *thread;
 	struct J9Class *parkedClass;
 	I_64 timeOut;
 	I_64 untilTime;
@@ -462,9 +467,9 @@ typedef struct J9JFRThreadParked {
 typedef struct J9JFRMonitorEntered {
 	J9JFR_EVENT_WITH_STACKTRACE_FIELDS
 	I_64 duration;
-	struct J9VMThread *thread;
+	I_64 threadTID;
 	struct J9Class *monitorClass;
-	struct J9VMThread *previousOwner;
+	I_64 previousOwnerTID;
 	UDATA monitorAddress;
 } J9JFRMonitorEntered;
 
@@ -6177,6 +6182,8 @@ typedef struct JFRState {
 	jclass jfrEventClassRef;
 	J9Method *onRetransformUpcallMethod;
 	J9Method *transformToListMethod;
+	J9HashTable *threadObjectJNIRefTable;
+	omrthread_monitor_t threadObjectsMutex;
 } JFRState;
 
 typedef struct J9ReflectFunctionTable {

--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -98,28 +98,11 @@ VM_JFRConstantPoolTypes::methodNameHashEqualFn(void *tableNode, void *queryNode,
 }
 
 UDATA
-VM_JFRConstantPoolTypes::threadHashFn(void *key, void *userData)
-{
-	ThreadEntry *threadEntry = (ThreadEntry *) key;
-
-	return (UDATA) threadEntry->vmThread;
-}
-
-UDATA
-VM_JFRConstantPoolTypes::threadHashEqualFn(void *tableNode, void *queryNode, void *userData)
-{
-	ThreadEntry *tableEntry = (ThreadEntry *) tableNode;
-	ThreadEntry *queryEntry = (ThreadEntry *) queryNode;
-
-	return tableEntry->vmThread == queryEntry->vmThread;
-}
-
-UDATA
 VM_JFRConstantPoolTypes::stackTraceHashFn(void *key, void *userData)
 {
 	StackTraceEntry *entry = (StackTraceEntry*) key;
 
-	return (U_64)(UDATA)entry->vmThread ^ (U_64)entry->ticks;
+	return (UDATA)(entry->currentThreadID ^ entry->ticks);
 }
 
 UDATA
@@ -273,16 +256,34 @@ VM_JFRConstantPoolTypes::walkPackageTablePrint(void *entry, void *userData)
 	return FALSE;
 }
 
-UDATA
+void
 VM_JFRConstantPoolTypes::walkThreadTablePrint(void *entry, void *userData)
 {
 	ThreadEntry *tableEntry = (ThreadEntry *) entry;
 	J9VMThread *currentThread = (J9VMThread *)userData;
 	PORT_ACCESS_FROM_VMC(currentThread);
 
-	j9tty_printf(PORTLIB, "%u) osTID=%lu javaTID=%lu javaThreadName=%.*s osThreadName=%.*s threadGroupIndex=%u\n", tableEntry->index, tableEntry->osTID, tableEntry->javaTID, J9UTF8_LENGTH(tableEntry->javaThreadName), J9UTF8_DATA(tableEntry->javaThreadName), J9UTF8_LENGTH(tableEntry->osThreadName), J9UTF8_DATA(tableEntry->osThreadName), tableEntry->threadGroupIndex);
+	j9tty_printf(PORTLIB, "%u) osTID=%lld javaTID=%lld javaThreadName=%.*s osThreadName=%.*s threadGroupIndex=%u\n", tableEntry->index, tableEntry->osTID, tableEntry->javaTID, J9UTF8_LENGTH(tableEntry->javaThreadName), J9UTF8_DATA(tableEntry->javaThreadName), J9UTF8_LENGTH(tableEntry->osThreadName), J9UTF8_DATA(tableEntry->osThreadName), tableEntry->threadGroupIndex);
+}
 
-	return FALSE;
+void
+VM_JFRConstantPoolTypes::walkThreadStartTablePrint(void *entry, void *userData)
+{
+	ThreadStartEntry *tableEntry = (ThreadStartEntry *) entry;
+	J9VMThread *currentThread = (J9VMThread *)userData;
+	PORT_ACCESS_FROM_VMC(currentThread);
+
+	j9tty_printf(PORTLIB, "ticks=%lld stackTraceIndex=%u threadIndex=%llu eventThreadIndex=%llu parentThreadIndex=%llu\n", tableEntry->ticks, tableEntry->stackTraceIndex, tableEntry->threadIndex, tableEntry->eventThreadIndex, tableEntry->parentThreadIndex);
+}
+
+void
+VM_JFRConstantPoolTypes::walkThreadParkTablePrint(void *entry, void *userData)
+{
+	ThreadParkEntry *tableEntry = (ThreadParkEntry *) entry;
+	J9VMThread *currentThread = (J9VMThread *)userData;
+	PORT_ACCESS_FROM_VMC(currentThread);
+
+	j9tty_printf(PORTLIB, "ticks=%lld duration=%lld threadIndex=%llu eventThreadIndex=%llu stackTraceIndex=%u parkedClass=%u timeOut=%lld untilTime=%lld parkedAddress=%llx\n", tableEntry->ticks, tableEntry->duration, tableEntry->threadIndex, tableEntry->eventThreadIndex, tableEntry->stackTraceIndex, tableEntry->parkedClass, tableEntry->timeOut, tableEntry->untilTime, tableEntry->parkedAddress);
 }
 
 UDATA
@@ -849,49 +850,34 @@ VM_JFRConstantPoolTypes::addStringEntry(j9object_t string)
 	}
 }
 
-U_32
-VM_JFRConstantPoolTypes::addThreadEntry(J9VMThread *vmThread)
+void
+VM_JFRConstantPoolTypes::addAllThreads()
 {
-	U_32 index = U_32_MAX;
+	omrthread_monitor_enter(_vm->jfrState.threadObjectsMutex);
+	J9HashTableState hashTableState = {0};
+	J9JFRThreadObject *entry = (J9JFRThreadObject *)hashTableStartDo(_vm->jfrState.threadObjectJNIRefTable, &hashTableState);
+	while (NULL != entry) {
+		addThreadObjectEntry(entry);
+		entry = (J9JFRThreadObject *)hashTableNextDo(&hashTableState);
+	}
+	omrthread_monitor_exit(_vm->jfrState.threadObjectsMutex);
+}
+
+void
+VM_JFRConstantPoolTypes::addThreadObjectEntry(J9JFRThreadObject *tableEntry)
+{
 	ThreadEntry *entry = NULL;
-	ThreadEntry entryBuffer = {0};
-	omrthread_t osThread = NULL;
-	j9object_t threadObject = NULL;
+	j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(tableEntry->threadObject);
 
-	if (NULL == vmThread) {
-		index = 0;
+	entry = (ThreadEntry *)pool_newElement(_threadTable);
+	if (NULL == entry) {
+		_buildResult = OutOfMemory;
 		goto done;
 	}
 
-	entry = &entryBuffer;
-	entry->vmThread = vmThread;
-	osThread = vmThread->osThread;
-#if JAVA_SPEC_VERSION >= 19
-	threadObject = vmThread->carrierThreadObject;
-#else /* JAVA_SPEC_VERSION >= 19 */
-	threadObject = vmThread->threadObject;
-#endif /* JAVA_SPEC_VERSION >= 19 */
-
-	if ((NULL == osThread) || (NULL == threadObject)) {
-		/* this can happen if a thread dies during a monitor enter */
-		index = 0;
-		goto done;
-	}
-
-	entry = (ThreadEntry *) hashTableFind(_threadTable, entry);
-	if (NULL != entry) {
-		index = entry->index;
-		goto done;
-	} else {
-		entry = &entryBuffer;
-	}
-
-	entry->osTID = ((J9AbstractThread*)osThread)->tid;
 	if ((NULL != threadObject) && J9VMJAVALANGTHREAD_STARTED(_currentThread, threadObject)) {
-		entry->javaTID = J9VMJAVALANGTHREAD_TID(_currentThread, threadObject);
-
 		entry->javaThreadName = copyStringToJ9UTF8WithMemAlloc(_currentThread, J9VMJAVALANGTHREAD_NAME(_currentThread, threadObject), J9_STR_NONE, "", 0, NULL, 0);
-
+		entry->freeName = TRUE;
 		if (isResultNotOKay()) goto done;
 #if JAVA_SPEC_VERSION >= 19
 		entry->threadGroupIndex = addThreadGroupEntry(J9VMJAVALANGTHREADFIELDHOLDER_GROUP(_currentThread, (J9VMJAVALANGTHREAD_HOLDER(_currentThread, threadObject))));
@@ -904,14 +890,11 @@ VM_JFRConstantPoolTypes::addThreadEntry(J9VMThread *vmThread)
 	/* TODO is this always true? */
 	entry->osThreadName = entry->javaThreadName;
 
-	entry->index = _threadCount;
-	_threadCount++;
+	entry->javaTID = tableEntry->javaTID;
+	entry->osTID = tableEntry->nativeTID;
+	entry->index = entry->javaTID;
 
-	entry = (ThreadEntry*) hashTableAdd(_threadTable, &entryBuffer);
-	if (NULL == entry) {
-		_buildResult = OutOfMemory;
-		goto done;
-	}
+	_threadCount++;
 
 	if (NULL == _firstThreadEntry) {
 		_firstThreadEntry = entry;
@@ -922,10 +905,8 @@ VM_JFRConstantPoolTypes::addThreadEntry(J9VMThread *vmThread)
 	}
 	_previousThreadEntry = entry;
 
-	index = entry->index;
-
 done:
-	return index;
+	return;
 }
 
 U_32
@@ -1038,14 +1019,14 @@ done:
 }
 
 U_32
-VM_JFRConstantPoolTypes::addStackTraceEntry(J9VMThread *vmThread, I_64 ticks, U_32 numOfFrames)
+VM_JFRConstantPoolTypes::addStackTraceEntry(U_64 threadTID, I_64 ticks, U_32 numOfFrames)
 {
 	U_32 index = U_32_MAX;
 	StackTraceEntry *entry = NULL;
 	StackTraceEntry entryBuffer = {0};
 
 	entry = &entryBuffer;
-	entry->vmThread = vmThread;
+	entry->currentThreadID = threadTID;
 	entry->ticks = ticks;
 
 	entry = (StackTraceEntry *) hashTableFind(_stackTraceTable, entry);
@@ -1098,14 +1079,13 @@ VM_JFRConstantPoolTypes::addExecutionSampleEntry(J9JFRExecutionSample *execution
 		goto done;
 	}
 
-	entry->vmThread = executionSampleData->vmThread;
 	entry->ticks = executionSampleData->startTicks;
 	entry->state = RUNNABLE; //TODO
 
-	entry->threadIndex = addThreadEntry(entry->vmThread);
-	if (isResultNotOKay()) goto done;
+	/* Use the TID directly as the thread index */
+	entry->threadIndex = executionSampleData->currentThreadTID;
 
-	entry->stackTraceIndex = consumeStackTrace(entry->vmThread, J9JFREXECUTIONSAMPLE_STACKTRACE(executionSampleData), executionSampleData->stackTraceSize);
+	entry->stackTraceIndex = consumeStackTrace(executionSampleData->currentThreadTID, J9JFREXECUTIONSAMPLE_STACKTRACE(executionSampleData), executionSampleData->stackTraceSize);
 	if (isResultNotOKay()) goto done;
 
 	_executionSampleCount += 1;
@@ -1126,16 +1106,11 @@ VM_JFRConstantPoolTypes::addThreadStartEntry(J9JFRThreadStart *threadStartData)
 
 	entry->ticks = threadStartData->startTicks;
 
-	entry->threadIndex = addThreadEntry(threadStartData->thread);
-	if (isResultNotOKay()) goto done;
-
-	entry->eventThreadIndex = addThreadEntry(threadStartData->thread);
-	if (isResultNotOKay()) goto done;
-
-	entry->parentThreadIndex = addThreadEntry(threadStartData->parentThread);
-	if (isResultNotOKay()) goto done;
-
-	entry->stackTraceIndex = consumeStackTrace(threadStartData->parentThread, J9JFRTHREADSTART_STACKTRACE(threadStartData), threadStartData->stackTraceSize);
+	/* Use the TIDs directly as thread indices */
+	entry->threadIndex = threadStartData->threadTID;
+	entry->eventThreadIndex = threadStartData->threadTID;
+	entry->parentThreadIndex = threadStartData->parentThreadTID;
+	entry->stackTraceIndex = consumeStackTrace(threadStartData->currentThreadTID, J9JFRTHREADSTART_STACKTRACE(threadStartData), threadStartData->stackTraceSize);
 	if (isResultNotOKay()) goto done;
 
 	_threadStartCount += 1;
@@ -1156,11 +1131,9 @@ VM_JFRConstantPoolTypes::addThreadEndEntry(J9JFREvent *threadEndData)
 
 	entry->ticks = threadEndData->startTicks;
 
-	entry->threadIndex = addThreadEntry(threadEndData->vmThread);
-	if (isResultNotOKay()) goto done;
-
-	entry->eventThreadIndex = addThreadEntry(threadEndData->vmThread);
-	if (isResultNotOKay()) goto done;
+	/* Use the TID directly as the thread index */
+	entry->threadIndex = threadEndData->currentThreadTID;
+	entry->eventThreadIndex = threadEndData->currentThreadTID;
 
 	_threadEndCount += 1;
 
@@ -1182,13 +1155,11 @@ VM_JFRConstantPoolTypes::addThreadSleepEntry(J9JFRThreadSlept *threadSleepData)
 	entry->duration = threadSleepData->duration;
 	entry->sleepTime = threadSleepData->time;
 
-	entry->threadIndex = addThreadEntry(threadSleepData->vmThread);
-	if (isResultNotOKay()) goto done;
+	/* Use the TID directly as the thread index */
+	entry->threadIndex = threadSleepData->currentThreadTID;
+	entry->eventThreadIndex = threadSleepData->currentThreadTID;
 
-	entry->eventThreadIndex = addThreadEntry(threadSleepData->vmThread);
-	if (isResultNotOKay()) goto done;
-
-	entry->stackTraceIndex = consumeStackTrace(threadSleepData->vmThread, J9JFRTHREADSLEPT_STACKTRACE(threadSleepData), threadSleepData->stackTraceSize);
+	entry->stackTraceIndex = consumeStackTrace(threadSleepData->currentThreadTID, J9JFRTHREADSLEPT_STACKTRACE(threadSleepData), threadSleepData->stackTraceSize);
 	if (isResultNotOKay()) goto done;
 
 	_threadSleepCount += 1;
@@ -1213,13 +1184,11 @@ VM_JFRConstantPoolTypes::addMonitorWaitEntry(J9JFRMonitorWaited* threadWaitData)
 	entry->monitorAddress = (I_64)(U_64)threadWaitData->monitorAddress;
 	entry->timedOut = threadWaitData->timedOut;
 
-	entry->threadIndex = addThreadEntry(threadWaitData->vmThread);
-	if (isResultNotOKay()) goto done;
+	/* Use the TIDs directly as thread indices */
+	entry->threadIndex = threadWaitData->currentThreadTID;
+	entry->eventThreadIndex = threadWaitData->currentThreadTID;
 
-	entry->eventThreadIndex = addThreadEntry(threadWaitData->vmThread);
-	if (isResultNotOKay()) goto done;
-
-	entry->stackTraceIndex = consumeStackTrace(threadWaitData->vmThread, J9JFRMonitorWaitedED_STACKTRACE(threadWaitData), threadWaitData->stackTraceSize);
+	entry->stackTraceIndex = consumeStackTrace(threadWaitData->currentThreadTID, J9JFRMonitorWaitedED_STACKTRACE(threadWaitData), threadWaitData->stackTraceSize);
 	if (isResultNotOKay()) goto done;
 
 	entry->monitorClass = getClassEntry(threadWaitData->monitorClass);
@@ -1246,16 +1215,12 @@ VM_JFRConstantPoolTypes::addMonitorEnterEntry(J9JFRMonitorEntered *monitorEnterD
 	entry->duration = monitorEnterData->duration;
 	entry->monitorAddress = monitorEnterData->monitorAddress;
 
-	entry->threadIndex = addThreadEntry(monitorEnterData->vmThread);
-	if (isResultNotOKay()) goto done;
+	/* Use the TIDs directly as thread indices */
+	entry->threadIndex = monitorEnterData->currentThreadTID;
+	entry->previousOwnerThread = monitorEnterData->previousOwnerTID;
+	entry->eventThreadIndex = monitorEnterData->currentThreadTID;
 
-	entry->previousOwnerThread = addThreadEntry(monitorEnterData->previousOwner);
-	if (isResultNotOKay()) goto done;
-
-	entry->eventThreadIndex = addThreadEntry(monitorEnterData->vmThread);
-	if (isResultNotOKay()) goto done;
-
-	entry->stackTraceIndex = consumeStackTrace(monitorEnterData->vmThread, J9JFRMONITORENTERED_STACKTRACE(monitorEnterData), monitorEnterData->stackTraceSize);
+	entry->stackTraceIndex = consumeStackTrace(monitorEnterData->currentThreadTID, J9JFRMONITORENTERED_STACKTRACE(monitorEnterData), monitorEnterData->stackTraceSize);
 	if (isResultNotOKay()) goto done;
 
 	entry->monitorClass = getClassEntry(monitorEnterData->monitorClass);
@@ -1281,14 +1246,10 @@ VM_JFRConstantPoolTypes::addThreadParkEntry(J9JFRThreadParked* threadParkData)
 	entry->duration = threadParkData->duration;
 
 	entry->parkedAddress = (U_64)threadParkData->parkedAddress;
+	entry->threadIndex = threadParkData->currentThreadTID;
+	entry->eventThreadIndex = threadParkData->currentThreadTID;
 
-	entry->threadIndex = addThreadEntry(threadParkData->vmThread);
-	if (isResultNotOKay()) goto done;
-
-	entry->eventThreadIndex = addThreadEntry(threadParkData->vmThread);
-	if (isResultNotOKay()) goto done;
-
-	entry->stackTraceIndex = consumeStackTrace(threadParkData->vmThread, J9JFRTHREADPARKED_STACKTRACE(threadParkData), threadParkData->stackTraceSize);
+	entry->stackTraceIndex = consumeStackTrace(threadParkData->currentThreadTID, J9JFRTHREADPARKED_STACKTRACE(threadParkData), threadParkData->stackTraceSize);
 	if (isResultNotOKay()) goto done;
 
 	entry->parkedClass = getClassEntry(threadParkData->parkedClass);
@@ -1338,10 +1299,8 @@ VM_JFRConstantPoolTypes::addThreadCPULoadEntry(J9JFRThreadCPULoad *threadCPULoad
 	entry->userCPULoad = threadCPULoadData->userCPULoad;
 	entry->systemCPULoad = threadCPULoadData->systemCPULoad;
 
-	entry->threadIndex = addThreadEntry(threadCPULoadData->vmThread);
-	if (isResultNotOKay()) {
-		goto done;
-	}
+	/* Use the TID directly as the thread index */
+	entry->threadIndex = threadCPULoadData->currentThreadTID;
 
 	_threadCPULoadCount += 1;
 
@@ -1419,10 +1378,10 @@ VM_JFRConstantPoolTypes::addSystemGCEntry(J9JFRSystemGC *systemGCData)
 	entry->ticks = systemGCData->startTicks;
 	entry->duration = systemGCData->duration;
 
-	entry->eventThreadIndex = addThreadEntry(systemGCData->vmThread);
-	if (isResultNotOKay()) goto done;
+	/* Use the TID directly as the thread index */
+	entry->eventThreadIndex = systemGCData->currentThreadTID;
 
-	entry->stackTraceIndex = consumeStackTrace(systemGCData->vmThread, J9JFRSYSTEMGC_STACKTRACE(systemGCData), systemGCData->stackTraceSize);
+	entry->stackTraceIndex = consumeStackTrace(systemGCData->currentThreadTID, J9JFRSYSTEMGC_STACKTRACE(systemGCData), systemGCData->stackTraceSize);
 	if (isResultNotOKay()) goto done;
 
 	_systemGCCount += 1;
@@ -1570,7 +1529,16 @@ VM_JFRConstantPoolTypes::printTables()
 	hashTableForEachDo(_packageTable, &walkPackageTablePrint, _currentThread);
 
 	j9tty_printf(PORTLIB, "--------------- Thread Table ---------------\n");
-	hashTableForEachDo(_threadTable, &walkThreadTablePrint, _currentThread);
+	pool_do(_threadTable, &walkThreadTablePrint, _currentThread);
+	j9tty_printf(PORTLIB, "total count %d\n", (int)_threadCount);
+
+	j9tty_printf(PORTLIB, "--------------- ThreadStart Table ---------------\n");
+	pool_do(_threadStartTable, &walkThreadStartTablePrint, _currentThread);
+	j9tty_printf(PORTLIB, "total count %d\n", (int)_threadStartCount);
+
+	j9tty_printf(PORTLIB, "--------------- ThreadPark Table ---------------\n");
+	pool_do(_threadParkTable, &walkThreadParkTablePrint, _currentThread);
+	j9tty_printf(PORTLIB, "total count %d\n", (int)_threadParkCount);
 
 	j9tty_printf(PORTLIB, "--------------- ThreadGroup Table ---------------\n");
 	hashTableForEachDo(_threadGroupTable, &walkThreadGroupTablePrint, _currentThread);
@@ -1638,7 +1606,7 @@ VM_JFRConstantPoolTypes::freeStackStraceEntries(void *entry, void *userData)
 	return FALSE;
 }
 
-UDATA
+void
 VM_JFRConstantPoolTypes::freeThreadNameEntries(void *entry, void *userData)
 {
 	ThreadEntry *tableEntry = (ThreadEntry *) entry;
@@ -1646,12 +1614,10 @@ VM_JFRConstantPoolTypes::freeThreadNameEntries(void *entry, void *userData)
 	PORT_ACCESS_FROM_VMC(currentThread);
 
 	/* Name of the unknown thread entry cannot be freed */
-	if (0 != tableEntry->index) {
+	if (tableEntry->freeName) {
 		j9mem_free_memory(tableEntry->javaThreadName);
 	}
 	tableEntry->javaThreadName = NULL;
-
-	return FALSE;
 }
 
 UDATA

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -165,14 +165,14 @@ struct StringUTF8Entry {
 };
 
 struct ThreadEntry {
-	J9VMThread *vmThread;
-	U_32 index;
-	U_64 osTID;
-	U_64 javaTID;
+	U_64 index;
+	I_64 osTID;
+	I_64 javaTID;
 	J9UTF8 *javaThreadName;
 	J9UTF8 *osThreadName;
 	U_32 threadGroupIndex;
 	ThreadEntry *next;
+	BOOLEAN freeName;
 };
 
 struct ThreadGroupEntry {
@@ -197,33 +197,32 @@ struct StackFrame {
 };
 
 struct ExecutionSampleEntry {
-	J9VMThread *vmThread;
 	I_64 ticks;
 	ThreadState state;
 	U_32 stackTraceIndex;
-	U_32 threadIndex;
+	U_64 threadIndex;
 };
 
 struct ThreadStartEntry {
 	I_64 ticks;
 	U_32 stackTraceIndex;
-	U_32 threadIndex;
-	U_32 eventThreadIndex;
-	U_32 parentThreadIndex;
+	U_64 threadIndex;
+	U_64 eventThreadIndex;
+	U_64 parentThreadIndex;
 };
 
 struct ThreadEndEntry {
 	I_64 ticks;
-	U_32 threadIndex;
-	U_32 eventThreadIndex;
+	U_64 threadIndex;
+	U_64 eventThreadIndex;
 };
 
 struct ThreadSleepEntry {
 	I_64 ticks;
 	I_64 duration;
 	I_64 sleepTime;
-	U_32 threadIndex;
-	U_32 eventThreadIndex;
+	U_64 threadIndex;
+	U_64 eventThreadIndex;
 	U_32 stackTraceIndex;
 };
 
@@ -233,9 +232,9 @@ struct MonitorWaitEntry {
 	I_64 timeOut;
 	I_64 monitorAddress;
 	U_32 monitorClass;
-	U_32 notifierThread;
-	U_32 threadIndex;
-	U_32 eventThreadIndex;
+	U_64 notifierThread;
+	U_64 threadIndex;
+	U_64 eventThreadIndex;
 	U_32 stackTraceIndex;
 	BOOLEAN timedOut;
 };
@@ -245,17 +244,17 @@ struct MonitorEnterEntry {
 	I_64 duration;
 	I_64 monitorAddress;
 	U_32 monitorClass;
-	U_32 previousOwnerThread;
-	U_32 threadIndex;
-	U_32 eventThreadIndex;
+	I_64 previousOwnerThread;
+	U_64 threadIndex;
+	U_64 eventThreadIndex;
 	U_32 stackTraceIndex;
 };
 
 struct ThreadParkEntry {
 	I_64 ticks;
 	I_64 duration;
-	U_32 threadIndex;
-	U_32 eventThreadIndex;
+	U_64 threadIndex;
+	U_64 eventThreadIndex;
 	U_32 stackTraceIndex;
 	U_32 parkedClass;
 	I_64 timeOut;
@@ -264,7 +263,8 @@ struct ThreadParkEntry {
 };
 
 struct StackTraceEntry {
-	J9VMThread *vmThread;
+	U_64 currentThreadID;
+	U_64 vmThread;
 	I_64 ticks;
 	U_32 numOfFrames;
 	U_32 index;
@@ -282,7 +282,7 @@ struct CPULoadEntry {
 
 struct ThreadCPULoadEntry {
 	I_64 ticks;
-	U_32 threadIndex;
+	U_64 threadIndex;
 	float userCPULoad;
 	float systemCPULoad;
 };
@@ -322,7 +322,7 @@ struct ThreadStatisticsEntry {
 struct SystemGCEntry {
 	I_64 ticks;
 	I_64 duration;
-	U_32 eventThreadIndex;
+	U_64 eventThreadIndex;
 	U_32 stackTraceIndex;
 };
 
@@ -466,7 +466,7 @@ private:
 	J9HashTable *_methodTable;
 	J9HashTable *_stackTraceTable;
 	J9HashTable *_stringUTF8Table;
-	J9HashTable *_threadTable;
+	J9Pool *_threadTable;
 	J9HashTable *_threadGroupTable;
 	U_32 _classCount;
 	U_32 _packageCount;
@@ -626,7 +626,11 @@ private:
 
 	static UDATA walkClassLoadersTablePrint(void *entry, void *userData);
 
-	static UDATA walkThreadTablePrint(void *entry, void *userData);
+	static void walkThreadTablePrint(void *entry, void *userData);
+
+	static void walkThreadStartTablePrint(void *entry, void *userData);
+
+	static void walkThreadParkTablePrint(void *entry, void *userData);
 
 	static UDATA walkThreadGroupTablePrint(void *entry, void *userData);
 
@@ -652,7 +656,7 @@ private:
 
 	static UDATA freeStackStraceEntries(void *entry, void *userData);
 
-	static UDATA freeThreadNameEntries(void *entry, void *userData);
+	static void freeThreadNameEntries(void *entry, void *userData);
 
 	static UDATA freeThreadGroupNameEntries(void *entry, void *userData);
 
@@ -688,7 +692,9 @@ private:
 
 	U_32 addThreadGroupEntry(j9object_t threadGroup);
 
-	U_32 addStackTraceEntry(J9VMThread *vmThread, I_64 ticks, U_32 numOfFrames);
+	U_32 addStackTraceEntry(U_64 walkThreadID, I_64 ticks, U_32 numOfFrames);
+
+	void addAllThreads();
 
 	void printMergedStringTables();
 
@@ -772,18 +778,17 @@ done:
 	}
 
 	void addUnknownThreadEntry() {
-		ThreadEntry unknownThreadEntry = {0};
-		unknownThreadEntry.vmThread = NULL;
-		unknownThreadEntry.index = 0;
-		unknownThreadEntry.osTID = 0;
-		unknownThreadEntry.javaTID = 0;
-		unknownThreadEntry.javaThreadName = (J9UTF8 *)&unknownThread;
-		unknownThreadEntry.osThreadName = (J9UTF8 *)&unknownThread;
-		unknownThreadEntry.threadGroupIndex = 0;
+		ThreadEntry *unknownThreadEntry = (ThreadEntry *)pool_newElement(_threadTable);
+		unknownThreadEntry->index = 0;
+		unknownThreadEntry->osTID = (U_64)I_64_MAX;
+		unknownThreadEntry->javaTID = (U_64)I_64_MAX;
+		unknownThreadEntry->javaThreadName = (J9UTF8 *)&unknownThread;
+		unknownThreadEntry->osThreadName = (J9UTF8 *)&unknownThread;
+		unknownThreadEntry->threadGroupIndex = 0;
+		unknownThreadEntry->freeName = FALSE;
 
-		ThreadEntry *entry = (ThreadEntry *)hashTableAdd(_threadTable, &unknownThreadEntry);
-		_firstThreadEntry = entry;
-		_previousThreadEntry = entry;
+		_firstThreadEntry = unknownThreadEntry;
+		_previousThreadEntry = unknownThreadEntry;
 	}
 
 protected:
@@ -825,6 +830,8 @@ public:
 	void addGCHeapSummaryEntry(J9JFRGCHeapSummary *gcHeapSummaryData);
 
 	void addNetworkUtilizationEntry(J9JFRNetworkUtilization *networkUtilizationData);
+
+	void addThreadObjectEntry(J9JFRThreadObject *tableEntry);
 
 	J9Pool *getExecutionSampleTable()
 	{
@@ -1271,6 +1278,8 @@ public:
 			goto done;
 		}
 
+		addAllThreads();
+
 		if (dumpCalled) {
 			loadSystemProcesses(_currentThread);
 			loadNativeLibraries(_currentThread);
@@ -1295,7 +1304,7 @@ done:
 		return;
 	}
 
-	U_32 consumeStackTrace(J9VMThread *walkThread, UDATA *walkStateCache, UDATA numberOfFrames) {
+	U_32 consumeStackTrace(U_64 walkThreadTID, UDATA *walkStateCache, UDATA numberOfFrames) {
 		U_32 index = U_32_MAX;
 		UDATA expandedStackTraceCount = 0;
 
@@ -1315,7 +1324,7 @@ done:
 
 		iterateStackTraceImpl(_currentThread, (j9object_t *)walkStateCache, &stackTraceCallback, this, FALSE, FALSE, numberOfFrames, FALSE);
 
-		index = addStackTraceEntry(walkThread, j9time_nano_time(), _currentFrameCount);
+		index = addStackTraceEntry(walkThreadTID, j9time_nano_time(), _currentFrameCount);
 		_stackFrameCount += (U_32)expandedStackTraceCount;
 		_currentStackFrameBuffer = NULL;
 
@@ -1981,12 +1990,6 @@ done:
 			goto done;
 		}
 
-		_threadTable = hashTableNew(OMRPORT_FROM_J9PORT(privatePortLibrary), J9_GET_CALLSITE(), 0, sizeof(ThreadEntry), sizeof(U_64), 0, J9MEM_CATEGORY_JFR, threadHashFn, threadHashEqualFn, NULL, _currentThread);
-		if (NULL == _threadTable) {
-			_buildResult = OutOfMemory;
-			goto done;
-		}
-
 		_stackTraceTable = hashTableNew(OMRPORT_FROM_J9PORT(privatePortLibrary), J9_GET_CALLSITE(), 0, sizeof(StackTraceEntry), sizeof(U_64), 0, J9MEM_CATEGORY_JFR, stackTraceHashFn, stackTraceHashEqualFn, NULL, _vm);
 		if (NULL == _stackTraceTable) {
 			_buildResult = OutOfMemory;
@@ -1995,6 +1998,12 @@ done:
 
 		_threadGroupTable = hashTableNew(OMRPORT_FROM_J9PORT(privatePortLibrary), J9_GET_CALLSITE(), 0, sizeof(ThreadGroupEntry), sizeof(U_64), 0, J9MEM_CATEGORY_JFR, threadGroupHashFn, threadGroupHashEqualFn, NULL, _vm);
 		if (NULL == _threadGroupTable) {
+			_buildResult = OutOfMemory;
+			goto done;
+		}
+
+		_threadTable = pool_new(sizeof(ThreadEntry), 0, sizeof(U_64), 0, J9_GET_CALLSITE(), OMRMEM_CATEGORY_VM, POOL_FOR_PORT(privatePortLibrary));
+		if (NULL == _threadTable) {
 			_buildResult = OutOfMemory;
 			goto done;
 		}
@@ -2207,7 +2216,7 @@ done:
 	{
 		hashTableForEachDo(_stringUTF8Table, &freeUTF8Strings, _currentThread);
 		hashTableForEachDo(_stackTraceTable, &freeStackStraceEntries, _currentThread);
-		hashTableForEachDo(_threadTable, &freeThreadNameEntries, _currentThread);
+		pool_do(_threadTable, &freeThreadNameEntries, _currentThread);
 		hashTableForEachDo(_threadGroupTable, &freeThreadGroupNameEntries, _currentThread);
 		hashTableFree(_classTable);
 		hashTableFree(_packageTable);
@@ -2215,7 +2224,7 @@ done:
 		hashTableFree(_classLoaderTable);
 		hashTableFree(_methodTable);
 		hashTableFree(_stackTraceTable);
-		hashTableFree(_threadTable);
+		pool_kill(_threadTable);
 		hashTableFree(_threadGroupTable);
 		hashTableFree(_stringUTF8Table);
 		pool_kill(_executionSampleTable);

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -54,7 +54,7 @@ J9_DECLARE_CONSTANT_UTF8(jfrInternalEventClassUTF8, "jdk/internal/event/Event");
 J9_DECLARE_CONSTANT_UTF8(jfrEventClassUTF8, "jdk/jfr/Event");
 
 // TODO: allow configureable values
-#define J9JFR_THREAD_BUFFER_SIZE (1024*1024)
+#define J9JFR_THREAD_BUFFER_SIZE (128*1024)
 #define J9JFR_GLOBAL_BUFFER_SIZE (10 * J9JFR_THREAD_BUFFER_SIZE)
 #define J9JFR_SAMPLING_RATE 10
 #define J9JFR_CLASSNAME_BUFFER_SIZE 128
@@ -62,7 +62,8 @@ J9_DECLARE_CONSTANT_UTF8(jfrEventClassUTF8, "jdk/jfr/Event");
 #define INVALID_TYPE_ID -1
 
 static void jfrStartSamplingThread(J9JavaVM *vm);
-static void initializeEventFields(J9VMThread *currentThread, J9JFREvent *jfrEvent, UDATA eventType);
+static void initializeEventFields(J9VMThread *currentThread, J9VMThread *sampleThread, J9JFREvent *jfrEvent, UDATA eventType);
+static I_64 getThreadTID(J9VMThread *currentThread, J9VMThread *vmThread);
 static int J9THREAD_PROC jfrSamplingThreadProc(void *entryArg);
 static void jfrExecutionSampleCallback(J9VMThread *currentThread, IDATA handlerKey, void *userData);
 static void jfrThreadCPULoadCallback(J9VMThread *currentThread, IDATA handlerKey, void *userData);
@@ -73,6 +74,40 @@ static bool addEventIds(J9JavaVM *vm);
 static bool addTypeIds(J9JavaVM *vm);
 #endif /* JAVA_SPEC_VERSION >= 17 */
 static void jfrShutdownInternalStructures(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData);
+
+static void
+freeThreadIDs(J9VMThread *currentThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
+	J9HashTableState hashTableState = {0};
+	J9JFRThreadObject *entry = (J9JFRThreadObject *)hashTableStartDo(vm->jfrState.threadObjectJNIRefTable, &hashTableState);
+
+	while (NULL != entry) {
+		vmFuncs->j9jni_deleteGlobalRef((JNIEnv *)currentThread, entry->threadObject, false);
+		entry = (J9JFRThreadObject *)hashTableNextDo(&hashTableState);
+	}
+
+	hashTableFree(vm->jfrState.threadObjectJNIRefTable);
+	vm->jfrState.threadObjectJNIRefTable = NULL;
+}
+
+static UDATA
+jfrThreadObjectHashFn(void *key, void *userData)
+{
+	J9JFRThreadObject *entry = (J9JFRThreadObject *)key;
+
+	return (UDATA)entry->javaTID;
+}
+
+static UDATA
+jfrThreadObjectEqualFn(void *tableNode, void *queryNode, void *userData)
+{
+	J9JFRThreadObject *tableEntry = (J9JFRThreadObject *)tableNode;
+	J9JFRThreadObject *queryEntry = (J9JFRThreadObject *)queryNode;
+
+	return tableEntry->javaTID == queryEntry->javaTID;
+}
 
 /**
  * Calculate the size in bytes of a JFR event.
@@ -342,30 +377,30 @@ flushAllThreadBuffers(J9VMThread *currentThread, bool freeBuffers)
  * @returns pointer to the start of the reserved space or NULL if the space could not be reserved
  */
 U_8*
-reserveBuffer(J9VMThread *currentThread, UDATA size)
+reserveBuffer(J9VMThread *currentThread, J9VMThread *sampleThread, UDATA size)
 {
-	U_8 *jfrEvent = NULL;
 	J9JavaVM *vm = currentThread->javaVM;
+	U_8 *jfrEvent = NULL;
 
 	/* Either we are holding on to VM access or this operation is driven by another thread that has exclusive. */
-	Assert_VM_true(((currentThread)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)
-	|| ((J9_XACCESS_EXCLUSIVE == vm->exclusiveAccessState) || (J9_XACCESS_EXCLUSIVE == vm->safePointState)));
+	Assert_VM_mustHaveVMAccess(currentThread);
+	Assert_VM_true((currentThread != sampleThread) ? ((J9_XACCESS_EXCLUSIVE == vm->exclusiveAccessState) || (J9_XACCESS_EXCLUSIVE == vm->safePointState)) : TRUE);
 
-	if (!areJFRBuffersReadyForWrite(currentThread) || currentThread->threadJfrState.isJfrExcluded) {
+	if (!areJFRBuffersReadyForWrite(sampleThread) || sampleThread->threadJfrState.isJfrExcluded) {
 		goto done;
 	}
 
 	/* If the event is larger than the buffer, fail without attemptiong to flush */
-	if (size <= currentThread->jfrBuffer.bufferSize) {
+	if (size <= sampleThread->jfrBuffer.bufferSize) {
 		/* If there isn't enough space, flush the thread buffer to global */
-		if (size > currentThread->jfrBuffer.bufferRemaining) {
-			if (!flushBufferToGlobal(currentThread, currentThread)) {
+		if (size > sampleThread->jfrBuffer.bufferRemaining) {
+			if (!flushBufferToGlobal(currentThread, sampleThread)) {
 				goto done;
 			}
 		}
-		jfrEvent = currentThread->jfrBuffer.bufferCurrent;
-		currentThread->jfrBuffer.bufferCurrent += size;
-		currentThread->jfrBuffer.bufferRemaining -= size;
+		jfrEvent = sampleThread->jfrBuffer.bufferCurrent;
+		sampleThread->jfrBuffer.bufferCurrent += size;
+		sampleThread->jfrBuffer.bufferRemaining -= size;
 	}
 done:
 	return jfrEvent;
@@ -395,9 +430,10 @@ reserveBufferWithStackTrace(J9VMThread *currentThread, J9VMThread *sampleThread,
 		UDATA framesWalked = walkState->framesWalked;
 		UDATA stackTraceBytes = framesWalked * sizeof(UDATA);
 		UDATA eventSize = eventFixedSize + stackTraceBytes;
-		jfrEvent = (J9JFREvent*)reserveBuffer(sampleThread, eventSize);
+		jfrEvent = (J9JFREvent*)reserveBuffer(currentThread, sampleThread, eventSize);
 		if (NULL != jfrEvent) {
-			initializeEventFields(sampleThread, jfrEvent, eventType);
+			Assert_VM_mustHaveVMAccess(currentThread);
+			initializeEventFields(currentThread, sampleThread, jfrEvent, eventType);
 			((J9JFREventWithStackTrace*)jfrEvent)->stackTraceSize = framesWalked;
 			memcpy(((U_8*)jfrEvent) + eventFixedSize, walkState->cache, stackTraceBytes);
 		}
@@ -539,8 +575,8 @@ jfrThreadStarting(J9HookInterface **hook, UDATA eventNum, void *eventData, void 
 
 	J9JFRThreadStart *jfrEvent = (J9JFRThreadStart*)reserveBufferWithStackTrace(currentThread, currentThread, J9JFR_EVENT_TYPE_THREAD_START, sizeof(*jfrEvent));
 	if (NULL != jfrEvent) {
-		jfrEvent->thread = startedThread;
-		jfrEvent->parentThread = currentThread;
+		jfrEvent->threadTID = getThreadTID(currentThread, startedThread);
+		jfrEvent->parentThreadTID = getThreadTID(currentThread, currentThread);
 	}
 }
 
@@ -564,19 +600,16 @@ jfrThreadEnd(J9HookInterface **hook, UDATA eventNum, void *eventData, void *user
 #endif /* defined(DEBUG) */
 
 	internalAcquireVMAccess(currentThread);
-	J9JFREvent *jfrEvent = (J9JFREvent*)reserveBuffer(currentThread, sizeof(J9JFREvent));
+	J9JFREvent *jfrEvent = (J9JFREvent*)reserveBuffer(currentThread, currentThread, sizeof(J9JFREvent));
 	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, jfrEvent, J9JFR_EVENT_TYPE_THREAD_END);
+		initializeEventFields(currentThread, currentThread, jfrEvent, J9JFR_EVENT_TYPE_THREAD_END);
 	}
 	PORT_ACCESS_FROM_VMC(currentThread);
-	acquireExclusiveVMAccess(currentThread);
-	flushAllThreadBuffers(currentThread, false);
-	writeOutGlobalBuffer(currentThread, false, false);
+	flushBufferToGlobal(currentThread, currentThread);
 
 	/* Free the thread local buffer */
 	j9mem_free_memory((void*)currentThread->jfrBuffer.bufferStart);
 	memset(&currentThread->jfrBuffer, 0, sizeof(currentThread->jfrBuffer));
-	releaseExclusiveVMAccess(currentThread);
 	internalReleaseVMAccess(currentThread);
 }
 
@@ -701,12 +734,12 @@ jfrVMMonitorEntered(J9HookInterface **hook, UDATA eventNum, void *eventData, voi
 
 	J9JFRMonitorEntered *jfrEvent = (J9JFRMonitorEntered *)reserveBufferWithStackTrace(currentThread, currentThread, J9JFR_EVENT_TYPE_MONITOR_ENTER, sizeof(*jfrEvent));
 	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_MONITOR_ENTER);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_MONITOR_ENTER);
 
 		jfrEvent->duration = j9time_nano_time() - event->startTicks;
 		jfrEvent->monitorClass = event->monitorClass;
 		jfrEvent->monitorAddress = (UDATA)event->monitor;
-		jfrEvent->previousOwner = event->previousOwner;
+		jfrEvent->previousOwnerTID = getThreadTID(currentThread, event->previousOwner);
 	}
 }
 
@@ -774,9 +807,9 @@ jfrOldGarbageCollection(OMR_VMThread *omrVMThread)
 	J9VMThread *currentThread = (J9VMThread *)omrVMThread->_language_vmthread;
 	J9JavaVM *javaVM = currentThread->javaVM;
 
-	J9JFROldGarbageCollection *jfrEvent = (J9JFROldGarbageCollection *)reserveBuffer(currentThread, sizeof(J9JFROldGarbageCollection));
+	J9JFROldGarbageCollection *jfrEvent = (J9JFROldGarbageCollection *)reserveBuffer(currentThread, currentThread, sizeof(J9JFROldGarbageCollection));
 	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_OLD_GC_ENTRY);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_OLD_GC_ENTRY);
 		jfrEvent->startTicks = javaVM->memoryManagerFunctions->j9gc_get_cycle_start_time(currentThread);
 		jfrEvent->duration = javaVM->memoryManagerFunctions->j9gc_get_cycle_end_time(currentThread) - jfrEvent->startTicks;
 		jfrEvent->gcID = javaVM->memoryManagerFunctions->j9gc_get_unique_cycle_ID(currentThread);
@@ -794,9 +827,9 @@ jfrYoungGarbageCollection(OMR_VMThread *omrVMThread)
 	J9VMThread *currentThread = (J9VMThread *)omrVMThread->_language_vmthread;
 	J9JavaVM *javaVM = currentThread->javaVM;
 
-	J9JFRYoungGarbageCollection *jfrEvent = (J9JFRYoungGarbageCollection *)reserveBuffer(currentThread, sizeof(J9JFRYoungGarbageCollection));
+	J9JFRYoungGarbageCollection *jfrEvent = (J9JFRYoungGarbageCollection *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRYoungGarbageCollection));
 	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_YOUNG_GC_ENTRY);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_YOUNG_GC_ENTRY);
 		jfrEvent->startTicks = javaVM->memoryManagerFunctions->j9gc_get_cycle_start_time(currentThread);
 		jfrEvent->duration = javaVM->memoryManagerFunctions->j9gc_get_cycle_end_time(currentThread) - jfrEvent->startTicks;
 		jfrEvent->gcID = javaVM->memoryManagerFunctions->j9gc_get_unique_cycle_ID(currentThread);
@@ -817,10 +850,10 @@ jfrGarbageCollection(OMR_VMThread *omrVMThread)
 	J9JavaVM *javaVM = currentThread->javaVM;
 
 	/* Reserve buffer space for the JFR event */
-	J9JFRGarbageCollection *jfrEvent = (J9JFRGarbageCollection *)reserveBuffer(currentThread, sizeof(J9JFRGarbageCollection));
+	J9JFRGarbageCollection *jfrEvent = (J9JFRGarbageCollection *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRGarbageCollection));
 	if (NULL != jfrEvent) {
 		/* Initialize common event fields (timestamp, thread ID, etc.) */
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_GARBAGE_COLLECTION_ENTRY);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_GARBAGE_COLLECTION_ENTRY);
 
 		/* Populate GC-specific fields using memory manager functions */
 		jfrEvent->startTicks = javaVM->memoryManagerFunctions->j9gc_get_cycle_start_time(currentThread);
@@ -841,10 +874,10 @@ jfrGCHeapSummary(OMR_VMThread *omrVMThread, U_32 gcWhenID)
 	J9JavaVM *javaVM = currentThread->javaVM;
 
 	/* Reserve buffer space for the JFR event */
-	J9JFRGCHeapSummary *jfrEvent = (J9JFRGCHeapSummary *)reserveBuffer(currentThread, sizeof(J9JFRGCHeapSummary));
+	J9JFRGCHeapSummary *jfrEvent = (J9JFRGCHeapSummary *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRGCHeapSummary));
 	if (NULL != jfrEvent) {
 		/* Initialize common event fields (timestamp, thread ID, etc.) */
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_GC_HEAP_SUMMARY_ENTRY);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_GC_HEAP_SUMMARY_ENTRY);
 
 		/* Populate GC heap summary fields */
 		jfrEvent->startTicks = javaVM->memoryManagerFunctions->j9gc_get_cycle_start_time(currentThread);
@@ -951,6 +984,11 @@ initializeJFR(J9JavaVM *vm, BOOLEAN lateInit)
 		goto fail;
 	}
 
+	vm->jfrState.threadObjectJNIRefTable = hashTableNew(OMRPORT_FROM_J9PORT(privatePortLibrary), J9_GET_CALLSITE(), 0, sizeof(J9JFRThreadObject), sizeof(U_64), 0, J9MEM_CATEGORY_JFR, jfrThreadObjectHashFn, jfrThreadObjectEqualFn, NULL, NULL);
+	if (NULL == vm->jfrState.threadObjectJNIRefTable) {
+		goto fail;
+	}
+
 #if defined(DEBUG)
 	memset(buffer, 0, J9JFR_GLOBAL_BUFFER_SIZE);
 #endif /* defined(DEBUG) */
@@ -989,6 +1027,9 @@ initializeJFR(J9JavaVM *vm, BOOLEAN lateInit)
 		goto fail;
 	}
 	if (omrthread_monitor_init_with_name(&vm->jfrState.isConstantEventsInitializedMutex, 0, "Is JFR constantEvents initialized mutex")) {
+		goto fail;
+	}
+	if (omrthread_monitor_init_with_name(&vm->jfrState.threadObjectsMutex, 0, "Thread objects mutex")) {
 		goto fail;
 	}
 
@@ -1078,6 +1119,8 @@ tearDownJFR(J9JavaVM *vm)
 	/* Deregister GC-related hooks via gc_base */
 	vm->memoryManagerFunctions->j9gc_deregister_jfr_hooks(vm);
 
+	freeThreadIDs(currentThread);
+
 	/* Free global data */
 	VM_JFRConstantPoolTypes::freeJFRConstantEvents(vm);
 
@@ -1112,20 +1155,69 @@ tearDownJFR(J9JavaVM *vm)
 	}
 }
 
-/**
- * Fill in the common fields of a JFR event
- *
- * @param currentThread[in] the current J9VMThread
- * @param event[in] pointer to the event structure
- * @param eventType[in] the event type
- */
+static I_64
+getThreadTID(J9VMThread *currentThread, J9VMThread *vmThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	U_64 tid = 0;
+	j9object_t threadObject = NULL;
+
+	Assert_VM_mustHaveVMAccess(currentThread);
+
+	J9JFRThreadObject threadEntryBuffer = {0};
+	J9JFRThreadObject *threadEntry = &threadEntryBuffer;
+
+	if (NULL == vmThread) {
+		goto done;
+	}
+
+	if (NULL == vmThread->threadObject) {
+		goto done;
+	}
+
+	threadEntry->javaTID = J9VMJAVALANGTHREAD_TID(currentThread, vmThread->threadObject);
+
+	omrthread_monitor_enter(vm->jfrState.threadObjectsMutex);
+
+	threadEntry = (J9JFRThreadObject *)hashTableFind(vm->jfrState.threadObjectJNIRefTable, threadEntry);
+
+	if (NULL != threadEntry) {
+		tid = threadEntry->javaTID;
+		goto doneWithMutex;
+	}
+
+	threadEntry = &threadEntryBuffer;
+	threadObject = vmThread->threadObject;
+	if (NULL != threadObject) {
+		threadEntry->threadObject = vm->internalVMFunctions->j9jni_createGlobalRef((JNIEnv *)currentThread, vmThread->threadObject, FALSE);
+		threadEntry->javaTID = J9VMJAVALANGTHREAD_TID(currentThread, vmThread->threadObject);
+		threadEntry->nativeTID = threadEntry->javaTID;
+		/* TODO JMC has trouble distinguishing different threads with the same native TID
+		 * in the same chunk which will happen if a a lof of threads are created and die
+		 * very quickly.
+		 * threadEntry->nativeTID = ((J9AbstractThread *)vmThread->osThread)->tid;
+		 */
+		threadEntry = (J9JFRThreadObject *)hashTableAdd(vm->jfrState.threadObjectJNIRefTable, threadEntry);
+		tid = threadEntry->javaTID;
+		if (NULL == threadEntry) {
+			vm->internalVMFunctions->setNativeOutOfMemoryError(vmThread, 0, 0);
+		}
+	}
+
+doneWithMutex:
+	omrthread_monitor_exit(vm->jfrState.threadObjectsMutex);
+done:
+	return tid;
+}
+
 void
-initializeEventFields(J9VMThread *currentThread, J9JFREvent *event, UDATA eventType)
+initializeEventFields(J9VMThread *currentThread, J9VMThread *sampleThread, J9JFREvent *event, UDATA eventType)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
+	Assert_VM_mustHaveVMAccess(currentThread);
 	event->startTicks = j9time_nano_time();
 	event->eventType = eventType;
-	event->vmThread = currentThread;
+	event->currentThreadTID = getThreadTID(currentThread, sampleThread);
 }
 
 jboolean
@@ -1180,9 +1272,9 @@ jfrCPULoad(J9VMThread *currentThread)
 	intptr_t systemCPULoadRC = omrsysinfo_get_CPU_load(&systemCPULoad);
 
 	if ((0 == processTimeRC) && (0 == systemCPULoadRC)) {
-		J9JFRCPULoad *jfrEvent = (J9JFRCPULoad *)reserveBuffer(currentThread, sizeof(J9JFRCPULoad));
+		J9JFRCPULoad *jfrEvent = (J9JFRCPULoad *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRCPULoad));
 		if (NULL != jfrEvent) {
-			initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_CPU_LOAD);
+			initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_CPU_LOAD);
 
 			JFRState *jfrState = &currentThread->javaVM->jfrState;
 			uintptr_t numberOfCpus = j9sysinfo_get_number_CPUs_by_type(J9PORT_CPU_ONLINE);
@@ -1219,9 +1311,9 @@ jfrThreadCPULoad(J9VMThread *currentThread, J9VMThread *sampleThread)
 	intptr_t rc = omrthread_get_thread_times(&threadTimes);
 
 	if (-1 != rc) {
-		J9JFRThreadCPULoad *jfrEvent = (J9JFRThreadCPULoad *)reserveBuffer(currentThread, sizeof(J9JFRThreadCPULoad));
+		J9JFRThreadCPULoad *jfrEvent = (J9JFRThreadCPULoad *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRThreadCPULoad));
 		if (NULL != jfrEvent) {
-			initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_THREAD_CPU_LOAD);
+			initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_THREAD_CPU_LOAD);
 
 			J9ThreadJFRState *jfrState = &sampleThread->threadJfrState;
 			int64_t currentTime = j9time_nano_time();
@@ -1252,10 +1344,10 @@ static void
 jfrClassLoadingStatistics(J9VMThread *currentThread)
 {
 	J9JavaVM *vm = currentThread->javaVM;
-	J9JFRClassLoadingStatistics *jfrEvent = (J9JFRClassLoadingStatistics *)reserveBuffer(currentThread, sizeof(J9JFRClassLoadingStatistics));
+	J9JFRClassLoadingStatistics *jfrEvent = (J9JFRClassLoadingStatistics *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRClassLoadingStatistics));
 
 	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_CLASS_LOADING_STATISTICS);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_CLASS_LOADING_STATISTICS);
 
 		UDATA unloadedClassCount = 0;
 		UDATA unloadedAnonClassCount = 0;
@@ -1275,12 +1367,12 @@ jfrThreadContextSwitchRate(J9VMThread *currentThread)
 	int32_t rc = omrsysinfo_get_number_context_switches(&switches);
 
 	if (0 == rc) {
-		J9JFRThreadContextSwitchRate *jfrEvent = (J9JFRThreadContextSwitchRate *)reserveBuffer(currentThread, sizeof(J9JFRThreadContextSwitchRate));
+		J9JFRThreadContextSwitchRate *jfrEvent = (J9JFRThreadContextSwitchRate *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRThreadContextSwitchRate));
 		if (NULL != jfrEvent) {
 			JFRState *jfrState = &currentThread->javaVM->jfrState;
 			int64_t currentTime = j9time_nano_time();
 
-			initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_THREAD_CONTEXT_SWITCH_RATE);
+			initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_THREAD_CONTEXT_SWITCH_RATE);
 
 			if ((-1 == jfrState->prevContextSwitchTimestamp)
 				|| (currentTime == jfrState->prevContextSwitchTimestamp)
@@ -1327,9 +1419,9 @@ networkStatsCallback(const char *interfaceName, uint64_t rxBytes, uint64_t txByt
 	/* Look up previous stats for this interface in linked list. */
 	JFRNetworkInterfaceStats *prevStats = findNetworkInterfaceStats((JFRNetworkInterfaceStats *)jfrState->networkInterfaceStatsList, interfaceName);
 
-	J9JFRNetworkUtilization *jfrEvent = (J9JFRNetworkUtilization *)reserveBuffer(currentThread, sizeof(J9JFRNetworkUtilization));
+	J9JFRNetworkUtilization *jfrEvent = (J9JFRNetworkUtilization *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRNetworkUtilization));
 	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_NETWORKUTILIZATION);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_NETWORKUTILIZATION);
 
 		/* Copy interface name to char array. */
 		strncpy(jfrEvent->networkInterface, interfaceName, sizeof(jfrEvent->networkInterface) - 1);
@@ -1390,10 +1482,10 @@ static void
 jfrThreadStatistics(J9VMThread *currentThread)
 {
 	J9JavaVM *vm = currentThread->javaVM;
-	J9JFRThreadStatistics *jfrEvent = (J9JFRThreadStatistics *)reserveBuffer(currentThread, sizeof(J9JFRThreadStatistics));
+	J9JFRThreadStatistics *jfrEvent = (J9JFRThreadStatistics *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRThreadStatistics));
 
 	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_THREAD_STATISTICS);
+		initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_THREAD_STATISTICS);
 
 		jfrEvent->activeThreadCount = vm->totalThreadCount;
 		jfrEvent->daemonThreadCount = vm->daemonThreadCount;

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -36,9 +36,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
 	</test>
 	<test id="Test JFRv2 with file">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Xshare:off -Djfr.unsupported.vm=false  -version</command>
-		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
-		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Xshare:off -Djfr.unsupported.vm=false -cp $RESJAR$ org.openj9.test.WorkLoad</command>
+		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
+		<output type="required" caseSensitive="yes" regex="no">0 / 100 complete</output>
 	</test>
 	<test id="test jfr summary - approx 30seconds">
 		<command>$JFR_EXE$ summary experimentalRecording.jfr</command>


### PR DESCRIPTION
Remove all references to J9VMThread in the local jfr thread buffers.
This means that we dont need to flush the thread buffers when a thread
dies. Instead, this PR will keep (un-backed) thread objects alive via
global JNI refs for the duration of the recording. This will allow us to
write out the data and not trigger global flushes as frequently.

Fixes https://github.com/eclipse-openj9/openj9/issues/23852