### PR TITLE
Add bound checking to accelerated intrinsics

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -6871,6 +6871,8 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     doneLabel->setEndInternalControlFlow();
 
     generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicIndexOf/(%s)", cg->comp()->signature()));
 
     const int32_t vecWidth = 16;
     const int32_t shift = isLatin1 ? 0 : 1;
@@ -7157,6 +7159,9 @@ static TR::Register *inlineStringLatin1Inflate(TR::Node *node, TR::CodeGenerator
 
     TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
     TR_Debug *debugObj = cg->getDebug();
+
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicInflate/(%s)", cg->comp()->signature()));
 
     auto branchToDoneIfZeroInstr
         = generateCompareBranchInstruction(cg, TR::InstOpCode::cbzw, node, savedLengthReg, doneLabel);
@@ -7559,6 +7564,7 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
     TR::Compilation *comp = cg->comp();
     TR::MethodSymbol *methodSymbol = node->getSymbol()->getMethodSymbol();
     static const bool disableCRC32 = feGetEnv("TR_aarch64DisableCRC32") != NULL;
+    static const bool disableStringIntrinsicFlagChk = (feGetEnv("TR_DisableStringIntrinsicFlagChk") != NULL);
 
     if (OMR::CodeGeneratorConnector::inlineDirectCall(node, resultReg)) {
         return true;
@@ -7582,6 +7588,12 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
                 break;
 
             case TR::java_lang_StringLatin1_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
                 if (cg->getSupportsInlineStringIndexOfString()) {
                     resultReg = inlineIntrinsicStringIndexOfString(node, cg, true);
@@ -7590,6 +7602,12 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
                 break;
 
             case TR::java_lang_StringUTF16_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::java_lang_StringUTF16_indexOfUnsafe:
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
                 if (cg->getSupportsInlineStringIndexOfString()) {
@@ -7701,6 +7719,11 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
 
             case TR::java_lang_StringLatin1_inflate_BICII:
                 if (cg->getSupportsInlineStringLatin1Inflate()) {
+#if JAVA_SPEC_VERSION < 25
+                    if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                        break;
+                    }
+#endif /* JAVA_SPEC_VERSION < 25 */
                     resultReg = inlineStringLatin1Inflate(node, cg);
                     return true;
                 }

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -6822,6 +6822,8 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     doneLabel->setEndInternalControlFlow();
 
     generateLabelInstruction(cg, OP::label, node, startLabel);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicIndexOf/(%s)", cg->comp()->signature()));
 
     const int32_t vecWidth = 16;
     const int32_t shift = isLatin1 ? 0 : 1;
@@ -7102,6 +7104,9 @@ static TR::Register *inlineStringLatin1Inflate(TR::Node *node, TR::CodeGenerator
 
     TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
     TR_Debug *debugObj = cg->getDebug();
+
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicInflate/(%s)", cg->comp()->signature()));
 
     auto branchToDoneIfZeroInstr = generateCompareBranchInstruction(cg, OP::cbzw, node, savedLengthReg, doneLabel);
     if (debugObj) {
@@ -7493,6 +7498,7 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
     TR::Compilation *comp = cg->comp();
     TR::MethodSymbol *methodSymbol = node->getSymbol()->getMethodSymbol();
     static const bool disableCRC32 = feGetEnv("TR_aarch64DisableCRC32") != NULL;
+    static const bool disableStringIntrinsicBoundChk = (feGetEnv("TR_DisableStringIntrinsicBoundChk") != NULL);
 
     if (OMR::CodeGeneratorConnector::inlineDirectCall(node, resultReg)) {
         return true;
@@ -7516,6 +7522,12 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
                 break;
 
             case TR::java_lang_StringLatin1_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
                 if (cg->getSupportsInlineStringIndexOfString()) {
                     resultReg = inlineIntrinsicStringIndexOfString(node, cg, true);
@@ -7524,6 +7536,12 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
                 break;
 
             case TR::java_lang_StringUTF16_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::java_lang_StringUTF16_indexOfUnsafe:
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
                 if (cg->getSupportsInlineStringIndexOfString()) {
@@ -7635,6 +7653,11 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
 
             case TR::java_lang_StringLatin1_inflate_BICII:
                 if (cg->getSupportsInlineStringLatin1Inflate()) {
+#if JAVA_SPEC_VERSION < 25
+                    if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                        break;
+                    }
+#endif /* JAVA_SPEC_VERSION < 25 */
                     resultReg = inlineStringLatin1Inflate(node, cg);
                     return true;
                 }

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -914,8 +914,251 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_compareTo_BBI
         storeTreeTop2, comp()->getFlowGraph(), false, false);
 }
 
+void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BICII(TR::TreeTop *treetop, TR::Node *node,
+    bool isByteToChar)
+{
+    /*
+     * Prior to JDK25, it is possible for an AbstractStringBuilder race condition to trigger a call to
+     * java/lang/StringLatin1.inflate([BI[CII)V in such a way that an out of bounds exception gets triggered. This
+     * transformation adds a check for that possibility and calls the slow path if an exception needs to be thrown in
+     * the future.
+     *
+     * Prior to JDK25 under Z, these checks are also needed to accelerate java/lang/StringLatin1.inflate([BI[BII)V
+     * As a result, process_java_lang_StringLatin1_inflate_BIBII will call this function with isByteToChar set to false.
+     * isByteToChar being false indicates that this is the Byte array to Byte array case.
+     */
+    TransformUtil::createTempsForCall(this, treetop);
+
+    /* Input byte array containing the string to inflate. */
+    TR::Node *srcObjNode = node->getFirstChild();
+
+    /* Offset into the input byte array. Unit is number of bytes. */
+    TR::Node *srcOffNode = node->getSecondChild();
+
+    /* Output char array to be modified with the result. */
+    TR::Node *dstObjNode = node->getChild(2);
+
+    /* Offset into the output char array. Unit is number of chars. */
+    TR::Node *dstOffNode = node->getChild(3);
+
+    /* Number of bytes to read from source and also number of chars to write to destination. */
+    TR::Node *copyLenNode = node->getChild(4);
+
+    TR::Node *srcArrayLenNode = TR::Node::create(TR::arraylength, 1, srcObjNode->duplicateTree());
+    srcArrayLenNode->setIsNonNegative(true);
+
+    TR::Node *dstArrayLenNode = TR::Node::create(TR::arraylength, 1, dstObjNode->duplicateTree());
+    dstArrayLenNode->setIsNonNegative(true);
+
+    /*
+     * For the Byte array to Byte Array case, the output array length is shifted right by 1.
+     * This is to account for the fact that the byte array can hold half as many characters as its length.
+     */
+    if (!isByteToChar) {
+        dstArrayLenNode = TR::Node::create(TR::ishr, 2, dstArrayLenNode, TR::Node::create(TR::iconst, 0, 1));
+    }
+
+    /*
+     * The call node is duplicated to set up a fast path and a slow path.
+     * The slow path has the skipRecognizedCallTransformation flag set so it doesn't get transformed and
+     * RecognizedCallTransformer won't look at it again.
+     * The fast path has the inlineStringIntrinsic flag set so that it gets transformed by inlineDirectCall.
+     */
+    TR::TreeTop *slowPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    slowPathTreeTop->getNode()->getFirstChild()->setSkippedInRecognizedCallTransformation(true);
+
+    TR::TreeTop *fastPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    fastPathTreeTop->getNode()->getFirstChild()->setIsSafeForCGToInlineStringIntrinsic(true);
+
+    /*
+     * Put down the following two checks to confirm that src and dst arrays are big enough:
+     *   (srcArray.length - srcOffNode) < copyLenNode
+     *   (dstArray.length - dstOffNode) < copyLenNode
+     * If either is true, an out of bounds exception will occur so the code must branch to the slow path.
+     */
+    TR::Node *srcLenMinusOffsetNode = TR::Node::create(TR::isub, 2, srcArrayLenNode, srcOffNode->duplicateTree());
+    TR::Node *dstLenMinusOffsetNode = TR::Node::create(TR::isub, 2, dstArrayLenNode, dstOffNode->duplicateTree());
+
+    TR::Node *srcCmpNode = TR::Node::createif(TR::ificmplt, srcLenMinusOffsetNode, copyLenNode->duplicateTree(), NULL);
+    TR::TreeTop *srcCmpTree = TR::TreeTop::create(comp(), srcCmpNode);
+
+    TR::Node *dstCmpNode = TR::Node::createif(TR::ificmplt, dstLenMinusOffsetNode, copyLenNode->duplicateTree(), NULL);
+    TR::TreeTop *dstCmpTree = TR::TreeTop::create(comp(), dstCmpNode);
+
+    TR::Block *callBlock = treetop->getEnclosingBlock();
+
+    /*
+     * createConditionalBlocksBeforeTree is used to create the source array length check.
+     * treetop is the current call treetop and the split point.
+     * srcCmpTree is the check to see if out of bounds access will occur in the src array.
+     * slowPathTreeTop is the slow path. This is a cold block that is branched to if an OOB exception will happen.
+     * fastPathTreeTop is the fast path. This is the fallthrough path.
+     * The slow path and fast path then merge back into each other.
+     */
+    callBlock->createConditionalBlocksBeforeTree(treetop, srcCmpTree, slowPathTreeTop, fastPathTreeTop,
+        comp()->getFlowGraph(), false /* changeBlockExtensions */, true /* markCold */);
+
+    /*
+     * dstCmpTree is the check to see if out of bounds access will occur in the dst array.
+     * The check is placed after the src out of bounds access check.
+     * If the dst array is too small, the code branches to the slow path to handle the OOB exception.
+     */
+    TR::Block *dstCmpBlock = TR::Block::createEmptyBlock(srcCmpNode, comp(), 0, NULL);
+    dstCmpBlock->setFrequency(callBlock->getFrequency());
+    comp()->getFlowGraph()->addNode(dstCmpBlock);
+
+    callBlock->getExit()->join(dstCmpBlock->getEntry());
+    dstCmpBlock->getExit()->join(fastPathTreeTop->getEnclosingBlock()->getEntry());
+    comp()->getFlowGraph()->copyExceptionSuccessors(callBlock, dstCmpBlock);
+
+    dstCmpBlock->append(dstCmpTree);
+    dstCmpNode->setBranchDestination(srcCmpNode->getBranchDestination());
+
+    comp()->getFlowGraph()->addEdge(TR::CFGEdge::createEdge(callBlock, dstCmpBlock, comp()->trMemory()));
+    comp()->getFlowGraph()->addEdge(
+        TR::CFGEdge::createEdge(dstCmpBlock, fastPathTreeTop->getEnclosingBlock(), comp()->trMemory()));
+    comp()->getFlowGraph()->addEdge(
+        TR::CFGEdge::createEdge(dstCmpBlock, slowPathTreeTop->getEnclosingBlock(), comp()->trMemory()));
+
+    comp()->getFlowGraph()->removeEdge(callBlock, fastPathTreeTop->getEnclosingBlock());
+
+    TR::DebugCounter::prependDebugCounter(comp(),
+        TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1Inflate/fast/(%s)", comp()->signature()),
+        fastPathTreeTop);
+    TR::DebugCounter::prependDebugCounter(comp(),
+        TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1Inflate/slow/(%s)", comp()->signature()),
+        slowPathTreeTop);
+}
+
+void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_indexOf_BIBII(TR::TreeTop *treetop, TR::Node *node)
+{
+    process_java_lang_StringLatin1_indexOf_BIBII(treetop, node, false /* isLatin1 */);
+}
+
+void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_indexOf_BIBII(TR::TreeTop *treetop, TR::Node *node,
+    bool isLatin1)
+{
+    /*
+     * The indexOf operation is searching for an index of a substring inside of another string. Prior to JDK25, it is
+     * possible for an AbstractStringBuilder race condition to trigger a call to indexOf in such a way that an out of
+     * bounds exception gets triggered. This transformation checks for that possibility and calls the slow path for
+     * safety if there is a chance it may occur.
+     *
+     * This section of code is also used for StringUTF16_indexOf_BIBII. In this case, the value of the isLatin1
+     * parameter will be false.
+     */
+
+    TransformUtil::createTempsForCall(this, treetop);
+
+    /* This is the byte[] containing the characters for the string being searched in. */
+    TR::Node *arrayObjNode = node->getFirstChild();
+
+    /*
+     * This is the number of characters thought to be in the string being searched in. Due to the race condition, it
+     * may be incorrect.
+     */
+    TR::Node *arrayLenNode = node->getSecondChild();
+
+    /*
+     * maxArrayLenNode represents the maxmimum number of bytes that can be in the String being searched in without going
+     * out of bounds.
+     */
+    TR::Node *maxArrayLenNode = TR::Node::create(TR::arraylength, 1, arrayObjNode->duplicateTree());
+    maxArrayLenNode->setIsNonNegative(true);
+
+    /*
+     * The call node is duplicated to set up a fast path and a slow path.
+     * The slow path has the skipRecognizedCallTransformation flag set so it doesn't get transformed and
+     * RecognizedCallTransformer won't look at it again.
+     * The fast path has the inlineStringIntrinsic flag set so that it gets transformed by inlineDirectCall.
+     */
+    TR::TreeTop *slowPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    slowPathTreeTop->getNode()->getFirstChild()->setSkippedInRecognizedCallTransformation(true);
+
+    TR::TreeTop *fastPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    fastPathTreeTop->getNode()->getFirstChild()->setIsSafeForCGToInlineStringIntrinsic(true);
+
+    TR::SymbolReference *newSymbolReference = NULL;
+    TR::DataType dataType = node->getDataType();
+
+    /* If the call node has a reference count >1, a symref is created to hold the result. */
+    if (node->getReferenceCount() > 1) {
+        newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), dataType);
+        TR::Node::recreate(node, comp()->il.opCodeForDirectLoad(dataType));
+        node->setSymbolReference(newSymbolReference);
+        node->removeAllChildren();
+    }
+
+    /*
+     * For Latin1, the value of maxArrayLenNode must be greater than or equal to the value of arrayLenNode.
+     * For UTF16, the value of (maxArrayLenNode >> 1) must be greater than or equal to the value of arrayLenNode.
+     * If this isn't true, it is possible for the indexOf operation to go out of bounds so the slow path must be taken.
+     */
+    if (!isLatin1) {
+        maxArrayLenNode = TR::Node::create(TR::ishr, 2, maxArrayLenNode, TR::Node::create(TR::iconst, 0, 1));
+    }
+    TR::Node *cmpNode = TR::Node::createif(TR::ificmpgt, arrayLenNode->duplicateTree(), maxArrayLenNode, NULL);
+    TR::TreeTop *cmpTree = TR::TreeTop::create(comp(), cmpNode);
+
+    TR::Block *callBlock = treetop->getEnclosingBlock();
+
+    /*
+     * createConditionalBlocksBeforeTree puts everything together.
+     * treetop is the current call treetop and the split point.
+     * cmpTree is the check to see if out of bounds access is possible.
+     * slowPathTreeTop is the slow path. This is a cold block that is branched to if OOB is possible.
+     * fastPathTreeTop is the fast path. This is the fallthrough path.
+     * The slow path and fast path then merge back into each other.
+     */
+    callBlock->createConditionalBlocksBeforeTree(treetop, cmpTree, slowPathTreeTop, fastPathTreeTop,
+        comp()->getFlowGraph(), false /* changeBlockExtensions */, true /* markCold */);
+
+    /* If the call node has a reference count >1, a symref is used to record the return value from the call. */
+    if (newSymbolReference) {
+        TR::Node *fastPathStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1,
+            fastPathTreeTop->getNode()->getFirstChild(), newSymbolReference);
+        TR::TreeTop *fastPathStoreTree = TR::TreeTop::create(comp(), fastPathStoreNode);
+        fastPathTreeTop->insertAfter(fastPathStoreTree);
+
+        TR::Node *slowPathStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1,
+            slowPathTreeTop->getNode()->getFirstChild(), newSymbolReference);
+        TR::TreeTop *slowPathStoreTree = TR::TreeTop::create(comp(), slowPathStoreNode);
+        slowPathTreeTop->insertAfter(slowPathStoreTree);
+    }
+
+    if (isLatin1) {
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1IndexOf/fast/(%s)", comp()->signature()),
+            fastPathTreeTop);
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1IndexOf/slow/(%s)", comp()->signature()),
+            slowPathTreeTop);
+    } else {
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicUTF16IndexOf/fast/(%s)", comp()->signature()),
+            fastPathTreeTop);
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicUTF16IndexOf/slow/(%s)", comp()->signature()),
+            slowPathTreeTop);
+    }
+}
+
 void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII(TR::TreeTop *treetop, TR::Node *node)
 {
+#if JAVA_SPEC_VERSION < 25
+    /*
+     * Prior to JDK25 on Z, it is possible for an AbstractStringBuilder race condition to trigger a call to
+     * java/lang/StringLatin1.inflate([BI[BII)V in such a way that an out of bounds exception gets triggered. This
+     * calls process_java_lang_StringLatin1_inflate_BICII to perform a transformation to add a check for that
+     * possibility and call the slow path if an exception needs to be thrown in the future.
+     *
+     * isByteToChar being false indicates that this is the Byte array to Byte array case.
+     */
+    if (comp()->target().cpu.isZ()) {
+        return process_java_lang_StringLatin1_inflate_BICII(treetop, node, false /* isByteToChar */);
+    }
+#endif /* JAVA_SPEC_VERSION < 25 */
+
     /*
      * Replace the call with the following tree (+ boundary checks)
      *
@@ -1004,21 +1247,21 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     TR::Node *constZeroNode2 = TR::Node::create(node, TR::iconst, 0, 0);
     TR::Node *ifCmpNode2 = TR::Node::createif(TR::ificmplt, srcOff, constZeroNode2);
     TR::TreeTop *ifCmpTreeTop2 = TR::TreeTop::create(comp(), ifCmpTreeTop1, ifCmpNode2);
-    // if (srcObj.length < srcOff + length) { call the original method }
+    // if (srcObj.length - srcOff < length) { call the original method }
     TR::Node *arrayLenNode1 = TR::Node::create(node, TR::arraylength, 1, srcObj);
-    TR::Node *iaddNode1 = TR::Node::create(node, TR::iadd, 2, srcOff, length);
-    TR::Node *ifCmpNode3 = TR::Node::createif(TR::ificmplt, arrayLenNode1, iaddNode1);
+    TR::Node *isubNode1 = TR::Node::create(node, TR::isub, 2, arrayLenNode1, srcOff);
+    TR::Node *ifCmpNode3 = TR::Node::createif(TR::ificmplt, isubNode1, length);
     TR::TreeTop *ifCmpTreeTop3 = TR::TreeTop::create(comp(), ifCmpTreeTop2, ifCmpNode3);
     // if (dstOff < 0) { call the original method }
     TR::Node *constZeroNode3 = TR::Node::create(node, TR::iconst, 0, 0);
     TR::Node *ifCmpNode4 = TR::Node::createif(TR::ificmplt, dstOff, constZeroNode3);
     TR::TreeTop *ifCmpTreeTop4 = TR::TreeTop::create(comp(), ifCmpTreeTop3, ifCmpNode4);
-    // if ((dstObj.length >> 1) < dstOff + length) { call the original method }
+    // if ((dstObj.length >> 1) - dstOff < length) { call the original method }
     TR::Node *arrayLenNode2 = TR::Node::create(node, TR::arraylength, 1, dstObj);
     TR::Node *constOneNode = TR::Node::create(node, TR::iconst, 0, 1);
     TR::Node *ishrNode = TR::Node::create(node, TR::ishr, 2, arrayLenNode2, constOneNode);
-    TR::Node *iaddNode2 = TR::Node::create(node, TR::iadd, 2, dstOff, length);
-    TR::Node *ifCmpNode5 = TR::Node::createif(TR::ificmplt, ishrNode, iaddNode2);
+    TR::Node *isubNode2 = TR::Node::create(node, TR::isub, 2, ishrNode, dstOff);
+    TR::Node *ifCmpNode5 = TR::Node::createif(TR::ificmplt, isubNode2, length);
     TR::TreeTop *ifCmpTreeTop5 = TR::TreeTop::create(comp(), ifCmpTreeTop4, ifCmpNode5);
 
     TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arraytranslateAnchorNode);
@@ -2443,6 +2686,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop *treetop)
     TR::RecognizedMethod rm = node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod();
 
     bool isILGenPass = !getLastRun();
+    static const bool disableStringIntrinsicBoundChk = (feGetEnv("TR_DisableStringIntrinsicBoundChk") != NULL);
     if (isILGenPass) {
         switch (rm) {
             case TR::sun_misc_Unsafe_getAndAddInt:
@@ -2523,7 +2767,27 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop *treetop)
             case TR::java_lang_StringLatin1_compareTo_BBII:
                 return cg()->getSupportsArrayCmpLen();
             case TR::java_lang_StringLatin1_inflate_BIBII:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && cg()->getSupportsInlineStringLatin1Inflate()
+                    && !node->isSafeForCGToInlineStringIntrinsic() && !node->isSkippedInRecognizedCallTransformation()
+                    && comp()->target().cpu.isZ()) {
+                    return true;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 return (cg()->getSupportsArrayTranslateTROTNoBreak() && !comp()->target().cpu.isPower());
+#if JAVA_SPEC_VERSION < 25
+            case TR::java_lang_StringLatin1_inflate_BICII:
+                return (!disableStringIntrinsicBoundChk && cg()->getSupportsInlineStringLatin1Inflate()
+                    && !node->isSafeForCGToInlineStringIntrinsic() && !node->isSkippedInRecognizedCallTransformation());
+            case TR::java_lang_StringUTF16_indexOf:
+                if (comp()->target().cpu.isPower()) {
+                    return false;
+                }
+                /* Intentional fallthrough. */
+            case TR::java_lang_StringLatin1_indexOf:
+                return (!disableStringIntrinsicBoundChk && cg()->getSupportsInlineStringIndexOfString()
+                    && !node->isSafeForCGToInlineStringIntrinsic() && !node->isSkippedInRecognizedCallTransformation());
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::jdk_internal_util_ArraysSupport_vectorizedMismatch:
                 return cg()->getSupportsInlineVectorizedMismatch();
 #if JAVA_SPEC_VERSION >= 21
@@ -2700,6 +2964,17 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop *treetop)
             case TR::java_lang_StringLatin1_inflate_BIBII:
                 process_java_lang_StringLatin1_inflate_BIBII(treetop, node);
                 break;
