### PR TITLE
Fix port library access function for z/OS CPU capacity macro

### DIFF
--- a/runtime/oti/j9port_generated.h
+++ b/runtime/oti/j9port_generated.h
@@ -757,7 +757,7 @@ extern J9_CFUNC int32_t j9port_isCompatible(struct J9PortLibraryVersion *expecte
 #define j9sysinfo_os_has_feature(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_os_has_feature(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)
 #define j9sysinfo_get_CPU_load(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_CPU_load(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
 #if defined(J9ZOS390)
-#define j9sysinfo_get_CPU_capacity(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_CPU_load(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
+#define j9sysinfo_get_CPU_capacity(param1) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_CPU_capacity(OMRPORT_FROM_J9PORT(privatePortLibrary),param1)
 #endif /* defined(J9ZOS390) */
 #if defined(J9VM_OPT_CRIU_SUPPORT)
 #define j9sysinfo_get_process_start_time(param1,param2) OMRPORT_FROM_J9PORT(privatePortLibrary)->sysinfo_get_process_start_time(OMRPORT_FROM_J9PORT(privatePortLibrary),param1,param2)


### PR DESCRIPTION
The j9sysinfo_get_CPU_capacity macro was incorrectly calling
sysinfo_get_CPU_load instead of sysinfo_get_CPU_capacity on z/OS
platforms (J9ZOS390). This caused CPU capacity queries to return
CPU load data instead, leading to incorrect performance metrics.

This fix ensures the macro calls the correct underlying port
library function to retrieve CPU capacity information.