### PR TITLE
Use condition else attribute and remove is_not_JDK_VERSION_8

### DIFF
--- a/test/TestConfig/build.xml
+++ b/test/TestConfig/build.xml
@@ -36,10 +36,9 @@
 		<mkdir dir="${DEST}" />
 	</target>
 
-		<condition property="TEXT_ENCODING" value="IBM-1047">
+	<condition property="TEXT_ENCODING" value="IBM-1047" else="ISO-8859-1">
 		<contains string="${SPEC}" substring="zos"/>
 	</condition>
-	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="build" depends="init">
 			<copy todir="${DEST}">

--- a/test/functional/Java17andUp/build.xml
+++ b/test/functional/Java17andUp/build.xml
@@ -37,10 +37,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
 	<property name="TestUtilities" location="../TestUtilities/src"/>
 
-		<condition property="src_170" value="src_170">
+	<condition property="src_170" value="src_170" else="">
 		<equals arg1="${JDK_VERSION}" arg2="17" />
 	</condition>
-	<property name="src_170" value=""/>
 
 	<target name="init">
 		<mkdir dir="${DEST}" />

--- a/test/functional/Java8andUp/build.xml
+++ b/test/functional/Java8andUp/build.xml
@@ -41,31 +41,27 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src" />
 	<property name="TestUtilities" location="../TestUtilities/src" />
 	<property name="TestUtilitiesJ9" location="../TestUtilitiesJ9/src" />
-	<condition property="src_90_jcl_dir" value="src_90_current">
+	<condition property="src_90_jcl_dir" value="src_90_current" else="src_90_latest">
 		<equals arg1="${JCL_VERSION}" arg2="current" />
 	</condition>
-	<property name="src_90_jcl_dir" value="src_90_latest"/>
 	<property name="src_90_jcl" location="${src_90_jcl_dir}"/>
-	<condition property="addExports_90_jcl" value="--add-exports java.management/sun.management=ALL-UNNAMED">
+	<condition property="addExports_90_jcl" value="--add-exports java.management/sun.management=ALL-UNNAMED" else="--add-exports jdk.management.agent/jdk.internal.agent=ALL-UNNAMED">
 		<equals arg1="${JCL_VERSION}" arg2="current" />
 	</condition>
-	<property name="addExports_90_jcl" value="--add-exports jdk.management.agent/jdk.internal.agent=ALL-UNNAMED"/>
 
-		<condition property="is_JDK_VERSION_8">
+	<condition property="is_JDK_VERSION_8">
 		<equals arg1="${JDK_VERSION}" arg2="8" />
 	</condition>
 
 	<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" if:set="is_JDK_VERSION_8"/>
-	<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+	<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" else="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8">
 		<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
 	</condition>
-	<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
 	<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
 
-	<condition property="addModules" value="--add-modules java.se.ee">
+	<condition property="addModules" value="--add-modules java.se.ee" else="">
 		<matches string="${JDK_VERSION}" pattern="^(9|10)$$" />
 	</condition>
-	<property name="addModules" value=""/>
 	<property name="LIB" value="asm_all,javassist,testng,jcommander,commons_cli,jaxb_api,asmtools" />
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml" />
 
@@ -86,27 +82,24 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<copy overwrite="true" file="${NoSuchMethod_src}/java/lang/String.java.hide" tofile="${NoSuchMethod_src}/java/lang/String.java" />
 		<copy overwrite="true" file="${NoSuchMethod_src}/AppLoaderCallee.java.fake" tofile="${NoSuchMethod_src}/AppLoaderCallee.java" />
 		<!-- Compile the fake string impl and AppLoader caller with it -->
-		<condition property="is_JDK_VERSION_8">
-			<equals arg1="${JDK_VERSION}" arg2="8" />
-		</condition>
 
 		<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
-			debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
+				debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
 			<src path="${src_access}" />
 			<classpath>