+#if JAVA_SPEC_VERSION < 25
+            case TR::java_lang_StringLatin1_inflate_BICII:
+                process_java_lang_StringLatin1_inflate_BICII(treetop, node, true /* isByteToChar */);
+                break;
+            case TR::java_lang_StringUTF16_indexOf:
+                process_java_lang_StringUTF16_indexOf_BIBII(treetop, node);
+                break;
+            case TR::java_lang_StringLatin1_indexOf:
+                process_java_lang_StringLatin1_indexOf_BIBII(treetop, node, true /* isLatin1 */);
+                break;
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::java_lang_StrictMath_sqrt:
             case TR::java_lang_Math_sqrt:
                 process_java_lang_StrictMath_and_Math_sqrt(treetop, node);

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -914,8 +914,251 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_compareTo_BBI
         storeTreeTop2, comp()->getFlowGraph(), false, false);
 }
 
+void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BICII(TR::TreeTop *treetop, TR::Node *node,
+    bool isByteToChar)
+{
+    /*
+     * Prior to JDK25, it is possible for an AbstractStringBuilder race condition to trigger a call to
+     * java/lang/StringLatin1.inflate([BI[CII)V in such a way that an out of bounds exception gets triggered. This
+     * transformation adds a check for that possibility and calls the slow path if an exception needs to be thrown in
+     * the future.
+     *
+     * Prior to JDK under Z, these checks are also needed to accelerate java/lang/StringLatin1.inflate([BI[BII)V
+     * As a result, process_java_lang_StringLatin1_inflate_BIBII will call this function with isByteToChar set to false.
+     * isByteToChar being false indicates that this is the Byte array to Byte array case.
+     */
+    TransformUtil::createTempsForCall(this, treetop);
+
+    /* Input byte array containing the string to inflate. */
+    TR::Node *srcObjNode = node->getFirstChild();
+
+    /* Offset into the input byte array. Unit is number of bytes. */
+    TR::Node *srcOffNode = node->getSecondChild();
+
+    /* Output char array to be modified with the result. */
+    TR::Node *dstObjNode = node->getChild(2);
+
+    /* Offset into the output char array. Unit is number of chars. */
+    TR::Node *dstOffNode = node->getChild(3);
+
+    /* Number of bytes to read from source and also number of chars to write to destination. */
+    TR::Node *copyLenNode = node->getChild(4);
+
+    TR::Node *srcArrayLenNode = TR::Node::create(TR::arraylength, 1, srcObjNode->duplicateTree());
+    srcArrayLenNode->setIsNonNegative(true);
+
+    TR::Node *dstArrayLenNode = TR::Node::create(TR::arraylength, 1, dstObjNode->duplicateTree());
+    dstArrayLenNode->setIsNonNegative(true);
+
+    /*
+     * For the Byte array to Byte Array case, the output array length is shifted right by 1.
+     * This is to account for the fact that the byte array can hold half as many characters as its length.
+     */
+    if (!isByteToChar) {
+        dstArrayLenNode = TR::Node::create(TR::ishr, 2, dstArrayLenNode, TR::Node::create(TR::iconst, 0, 1));
+    }
+
+    /*
+     * The call node is duplicated to set up a fast path and a slow path.
+     * The slow path has the skipRecognizedCallTransformation flag set so it doesn't get transformed and
+     * RecognizedCallTransformer won't look at it again.
+     * The fast path has the inlineStringIntrinsic flag set so that it gets transformed by inlineDirectCall.
+     */
+    TR::TreeTop *slowPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    slowPathTreeTop->getNode()->getFirstChild()->setSkipRecognizedCallTransformation(true);
+
+    TR::TreeTop *fastPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    fastPathTreeTop->getNode()->getFirstChild()->setIsSafeForCGToInlineStringIntrinsic(true);
+
+    /*
+     * Put down the following two checks to confirm that src and dst arrays are big enough:
+     *   (srcArray.length - srcOffNode) < copyLenNode
+     *   (dstArray.length - dstOffNode) < copyLenNode
+     * If either is true, an out of bounds exception will occur so the code must branch to the slow path.
+     */
+    TR::Node *srcLenMinusOffsetNode = TR::Node::create(TR::isub, 2, srcArrayLenNode, srcOffNode->duplicateTree());
+    TR::Node *dstLenMinusOffsetNode = TR::Node::create(TR::isub, 2, dstArrayLenNode, dstOffNode->duplicateTree());
+
+    TR::Node *srcCmpNode = TR::Node::createif(TR::ificmplt, srcLenMinusOffsetNode, copyLenNode->duplicateTree(), NULL);
+    TR::TreeTop *srcCmpTree = TR::TreeTop::create(comp(), srcCmpNode);
+
+    TR::Node *dstCmpNode = TR::Node::createif(TR::ificmplt, dstLenMinusOffsetNode, copyLenNode->duplicateTree(), NULL);
+    TR::TreeTop *dstCmpTree = TR::TreeTop::create(comp(), dstCmpNode);
+
+    TR::Block *callBlock = treetop->getEnclosingBlock();
+
+    /*
+     * createConditionalBlocksBeforeTree is used to create the source array length check.
+     * treetop is the current call treetop and the split point.
+     * srcCmpTree is the check to see if out of bounds access will occur in the src array.
+     * slowPathTreeTop is the slow path. This is a cold block that is branched to if an OOB exception will happen.
+     * fastPathTreeTop is the fast path. This is the fallthrough path.
+     * The slow path and fast path then merge back into each other.
+     */
+    callBlock->createConditionalBlocksBeforeTree(treetop, srcCmpTree, slowPathTreeTop, fastPathTreeTop,
+        comp()->getFlowGraph(), false, true);
+
+    /*
+     * dstCmpTree is the check to see if out of bounds access will occur in the dst array.
+     * The check is placed after the src out of bounds access check.
+     * If the dst array is too small, the code branches to the slow path to handle the OOB exception.
+     */
+    TR::Block *dstCmpBlock = TR::Block::createEmptyBlock(srcCmpNode, comp(), 0, NULL);
+    dstCmpBlock->setFrequency(callBlock->getFrequency());
+    comp()->getFlowGraph()->addNode(dstCmpBlock);
+
+    callBlock->getExit()->join(dstCmpBlock->getEntry());
+    dstCmpBlock->getExit()->join(fastPathTreeTop->getEnclosingBlock()->getEntry());
+    comp()->getFlowGraph()->copyExceptionSuccessors(callBlock, dstCmpBlock);
+
+    dstCmpBlock->append(dstCmpTree);
+    dstCmpNode->setBranchDestination(srcCmpNode->getBranchDestination());
+
+    comp()->getFlowGraph()->addEdge(TR::CFGEdge::createEdge(callBlock, dstCmpBlock, comp()->trMemory()));
+    comp()->getFlowGraph()->addEdge(
+        TR::CFGEdge::createEdge(dstCmpBlock, fastPathTreeTop->getEnclosingBlock(), comp()->trMemory()));
+    comp()->getFlowGraph()->addEdge(
+        TR::CFGEdge::createEdge(dstCmpBlock, slowPathTreeTop->getEnclosingBlock(), comp()->trMemory()));
+
+    comp()->getFlowGraph()->removeEdge(callBlock, fastPathTreeTop->getEnclosingBlock());
+
+    TR::DebugCounter::prependDebugCounter(comp(),
+        TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1Inflate/fast/(%s)", comp()->signature()),
+        fastPathTreeTop);
+    TR::DebugCounter::prependDebugCounter(comp(),
+        TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1Inflate/slow/(%s)", comp()->signature()),
+        slowPathTreeTop);
+}
+
+void J9::RecognizedCallTransformer::process_java_lang_StringUTF16_indexOf_BIBII(TR::TreeTop *treetop, TR::Node *node)
+{
+    process_java_lang_StringLatin1_indexOf_BIBII(treetop, node, false /* isLatin1 */);
+}
+
+void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_indexOf_BIBII(TR::TreeTop *treetop, TR::Node *node,
+    bool isLatin1)
+{
+    /*
+     * The indexOf operation is searching for an index of a substring inside of another string. Prior to JDK25, it is
+     * possible for an AbstractStringBuilder race condition to trigger a call to indexOf in such a way that an out of
+     * bounds exception gets triggered. This transformation checks for that possibility and calls the slow path for
+     * safety if there is a chance it may occur.
+     *
+     * This section of code is also used for StringUTF16_indexOf_BIBII. In this case, the value of the isLatin1
+     * parameter will be false.
+     */
+
+    TransformUtil::createTempsForCall(this, treetop);
+
+    /* This is the byte[] containing the characters for the string being searched in. */
+    TR::Node *arrayObjNode = node->getFirstChild();
+
+    /*
+     * This is the number of characters thought to be in the string being searched in. Due to the race condition, it
+     * may be incorrect.
+     */
+    TR::Node *arrayLenNode = node->getSecondChild();
+
+    /*
+     * maxArrayLenNode represents the maxmimum number of bytes that can be in the String being searched in without going
+     * out of bounds.
+     */
+    TR::Node *maxArrayLenNode = TR::Node::create(TR::arraylength, 1, arrayObjNode->duplicateTree());
+    maxArrayLenNode->setIsNonNegative(true);
+
+    /*
+     * The call node is duplicated to set up a fast path and a slow path.
+     * The slow path has the skipRecognizedCallTransformation flag set so it doesn't get transformed and
+     * RecognizedCallTransformer won't look at it again.
+     * The fast path has the inlineStringIntrinsic flag set so that it gets transformed by inlineDirectCall.
+     */
+    TR::TreeTop *slowPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    slowPathTreeTop->getNode()->getFirstChild()->setSkipRecognizedCallTransformation(true);
+
+    TR::TreeTop *fastPathTreeTop = TR::TreeTop::create(comp(), treetop->getNode()->duplicateTree());
+    fastPathTreeTop->getNode()->getFirstChild()->setIsSafeForCGToInlineStringIntrinsic(true);
+
+    TR::SymbolReference *newSymbolReference = NULL;
+    TR::DataType dataType = node->getDataType();
+
+    /* If the call node has a reference count >1, a symref is created to hold the result. */
+    if (node->getReferenceCount() > 1) {
+        newSymbolReference = comp()->getSymRefTab()->createTemporary(comp()->getMethodSymbol(), dataType);
+        TR::Node::recreate(node, comp()->il.opCodeForDirectLoad(dataType));
+        node->setSymbolReference(newSymbolReference);
+        node->removeAllChildren();
+    }
+
+    /*
+     * For Latin1, the value of maxArrayLenNode must be greater than or equal to the value of arrayLenNode.
+     * For UTF16, the value of (maxArrayLenNode >> 1) must be greater than or equal to the value of arrayLenNode.
+     * If this isn't true, it is possible for the indexOf operation to go out of bounds so the slow path must be taken.
+     */
+    if (!isLatin1) {
+        maxArrayLenNode = TR::Node::create(TR::ishr, 2, maxArrayLenNode, TR::Node::create(TR::iconst, 0, 1));
+    }
+    TR::Node *cmpNode = TR::Node::createif(TR::ificmpgt, arrayLenNode->duplicateTree(), maxArrayLenNode, NULL);
+    TR::TreeTop *cmpTree = TR::TreeTop::create(comp(), cmpNode);
+
+    TR::Block *callBlock = treetop->getEnclosingBlock();
+
+    /*
+     * createConditionalBlocksBeforeTree puts everything together.
+     * treetop is the current call treetop and the split point.
+     * cmpTree is the check to see if out of bounds access is possible.
+     * slowPathTreeTop is the slow path. This is a cold block that is branched to if OOB is possible.
+     * fastPathTreeTop is the fast path. This is the fallthrough path.
+     * The slow path and fast path then merge back into each other.
+     */
+    callBlock->createConditionalBlocksBeforeTree(treetop, cmpTree, slowPathTreeTop, fastPathTreeTop,
+        comp()->getFlowGraph(), false, true);
+
+    /* If the call node has a reference count >1, a symref is used to record the return value from the call. */
+    if (newSymbolReference) {
+        TR::Node *fastPathStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1,
+            fastPathTreeTop->getNode()->getFirstChild(), newSymbolReference);
+        TR::TreeTop *fastPathStoreTree = TR::TreeTop::create(comp(), fastPathStoreNode);
+        fastPathTreeTop->insertAfter(fastPathStoreTree);
+
+        TR::Node *slowPathStoreNode = TR::Node::createWithSymRef(comp()->il.opCodeForDirectStore(dataType), 1, 1,
+            slowPathTreeTop->getNode()->getFirstChild(), newSymbolReference);
+        TR::TreeTop *slowPathStoreTree = TR::TreeTop::create(comp(), slowPathStoreNode);
+        slowPathTreeTop->insertAfter(slowPathStoreTree);
+    }
+
+    if (isLatin1) {
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1IndexOf/fast/(%s)", comp()->signature()),
+            fastPathTreeTop);
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicLatin1IndexOf/slow/(%s)", comp()->signature()),
+            slowPathTreeTop);
+    } else {
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicUTF16IndexOf/fast/(%s)", comp()->signature()),
+            fastPathTreeTop);
+        TR::DebugCounter::prependDebugCounter(comp(),
+            TR::DebugCounter::debugCounterName(comp(), "treesIntrinsicUTF16IndexOf/slow/(%s)", comp()->signature()),
+            slowPathTreeTop);
+    }
+}
+
 void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII(TR::TreeTop *treetop, TR::Node *node)
 {
+#if JAVA_SPEC_VERSION < 25
+    /*
+     * Prior to JDK25 on Z, it is possible for an AbstractStringBuilder race condition to trigger a call to
+     * java/lang/StringLatin1.inflate([BI[BII)V in such a way that an out of bounds exception gets triggered. This
+     * calls process_java_lang_StringLatin1_inflate_BICII to perform a transformation to add a check for that
+     * possibility and call the slow path if an exception needs to be thrown in the future.
+     *
+     * isByteToChar being false indicates that this is the Byte array to Byte array case.
+     */
+    if (comp()->target().cpu.isZ()) {
+        return process_java_lang_StringLatin1_inflate_BICII(treetop, node, false /* isByteToChar */);
+    }
+#endif /* JAVA_SPEC_VERSION < 25 */
+
     /*
      * Replace the call with the following tree (+ boundary checks)
      *
@@ -1004,21 +1247,21 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     TR::Node *constZeroNode2 = TR::Node::create(node, TR::iconst, 0, 0);
     TR::Node *ifCmpNode2 = TR::Node::createif(TR::ificmplt, srcOff, constZeroNode2);
     TR::TreeTop *ifCmpTreeTop2 = TR::TreeTop::create(comp(), ifCmpTreeTop1, ifCmpNode2);
-    // if (srcObj.length < srcOff + length) { call the original method }
+    // if (srcObj.length - srcOff < length) { call the original method }
     TR::Node *arrayLenNode1 = TR::Node::create(node, TR::arraylength, 1, srcObj);
-    TR::Node *iaddNode1 = TR::Node::create(node, TR::iadd, 2, srcOff, length);
-    TR::Node *ifCmpNode3 = TR::Node::createif(TR::ificmplt, arrayLenNode1, iaddNode1);
+    TR::Node *isubNode1 = TR::Node::create(node, TR::isub, 2, arrayLenNode1, srcOff);
+    TR::Node *ifCmpNode3 = TR::Node::createif(TR::ificmplt, isubNode1, length);
     TR::TreeTop *ifCmpTreeTop3 = TR::TreeTop::create(comp(), ifCmpTreeTop2, ifCmpNode3);
     // if (dstOff < 0) { call the original method }
     TR::Node *constZeroNode3 = TR::Node::create(node, TR::iconst, 0, 0);
     TR::Node *ifCmpNode4 = TR::Node::createif(TR::ificmplt, dstOff, constZeroNode3);
     TR::TreeTop *ifCmpTreeTop4 = TR::TreeTop::create(comp(), ifCmpTreeTop3, ifCmpNode4);
-    // if ((dstObj.length >> 1) < dstOff + length) { call the original method }
+    // if ((dstObj.length >> 1) - dstOff < length) { call the original method }
     TR::Node *arrayLenNode2 = TR::Node::create(node, TR::arraylength, 1, dstObj);
     TR::Node *constOneNode = TR::Node::create(node, TR::iconst, 0, 1);
     TR::Node *ishrNode = TR::Node::create(node, TR::ishr, 2, arrayLenNode2, constOneNode);
-    TR::Node *iaddNode2 = TR::Node::create(node, TR::iadd, 2, dstOff, length);
-    TR::Node *ifCmpNode5 = TR::Node::createif(TR::ificmplt, ishrNode, iaddNode2);
+    TR::Node *isubNode2 = TR::Node::create(node, TR::isub, 2, ishrNode, dstOff);
+    TR::Node *ifCmpNode5 = TR::Node::createif(TR::ificmplt, isubNode2, length);
     TR::TreeTop *ifCmpTreeTop5 = TR::TreeTop::create(comp(), ifCmpTreeTop4, ifCmpNode5);
 
     TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arraytranslateAnchorNode);
@@ -2443,6 +2686,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop *treetop)
     TR::RecognizedMethod rm = node->getSymbol()->castToMethodSymbol()->getMandatoryRecognizedMethod();
 
     bool isILGenPass = !getLastRun();
+    static const bool disableStringIntrinsicFlagChk = (feGetEnv("TR_DisableStringIntrinsicFlagChk") != NULL);
     if (isILGenPass) {
         switch (rm) {
             case TR::sun_misc_Unsafe_getAndAddInt:
@@ -2523,7 +2767,27 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop *treetop)
             case TR::java_lang_StringLatin1_compareTo_BBII:
                 return cg()->getSupportsArrayCmpLen();
             case TR::java_lang_StringLatin1_inflate_BIBII:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && cg()->getSupportsInlineStringLatin1Inflate()
+                    && !node->isSafeForCGToInlineStringIntrinsic() && !node->checkSkipRecognizedCallTransformation()
+                    && comp()->target().cpu.isZ()) {
+                    return true;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 return (cg()->getSupportsArrayTranslateTROTNoBreak() && !comp()->target().cpu.isPower());
+#if JAVA_SPEC_VERSION < 25
+            case TR::java_lang_StringLatin1_inflate_BICII:
+                return (!disableStringIntrinsicFlagChk && cg()->getSupportsInlineStringLatin1Inflate()
+                    && !node->isSafeForCGToInlineStringIntrinsic() && !node->checkSkipRecognizedCallTransformation());
+            case TR::java_lang_StringUTF16_indexOf:
+                if (comp()->target().cpu.isPower()) {
+                    return false;
+                }
+                /* Intentional fallthrough. */
+            case TR::java_lang_StringLatin1_indexOf:
+                return (!disableStringIntrinsicFlagChk && cg()->getSupportsInlineStringIndexOfString()
+                    && !node->isSafeForCGToInlineStringIntrinsic() && !node->checkSkipRecognizedCallTransformation());
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::jdk_internal_util_ArraysSupport_vectorizedMismatch:
                 return cg()->getSupportsInlineVectorizedMismatch();
 #if JAVA_SPEC_VERSION >= 21
@@ -2700,6 +2964,17 @@ void J9::RecognizedCallTransformer::transform(TR::TreeTop *treetop)
             case TR::java_lang_StringLatin1_inflate_BIBII:
                 process_java_lang_StringLatin1_inflate_BIBII(treetop, node);
                 break;
+#if JAVA_SPEC_VERSION < 25
+            case TR::java_lang_StringLatin1_inflate_BICII:
+                process_java_lang_StringLatin1_inflate_BICII(treetop, node, true /* isByteToChar */);
+                break;
+            case TR::java_lang_StringUTF16_indexOf:
+                process_java_lang_StringUTF16_indexOf_BIBII(treetop, node);
+                break;
+            case TR::java_lang_StringLatin1_indexOf:
+                process_java_lang_StringLatin1_indexOf_BIBII(treetop, node, true /* isLatin1 */);
+                break;
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::java_lang_StrictMath_sqrt:
             case TR::java_lang_Math_sqrt:
                 process_java_lang_StrictMath_and_Math_sqrt(treetop, node);

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -181,6 +181,69 @@ private:
      */
     void process_java_lang_StringLatin1_inflate_BIBII(TR::TreeTop *treetop, TR::Node *node);
     /** \brief
+     *     Transforms java/lang/StringUTF16.indexOf([BI[BII)I
+     *
+     *  \param treetop
+     *     The treetop which anchors the call node.
+     *
+     *  \param node
+     *     The call node representing a call to java/lang/StringUTF16.indexOf([BI[BII)I which has the following shape:
+     *
+     *     \code
+     *     icall <java/lang/StringUTF16.indexOf([BI[BII)I>
+     *       <byte array containing StringUTF16 characters to search in>
+     *       <num of StringUTF16 characters in the array being searched in (2 bytes each)>
+     *       <byte array containing StringUTF16 characters to search for>
+     *       <num of StringUTF16 characters in the array containing characters being searched for (2 bytes each)>
+     *       <offset>
+     *     \endcode
+     */
+    void process_java_lang_StringUTF16_indexOf_BIBII(TR::TreeTop *treetop, TR::Node *node);
+    /** \brief
+     *     Transforms java/lang/StringLatin1.indexOf([BI[BII)I
+     *
+     *  \param treetop
+     *     The treetop which anchors the call node.
+     *
+     *  \param node
+     *     The call node representing a call to java/lang/StringLatin1.indexOf([BI[BII)I which has the following shape:
+     *
+     *     \code
+     *     icall <java/lang/StringLatin1.indexOf([BI[BII)I>
+     *       <byte array containing StringLatin1 characters to search in>
+     *       <num of StringLatin1 characters in the array being searched in (1 byte each)>
+     *       <byte array containing StringLatin1 characters to search for>
+     *       <num of StringLatin1 characters in the array containing characters being searched for (1 byte each)>
+     *       <offset>
+     *
+     *  \param isLatin1
+     *     Boolean is set to true for the StringLatin1 case and false for the StringUTF16 case.
+     *     \endcode
+     */
+    void process_java_lang_StringLatin1_indexOf_BIBII(TR::TreeTop *treetop, TR::Node *node, bool isLatin1);
+    /** \brief
+     *     Transforms java/lang/StringLatin1.inflate([BI[CII)V
+     *
+     *  \param treetop
+     *     The treetop which anchors the call node.
+     *
+     *  \param node
+     *     The call node representing a call to java/lang/StringLatin1.inflate([BI[CII)V which has the following shape:
+     *
+     *     \code
+     *     call <java/lang/StringLatin1.inflate([BI[CII)V>
+     *       <src byte array>
+     *       <src offset>
+     *       <dst char array>
+     *       <dst offset>
+     *       <length>
+     *
+     *  \param isByteToChar
+     *     Boolean is set to true for the byte array to char array case and false for byte array to byte array case.
+     *     \endcode
+     */
+    void process_java_lang_StringLatin1_inflate_BICII(TR::TreeTop *treetop, TR::Node *node, bool isByteToChar);
+    /** \brief
      *     Transforms java/lang/StringUTF16.toBytes([CII)[B into a fast allocate and arraycopy sequence with equivalent
      *     semantics.
      *

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12561,6 +12561,8 @@ static TR::Register *inlineIntrinsicIndexOfString(TR::Node *node, TR::CodeGenera
     endLabel->setEndInternalControlFlow();
 
     generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(comp, "inlineIntrinsicIndexOf/(%s)", comp->signature()));
 
     {
         /* If offset + number of characters in the substring is greater than the number of characters in the main string
@@ -14305,6 +14307,8 @@ bool J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
         bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
         bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
         static bool disableOSW = feGetEnv("TR_noPauseOnSpinWait") != NULL;
+        static const bool disableStringIntrinsicFlagChk = (feGetEnv("TR_DisableStringIntrinsicFlagChk") != NULL);
+
         switch (methodSymbol->getRecognizedMethod()) {
             case TR::java_lang_Thread_onSpinWait: {
                 if (!disableOSW) {
@@ -14585,6 +14589,11 @@ bool J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
 
             case TR::java_lang_StringLatin1_indexOf:
                 if (cg->getSupportsInlineStringIndexOfString()) {
+#if JAVA_SPEC_VERSION < 25
+                    if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                        break;
+                    }
+#endif /* JAVA_SPEC_VERSION < 25 */
                     resultReg = inlineIntrinsicIndexOfString(node, cg, true);
                     return resultReg != nullptr;
                 }
