### PR TITLE
Exclude libpathTestRtf on AIX to avoid intermittent AWTError

### DIFF
--- a/test/functional/cmdLineTests/libpathTest/playlist.xml
+++ b/test/functional/cmdLineTests/libpathTest/playlist.xml
@@ -27,6 +27,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<testCaseName>cmdLineTester_libpathTestRtf</testCaseName>
 		<disables>
 			<disable>
+				<comment>https://github.com/eclipse-openj9/openj9/issues/14943</comment>
+				<platform>.*aix.*</platform>
+			</disable>
+			<disable>
 				<comment>https://github.com/eclipse-openj9/openj9/issues/3787</comment>
 				<platform>.*mac.*</platform>
 			</disable>


### PR DESCRIPTION
java.awt.AWTError: Can't connect to X11 window server using 'unix:0' as the value of the DISPLAY variable.

Issue https://github.com/eclipse-openj9/openj9/issues/14943