-			<pathelement location="${LIB_DIR}/asm-all.jar" />
-			<pathelement location="${LIB_DIR}/testng.jar" />
-			<pathelement location="${LIB_DIR}/jcommander.jar" />
+				<pathelement location="${LIB_DIR}/asm-all.jar" />
+				<pathelement location="${LIB_DIR}/testng.jar" />
+				<pathelement location="${LIB_DIR}/jcommander.jar" />
 			</classpath>
 		</javac>
 		<javac srcdir="${NoSuchMethod_src}" destdir="${build}" includes="**/String.java,*AppLoaderCaller2.java" fork="true"
-			debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
+				debug="on" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
 			<compilerarg line ="--patch-module java.base=${NoSuchMethod_src}/java/lang" />
 			<src path="${src_access}" />
 			<classpath>
-			<pathelement location="${LIB_DIR}/asm-all.jar" />
-			<pathelement location="${LIB_DIR}/testng.jar" />
-			<pathelement location="${LIB_DIR}/jcommander.jar" />
+				<pathelement location="${LIB_DIR}/asm-all.jar" />
+				<pathelement location="${LIB_DIR}/testng.jar" />
+				<pathelement location="${LIB_DIR}/jcommander.jar" />
 			</classpath>
 		</javac>
 		<!-- remove our fake java.lang.string impl -->
@@ -159,9 +152,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 				<pathelement location="${LIB_DIR}/testng.jar" />
 			</classpath>
 		</javac>
-		<condition property="is_JDK_VERSION_8">
-			<equals arg1="${JDK_VERSION}" arg2="8" />
-		</condition>
 
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" if:set="is_JDK_VERSION_8">
 			<src path="${src}" />
@@ -175,23 +165,21 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<!-- requires special compilation methods -->
 			<exclude name="**/NoSuchMethod/**" />
 			<classpath>
-			<pathelement location="${LIB_DIR}/asm-all.jar" />
-			<pathelement location="${LIB_DIR}/testng.jar" />
-			<pathelement location="${LIB_DIR}/jcommander.jar" />
-			<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
-			<pathelement location="${LIB_DIR}/commons-cli.jar" />
-			<pathelement location="${LIB_DIR}/javassist.jar" />
+				<pathelement location="${LIB_DIR}/asm-all.jar" />
+				<pathelement location="${LIB_DIR}/testng.jar" />
+				<pathelement location="${LIB_DIR}/jcommander.jar" />
+				<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
+				<pathelement location="${LIB_DIR}/commons-cli.jar" />
+				<pathelement location="${LIB_DIR}/javassist.jar" />
 			</classpath>
 		</javac>
-		<condition property="src_version_dir" value="src_110" unless:set="is_JDK_VERSION_8">
+		<condition property="src_version_dir" value="src_110" else="src_170" unless:set="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="11" />
 		</condition>
-		<property name="src_version_dir" value="src_170" unless:set="is_JDK_VERSION_8"/>
 		<property name="src_version" location="${src_version_dir}" unless:set="is_JDK_VERSION_8"/>
-		<condition property="addExports_version" value="" unless:set="is_JDK_VERSION_8">
+		<condition property="addExports_version" value="" else="--add-exports java.base/jdk.internal.access=ALL-UNNAMED" unless:set="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="11" />
 		</condition>
-		<property name="addExports_version" value="--add-exports java.base/jdk.internal.access=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 
 		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/com.ibm.oti.util=ALL-UNNAMED --add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED --add-exports java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED --add-exports java.base/com.ibm.jit.crypto=ALL-UNNAMED --add-exports java.base/com.ibm.jit=ALL-UNNAMED --add-exports java.base/com.ibm.oti.reflect=ALL-UNNAMED --add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED --add-exports jdk.attach/com.ibm.tools.attach.attacher=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 		<echo unless:set="is_JDK_VERSION_8">===addExports:        ${addExports}</echo>
@@ -208,15 +196,37 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<fileset dir="${LIB_DIR}/" includes="jaxb-api.jar"/>
 		</path>
 		<property name="commonArgs" value="${addExports} ${addExports_90_jcl} ${addExports_version} --add-modules openj9.sharedclasses" unless:set="is_JDK_VERSION_8"/>
