### PR TITLE
Remove ant-contrib dependency from test build files

### DIFF
--- a/NOTICES.md
+++ b/NOTICES.md
@@ -146,11 +146,6 @@ Apache Log4J (2.16)
 
 * License: Apache-2.0
 
-apache-ant-contrib (1.0)
-
-* License: Apache-1.1 AND Apache-2.0
-* Project: http://ant-contrib.sourceforge.net/
-
 ASM (9.0)
 
 * License: New BSD License

--- a/buildenv/docker/mkdocker.sh
+++ b/buildenv/docker/mkdocker.sh
@@ -447,10 +447,7 @@ fi
   echo " && unzip -q ant.zip -d /opt \\"
   echo " && ln -s apache-ant-$ant_version /opt/ant \\"
   echo " && ln -s /opt/ant/bin/ant /usr/bin/ant \\"
-  echo " && $wget_O ant-contrib.tar.gz https://sourceforge.net/projects/ant-contrib/files/ant-contrib/1.0b3/ant-contrib-1.0b3-bin.tar.gz \\"
-  echo " && tar -xzf ant-contrib.tar.gz \\"
-  echo " && mv ant-contrib/ant-contrib-1.0b3.jar /opt/ant/lib \\"
-  echo " && rm -rf ant-contrib ant.zip ant-contrib.tar.gz"
+  echo " && rm -f ant.zip"
   echo ""
   local git_version=2.5.3
   echo "# Install git."
@@ -538,7 +535,6 @@ if [ $version = 18.04 ] || [ $version = 20.04 ] ; then
 fi
   echo " && apt-get install -qq -y --no-install-recommends \\"
   echo "    ant \\"
-  echo "    ant-contrib \\"
   echo "    autoconf \\"
   echo "    build-essential \\"
   echo "    ca-certificates \\"

--- a/buildenv/docker/test/Dockerfile
+++ b/buildenv/docker/test/Dockerfile
@@ -57,7 +57,6 @@ FROM ${IMAGE_NAME}:${IMAGE_VERSION}
 RUN apt-get update \
  && apt-get install -qq -y --no-install-recommends \
     ant \
-    ant-contrib \
     build-essential \
     perl \
     vim \

