### PR TITLE
Avoid inlining StringCoding.countPositives on x86

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5816,11 +5816,7 @@ TR_InlinerFailureReason TR_J9InlinerPolicy::checkIfTargetInlineable(TR_CallTarge
     if (comp->target().cpu.isX86()) {
         if (rm == TR::java_lang_StringCoding_countPositives) {
             // countPositives can only be accelerated if target is 64 bit and arrays are contiguous, so inline it if not
-            // Even if target is 64 bit and arrays are contiguous, a performance anomaly occurs when countPositives is
-            // inlined into hasNegatives, causing it to perform faster than accelerated implementation For that reason,
-            // countPositives will be inlined into hasNegatives no matter what
-            if (!comp->target().is64Bit() || TR::Compiler->om.canGenerateArraylets()
-                || callsite->_callerResolvedMethod->getRecognizedMethod() == TR::java_lang_StringCoding_hasNegatives) {
+            if (!comp->target().is64Bit() || TR::Compiler->om.canGenerateArraylets()) {
                 return InlineableTarget;
             }
             // If target is 64 bit, arrays are contiguous, and caller is not hasNegatives,
@@ -5829,17 +5825,21 @@ TR_InlinerFailureReason TR_J9InlinerPolicy::checkIfTargetInlineable(TR_CallTarge
                 return DontInline_Callee;
             }
         }
+
         if (rm == TR::java_lang_StringCoding_hasNegatives) {
+            // In JDK 19+, StringCoding.hasNegatives is implemented in terms of StringCoding.countPositives, so rely
+            // on inline code generation for countPositives and regular inlining of hasNegatives for best performance.
+            // Before JDK 19, rely on inline code generation for hasNegatives itself for best performance.
+            //
 #if JAVA_SPEC_VERSION >= 19
-            // Take advantage of performance anomaly mentioned above by inlining both countPositives (which only exists
-            // for JDK 19+) and hasNegatives
             return InlineableTarget;
 #else
             // hasNegatives can only be accelerated if target is 64 bit and arrays are contiguous, so inline it if not
-            if (!comp->target().is64Bit() || TR::Compiler->om.canGenerateArraylets())
+            if (!comp->target().is64Bit() || TR::Compiler->om.canGenerateArraylets()) {
                 return InlineableTarget;
-            else
+            } else {
                 return DontInline_Callee;
+            }
 #endif /* JAVA_SPEC_VERSION >=19 */
         }
     }


### PR DESCRIPTION
`TR_J9InlinerPolicy::checkIfTargetInlineable` treated `StringCoding.countPositives` as an intrinsic, avoiding inlining it only if the call to it didn't come from `StringCoding.hasNegatives` for the target architecture of x86.  However, it should be treated as an intrinsic function always &mdash; except if the target architecture is 32 bits or if arraylets are required, where code generation doesn't support the method as an intrinsic.