+		<condition property="is_JDK_VERSION_11_to_18">
+			<matches string="${JDK_VERSION}" pattern="^(1[1-8])$$" />
+		</condition>
+		<condition property="is_JDK_VERSION_19_to_22">
+			<matches string="${JDK_VERSION}" pattern="^(19|2[0-2])$$" />
+		</condition>
 		<condition property="is_JDK_VERSION_match">
-			<matches string="${JDK_VERSION}" pattern="^(8|1[1-8])$$" />
+			<matches string="${JDK_VERSION}" pattern="^(8|1[1-8]|19|2[0-2])$$" />
 		</condition>
 
 		<!-- Java 11-18 -->
-		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_VERSION_match" unless:set="is_JDK_VERSION_8">
+		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_VERSION_11_to_18">
 			<compilerarg line='${commonArgs}' />
 		</javac>
-		<!-- Java 23+ (SecurityManage and Thread functions removed) -->
+		<!-- Java 19-22 (SecurityManager removed) -->
+		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" if:set="is_JDK_VERSION_19_to_22">
+			<compilerarg line='${commonArgs}' />
+			<!-- exclude tests that depend on SecurityManager -->
+			<exclude name="org/openj9/test/java/security/Test_AccessController.java" />
+			<exclude name="org/openj9/test/java/security/Test_AccessControlContext.java" />
+			<exclude name="org/openj9/test/java/lang/Test_Class_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_System_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_Thread_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_ThreadGroup_SM.java" />
+			<exclude name="org/openj9/test/java/lang/invoke/Test_MethodHandleInfo_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_ClassLoader_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_J9VMInternals_SM.java" />
+			<exclude name="org/openj9/test/java/lang/Test_J9VMInternalsImpl_SM.java" />
+			<exclude name="org/openj9/test/vm/Test_VM.java" />
+		</javac>
+		<!-- Java 23+ (SecurityManager and Thread functions removed) -->
 		<javac srcdir="${srcpath}" excludes="${commonExcludes}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" classpathref="build.cp" unless:set="is_JDK_VERSION_match">
 			<compilerarg line='${commonArgs}' />
 			<!-- exclude tests that depend on SecurityManager or Thread functions -->

--- a/test/functional/Java9andUp/build.xml
+++ b/test/functional/Java9andUp/build.xml
@@ -150,13 +150,11 @@
 			</or>
 		</condition>
 
-		<condition property="is_not_JDK_VERSION_8" if:set="is_JDK_IMPL_ibm">
-			<not>
-				<equals arg1="${JDK_VERSION}" arg2="8"/>
-			</not>
+		<condition property="is_JDK_VERSION_8">
+			<equals arg1="${JDK_VERSION}" arg2="8"/>
 		</condition>
 
-		<antcall target="clean" inheritall="true" if:set="is_not_JDK_VERSION_8"/>
+		<antcall target="clean" inheritall="true" if:set="is_JDK_IMPL_ibm" unless:set="is_JDK_VERSION_8"/>
 	</target>
 
 	<target name="clean" depends="dist" description="clean up" >

--- a/test/functional/JavaAgentTest/build.xml
+++ b/test/functional/JavaAgentTest/build.xml
@@ -47,10 +47,9 @@
 		<echo>============COMPILER SETTINGS============</echo>
 		<echo>===executable:                   ${compiler.javac}</echo>
 		<echo>===destdir:                      ${DEST}</echo>
-		<condition property="src_version_dir" value="./src_java8">
+		<condition property="src_version_dir" value="./src_java8" else="./src_java12">
 			<matches string="${JDK_VERSION}" pattern="^(8|9|10|11)$$" />
 		</condition>
-		<property name="src_version_dir" value="./src_java12"/>
 		<property name="src_version" location="${src_version_dir}"/>
 		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>

--- a/test/functional/Jsr292/build.xml
+++ b/test/functional/Jsr292/build.xml
@@ -121,9 +121,6 @@
 			<src path="${bootstrapSrc}"/>
 			<src path="${bootstrapSrc_80}"/>
 		</javac>