--- a/doc/compiler/jitserver/Testing.md
+++ b/doc/compiler/jitserver/Testing.md
@@ -76,13 +76,6 @@ These are the steps to run the tests on your machine.
    make compile
    ```
 
-   NOTE: to compile and run tests, ant-contrib.jar is needed, and on some systems just installing ant will not install ant-contrib.
-   On Ubuntu, the easiest way to get it is to run:
-
-   ```
-   sudo apt-get install ant-contrib
-   ```
-
 4. Run the tests!
 
    Manually start the server if `JITAAS` TEST_FLAG is not used.

--- a/sourcetools/JCL_Ant_Build/symlink_jcl.xml
+++ b/sourcetools/JCL_Ant_Build/symlink_jcl.xml
@@ -1,4 +1,6 @@
-<project name="symlink_jcl" basedir=".">
+<project name="symlink_jcl" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<!--
 	   Copyright IBM Corp. and others 2014
 
@@ -23,7 +25,6 @@
 	<description>Creates symlinks between </description>
 
 	<!-- Import custom tasks -->
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
 	<taskdef resource='com/ibm/j9/ant/antlib.xml'/>
 	<taskdef name="stringutil" classname="ise.antelope.tasks.StringUtilTask"/>
 
@@ -45,83 +46,50 @@
 		<lowercase/>
 	</stringutil>
 
-	<if>
+	<condition property="build.tag" value="cbuild_${build.component}">
 		<equals arg1="${build.type}" arg2="continuous"/>
-		<then>
-			<property name="build.tag" value="cbuild_${build.component}" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="pbuild_${build.component}">
 		<equals arg1="${build.type}" arg2="promotion"/>
-		<then>
-			<property name="build.tag" value="pbuild_${build.component}" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="ibuild">
 		<equals arg1="${build.type}" arg2="integration"/>
-		<then>
-			<property name="build.tag" value="ibuild" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="fbuild">
 		<equals arg1="${build.type}" arg2="feature"/>
-		<then>
-			<property name="build.tag" value="fbuild" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="sbuild">
 		<equals arg1="${build.type}" arg2="service"/>
-		<then>
-			<property name="build.tag" value="sbuild" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="ibuild">
 		<equals arg1="${build.type}" arg2="monolithic"/>
-		<then>
-			<property name="build.tag" value="ibuild" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="developer">
 		<equals arg1="${build.type}" arg2="developer"/>
-		<then>
-			<property name="build.tag" value="developer" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="customized">
 		<equals arg1="${build.type}" arg2="customized" />
-		<then>
-			<property name="build.tag" value="customized" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="codecoverage">
 		<equals arg1="${build.type}" arg2="codecoverage"/>
-		<then>
-			<property name="build.tag" value="codecoverage" />
-		</then>
-	</if>
-	<if>
+	</condition>
+	<condition property="build.tag" value="acceptance">
 		<equals arg1="${build.type}" arg2="acceptance"/>
-		<then>
-			<property name="build.tag" value="acceptance" />
-		</then>
-	</if>
+	</condition>
 
     <target name="symlink_JCLs_in_vmtank">
 
     <property name="dest.dir"           value="${store.root.dir}/${stream}/JCLandJCLTests/${job.buildId}" />
 
-    <if>
-            <equals arg1="${build.type}" arg2="feature" />
-            <then>
-                    <property name="feature.dest.dir"     value="${store.root.dir}/${product}/JCLandJCLTests" />
-                    <property name="command_line"         value="mkdir -p ${feature.dest.dir}/ ; rm -r ${feature.dest.dir}/${job.buildId} ; ln -s ${dest.dir} ${feature.dest.dir}/${job.buildId}" />
-            </then>
-            <else>
-                    <property name="dest.dir.symlink_1"   value="${store.root.dir}/${stream}/JCLandJCLTests/${build.tag}_${job.buildId}" />
-                    <property name="dest.dir.symlink_2"   value="${store.root.dir}/${stream}/JCLandJCLTests/${timestamp}_${job.buildId}" />
-                    <property name="command_line"         value="cd ${dest.dir} ; rm -r ${dest.dir.symlink_1}; ln -s ${job.buildId} ${dest.dir.symlink_1}; rm -r ${dest.dir.symlink_2}; ln -s ${job.buildId} ${dest.dir.symlink_2}" />
-            </else>
-    </if>
+    <condition property="condition_flag">
+        <equals arg1="${build.type}" arg2="feature" />
+    </condition>
+
+    <property name="feature.dest.dir"     value="${store.root.dir}/${product}/JCLandJCLTests" if:set="condition_flag"/>
+    <property name="command_line"         value="mkdir -p ${feature.dest.dir}/ ; rm -r ${feature.dest.dir}/${job.buildId} ; ln -s ${dest.dir} ${feature.dest.dir}/${job.buildId}" if:set="condition_flag"/>
+    <property name="dest.dir.symlink_1"   value="${store.root.dir}/${stream}/JCLandJCLTests/${build.tag}_${job.buildId}" unless:set="condition_flag"/>
+    <property name="dest.dir.symlink_2"   value="${store.root.dir}/${stream}/JCLandJCLTests/${timestamp}_${job.buildId}" unless:set="condition_flag"/>
+    <property name="command_line"         value="cd ${dest.dir} ; rm -r ${dest.dir.symlink_1}; ln -s ${job.buildId} ${dest.dir.symlink_1}; rm -r ${dest.dir.symlink_2}; ln -s ${job.buildId} ${dest.dir.symlink_2}" unless:set="condition_flag"/>
 		
 		<echo>Symlinking ${job.buildId} to ${dest.dir.symlink}</echo>
 		<sshexec host="${storage.server}"

--- a/test/TestConfig/build.xml
+++ b/test/TestConfig/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="TestConfig" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="TestConfig" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build TestConfig 
 	</description>
@@ -35,15 +36,10 @@
 		<mkdir dir="${DEST}" />
 	</target>
 
-	<if>
+		<condition property="TEXT_ENCODING" value="IBM-1047">
 		<contains string="${SPEC}" substring="zos"/>
-		<then>
-			<property name="TEXT_ENCODING" value="IBM-1047"/>
-		</then>
-		<else>
-			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
-		</else>
-	</if>
+	</condition>
+	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="build" depends="init">
 			<copy todir="${DEST}">

--- a/test/docs/Prerequisites.md
+++ b/test/docs/Prerequisites.md
@@ -22,7 +22,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 # Prerequisites:
 
-  * ant 1.9.6 or above with ant-contrib (1.0b2 or above)
+  * ant 1.9.6 or above
   * make 4.1 or above
   * perl 5.10.1 or above** 
   * curl 7.20.0 or above (needs -J/--remote-header-name support)

--- a/test/functional/CacheManagement/build.xml
+++ b/test/functional/CacheManagement/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="CacheManagement" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml' />
+<project name="CacheManagement" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build CacheManagement Tests
 	</description>
@@ -89,14 +90,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build" depends="buildCmdLineTestUtils">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/DDR_Test/build.xml
+++ b/test/functional/DDR_Test/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="DDR_Test" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="DDR_Test" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		DDR_Test
 	</description>
@@ -49,44 +50,41 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${transformerListener}" />
-					<src path="${TestUtilities}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/junit4.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-						<pathelement location="${TEST_JDK_HOME}/jre/lib/ddr/j9ddr.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${transformerListener}" />
-					<src path="${TestUtilities}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/junit4.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-					</classpath>
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.tools.ddrinteractive=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.tools.ddrinteractive.annotations=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9.gc=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9.walkers=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer.generated=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer.helper=ALL-UNNAMED" />
-					<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.types=ALL-UNNAMED" />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${transformerListener}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/junit4.jar" />
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/asm-all.jar" />
+			<pathelement location="${TEST_JDK_HOME}/jre/lib/ddr/j9ddr.jar" />
+			</classpath>
+		</javac>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${transformerListener}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/junit4.jar" />
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/asm-all.jar" />
+			</classpath>
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.tools.ddrinteractive=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.tools.ddrinteractive.annotations=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9.gc=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.j9.walkers=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer.generated=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.pointer.helper=ALL-UNNAMED" />
+			<compilerarg value="--add-exports=openj9.dtfj/com.ibm.j9ddr.vm29.types=ALL-UNNAMED" />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -119,26 +117,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<target name="build">
 		<echo>os.name: ${os.name}</echo>
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<if>
-					<resourcecount when="greater" count="0">
-						<fileset dir="${TEST_JDK_HOME}">
-							<include name="**/j9ddr.dat" />
-						</fileset>
-					</resourcecount>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-					<else>
-						<echo>File 'j9ddr.dat' not found; assuming JDK '${TEST_JDK_HOME}' does not support DDR.</echo>
-					</else>
-				</if>
-			</then>
-		</if>
+		</condition>
+
+		<condition property="condition_flag" if:set="is_JDK_IMPL_ibm">
+			<resourcecount when="greater" count="0">
+			<fileset dir="${TEST_JDK_HOME}">
+			<include name="**/j9ddr.dat" />
+			</fileset>
+			</resourcecount>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="condition_flag"/>
+		<echo unless:set="condition_flag" if:set="is_JDK_IMPL_ibm">File 'j9ddr.dat' not found; assuming JDK '${TEST_JDK_HOME}' does not support DDR.</echo>
 	</target>
 </project>

--- a/test/functional/DDR_Test/tck_ddrext.xml
+++ b/test/functional/DDR_Test/tck_ddrext.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="DDR Extension Test" default="clean">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="DDR Extension Test" default="clean"
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 
 	<property name="JAVA_COMMAND" value="${JAVA_COMMAND}" />
 	<property name="TEST_ROOT" value="${TEST_ROOT}" />
@@ -38,36 +39,25 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<property name="dump.name" value="DDREXT.J9CORE.DMP" />
 	<property name="system.dump" value="${REPORTDIR}/${dump.name}" />
-	<if>
+		<condition property="condition_flag">
 		<equals arg1="${OS}" arg2="os.zos" />
-		<then>
-			<property name="DUMP_OPTION" value="-Xdump:system:defaults:label=%uid.${dump.name},request=exclusive+compact+prepwalk -Xscmx16m -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M" />
-			<if>
-				<equals arg1="${BITS}" arg2="bits.64" />
-				<then>
-					<property name="zos.core.suffix" value=".X001" />
-				</then>
-				<else>
-					<property name="zos.core.suffix" value="" />
-				</else>
-			</if>
-		</then>
-		<else>
-			<property name="DUMP_OPTION" value="-Xdump:system:defaults:label=${system.dump},request=exclusive+compact+prepwalk -Xscmx16m -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit:count=0 -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M" />
-		</else>
-	</if>
+	</condition>
 
-	<if>
+	<property name="DUMP_OPTION" value="-Xdump:system:defaults:label=%uid.${dump.name},request=exclusive+compact+prepwalk -Xscmx16m -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M" if:set="condition_flag"/>
+	<condition property="zos.core.suffix" value=".X001" if:set="condition_flag">
+		<equals arg1="${BITS}" arg2="bits.64" />
+	</condition>
+	<property name="zos.core.suffix" value="" if:set="condition_flag"/>
+	<property name="DUMP_OPTION" value="-Xdump:system:defaults:label=${system.dump},request=exclusive+compact+prepwalk -Xscmx16m -Xshareclasses:name=ddrextjunitSCC,addtestjithints -Xjit:count=0 -Xaot:forceaot,count=5,disableAsyncCompilation -Xmx512M" unless:set="condition_flag"/>
+
+		<condition property="is_JDK_VERSION_8">
 		<equals arg1="${JDK_VERSION}" arg2="8" />
-		<then>
-			<path id="tck.class.path.j9ddr.jar">
-				<pathelement location="${TEST_JDK_HOME}/jre/lib/ddr/j9ddr.jar" />
-			</path>
-		</then>
-		<else>
-			<path id="tck.class.path.j9ddr.jar" />
-		</else>
-	</if>
+	</condition>
+
+	<path id="tck.class.path.j9ddr.jar" if:set="is_JDK_VERSION_8">
+		<pathelement location="${TEST_JDK_HOME}/jre/lib/ddr/j9ddr.jar" />
+	</path>
+	<path id="tck.class.path.j9ddr.jar" unless:set="is_JDK_VERSION_8"/>
 	<path id="tck.class.path">
 		<pathelement location="${LIB_DIR}/junit4.jar" />
 		<pathelement location="${LIB_DIR}/testng.jar" />
@@ -93,42 +83,39 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</java>
 	</target>
 
-	<if>
+		<condition property="is_JDK_VERSION_8">
 		<equals arg1="${JDK_VERSION}" arg2="8" />
-		<then>
-			<macrodef name="java-wrapper">
-				<attribute name="classname" />
-				<attribute name="failonerror" />
-				<attribute name="fork" default="true" />
-				<attribute name="jvm" />
-				<attribute name="timeout" />
-				<element name="common-elements" />
-				<element name="modular-elements" />
-				<sequential>
-					<java classname="@{classname}" failonerror="@{failonerror}" fork="@{fork}" jvm="@{jvm}" timeout="@{timeout}">
-						<common-elements />
-					</java>
-				</sequential>
-			</macrodef>
-		</then>
-		<else>
-			<macrodef name="java-wrapper">
-				<attribute name="classname" />
-				<attribute name="failonerror" />
-				<attribute name="fork" default="true" />
-				<attribute name="jvm" />
-				<attribute name="timeout" />
-				<element name="common-elements" />
-				<element name="modular-elements" />
-				<sequential>
-					<java classname="@{classname}" failonerror="@{failonerror}" fork="@{fork}" jvm="@{jvm}" timeout="@{timeout}">
-						<common-elements />
-						<modular-elements />
-					</java>
-				</sequential>
-			</macrodef>
-		</else>
-	</if>
+	</condition>
+
+	<macrodef name="java-wrapper" if:set="is_JDK_VERSION_8">
+		<attribute name="classname" />
+		<attribute name="failonerror" />
+		<attribute name="fork" default="true" />
+		<attribute name="jvm" />
+		<attribute name="timeout" />
+		<element name="common-elements" />
+		<element name="modular-elements" />
+		<sequential>
+		<java classname="@{classname}" failonerror="@{failonerror}" fork="@{fork}" jvm="@{jvm}" timeout="@{timeout}">
+		<common-elements />
+		</java>
+		</sequential>
+	</macrodef>
+	<macrodef name="java-wrapper" unless:set="is_JDK_VERSION_8">
+		<attribute name="classname" />
+		<attribute name="failonerror" />
+		<attribute name="fork" default="true" />
+		<attribute name="jvm" />
+		<attribute name="timeout" />
+		<element name="common-elements" />
+		<element name="modular-elements" />
+		<sequential>
+		<java classname="@{classname}" failonerror="@{failonerror}" fork="@{fork}" jvm="@{jvm}" timeout="@{timeout}">
+		<common-elements />
+		<modular-elements />
+		</java>
+		</sequential>
+	</macrodef>
 
 	<target name="TCK.run.tests.ddrext" depends="TCK.destroy.cache">
 		<!-- MacOSX needs -XstartOnFirstThread -->
@@ -209,12 +196,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<arg value="${TESTNUM}" />
 		</exec>
 
-		<if>
+		<condition property="condition_flag">
 			<equals arg1="${OS}" arg2="os.zos" />
-			<then>
-				<antcall target="TCK.move.dump.ddrext" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="TCK.move.dump.ddrext" if:set="condition_flag"/>
 	</target>
 
 	<target name="TCK.move.dump.ddrext" description="Move core file from MVS to HFS">
@@ -276,15 +262,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<os family="z/os" />
 		</condition>
 
-		<if>
+		<condition property="system.dump.location" value="${dump.name}${zos.core.suffix}">
 			<isset property="isZOS" />
-			<then>
-				<property name="system.dump.location" value="${dump.name}${zos.core.suffix}" />
-			</then>
-			<else>
-				<property name="system.dump.location" location="${system.dump}" />
-			</else>
-		</if>
+		</condition>
+		<property name="system.dump.location" location="${system.dump}"/>
 		<property name="tck.config.dump.opt.1" value="-Xdump:system:defaults:label=${system.dump.location},request=exclusive+compact+prepwalk" />
 
 		<property name="tck.config.dump.opts" value="${tck.config.dump.opt.1} ${tck.config.dump.opt.2} ${tck.config.dump.opt.3} ${tck.config.dump.opt.4} ${tck.core.xmx} ${tck.config.dump.opt.extra}" />

--- a/test/functional/HealthCenter/healthcenter.xml
+++ b/test/functional/HealthCenter/healthcenter.xml
@@ -20,31 +20,29 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="HealthCenter" default="sanity">
+<project name="HealthCenter" default="sanity"
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 
 	<target name="sanity">
-		<if>
+		<condition property="condition_flag">
 			<resourcecount when="greater" count="0">
 				<fileset dir="${TEST_JDK_HOME}">
 					<include name="**/healthcenter.properties" />
 				</fileset>
 			</resourcecount>
-			<then>
-				<echo>Running 'java -Xhealthcenter -version'</echo>
-				<echo>JAVA_COMMAND:  ${JAVA_COMMAND}</echo>
-				<echo>os.name:       ${os.name}</echo>
+		</condition>
 
-				<exec executable="${JAVA_COMMAND}" failonerror="true">
-					<arg value="-Xhealthcenter" />
-					<arg value="-version" />
-				</exec>
-			</then>
-			<else>
-				<echo>File 'healthcenter.properties' not found; assuming JDK '${TEST_JDK_HOME}' does not support HealthCenter.</echo>
-			</else>
-		</if>
+		<echo if:set="condition_flag">Running 'java -Xhealthcenter -version'</echo>
+		<echo if:set="condition_flag">JAVA_COMMAND:  ${JAVA_COMMAND}</echo>
+		<echo if:set="condition_flag">os.name:       ${os.name}</echo>
+
+		<exec executable="${JAVA_COMMAND}" failonerror="true" if:set="condition_flag">
+			<arg value="-Xhealthcenter" />
+			<arg value="-version" />
+		</exec>
+		<echo unless:set="condition_flag">File 'healthcenter.properties' not found; assuming JDK '${TEST_JDK_HOME}' does not support HealthCenter.</echo>
 	</target>
 
 </project>

--- a/test/functional/IllegalAccessError_for_protected_method/build.xml
+++ b/test/functional/IllegalAccessError_for_protected_method/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="IllegalAccessError_for_protected_method" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build IllegalAccessError for protected method test
 	</description>

--- a/test/functional/InstrumentationAgent/.classpath
+++ b/test/functional/InstrumentationAgent/.classpath
@@ -2,6 +2,5 @@
 <classpath>
 	<classpathentry kind="src" path="src"/>
 	<classpathentry kind="con" path="org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.8"/>
-	<classpathentry kind="lib" path="/binaries/common/third/ant-contrib.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/test/functional/InstrumentationAgent/build.xml
+++ b/test/functional/InstrumentationAgent/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="Instrumentation javaagent jar" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build Instrumentation agent java agent
 	</description>

--- a/test/functional/JIT_Test/build.xml
+++ b/test/functional/JIT_Test/build.xml
@@ -21,7 +21,6 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <project name="JIT_Test" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		JIT_Test
 	</description>

--- a/test/functional/JLM_Tests/build.xml
+++ b/test/functional/JLM_Tests/build.xml
@@ -20,7 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="JLM_Tests" default="build" basedir=".">
+<project name="JLM_Tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 
 	<description>
 		Build JLM Tests
@@ -55,58 +57,62 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${build}</echo>
 
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_80}" />
-					<src path="${transformerListener}" />
-					<src path="${TestUtilities}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/commons-exec.jar" />
-						<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
-					</classpath>
-					<exclude name="${excludeTestCRaCMXBean}" />
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED
-					--add-exports java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED
-					--add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
-					--add-exports java.management/javax.management=ALL-UNNAMED
-					--add-exports java.base/java.security=ALL-UNNAMED" />
-				<property name="TestUtilitiesExports" value="--add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED" />
-				<property name="srcpath" location="${src}:${src_90}:${transformerListener}:${TestUtilities}" />
-				<path id="build.cp">
-					<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="commons-exec.jar"/>
-				</path>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^(9|(1[0-8]))$$" />
-					<then>
-						<!-- Java 9-18 -->
-						<javac srcdir="${srcpath}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-							<compilerarg line='${addExports} ${TestUtilitiesExports}' />
-							<exclude name="${excludeTestCRaCMXBean}" />
-						</javac>
-					</then>
-					<else>
-						<!-- Java 19+ (SecurityManager removed) -->
-						<javac srcdir="${srcpath}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-							<compilerarg line='${addExports} ${TestUtilitiesExports}' />
-							<!-- exclude tests that depend on SecurityManager -->
-							<exclude name="org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean_SM.java" />
-							<exclude name="org/openj9/test/java/lang/management/TestRegression_SM.java" />
-							<exclude name="${excludeTestCRaCMXBean}" />
-						</javac>
-					</else>
-				</if>
-			</else>
-		</if>
+		</condition>
+
+		<!-- JDK 8 compilation -->
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${src_80}" />
+			<src path="${transformerListener}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar" />
+				<pathelement location="${LIB_DIR}/jcommander.jar" />
+				<pathelement location="${LIB_DIR}/commons-exec.jar" />
+				<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
+			</classpath>
+			<exclude name="${excludeTestCRaCMXBean}" />
+		</javac>
+
+		<!-- JDK 9+ properties -->
+		<property name="addExports" value="--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED
+			--add-exports java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED
+			--add-exports jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED
+			--add-exports java.management/javax.management=ALL-UNNAMED
+			--add-exports java.base/java.security=ALL-UNNAMED" />
+		<property name="TestUtilitiesExports" value="--add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED" />
+		<property name="srcpath" location="${src}:${src_90}:${transformerListener}:${TestUtilities}" />
+		<path id="build.cp">
+			<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="commons-exec.jar"/>
+		</path>
+
+		<condition property="is_JDK_9_to_18" unless:set="is_JDK_VERSION_8">
+			<matches string="${JDK_VERSION}" pattern="^(9|(1[0-8]))$$" />
+		</condition>
+		<condition property="is_JDK_19_plus" unless:set="is_JDK_VERSION_8">
+			<not>
+				<matches string="${JDK_VERSION}" pattern="^(8|9|(1[0-8]))$$" />
+			</not>
+		</condition>
+
+		<!-- Java 9-18 -->
+		<javac srcdir="${srcpath}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_9_to_18">
+			<compilerarg line='${addExports} ${TestUtilitiesExports}' />
+			<exclude name="${excludeTestCRaCMXBean}" />
+		</javac>
+
+		<!-- Java 19+ (SecurityManager removed) -->
+		<javac srcdir="${srcpath}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_19_plus">
+			<compilerarg line='${addExports} ${TestUtilitiesExports}' />
+			<!-- exclude tests that depend on SecurityManager -->
+			<exclude name="org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean_SM.java" />
+			<exclude name="org/openj9/test/java/lang/management/TestRegression_SM.java" />
+			<exclude name="${excludeTestCRaCMXBean}" />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -131,14 +137,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/Java10andUp/build.xml
+++ b/test/functional/Java10andUp/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="Java10AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="Java10AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Test Example
 	</description>
@@ -79,22 +80,20 @@
 	</target>
 	
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<if>
-					<not>
-						<matches string="${JDK_VERSION}" pattern="^(8|9)$$" />
-					</not>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-				</if>
-			</then>
-		</if>
+		</condition>
+
+		<condition property="is_JDK_VERSION_match" if:set="is_JDK_IMPL_ibm">
+			<not>
+			<matches string="${JDK_VERSION}" pattern="^(8|9)$$" />
+			</not>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/Java11andUp/build.xml
+++ b/test/functional/Java11andUp/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="Java11AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="Java11AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 11 and up
 	</description>
@@ -114,22 +115,20 @@
 	</target>
 	
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<if>
-					<not>
-						<matches string="${JDK_VERSION}" pattern="^(8|9|10)$$" />
-					</not>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-				</if>
-			</then>
-		</if>
+		</condition>
+
+		<condition property="is_JDK_VERSION_match" if:set="is_JDK_IMPL_ibm">
+			<not>
+			<matches string="${JDK_VERSION}" pattern="^(8|9|10)$$" />
+			</not>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/Java12andUp/build.xml
+++ b/test/functional/Java12andUp/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="Java12AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="Java12AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 12 and up
 	</description>
@@ -75,14 +76,13 @@
 	</target>
 	
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_VERSION_match">
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11)$$" />
 			</not>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/Java14andUp/build.xml
+++ b/test/functional/Java14andUp/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="Java14AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="Java14AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 14 and up
 	</description>
@@ -104,22 +105,20 @@
 	</target>
 	
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<if>
-					<not>
-						<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13)$$" />
-					</not>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-				</if>
-			</then>
-		</if>
+		</condition>
+
+		<condition property="is_JDK_VERSION_match" if:set="is_JDK_IMPL_ibm">
+			<not>
+			<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13)$$" />
+			</not>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/Java15andUp/build.xml
+++ b/test/functional/Java15andUp/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="Java15AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="Java15AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 15 and up
 	</description>
@@ -78,14 +79,13 @@
 	</target>
 	
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_VERSION_match">
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14)$$" />
 			</not>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/Java16andUp/build.xml
+++ b/test/functional/Java16andUp/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="Java16AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml' />
+<project name="Java16AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 16 and up
 	</description>
@@ -47,37 +48,39 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<property name="MODULE_NAME_ROOT" value="org.openj9test.modularity" />
 	<property name="MODULE_PATH_ROOT" value="org/openj9/test/modularity" />
 
+	<!-- Macrodef to compile a single module, replacing ant-contrib <for>/<var> loop -->
+	<macrodef name="compile-module">
+		<attribute name="mod"/>
+		<sequential>
+			<mkdir dir="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
+			<javac srcdir="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}"
+				destdir="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}"
+				includes="org/openj9/test/modularity/**,org/openj9/test/util/VersionCheck.java"
+				debug="true" fork="true"
+				executable="${compiler.javac}"
+				includeAntRuntime="false"
+				encoding="ISO-8859-1">
+				<compilerarg line='--add-reads org.openj9test.modularity.@{mod}=ALL-UNNAMED' />
+				<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+				<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+				<compilerarg line="--module-path ${module_bin_root} -d ${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
+				<classpath>
+					<pathelement location="${LIB_DIR}/testng.jar" />
+					<pathelement location="${LIB_DIR}/jcommander.jar" />
+					<pathelement location="${LIB_DIR}/asm.jar" />
+					<pathelement location="${build}" />
+				</classpath>
+			</javac>
+		</sequential>
+	</macrodef>
+
 	<target name="compile_modules" depends="init" description="Create the base modules for the sealed classes">
 		<mkdir dir="${module_bin_root}" />
 		<copy file="${LIB_DIR}/testng.jar" todir="${module_bin_root}" />
 		<copy file="${LIB_DIR}/jcommander.jar" todir="${module_bin_root}" />
 		<copy file="${LIB_DIR}/asm.jar" todir="${module_bin_root}" />
-		<for list="moduleX,moduleY" param="mod">
-			<sequential>
-				<var name="module_src_dir" value="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<var name="module_bin_dir" value="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<mkdir dir="${module_bin_dir}" />
-				<var name="modpath" value="--module-path ${module_bin_root} -d ${module_bin_dir}" />
-				<javac srcdir="${module_src_dir}"
-					destdir="${module_bin_dir}"
-					includes="org/openj9/test/modularity/**,org/openj9/test/util/VersionCheck.java"
-					debug="true" fork="true"
-					executable="${compiler.javac}"
-					includeAntRuntime="false"
-					encoding="ISO-8859-1">
-					<compilerarg line='--add-reads org.openj9test.modularity.@{mod}=ALL-UNNAMED' />
-					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
-					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
-					<compilerarg line="${modpath}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/asm.jar" />
-						<pathelement location="${build}" />
-					</classpath>
-				</javac>
-			</sequential>
-		</for>
+		<compile-module mod="moduleX"/>
+		<compile-module mod="moduleY"/>
 	</target>
 
 	<target name="compile" depends="init,getDependentLibs" description="Using java ${JDK_VERSION} to compile the source">
@@ -125,7 +128,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<and>
 				<or>
 					<!-- Exclude the tests for other impls, issue: https://github.com/eclipse-openj9/openj9/issues/14028#issuecomment-988225623 -->
@@ -136,10 +139,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 					<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15)$$" />
 				</not>
 			</and>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up">

--- a/test/functional/Java17andUp/build.xml
+++ b/test/functional/Java17andUp/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="Java17AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml' />
+<project name="Java17AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 17 and up
 	</description>
@@ -36,16 +37,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
 	<property name="TestUtilities" location="../TestUtilities/src"/>
 
-	<if>
+		<condition property="src_170" value="src_170">
 		<equals arg1="${JDK_VERSION}" arg2="17" />
-		<then>
-			<!-- Java APIs of JEP389 and related features in Java 16 is incompatible with the APIs in Java17 and beyond -->
-			<property name="src_170" value="src_170" />
-		</then>
-		<else>
-			<property name="src_170" value="" />
-		</else>
-	</if>
+	</condition>
+	<property name="src_170" value=""/>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -60,38 +55,35 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<if>
+		<condition property="is_JDK_VERSION_17">
 			<equals arg1="${JDK_VERSION}" arg2="17"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_170}" />
-					<src path="${TestUtilities}" />
-					<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
-					<compilerarg line='--add-modules jdk.incubator.foreign' />
-					<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
-					<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
-					<compilerarg line='--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/asm.jar" />
-						<pathelement location="${build}" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/asm.jar" />
-						<pathelement location="${build}" />
-					</classpath>
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_17">
+			<src path="${src}" />
+			<src path="${src_170}" />
+			<src path="${TestUtilities}" />
+			<compilerarg line='--enable-preview --source ${JDK_VERSION}' />
+			<compilerarg line='--add-modules jdk.incubator.foreign' />
+			<compilerarg line='--add-opens jdk.incubator.foreign/jdk.internal.foreign=ALL-UNNAMED' />
+			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
+			<compilerarg line='--add-opens java.base/jdk.internal.misc=ALL-UNNAMED' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/jcommander.jar" />
+			<pathelement location="${LIB_DIR}/asm.jar" />
+			<pathelement location="${build}" />
+			</classpath>
+		</javac>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_17">
+			<src path="${src}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/jcommander.jar" />
+			<pathelement location="${LIB_DIR}/asm.jar" />
+			<pathelement location="${build}" />
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -107,14 +99,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build">
-		<if>
+		<condition property="is_JDK_VERSION_match">
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9|10|11|12|13|14|15|16)$$" />
 			</not>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up">

--- a/test/functional/Java21Only/build.xml
+++ b/test/functional/Java21Only/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="Java21Only" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml' />
+<project name="Java21Only" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 21 only
 	</description>
@@ -77,12 +78,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build">
-		<if>
+		<condition property="is_JDK_VERSION_21">
 			<equals arg1="${JDK_VERSION}" arg2="21" />
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_21"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up">

--- a/test/functional/Java21andUp/build.xml
+++ b/test/functional/Java21andUp/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="Java21AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml' />
+<project name="Java21AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 21 and up
 	</description>
@@ -75,14 +76,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build">
-		<if>
+		<condition property="is_JDK_VERSION_match">
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|20)$$" />
 			</not>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up">

--- a/test/functional/Java22andUp/build.xml
+++ b/test/functional/Java22andUp/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="Java22AndUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml' />
+<project name="Java22AndUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java 22 and up
 	</description>
@@ -74,14 +75,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build">
-		<if>
+		<condition property="is_JDK_VERSION_match">
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-1])$$" />
 			</not>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up">

--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="J9 VM Java8andUp General Bucket" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="J9 VM Java8andUp General Bucket" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build J9 VM Java8andUp General Bucket
 	</description>
@@ -40,47 +41,31 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src" />
 	<property name="TestUtilities" location="../TestUtilities/src" />
 	<property name="TestUtilitiesJ9" location="../TestUtilitiesJ9/src" />
-	<if>
+	<condition property="src_90_jcl_dir" value="src_90_current">
 		<equals arg1="${JCL_VERSION}" arg2="current" />
-		<then>
-			<property name="src_90_jcl" location="src_90_current" />
-			<property name="addExports_90_jcl" value="--add-exports java.management/sun.management=ALL-UNNAMED" />
-		</then>
-		<else>
-			<property name="src_90_jcl" location="src_90_latest" />
-			<property name="addExports_90_jcl" value="--add-exports jdk.management.agent/jdk.internal.agent=ALL-UNNAMED" />
-		</else>
-	</if>
+	</condition>
+	<property name="src_90_jcl_dir" value="src_90_latest"/>
+	<property name="src_90_jcl" location="${src_90_jcl_dir}"/>
+	<condition property="addExports_90_jcl" value="--add-exports java.management/sun.management=ALL-UNNAMED">
+		<equals arg1="${JCL_VERSION}" arg2="current" />
+	</condition>
+	<property name="addExports_90_jcl" value="--add-exports jdk.management.agent/jdk.internal.agent=ALL-UNNAMED"/>
 
-	<if>
+		<condition property="is_JDK_VERSION_8">
 		<equals arg1="${JDK_VERSION}" arg2="8" />
-		<then>
-			<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" />
-		</then>
-		<else>
-			<if>
-				<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
-				<then>
-					<!-- Java 11-16 -->
-					<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_110" />
-				</then>
-				<else>
-					<!-- Java 17+ -->
-					<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_170" />
-				</else>
-			</if>
-		</else>
-	</if>
+	</condition>
 
-	<if>
+	<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" if:set="is_JDK_VERSION_8"/>
+	<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+		<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
+	</condition>
+	<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
+	<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
+
+	<condition property="addModules" value="--add-modules java.se.ee">
 		<matches string="${JDK_VERSION}" pattern="^(9|10)$$" />
-		<then>
-			<property name="addModules" value="--add-modules java.se.ee" />
-		</then>
-		<else>
-			<property name="addModules" value="" />
-		</else>
-	</if>
+	</condition>
+	<property name="addModules" value=""/>
 	<property name="LIB" value="asm_all,javassist,testng,jcommander,commons_cli,jaxb_api,asmtools" />
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
 
@@ -101,32 +86,29 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<copy overwrite="true" file="${NoSuchMethod_src}/java/lang/String.java.hide" tofile="${NoSuchMethod_src}/java/lang/String.java" />
 		<copy overwrite="true" file="${NoSuchMethod_src}/AppLoaderCallee.java.fake" tofile="${NoSuchMethod_src}/AppLoaderCallee.java" />
 		<!-- Compile the fake string impl and AppLoader caller with it -->
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
-						debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_access}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
-						debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<compilerarg line ="--patch-module java.base=${NoSuchMethod_src}/java/lang" />
-					<src path="${src_access}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-					</classpath>
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
+			debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src_access}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/asm-all.jar" />
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/jcommander.jar" />
+			</classpath>
+		</javac>
+		<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
+			debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<compilerarg line ="--patch-module java.base=${NoSuchMethod_src}/java/lang" />
+			<src path="${src_access}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/asm-all.jar" />
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/jcommander.jar" />
+			</classpath>
+		</javac>
 		<!-- remove our fake java.lang.string impl -->
 		<delete file="${NoSuchMethod_src}/java/lang/String.java" />
 		<!-- compile the rest of test code -->
@@ -177,159 +159,81 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 				<pathelement location="${LIB_DIR}/testng.jar" />
 			</classpath>
 		</javac>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_80}" />
-					<src path="${src_access}" />
-					<src path="${TestUtilities}" />
-					<src path="${TestUtilitiesJ9}" />
-					<src path="${transformerListener}" />
-					<exclude name="**/Cmvc194280.java" />
-					<exclude name="**/resources/**" />
-					<!-- requires special compilation methods -->
-					<exclude name="**/NoSuchMethod/**" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
-						<pathelement location="${LIB_DIR}/commons-cli.jar" />
-						<pathelement location="${LIB_DIR}/javassist.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<elseif>
-				<matches string="${JDK_VERSION}" pattern="^(9|10)$$" />
-				<then>
-					<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind.annotation=ALL-UNNAMED --add-exports java.xml.bind/javax.xml.bind=ALL-UNNAMED" />
-					<echo>===addExports:        ${addExports}</echo>
-					<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-						<src path="${src}" />
-						<src path="${src_90}" />
-						<src path="${src_90_jcl}" />
-						<src path="${src_access}" />
-						<src path="${TestUtilities}" />
-						<src path="${TestUtilitiesJ9}" />
-						<src path="${transformerListener}" />
-						<compilerarg line='${addExports}' />
-						<compilerarg line='${addExports_90_jcl}' />
-						<compilerarg line='${addModules}' />
-						<compilerarg line='--add-modules openj9.sharedclasses' />
-						<!-- PR117298 -->
-						<exclude name="**/Cmvc194280.java" />
-						<exclude name="**/resources/**" />
-						<!-- requires special compilation methods -->
-						<exclude name="**/NoSuchMethod/**" />
-						<classpath>
-							<pathelement location="${LIB_DIR}/asm-all.jar" />
-							<pathelement location="${LIB_DIR}/testng.jar" />
-							<pathelement location="${LIB_DIR}/jcommander.jar" />
-							<pathelement location="${LIB_DIR}/commons-cli.jar" />
-							<pathelement location="${LIB_DIR}/javassist.jar" />
-						</classpath>
-					</javac>
-					<javac srcdir="${src_80}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-						<include name="org/openj9/test/java/lang/Test_Thread_Extra.java" />
-						<src path="${src_access}" />
-						<classpath>
-							<pathelement location="${LIB_DIR}/testng.jar" />
-						</classpath>
-					</javac>
-				</then>
-			</elseif>
-			<else>
-				<if>
-					<equals arg1="${JDK_VERSION}" arg2="11" />
-					<then>
-						<!-- Java 11 -->
-						<property name="src_version" location="src_110" />
-						<property name="addExports_version" value="" />
-					</then>
-					<elseif>
-						<matches string="${JDK_VERSION}" pattern="^1[2-6]$$" />
-						<then>
-							<!-- Java 12-16 -->
-							<property name="src_version" location="src_120" />
-							<property name="addExports_version" value="--add-exports java.base/jdk.internal.access=ALL-UNNAMED" />
-						</then>
-					</elseif>
-					<else>
-						<!-- Java 17+ -->
-						<property name="src_version" location="src_170" />
-						<property name="addExports_version" value="--add-exports java.base/jdk.internal.access=ALL-UNNAMED" />
-					</else>
-				</if>
+		</condition>
 
-				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED --add-exports jdk.attach/com.ibm.tools.attach.attacher=ALL-UNNAMED" />
-				<echo>===addExports:        ${addExports}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${src_80}" />
+			<src path="${src_access}" />
+			<src path="${TestUtilities}" />
+			<src path="${TestUtilitiesJ9}" />
+			<src path="${transformerListener}" />
+			<exclude name="**/Cmvc194280.java" />
+			<exclude name="**/resources/**" />
+			<!-- requires special compilation methods -->
+			<exclude name="**/NoSuchMethod/**" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/asm-all.jar" />
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/jcommander.jar" />
+			<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
+			<pathelement location="${LIB_DIR}/commons-cli.jar" />
+			<pathelement location="${LIB_DIR}/javassist.jar" />
+			</classpath>
+		</javac>
+		<condition property="src_version_dir" value="src_110" unless:set="is_JDK_VERSION_8">
+			<equals arg1="${JDK_VERSION}" arg2="11" />
+		</condition>
+		<property name="src_version_dir" value="src_170" unless:set="is_JDK_VERSION_8"/>
+		<property name="src_version" location="${src_version_dir}" unless:set="is_JDK_VERSION_8"/>
+		<condition property="addExports_version" value="" unless:set="is_JDK_VERSION_8">
+			<equals arg1="${JDK_VERSION}" arg2="11" />
+		</condition>
+		<property name="addExports_version" value="--add-exports java.base/jdk.internal.access=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 
-				<property name="srcpath" location="${src}:${src_110_up}:${src_version}:${src_90_jcl}:${src_access}:${TestUtilities}:${TestUtilitiesJ9}:${transformerListener}" />
-				<!-- first two excludes are from PR117298, third exclude requires special compilation methods -->
-				<property name="commonExcludes" value="**/Cmvc194280.java,**/resources/**,**/NoSuchMethod/**" />
-				<path id="build.cp">
-					<fileset dir="${LIB_DIR}/" includes="asm-all.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="commons-cli.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="javassist.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="jaxb-api.jar"/>
-				</path>
-				<property name="commonArgs" value="${addExports} ${addExports_90_jcl} ${addExports_version} --add-modules openj9.sharedclasses" />
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^(1[1-8])$$" />
-					<then>
-						<!-- Java 11-18 -->
-						<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-							<compilerarg line='${commonArgs}' />
-						</javac>
-					</then>
-					<elseif>
-						<matches string="${JDK_VERSION}" pattern="^(19|2[0-2])$$" />
-						<then>
-							<!-- Java 19 - 22 (SecurityManager removed) -->
-							<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-								<compilerarg line='${commonArgs}' />
-								<!-- exclude tests that depend on SecurityManager -->
-								<exclude name="org/openj9/test/java/security/Test_AccessController.java" />
-								<exclude name="org/openj9/test/java/security/Test_AccessControlContext.java" />
-								<exclude name="org/openj9/test/java/lang/Test_Class_SM.java" />
-								<exclude name="org/openj9/test/java/lang/Test_System_SM.java" />
-								<exclude name="org/openj9/test/java/lang/Test_Thread_SM.java" />
-								<exclude name="org/openj9/test/java/lang/Test_ThreadGroup_SM.java" />
-								<exclude name="org/openj9/test/java/lang/invoke/Test_MethodHandleInfo_SM.java" />
-								<exclude name="org/openj9/test/java/lang/Test_ClassLoader_SM.java" />
-								<exclude name="org/openj9/test/java/lang/Test_J9VMInternals_SM.java" />
-								<exclude name="org/openj9/test/java/lang/Test_J9VMInternalsImpl_SM.java" />
-								<exclude name="org/openj9/test/vm/Test_VM.java" />
-							</javac>
-						</then>
-					</elseif>
-					<else>
-						<!-- Java 23+ (SecurityManage and Thread functions removed) -->
-						<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-							<compilerarg line='${commonArgs}' />
-							<!-- exclude tests that depend on SecurityManager or Thread functions -->
-							<exclude name="org/openj9/test/java/security/Test_AccessController.java" />
-							<exclude name="org/openj9/test/java/security/Test_AccessControlContext.java" />
-							<exclude name="org/openj9/test/java/lang/Test_Class_SM.java" />
-							<exclude name="org/openj9/test/java/lang/Test_System_SM.java" />
-							<exclude name="org/openj9/test/java/lang/Test_Thread_SM.java" />
-							<exclude name="org/openj9/test/java/lang/Test_ThreadGroup_SM.java" />
-							<exclude name="org/openj9/test/java/lang/invoke/Test_MethodHandleInfo_SM.java" />
-							<exclude name="org/openj9/test/java/lang/Test_ClassLoader_SM.java" />
-							<exclude name="org/openj9/test/java/lang/Test_J9VMInternals_SM.java" />
-							<exclude name="org/openj9/test/java/lang/Test_J9VMInternalsImpl_SM.java" />
-							<exclude name="org/openj9/test/java/lang/Test_Thread.java" />
-							<exclude name="org/openj9/test/java/lang/Test_ThreadGroup.java" />
-							<exclude name="org/openj9/test/vm/Test_VM.java" />
-						</javac>
-					</else>
-				</if>
-			</else>
-		</if>
+		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED --add-exports jdk.attach/com.ibm.tools.attach.attacher=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<echo unless:set="is_JDK_VERSION_8">===addExports:        ${addExports}</echo>
+
+		<property name="srcpath" location="${src}:${src_110_up}:${src_version}:${src_90_jcl}:${src_access}:${TestUtilities}:${TestUtilitiesJ9}:${transformerListener}" unless:set="is_JDK_VERSION_8"/>
+		<!-- first two excludes are from PR117298, third exclude requires special compilation methods -->
+		<property name="commonExcludes" value="**/Cmvc194280.java,**/resources/**,**/NoSuchMethod/**" unless:set="is_JDK_VERSION_8"/>
+		<path id="build.cp" unless:set="is_JDK_VERSION_8">
+			<fileset dir="${LIB_DIR}/" includes="asm-all.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="commons-cli.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="javassist.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="jaxb-api.jar"/>
+		</path>
+		<property name="commonArgs" value="${addExports} ${addExports_90_jcl} ${addExports_version} --add-modules openj9.sharedclasses" unless:set="is_JDK_VERSION_8"/>
+		<condition property="is_JDK_VERSION_match">
+			<matches string="${JDK_VERSION}" pattern="^(8|1[1-8])$$" />
+		</condition>
+
+		<!-- Java 11-18 -->
+		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_VERSION_match" unless:set="is_JDK_VERSION_8">
+			<compilerarg line='${commonArgs}' />
+		</javac>
+		<!-- Java 23+ (SecurityManage and Thread functions removed) -->
+		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" unless:set="is_JDK_VERSION_match">
+			<compilerarg line='${commonArgs}' />
+			<!-- exclude tests that depend on SecurityManager or Thread functions -->
+			<exclude name="org/openj9/test/java/security/Test_AccessController.java" />
+			<exclude name="org/openj9/test/java/security/Test_AccessControlContext.java" />
+			<exclude name="org/openj9/test/java/lang/Test_Class_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_System_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_Thread_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_ThreadGroup_SM.java" />
+			<exclude name="org/openj9/test/java/lang/invoke/Test_MethodHandleInfo_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_ClassLoader_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_J9VMInternals_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_J9VMInternalsImpl_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_Thread.java" />
+			<exclude name="org/openj9/test/java/lang/Test_ThreadGroup.java" />
+			<exclude name="org/openj9/test/vm/Test_VM.java" />
+		</javac>
 	</target>
 
 	<target name="jasm_generator" depends="init,getDependentLibs" description="prepare jasm files">
@@ -433,17 +337,16 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<subant target="build">
-					<fileset dir="${TEST_ROOT}/functional/InstrumentationAgent" includes="build.xml" />
-				</subant>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<subant target="build" if:set="is_JDK_IMPL_ibm">
+			<fileset dir="${TEST_ROOT}/functional/InstrumentationAgent" includes="build.xml" />
+		</subant>
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/Java9andUp/build.xml
+++ b/test/functional/Java9andUp/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="Java9andUp" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="Java9andUp" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Tests for Java9andUp
 	</description>
@@ -75,52 +76,45 @@
 
 	<property name="MODULE_NAME_ROOT" value="org.openj9test.modularity" />
 	<property name="MODULE_PATH_ROOT" value="org/openj9/test/modularity"/>
+
+	<!-- Macrodef to compile a single module, replacing ant-contrib <for>/<var> loop -->
+	<macrodef name="compile-module">
+		<attribute name="mod"/>
+		<attribute name="modpath-prefix" default="--module-path ${module_bin_root} -d"/>
+		<attribute name="modpath-suffix" default=""/>
+		<element name="extra-classpath" optional="true"/>
+		<sequential>
+			<mkdir dir="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
+			<javac srcdir="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" destdir="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
+				<src path="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" />
+				<compilerarg line="@{modpath-prefix} ${module_bin_root}/${MODULE_NAME_ROOT}.@{mod} @{modpath-suffix}" />
+				<extra-classpath/>
+			</javac>
+		</sequential>
+	</macrodef>
+
 	<target name="build_modules" depends="init" description="Create the base modules for the modularity tests ">
 		<mkdir dir="${module_bin_root}" />
 		<copy file="${LIB_DIR}/testng.jar" todir="${module_bin_root}" />
 		<copy file="${LIB_DIR}/jcommander.jar" todir="${module_bin_root}" />
-		<for list="common,moduleD,moduleC,moduleB,moduleA,testerModule,dummy" param="mod">
-			<sequential>
-				<var name="module_src_dir" value="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<var name="module_bin_dir" value="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<mkdir dir="${module_bin_dir}" />
-				<var name="modpath" value="--module-path ${module_bin_root} -d ${module_bin_dir}" />
-				<javac srcdir="${module_src_dir}" destdir="${module_bin_dir}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${module_src_dir}" />
-					<compilerarg line="${modpath}" />
-				</javac>
-			</sequential>
-		</for>
+		<compile-module mod="common"/>
+		<compile-module mod="moduleD"/>
+		<compile-module mod="moduleC"/>
+		<compile-module mod="moduleB"/>
+		<compile-module mod="moduleA"/>
+		<compile-module mod="testerModule"/>
+		<compile-module mod="dummy"/>
 		<!-- compile unnamed module depending on module org.openj9test.modularity.dummy -->
-		<for list="unnamed" param="mod">
-			<sequential>
-				<var name="module_src_dir" value="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<var name="module_bin_dir" value="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<mkdir dir="${module_bin_dir}" />
-				<var name="modpath" value="-cp ${LIB_DIR}/testng.jar --module-path ${module_bin_root} -d ${module_bin_dir} --add-modules org.openj9test.modularity.dummy --add-exports org.openj9test.modularity.dummy/org.openj9.test.modularity.dummy=ALL-UNNAMED" />
-				<javac srcdir="${module_src_dir}" destdir="${module_bin_dir}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${module_src_dir}" />
-					<compilerarg line="${modpath}" />
-				</javac>
-			</sequential>
-		</for>
+		<compile-module mod="unnamed" modpath-prefix="-cp ${LIB_DIR}/testng.jar --module-path ${module_bin_root} -d" modpath-suffix="--add-modules org.openj9test.modularity.dummy --add-exports org.openj9test.modularity.dummy/org.openj9.test.modularity.dummy=ALL-UNNAMED"/>
 		<!-- compile module org.openj9test.modularity.testUnreflect depending on unnamed module above -->
-		<for list="testUnreflect" param="mod">
-			<sequential>
-				<var name="module_src_dir" value="${module_src_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<var name="module_bin_dir" value="${module_bin_root}/${MODULE_NAME_ROOT}.@{mod}" />
-				<mkdir dir="${module_bin_dir}" />
-				<var name="modpath" value="--module-path ${module_bin_root} -d ${module_bin_dir} --add-reads org.openj9test.modularity.testUnreflect=ALL-UNNAMED" />
-				<javac srcdir="${module_src_dir}" destdir="${module_bin_dir}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${module_src_dir}" />
-					<classpath>
-						<pathelement location="${module_bin_root}/org.openj9test.modularity.unnamed" />
-						<pathelement location="${LIB_DIR}/testng.jar" />
-					</classpath>
-					<compilerarg line="${modpath}" />
-				</javac>
-			</sequential>
-		</for>
+		<compile-module mod="testUnreflect" modpath-suffix="--add-reads org.openj9test.modularity.testUnreflect=ALL-UNNAMED">
+			<extra-classpath>
+				<classpath>
+					<pathelement location="${module_bin_root}/org.openj9test.modularity.unnamed" />
+					<pathelement location="${LIB_DIR}/testng.jar" />
+				</classpath>
+			</extra-classpath>
+		</compile-module>
 		<exec executable="${TEST_JDK_HOME}/bin/java" failonerror="true">
 			<arg line="-jar ${LIB_DIR}/asmtools.jar jasm -d ${module_bin_root}/${MODULE_NAME_ROOT}.testerModule ${module_src_root}/${MODULE_NAME_ROOT}.testerModule/${MODULE_PATH_ROOT}/tests/MethodHandleTester.jasm" />
 		</exec>
@@ -136,36 +130,33 @@
 			<fileset dir="${src}/../" includes="*.xml" />
 			<fileset dir="${src}/../" includes="*.mk" />
 		</copy>
-		<if>
+		<condition property="is_JCL_VERSION_latest">
 			<!-- These tests are not supported for build 148 -->
 			<equals arg1="${JCL_VERSION}" arg2="latest"/>
-			<then>
-				<echo>copy ${module_bin_root} to ${dest_module_bin}</echo>
-				<mkdir dir="${dest_module_bin}"/>
-				<copy todir="${dest_module_bin}">
-					<fileset dir="${module_bin_root}"/>
-				</copy>
-			</then>
-		</if>
+		</condition>
+
+		<echo if:set="is_JCL_VERSION_latest">copy ${module_bin_root} to ${dest_module_bin}</echo>
+		<mkdir dir="${dest_module_bin}" if:set="is_JCL_VERSION_latest"/>
+		<copy todir="${dest_module_bin}" if:set="is_JCL_VERSION_latest">
+			<fileset dir="${module_bin_root}"/>
+		</copy>
 	</target>
 
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<if>
-					<not>
-						<equals arg1="${JDK_VERSION}" arg2="8"/>
-					</not>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-				</if>
-			</then>
-		</if>
+		</condition>
+
+		<condition property="is_not_JDK_VERSION_8" if:set="is_JDK_IMPL_ibm">
+			<not>
+				<equals arg1="${JDK_VERSION}" arg2="8"/>
+			</not>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_not_JDK_VERSION_8"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/JavaAgentTest/build.xml
+++ b/test/functional/JavaAgentTest/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="J9 Javaagent tests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="J9 Javaagent tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
        Build J9 Javaagent tests
     </description>
@@ -46,53 +47,42 @@
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="src_version_dir" value="./src_java8">
 			<matches string="${JDK_VERSION}" pattern="^(8|9|10|11)$$" />
-			<then>
-				<property name="src_version" location="./src_java8" />
-			</then>
-			<else> 
-				<!-- Java 12+ -->
-				<property name="src_version" location="./src_java12" />
-			</else>
-		</if>
-		<if>
+		</condition>
+		<property name="src_version_dir" value="./src_java12"/>
+		<property name="src_version" location="${src_version_dir}"/>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_version}" />
-					<src path="${transformerListener}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/jcommander.jar" />
-						<pathelement location="${LIB_DIR}/asm-all.jar"/>
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^(1[1-9]|2[0-4])$$" />
-					<then>
-						<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.util=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.commons=ALL-UNNAMED"/>
-						<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-							<src path="${src}" />
-							<src path="${src_version}" />
-							<src path="${transformerListener}" />
-							<compilerarg line='${addExports}' />
-							<classpath>
-								<pathelement location="${LIB_DIR}/testng.jar" />
-								<pathelement location="${LIB_DIR}/jcommander.jar" />
-								<pathelement location="${LIB_DIR}/asm-all.jar"/>
-							</classpath>
-						</javac>
-					</then>
-					<else>
-						<!-- Java 25+ is disabled temporarily - https://github.com/eclipse-openj9/openj9/issues/21463 -->
-					</else>
-				</if>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${src_version}" />
+			<src path="${transformerListener}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/jcommander.jar" />
+			<pathelement location="${LIB_DIR}/asm-all.jar"/>
+			</classpath>
+		</javac>
+		<condition property="is_JDK_VERSION_match" unless:set="is_JDK_VERSION_8">
+			<matches string="${JDK_VERSION}" pattern="^(1[1-9]|2[0-4])$$" />
+		</condition>
+
+		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.tree=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.util=ALL-UNNAMED --add-exports java.base/jdk.internal.org.objectweb.asm.commons=ALL-UNNAMED" if:set="is_JDK_VERSION_match" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_match" unless:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${src_version}" />
+			<src path="${transformerListener}" />
+			<compilerarg line='${addExports}' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/jcommander.jar" />
+			<pathelement location="${LIB_DIR}/asm-all.jar"/>
+			</classpath>
+		</javac>
+		<!-- Java 25+ is disabled temporarily - https://github.com/eclipse-openj9/openj9/issues/21463 -->
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution" >
@@ -113,14 +103,13 @@
 	</target>
 
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/Jsr292/build.xml
+++ b/test/functional/Jsr292/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="J9 JSR 292 Tests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="J9 JSR 292 Tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build J9 JSR 292 Tests 
 	</description>
@@ -112,31 +113,23 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${bootstrapSrc}" destdir="${bootstrapBuild}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${bootstrapSrc}"/>
-					<src path="${bootstrapSrc_80}"/>
-				</javac>
-			</then>
-			<else>
-				<if>
-					<equals arg1="${JCL_VERSION}" arg2="latest"/>
-					<then>
-						<property name="addExports" value="--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" />
-					</then>
-					<else>
-						<property name="addExports" value="--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" />
-					</else>
-				</if>
-				<javac srcdir="${bootstrapSrc}" destdir="${bootstrapBuild}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${bootstrapSrc}"/>
-					<src path="${bootstrapSrc_90}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${bootstrapSrc}" destdir="${bootstrapBuild}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${bootstrapSrc}"/>
+			<src path="${bootstrapSrc_80}"/>
+		</javac>
+		<condition property="addExports" value="--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8">
+			<equals arg1="${JCL_VERSION}" arg2="latest"/>
+		</condition>
+		<property name="addExports" value="--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${bootstrapSrc}" destdir="${bootstrapBuild}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${bootstrapSrc}"/>
+			<src path="${bootstrapSrc_90}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 	</target>
 
 	<target name="compile" depends="compile_bootstrap, generate_indyn" description="compile the test source " >
@@ -146,76 +139,70 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}"/>
-					<src path="${transformerListener}" />
-					<src path="${TestUtilities}" /> 
-					<!-- exclude files only for jdk9 -->
-					<exclude name="**/MethodHandleAPI_asCollector.java" />
-					<exclude name="**/MethodHandleAPI_asSpreader.java" />
-					<exclude name="**/MethodHandleAPI_foldArguments.java" />
-					<exclude name="**/MethodHandleAPI_withVarargs.java" />
-					<exclude name="**/MethodHandleAPI_tryFinally.java" />
-					<exclude name="**/MethodHandleAPI_loop.java" />
-					<exclude name="**/MethodHandleAPI_iteratedLoop.java" />
-					<exclude name="**/MethodHandleAPI_zero.java" />
-					<exclude name="**/MethodHandleAPI_whileLoop.java" />
-					<exclude name="**/MethodHandleAPI_countedLoop.java"/>
-					<exclude name="**/MethodHandleAPI_arrayLength.java" />
-					<exclude name="**/MethodHandleAPI_arrayConstructor.java" />
-					<exclude name="**/MethodHandleAPI_dropLookupMode.java" />
-					<exclude name="**/SamePackageExample.java" />
-					<exclude name="**/LookupAPITests_FindClass.java" />
-					<exclude name="**/LookupAPITests_AccessClass.java"/>
-					<exclude name="**/MethodHandleAPI_dropArgumentsToMatch.java" />
-					
-					<!-- exclude non test files for indyn test -->
-					<exclude name="**/indyn/BootstrapMethods.java" />
-					<exclude name="**/indyn/ComplexIndyGenerator.java" />
-					<exclude name="**/indyn/Helper.java" />
-					<exclude name="**/indyn/SimpleIndyGenerator.java" />
-					<exclude name="**/CrossPackageHelper.java"/>
-					<exclude name="**/attachAPI/**" />
-					<classpath>
-						<pathelement location="${bootstrapBuild}"/>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-						<pathelement location="${LIB_DIR}/junit4.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-						<pathelement location="${LIB_DIR}/jcommander.jar"/>
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<property name="srcpath" location="${src}:${transformerListener}:${TestUtilities}" />
-				<!-- exclude non test files for indyn test -->
-				<property name="commonExcludes" value="**/indyn/BootstrapMethods.java,**/indyn/ComplexIndyGenerator.java,**/indyn/Helper.java,**/indyn/SimpleIndyGenerator.java,**/CrossPackageHelper.java,**/attachAPI/**" />
-				<path id="build.cp">
-					<pathelement location="${bootstrapBuild}/"/>
-					<fileset dir="${LIB_DIR}/" includes="asm-all.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="junit4.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
-					<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
-				</path>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^(9|(1[0-8]))$$" />
-					<then>
-						<!-- Java 9-18 -->
-						<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-						</javac>
-					</then>
-					<else>
-						<!-- Java 19+ (SecurityManager removed) -->
-						<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-							<!-- exclude tests that depend on SecurityManager -->
-							<exclude name="com/ibm/j9/jsr292/MethodTypeTests_SM.java"/>
-						</javac>
-					</else>
-				</if>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}"/>
+			<src path="${transformerListener}" />
+			<src path="${TestUtilities}" />
+			<!-- exclude files only for jdk9 -->
+			<exclude name="**/MethodHandleAPI_asCollector.java" />
+			<exclude name="**/MethodHandleAPI_asSpreader.java" />
+			<exclude name="**/MethodHandleAPI_foldArguments.java" />
+			<exclude name="**/MethodHandleAPI_withVarargs.java" />
+			<exclude name="**/MethodHandleAPI_tryFinally.java" />
+			<exclude name="**/MethodHandleAPI_loop.java" />
+			<exclude name="**/MethodHandleAPI_iteratedLoop.java" />
+			<exclude name="**/MethodHandleAPI_zero.java" />
+			<exclude name="**/MethodHandleAPI_whileLoop.java" />
+			<exclude name="**/MethodHandleAPI_countedLoop.java"/>
+			<exclude name="**/MethodHandleAPI_arrayLength.java" />
+			<exclude name="**/MethodHandleAPI_arrayConstructor.java" />
+			<exclude name="**/MethodHandleAPI_dropLookupMode.java" />
+			<exclude name="**/SamePackageExample.java" />
+			<exclude name="**/LookupAPITests_FindClass.java" />
+			<exclude name="**/LookupAPITests_AccessClass.java"/>
+			<exclude name="**/MethodHandleAPI_dropArgumentsToMatch.java" />
+
+			<!-- exclude non test files for indyn test -->
+			<exclude name="**/indyn/BootstrapMethods.java" />
+			<exclude name="**/indyn/ComplexIndyGenerator.java" />
+			<exclude name="**/indyn/Helper.java" />
+			<exclude name="**/indyn/SimpleIndyGenerator.java" />
+			<exclude name="**/CrossPackageHelper.java"/>
+			<exclude name="**/attachAPI/**" />
+			<classpath>
+			<pathelement location="${bootstrapBuild}"/>
+			<pathelement location="${LIB_DIR}/asm-all.jar" />
+			<pathelement location="${LIB_DIR}/junit4.jar" />
+			<pathelement location="${LIB_DIR}/testng.jar"/>
+			<pathelement location="${LIB_DIR}/jcommander.jar"/>
+			</classpath>
+		</javac>
+		<property name="srcpath" location="${src}:${transformerListener}:${TestUtilities}" unless:set="is_JDK_VERSION_8"/>
+		<!-- exclude non test files for indyn test -->
+		<property name="commonExcludes" value="**/indyn/BootstrapMethods.java,**/indyn/ComplexIndyGenerator.java,**/indyn/Helper.java,**/indyn/SimpleIndyGenerator.java,**/CrossPackageHelper.java,**/attachAPI/**" unless:set="is_JDK_VERSION_8"/>
+		<path id="build.cp" unless:set="is_JDK_VERSION_8">
+			<pathelement location="${bootstrapBuild}/"/>
+			<fileset dir="${LIB_DIR}/" includes="asm-all.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="junit4.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="testng.jar"/>
+			<fileset dir="${LIB_DIR}/" includes="jcommander.jar"/>
+		</path>
+		<condition property="is_JDK_VERSION_match">
+			<matches string="${JDK_VERSION}" pattern="^(8|9|(1[0-8]))$$" />
+		</condition>
+
+		<!-- Java 9-18 -->
+		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_VERSION_match" unless:set="is_JDK_VERSION_8">
+		</javac>
+		<!-- Java 19+ (SecurityManager removed) -->
+		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" unless:set="is_JDK_VERSION_match">
+			<!-- exclude tests that depend on SecurityManager -->
+			<exclude name="com/ibm/j9/jsr292/MethodTypeTests_SM.java"/>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution" >

--- a/test/functional/Jsr335/build.xml
+++ b/test/functional/Jsr335/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="J9 JSR335 Test" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="J9 JSR335 Test" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build J9 JSR335 Test
 	</description>
@@ -49,27 +50,18 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
 
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" />
-				<property name="addExports" value="" />
-			</then>
-			<else>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
-					<then>
-						<!-- Java 11-16 -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_110" />
-					</then>
-					<else>
-						<!-- Java 17+ -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_170" />
-					</else>
-				</if>
-				<property name="addExports" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
-			</else>
-		</if>
+		</condition>
+
+		<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" if:set="is_JDK_VERSION_8"/>
+		<property name="addExports" value="" if:set="is_JDK_VERSION_8"/>
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
+		</condition>
+		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
+		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
+		<property name="addExports" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<src path="${src}" />
@@ -102,15 +94,14 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 
 </project>

--- a/test/functional/Jsr335_interfaceStaticMethod/build.xml
+++ b/test/functional/Jsr335_interfaceStaticMethod/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name=" JSR335 InterfaceStaticMethod Test" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build JSR335 InterfaceStaticMethod Test
 	</description>

--- a/test/functional/NativeTest/build.xml
+++ b/test/functional/NativeTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="NativeTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build NativeTest
 	</description>

--- a/test/functional/NativeTest/jniargtests/build.xml
+++ b/test/functional/NativeTest/jniargtests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="JNIARGTESTS" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>JNIARGTESTS</description>
 
 	<!-- set global properties for this build -->

--- a/test/functional/OpenJ9_Jsr_292_API/build.xml
+++ b/test/functional/OpenJ9_Jsr_292_API/build.xml
@@ -20,8 +20,9 @@
 
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="OpenJ9 JSR 292 API Tests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="OpenJ9 JSR 292 API Tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build OpenJ9 JSR 292 API Tests 
 	</description>
@@ -68,18 +69,17 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
 			</not>
-			<then>
-				<property name="modulec_path" value="--module-path ${mods_dir} -d ${modulec_bin}" />
-				<javac srcdir="${modulec_src}" destdir="${modulec_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${modulec_src}"/>
-					<compilerarg line='${modulec_path}' />
-				</javac>
-			</then>
-		</if>
+		</condition>
+
+		<property name="modulec_path" value="--module-path ${mods_dir} -d ${modulec_bin}" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${modulec_src}" destdir="${modulec_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${modulec_src}"/>
+			<compilerarg line='${modulec_path}' />
+		</javac>
 	</target>
 
 	<target name="compile_moduleb" depends="init" description="Compile the module files in mods.moduleb">
@@ -91,18 +91,17 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
 			</not>
-			<then>
-				<property name="moduleb_path" value="--module-path ${mods_dir} -d ${moduleb_bin}" />
-				<javac srcdir="${moduleb_src}" destdir="${moduleb_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${moduleb_src}"/>
-					<compilerarg line='${moduleb_path}' />
-				</javac>
-			</then>
-		</if>
+		</condition>
+
+		<property name="moduleb_path" value="--module-path ${mods_dir} -d ${moduleb_bin}" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${moduleb_src}" destdir="${moduleb_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${moduleb_src}"/>
+			<compilerarg line='${moduleb_path}' />
+		</javac>
 	</target>
 	
 	<target name="compile_modulea" depends="init,compile_moduleb,compile_modulec" description="Compile the module files in mods.modulea">
@@ -114,18 +113,17 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
 			</not>
-			<then>
-				<property name="modulea_path" value="--module-path ${mods_dir} -d ${modulea_bin}" />
-				<javac srcdir="${modulea_src}" destdir="${modulea_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${modulea_src}"/>
-					<compilerarg line='${modulea_path}' />
-				</javac>
-			</then>
-		</if>
+		</condition>
+
+		<property name="modulea_path" value="--module-path ${mods_dir} -d ${modulea_bin}" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${modulea_src}" destdir="${modulea_bin}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${modulea_src}"/>
+			<compilerarg line='${modulea_path}' />
+		</javac>
 	</target>
 	
 	<target name="compile_tests" depends="init,compile_modulea,compile_moduleb,compile_modulec,getDependentLibs" description="compile the test source code" >
@@ -136,24 +134,23 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<not>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
 			</not>
-			<then>
-				<property name="addModules" value="--add-modules ${modulea_name},${moduleb_name},${modulec_name}  --module-path ${mods_dir}" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}"/>
-					<src path="${transformerListener}" />
-					<compilerarg line='${addModules}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm-all.jar" />
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-						<pathelement location="${LIB_DIR}/jcommander.jar"/>
-					</classpath>
-				</javac>
-			</then>
-		</if>
+		</condition>
+
+		<property name="addModules" value="--add-modules ${modulea_name},${moduleb_name},${modulec_name}  --module-path ${mods_dir}" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}"/>
+			<src path="${transformerListener}" />
+			<compilerarg line='${addModules}' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/asm-all.jar" />
+			<pathelement location="${LIB_DIR}/testng.jar"/>
+			<pathelement location="${LIB_DIR}/jcommander.jar"/>
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="DEST" depends="compile_tests" description="generate the distribution" >
@@ -174,16 +171,15 @@
 	</target>
 
 	<target name="build" >
-		<if>
+		<condition property="is_JCL_VERSION_current">
 			<not>
 				<and>
 					<matches string="${JDK_VERSION}" pattern="^(9|10)$$" />
 					<equals arg1="${JCL_VERSION}" arg2="current"/>
 				</and>
 			</not>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JCL_VERSION_current"/>
 	</target>
 </project>

--- a/test/functional/RasapiTest/build.xml
+++ b/test/functional/RasapiTest/build.xml
@@ -20,7 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="Build script for com.ibm.jvm.ras.tests" default="check" basedir=".">
+<project name="Build script for com.ibm.jvm.ras.tests" default="check" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 
 	<property name="build.jar.tests" value="com.ibm.jvm.ras.tests.jar" />
 	<property name="DEST" value="${BUILD_ROOT}/functional/RasapiTest" />
@@ -101,15 +103,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="check">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="build" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+		<antcall target="build" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 
 	<target name="build" depends="compile">

--- a/test/functional/SharedCPEntryInvokerTests/build.xml
+++ b/test/functional/SharedCPEntryInvokerTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="J9 Shared ConstantPoolEntry Invoker Tests" default="clean" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
 	<description>
        Build J9 Shared ConstantPoolEntry Invoker Tests
     </description>

--- a/test/functional/TestExample/build.xml
+++ b/test/functional/TestExample/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="Test Example" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
     	Test Example
     </description>

--- a/test/functional/UnsafeTest/build.xml
+++ b/test/functional/UnsafeTest/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="OpenJ9 Unsafe Tests" default="build" basedir=".">
-<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="OpenJ9 Unsafe Tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build OpenJ9 Unsafe Tests
 	</description>
@@ -52,59 +53,44 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_80}" />
-					<src path="${src_access}" />
-					<src path="${transformerListener}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/asm.jar"/>
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
-					<then>
-						<!-- Java 11-16 -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_110" />
-					</then>
-					<else>
-						<!-- Java 17+ -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_170" />
-					</else>
-				</if>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^(1[0-9]|2[0-1])$$" />
-					<then>
-						<!-- Java 11-21 -->
-						<property name="test_src" location="${src_11}" />
-					</then>
-					<else>
-						<!-- Java 25+ -->
-						<property name="test_src" location="${src_25}" />
-					</else>
-				</if>
-				<property name="src_util" location="../TestUtilities/src" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${test_src}" />
-					<src path="${src_90}" />
-					<src path="${src_access}" />
-					<src path="${transformerListener}" />
-					<src path="${src_util}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-						<pathelement location="${LIB_DIR}/asm.jar"/>
-					</classpath>
-					<compilerarg value="--add-exports" />
-					<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src_80}" />
+			<src path="${src_access}" />
+			<src path="${transformerListener}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/asm.jar"/>
+			</classpath>
+		</javac>
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
+		</condition>
+		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
+		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
+		<condition property="test_src_dir" value="${src_11}" unless:set="is_JDK_VERSION_8">
+			<matches string="${JDK_VERSION}" pattern="^(1[0-9]|2[0-1])$$" />
+		</condition>
+		<property name="test_src_dir" value="${src_25}" unless:set="is_JDK_VERSION_8"/>
+		<property name="test_src" location="${test_src_dir}" unless:set="is_JDK_VERSION_8"/>
+		<property name="src_util" location="../TestUtilities/src" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${test_src}" />
+			<src path="${src_90}" />
+			<src path="${src_access}" />
+			<src path="${transformerListener}" />
+			<src path="${src_util}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			<pathelement location="${LIB_DIR}/asm.jar"/>
+			</classpath>
+			<compilerarg value="--add-exports" />
+			<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -125,24 +111,22 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<if>
-					<not>
-						<and>
-							<equals arg1="${JDK_VERSION}" arg2="9" />
-							<equals arg1="${JCL_VERSION}" arg2="current" />
-						</and>
-					</not>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-				</if>
-			</then>
-		</if>
+		</condition>
+
+		<condition property="is_JDK_VERSION_9" if:set="is_JDK_IMPL_ibm">
+			<not>
+			<and>
+			<equals arg1="${JDK_VERSION}" arg2="9" />
+			<equals arg1="${JCL_VERSION}" arg2="current" />
+			</and>
+			</not>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_9"/>
 	</target>
 </project>

--- a/test/functional/VM_Test/build.xml
+++ b/test/functional/VM_Test/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="VM_Test" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="VM_Test" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build VM_Test
 	</description>
@@ -85,102 +86,83 @@
 
 		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports=java.management/com.ibm.java.lang.management.internal=ALL-UNNAMED --add-exports=jdk.management/com.ibm.lang.management.internal=ALL-UNNAMED" />
 
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac destdir="${classUnloadingBin}" nowarn="on" debug="true" fork="true" executable="${compiler.javac}" classpathref="build.cp" encoding="ISO-8859-1">
-					<src path="${classUnloadingSupportTests}"/>
-					<src path="${src}"/>
-					<include name="j9vm/test/classunloading/**"/>
-				</javac>
-			</then>
-			<else>
-				<javac destdir="${classUnloadingBin}" nowarn="on" debug="true" fork="true" executable="${compiler.javac}" classpathref="build.cp" encoding="ISO-8859-1">
-					<src path="${classUnloadingSupportTests}"/>
-					<src path="${src}"/>
-					<include name="j9vm/test/classunloading/**"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
 
-		<if>
+		<javac destdir="${classUnloadingBin}" nowarn="on" debug="true" fork="true" executable="${compiler.javac}" classpathref="build.cp" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${classUnloadingSupportTests}"/>
+			<src path="${src}"/>
+			<include name="j9vm/test/classunloading/**"/>
+		</javac>
+		<javac destdir="${classUnloadingBin}" nowarn="on" debug="true" fork="true" executable="${compiler.javac}" classpathref="build.cp" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${classUnloadingSupportTests}"/>
+			<src path="${src}"/>
+			<include name="j9vm/test/classunloading/**"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-					<src path="${src}" />
-					<src path="${excludeFiles}"/>
-					<src path="${TestUtilities}" />
-					<exclude name="**/attachAPI/**" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-					</classpath>
-				</javac>
-			</then>
-			<elseif>
-					<matches string="${JDK_VERSION}" pattern="^(9|10)$$" />
-				<then>
-					<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-						<src path="${src}" />
-						<src path="${excludeFiles}"/>
-						<src path="${TestUtilities}" />
-						<exclude name="**/attachAPI/**" />
-						<!-- 133609: ClassPathSettingClassLoaderTest failed in jdk9 -->
-						<exclude name="**/ClassPathSettingClassLoader.java" />
-						<exclude name="**/ClassPathSettingClassLoaderTest.java" />
-						<compilerarg line='${addExports}' />
-						<classpath>
-							<pathelement location="${LIB_DIR}/testng.jar"/>
-						</classpath>
-					</javac>
-				</then>
-			</elseif>
-			<elseif>
-				<matches string="${JDK_VERSION}" pattern="^(1[1-9]|2[0-5])$" />
-				<!-- JDK_VERSION JDK11 - 25 -->
-				<then>
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-					<src path="${src}" />
-					<src path="${excludeFiles}"/>
-					<src path="${TestUtilities}" />
-					<exclude name="**/attachAPI/**" />
-					<!-- 133609: ClassPathSettingClassLoaderTest failed in jdk9 -->
-					<exclude name="**/ClassPathSettingClassLoader.java" />
-					<exclude name="**/ClassPathSettingClassLoaderTest.java" />
-					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-					</classpath>
-				</javac>
-				</then>
-			</elseif>
-			<else>
-				<!-- JDK_VERSION JDK26+ -->
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-					<src path="${src}"/>
-					<src path="${excludeFiles}"/>
-					<src path="${TestUtilities}" />
-					<exclude name="**/attachAPI/**" />
-					<!-- 133609: ClassPathSettingClassLoaderTest failed in jdk9 -->
-					<exclude name="**/ClassPathSettingClassLoader.java" />
-					<exclude name="**/ClassPathSettingClassLoaderTest.java" />
-					<!-- Thread.stop() is no longer available starting from JDK 26 -->
-					<exclude name="j9vm/test/threads/regression/RegressionTests.java" />
-					<exclude name="j9vm/test/threads/regression/ProcessWaitForStop.java" />
-					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-					</classpath>
-				</javac>
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp">
-					<src path="${src_26}"/>
-					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-					</classpath>
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${excludeFiles}"/>
+			<src path="${TestUtilities}" />
+			<exclude name="**/attachAPI/**" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
+		</javac>
+		<condition property="is_JDK_26_plus" unless:set="is_JDK_VERSION_8">
+			<not>
+				<matches string="${JDK_VERSION}" pattern="^(9|10|1[1-9]|2[0-5])$$" />
+			</not>
+		</condition>
+		<condition property="is_JDK_9_to_25" unless:set="is_JDK_VERSION_8">
+			<not>
+				<isset property="is_JDK_26_plus" />
+			</not>
+		</condition>
+		<!-- JDK 9-25 -->
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_9_to_25">
+			<src path="${src}"/>
+			<src path="${excludeFiles}"/>
+			<src path="${TestUtilities}" />
+			<exclude name="**/attachAPI/**" />
+			<!-- 133609: ClassPathSettingClassLoaderTest failed in jdk9 -->
+			<exclude name="**/ClassPathSettingClassLoader.java" />
+			<exclude name="**/ClassPathSettingClassLoaderTest.java" />
+			<compilerarg line='${addExports}' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
+		</javac>
+		<!-- JDK 26+ -->
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_26_plus">
+			<src path="${src}"/>
+			<src path="${excludeFiles}"/>
+			<src path="${TestUtilities}" />
+			<exclude name="**/attachAPI/**" />
+			<!-- 133609: ClassPathSettingClassLoaderTest failed in jdk9 -->
+			<exclude name="**/ClassPathSettingClassLoader.java" />
+			<exclude name="**/ClassPathSettingClassLoaderTest.java" />
+			<!-- Thread.stop() is no longer available starting from JDK 26 -->
+			<exclude name="j9vm/test/threads/regression/RegressionTests.java" />
+			<exclude name="j9vm/test/threads/regression/ProcessWaitForStop.java" />
+			<compilerarg line='${addExports}' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
+		</javac>
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_26_plus">
+			<src path="${src_26}"/>
+			<compilerarg line='${addExports}' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -237,14 +219,13 @@
 	</target>
 
 	<target name="build" depends="check-jar" unless="jar.exist">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -21,8 +21,9 @@
 
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="Valhalla Tests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="Valhalla Tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build Valhalla Tests
 	</description>
@@ -88,12 +89,11 @@
 	</target>
 
 	<target name="build" >
-		<if>
+		<condition property="is_JDK_VERSION_Valhalla">
 			<equals arg1="${JDK_VERSION}" arg2="Valhalla"/>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_Valhalla"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/build.xml
+++ b/test/functional/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="BUILD_FUNCTIONAL_TEST" default="build_functional" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="BUILD_FUNCTIONAL_TEST" default="build_functional" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build functional tests
 	</description>
@@ -39,22 +40,19 @@
 	</target>
 	
 	<target name="build_functional" depends="dist_functional">
-		<if>
+		<condition property="is_JDK_VERSION_Panama">
 			<equals arg1="${JDK_VERSION}" arg2="Panama"/>
-			<then>
-				<subant target="">
-					<fileset dir="./">
-						<include name="Panama/build.xml" />
-					</fileset>
-				</subant>
-			</then>
-			<else>
-				<subant target="">
-					<fileset dir="." includes="*/build.xml" >
-						<exclude name="Panama/build.xml" />
-					</fileset>
-				</subant>
-			</else>
-		</if>
+		</condition>
+
+		<subant target="" if:set="is_JDK_VERSION_Panama">
+			<fileset dir="./">
+			<include name="Panama/build.xml" />
+			</fileset>
+		</subant>
+		<subant target="" unless:set="is_JDK_VERSION_Panama">
+			<fileset dir="." includes="*/build.xml" >
+			<exclude name="Panama/build.xml" />
+			</fileset>
+		</subant>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/CDSAdaptorTest/build.xml
+++ b/test/functional/cmdLineTests/CDSAdaptorTest/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="CDS Adaptor Tests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="CDS Adaptor Tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build CDSAdaptorTest 
 	</description>
@@ -105,14 +106,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/J9security/build.xml
+++ b/test/functional/cmdLineTests/J9security/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="J9security" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="J9security" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests_J9security
 	</description>
@@ -97,14 +98,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/SystemPropertiesTest/build.xml
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTester_SystemPropertiesTest
 	</description>

--- a/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
+++ b/test/functional/cmdLineTests/URLClassLoaderTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="URLClassLoaderTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build DataHelperTests   
 	</description>

--- a/test/functional/cmdLineTests/ValueBasedClassTest/build.xml
+++ b/test/functional/cmdLineTests/ValueBasedClassTest/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTester_ValueBasedClassTest
 	</description>
@@ -70,22 +71,20 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<if>
-					<not>
-						<!--Only need this test for Java 16 and up-->
-						<matches string="${JDK_VERSION}" pattern="^(8|11)$$" />
-					</not>
-					<then>
-						<antcall target="clean" inheritall="true" />
-					</then>
-				</if>
-			</then>
-		</if>
+		</condition>
+
+		<condition property="is_JDK_VERSION_match" if:set="is_JDK_IMPL_ibm">
+			<not>
+			<!--Only need this test for Java 16 and up-->
+			<matches string="${JDK_VERSION}" pattern="^(8|11)$$" />
+			</not>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/bootStrapStaticVerify/build.xml
+++ b/test/functional/cmdLineTests/bootStrapStaticVerify/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests bootStrapStaticVerify
 	</description>

--- a/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
+++ b/test/functional/cmdLineTests/bootstrapMethodArgumentTest/build.xml
@@ -21,7 +21,6 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <project name="bootstrapMethodArgumentTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build bootstrapMethodArgumentTest
 	</description>

--- a/test/functional/cmdLineTests/build.xml
+++ b/test/functional/cmdLineTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests
 	</description>

--- a/test/functional/cmdLineTests/callsitedbgddrext/build.xml
+++ b/test/functional/cmdLineTests/callsitedbgddrext/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests callsitedbgddrext
 	</description>

--- a/test/functional/cmdLineTests/classLoaderTest/build.xml
+++ b/test/functional/cmdLineTests/classLoaderTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="EnableAssertionStatusTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_EnableAssertionStatusTest
 	</description>

--- a/test/functional/cmdLineTests/classesdbgddrext/build.xml
+++ b/test/functional/cmdLineTests/classesdbgddrext/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests classesddrtests
 	</description>

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTest_J9tests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTest_J9tests
 	</description>

--- a/test/functional/cmdLineTests/cmdlinetestertests/build.xml
+++ b/test/functional/cmdLineTests/cmdlinetestertests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests
 	</description>

--- a/test/functional/cmdLineTests/criu/build.xml
+++ b/test/functional/cmdLineTests/criu/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="criu" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="criu" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests_criu
 	</description>
@@ -49,59 +50,50 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_match">
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9])$$" />
 			</not>
-			<then>
-				<property name="enablePreview" value="--enable-preview -source ${JDK_VERSION}" />
-			</then>
-			<else>
-				<property name="enablePreview" value="" />
-				<property name="excludeTestMachineResourceChange" value="org/openj9/criu/TestMachineResourceChange.java" />
-			</else>
-		</if>
-		<if>
+		</condition>
+
+		<property name="enablePreview" value="--enable-preview -source ${JDK_VERSION}" if:set="is_JDK_VERSION_match"/>
+		<property name="enablePreview" value="" unless:set="is_JDK_VERSION_match"/>
+		<property name="excludeTestMachineResourceChange" value="org/openj9/criu/TestMachineResourceChange.java" unless:set="is_JDK_VERSION_match"/>
+		<condition property="excludeTestJDKCRAC" value="org/openj9/criu/TestJDKCRAC.java">
 			<not>
 				<contains string="${TEST_FLAG}" substring="CRAC" />
 			</not>
-			<then>
-				<property name="excludeTestJDKCRAC" value="org/openj9/criu/TestJDKCRAC.java" />
-			</then>
-		</if>
-		<if>
+		</condition>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<property name="excludeJDK11UpTimeoutAdjustmentTest" value="org/openj9/criu/JDK11UpTimeoutAdjustmentTest.java" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<exclude name="${excludeJDK11UpTimeoutAdjustmentTest}" />
-					<exclude name="${excludeTestMachineResourceChange}" />
-					<src path="${src}" />
-					<src path="${TestUtilities}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED --add-exports java.base/jdk.crac=ALL-UNNAMED
-					--add-exports java.base/openj9.internal.criu=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
-				<echo>===addExports:        ${addExports}</echo>
-				<echo>===enablePreview:     ${enablePreview}</echo>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<compilerarg line="${addExports}" />
-					<compilerarg line="${enablePreview}" />
-					<exclude name="${excludeTestJDKCRAC}" />
-					<exclude name="${excludeTestMachineResourceChange}" />
-					<src path="${src}" />
-					<src path="${TestUtilities}" />
-					<src path="${TestUtilitiesJ9}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-					</classpath>
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<property name="excludeJDK11UpTimeoutAdjustmentTest" value="org/openj9/criu/JDK11UpTimeoutAdjustmentTest.java" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<exclude name="${excludeJDK11UpTimeoutAdjustmentTest}" />
+			<exclude name="${excludeTestMachineResourceChange}" />
+			<src path="${src}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
+		</javac>
+		<property name="addExports" value="--add-exports jdk.management/jdk.crac.management=ALL-UNNAMED --add-exports java.base/jdk.crac=ALL-UNNAMED
+			--add-exports java.base/openj9.internal.criu=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED" />
+		<echo unless:set="is_JDK_VERSION_8">===addExports:        ${addExports}</echo>
+		<echo unless:set="is_JDK_VERSION_8">===enablePreview:     ${enablePreview}</echo>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<compilerarg line="${addExports}" />
+			<compilerarg line="${enablePreview}" />
+			<exclude name="${excludeTestJDKCRAC}" />
+			<exclude name="${excludeTestMachineResourceChange}" />
+			<src path="${src}" />
+			<src path="${TestUtilities}" />
+			<src path="${TestUtilitiesJ9}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -123,14 +115,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_CRAC">
 			<or>
 				<contains string="${TEST_FLAG}" substring="CRAC" />
 				<contains string="${TEST_FLAG}" substring="CRIU" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_CRAC"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/defaultLazySymbolResolution/build.xml
+++ b/test/functional/cmdLineTests/defaultLazySymbolResolution/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests defaultLazySymbolResolution
 	</description>
@@ -53,14 +54,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="dist" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="dist" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/doProtectedAccessCheck/build.xml
+++ b/test/functional/cmdLineTests/doProtectedAccessCheck/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="loadLibraryTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests doProtectedAccessCheck
 	</description>

--- a/test/functional/cmdLineTests/dscr/build.xml
+++ b/test/functional/cmdLineTests/dscr/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests dscr
 	</description>

--- a/test/functional/cmdLineTests/dumpromtests/build.xml
+++ b/test/functional/cmdLineTests/dumpromtests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests GCCheck
 	</description>

--- a/test/functional/cmdLineTests/fastClassHashTable/build.xml
+++ b/test/functional/cmdLineTests/fastClassHashTable/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests fastClassHashTable
 	</description>

--- a/test/functional/cmdLineTests/fips/build.xml
+++ b/test/functional/cmdLineTests/fips/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="fips" default="build" basedir=".">
-    <taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="fips" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
     <description>
         Build cmdLineTests_fips
     </description>
@@ -67,11 +68,10 @@
     </target>
 
     <target name="build" depends="buildCmdLineTestTools">
-        <if>
-            <contains string="${TEST_FLAG}" substring="FIPS" />
-            <then>
-                <antcall target="clean" inheritall="true" />
-            </then>
-        </if>
+		<condition property="is_FIPS">
+			<contains string="${TEST_FLAG}" substring="FIPS" />
+		</condition>
+
+        <antcall target="clean" inheritall="true" if:set="is_FIPS"/>
     </target>
 </project>

--- a/test/functional/cmdLineTests/forceLazySymbolResolution/build.xml
+++ b/test/functional/cmdLineTests/forceLazySymbolResolution/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests forceLazySymbolResolution
 	</description>
@@ -53,14 +54,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="dist" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="dist" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/gcCheck/build.xml
+++ b/test/functional/cmdLineTests/gcCheck/build.xml
@@ -21,8 +21,9 @@
 
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests GCCheck
 	</description>
@@ -70,14 +71,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/gcRegressionTests/build.xml
+++ b/test/functional/cmdLineTests/gcRegressionTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="gcRegressionTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_GCRegressionTests
 	</description>

--- a/test/functional/cmdLineTests/gcsuballoctests/build.xml
+++ b/test/functional/cmdLineTests/gcsuballoctests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="gcsuballoctests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests gcsuballoctests
 	</description>

--- a/test/functional/cmdLineTests/getCallerClassTests/build.xml
+++ b/test/functional/cmdLineTests/getCallerClassTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests
 	</description>

--- a/test/functional/cmdLineTests/gptest/build.xml
+++ b/test/functional/cmdLineTests/gptest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests gptest
 	</description>

--- a/test/functional/cmdLineTests/gputests/build.xml
+++ b/test/functional/cmdLineTests/gputests/build.xml
@@ -21,7 +21,6 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <project name="Command-line GPU Tests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests/gputests
 	</description>

--- a/test/functional/cmdLineTests/hangTest/build.xml
+++ b/test/functional/cmdLineTests/hangTest/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="loadLibraryTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="loadLibraryTest" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests hangTest
 	</description>
@@ -69,14 +70,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools,buildCmdLineTestUtils">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/ignoreUnrecognizedVMOptions/build.xml
+++ b/test/functional/cmdLineTests/ignoreUnrecognizedVMOptions/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests
 	</description>

--- a/test/functional/cmdLineTests/imageReaderInitializationTest/build.xml
+++ b/test/functional/cmdLineTests/imageReaderInitializationTest/build.xml
@@ -22,7 +22,6 @@ OpenJDK Assembly Exception [2].
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 <project name="ImageReader" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_imageReaderInitializationTest
 	</description>

--- a/test/functional/cmdLineTests/javaAssertions/build.xml
+++ b/test/functional/cmdLineTests/javaAssertions/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="javaAssertions" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_javaAssertions
 	</description>

--- a/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
+++ b/test/functional/cmdLineTests/jep178staticLinkingTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="libpathTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_libpathTest
 	</description>

--- a/test/functional/cmdLineTests/jfr/build.xml
+++ b/test/functional/cmdLineTests/jfr/build.xml
@@ -21,8 +21,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="jfr" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="jfr" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests_jfr
 	</description>
@@ -37,44 +38,38 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 	<!-- Download Liberty runtime using curl with retry (following AQA test pattern). -->
 	<target name="getLibertyRuntime" depends="init">
-		<if>
+		<condition property="liberty.zip.exists">
 			<available file="${liberty.zip}" type="file"/>
-			<then>
-				<echo message="${liberty.zip} exists. Hence, not downloading it."/>
-			</then>
-			<else>
-				<var name="curl_options" value="-Lks -C - ${liberty.url} -o ${liberty.zip}"/>
-				<retry retrycount="3">
-					<sequential>
-						<echo message="curl ${curl_options}"/>
-						<exec executable="curl" failonerror="true">
-							<arg line="${curl_options}"/>
-						</exec>
-					</sequential>
-				</retry>
-				<echo message="Liberty runtime downloaded successfully."/>
-			</else>
-		</if>
+		</condition>
+
+		<echo message="${liberty.zip} exists. Hence, not downloading it." if:set="liberty.zip.exists"/>
+		<property name="curl_options" value="-Lks -C - ${liberty.url} -o ${liberty.zip}"/>
+		<retry retrycount="3" unless:set="liberty.zip.exists">
+			<sequential>
+				<echo message="curl ${curl_options}"/>
+				<exec executable="curl" failonerror="true">
+					<arg line="${curl_options}"/>
+				</exec>
+			</sequential>
+		</retry>
+		<echo message="Liberty runtime downloaded successfully." unless:set="liberty.zip.exists"/>
 
 		<!-- Verify SHA1 checksum (skip on z/OS due to I/O issues with checksum task). -->
-		<if>
+		<condition property="is_zos">
 			<contains string="${SPEC}" substring="zos"/>
-			<then>
-				<echo message="Skipping Liberty runtime checksum verification on z/OS."/>
-			</then>
-			<else>
-				<checksum file="${liberty.zip}" algorithm="SHA1" property="${liberty.sha1}" verifyproperty="liberty.checksum.verified"/>
-				<if>
-					<equals arg1="${liberty.checksum.verified}" arg2="true"/>
-					<then>
-						<echo message="Liberty runtime checksum verified successfully."/>
-					</then>
-					<else>
-						<fail message="Liberty runtime checksum verification failed. Expected SHA1: ${liberty.sha1}"/>
-					</else>
-				</if>
-			</else>
-		</if>
+		</condition>
+
+		<echo message="Skipping Liberty runtime checksum verification on z/OS." if:set="is_zos"/>
+		<checksum file="${liberty.zip}" algorithm="SHA1" property="${liberty.sha1}" verifyproperty="liberty.checksum.verified" unless:set="is_zos"/>
+		<condition property="liberty.checksum.ok" unless:set="is_zos">
+			<equals arg1="${liberty.checksum.verified}" arg2="true"/>
+		</condition>
+
+		<echo message="Liberty runtime checksum verified successfully." if:set="liberty.checksum.ok"/>
+		<condition property="liberty.checksum.failed" unless:set="is_zos">
+			<not><isset property="liberty.checksum.ok"/></not>
+		</condition>
+		<fail message="Liberty runtime checksum verification failed. Expected SHA1: ${liberty.sha1}" if:set="liberty.checksum.failed"/>
 	</target>
 
 	<!-- Extract Liberty runtime after download. -->
@@ -82,22 +77,19 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<condition property="liberty.extracted">
 			<available file="${LIB_DIR}/wlp" type="dir"/>
 		</condition>
-		<if>
+		<condition property="liberty.not.extracted">
 			<not>
 				<isset property="liberty.extracted"/>
 			</not>
-			<then>
-				<echo message="Extracting Liberty runtime to ${LIB_DIR}."/>
-				<mkdir dir="${LIB_DIR}"/>
-				<unzip src="${liberty.zip}" dest="${LIB_DIR}"/>
-				<echo message="Setting execute permissions on Liberty scripts."/>
-				<chmod dir="${LIB_DIR}/wlp/bin" perm="755" includes="*"/>
-				<echo message="Liberty runtime extracted successfully."/>
-			</then>
-			<else>
-				<echo message="Liberty runtime already extracted: ${LIB_DIR}/wlp."/>
-			</else>
-		</if>
+		</condition>
+
+		<echo message="Extracting Liberty runtime to ${LIB_DIR}." if:set="liberty.not.extracted"/>
+		<mkdir dir="${LIB_DIR}" if:set="liberty.not.extracted"/>
+		<unzip src="${liberty.zip}" dest="${LIB_DIR}" if:set="liberty.not.extracted"/>
+		<echo message="Setting execute permissions on Liberty scripts." if:set="liberty.not.extracted"/>
+		<chmod dir="${LIB_DIR}/wlp/bin" perm="755" includes="*" if:set="liberty.not.extracted"/>
+		<echo message="Liberty runtime extracted successfully." if:set="liberty.not.extracted"/>
+		<echo message="Liberty runtime already extracted: ${LIB_DIR}/wlp." unless:set="liberty.not.extracted"/>
 	</target>
 
 	<!-- Set properties for this build. -->

--- a/test/functional/cmdLineTests/jimageinterface/build.xml
+++ b/test/functional/cmdLineTests/jimageinterface/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests
 	</description>

--- a/test/functional/cmdLineTests/jit/build.xml
+++ b/test/functional/cmdLineTests/jit/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTest_jit" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTest_jit
 	</description>

--- a/test/functional/cmdLineTests/jitserver/build.xml
+++ b/test/functional/cmdLineTests/jitserver/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTest_jitserver" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTest_jitserver
 	</description>

--- a/test/functional/cmdLineTests/jrvTest/build.xml
+++ b/test/functional/cmdLineTests/jrvTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests jrvTest
 	</description>

--- a/test/functional/cmdLineTests/jvmtitests/build.xml
+++ b/test/functional/cmdLineTests/jvmtitests/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="JVMTI tests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml' />
+<project name="JVMTI tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build JVMTI tests
 	</description>
@@ -52,77 +53,65 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===destdir:                      ${build}</echo>
 
 		<!-- Define variables to exclude Java21 and up tests for Java 8, 11 and 17. -->
-		<if>
+		<condition property="excludeJDK21UpGetStackTraceExtendedTest" value="com/ibm/jvmti/tests/getStackTraceExtended/gste002.java">
 			<matches string="${JDK_VERSION}" pattern="^(8|11|17)$$" />
-			<then>
-				<property name="excludeJDK21UpGetStackTraceExtendedTest" value="com/ibm/jvmti/tests/getStackTraceExtended/gste002.java" />
-				<property name="excludeJDK21UpGetThreadListStackTracesExtendedTest" value="com/ibm/jvmti/tests/getThreadListStackTracesExtended/gtlste002.java" />
-			</then>
-			<else>
-				<property name="excludeJDK21UpGetStackTraceExtendedTest" value="" />
-				<property name="excludeJDK21UpGetThreadListStackTracesExtendedTest" value="" />
-			</else>
-		</if>
+		</condition>
+		<property name="excludeJDK21UpGetStackTraceExtendedTest" value=""/>
+		<condition property="excludeJDK21UpGetThreadListStackTracesExtendedTest" value="com/ibm/jvmti/tests/getThreadListStackTracesExtended/gtlste002.java">
+			<matches string="${JDK_VERSION}" pattern="^(8|11|17)$$" />
+		</condition>
+		<property name="excludeJDK21UpGetThreadListStackTracesExtendedTest" value=""/>
 
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
-					<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
-					<classpath>
-						<pathelement location="${asm.jar}" />
-						<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-exports java.base/jdk.internal.module=ALL-UNNAMED --add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED --add-exports java.base/com.ibm.tools.attach=ALL-UNNAMED --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED" />
-				<if>
-					<equals arg1="${JCL_VERSION}" arg2="latest" />
-					<then>
-						<property name="extraSrc" value="${src_latest}" />
-						<property name="excludeFile" value="**/modularityTests/**" />
-					</then>
-					<else>
-						<property name="extraSrc" value="${src_current}" />
-						<property name="excludeFile" value="" />
-					</else>
-				</if>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-2])$$" />
-					<then>
-						<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-							<src path="${src}" />
-							<src path="${extraSrc}" />
-							<exclude name="${excludeFile}" />
-							<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
-							<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
-							<compilerarg line="${addExports}" />
-							<classpath>
-								<pathelement location="${asm.jar}" />
-							</classpath>
-						</javac>
-					</then>
-					<else>
-						<!-- Java 23+ (SecurityManage and several Thread functions removed) -->
-						<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-							<src path="${src}" />
-							<src path="${extraSrc}" />
-							<exclude name="${excludeFile}" />
-							<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
-							<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
-							<compilerarg line="${addExports}" />
-							<exclude name="com/ibm/jvmti/tests/getThreadState/gts001.java" />
-							<classpath>
-								<pathelement location="${asm.jar}" />
-							</classpath>
-						</javac>
-					</else>
-				</if>
-			</else>
-		</if>
+		</condition>
+
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
+			<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
+			<classpath>
+			<pathelement location="${asm.jar}" />
+			<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
+			</classpath>
+		</javac>
+		<property name="addExports" value="--add-exports java.base/jdk.internal.module=ALL-UNNAMED --add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED --add-exports java.base/com.ibm.tools.attach=ALL-UNNAMED --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<condition property="extraSrc" value="${src_latest}" unless:set="is_JDK_VERSION_8">
+			<equals arg1="${JCL_VERSION}" arg2="latest" />
+		</condition>
+		<property name="extraSrc" value="${src_current}" unless:set="is_JDK_VERSION_8"/>
+		<condition property="excludeFile" value="**/modularityTests/**" unless:set="is_JDK_VERSION_8">
+			<equals arg1="${JCL_VERSION}" arg2="latest" />
+		</condition>
+		<property name="excludeFile" value="" unless:set="is_JDK_VERSION_8"/>
+		<condition property="is_JDK_VERSION_match">
+			<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-2])$$" />
+		</condition>
+
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_match" unless:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${extraSrc}" />
+			<exclude name="${excludeFile}" />
+			<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
+			<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
+			<compilerarg line="${addExports}" />
+			<classpath>
+			<pathelement location="${asm.jar}" />
+			</classpath>
+		</javac>
+		<!-- Java 23+ (SecurityManage and several Thread functions removed) -->
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_match">
+			<src path="${src}" />
+			<src path="${extraSrc}" />
+			<exclude name="${excludeFile}" />
+			<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
+			<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
+			<compilerarg line="${addExports}" />
+			<exclude name="com/ibm/jvmti/tests/getThreadState/gts001.java" />
+			<classpath>
+			<pathelement location="${asm.jar}" />
+			</classpath>
+		</javac>
 
 		<!-- Compile VersionedClass separately -->
 		<copy file="${src}/com/ibm/jvmti/tests/getClassVersionNumbers/VersionedClass.java.dont_auto_compile"
@@ -162,14 +151,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/jython/build.xml
+++ b/test/functional/cmdLineTests/jython/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="libpathTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build jython hello
 	</description>

--- a/test/functional/cmdLineTests/lazyClassLoadingTest/build.xml
+++ b/test/functional/cmdLineTests/lazyClassLoadingTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="libpathTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_lazyClassLoading
 	</description>

--- a/test/functional/cmdLineTests/libpathTest/build.xml
+++ b/test/functional/cmdLineTests/libpathTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="libpathTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_libpathTest
 	</description>

--- a/test/functional/cmdLineTests/loadLibraryTest/build.xml
+++ b/test/functional/cmdLineTests/loadLibraryTest/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="loadLibraryTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="loadLibraryTest" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests_loadLibraryTest
 	</description>
@@ -47,15 +48,9 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="addExports" value="" else="--add-exports java.desktop/sun.font=ALL-UNNAMED">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<property name="addExports" value="" />
-			</then>
-			<else>
-				<property name="addExports" value='--add-exports java.desktop/sun.font=ALL-UNNAMED' />
-			</else>
-		</if>
+		</condition>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
 			<compilerarg line='${addExports}' />

--- a/test/functional/cmdLineTests/locales/build.xml
+++ b/test/functional/cmdLineTests/locales/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests locales
 	</description>
@@ -34,15 +35,10 @@
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/locales" />
 	<property name="src" location="." />
 
-	<if>
+		<condition property="TEXT_ENCODING" value="IBM-1047">
 		<contains string="${SPEC}" substring="zos"/>
-		<then>
-			<property name="TEXT_ENCODING" value="IBM-1047"/>
-		</then>
-		<else>
-			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
-		</else>
-	</if>
+	</condition>
+	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="dist" description="generate the distribution">
 		<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">

--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="lockWordAlignment" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="lockWordAlignment" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests_lockWordAlignment
 	</description>
@@ -50,39 +51,31 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm.jar"/>
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/asm.jar"/>
-					</classpath>
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/asm.jar"/>
+			</classpath>
+		</javac>
+		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<compilerarg line='${addExports}' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/asm.jar"/>
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="generateTestClass" depends="compile" description="Generate test class files ">
-		<if>
+		<condition property="addExports" value="">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<property name="addExports" value="" />
-			</then>
-			<else>
-				<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED" />
-			</else>
-		</if>			
+		</condition>
+		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED"/>
 		<property name="build.javaexecutable" value="${TEST_JDK_HOME}/bin/java"/>
 		<java classname="IntLongObjectAlignmentTestGenerator" failonerror="true" fork="true" logError="true" jvm="${build.javaexecutable}">
 			<jvmarg line='${addExports}' />
@@ -118,14 +111,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/loopReduction/build.xml
+++ b/test/functional/cmdLineTests/loopReduction/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build loopReduction
 	</description>

--- a/test/functional/cmdLineTests/modularityddrtests/build.xml
+++ b/test/functional/cmdLineTests/modularityddrtests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests modularityddrtests
 	</description>

--- a/test/functional/cmdLineTests/openssl/build.xml
+++ b/test/functional/cmdLineTests/openssl/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="OpenSSL" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_OpenSSL
 	</description>

--- a/test/functional/cmdLineTests/pageAlignDirectMemory/build.xml
+++ b/test/functional/cmdLineTests/pageAlignDirectMemory/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests
 	</description>

--- a/test/functional/cmdLineTests/pltest/build.xml
+++ b/test/functional/cmdLineTests/pltest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTestspltest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build pltest
 	</description>

--- a/test/functional/cmdLineTests/proxyFieldAccess/build.xml
+++ b/test/functional/cmdLineTests/proxyFieldAccess/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests_proxyFieldAccess
 	</description>
@@ -47,20 +48,17 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${build}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${src.dir}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${src.dir}" />
-				</javac>
-			</then>
-			<else>
-				<javac srcdir="${src.dir}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src.dir}" />
-					<compilerarg line='--patch-module java.base=${src.dir} --add-modules jdk.unsupported --add-reads java.base=jdk.unsupported' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src.dir}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src.dir}" />
+		</javac>
+		<javac srcdir="${src.dir}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src.dir}" />
+			<compilerarg line='--patch-module java.base=${src.dir} --add-modules jdk.unsupported --add-reads java.base=jdk.unsupported' />
+		</javac>
 	</target>
 	
 	<target name="dist" depends="compile" description="generate the distribution">

--- a/test/functional/cmdLineTests/reflectCache/build.xml
+++ b/test/functional/cmdLineTests/reflectCache/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="loadLibraryTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="loadLibraryTest" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests reflectCache
 	</description>
@@ -49,25 +50,22 @@
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<or>
 				<equals arg1="${JDK_VERSION}" arg2="8"/>
 				<equals arg1="${JDK_VERSION}" arg2="11"/>
 			</or>
-			<then>
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_8}"/>
-				</javac>
-			</then>
-			<else>
-				<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}"/>
-					<src path="${src_15}"/>
-					<compilerarg line="--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED" />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${src_8}"/>
+		</javac>
+		<javac destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src}"/>
+			<src path="${src_15}"/>
+			<compilerarg line="--add-exports=java.base/jdk.internal.misc=ALL-UNNAMED" />
+		</javac>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" />
 	</target>

--- a/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
+++ b/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="runtimemxbeanTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="runtimemxbeanTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests_runtimemxbeanTests
 	</description>
@@ -52,15 +53,10 @@
 		</javac>
 	</target>
 
-	<if>
+		<condition property="TEXT_ENCODING" value="IBM-1047">
 		<contains string="${SPEC}" substring="zos"/>
-		<then>
-			<property name="TEXT_ENCODING" value="IBM-1047"/>
-		</then>
-		<else>
-			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
-		</else>
-	</if>
+	</condition>
+	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="dist" depends="compile" description="generate the distribution">
 		<jar jarfile="${DEST}/runtimemxbeanTests.jar" filesonly="true">
@@ -83,13 +79,12 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_VERSION_match">
 			<not>
 				<matches string="${JDK_VERSION}" pattern="^(8|9)$$" />
 			</not>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_VERSION_match"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/BadStackMap/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/BadStackMap/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="loadLibraryTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests badStackMap
 	</description>

--- a/test/functional/cmdLineTests/shareClassTests/DataHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/DataHelperTests/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="DataHelperTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="DataHelperTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build DataHelperTests   
 	</description>
@@ -59,35 +60,9 @@
 		<!--
 		2.) datacaching directory ...
 		-->
-		<trycatch>
-			<try>
-				<mkdir dir="${build}/datacaching"/>
-			</try>
-			<catch>
-				<sleep milliseconds="10"/>	
-				<mkdir dir="${build}/datacaching"/>
-			</catch>	
-		</trycatch>
-		
-		<trycatch>
-			<try>
-				<mkdir dir="${build}/datacaching/dataone.contents"/>
-			</try>
-			<catch>
-				<sleep milliseconds="10"/>	
-				<mkdir dir="${build}/datacaching/dataone.contents"/>
-			</catch>
-		</trycatch>
-		
-		<trycatch>
-			<try>
-				<mkdir dir="${build}/datacaching/datatwo.contents"/>		
-			</try>
-			<catch>
-				<sleep milliseconds="10"/>	
-				<mkdir dir="${build}/datacaching/datatwo.contents"/>		
-			</catch>
-		</trycatch>
+		<mkdir dir="${build}/datacaching"/>
+		<mkdir dir="${build}/datacaching/dataone.contents"/>
+		<mkdir dir="${build}/datacaching/datatwo.contents"/>
 		
 		<copy todir="${build}/datacaching/dataone.contents">
 			<fileset dir="./datacaching/dataone.contents"/>
@@ -96,21 +71,18 @@
 			<fileset dir="./datacaching/datatwo.contents"/>
 		</copy>		
 		
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
-					<src path="${src}" />
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
-					<src path="${src}" />
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<compilerarg line='${addExports}' />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -133,14 +105,13 @@
 	</target>
 
 	<target name="build" depends="check-jar,buildCmdLineTestTools" unless="jar.exist">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ListAllCachesTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="ShareClassesListAllCachesTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build ShareClassesListAllCachesTests
 	</description>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="ShareClassesCMLTEST" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build ShareClassesCMLTEST
 	</description>

--- a/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCommandLineOptionTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="SCCommandLineOptionTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build SCCommandLineOptionTests
 	</description>

--- a/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCHelperCompatTests/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="SCHelperCompatTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="SCHelperCompatTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build SCHelperCompatTests
 	</description>
@@ -64,63 +65,60 @@
 			<fileset dir="${src}" includes="*.xml,*.java" excludes="playlist.xml" />
 		</copy>
 	
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${build}" includes="PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="TokenIncompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
-				<javac srcdir="${build}" includes="PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-				<javac srcdir="${build}" includes="PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-				<javac srcdir="${build}" includes="TokenIncompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-				<javac srcdir="${build}" includes="URLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>	
-					<compilerarg line='${addExports}' />
-				</javac>
-				<javac srcdir="${build}" includes="URLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${build}" includes="PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<javac srcdir="${build}" includes="PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<javac srcdir="${build}" includes="TokenIncompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<javac srcdir="${build}" includes="URLClassPathHelperURLHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<javac srcdir="${build}" includes="URLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<javac srcdir="${build}" includes="URLHelperURLClassPathHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<javac srcdir="${build}" includes="URLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${build}" includes="PartitioningURLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+		<javac srcdir="${build}" includes="PartitioningURLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+		<javac srcdir="${build}" includes="TokenIncompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+		<javac srcdir="${build}" includes="URLClassPathHelperURLHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+		<javac srcdir="${build}" includes="URLClassPathHelperURLHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+		<javac srcdir="${build}" includes="URLHelperURLClassPathHelperCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+		<javac srcdir="${build}" includes="URLHelperURLClassPathHelperStaleEntryCompatibilityTest.java" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
 		<mkdir dir="${build}/props_unix"/>
 		<mkdir dir="${build}/props_win"/>
@@ -148,14 +146,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/ShareClassesSimpleSanity/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="ShareClassesSimpleSanity" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build ShareClassesSimpleSanity
 	</description>

--- a/test/functional/cmdLineTests/shareClassTests/StorageKey/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StorageKey/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests locales
 	</description>

--- a/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/StoreFilterTests/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="StoreFilterTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="StoreFilterTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build StoreFilterTests
 	</description>
@@ -59,23 +60,20 @@
 			<fileset dir="./APITests/"/>
 		</copy>
 
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${build}/APITests" destdir="${build}" debug="true" debuglevel="lines,vars,source" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
-					<src path="${SharedClassUtils_srddir}"/>
-					<src path="${build}/APITests"/>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
-				<javac srcdir="${build}/APITests" destdir="${build}" classpath="${build}" fork="true" debug="true" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" >
-					<src path="${build}/APITests"/>
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${build}/APITests" destdir="${build}" debug="true" debuglevel="lines,vars,source" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<src path="${build}/APITests"/>
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${build}/APITests" destdir="${build}" classpath="${build}" fork="true" debug="true" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${build}/APITests"/>
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
 		<!--
 		2.) Resources directory ...
@@ -84,21 +82,18 @@
 		<copy todir="${build}/Resources">
 			<fileset dir="./Resources/"/>
 		</copy>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${build}/Resources" destdir="${build}/Resources" fork="true" debug="true" debuglevel="lines,vars,source" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
-				<javac srcdir="${build}/Resources" destdir="${build}/Resources"  classpath="${build}" fork="true" debug="true" debuglevel="lines,vars,source" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" >
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${build}/Resources" destdir="${build}/Resources" fork="true" debug="true" debuglevel="lines,vars,source" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${build}/Resources" destdir="${build}/Resources"  classpath="${build}" fork="true" debug="true" debuglevel="lines,vars,source" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -117,14 +112,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/TokenHelperTests/build.xml
@@ -20,8 +20,9 @@
 
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="TokenHelperTests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="TokenHelperTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build TokenHelperTests
 	</description>
@@ -75,21 +76,18 @@
 		<copy todir="${build}/APITests">
 			<fileset dir="${src}/APITests/"/>
 		</copy>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${build}/APITests" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
-				<javac srcdir="${build}/APITests" destdir="${build}" classpath="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${build}/APITests" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${build}/APITests" destdir="${build}" classpath="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 		
 		<!--
 		3.) StaleMarkingTests directory ...
@@ -138,14 +136,13 @@
 	</target>
 
 	<target name="build" depends="check-jar,buildCmdLineTestTools" unless="jar.exist">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/URLHelperTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/URLHelperTests/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="URLHelperTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="URLHelperTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build URLHelperTests
 	</description>
@@ -80,21 +81,18 @@
 		<copy todir="${build}/APITests">
 			<fileset dir="${src}/APITests/"/>
 		</copy>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${build}/APITests" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
-				<javac srcdir="${build}/APITests" destdir="${build}" classpath="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${build}/APITests" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${build}/APITests" destdir="${build}" classpath="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 		
 		<!--
 		3.) ClassPathMatchingTests directory ...
@@ -103,21 +101,18 @@
 		<copy todir="${build}/ClassPathMatchingTests">
 			<fileset dir="${src}/ClassPathMatchingTests/"/>
 		</copy>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${build}/ClassPathMatchingTests" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
-				<javac srcdir="${build}/ClassPathMatchingTests" destdir="${build}" classpath="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${build}/ClassPathMatchingTests" destdir="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${build}/ClassPathMatchingTests" destdir="${build}" classpath="${build}" fork="true" debug="on" debuglevel="lines,vars,source" executable="${compiler.javac}" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 		
 		<!--
 		4.) PartitioningTests directory ...
@@ -176,14 +171,13 @@
 	</target>
 
 	<target name="build" depends="check-jar,buildCmdLineTestTools" unless="jar.exist">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shareClassTests/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build shareClassTests
 	</description>

--- a/test/functional/cmdLineTests/shareClassTests/testClasses/build.xml
+++ b/test/functional/cmdLineTests/shareClassTests/testClasses/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="testClasses" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="testClasses" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	
 	<description>
        Build sharedClass testClasses  
@@ -125,181 +126,178 @@
 		</copy>			
 
 		<!-- compile sources -->
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${sharedClassTestClasses_srddir}/Alphabet" classpath="${build}:" destdir="${build}/Alphabet" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		</condition>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AlphabetJar" classpath="${build}" destdir="${build}/AlphabetJar" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/Alphabet" classpath="${build}:" destdir="${build}/Alphabet" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<jar destfile="${build}/AlphabetJar/Alphabet.jar" basedir="${build}/AlphabetJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/AlphabetJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AlphabetJar" classpath="${build}" destdir="${build}/AlphabetJar" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Animals" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Animals" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<jar destfile="${build}/AlphabetJar/Alphabet.jar" basedir="${build}/AlphabetJar/" includes="*.class" duplicate="fail" if:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/AlphabetJar/" excludes="*.jar,*.java" if:set="is_JDK_VERSION_8"/>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AnimalsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/AnimalsJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Animals" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Animals" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<jar destfile="${build}/AnimalsJar/Animals.jar" basedir="${build}/AnimalsJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/AnimalsJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AnimalsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/AnimalsJar" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}BallSports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/BallSports" debug="on">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<jar destfile="${build}/AnimalsJar/Animals.jar" basedir="${build}/AnimalsJar/" includes="*.class" duplicate="fail" if:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/AnimalsJar/" excludes="*.jar,*.java" if:set="is_JDK_VERSION_8"/>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}DuplicateOrphansTest" excludes="temp/DuplicateOrphan.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/DuplicateOrphansTest" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}BallSports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/BallSports" debug="on" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Food" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Food" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}DuplicateOrphansTest" excludes="temp/DuplicateOrphan.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/DuplicateOrphansTest" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}FoodJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/FoodJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Food" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Food" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<jar destfile="${build}/FoodJar/Food.jar" basedir="${build}/FoodJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/FoodJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}FoodJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/FoodJar" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pets" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pets" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<jar destfile="${build}/FoodJar/Food.jar" basedir="${build}/FoodJar/" includes="*.class" duplicate="fail" if:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/FoodJar/" excludes="*.jar,*.java" if:set="is_JDK_VERSION_8"/>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pudding" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pudding" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pets" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pets" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Sports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Sports" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pudding" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pudding" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}SportsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/SportsJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-				
-				<jar destfile="${build}/SportsJar/Sports.jar" basedir="${build}/SportsJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/SportsJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Sports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Sports" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}SportsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/SportsJar" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest/temp" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest/temp" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<jar destfile="${build}/SportsJar/Sports.jar" basedir="${build}/SportsJar/" includes="*.class" duplicate="fail" if:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/SportsJar/" excludes="*.jar,*.java" if:set="is_JDK_VERSION_8"/>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest1" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest1" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Vowels" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Vowels" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-				</javac>
-			</then>
-			<else>
-				<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest/temp" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest/temp" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/Alphabet" classpath="${build}:" destdir="${build}/Alphabet" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest1" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest1" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AlphabetJar" classpath="${build}" destdir="${build}/AlphabetJar" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Vowels" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Vowels" debug="on" debuglevel="lines,vars,source" if:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+		</javac>
+		<property name="addExports" value="--add-modules openj9.sharedclasses --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 
-				<jar destfile="${build}/AlphabetJar/Alphabet.jar" basedir="${build}/AlphabetJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/AlphabetJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/Alphabet" classpath="${build}:" destdir="${build}/Alphabet" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Animals" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Animals" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AlphabetJar" classpath="${build}" destdir="${build}/AlphabetJar" fork="true" executable="${compiler.javac}" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AnimalsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/AnimalsJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<jar destfile="${build}/AlphabetJar/Alphabet.jar" basedir="${build}/AlphabetJar/" includes="*.class" duplicate="fail" unless:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/AlphabetJar/" excludes="*.jar,*.java" unless:set="is_JDK_VERSION_8"/>
 
-				<jar destfile="${build}/AnimalsJar/Animals.jar" basedir="${build}/AnimalsJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/AnimalsJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Animals" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Animals" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}BallSports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/BallSports" debug="on">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}AnimalsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/AnimalsJar" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}DuplicateOrphansTest" excludes="temp/DuplicateOrphan.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/DuplicateOrphansTest" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<jar destfile="${build}/AnimalsJar/Animals.jar" basedir="${build}/AnimalsJar/" includes="*.class" duplicate="fail" unless:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/AnimalsJar/" excludes="*.jar,*.java" unless:set="is_JDK_VERSION_8"/>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Food" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Food" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}BallSports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/BallSports" debug="on" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}FoodJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/FoodJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}DuplicateOrphansTest" excludes="temp/DuplicateOrphan.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/DuplicateOrphansTest" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<jar destfile="${build}/FoodJar/Food.jar" basedir="${build}/FoodJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/FoodJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Food" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Food" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pets" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pets" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}FoodJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/FoodJar" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pudding" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pudding" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<jar destfile="${build}/FoodJar/Food.jar" basedir="${build}/FoodJar/" includes="*.class" duplicate="fail" unless:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/FoodJar/" excludes="*.jar,*.java" unless:set="is_JDK_VERSION_8"/>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Sports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Sports" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pets" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pets" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}SportsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/SportsJar" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-				
-				<jar destfile="${build}/SportsJar/Sports.jar" basedir="${build}/SportsJar/" includes="*.class" duplicate="fail"/>
-				<delete dir="${build}/SportsJar/" excludes="*.jar,*.java" />
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Pudding" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Pudding" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Sports" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Sports" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest/temp" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest/temp" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}SportsJar" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/SportsJar" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest1" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest1" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
+		<jar destfile="${build}/SportsJar/Sports.jar" basedir="${build}/SportsJar/" includes="*.class" duplicate="fail" unless:set="is_JDK_VERSION_8"/>
+		<delete dir="${build}/SportsJar/" excludes="*.jar,*.java" unless:set="is_JDK_VERSION_8"/>
 
-				<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Vowels" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Vowels" debug="on" debuglevel="lines,vars,source">
-					<src path="${SharedClassUtils_srddir}"/>
-					<compilerarg line='${addExports}' />
-				</javac>
-			</else>
-		</if>
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest/temp" excludes="**/*.java" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest/temp" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}StaleOrphansTest1" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/StaleOrphansTest1" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
+
+		<javac srcdir="${sharedClassTestClasses_srddir}/${sharedClassTestClasses_srddir}Vowels" classpath="${build}" fork="true" executable="${compiler.javac}" destdir="${build}/Vowels" debug="on" debuglevel="lines,vars,source" unless:set="is_JDK_VERSION_8">
+			<src path="${SharedClassUtils_srddir}"/>
+			<compilerarg line='${addExports}' />
+		</javac>
 			
 		<copy todir="${build}/tempfiles">
 			<fileset dir="${build}/Sports" includes="*.class"/>			
@@ -329,14 +327,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/shrcdbgddrext/build.xml
+++ b/test/functional/cmdLineTests/shrcdbgddrext/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests shrcdbgddrext
 	</description>

--- a/test/functional/cmdLineTests/sigabrtHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigabrtHandlingTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="sigabrtHandlingTest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests sigabrtHandlingTest
 	</description>

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests sigxfszHandlingTest
 	</description>
@@ -34,15 +35,10 @@
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/sigxfszHandlingTest" />
 	<property name="src" location="." />
 
-	<if>
+		<condition property="TEXT_ENCODING" value="IBM-1047">
 		<contains string="${SPEC}" substring="zos"/>
-		<then>
-			<property name="TEXT_ENCODING" value="IBM-1047"/>
-		</then>
-		<else>
-			<property name="TEXT_ENCODING" value="ISO-8859-1"/>
-		</else>
-	</if>
+	</condition>
+	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="dist" description="generate the distribution">
 		<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">

--- a/test/functional/cmdLineTests/softmxCmdOptTest/build.xml
+++ b/test/functional/cmdLineTests/softmxCmdOptTest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests
 	</description>

--- a/test/functional/cmdLineTests/stackSizeInfoTest/build.xml
+++ b/test/functional/cmdLineTests/stackSizeInfoTest/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdLineTests stackSizeInfoTest
 	</description>
@@ -42,14 +43,13 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="dist" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="dist" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/utils/build.xml
+++ b/test/functional/cmdLineTests/utils/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="utils" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="utils" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build utils
 	</description>
@@ -49,41 +50,32 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_shared}" />
-					<src path="${src_access}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
-					<then>
-						<!-- Java 11-16 -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_110" />
-					</then>
-					<else>
-						<!-- Java 17+ -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_170" />
-					</else>
-				</if>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_shared}" />
-					<src path="${src_access}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-					</classpath>
-					<compilerarg value="--add-exports" />
-					<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src_shared}" />
+			<src path="${src_access}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			</classpath>
+		</javac>
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
+		</condition>
+		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
+		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src_shared}" />
+			<src path="${src_access}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			</classpath>
+			<compilerarg value="--add-exports" />
+			<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -107,14 +99,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build" depends="check-jar" unless="jar.exist">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/utils2/build.xml
+++ b/test/functional/cmdLineTests/utils2/build.xml
@@ -20,8 +20,9 @@ OpenJDK Assembly Exception [2].
 
 SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
-<project name="utils2" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="utils2" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build utils2. It only contains the modified AnonClassAndUnsafeClassTest.java and the duplicated ClassTest.java which are used on the ShareClassesCMLTests-1 test 62-d.
 	</description>
@@ -47,41 +48,32 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===debug:                        on</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
-			<then>
-				<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" />
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_shared}" />
-					<src path="${src_access}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-					</classpath>
-				</javac>
-			</then>
-			<else>
-				<if>
-					<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
-					<then>
-						<!-- Java 11-16 -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_110" />
-					</then>
-					<else>
-						<!-- Java 17+ -->
-						<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src_170" />
-					</else>
-				</if>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src_shared}" />
-					<src path="${src_access}" />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar" />
-					</classpath>
-					<compilerarg value="--add-exports" />
-					<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" if:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src_shared}" />
+			<src path="${src_access}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			</classpath>
+		</javac>
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
+		</condition>
+		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
+		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src_shared}" />
+			<src path="${src_access}" />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar" />
+			</classpath>
+			<compilerarg value="--add-exports" />
+			<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution">
@@ -105,14 +97,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</target>
 
 	<target name="build" depends="check-jar" unless="jar.exist">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm" />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/valuetypeddrtests/build.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
+<project name="cmdLineTests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build valuetype ddr tests
 	</description>
@@ -42,11 +43,10 @@
 	</target>
 
 	<target name="build" depends="buildCmdLineTestTools,getDependentLibs">
-		<if>
+		<condition property="is_JDK_VERSION_Valhalla">
 			<equals arg1="${JDK_VERSION}" arg2="Valhalla"/>
-			<then>
-				<antcall target="dist" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="dist" inheritall="true" if:set="is_JDK_VERSION_Valhalla"/>
 	</target>
 </project>

--- a/test/functional/cmdLineTests/verboseVerification/build.xml
+++ b/test/functional/cmdLineTests/verboseVerification/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build verboseVerification
 	</description>

--- a/test/functional/cmdLineTests/verbosetest/build.xml
+++ b/test/functional/cmdLineTests/verbosetest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build verbosetest
 	</description>

--- a/test/functional/cmdLineTests/vmRuntimeState/build.xml
+++ b/test/functional/cmdLineTests/vmRuntimeState/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="vmRuntimeState" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests_vmRuntimeState
 	</description>

--- a/test/functional/cmdLineTests/xcheckjni/build.xml
+++ b/test/functional/cmdLineTests/xcheckjni/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTester_XcheckJNI" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTester_XcheckJNI
 	</description>

--- a/test/functional/cmdLineTests/xlogTests/build.xml
+++ b/test/functional/cmdLineTests/xlogTests/build.xml
@@ -23,7 +23,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests xlogTests
 	</description>

--- a/test/functional/cmdLineTests/xlpCMLTests/build.xml
+++ b/test/functional/cmdLineTests/xlpCMLTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests xlpCMLTests
 	</description>

--- a/test/functional/cmdLineTests/xtraceTests/build.xml
+++ b/test/functional/cmdLineTests/xtraceTests/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTests" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTests xtraceTests
 	</description>

--- a/test/functional/cmdLineTests/xxargtest/build.xml
+++ b/test/functional/cmdLineTests/xxargtest/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdLineTest_XXArgtest" default="build" basedir=".">
-	<taskdef resource="net/sf/antcontrib/antlib.xml" />
 	<description>
 		Build cmdLineTest_XXArgtest
 	</description>

--- a/test/functional/cmdline_options_tester/build.xml
+++ b/test/functional/cmdline_options_tester/build.xml
@@ -23,7 +23,6 @@
 -->
 
 <project name="cmdline_options_tester" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
 	<description>
 		Build cmdline_options_tester
 	</description>

--- a/test/functional/cmdline_options_testresources/build.xml
+++ b/test/functional/cmdline_options_testresources/build.xml
@@ -22,8 +22,9 @@
   SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 -->
 
-<project name="cmdline_options_testresources tests" default="build" basedir=".">
-	<taskdef resource='net/sf/antcontrib/antlib.xml'/>
+<project name="cmdline_options_testresources tests" default="build" basedir="."
+	xmlns:if="ant:if"
+	xmlns:unless="ant:unless">
 	<description>
 		Build cmdline_options_testresources
 	</description>
@@ -55,35 +56,27 @@
 		<echo>===destdir:                      ${DEST}</echo>
 
 
-		<if>
+		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
-			<then>
-				<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_80}" />
-				</javac>
-			</then>
-			<else>
-				<if>
-					<equals arg1="${JCL_VERSION}" arg2="latest"/>
-					<then>
-						<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" />
-					</then>
-					<else>
-						<property name="addExports" value='--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED' />
-					</else>
-				</if>
-				<javac srcdir="${src}" destdir="${build}" source="1.9" target="1.9" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
-					<src path="${src}" />
-					<src path="${src_90}" />
-					<src path="${TestUtilities}" />
-					<compilerarg line='${addExports}' />
-					<classpath>
-						<pathelement location="${LIB_DIR}/testng.jar"/>
-					</classpath>
-				</javac>
-			</else>
-		</if>
+		</condition>
+
+		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${src_80}" />
+		</javac>
+		<condition property="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8">
+			<equals arg1="${JCL_VERSION}" arg2="latest"/>
+		</condition>
+		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
+		<javac srcdir="${src}" destdir="${build}" source="1.9" target="1.9" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+			<src path="${src}" />
+			<src path="${src_90}" />
+			<src path="${TestUtilities}" />
+			<compilerarg line='${addExports}' />
+			<classpath>
+			<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
+		</javac>
 	</target>
 
 	<target name="dist" depends="compile" description="generate the distribution" >
@@ -107,14 +100,13 @@
 	</target>
 
 	<target name="build" depends="check-jar" unless="jar.exist">
-		<if>
+		<condition property="is_JDK_IMPL_ibm">
 			<or>
 				<equals arg1="${JDK_IMPL}" arg2="ibm"  />
 				<equals arg1="${JDK_IMPL}" arg2="openj9" />
 			</or>
-			<then>
-				<antcall target="clean" inheritall="true" />
-			</then>
-		</if>
+		</condition>
+
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm"/>
 	</target>
 </project>


### PR DESCRIPTION
## Summary

Replace all ant-contrib constructs with native Ant 1.9.1+ equivalents across 119 test build files. This eliminates the ant-contrib dependency that causes build failures when the ant-contrib JAR is not available on the classpath.

## Changes

- Remove `<taskdef resource='net/sf/antcontrib/antlib.xml'/>` from all files
- Add `xmlns:if='ant:if'` and `xmlns:unless='ant:unless'` namespaces to `<project>` tags
- Convert `<if>/<then>/<else>` property conditionals to `<condition>` + first-set-wins `<property>`
- Convert `<if>/<then>/<else>` task conditionals to condition flags + `if:set`/`unless:set` attributes
- Convert `<for>/<var>` loops to `<macrodef>` with explicit calls (Java9andUp, Java16andUp)
- Convert `<trycatch>` wrapping `<mkdir>` to plain `<mkdir>` (DataHelperTests — mkdir is idempotent)
- Convert `<var>` (mutable property) to `<property>` with unique condition names (jfr)

## Notes

- `sourcetools/JCL_Ant_Build/symlink_jcl.xml` retains `<taskdef resource='com/ibm/j9/ant/antlib.xml'/>` — this is an IBM-specific antlib, **not** ant-contrib
- `debugtools/DDR_VM/test.xml` uses `com/ibm/dtfj/anttasks/antlib.xml` — also not ant-contrib, left untouched
- All conversions use Ant 1.9.1+ native features (`xmlns:if`/`xmlns:unless` namespace attributes)

Signed-off-by: George Adams <george.adams@microsoft.com>