### PR TITLE
Add support for Nursery only compact

### DIFF
--- a/runtime/gc_glue_java/CompactDelegate.cpp
+++ b/runtime/gc_glue_java/CompactDelegate.cpp
@@ -116,9 +116,9 @@ MM_CompactDelegate::verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap)
 }
 
 void
-MM_CompactDelegate::fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme)
+MM_CompactDelegate::fixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme, bool nurseryOnly)
 {
-	MM_CompactSchemeFixupRoots rootScanner(env, compactScheme);
+	MM_CompactSchemeFixupRoots rootScanner(env, compactScheme, nurseryOnly);
 	rootScanner.scanAllSlots(env);
 }
 

--- a/runtime/gc_glue_java/CompactDelegate.hpp
+++ b/runtime/gc_glue_java/CompactDelegate.hpp
@@ -72,7 +72,7 @@ public:
 
 	void verifyHeap(MM_EnvironmentBase *env, MM_MarkMap *markMap);
 
-	void fixupRoots(MM_EnvironmentBase *env,  MM_CompactScheme *compactScheme);
+	void fixupRoots(MM_EnvironmentBase *env,  MM_CompactScheme *compactScheme, bool nurseryOnly = false);
 
 	void workerCleanupAfterGC(MM_EnvironmentBase *env);
 

--- a/runtime/gc_glue_java/CompactSchemeFixupRoots.hpp
+++ b/runtime/gc_glue_java/CompactSchemeFixupRoots.hpp
@@ -33,11 +33,20 @@
 
 class MM_CompactSchemeFixupRoots : public MM_RootScanner {
 private:
-	MM_CompactScheme* _compactScheme;
+#if defined(J9VM_GC_MODRON_SCAVENGER)
+	MM_CompactSchemeFixupObject _fixupObject;
+	bool _nurseryOnly; /**< if true, Nursery is only compacted and Tenure fixed-up via RS, otherwise whole heap is compacted/fixed-up */
+#endif /* defined(J9VM_GC_MODRON_SCAVENGER) */
+
+	MM_CompactScheme *_compactScheme;
 
 public:
-	MM_CompactSchemeFixupRoots(MM_EnvironmentBase *env, MM_CompactScheme* compactScheme) :
+	MM_CompactSchemeFixupRoots(MM_EnvironmentBase *env, MM_CompactScheme *compactScheme, bool nurseryOnly = false) :
 		MM_RootScanner(env),
+#if defined(J9VM_GC_MODRON_SCAVENGER)
+		_fixupObject(env, compactScheme),
+		_nurseryOnly(nurseryOnly),
+#endif /* defined(J9VM_GC_MODRON_SCAVENGER) */
 		_compactScheme(compactScheme)
 	{
 		setIncludeStackFrameClassReferences(false);
@@ -98,6 +107,25 @@ public:
 		fixupContinuationObjects(env);
 		reportScanningEnded(RootScannerEntity_ContinuationObjects);
 	}
+
+#if defined(J9VM_GC_MODRON_SCAVENGER)
+	virtual void doRememberedSetSlot(J9Object **slotPtr, GC_RememberedSetSlotIterator *rememberedSetSlotIterator)
+	{
+		if (_nurseryOnly) {
+			/* Objects in Tenure did not move -> no need to fix up RS slots.
+			 * Object in Nursery moved -> slots of remembered objects in Nursery need to fix up.
+			 */
+			_fixupObject.fixupObject(MM_EnvironmentStandard::getEnvironment(_env), *slotPtr);
+		} else {
+			/* Objects in tenure moved -> need to fix up RS slots.
+			 * Remembered (Tenured) object slots have been already fixed up by now (as any other object slots).
+			 */
+			MM_RootScanner::doRememberedSetSlot(slotPtr, rememberedSetSlotIterator);
+		}
+	}
+#endif /* defined(J9VM_GC_MODRON_SCAVENGER) */
+
+
 
 private:
 #if defined(J9VM_GC_FINALIZATION)


### PR DESCRIPTION
Add support for Nursery only compact

For Sliding compact RootScanner, for Gencon, added support to compact Nursery only. An extra flag is passed that controls if Nursery only is compacted or the whole heap.

RootSanner RS processing uses that flag to:
- if case of nursery only compact, remembered object are fixed up
- in case of global compact, RS slots are fixed up

Issue: https://github.com/eclipse-openj9/openj9/issues/20515

Signed-off-by: Shadman Siddiqui shadman2606@gmail.com