-		<condition property="addExports" value="--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8">
-			<equals arg1="${JCL_VERSION}" arg2="latest"/>
-		</condition>
 		<property name="addExports" value="--add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 		<javac srcdir="${bootstrapSrc}" destdir="${bootstrapBuild}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
 			<src path="${bootstrapSrc}"/>

--- a/test/functional/Jsr335/build.xml
+++ b/test/functional/Jsr335/build.xml
@@ -56,10 +56,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 		<property name="src_access" location="${TEST_ROOT}/functional/UnsafeAccess/src" if:set="is_JDK_VERSION_8"/>
 		<property name="addExports" value="" if:set="is_JDK_VERSION_8"/>
-		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" else="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8">
 			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
 		</condition>
-		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
 		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
 		<property name="addExports" value="--add-exports java.base/jdk.internal.misc=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 

--- a/test/functional/UnsafeTest/build.xml
+++ b/test/functional/UnsafeTest/build.xml
@@ -63,19 +63,17 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<src path="${src_access}" />
 			<src path="${transformerListener}" />
 			<classpath>
-			<pathelement location="${LIB_DIR}/testng.jar" />
-			<pathelement location="${LIB_DIR}/asm.jar"/>
+				<pathelement location="${LIB_DIR}/testng.jar" />
+				<pathelement location="${LIB_DIR}/asm.jar"/>
 			</classpath>
 		</javac>
-		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" else="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8">
 			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
 		</condition>
-		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
 		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
-		<condition property="test_src_dir" value="${src_11}" unless:set="is_JDK_VERSION_8">
+		<condition property="test_src_dir" value="${src_11}" else="${src_25}" unless:set="is_JDK_VERSION_8">
 			<matches string="${JDK_VERSION}" pattern="^(1[0-9]|2[0-1])$$" />
 		</condition>
-		<property name="test_src_dir" value="${src_25}" unless:set="is_JDK_VERSION_8"/>
 		<property name="test_src" location="${test_src_dir}" unless:set="is_JDK_VERSION_8"/>
 		<property name="src_util" location="../TestUtilities/src" unless:set="is_JDK_VERSION_8"/>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
@@ -85,8 +83,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<src path="${transformerListener}" />
 			<src path="${src_util}" />
 			<classpath>
-			<pathelement location="${LIB_DIR}/testng.jar" />
-			<pathelement location="${LIB_DIR}/asm.jar"/>
+				<pathelement location="${LIB_DIR}/testng.jar" />
+				<pathelement location="${LIB_DIR}/asm.jar"/>
 			</classpath>
 			<compilerarg value="--add-exports" />
 			<compilerarg value="java.base/jdk.internal.misc=ALL-UNNAMED" />
@@ -120,10 +118,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 		<condition property="is_JDK_VERSION_9" if:set="is_JDK_IMPL_ibm">
 			<not>
-			<and>
-			<equals arg1="${JDK_VERSION}" arg2="9" />
-			<equals arg1="${JCL_VERSION}" arg2="current" />
-			</and>
+				<and>
+					<equals arg1="${JDK_VERSION}" arg2="9" />
+					<equals arg1="${JCL_VERSION}" arg2="current" />
+				</and>
 			</not>
 		</condition>
 

--- a/test/functional/cmdLineTests/jvmtitests/build.xml
+++ b/test/functional/cmdLineTests/jvmtitests/build.xml
@@ -53,14 +53,12 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<echo>===destdir:                      ${build}</echo>
 
 		<!-- Define variables to exclude Java21 and up tests for Java 8, 11 and 17. -->
-		<condition property="excludeJDK21UpGetStackTraceExtendedTest" value="com/ibm/jvmti/tests/getStackTraceExtended/gste002.java">
+		<condition property="excludeJDK21UpGetStackTraceExtendedTest" value="com/ibm/jvmti/tests/getStackTraceExtended/gste002.java" else="">
 			<matches string="${JDK_VERSION}" pattern="^(8|11|17)$$" />
 		</condition>