@@ -14592,6 +14601,11 @@ bool J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
 
             case TR::java_lang_StringLatin1_inflate_BICII:
                 if (cg->getSupportsInlineStringLatin1Inflate()) {
+#if JAVA_SPEC_VERSION < 25
+                    if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                        break;
+                    }
+#endif /* JAVA_SPEC_VERSION < 25 */
                     bool result = inlineIntrinsicInflate(node, cg);
                     if (result) {
                         resultReg = nullptr;

--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -12561,6 +12561,8 @@ static TR::Register *inlineIntrinsicIndexOfString(TR::Node *node, TR::CodeGenera
     endLabel->setEndInternalControlFlow();
 
     generateLabelInstruction(cg, TR::InstOpCode::label, node, startLabel);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(comp, "inlineIntrinsicIndexOf/(%s)", comp->signature()));
 
     {
         /* If offset + number of characters in the substring is greater than the number of characters in the main string
@@ -14305,6 +14307,8 @@ bool J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
         bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
         bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
         static bool disableOSW = feGetEnv("TR_noPauseOnSpinWait") != NULL;
+        static const bool disableStringIntrinsicBoundChk = (feGetEnv("TR_DisableStringIntrinsicBoundChk") != NULL);
+
         switch (methodSymbol->getRecognizedMethod()) {
             case TR::java_lang_Thread_onSpinWait: {
                 if (!disableOSW) {
@@ -14585,6 +14589,11 @@ bool J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
 
             case TR::java_lang_StringLatin1_indexOf:
                 if (cg->getSupportsInlineStringIndexOfString()) {
+#if JAVA_SPEC_VERSION < 25
+                    if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                        break;
+                    }
+#endif /* JAVA_SPEC_VERSION < 25 */
                     resultReg = inlineIntrinsicIndexOfString(node, cg, true);
                     return resultReg != nullptr;
                 }
@@ -14592,6 +14601,11 @@ bool J9::Power::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
 
             case TR::java_lang_StringLatin1_inflate_BICII:
                 if (cg->getSupportsInlineStringLatin1Inflate()) {
+#if JAVA_SPEC_VERSION < 25
+                    if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                        break;
+                    }
+#endif /* JAVA_SPEC_VERSION < 25 */
                     bool result = inlineIntrinsicInflate(node, cg);
                     if (result) {
                         resultReg = nullptr;

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -10613,6 +10613,8 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     doneLabel->setEndInternalControlFlow();
 
     Inst_Label(OP::label, node, startLabel, cg);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicIndexOf/(%s)", cg->comp()->signature()));
 
     int32_t hdrSize = static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
 
@@ -12931,6 +12933,8 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
         }
     }
 
