### PR TITLE
Initialize core JFR classes and upcall hook early

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
@@ -769,6 +769,11 @@ public static native boolean isStartFlightRecordingSpecified();
  * @return a Module which is the unnamed module for system loader
  */
 public static native Module getUnnamedModuleForSystemLoader();
+
+/**
+ * Native used to initialize internal JFR structures
+ */
+public static native void initializeInternalJFRStructures();
 /*[ENDIF] JFR_SUPPORT */
 
 /*[IF JAVA_SPEC_VERSION >= 24]*/

--- a/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
+++ b/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
@@ -48,7 +48,14 @@ final class JFRHelpers {
 	private static Method bytesForEagerInstrumentation;
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 	private static volatile boolean jfrClassesInitialized = false;
-	private static String jfrCMDLineOption = VM.getjfrCMDLineOption();
+	private static String jfrCMDLineOption = null;
+
+	static {
+		if (VM.isJFREnabled() && VM.isJFRV2SupportEnabled()) {
+			VM.initializeInternalJFRStructures();
+			initJFRClasses();
+		}
+	}
 
 	private static Long convertToBytes(String text) {
 		Pattern pattern = Pattern.compile("(\\d+)([gkm]b?)?", Pattern.CASE_INSENSITIVE);
@@ -310,8 +317,13 @@ final class JFRHelpers {
 
 	/*[IF JAVA_SPEC_VERSION == 17]*/
 	private static byte[] transformClassAndInvokebytesForEagerInstrumentation(long traceId, boolean forceInstrumentation, Class<?> superClass, byte[] oldBytes, boolean addMethods) throws ReflectiveOperationException {
-		oldBytes = JFRClassTransformer.transformClass(oldBytes, addMethods);
-		return (byte[])bytesForEagerInstrumentation.invoke(null, traceId, forceInstrumentation, superClass, oldBytes);
+		try {
+			oldBytes = JFRClassTransformer.transformClass(oldBytes, addMethods);
+			return (byte[])bytesForEagerInstrumentation.invoke(null, traceId, forceInstrumentation, superClass, oldBytes);
+		} catch (Throwable t) {
+			t.printStackTrace();
+			throw t;
+		}
 	}
 
 	private static List<?> transformToList(Object[] array) {
@@ -326,6 +338,8 @@ final class JFRHelpers {
 		if (!VM.isJFREnabled() || !VM.isJFRV2SupportEnabled()) {
 			return;
 		}
+
+		jfrCMDLineOption = VM.getjfrCMDLineOption();
 		// JFR support is enabled with V2 implementation.
 		if (null != jfrCMDLineOption) {
 			initJFRClasses();

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -158,7 +158,8 @@ internalDefineClass(
 			/* CTM is already released in this case. */
 			return NULL;
 		} else if (NULL != superClass) {
-			if (isSameOrSuperClassOf(J9VMJAVALANGCLASS_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrInternalEventClassRef)), superClass)) {
+			J9Class *internalEventClass = J9VMJAVALANGCLASS_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrInternalEventClassRef));
+			if (isSameOrSuperClassOf(internalEventClass, superClass)) {
 				U_8* jfrModifiedBytes = NULL;
 				UDATA jfrModifiedBytesLength = 0;
 				omrthread_monitor_exit(vm->classTableMutex);

--- a/runtime/jcl/common/jclvm.c
+++ b/runtime/jcl/common/jclvm.c
@@ -640,6 +640,18 @@ Java_com_ibm_oti_vm_VM_getUnnamedModuleForSystemLoader(JNIEnv *env, jclass clazz
 	return moduleObject;
 }
 
+void JNICALL
+Java_com_ibm_oti_vm_VM_initializeInternalJFRStructures(JNIEnv *env, jclass clazz)
+{
+	J9VMThread *currentThread = (J9VMThread *) env;
+	J9JavaVM *javaVM = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = javaVM->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->jfrInitializeInternalStructures(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
+}
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 /*

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -29,9 +29,6 @@
 
 extern "C" {
 
-J9_DECLARE_CONSTANT_UTF8(jfrInternalEventClassUTF8, "jdk/internal/event/Event");
-J9_DECLARE_CONSTANT_UTF8(jfrEventClassUTF8, "jdk/jfr/Event");
-
 /* Make sure these logging levels lineup with jdk/jfr/internal/LogLevel.java */
 #define LOG_LEVEL_TRACE 1
 #define LOG_LEVEL_DEBUG 2
@@ -347,33 +344,12 @@ jboolean JNICALL
 Java_jdk_jfr_internal_JVM_createJFR(JNIEnv *env, jobject obj, jboolean simulateFailure)
 {
 	jboolean rc = JNI_TRUE;
-	J9VMThread *currentThread = (J9VMThread *)env;
-	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	J9Class *jfrInternalEventClass = NULL;
-	J9Class *jfrEventClass = NULL;
 
 	if (simulateFailure) {
 		rc = JNI_FALSE;
 		goto done;
 	}
 
-	vmFuncs->internalEnterVMFromJNI(currentThread);
-	jfrInternalEventClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrInternalEventClassUTF8), J9UTF8_LENGTH(&jfrInternalEventClassUTF8), vm->systemClassLoader, 0);
-	jfrEventClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrEventClassUTF8), J9UTF8_LENGTH(&jfrEventClassUTF8), vm->systemClassLoader, 0);
-
-	if ((NULL != jfrInternalEventClass) && (NULL != jfrEventClass)) {
-		vm->jfrState.jfrInternalEventClassRef = (jclass) vmFuncs->j9jni_createGlobalRef(env, jfrInternalEventClass->classObject, FALSE);
-		vm->jfrState.jfrEventClassRef = (jclass) vmFuncs->j9jni_createGlobalRef(env, jfrEventClass->classObject, FALSE);
-	}
-	vmFuncs->internalExitVMToJNI(currentThread);
-
-	if ((NULL == vm->jfrState.jfrEventClassRef) || (NULL == vm->jfrState.jfrInternalEventClassRef)) {
-		rc = JNI_FALSE;
-		goto done;
-	}
-
-	vm->extendedRuntimeFlags3 |= J9_EXTENDED_RUNTIME3_ENABLE_JFR_CLASSLOAD_TRANSFORM;
 done:
 	return rc;
 }
@@ -382,18 +358,6 @@ jboolean JNICALL
 Java_jdk_jfr_internal_JVM_destroyJFR(JNIEnv *env, jobject obj)
 {
 	jboolean rc = JNI_TRUE;
-	J9VMThread *currentThread = (J9VMThread *)env;
-	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-
-	vm->extendedRuntimeFlags3 &= ~J9_EXTENDED_RUNTIME3_ENABLE_JFR_CLASSLOAD_TRANSFORM;
-
-	vmFuncs->internalEnterVMFromJNI(currentThread);
-	vmFuncs->j9jni_deleteGlobalRef(env, vm->jfrState.jfrEventClassRef, FALSE);
-	vmFuncs->j9jni_deleteGlobalRef(env, vm->jfrState.jfrInternalEventClassRef, FALSE);
-	vm->jfrState.jfrEventClassRef = NULL;
-	vm->jfrState.jfrInternalEventClassRef = NULL;
-	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return rc;
 }

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -700,6 +700,7 @@ if(J9VM_OPT_JFR)
 		Java_com_ibm_oti_vm_VM_getJfrDuration
 		Java_com_ibm_oti_vm_VM_getJfrRecordingFileName
 		Java_com_ibm_oti_vm_VM_getUnnamedModuleForSystemLoader
+		Java_com_ibm_oti_vm_VM_initializeInternalJFRStructures
 		Java_com_ibm_oti_vm_VM_isJFREnabled
 		Java_com_ibm_oti_vm_VM_isJFRV2SupportEnabled
 		Java_com_ibm_oti_vm_VM_isJFRRecordingStarted

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5629,6 +5629,7 @@ typedef struct J9InternalVMFunctions {
 	jlong (*getTypeId)(struct J9VMThread *currentThread, struct J9Class *clazz);
 	void (*jvmUpcallsEagerByteInstrumentation)(struct J9VMThread *currentThread, struct J9Class *superClass, U_8 *className, U_16 classNameLength, struct J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 	j9object_t (*jvmUpcallTransformArrayToList)(struct J9VMThread *currentThread, j9object_t array);
+	void (*jfrInitializeInternalStructures)(struct J9VMThread *currentThread);
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	void (*initializeSnapshotClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1303,6 +1303,8 @@ jstring JNICALL
 Java_com_ibm_oti_vm_VM_getJfrDuration(JNIEnv *env, jclass clazz);
 jobject JNICALL
 Java_com_ibm_oti_vm_VM_getUnnamedModuleForSystemLoader(JNIEnv *env, jclass clazz);
+void JNICALL
+Java_com_ibm_oti_vm_VM_initializeInternalJFRStructures(JNIEnv *env, jclass clazz);
 jboolean JNICALL
 Java_com_ibm_oti_vm_VM_isStartFlightRecordingSpecified(JNIEnv *env, jclass clazz);
 jboolean JNICALL

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5935,6 +5935,17 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 j9object_t
 jvmUpcallTransformArrayToList(J9VMThread *currentThread, j9object_t array);
 
+/**
+ * Initialize internal VM structures for JFR. This must be called before triggering
+ * JFR initialization in the JCL.
+ *
+ * Sets exception in the current thread if there is a failure. Must be called without VM access.
+ *
+ * @param currentThread[in] the current J9VMThread
+ */
+void
+jfrInitializeInternalStructures(J9VMThread *currentThread);
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 #ifdef __cplusplus

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -485,6 +485,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	getTypeId,
 	jvmUpcallsEagerByteInstrumentation,
 	jvmUpcallTransformArrayToList,
+	jfrInitializeInternalStructures,
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	initializeSnapshotClassLoaderObject,

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -50,6 +50,8 @@ J9_DECLARE_CONSTANT_NAS(bytesForEagerInstrumentationNAS, bytesForEagerInstrument
 J9_DECLARE_CONSTANT_UTF8(transformToListUTF8, "transformToList");
 J9_DECLARE_CONSTANT_UTF8(transformToListSigUTF8, "([Ljava/lang/Object;)Ljava/util/List;");
 J9_DECLARE_CONSTANT_NAS(transformToListNAS, transformToListUTF8, transformToListSigUTF8);
+J9_DECLARE_CONSTANT_UTF8(jfrInternalEventClassUTF8, "jdk/internal/event/Event");
+J9_DECLARE_CONSTANT_UTF8(jfrEventClassUTF8, "jdk/jfr/Event");
 
 // TODO: allow configureable values
 #define J9JFR_THREAD_BUFFER_SIZE (1024*1024)
@@ -70,6 +72,7 @@ static jlong getTypeIdImpl(J9VMThread *currentThread, J9ClassLoader *classLoader
 static bool addEventIds(J9JavaVM *vm);
 static bool addTypeIds(J9JavaVM *vm);
 #endif /* JAVA_SPEC_VERSION >= 17 */
+static void jfrShutdownInternalStructures(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData);
 
 /**
  * Calculate the size in bytes of a JFR event.
@@ -1473,6 +1476,10 @@ initializeJFRv2(J9JavaVM *vm)
 		goto done;
 	}
 
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_SHUTTING_DOWN, jfrShutdownInternalStructures, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+
 	if (0 != initializeJFRIDs(vm)) {
 		goto done;
 	}
@@ -1481,6 +1488,49 @@ initializeJFRv2(J9JavaVM *vm)
 
 done:
 	return rc;
+}
+
+void
+jfrInitializeInternalStructures(J9VMThread *currentThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9Class *jfrInternalEventClass = NULL;
+	J9Class *jfrEventClass = NULL;
+
+	jfrInternalEventClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrInternalEventClassUTF8), J9UTF8_LENGTH(&jfrInternalEventClassUTF8), vm->systemClassLoader, 0);
+	Assert_VM_notNull(jfrInternalEventClass);
+
+	jfrEventClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrEventClassUTF8), J9UTF8_LENGTH(&jfrEventClassUTF8), vm->systemClassLoader, 0);
+	Assert_VM_notNull(jfrEventClass);
+
+	vm->jfrState.jfrInternalEventClassRef = (jclass) vmFuncs->j9jni_createGlobalRef((JNIEnv *)currentThread, jfrInternalEventClass->classObject, FALSE);
+	vm->jfrState.jfrEventClassRef = (jclass) vmFuncs->j9jni_createGlobalRef((JNIEnv *)currentThread, jfrEventClass->classObject, FALSE);
+
+	if ((NULL == vm->jfrState.jfrEventClassRef) || (NULL == vm->jfrState.jfrInternalEventClassRef)) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+	} else {
+		vm->extendedRuntimeFlags3 |= J9_EXTENDED_RUNTIME3_ENABLE_JFR_CLASSLOAD_TRANSFORM;
+	}
+
+	return;
+}
+
+static void
+jfrShutdownInternalStructures(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData)
+{
+	J9VMThread *currentThread = ((J9VMInitEvent *)eventData)->vmThread;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vm->extendedRuntimeFlags3 &= ~J9_EXTENDED_RUNTIME3_ENABLE_JFR_CLASSLOAD_TRANSFORM;
+
+	internalAcquireVMAccess(currentThread);
+	vmFuncs->j9jni_deleteGlobalRef((JNIEnv *)currentThread, vm->jfrState.jfrEventClassRef, FALSE);
+	vmFuncs->j9jni_deleteGlobalRef((JNIEnv *)currentThread, vm->jfrState.jfrInternalEventClassRef, FALSE);
+	internalReleaseVMAccess(currentThread);
+	vm->jfrState.jfrEventClassRef = NULL;
+	vm->jfrState.jfrInternalEventClassRef = NULL;
 }
 
 static void

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -31,7 +31,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
 	</test>
 	<test id="Test JFRv2 cmdline option - memcheck">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -Xshare:off -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -Xshare:off -Djfr.unsupported.vm=false  -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
 	</test>
@@ -55,5 +55,15 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="required" caseSensitive="yes" regex="no">ExecutionSample</output>
 		<output type="success" caseSensitive="yes" regex="no">stackTrace</output>
 		<output type="required" caseSensitive="yes" regex="no">JVMInformation</output>
+	</test>
+	<test id="Test JFRv2 with JMX">
+		<command>$EXE$ -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Xshare:off -Djfr.unsupported.vm=false  -version</command>
+		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
+		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
+	</test>
+	<test id="Test JFRv2 with JMX and memcheck">
+		<command>$EXE$ -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Xshare:off -Djfr.unsupported.vm=false  -version</command>
+		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
+		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
 	</test>
 </suite>


### PR DESCRIPTION
Classfile modification capabilities need to be available before the
first subclass of jdk.jfr.Event is loaded as jfr may be enabled later
on in the JVM lifecycle. Currently we wait until jfr is started via
`createjfr`, however this will result in failures as some jfr event
classes (such as SecurityProviderServiceEvent) are loaded very early.

This change detects if jfr is enabled and initializes the jfr structures
and enables the upcall hook if jfr is enabled.

Fixes #23798