-		<property name="excludeJDK21UpGetStackTraceExtendedTest" value=""/>
-		<condition property="excludeJDK21UpGetThreadListStackTracesExtendedTest" value="com/ibm/jvmti/tests/getThreadListStackTracesExtended/gtlste002.java">
+		<condition property="excludeJDK21UpGetThreadListStackTracesExtendedTest" value="com/ibm/jvmti/tests/getThreadListStackTracesExtended/gtlste002.java" else="">
 			<matches string="${JDK_VERSION}" pattern="^(8|11|17)$$" />
 		</condition>
-		<property name="excludeJDK21UpGetThreadListStackTracesExtendedTest" value=""/>
 
 		<condition property="is_JDK_VERSION_8">
 			<equals arg1="${JDK_VERSION}" arg2="8" />
@@ -71,19 +69,17 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<exclude name="${excludeJDK21UpGetStackTraceExtendedTest}" />
 			<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
 			<classpath>
-			<pathelement location="${asm.jar}" />
-			<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
+				<pathelement location="${asm.jar}" />
+				<pathelement location="${TEST_JDK_HOME}/lib/tools.jar" />
 			</classpath>
 		</javac>
 		<property name="addExports" value="--add-exports java.base/jdk.internal.module=ALL-UNNAMED --add-exports java.base/openj9.internal.tools.attach.target=ALL-UNNAMED --add-exports java.base/com.ibm.tools.attach=ALL-UNNAMED --add-exports=java.base/jdk.internal.misc=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
-		<condition property="extraSrc" value="${src_latest}" unless:set="is_JDK_VERSION_8">
+		<condition property="extraSrc" value="${src_latest}" else="${src_current}">
 			<equals arg1="${JCL_VERSION}" arg2="latest" />
 		</condition>
-		<property name="extraSrc" value="${src_current}" unless:set="is_JDK_VERSION_8"/>
-		<condition property="excludeFile" value="**/modularityTests/**" unless:set="is_JDK_VERSION_8">
+		<condition property="excludeFile" value="**/modularityTests/**" else="">
 			<equals arg1="${JCL_VERSION}" arg2="latest" />
 		</condition>
-		<property name="excludeFile" value="" unless:set="is_JDK_VERSION_8"/>
 		<condition property="is_JDK_VERSION_match">
 			<matches string="${JDK_VERSION}" pattern="^(8|9|1[0-9]|2[0-2])$$" />
 		</condition>
@@ -96,7 +92,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<exclude name="${excludeJDK21UpGetThreadListStackTracesExtendedTest}" />
 			<compilerarg line="${addExports}" />
 			<classpath>
-			<pathelement location="${asm.jar}" />
+				<pathelement location="${asm.jar}" />
 			</classpath>
 		</javac>
 		<!-- Java 23+ (SecurityManage and several Thread functions removed) -->
@@ -109,7 +105,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<compilerarg line="${addExports}" />
 			<exclude name="com/ibm/jvmti/tests/getThreadState/gts001.java" />
 			<classpath>
-			<pathelement location="${asm.jar}" />
+				<pathelement location="${asm.jar}" />
 			</classpath>
 		</javac>
 

--- a/test/functional/cmdLineTests/locales/build.xml
+++ b/test/functional/cmdLineTests/locales/build.xml
@@ -35,10 +35,9 @@
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/locales" />
 	<property name="src" location="." />
 
-		<condition property="TEXT_ENCODING" value="IBM-1047">
+	<condition property="TEXT_ENCODING" value="IBM-1047" else="ISO-8859-1">
 		<contains string="${SPEC}" substring="zos"/>
 	</condition>
-	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="dist" description="generate the distribution">
 		<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">

--- a/test/functional/cmdLineTests/lockWordAlignment/build.xml
+++ b/test/functional/cmdLineTests/lockWordAlignment/build.xml
@@ -72,10 +72,9 @@
 	</target>
 
 	<target name="generateTestClass" depends="compile" description="Generate test class files ">
-		<condition property="addExports" value="">
+		<condition property="addExports" value="" else="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED">
 			<equals arg1="${JDK_VERSION}" arg2="8"/>
 		</condition>