+    static const bool disableStringIntrinsicFlagChk = (feGetEnv("TR_DisableStringIntrinsicFlagChk") != NULL);
+
     switch (symbol->getMandatoryRecognizedMethod()) {
         case TR::java_lang_StringLatin1_indexOfChar:
         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
@@ -12945,6 +12949,12 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             break;
 
         case TR::java_lang_StringLatin1_indexOf:
+#if JAVA_SPEC_VERSION < 25
+            if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                break;
+            }
+            /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
             if (cg->getSupportsInlineStringIndexOfString())
                 returnRegister = inlineIntrinsicStringIndexOfString(node, cg, true);
@@ -12953,6 +12963,12 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             break;
 
         case TR::java_lang_StringUTF16_indexOf:
+#if JAVA_SPEC_VERSION < 25
+            if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                break;
+            }
+            /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
         case TR::java_lang_StringUTF16_indexOfUnsafe:
         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
             if (cg->getSupportsInlineStringIndexOfString())
@@ -13066,6 +13082,11 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             break;
         case TR::java_lang_StringLatin1_inflate_BICII:
             if (cg->getSupportsInlineStringLatin1Inflate()) {
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 return TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
             }
             break;
@@ -13172,6 +13193,8 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
     Inst_Label(OP::label, node, startLabel, cg);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicInflate/(%s)", cg->comp()->signature()));
 
     TR::Node *destOffsetNode = node->getChild(3);
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -10613,6 +10613,8 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     doneLabel->setEndInternalControlFlow();
 
     Inst_Label(OP::label, node, startLabel, cg);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicIndexOf/(%s)", cg->comp()->signature()));
 
     int32_t hdrSize = static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
 
