### PR TITLE
Implement JVM_NewReferenceArray

### DIFF
--- a/runtime/j9vm/valhallavmi.cpp
+++ b/runtime/j9vm/valhallavmi.cpp
@@ -243,8 +243,7 @@ JVM_NewNullRestrictedNonAtomicArray(JNIEnv *env, jclass componentType, jint leng
 JNIEXPORT jarray JNICALL
 JVM_NewReferenceArray(JNIEnv *env, jclass componentType, jint length)
 {
-	assert(!"JVM_NewReferenceArray() stubbed!");
-	return NULL;
+	return newArrayHelper(env, componentType, length, false, NULL);
 }
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 


### PR DESCRIPTION
Reuse newArrayHelper, in J9 a nullable array will always be a reference array.

I ran functional tests locally with this change and Jason's mergetmp extensions branch. Only two tests are failing in cmdLineTester_flattenedvaluetypeddrtests_0 now which I don't think is related to this method.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23924