-		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED"/>
 		<property name="build.javaexecutable" value="${TEST_JDK_HOME}/bin/java"/>
 		<java classname="IntLongObjectAlignmentTestGenerator" failonerror="true" fork="true" logError="true" jvm="${build.javaexecutable}">
 			<jvmarg line='${addExports}' />

--- a/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
+++ b/test/functional/cmdLineTests/runtimemxbeanTests/build.xml
@@ -53,10 +53,9 @@
 		</javac>
 	</target>
 
-		<condition property="TEXT_ENCODING" value="IBM-1047">
+	<condition property="TEXT_ENCODING" value="IBM-1047" else="ISO-8859-1">
 		<contains string="${SPEC}" substring="zos"/>
 	</condition>
-	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="dist" depends="compile" description="generate the distribution">
 		<jar jarfile="${DEST}/runtimemxbeanTests.jar" filesonly="true">

--- a/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
+++ b/test/functional/cmdLineTests/sigxfszHandlingTest/build.xml
@@ -35,10 +35,9 @@
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/sigxfszHandlingTest" />
 	<property name="src" location="." />
 
-		<condition property="TEXT_ENCODING" value="IBM-1047">
+	<condition property="TEXT_ENCODING" value="IBM-1047" else="ISO-8859-1">
 		<contains string="${SPEC}" substring="zos"/>
 	</condition>
-	<property name="TEXT_ENCODING" value="ISO-8859-1"/>
 
 	<target name="dist" description="generate the distribution">
 		<copy todir="${DEST}" outputencoding="${TEXT_ENCODING}">

--- a/test/functional/cmdLineTests/utils/build.xml
+++ b/test/functional/cmdLineTests/utils/build.xml
@@ -62,10 +62,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<pathelement location="${LIB_DIR}/testng.jar" />
 			</classpath>
 		</javac>
-		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" else="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8">
 			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
 		</condition>
-		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
 		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
 			<src path="${src_shared}" />

--- a/test/functional/cmdLineTests/utils2/build.xml
+++ b/test/functional/cmdLineTests/utils2/build.xml
@@ -60,10 +60,9 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			<pathelement location="${LIB_DIR}/testng.jar" />
 			</classpath>
 		</javac>
-		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" unless:set="is_JDK_VERSION_8">
+		<condition property="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_110" else="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8">
 			<matches string="${JDK_VERSION}" pattern="^1[1-6]$$" />
 		</condition>
-		<property name="src_access_dir" value="${TEST_ROOT}/functional/UnsafeAccess/src_170" unless:set="is_JDK_VERSION_8"/>
 		<property name="src_access" location="${src_access_dir}" unless:set="is_JDK_VERSION_8"/>
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
 			<src path="${src_shared}" />

--- a/test/functional/cmdline_options_testresources/build.xml
+++ b/test/functional/cmdline_options_testresources/build.xml
@@ -64,17 +64,13 @@
 			<src path="${src}" />
 			<src path="${src_80}" />
 		</javac>
-		<condition property="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8">
-			<equals arg1="${JCL_VERSION}" arg2="latest"/>
-		</condition>
-		<property name="addExports" value="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" unless:set="is_JDK_VERSION_8"/>
 		<javac srcdir="${src}" destdir="${build}" source="1.9" target="1.9" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1" unless:set="is_JDK_VERSION_8">
 			<src path="${src}" />
 			<src path="${src_90}" />
 			<src path="${TestUtilities}" />
-			<compilerarg line='${addExports}' />
+			<compilerarg line="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED --add-exports java.base/jdk.internal.reflect=ALL-UNNAMED" />
 			<classpath>
-			<pathelement location="${LIB_DIR}/testng.jar"/>
+				<pathelement location="${LIB_DIR}/testng.jar"/>
 			</classpath>
 		</javac>
 	</target>


### PR DESCRIPTION
Follow-up cleanup from PR #23921:
- Replace condition+property default pairs with condition else attribute
- Replace is_not_JDK_VERSION_8 with unless:set in Java9andUp
- Remove redundant conditions where value equals default (Jsr292, cmdline_options_testresources)