### PR TITLE
Avoid warning from macOS linker on x86_64

### DIFF
--- a/runtime/makelib/targets.mk.osx.inc.ftl
+++ b/runtime/makelib/targets.mk.osx.inc.ftl
@@ -53,9 +53,9 @@ endif
 UMA_BEGIN_DASH_L =
 UMA_END_DASH_L =
 
-<#-- Reduce __PAGEZERO segment size from 4GB to 4KB to allocate memory below 4 GB. -->
+<#-- Reduce __PAGEZERO segment size from 4GB to 16KB to allocate memory below 4GB. -->
 <#if uma.spec.processor.amd64>
-UMA_EXE_PREFIX_FLAGS += -pagezero_size 0x1000
+UMA_EXE_PREFIX_FLAGS += -pagezero_size 0x4000
 </#if>
 
 UMA_EXE_POSTFIX_FLAGS += -lm -liconv -lc -ldl -lutil -Wl,-rpath,@loader_path


### PR DESCRIPTION
The linker warns `-pagezero_size not aligned, rounded up to: 0x4000`; just specify the aligned size to avoid the warning.

This is the equivalent to https://github.com/eclipse-omr/omr/pull/8253, but for UMA builds.