### PR TITLE
Fix JFR GC Event pause reporting

### DIFF
--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -827,8 +827,8 @@ jfrGarbageCollection(OMR_VMThread *omrVMThread)
 		jfrEvent->gcID = javaVM->memoryManagerFunctions->j9gc_get_unique_cycle_ID(currentThread);
 		jfrEvent->gcNameID = javaVM->memoryManagerFunctions->j9gc_get_gc_collector_type(currentThread);
 		jfrEvent->gcCauseID = javaVM->memoryManagerFunctions->j9gc_get_gc_cause_type(currentThread);
-		jfrEvent->sumOfPauses = javaVM->memoryManagerFunctions->j9gc_get_longest_pause(currentThread);
-		jfrEvent->longestPause = javaVM->memoryManagerFunctions->j9gc_get_sum_of_pauses(currentThread);
+		jfrEvent->sumOfPauses = javaVM->memoryManagerFunctions->j9gc_get_sum_of_pauses(currentThread);
+		jfrEvent->longestPause = javaVM->memoryManagerFunctions->j9gc_get_longest_pause(currentThread);
 	}
 }
 


### PR DESCRIPTION
This change fixes the ordering of the sum of pauses and longest pause in
 the JFR GC Event.