@@ -12931,6 +12933,8 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
         }
     }
 
+    static const bool disableStringIntrinsicBoundChk = (feGetEnv("TR_DisableStringIntrinsicBoundChk") != NULL);
+
     switch (symbol->getMandatoryRecognizedMethod()) {
         case TR::java_lang_StringLatin1_indexOfChar:
         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfLatin1:
@@ -12945,6 +12949,12 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             break;
 
         case TR::java_lang_StringLatin1_indexOf:
+#if JAVA_SPEC_VERSION < 25
+            if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                break;
+            }
+            /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
             if (cg->getSupportsInlineStringIndexOfString())
                 returnRegister = inlineIntrinsicStringIndexOfString(node, cg, true);
@@ -12953,6 +12963,12 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             break;
 
         case TR::java_lang_StringUTF16_indexOf:
+#if JAVA_SPEC_VERSION < 25
+            if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                break;
+            }
+            /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
         case TR::java_lang_StringUTF16_indexOfUnsafe:
         case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
             if (cg->getSupportsInlineStringIndexOfString())
@@ -13066,6 +13082,11 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             break;
         case TR::java_lang_StringLatin1_inflate_BICII:
             if (cg->getSupportsInlineStringLatin1Inflate()) {
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 return TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
             }
             break;
@@ -13172,6 +13193,8 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
     Inst_Label(OP::label, node, startLabel, cg);
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicInflate/(%s)", cg->comp()->signature()));
 
     TR::Node *destOffsetNode = node->getChild(3);
 

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3606,11 +3606,13 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
 
     static const char *enableTRTRE = feGetEnv("TR_enableTRTRE");
     static const bool enableOSW = feGetEnv("TR_noPauseOnSpinWait") == NULL;
