### PR TITLE
Update tests to add a sleep before destroying nonpersistent cache

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
@@ -152,6 +152,8 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
+
+	<exec command="sleep 0.5" platforms="linux.*" />
 	
 	<test id="Test 6: Clean up, destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>


### PR DESCRIPTION
Fix another failure in testSCCMLSnapshot which occurred once in the last nightly testing.

Related to https://github.com/eclipse-openj9/openj9/pull/23881