### PR TITLE
Add version.lib to Windows build dependencies

### DIFF
--- a/runtime/ddr/module.xml
+++ b/runtime/ddr/module.xml
@@ -353,6 +353,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<library name="pdh.lib" type="system" delayload="true">
 				<include-if condition="spec.win_.*"/>
 			</library>
+			<library name="version.lib" type="system" delayload="true">
+				<include-if condition="spec.win_.*"/>
+			</library>
 		</libraries>
 	</artifact>
 

--- a/runtime/jilgen/module.xml
+++ b/runtime/jilgen/module.xml
@@ -90,6 +90,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<library name="pdh.lib" type="system" delayload="true">
 				<include-if condition="spec.win_.*"/>
 			</library>
+			<library name="version.lib" type="system" delayload="true">
+				<include-if condition="spec.win_.*"/>
+			</library>
 		</libraries>
 	</artifact>
 

--- a/runtime/port/CMakeLists.txt
+++ b/runtime/port/CMakeLists.txt
@@ -166,6 +166,7 @@ if(OMR_OS_WINDOWS)
 			Iphlpapi.lib
 			psapi.lib
 			pdh.lib
+			version.lib
 	)
 endif()
 

--- a/runtime/port/module.xml
+++ b/runtime/port/module.xml
@@ -366,6 +366,9 @@
 			<library name="pdh.lib" type="system" delayload="true">
 				<include-if condition="spec.win_.*"/>
 			</library>
+			<library name="version.lib" type="system" delayload="true">
+				<include-if condition="spec.win_.*"/>
+			</library>
 		</libraries>
 	</artifact>
 </module>


### PR DESCRIPTION
version.lib must be linked at build time to call
the Windows version APIs directly, instead of 
loading them at runtime via LoadLibraryW and GetProcAddress.

Added to CMakeLists.txt and module.xml in the OpenJ9 port library.

Related: https://github.com/eclipse-omr/omr/pull/8233