### PR TITLE
Fix formatting in gc

### DIFF
--- a/runtime/gc_glue_java/ConfigurationDelegate.hpp
+++ b/runtime/gc_glue_java/ConfigurationDelegate.hpp
@@ -123,18 +123,18 @@ public:
 		 * the default min and max DNSS expected ratios by a constant factor,
 		 * unless at least one ratio was directly specified by the user.
 		 */
-        double scaleFactor = 1;
-        bool xtune_footprint = javaVM->runtimeFlags & J9_RUNTIME_TUNE_FOOTPRINT;
-        if (xtune_footprint) {
-            scaleFactor = 4;
-        } else {
+		double scaleFactor = 1;
+		bool xtune_footprint = javaVM->runtimeFlags & J9_RUNTIME_TUNE_FOOTPRINT;
+		if (xtune_footprint) {
+			scaleFactor = 4;
+		} else {
 #if defined(J9VM_OPT_CRIU_SUPPORT)
-            if (javaVM->internalVMFunctions->isCRaCorCRIUSupportEnabled(javaVM)) {
-                scaleFactor = 2;
-            }
-#endif
-        }
-        if (!_extensions->dnssExpectedRatioMaximum._wasSpecified &&
+			if (javaVM->internalVMFunctions->isCRaCorCRIUSupportEnabled(javaVM)) {
+				scaleFactor = 2;
+			}
+#endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
+		}
+		if (!_extensions->dnssExpectedRatioMaximum._wasSpecified &&
 			!_extensions->dnssExpectedRatioMinimum._wasSpecified) {
 			_extensions->dnssExpectedRatioMaximum._valueSpecified *= scaleFactor;
 			_extensions->dnssExpectedRatioMinimum._valueSpecified *= scaleFactor;


### PR DESCRIPTION
Pull request https://github.com/eclipse-openj9/openj9/pull/23543 used spaces where it should have used tabs in the
file runtime/gc_glue_java/ConfigurationDelegate.hpp. This
pull request fixes it.

https://github.com/eclipse-openj9/openj9/pull/23543