### PR TITLE
Update tests to add a sleep before destroying nonpersistent cache

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -557,6 +557,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 
+	<exec command="sleep 0.5" platforms="linux.*" />
+
 	<test id="Test 35: CMVC 168131 : Cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
@@ -188,6 +188,8 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
+	<exec command="sleep 0.5" platforms="linux.*" />
+
 	<test id="Test 9s: Set up for test 9. Destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
@@ -253,6 +255,8 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
+	<exec command="sleep 0.5" platforms="linux.*" />
+
 	<test id="Test 11 - b: Setup for test 11. Destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
@@ -302,6 +306,8 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
+	<exec command="sleep 0.5" platforms="linux.*" />
+
 	<test id="Test 14: Clean up, destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>


### PR DESCRIPTION
Issue https://github.com/eclipse-openj9/openj9/issues/23288#issuecomment-4424646719

Tested in grinders.

testSCCMLTests1_openj9
aarch64 https://openj9-jenkins.osuosl.org/job/Grinder/5174
ppc64le https://openj9-jenkins.osuosl.org/job/Grinder/5176

testSCCMLSnapshot
ppc64le https://openj9-jenkins.osuosl.org/job/Grinder/5178