### PR TITLE
Remove dead code

### DIFF
--- a/runtime/oti/shcdatautils.h
+++ b/runtime/oti/shcdatautils.h
@@ -29,17 +29,6 @@
 extern "C" {
 #endif
 
-/* ---------------- dbgsharedcache.c ---------------- */
-
-/**
- * @brief
- * @param srcaddr
- * @param size
- * @return UDATA
- */
-J9SRP
-shcDbgReadSRP(UDATA srcaddr);
-
 /* ---------------- shcdatautils.c ---------------- */
 
 /**


### PR DESCRIPTION
`dbgsharedcache.c` and `shcDbgReadSRP()` do not exist anymore.