### PR TITLE
Fix compilation error: use of undeclared identifier vm

### DIFF
--- a/runtime/vm/threadhelp.cpp
+++ b/runtime/vm/threadhelp.cpp
@@ -544,7 +544,7 @@ continueTimeCompensation:
 		break;
 	case HELPER_TYPE_MONITOR_WAIT_TIMED:
 #if JAVA_SPEC_VERSION >= 24
-		if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)) {
+		if (J9_ARE_ANY_BITS_SET(vmThread->javaVM->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)) {
 			rc = omrthread_monitor_wait_timed_with_callback(monitor, millis, nanos, notifyUnblocker, vmThread);
 		} else
 #endif /* JAVA_SPEC_VERSION >= 24 */


### PR DESCRIPTION
[Fix compilation error: use of undeclared identifier vm](https://github.com/eclipse-openj9/openj9/commit/437cf7db3d905f811a17f78b8da4856955184704) 

Fix https://openj9-jenkins.osuosl.org/job/Build_JDK25_aarch64_mac_Nightly/220/consoleFull
```
21:44:21  /Users/jenkins/workspace/Build_JDK25_aarch64_mac_Nightly/openj9/runtime/vm/threadhelp.cpp:547:27: error: use of undeclared identifier 'vm'
21:44:21                  if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)) {
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>