### PR TITLE
Update tests to add a sleep before destroying nonpersistent cache

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
@@ -410,6 +410,8 @@
 		<output type="failure" caseSensitive="yes" regex="no">JVM requested Snap dump</output>
 	</test>
 	
+	<exec command="sleep 0.5" platforms="linux.*" />
+
 	<test id="At end destroy non-persistent cache for cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>


### PR DESCRIPTION
Fix another failure in testSCCMLSnapshot.

https://openj9-jenkins.osuosl.org/job/Test_openjdk21_j9_extended.functional_ppc64le_linux_Nightly_testList_0/638

Related to https://github.com/eclipse-openj9/openj9/pull/23881