### PR TITLE
AArch64: Fix MemoryReference with index register

### DIFF
--- a/runtime/compiler/aarch64/codegen/MemoryReference.hpp
+++ b/runtime/compiler/aarch64/codegen/MemoryReference.hpp
@@ -61,7 +61,7 @@ private:
 public:
     static TR::MemoryReference *create(TR::CodeGenerator *cg);
     static TR::MemoryReference *createWithIndexReg(TR::CodeGenerator *cg, TR::Register *baseReg, TR::Register *indexReg,
-        uint8_t scale = 0, TR::ARM64ExtendCode extendCode = TR::ARM64ExtendCode::EXT_UXTX);
+        uint8_t scale = 0);
     static TR::MemoryReference *createWithDisplacement(TR::CodeGenerator *cg, TR::Register *baseReg,
         int64_t displacement);
     static TR::MemoryReference *createWithRootLoadOrStore(TR::CodeGenerator *cg, TR::Node *rootLoadOrStore);


### PR DESCRIPTION
This commit removes unused extendCode parameter from the MemoryReference::createWithIndexReg() function for AArch64.