-    static const bool enableStringInflateByteToByte = feGetEnv("TR_EnableStringInflateByteToByte") != NULL;
+    static const bool disableStringInflateByteToByte = feGetEnv("TR_DisableStringInflateByteToByte") != NULL;
     static const bool disableStringInflateByteToChar = feGetEnv("TR_DisableStringInflateByteToChar") != NULL;
 
     bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
     bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
+
+    static const bool disableStringIntrinsicFlagChk = (feGetEnv("TR_DisableStringIntrinsicFlagChk") != NULL);
 
     switch (methodSymbol->getRecognizedMethod()) {
         case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
@@ -3808,13 +3810,23 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
             break;
         }
         case TR::java_lang_StringLatin1_inflate_BIBII:
-            if (cg->getSupportsInlineStringLatin1Inflate() && enableStringInflateByteToByte) {
+            if (cg->getSupportsInlineStringLatin1Inflate() && !disableStringInflateByteToByte) {
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
                 return resultReg != NULL;
             }
             break;
         case TR::java_lang_StringLatin1_inflate_BICII:
             if (cg->getSupportsInlineStringLatin1Inflate() && !disableStringInflateByteToChar) {
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
                 return resultReg != NULL;
             }
@@ -3936,10 +3948,22 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
     if (cg->getSupportsInlineStringIndexOfString()) {
         switch (methodSymbol->getRecognizedMethod()) {
             case TR::java_lang_StringLatin1_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
                 resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, false);
                 return resultReg != NULL;
             case TR::java_lang_StringUTF16_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicFlagChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::java_lang_StringUTF16_indexOfUnsafe:
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
                 resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, true);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3606,11 +3606,13 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
 
     static const char *enableTRTRE = feGetEnv("TR_enableTRTRE");
     static const bool enableOSW = feGetEnv("TR_noPauseOnSpinWait") == NULL;
-    static const bool enableStringInflateByteToByte = feGetEnv("TR_EnableStringInflateByteToByte") != NULL;
+    static const bool disableStringInflateByteToByte = feGetEnv("TR_DisableStringInflateByteToByte") != NULL;
     static const bool disableStringInflateByteToChar = feGetEnv("TR_DisableStringInflateByteToChar") != NULL;
 
     bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
     bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
+
+    static const bool disableStringIntrinsicBoundChk = (feGetEnv("TR_DisableStringIntrinsicBoundChk") != NULL);
 
     switch (methodSymbol->getRecognizedMethod()) {
         case TR::sun_misc_Unsafe_compareAndSwapInt_jlObjectJII_Z:
@@ -3808,13 +3810,23 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
             break;
         }
         case TR::java_lang_StringLatin1_inflate_BIBII:
-            if (cg->getSupportsInlineStringLatin1Inflate() && enableStringInflateByteToByte) {
+            if (cg->getSupportsInlineStringLatin1Inflate() && !disableStringInflateByteToByte) {
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
                 return resultReg != NULL;
             }
             break;
         case TR::java_lang_StringLatin1_inflate_BICII:
             if (cg->getSupportsInlineStringLatin1Inflate() && !disableStringInflateByteToChar) {
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+#endif /* JAVA_SPEC_VERSION < 25 */
                 resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
                 return resultReg != NULL;
             }
@@ -3936,10 +3948,22 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
     if (cg->getSupportsInlineStringIndexOfString()) {
         switch (methodSymbol->getRecognizedMethod()) {
             case TR::java_lang_StringLatin1_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringLatin1:
                 resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, false);
                 return resultReg != NULL;
             case TR::java_lang_StringUTF16_indexOf:
+#if JAVA_SPEC_VERSION < 25
+                if (!disableStringIntrinsicBoundChk && !node->isSafeForCGToInlineStringIntrinsic()) {
+                    break;
+                }
+                /* Intentional fallthrough. */
+#endif /* JAVA_SPEC_VERSION < 25 */
             case TR::java_lang_StringUTF16_indexOfUnsafe:
             case TR::com_ibm_jit_JITHelpers_intrinsicIndexOfStringUTF16:
                 resultReg = TR::TreeEvaluator::inlineVectorizedStringIndexOf(node, cg, true);

--- a/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/z/codegen/J9TreeEvaluator.cpp
@@ -308,6 +308,8 @@ TR::Register *J9::Z::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, TR
     TR::Register *charArrayReferenceRegister = cg->gprClobberEvaluate(charArrayReferenceNode);
     TR::Register *dstOffRegister = cg->gprClobberEvaluate(dstOffNode);
 
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicInflate/(%s)", cg->comp()->signature()));
     // Offset to be added to array object pointer to get to the data elements
     int32_t offsetToDataElements = TR::Compiler->om.contiguousArrayHeaderSizeInBytes();
 #ifdef J9VM_GC_SPARSE_HEAP_ALLOCATION
@@ -1127,6 +1129,9 @@ TR::Register *J9::Z::TreeEvaluator::inlineVectorizedStringIndexOf(TR::Node *node
     TR::Register *patternValueReg = NULL;
     TR::Register *patternLenReg = cg->gprClobberEvaluate(node->getChild(firstCallArgIdx + 3));
     TR::Register *stringIndexReg = cg->gprClobberEvaluate(node->getChild(firstCallArgIdx + 4));
+
+    cg->generateDebugCounter(
+        TR::DebugCounter::debugCounterName(cg->comp(), "inlineIntrinsicIndexOf/(%s)", cg->comp()->signature()));
 
     // Offset to be added to array object pointer to get to the data elements
     int32_t offsetToDataElements = static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());


### PR DESCRIPTION
Prior to JDK25, due to a race condition in AbstractStringBuilder, it is possible for some accelerated String intrinsics to perform an out of bounds array access. This applies to:

```
java/lang/StringLatin1.inflate([BI[CII)V
java/lang/StringLatin1.inflate([BI[BII)V
java/lang/StringLatin1.indexOf([BI[BII)I
java/lang/StringUTF16.indexOf([BI[BII)I
```

To address this, bound checking has been added such that the safe slow path code is performed in the rares cases that an out of bounds array access may occur.

Former behavior is restored via the `TR_DisableStringIntrinsicFlagChk` envvar. As the problem does not exist in JDK25, the bound checking is not added in JDK25 and onward.

Depends on:
https://github.com/eclipse-omr/omr/pull/8255

Issue with more details here:
https://github.com/eclipse-openj9/openj9/issues/23880
Original Issue the problem was found is here:
https://github.com/eclipse-openj9/openj9/issues/23353