### PR TITLE
JDK27+ adopts jimage API to support classes with preview feature enabled

### DIFF
--- a/runtime/bcutil/jimageintf.c
+++ b/runtime/bcutil/jimageintf.c
@@ -91,11 +91,12 @@ lookupSymbolsInJImageLib(J9PortLibrary *portLibrary, UDATA libJImageHandle)
 		j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_JIMAGE_INTF_LIBJIMAGE_SYMBOL_LOOKUP_FAILED, "JIMAGE_Close");
 		goto _end;
 	}
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+
+#if JAVA_SPEC_VERSION >= 27
 	rc = j9sl_lookup_name(libJImageHandle, "JIMAGE_FindResource", (UDATA *)&libJImageFindResource, "JPPPZP");
-#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#else /* JAVA_SPEC_VERSION >= 27 */
 	rc = j9sl_lookup_name(libJImageHandle, "JIMAGE_FindResource", (UDATA *)&libJImageFindResource, "JPPPPP");
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#endif /* JAVA_SPEC_VERSION >= 27 */
 	if (0 != rc) {
 		j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_JIMAGE_INTF_LIBJIMAGE_SYMBOL_LOOKUP_FAILED, "JIMAGE_FindResource");
 		goto _end;
@@ -300,14 +301,14 @@ jimageFindResource(J9JImageIntf *jimageIntf, UDATA handle, const char *moduleNam
 		JImageLocationRef *locationRef = (JImageLocationRef *)j9mem_allocate_memory(sizeof(*locationRef), J9MEM_CATEGORY_CLASSES);
 
 		if (NULL != locationRef) {
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if JAVA_SPEC_VERSION >= 27
 			J9JavaVM *vm = jimageIntf->vm;
 			BOOLEAN enablePreview = J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW);
 
 			*locationRef = libJImageFindResource(jimage, moduleName, name, enablePreview, (jlong *)size);
-#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#else /* JAVA_SPEC_VERSION >= 27 */
 			*locationRef = libJImageFindResource(jimage, moduleName, JIMAGE_VERSION_NUMBER, name, (jlong *)size);
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#endif /* JAVA_SPEC_VERSION >= 27 */
 			if (JIMAGE_NOT_FOUND != *(I_64 *)locationRef) {
 				*resourceLocation = (UDATA)locationRef;
 			} else {

--- a/runtime/oti/libjimage.h
+++ b/runtime/oti/libjimage.h
@@ -32,13 +32,13 @@ typedef jlong JImageLocationRef;
 
 typedef JImageFile * (*libJImageOpenType)(const char *name, jint *error);
 typedef void (*libJImageCloseType)(JImageFile *jimage);
-#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#if JAVA_SPEC_VERSION >= 27
 typedef JImageLocationRef (*libJImageFindResourceType)(JImageFile *jimage,
 		const char *module_name, const char *name, BOOLEAN is_preview_mode, jlong *size);
-#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#else /* JAVA_SPEC_VERSION >= 27 */
 typedef JImageLocationRef (*libJImageFindResourceType)(JImageFile *jimage,
 		const char *module_name, const char *version, const char *name, jlong *size);
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+#endif /* JAVA_SPEC_VERSION >= 27 */
 typedef jlong (*libJImageGetResourceType)(JImageFile *jimage, JImageLocationRef location,
 		char *buffer, jlong size);
 #if JAVA_SPEC_VERSION < 26


### PR DESCRIPTION
[JDK27+ adopts jimage API to support classes with preview feature enabled](https://github.com/eclipse-openj9/openj9/commit/71e9dc0334862e68c205c98dda20d2ae3a19729e) 

Valhalla project already uses the new `JIMAGE_FindResource` API, switch JDK27+ to the same usage.

closes https://github.com/eclipse-openj9/openj9/issues/23894

Signed-off-by: Jason Feng <fengj@ca.ibm.com>