### PR TITLE
Fix typos in RootPathCommand

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/RootPathCommand.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/tools/ddrinteractive/commands/RootPathCommand.java
@@ -31,7 +31,6 @@ import com.ibm.j9ddr.tools.ddrinteractive.Command;
 import com.ibm.j9ddr.tools.ddrinteractive.CommandUtils;
 import com.ibm.j9ddr.tools.ddrinteractive.Context;
 import com.ibm.j9ddr.tools.ddrinteractive.DDRInteractiveCommandException;
-import com.ibm.j9ddr.vm29.pointer.generated.J9IndexableObjectPointer;
 import com.ibm.j9ddr.vm29.events.DefaultEventListener;
 import com.ibm.j9ddr.vm29.events.EventManager;
 import com.ibm.j9ddr.vm29.j9.ConstantPoolHelpers;
@@ -42,42 +41,47 @@ import com.ibm.j9ddr.vm29.j9.RootSet.RootSetType;
 import com.ibm.j9ddr.vm29.pointer.VoidPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9BuildFlags;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
+import com.ibm.j9ddr.vm29.pointer.generated.J9IndexableObjectPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ClassHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9IndexableObjectHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
 
-public class RootPathCommand extends Command 
-{
-	boolean _verboseEnabled = false;
-	DefaultEventListener _listener = new DefaultEventListener();
+public class RootPathCommand extends Command {
 
-	public RootPathCommand()
-	{
-		addCommand("rootpathfindall", "<address>", "prints out all the paths from a (strong) root to an object");
-		addCommand("rootpathfind", "<address>", "prints out a path from a (strong) root to an object");
-		addCommand("isobjectalive", "<address>", "determines whether an object is reachable from a (strong) roots or not.  Use !rootfind <address> or !rootfindall <address> to print out the path(s)");
-		
-		addCommand("strongrootpathfindall", "<address>", "prints out all the paths from a (strong) root to an object");
-		addCommand("strongrootpathfind", "<address>", "prints out a path from a (strong) root to an object");
-		
-		addCommand("anyrootpathfindall", "<address>", "same as rootpathfindall but also includes weak roots e.g. classes, classloaders, weak references");
-		addCommand("anyrootpathfind", "<address>", "same as rootpathfind but also includes weak roots e.g. classes, classloaders, weak references");
-		
-		addCommand("weakrootpathfindall", "<address>", "same as rootpathfindall but only for weak roots e.g. classes, classloaders, weak references");
-		addCommand("weakrootpathfind", "<address>", "same as rootpathfind but only weak for roots e.g. classes, classloaders, weak references");
-		
-		addCommand("rootpathverbose", "", "enables displaying errors when walking live set");
-		addCommand("rootpathnoverbose", "", "disables displaying errors when walking live set");
+	boolean _verboseEnabled;
+	final DefaultEventListener _listener = new DefaultEventListener();
+
+	public RootPathCommand() {
+		addCommand("rootpathfindall", "<address>",
+				"prints out all the paths from a (strong) root to an object");
+		addCommand("rootpathfind", "<address>",
+				"prints out a path from a (strong) root to an object");
+		addCommand("isobjectalive", "<address>",
+				"determines whether an object is reachable from a (strong) root or not.  Use !rootpathfind <address> or !rootpathfindall <address> to print out the path(s)");
+		addCommand("strongrootpathfindall", "<address>",
+				"prints out all the paths from a (strong) root to an object");
+		addCommand("strongrootpathfind", "<address>",
+				"prints out a path from a (strong) root to an object");
+		addCommand("anyrootpathfindall", "<address>",
+				"same as rootpathfindall but also includes weak roots e.g. classes, classloaders, weak references");
+		addCommand("anyrootpathfind", "<address>",
+				"same as rootpathfind but also includes weak roots e.g. classes, classloaders, weak references");
+		addCommand("weakrootpathfindall", "<address>",
+				"same as rootpathfindall but only for weak roots e.g. classes, classloaders, weak references");
+		addCommand("weakrootpathfind", "<address>",
+				"same as rootpathfind but only weak for roots e.g. classes, classloaders, weak references");
+		addCommand("rootpathverbose", "",
+				"enables displaying errors when walking live set");
+		addCommand("rootpathnoverbose", "",
+				"disables displaying errors when walking live set");
 	}
-	
-	public static String objectToString(J9ObjectPointer object) throws CorruptDataException
-	{
+
+	public static String objectToString(J9ObjectPointer object) throws CorruptDataException {
 		J9ClassPointer clazz = J9ObjectHelper.clazz(object);
 		StringWriter buf = new StringWriter();
-		String className;
-		
-		className = J9ClassHelper.getJavaName(clazz);
+		String className = J9ClassHelper.getJavaName(clazz);
+
 		if (className.equals("java/lang/Class")) {
 			buf.write("class ");
 			buf.write(J9ClassHelper.getJavaName(ConstantPoolHelpers.J9VM_J9CLASS_FROM_HEAPCLASS(object)));
@@ -89,10 +93,10 @@ public class RootPathCommand extends Command
 			buf.write("\"@");
 			buf.write(object.getHexAddress());
 		} else {
-			buf.write(className);	
+			buf.write(className);
 			buf.write('@');
 			buf.write(object.getHexAddress());
-			
+
 			if (ObjectModel.isIndexable(object)) {
 				buf.write(" = ");
 				buf.write(J9IndexableObjectHelper.getDataAsString(J9IndexableObjectPointer.cast(object)));
@@ -100,23 +104,23 @@ public class RootPathCommand extends Command
 		}
 		return buf.toString();
 	}
-	
-	private class RootPathFinder implements ObjectVisitor 
-	{
-		boolean _pathFound = false;
-		J9ObjectPointer _objectToFind;
-		Stack<J9ObjectPointer> _scanStack = new Stack<J9ObjectPointer>();
-		PrintStream _out;
-		
-		public RootPathFinder(J9ObjectPointer objectToFind, PrintStream out) {
+
+	private static final class RootPathFinder implements ObjectVisitor {
+
+		boolean _pathFound;
+		final J9ObjectPointer _objectToFind;
+		final Stack<J9ObjectPointer> _scanStack = new Stack<>();
+		final PrintStream _out;
+
+		RootPathFinder(J9ObjectPointer objectToFind, PrintStream out) {
 			_objectToFind = objectToFind;
 			_out = out;
 		}
-		
-		public boolean visit(J9ObjectPointer object, VoidPointer address) 
-		{
+
+		@Override
+		public boolean visit(J9ObjectPointer object, VoidPointer address) {
 			if (_pathFound) {
-				/* Don't bother to keep visiting if we've already found our object */
+				/* Don't bother to keep visiting if we've already found our object. */
 				return false;
 			} else {
 				_scanStack.push(object);
@@ -127,14 +131,13 @@ public class RootPathCommand extends Command
 					return false;
 				}
 			}
-			
-			/* Haven't found a path yet */
+
+			/* Haven't found a path yet. */
 			return true;
 		}
-		
-		private void dumpTree()
-		{
-			_out.println("\n========================================");
+
+		private void dumpTree() {
+			_out.format("%n========================================%n");
 			for (int i = 0; i < _scanStack.size(); i++) {
 				for (int j = i; j > 0; j--) {
 					_out.print("  ");
@@ -146,27 +149,26 @@ public class RootPathCommand extends Command
 				}
 			}
 		}
-		
-		public void finishVisit(J9ObjectPointer object, VoidPointer address)
-		{
+
+		@Override
+		public void finishVisit(J9ObjectPointer object, VoidPointer address) {
 			_scanStack.pop();
 		}
 	}
-	
-	private class ObjectFinderVisitor implements ObjectVisitor 
-	{
-		boolean _objectFound = false;
-		J9ObjectPointer _objectToFind;
-		
-		public ObjectFinderVisitor(J9ObjectPointer objectToFind) 
-		{
+
+	private static final class ObjectFinderVisitor implements ObjectVisitor {
+
+		boolean _objectFound;
+		final J9ObjectPointer _objectToFind;
+
+		ObjectFinderVisitor(J9ObjectPointer objectToFind) {
 			_objectToFind = objectToFind;
 		}
-		
-		public boolean visit(J9ObjectPointer object, VoidPointer address) 
-		{
+
+		@Override
+		public boolean visit(J9ObjectPointer object, VoidPointer address) {
 			if (_objectFound) {
-				/* Don't bother to keep visiting if we've already found our object */
+				/* Don't bother to keep visiting if we've already found our object. */
 				return false;
 			} else {
 				if (object.equals(_objectToFind)) {
@@ -176,23 +178,24 @@ public class RootPathCommand extends Command
 			}
 			return true;
 		}
-		
-		public void finishVisit(J9ObjectPointer object, VoidPointer address) 
-		{
+
+		@Override
+		public void finishVisit(J9ObjectPointer object, VoidPointer address) {
 		}
 	}
-	
-	private class RootPathsFinder implements ObjectVisitor 
-	{
-		Stack<J9ObjectPointer> _scanStack = new Stack<J9ObjectPointer>();
-		J9ObjectPointer _objectToFind;
-		PrintStream _out;
-		
-		public RootPathsFinder(J9ObjectPointer objectToFind, PrintStream out) {
+
+	private static final class RootPathsFinder implements ObjectVisitor {
+
+		final Stack<J9ObjectPointer> _scanStack = new Stack<>();
+		final J9ObjectPointer _objectToFind;
+		final PrintStream _out;
+
+		RootPathsFinder(J9ObjectPointer objectToFind, PrintStream out) {
 			_objectToFind = objectToFind;
 			_out = out;
 		}
-		
+
+		@Override
 		public boolean visit(J9ObjectPointer object, VoidPointer address) {
 			_scanStack.push(object);
 			if (object.equals(_objectToFind)) {
@@ -203,9 +206,9 @@ public class RootPathCommand extends Command
 				return true;
 			}
 		}
-		
+
 		private void dumpTree() {
-			_out.println("\n========================================");
+			_out.format("%n========================================%n");
 			for (int i = 0; i < _scanStack.size(); i++) {
 				for (int j = i; j > 0; j--) {
 					_out.print("  ");
@@ -217,63 +220,62 @@ public class RootPathCommand extends Command
 				}
 			}
 		}
-		
+
+		@Override
 		public void finishVisit(J9ObjectPointer object, VoidPointer address) {
 			_scanStack.pop();
 		}
 	}
-	
-	private class RootPathCommandListener implements IEventListener
-	{
-		public boolean _corruptionFound = false;
-		
-		public void corruptData(String message, CorruptDataException e, boolean fatal) 
-		{
+
+	private final class RootPathCommandListener implements IEventListener {
+
+		boolean _corruptionFound;
+
+		@Override
+		public void corruptData(String message, CorruptDataException e, boolean fatal) {
 			_corruptionFound = true;
 			if (_verboseEnabled) {
 				/* re-using DefaultListener to log error */
 				_listener.corruptData(message, e, fatal);
-			} 
+			}
 		}
 	}
 
-	public void run(String command, String[] args, Context context,
-			final PrintStream out) throws DDRInteractiveCommandException 
-	{
+	@Override
+	public void run(String command, String[] args, Context context, final PrintStream out)
+			throws DDRInteractiveCommandException {
 		switch (args.length) {
 		case 0:
-			if (args.length == 0) {
-				if (command.equals("!rootpathverbose")) {
-					out.println("verbose output enabled for rootpath command.  run !rootpathnoverbose to disable verbose output");
-					_verboseEnabled = true;
-				} else if (command.equals("!rootpathnoverbose")) {
-					out.println("verbose output disabled for rootpath command.  run !rootpathverbose to enable verbose output");
-					_verboseEnabled = false;
-				} else {
-					throw new UnsupportedOperationException("Unrecognized command passed to RoothPathCommand");
-				}
+			if (command.equals("!rootpathverbose")) {
+				out.println("verbose output enabled for rootpath command.  run !rootpathnoverbose to disable verbose output");
+				_verboseEnabled = true;
+			} else if (command.equals("!rootpathnoverbose")) {
+				out.println("verbose output disabled for rootpath command.  run !rootpathverbose to enable verbose output");
+				_verboseEnabled = false;
+			} else {
+				throw new UnsupportedOperationException("Unrecognized command passed to RoothPathCommand");
 			}
 			break;
 		case 1:
 			long address = CommandUtils.parsePointer(args[0], J9BuildFlags.J9VM_ENV_DATA64);
 			final J9ObjectPointer objectToFind = J9ObjectPointer.cast(address);
-			
+
 			try {
 				J9ClassPointer clazz = J9ObjectHelper.clazz(objectToFind);
 				if (!J9ClassHelper.hasValidEyeCatcher(clazz)) {
 					throw new DDRInteractiveCommandException("object class is not valid (eyecatcher is not 0x99669966)");
 				}
 			} catch (CorruptDataException cde) {
-				throw new DDRInteractiveCommandException("memory fault de-referencing address argument", cde); 
+				throw new DDRInteractiveCommandException("memory fault dereferencing address argument", cde);
 			}
-			
+
 			try {
 				/* Create a custom event listener so that CorruptDataExceptions that are found
-				 * while iterating through the live set aren't all printed to the output stream
+				 * while iterating through the live set aren't all printed to the output stream.
 				 */
 				RootPathCommandListener listener = new RootPathCommandListener();
 				EventManager.register(listener);
-				
+
 				if (command.equals("!rootpathfindall") || command.equals("!strongrootpathfindall")) {
 					LiveSetWalker.walkLiveSet(new RootPathsFinder(objectToFind, out), RootSetType.STRONG_REACHABLE);
 				} else if (command.equals("!anyrootpathfindall")) {
@@ -307,11 +309,11 @@ public class RootPathCommand extends Command
 						out.println("Object is not live");
 					}
 				}
-				
+
 				if (listener._corruptionFound) {
 					out.println("Corruption detected walking live set");
-					if (!_verboseEnabled) {		
-						out.println("run !rootpathverbose and re-run command to see corruptions");
+					if (!_verboseEnabled) {
+						out.println("run !rootpathverbose and rerun command to see corruptions");
 					}
 				}
 				EventManager.unregister(listener);
@@ -319,11 +321,8 @@ public class RootPathCommand extends Command
 				throw new DDRInteractiveCommandException("Memory fault while walking live set", cde);
 			}
 			break;
-			
-			default:
-				throw new DDRInteractiveCommandException("Invalid number of arguments");
+		default:
+			throw new DDRInteractiveCommandException("Invalid number of arguments");
 		}
-		
-		
 	}
 }


### PR DESCRIPTION
There are no DDR commands named `rootfind` or `rootfindall`; fix the advice to suggest using `rootpathfind` or `rootpathfindall` instead.

Don't hyphenate 'dereferencing' or 'rerun'.

General cleanup:
* add missing `@Override` annotations
* use `final` and `static` where appropriate
* remove redundant test

Noticed while investigating https://github.com/eclipse-openj9/openj9/issues/23866.