### PR TITLE
Use new factory functions on x86 JIT for code readability

### DIFF
--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -86,8 +86,8 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
 
     TR::Register *returnReg;
 
-    TR::X86VFPDedicateInstruction *vfpDedicateInstruction = generateVFPDedicateInstruction(
-        machine()->getRealRegister(getProperties().getIntegerScratchRegister(0)), callNode, cg());
+    TR::X86VFPDedicateInstruction *vfpDedicateInstruction
+        = Inst_VFPDedicate(machine()->getRealRegister(getProperties().getIntegerScratchRegister(0)), callNode, cg());
 
     TR::J9LinkageUtils::switchToMachineCStack(callNode, cg());
 
@@ -123,13 +123,13 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
     TR::Instruction *instr;
     if (methodSymbol->getMethodAddress()) {
         TR_ASSERT(scratchReg, "could not find second scratch register");
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg,
-            (uintptr_t)methodSymbol->getMethodAddress(), cg());
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg, (uintptr_t)methodSymbol->getMethodAddress(),
+            cg());
 
-        instr = generateRegInstruction(TR::InstOpCode::CALLReg, callNode, scratchReg, preDeps, cg());
+        instr = Inst_Reg(TR::InstOpCode::CALLReg, callNode, scratchReg, preDeps, cg());
     } else {
-        instr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode,
-            (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, preDeps, cg());
+        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(),
+            methodSymRef, preDeps, cg());
     }
 
     instr->setNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
@@ -142,7 +142,7 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
         TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
         TR::InstOpCode::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? TR::InstOpCode::ADDRegImms()
                                                                                       : TR::InstOpCode::ADDRegImm4();
-        generateRegImmInstruction(op, callNode, espReal, memoryArgSize, cg());
+        Inst_RegImm(op, callNode, espReal, memoryArgSize, cg());
     }
 
     if (returnReg && !(methodSymbol->isHelper()))
@@ -150,10 +150,10 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
 
     TR::J9LinkageUtils::switchToJavaStack(callNode, cg());
 
-    generateVFPReleaseInstruction(vfpDedicateInstruction, callNode, cg());
+    Inst_VFPRelease(vfpDedicateInstruction, callNode, cg());
 
     TR::LabelSymbol *postDepLabel = generateLabelSymbol(cg());
-    generateLabelInstruction(TR::InstOpCode::label, callNode, postDepLabel, postDeps, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, postDepLabel, postDeps, cg());
 
     return returnReg;
 }

--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -98,8 +98,8 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
     //
     uint32_t pre = getProperties().getNumIntegerArgumentRegisters() + getProperties().getNumFloatArgumentRegisters();
     uint32_t post = getProperties().getNumVolatileRegisters() + 1 + (callNode->getDataType() == TR::NoType ? 0 : 1);
-    TR::RegisterDependencyConditions *preDeps = generateRegisterDependencyConditions(pre, 0, cg());
-    TR::RegisterDependencyConditions *postDeps = generateRegisterDependencyConditions(0, post, cg());
+    TR::RegisterDependencyConditions *preDeps = RegDeps(pre, 0, cg());
+    TR::RegisterDependencyConditions *postDeps = RegDeps(0, post, cg());
 
     // Evaluate outgoing arguments on the system stack and build pre-conditions.
     //

--- a/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64J9SystemLinkage.cpp
@@ -123,13 +123,12 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
     TR::Instruction *instr;
     if (methodSymbol->getMethodAddress()) {
         TR_ASSERT(scratchReg, "could not find second scratch register");
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg, (uintptr_t)methodSymbol->getMethodAddress(),
-            cg());
+        Inst_RegImm64(OP::MOV8RegImm64, callNode, scratchReg, (uintptr_t)methodSymbol->getMethodAddress(), cg());
 
-        instr = Inst_Reg(TR::InstOpCode::CALLReg, callNode, scratchReg, preDeps, cg());
+        instr = Inst_Reg(OP::CALLReg, callNode, scratchReg, preDeps, cg());
     } else {
-        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(),
-            methodSymRef, preDeps, cg());
+        instr = Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, preDeps,
+            cg());
     }
 
     instr->setNeedsGCMap(getProperties().getPreservedRegisterMapForGC());
@@ -140,8 +139,7 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
         // adjust sp is necessary, because for java, the stack is native stack, not java stack.
         // we need to restore native stack sp properly to the correct place.
         TR::RealRegister *espReal = machine()->getRealRegister(TR::RealRegister::esp);
-        TR::InstOpCode::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? TR::InstOpCode::ADDRegImms()
-                                                                                      : TR::InstOpCode::ADDRegImm4();
+        OP::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? OP::ADDRegImms() : OP::ADDRegImm4();
         Inst_RegImm(op, callNode, espReal, memoryArgSize, cg());
     }
 
@@ -153,7 +151,7 @@ TR::Register *TR::AMD64J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, 
     Inst_VFPRelease(vfpDedicateInstruction, callNode, cg());
 
     TR::LabelSymbol *postDepLabel = generateLabelSymbol(cg());
-    Inst_Label(TR::InstOpCode::label, callNode, postDepLabel, postDeps, cg());
+    Inst_Label(OP::label, callNode, postDepLabel, postDeps, cg());
 
     return returnReg;
 }

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -73,7 +73,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::processJNIReferenceArg(TR::Node *child
             //
             if (child->pointsToNull()) {
                 refReg = cg()->allocateRegister();
-                Inst_RegReg(TR::InstOpCode::XOR4RegReg, child, refReg, refReg, cg());
+                Inst_RegReg(OP::XOR4RegReg, child, refReg, refReg, cg());
                 // TODO (81564): We need to kill the scratch register to prevent an
                 // assertion error, but is this the right place to do so?
                 cg()->stopUsingRegister(refReg);
@@ -85,8 +85,8 @@ TR::Register *J9::X86::AMD64::JNILinkage::processJNIReferenceArg(TR::Node *child
         }
 
         if (needsNullParameterCheck) {
-            Inst_MemImm(TR::InstOpCode::CMPMemImms(), child, MRef_Bdisp32(refReg, 0, cg()), 0, cg());
-            Inst_RegMem(TR::InstOpCode::CMOVERegMem(), child, refReg,
+            Inst_MemImm(OP::CMPMemImms(), child, MRef_Bdisp32(refReg, 0, cg()), 0, cg());
+            Inst_RegMem(OP::CMOVERegMem(), child, refReg,
                 MRef_const(cg()->findOrCreateConstantDataSnippet<intptr_t>(child, 0), cg()), cg());
         }
     } else {
@@ -216,8 +216,7 @@ int32_t J9::X86::AMD64::JNILinkage::buildArgs(TR::Node *callNode, TR::RegisterDe
         if ((adjustedMemoryArgSize % 16) != 0)
             memoryArgSize += 8;
 
-        TR::InstOpCode::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? TR::InstOpCode::SUBRegImms()
-                                                                                      : TR::InstOpCode::SUBRegImm4();
+        OP::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? OP::SUBRegImms() : OP::SUBRegImm4();
         Inst_RegImm(op, callNode, espReal, memoryArgSize, cg());
     }
 
@@ -441,8 +440,8 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
 
     // Mask out the magic bit that indicates JIT frames below.
     //
-    Inst_MemImm(TR::InstOpCode::SMemImm4(), callNode,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
+    Inst_MemImm(OP::SMemImm4(), callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0,
+        cg());
 
     // Grab 5 slots in the frame.
     //
@@ -465,35 +464,35 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
 
     // Push tag bits (savedA0 slot).
     //
-    Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, tagBits, cg());
+    Inst_Imm(OP::PUSHImm4, callNode, tagBits, cg());
 
     // (skip savedPC slot).
     //
-    Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, 0, cg());
+    Inst_Imm(OP::PUSHImm4, callNode, 0, cg());
 
     // Push return address in this frame (savedCP slot).
     //
     if (!scratchReg)
         scratchReg = cg()->allocateRegister();
 
-    TR::AMD64RegImm64SymInstruction *returnAddressInstr = Inst_RegImm64Sym(TR::InstOpCode::MOV8RegImm64, callNode,
-        scratchReg, 0, new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), returnAddrLabel), cg());
+    TR::AMD64RegImm64SymInstruction *returnAddressInstr = Inst_RegImm64Sym(OP::MOV8RegImm64, callNode, scratchReg, 0,
+        new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), returnAddrLabel), cg());
 
     returnAddressInstr->setReloKind(TR_AbsoluteMethodAddress);
 
-    Inst_Reg(TR::InstOpCode::PUSHReg, callNode, scratchReg, cg());
+    Inst_Reg(OP::PUSHReg, callNode, scratchReg, cg());
 
     // Push frame flags.
     //
     static_assert(IS_32BIT_SIGNED(J9_SSF_JIT_JNI_CALLOUT), "J9_SSF_JIT_JNI_CALLOUT must fit in immediate");
-    Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, J9_SSF_JIT_JNI_CALLOUT, cg());
+    Inst_Imm(OP::PUSHImm4, callNode, J9_SSF_JIT_JNI_CALLOUT, cg());
 
     // Push the RAM method for the native.
     //
     auto tempMR = MRef_Bdisp32(espReal, 0, cg());
     uintptr_t methodAddr = (uintptr_t)resolvedMethod->resolvedMethodAddress();
     if (IS_32BIT_SIGNED(methodAddr) && !TR::Compiler->om.nativeAddressesCanChangeSize()) {
-        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, methodAddr, cg());
+        Inst_Imm(OP::PUSHImm4, callNode, methodAddr, cg());
     } else {
         if (!scratchReg)
             scratchReg = cg()->allocateRegister();
@@ -502,22 +501,22 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
             TR_NoRelocation /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst };
         int reloType = callSymbol->getMethodKind() - 1; // method kinds are 1-based!!
         TR_ASSERT(reloTypes[reloType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg, methodAddr, cg(), reloTypes[reloType]);
-        Inst_Reg(TR::InstOpCode::PUSHReg, callNode, scratchReg, cg());
+        Inst_RegImm64(OP::MOV8RegImm64, callNode, scratchReg, methodAddr, cg(), reloTypes[reloType]);
+        Inst_Reg(OP::PUSHReg, callNode, scratchReg, cg());
     }
 
     // Store out pc and literals values indicating the callout frame.
     //
     static_assert(IS_32BIT_SIGNED(J9SF_FRAME_TYPE_JIT_JNI_CALLOUT),
         "J9SF_FRAME_TYPE_JIT_JNI_CALLOUT must fit in immediate");
-    Inst_MemImm(TR::InstOpCode::SMemImm4(), callNode,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaPCOffset(), cg()), J9SF_FRAME_TYPE_JIT_JNI_CALLOUT, cg());
+    Inst_MemImm(OP::SMemImm4(), callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaPCOffset(), cg()),
+        J9SF_FRAME_TYPE_JIT_JNI_CALLOUT, cg());
 
     if (scratchReg)
         cg()->stopUsingRegister(scratchReg);
 
-    Inst_MemImm(TR::InstOpCode::SMemImm4(), callNode,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
+    Inst_MemImm(OP::SMemImm4(), callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0,
+        cg());
 }
 
 void J9::X86::AMD64::JNILinkage::buildJNIMergeLabelDependencies(TR::Node *callNode, bool killNonVolatileGPRs)
@@ -667,7 +666,7 @@ TR::Instruction *J9::X86::AMD64::JNILinkage::generateMethodDispatch(TR::Node *ca
 
     // Load machine bp esp + offsetof(J9CInterpreterStackFrame, machineBP) + argSize
     //
-    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, vmThreadReg,
+    Inst_RegMem(OP::LRegMem(), callNode, vmThreadReg,
         MRef_Bdisp32(espReal, offsetof(J9CInterpreterStackFrame, machineBP) + argSize, cg()), cg());
 
     // Dispatch JNI method directly.
@@ -690,11 +689,11 @@ TR::Instruction *J9::X86::AMD64::JNILinkage::generateMethodDispatch(TR::Node *ca
 
     TR_ASSERT(reloTypes[reloType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
 
-    TR::X86RegInstruction *patchedInstr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode,
+    TR::X86RegInstruction *patchedInstr = Inst_RegImm64(OP::MOV8RegImm64, callNode,
         _JNIDispatchInfo.dispatchTrampolineRegister, targetAddress, cg(), reloTypes[reloType]);
 
-    TR::X86RegInstruction *instr = Inst_Reg(TR::InstOpCode::CALLReg, callNode,
-        _JNIDispatchInfo.dispatchTrampolineRegister, _JNIDispatchInfo.callPostDeps, cg());
+    TR::X86RegInstruction *instr = Inst_Reg(OP::CALLReg, callNode, _JNIDispatchInfo.dispatchTrampolineRegister,
+        _JNIDispatchInfo.callPostDeps, cg());
     cg()->getJNICallSites().push_front(new (trHeapMemory())
             TR_Pair<TR_ResolvedMethod, TR::Instruction>(callSymbol->getResolvedMethod(), patchedInstr));
 
@@ -717,8 +716,7 @@ TR::Instruction *J9::X86::AMD64::JNILinkage::generateMethodDispatch(TR::Node *ca
                 "Caller cleanup argument size too large for one instruction on AMD64.");
 
         if (cleanUpSize != 0) {
-            TR::InstOpCode::Mnemonic op = (cleanUpSize >= -128 && cleanUpSize <= 127) ? TR::InstOpCode::ADDRegImms()
-                                                                                      : TR::InstOpCode::ADDRegImm4();
+            OP::Mnemonic op = (cleanUpSize >= -128 && cleanUpSize <= 127) ? OP::ADDRegImms() : OP::ADDRegImm4();
             Inst_RegImm(op, callNode, espReal, cleanUpSize, cg());
         }
     }
@@ -743,7 +741,7 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
     //    scratch2 <-> NoReg
     //    scratch3 <-> NoReg
     //
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     TR::Register *vmThreadReg = cg()->getMethodMetaDataRegister();
     TR::Register *scratchReg1 = cg()->allocateRegister();
@@ -751,15 +749,15 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
     TR::Register *scratchReg3 = NULL;
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
-    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg1,
+    Inst_RegMem(OP::LRegMem(), callNode, scratchReg1,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), cg());
 
     TR::LabelSymbol *loopHeadLabel = generateLabelSymbol(cg());
 
     // Loop head
     //
-    Inst_Label(TR::InstOpCode::label, callNode, loopHeadLabel, cg());
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), callNode, scratchReg2, scratchReg1, cg());
+    Inst_Label(OP::label, callNode, loopHeadLabel, cg());
+    Inst_RegReg(OP::MOVRegReg(), callNode, scratchReg2, scratchReg1, cg());
 
     TR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
@@ -770,19 +768,19 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
         if (!scratchReg3)
             scratchReg3 = cg()->allocateRegister();
 
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg3, mask, cg());
-        Inst_RegReg(TR::InstOpCode::TEST8RegReg, callNode, scratchReg1, scratchReg3, cg());
+        Inst_RegImm64(OP::MOV8RegImm64, callNode, scratchReg3, mask, cg());
+        Inst_RegReg(OP::TEST8RegReg, callNode, scratchReg1, scratchReg3, cg());
     } else {
-        op = (mask <= 255) ? TR::InstOpCode::TEST1RegImm1 : TR::InstOpCode::TEST4RegImm4;
+        op = (mask <= 255) ? OP::TEST1RegImm1 : OP::TEST4RegImm4;
         Inst_RegImm(op, callNode, scratchReg1, mask, cg());
     }
-    Inst_Label(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
+    Inst_Label(OP::JNE4, callNode, longReleaseSnippetLabel, cg());
 
     {
         TR_OutlinedInstructionsGenerator og(longReleaseSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getMethodSymbol());
-        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-        Inst_Label(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
+        Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(OP::JMP4, callNode, longReleaseRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
 
@@ -792,18 +790,18 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
         if (!scratchReg3)
             scratchReg3 = cg()->allocateRegister();
 
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg3, mask, cg());
-        Inst_RegReg(TR::InstOpCode::AND8RegReg, callNode, scratchReg2, scratchReg3, cg());
+        Inst_RegImm64(OP::MOV8RegImm64, callNode, scratchReg3, mask, cg());
+        Inst_RegReg(OP::AND8RegReg, callNode, scratchReg2, scratchReg3, cg());
     } else {
-        op = (mask <= 255) ? TR::InstOpCode::AND1RegImm1 : TR::InstOpCode::AND4RegImm4;
+        op = (mask <= 255) ? OP::AND1RegImm1 : OP::AND4RegImm4;
         Inst_RegImm(op, callNode, scratchReg2, mask, cg());
     }
 
-    op = comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg() : TR::InstOpCode::CMPXCHGMemReg(cg());
+    op = comp()->target().isSMP() ? OP::LCMPXCHGMemReg() : OP::CMPXCHGMemReg(cg());
     Inst_MemReg(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), scratchReg2,
         cg());
 
-    Inst_Label(TR::InstOpCode::JNE4, callNode, loopHeadLabel, cg());
+    Inst_Label(OP::JNE4, callNode, loopHeadLabel, cg());
 
     int8_t numDeps = scratchReg3 ? 3 : 2;
     TR::RegisterDependencyConditions *deps = RegDeps(numDeps, numDeps, cg());
@@ -823,7 +821,7 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
 
     deps->stopAddingConditions();
 
-    Inst_Label(TR::InstOpCode::label, callNode, longReleaseRestartLabel, deps, cg());
+    Inst_Label(OP::label, callNode, longReleaseRestartLabel, deps, cg());
 }
 
 void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
@@ -841,24 +839,23 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
     TR::Register *scratchReg1 = cg()->allocateRegister();
     TR::Register *scratchReg2 = cg()->allocateRegister();
 
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, callNode, scratchReg1, scratchReg1, cg());
+    Inst_RegReg(OP::XOR4RegReg, callNode, scratchReg1, scratchReg1, cg());
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
     uintptr_t mask = fej9->constAcquireVMAccessOutOfLineMask();
 
     if (comp()->target().is64Bit() && (mask > 0x7fffffff))
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg2, mask, cg());
+        Inst_RegImm64(OP::MOV8RegImm64, callNode, scratchReg2, mask, cg());
     else
-        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, callNode, scratchReg2, mask, cg());
+        Inst_RegImm(OP::MOV4RegImm4, callNode, scratchReg2, mask, cg());
 
     TR::LabelSymbol *longReacquireSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longReacquireRestartLabel = generateLabelSymbol(cg());
 
-    TR::InstOpCode::Mnemonic op
-        = comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg() : TR::InstOpCode::CMPXCHGMemReg(cg());
+    OP::Mnemonic op = comp()->target().isSMP() ? OP::LCMPXCHGMemReg() : OP::CMPXCHGMemReg(cg());
     Inst_MemReg(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), scratchReg2,
         cg());
-    Inst_Label(TR::InstOpCode::JNE4, callNode, longReacquireSnippetLabel, cg());
+    Inst_Label(OP::JNE4, callNode, longReacquireSnippetLabel, cg());
 
     // TODO: ecx may hold a reference across this snippet
     // If the return type is address something needs to be represented in the
@@ -867,8 +864,8 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
     {
         TR_OutlinedInstructionsGenerator og(longReacquireSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getMethodSymbol());
-        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-        Inst_Label(TR::InstOpCode::JMP4, callNode, longReacquireRestartLabel, cg());
+        Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(OP::JMP4, callNode, longReacquireRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
     TR::RegisterDependencyConditions *deps = RegDeps(2, 2, cg());
@@ -882,7 +879,7 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
 
     deps->stopAddingConditions();
 
-    Inst_Label(TR::InstOpCode::label, callNode, longReacquireRestartLabel, deps, cg());
+    Inst_Label(OP::label, callNode, longReacquireRestartLabel, deps, cg());
 }
 
 #ifdef J9VM_INTERP_ATOMIC_FREE_JNI
@@ -892,28 +889,28 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccessAtomicFree(TR::Node *callNode)
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
-    Inst_MemImm(TR::InstOpCode::S8MemImm4, callNode,
-        MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
+    Inst_MemImm(OP::S8MemImm4, callNode, MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 1,
+        cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
     TR::MemoryReference *mr = MRef_Bdisp32(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
     mr->setRequiresLockPrefix();
-    Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+    Inst_MemImm(OP::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
     TR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
 
     static_assert(IS_32BIT_SIGNED(J9_PUBLIC_FLAGS_VM_ACCESS), "J9_PUBLIC_FLAGS_VM_ACCESS must fit in immediate");
-    Inst_MemImm(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
+    Inst_MemImm(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? OP::CMP4MemImms : OP::CMP4MemImm4, callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-    Inst_Label(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
-    Inst_Label(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
+    Inst_Label(OP::JNE4, callNode, longReleaseSnippetLabel, cg());
+    Inst_Label(OP::label, callNode, longReleaseRestartLabel, cg());
 
     TR_OutlinedInstructionsGenerator og(longReleaseSnippetLabel, callNode, cg());
     auto helper = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getMethodSymbol());
-    Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-    Inst_Label(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
+    Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+    Inst_Label(OP::JMP4, callNode, longReleaseRestartLabel, cg());
     og.endOutlinedInstructionSequence();
 }
 
@@ -923,28 +920,28 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccessAtomicFree(TR::Node *callNode)
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
-    Inst_MemImm(TR::InstOpCode::S8MemImm4, callNode,
-        MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
+    Inst_MemImm(OP::S8MemImm4, callNode, MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 0,
+        cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
     TR::MemoryReference *mr = MRef_Bdisp32(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
     mr->setRequiresLockPrefix();
-    Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+    Inst_MemImm(OP::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
     TR::LabelSymbol *longAcquireSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longAcquireRestartLabel = generateLabelSymbol(cg());
 
     static_assert(IS_32BIT_SIGNED(J9_PUBLIC_FLAGS_VM_ACCESS), "J9_PUBLIC_FLAGS_VM_ACCESS must fit in immediate");
-    Inst_MemImm(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
+    Inst_MemImm(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? OP::CMP4MemImms : OP::CMP4MemImm4, callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-    Inst_Label(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
-    Inst_Label(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
+    Inst_Label(OP::JNE4, callNode, longAcquireSnippetLabel, cg());
+    Inst_Label(OP::label, callNode, longAcquireRestartLabel, cg());
 
     TR_OutlinedInstructionsGenerator og(longAcquireSnippetLabel, callNode, cg());
     auto helper = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getMethodSymbol());
-    Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-    Inst_Label(TR::InstOpCode::JMP4, callNode, longAcquireRestartLabel, cg());
+    Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+    Inst_Label(OP::JMP4, callNode, longAcquireRestartLabel, cg());
     og.endOutlinedInstructionSequence();
 }
 
@@ -957,7 +954,7 @@ void J9::X86::AMD64::JNILinkage::cleanupReturnValue(TR::Node *callNode, TR::Regi
         // Native and JNI methods may not return a full register in some cases so we need to get the declared
         // type so that we sign and zero extend the narrower integer return types properly.
         //
-        TR::InstOpCode::Mnemonic op;
+        OP::Mnemonic op;
         TR::SymbolReference *callSymRef = callNode->getSymbolReference();
         TR::ResolvedMethodSymbol *callSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
         TR_ResolvedMethod *resolvedMethod = callSymbol->getResolvedMethod();
@@ -969,30 +966,30 @@ void J9::X86::AMD64::JNILinkage::cleanupReturnValue(TR::Node *callNode, TR::Regi
                 if (comp()->getSymRefTab()->isReturnTypeBool(callSymRef)) {
                     // For bool return type, must check whether value returned by
                     // JNI is zero (false) or non-zero (true) to yield Java result
-                    Inst_RegReg(TR::InstOpCode::TEST1RegReg, callNode, linkageReturnReg, linkageReturnReg, cg());
-                    Inst_Reg(TR::InstOpCode::SETNE1Reg, callNode, linkageReturnReg, cg());
-                    op = comp()->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Reg1 : TR::InstOpCode::MOVZXReg4Reg1;
+                    Inst_RegReg(OP::TEST1RegReg, callNode, linkageReturnReg, linkageReturnReg, cg());
+                    Inst_Reg(OP::SETNE1Reg, callNode, linkageReturnReg, cg());
+                    op = comp()->target().is64Bit() ? OP::MOVZXReg8Reg1 : OP::MOVZXReg4Reg1;
                 } else if (isUnsigned) {
-                    op = comp()->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Reg1 : TR::InstOpCode::MOVZXReg4Reg1;
+                    op = comp()->target().is64Bit() ? OP::MOVZXReg8Reg1 : OP::MOVZXReg4Reg1;
                 } else {
-                    op = comp()->target().is64Bit() ? TR::InstOpCode::MOVSXReg8Reg1 : TR::InstOpCode::MOVSXReg4Reg1;
+                    op = comp()->target().is64Bit() ? OP::MOVSXReg8Reg1 : OP::MOVSXReg4Reg1;
                 }
                 break;
             case TR::Int16:
                 if (isUnsigned) {
-                    op = comp()->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Reg2 : TR::InstOpCode::MOVZXReg4Reg2;
+                    op = comp()->target().is64Bit() ? OP::MOVZXReg8Reg2 : OP::MOVZXReg4Reg2;
                 } else {
-                    op = comp()->target().is64Bit() ? TR::InstOpCode::MOVSXReg8Reg2 : TR::InstOpCode::MOVSXReg4Reg2;
+                    op = comp()->target().is64Bit() ? OP::MOVSXReg8Reg2 : OP::MOVSXReg4Reg2;
                 }
                 break;
             default:
                 // TR::Address, TR_[US]Int64, TR_[US]Int32
                 //
-                op = (linkageReturnReg != targetReg) ? TR::InstOpCode::MOVRegReg() : TR::InstOpCode::bad;
+                op = (linkageReturnReg != targetReg) ? OP::MOVRegReg() : OP::bad;
                 break;
         }
 
-        if (op != TR::InstOpCode::bad)
+        if (op != OP::bad)
             Inst_RegReg(op, callNode, targetReg, linkageReturnReg, cg());
     }
 }
@@ -1004,11 +1001,11 @@ void J9::X86::AMD64::JNILinkage::checkForJNIExceptions(TR::Node *callNode)
 
     // Check exceptions.
     //
-    Inst_MemImm(TR::InstOpCode::CMPMemImms(), callNode,
+    Inst_MemImm(OP::CMPMemImms(), callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
 
     TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
-    TR::Instruction *instr = Inst_Label(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
+    TR::Instruction *instr = Inst_Label(OP::JNE4, callNode, snippetLabel, cg());
 
     uint32_t gcMap = _systemLinkage->getProperties().getPreservedRegisterMapForGC();
     if (comp()->target().is32Bit()) {
@@ -1036,17 +1033,15 @@ void J9::X86::AMD64::JNILinkage::cleanupJNIRefPool(TR::Node *callNode)
     TR::LabelSymbol *refPoolSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *refPoolRestartLabel = generateLabelSymbol(cg());
 
-    Inst_MemImm(J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS <= 255 ? TR::InstOpCode::TEST1MemImm1
-                                                          : TR::InstOpCode::TESTMemImm4(),
-        callNode, MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()),
-        J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS, cg());
+    Inst_MemImm(J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS <= 255 ? OP::TEST1MemImm1 : OP::TESTMemImm4(), callNode,
+        MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()), J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS, cg());
 
-    Inst_Label(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
-    Inst_Label(TR::InstOpCode::label, callNode, refPoolRestartLabel, cg());
+    Inst_Label(OP::JNE4, callNode, refPoolSnippetLabel, cg());
+    Inst_Label(OP::label, callNode, refPoolRestartLabel, cg());
 
     TR_OutlinedInstructionsGenerator og(refPoolSnippetLabel, callNode, cg());
     Inst_HelperCall(callNode, TR_AMD64jitCollapseJNIReferenceFrame, NULL, cg());
-    Inst_Label(TR::InstOpCode::JMP4, callNode, refPoolRestartLabel, cg());
+    Inst_Label(OP::JMP4, callNode, refPoolRestartLabel, cg());
     og.endOutlinedInstructionSequence();
 }
 
@@ -1207,8 +1202,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
          * For virtual threads, bump the callOutCounter.  It is safe and most efficient to
          * do this unconditionally.  No need to check for overflow.
          */
-        Inst_Mem(TR::InstOpCode::INC8Mem, callNode,
-            MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
+        Inst_Mem(OP::INC8Mem, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
 #endif
     }
 
@@ -1218,14 +1212,14 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     // Preserve the VMThread pointer on the C stack.
     // Adjust the argSize to include the just pushed VMThread pointer.
     //
-    Inst_Reg(TR::InstOpCode::PUSHReg, callNode, vmThreadReg, cg());
+    Inst_Reg(OP::PUSHReg, callNode, vmThreadReg, cg());
     if (passThread || isGPUHelper) {
         _JNIDispatchInfo.argSize = TR::Compiler->om.sizeofReferenceAddress();
     }
 
     TR::LabelSymbol *startJNISequence = generateLabelSymbol(cg());
     startJNISequence->setStartInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, callNode, startJNISequence, cg());
+    Inst_Label(OP::label, callNode, startJNISequence, cg());
 
     if (isGPUHelper)
         callNode->setSymbolReference(gpuHelperSymRef);
@@ -1261,7 +1255,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     // TODO: will need an AOT relocation for this one at some point.
     // Lay down a label for the frame push to reference.
     //
-    Inst_Label(callInstr, TR::InstOpCode::label, returnAddrLabel, cg());
+    Inst_Label(callInstr, OP::label, returnAddrLabel, cg());
 
     if (_JNIDispatchInfo.JNIReturnRegister) {
         if (isGPUHelper)
@@ -1278,7 +1272,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
 
     // Restore the VMThread back from the C stack.
     //
-    Inst_Reg(TR::InstOpCode::POPReg, callNode, vmThreadReg, cg());
+    Inst_Reg(OP::POPReg, callNode, vmThreadReg, cg());
 
     if (dropVMAccess) {
 #ifdef J9VM_INTERP_ATOMIC_FREE_JNI
@@ -1295,18 +1289,18 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
         //
         TR::Register *targetReg = _JNIDispatchInfo.JNIReturnRegister;
         TR::LabelSymbol *nullLabel = generateLabelSymbol(cg());
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), callNode, targetReg, targetReg, cg());
-        Inst_Label(TR::InstOpCode::JE4, callNode, nullLabel, cg());
+        Inst_RegReg(OP::TESTRegReg(), callNode, targetReg, targetReg, cg());
+        Inst_Label(OP::JE4, callNode, nullLabel, cg());
 
-        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, targetReg, MRef_Bdisp32(targetReg, 0, cg()), cg());
+        Inst_RegMem(OP::LRegMem(), callNode, targetReg, MRef_Bdisp32(targetReg, 0, cg()), cg());
 
-        Inst_Label(TR::InstOpCode::label, callNode, nullLabel, cg());
+        Inst_Label(OP::label, callNode, nullLabel, cg());
     }
 
     //    1) Store out the machine sp into the vm thread.  It has to be done as sometimes
     //       it gets tromped on by call backs.
-    Inst_MemReg(TR::InstOpCode::SMemReg(), callNode,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg()), espReal, cg());
+    Inst_MemReg(OP::SMemReg(), callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg()), espReal,
+        cg());
 
     TR::J9LinkageUtils::switchToJavaStack(callNode, cg());
 
@@ -1316,11 +1310,10 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
          * For virtual threads, decrement the callOutCounter.  It is safe and most efficient to
          * do this unconditionally.  No need to check for underflow.
          */
-        Inst_Mem(TR::InstOpCode::DEC8Mem, callNode,
-            MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
+        Inst_Mem(OP::DEC8Mem, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
 #endif
 
-        Inst_RegMem(TR::InstOpCode::ADDRegMem(), callNode, espReal,
+        Inst_RegMem(OP::ADDRegMem(), callNode, espReal,
             MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
     }
 
@@ -1331,7 +1324,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     // Clean up JNI callout frame.
     //
     if (createJNIFrame) {
-        TR::X86RegImmInstruction *instr = Inst_RegImm(TR::InstOpCode::ADDRegImms(), callNode, espReal,
+        TR::X86RegImmInstruction *instr = Inst_RegImm(OP::ADDRegImms(), callNode, espReal,
             _JNIDispatchInfo.numJNIFrameSlotsPushed * TR::Compiler->om.sizeofReferenceAddress(), cg());
     }
 
@@ -1343,7 +1336,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
 
     TR::LabelSymbol *restartLabel = generateLabelSymbol(cg());
     restartLabel->setEndInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, callNode, restartLabel, _JNIDispatchInfo.mergeLabelPostDeps, cg());
+    Inst_Label(OP::label, callNode, restartLabel, _JNIDispatchInfo.mergeLabelPostDeps, cg());
 
     return _JNIDispatchInfo.JNIReturnRegister;
 }

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -73,7 +73,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::processJNIReferenceArg(TR::Node *child
             //
             if (child->pointsToNull()) {
                 refReg = cg()->allocateRegister();
-                generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, child, refReg, refReg, cg());
+                Inst_RegReg(TR::InstOpCode::XOR4RegReg, child, refReg, refReg, cg());
                 // TODO (81564): We need to kill the scratch register to prevent an
                 // assertion error, but is this the right place to do so?
                 cg()->stopUsingRegister(refReg);
@@ -85,8 +85,8 @@ TR::Register *J9::X86::AMD64::JNILinkage::processJNIReferenceArg(TR::Node *child
         }
 
         if (needsNullParameterCheck) {
-            generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), child, MRef_Bdisp32(refReg, 0, cg()), 0, cg());
-            generateRegMemInstruction(TR::InstOpCode::CMOVERegMem(), child, refReg,
+            Inst_MemImm(TR::InstOpCode::CMPMemImms(), child, MRef_Bdisp32(refReg, 0, cg()), 0, cg());
+            Inst_RegMem(TR::InstOpCode::CMOVERegMem(), child, refReg,
                 MRef_const(cg()->findOrCreateConstantDataSnippet<intptr_t>(child, 0), cg()), cg());
         }
     } else {
@@ -218,7 +218,7 @@ int32_t J9::X86::AMD64::JNILinkage::buildArgs(TR::Node *callNode, TR::RegisterDe
 
         TR::InstOpCode::Mnemonic op = (memoryArgSize >= -128 && memoryArgSize <= 127) ? TR::InstOpCode::SUBRegImms()
                                                                                       : TR::InstOpCode::SUBRegImm4();
-        generateRegImmInstruction(op, callNode, espReal, memoryArgSize, cg());
+        Inst_RegImm(op, callNode, espReal, memoryArgSize, cg());
     }
 
     // Evaluate the JNI env pointer first.
@@ -226,7 +226,7 @@ int32_t J9::X86::AMD64::JNILinkage::buildArgs(TR::Node *callNode, TR::RegisterDe
     if (passThread) {
         TR::RealRegister::RegNum rregIndex = _systemLinkage->getProperties().getIntegerArgumentRegister(0);
         TR::Register *argReg = cg()->allocateRegister();
-        generateRegRegInstruction(TR::Linkage::movOpcodes(RegReg, movType(TR::Address)), callNode, argReg,
+        Inst_RegReg(TR::Linkage::movOpcodes(RegReg, movType(TR::Address)), callNode, argReg,
             cg()->getMethodMetaDataRegister(), cg());
         deps->addPreCondition(argReg, rregIndex, cg());
         cg()->stopUsingRegister(argReg);
@@ -301,8 +301,7 @@ int32_t J9::X86::AMD64::JNILinkage::buildArgs(TR::Node *callNode, TR::RegisterDe
                 TR::Register *argReg = cg()->allocateRegister();
                 if (vreg->containsCollectedReference())
                     argReg->setContainsCollectedReference();
-                generateRegRegInstruction(TR::Linkage::movOpcodes(RegReg, movType(child->getDataType())), child, argReg,
-                    vreg, cg());
+                Inst_RegReg(TR::Linkage::movOpcodes(RegReg, movType(child->getDataType())), child, argReg, vreg, cg());
                 vreg = argReg;
                 copiedRegs[numCopiedRegs++] = vreg;
             }
@@ -313,7 +312,7 @@ int32_t J9::X86::AMD64::JNILinkage::buildArgs(TR::Node *callNode, TR::RegisterDe
                 needsStackOffsetUpdate = true;
         } else {
             // Ideally, we would like to push rather than move
-            generateMemRegInstruction(TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)), child,
+            Inst_MemReg(TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)), child,
                 MRef_Bdisp32(espReal, offset, cg()), vreg, cg());
 
             needsStackOffsetUpdate = true;
@@ -442,7 +441,7 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
 
     // Mask out the magic bit that indicates JIT frames below.
     //
-    generateMemImmInstruction(TR::InstOpCode::SMemImm4(), callNode,
+    Inst_MemImm(TR::InstOpCode::SMemImm4(), callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
 
     // Grab 5 slots in the frame.
@@ -466,36 +465,35 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
 
     // Push tag bits (savedA0 slot).
     //
-    generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, tagBits, cg());
+    Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, tagBits, cg());
 
     // (skip savedPC slot).
     //
-    generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, 0, cg());
+    Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, 0, cg());
 
     // Push return address in this frame (savedCP slot).
     //
     if (!scratchReg)
         scratchReg = cg()->allocateRegister();
 
-    TR::AMD64RegImm64SymInstruction *returnAddressInstr
-        = generateRegImm64SymInstruction(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg, 0,
-            new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), returnAddrLabel), cg());
+    TR::AMD64RegImm64SymInstruction *returnAddressInstr = Inst_RegImm64Sym(TR::InstOpCode::MOV8RegImm64, callNode,
+        scratchReg, 0, new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), returnAddrLabel), cg());
 
     returnAddressInstr->setReloKind(TR_AbsoluteMethodAddress);
 
-    generateRegInstruction(TR::InstOpCode::PUSHReg, callNode, scratchReg, cg());
+    Inst_Reg(TR::InstOpCode::PUSHReg, callNode, scratchReg, cg());
 
     // Push frame flags.
     //
     static_assert(IS_32BIT_SIGNED(J9_SSF_JIT_JNI_CALLOUT), "J9_SSF_JIT_JNI_CALLOUT must fit in immediate");
-    generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, J9_SSF_JIT_JNI_CALLOUT, cg());
+    Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, J9_SSF_JIT_JNI_CALLOUT, cg());
 
     // Push the RAM method for the native.
     //
     auto tempMR = MRef_Bdisp32(espReal, 0, cg());
     uintptr_t methodAddr = (uintptr_t)resolvedMethod->resolvedMethodAddress();
     if (IS_32BIT_SIGNED(methodAddr) && !TR::Compiler->om.nativeAddressesCanChangeSize()) {
-        generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, methodAddr, cg());
+        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, methodAddr, cg());
     } else {
         if (!scratchReg)
             scratchReg = cg()->allocateRegister();
@@ -504,22 +502,21 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
             TR_NoRelocation /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst };
         int reloType = callSymbol->getMethodKind() - 1; // method kinds are 1-based!!
         TR_ASSERT(reloTypes[reloType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg, methodAddr, cg(),
-            reloTypes[reloType]);
-        generateRegInstruction(TR::InstOpCode::PUSHReg, callNode, scratchReg, cg());
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg, methodAddr, cg(), reloTypes[reloType]);
+        Inst_Reg(TR::InstOpCode::PUSHReg, callNode, scratchReg, cg());
     }
 
     // Store out pc and literals values indicating the callout frame.
     //
     static_assert(IS_32BIT_SIGNED(J9SF_FRAME_TYPE_JIT_JNI_CALLOUT),
         "J9SF_FRAME_TYPE_JIT_JNI_CALLOUT must fit in immediate");
-    generateMemImmInstruction(TR::InstOpCode::SMemImm4(), callNode,
+    Inst_MemImm(TR::InstOpCode::SMemImm4(), callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaPCOffset(), cg()), J9SF_FRAME_TYPE_JIT_JNI_CALLOUT, cg());
 
     if (scratchReg)
         cg()->stopUsingRegister(scratchReg);
 
-    generateMemImmInstruction(TR::InstOpCode::SMemImm4(), callNode,
+    Inst_MemImm(TR::InstOpCode::SMemImm4(), callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
 }
 
@@ -670,7 +667,7 @@ TR::Instruction *J9::X86::AMD64::JNILinkage::generateMethodDispatch(TR::Node *ca
 
     // Load machine bp esp + offsetof(J9CInterpreterStackFrame, machineBP) + argSize
     //
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, vmThreadReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, vmThreadReg,
         MRef_Bdisp32(espReal, offsetof(J9CInterpreterStackFrame, machineBP) + argSize, cg()), cg());
 
     // Dispatch JNI method directly.
@@ -693,10 +690,10 @@ TR::Instruction *J9::X86::AMD64::JNILinkage::generateMethodDispatch(TR::Node *ca
 
     TR_ASSERT(reloTypes[reloType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
 
-    TR::X86RegInstruction *patchedInstr = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode,
+    TR::X86RegInstruction *patchedInstr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode,
         _JNIDispatchInfo.dispatchTrampolineRegister, targetAddress, cg(), reloTypes[reloType]);
 
-    TR::X86RegInstruction *instr = generateRegInstruction(TR::InstOpCode::CALLReg, callNode,
+    TR::X86RegInstruction *instr = Inst_Reg(TR::InstOpCode::CALLReg, callNode,
         _JNIDispatchInfo.dispatchTrampolineRegister, _JNIDispatchInfo.callPostDeps, cg());
     cg()->getJNICallSites().push_front(new (trHeapMemory())
             TR_Pair<TR_ResolvedMethod, TR::Instruction>(callSymbol->getResolvedMethod(), patchedInstr));
@@ -722,7 +719,7 @@ TR::Instruction *J9::X86::AMD64::JNILinkage::generateMethodDispatch(TR::Node *ca
         if (cleanUpSize != 0) {
             TR::InstOpCode::Mnemonic op = (cleanUpSize >= -128 && cleanUpSize <= 127) ? TR::InstOpCode::ADDRegImms()
                                                                                       : TR::InstOpCode::ADDRegImm4();
-            generateRegImmInstruction(op, callNode, espReal, cleanUpSize, cg());
+            Inst_RegImm(op, callNode, espReal, cleanUpSize, cg());
         }
     }
 
@@ -754,15 +751,15 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
     TR::Register *scratchReg3 = NULL;
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg1,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg1,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), cg());
 
     TR::LabelSymbol *loopHeadLabel = generateLabelSymbol(cg());
 
     // Loop head
     //
-    generateLabelInstruction(TR::InstOpCode::label, callNode, loopHeadLabel, cg());
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), callNode, scratchReg2, scratchReg1, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, loopHeadLabel, cg());
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), callNode, scratchReg2, scratchReg1, cg());
 
     TR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
@@ -773,20 +770,19 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
         if (!scratchReg3)
             scratchReg3 = cg()->allocateRegister();
 
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg3, mask, cg());
-        generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, callNode, scratchReg1, scratchReg3, cg());
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg3, mask, cg());
+        Inst_RegReg(TR::InstOpCode::TEST8RegReg, callNode, scratchReg1, scratchReg3, cg());
     } else {
         op = (mask <= 255) ? TR::InstOpCode::TEST1RegImm1 : TR::InstOpCode::TEST4RegImm4;
-        generateRegImmInstruction(op, callNode, scratchReg1, mask, cg());
+        Inst_RegImm(op, callNode, scratchReg1, mask, cg());
     }
-    generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
+    Inst_Label(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
 
     {
         TR_OutlinedInstructionsGenerator og(longReleaseSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getMethodSymbol());
-        generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper,
-            cg());
-        generateLabelInstruction(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
+        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
 
@@ -796,18 +792,18 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
         if (!scratchReg3)
             scratchReg3 = cg()->allocateRegister();
 
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg3, mask, cg());
-        generateRegRegInstruction(TR::InstOpCode::AND8RegReg, callNode, scratchReg2, scratchReg3, cg());
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg3, mask, cg());
+        Inst_RegReg(TR::InstOpCode::AND8RegReg, callNode, scratchReg2, scratchReg3, cg());
     } else {
         op = (mask <= 255) ? TR::InstOpCode::AND1RegImm1 : TR::InstOpCode::AND4RegImm4;
-        generateRegImmInstruction(op, callNode, scratchReg2, mask, cg());
+        Inst_RegImm(op, callNode, scratchReg2, mask, cg());
     }
 
     op = comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg() : TR::InstOpCode::CMPXCHGMemReg(cg());
-    generateMemRegInstruction(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
-        scratchReg2, cg());
+    Inst_MemReg(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), scratchReg2,
+        cg());
 
-    generateLabelInstruction(TR::InstOpCode::JNE4, callNode, loopHeadLabel, cg());
+    Inst_Label(TR::InstOpCode::JNE4, callNode, loopHeadLabel, cg());
 
     int8_t numDeps = scratchReg3 ? 3 : 2;
     TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(numDeps, numDeps, cg());
@@ -827,7 +823,7 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
 
     deps->stopAddingConditions();
 
-    generateLabelInstruction(TR::InstOpCode::label, callNode, longReleaseRestartLabel, deps, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, longReleaseRestartLabel, deps, cg());
 }
 
 void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
@@ -845,24 +841,24 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
     TR::Register *scratchReg1 = cg()->allocateRegister();
     TR::Register *scratchReg2 = cg()->allocateRegister();
 
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, callNode, scratchReg1, scratchReg1, cg());
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, callNode, scratchReg1, scratchReg1, cg());
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
     uintptr_t mask = fej9->constAcquireVMAccessOutOfLineMask();
 
     if (comp()->target().is64Bit() && (mask > 0x7fffffff))
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg2, mask, cg());
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, scratchReg2, mask, cg());
     else
-        generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, callNode, scratchReg2, mask, cg());
+        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, callNode, scratchReg2, mask, cg());
 
     TR::LabelSymbol *longReacquireSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longReacquireRestartLabel = generateLabelSymbol(cg());
 
     TR::InstOpCode::Mnemonic op
         = comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg() : TR::InstOpCode::CMPXCHGMemReg(cg());
-    generateMemRegInstruction(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
-        scratchReg2, cg());
-    generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longReacquireSnippetLabel, cg());
+    Inst_MemReg(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), scratchReg2,
+        cg());
+    Inst_Label(TR::InstOpCode::JNE4, callNode, longReacquireSnippetLabel, cg());
 
     // TODO: ecx may hold a reference across this snippet
     // If the return type is address something needs to be represented in the
@@ -871,9 +867,8 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
     {
         TR_OutlinedInstructionsGenerator og(longReacquireSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getMethodSymbol());
-        generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper,
-            cg());
-        generateLabelInstruction(TR::InstOpCode::JMP4, callNode, longReacquireRestartLabel, cg());
+        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(TR::InstOpCode::JMP4, callNode, longReacquireRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
     TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(2, 2, cg());
@@ -887,7 +882,7 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
 
     deps->stopAddingConditions();
 
-    generateLabelInstruction(TR::InstOpCode::label, callNode, longReacquireRestartLabel, deps, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, longReacquireRestartLabel, deps, cg());
 }
 
 #ifdef J9VM_INTERP_ATOMIC_FREE_JNI
@@ -897,29 +892,28 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccessAtomicFree(TR::Node *callNode)
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
-    generateMemImmInstruction(TR::InstOpCode::S8MemImm4, callNode,
+    Inst_MemImm(TR::InstOpCode::S8MemImm4, callNode,
         MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
     TR::MemoryReference *mr = MRef_Bdisp32(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
     mr->setRequiresLockPrefix();
-    generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+    Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
     TR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
 
     static_assert(IS_32BIT_SIGNED(J9_PUBLIC_FLAGS_VM_ACCESS), "J9_PUBLIC_FLAGS_VM_ACCESS must fit in immediate");
-    generateMemImmInstruction(
-        J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
+    Inst_MemImm(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-    generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
-    generateLabelInstruction(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
+    Inst_Label(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
 
     TR_OutlinedInstructionsGenerator og(longReleaseSnippetLabel, callNode, cg());
     auto helper = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getMethodSymbol());
-    generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-    generateLabelInstruction(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
+    Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+    Inst_Label(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
     og.endOutlinedInstructionSequence();
 }
 
@@ -929,29 +923,28 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccessAtomicFree(TR::Node *callNode)
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
-    generateMemImmInstruction(TR::InstOpCode::S8MemImm4, callNode,
+    Inst_MemImm(TR::InstOpCode::S8MemImm4, callNode,
         MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
     TR::MemoryReference *mr = MRef_Bdisp32(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
     mr->setRequiresLockPrefix();
-    generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+    Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
     TR::LabelSymbol *longAcquireSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *longAcquireRestartLabel = generateLabelSymbol(cg());
 
     static_assert(IS_32BIT_SIGNED(J9_PUBLIC_FLAGS_VM_ACCESS), "J9_PUBLIC_FLAGS_VM_ACCESS must fit in immediate");
-    generateMemImmInstruction(
-        J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
+    Inst_MemImm(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-    generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
-    generateLabelInstruction(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
+    Inst_Label(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
 
     TR_OutlinedInstructionsGenerator og(longAcquireSnippetLabel, callNode, cg());
     auto helper = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getMethodSymbol());
-    generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-    generateLabelInstruction(TR::InstOpCode::JMP4, callNode, longAcquireRestartLabel, cg());
+    Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+    Inst_Label(TR::InstOpCode::JMP4, callNode, longAcquireRestartLabel, cg());
     og.endOutlinedInstructionSequence();
 }
 
@@ -976,9 +969,8 @@ void J9::X86::AMD64::JNILinkage::cleanupReturnValue(TR::Node *callNode, TR::Regi
                 if (comp()->getSymRefTab()->isReturnTypeBool(callSymRef)) {
                     // For bool return type, must check whether value returned by
                     // JNI is zero (false) or non-zero (true) to yield Java result
-                    generateRegRegInstruction(TR::InstOpCode::TEST1RegReg, callNode, linkageReturnReg, linkageReturnReg,
-                        cg());
-                    generateRegInstruction(TR::InstOpCode::SETNE1Reg, callNode, linkageReturnReg, cg());
+                    Inst_RegReg(TR::InstOpCode::TEST1RegReg, callNode, linkageReturnReg, linkageReturnReg, cg());
+                    Inst_Reg(TR::InstOpCode::SETNE1Reg, callNode, linkageReturnReg, cg());
                     op = comp()->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Reg1 : TR::InstOpCode::MOVZXReg4Reg1;
                 } else if (isUnsigned) {
                     op = comp()->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Reg1 : TR::InstOpCode::MOVZXReg4Reg1;
@@ -1001,7 +993,7 @@ void J9::X86::AMD64::JNILinkage::cleanupReturnValue(TR::Node *callNode, TR::Regi
         }
 
         if (op != TR::InstOpCode::bad)
-            generateRegRegInstruction(op, callNode, targetReg, linkageReturnReg, cg());
+            Inst_RegReg(op, callNode, targetReg, linkageReturnReg, cg());
     }
 }
 
@@ -1012,11 +1004,11 @@ void J9::X86::AMD64::JNILinkage::checkForJNIExceptions(TR::Node *callNode)
 
     // Check exceptions.
     //
-    generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), callNode,
+    Inst_MemImm(TR::InstOpCode::CMPMemImms(), callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
 
     TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
-    TR::Instruction *instr = generateLabelInstruction(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
+    TR::Instruction *instr = Inst_Label(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
 
     uint32_t gcMap = _systemLinkage->getProperties().getPreservedRegisterMapForGC();
     if (comp()->target().is32Bit()) {
@@ -1044,17 +1036,17 @@ void J9::X86::AMD64::JNILinkage::cleanupJNIRefPool(TR::Node *callNode)
     TR::LabelSymbol *refPoolSnippetLabel = generateLabelSymbol(cg());
     TR::LabelSymbol *refPoolRestartLabel = generateLabelSymbol(cg());
 
-    generateMemImmInstruction(J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS <= 255 ? TR::InstOpCode::TEST1MemImm1
-                                                                        : TR::InstOpCode::TESTMemImm4(),
+    Inst_MemImm(J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS <= 255 ? TR::InstOpCode::TEST1MemImm1
+                                                          : TR::InstOpCode::TESTMemImm4(),
         callNode, MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()),
         J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS, cg());
 
-    generateLabelInstruction(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
-    generateLabelInstruction(TR::InstOpCode::label, callNode, refPoolRestartLabel, cg());
+    Inst_Label(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, refPoolRestartLabel, cg());
 
     TR_OutlinedInstructionsGenerator og(refPoolSnippetLabel, callNode, cg());
-    generateHelperCallInstruction(callNode, TR_AMD64jitCollapseJNIReferenceFrame, NULL, cg());
-    generateLabelInstruction(TR::InstOpCode::JMP4, callNode, refPoolRestartLabel, cg());
+    Inst_HelperCall(callNode, TR_AMD64jitCollapseJNIReferenceFrame, NULL, cg());
+    Inst_Label(TR::InstOpCode::JMP4, callNode, refPoolRestartLabel, cg());
     og.endOutlinedInstructionSequence();
 }
 
@@ -1195,8 +1187,8 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     // is because the subsequent manual adjustments of the stack pointer confuse the vfp logic.
     // This should be fixed in a subsquent revision of that code.
     //
-    TR::X86VFPDedicateInstruction *vfpDedicateInstruction = generateVFPDedicateInstruction(
-        machine()->getRealRegister(_JNIDispatchInfo.dedicatedFrameRegisterIndex), callNode, cg());
+    TR::X86VFPDedicateInstruction *vfpDedicateInstruction
+        = Inst_VFPDedicate(machine()->getRealRegister(_JNIDispatchInfo.dedicatedFrameRegisterIndex), callNode, cg());
 
     // First, build a JNI callout frame on the Java stack.
     //
@@ -1215,7 +1207,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
          * For virtual threads, bump the callOutCounter.  It is safe and most efficient to
          * do this unconditionally.  No need to check for overflow.
          */
-        generateMemInstruction(TR::InstOpCode::INC8Mem, callNode,
+        Inst_Mem(TR::InstOpCode::INC8Mem, callNode,
             MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
 #endif
     }
@@ -1226,14 +1218,14 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     // Preserve the VMThread pointer on the C stack.
     // Adjust the argSize to include the just pushed VMThread pointer.
     //
-    generateRegInstruction(TR::InstOpCode::PUSHReg, callNode, vmThreadReg, cg());
+    Inst_Reg(TR::InstOpCode::PUSHReg, callNode, vmThreadReg, cg());
     if (passThread || isGPUHelper) {
         _JNIDispatchInfo.argSize = TR::Compiler->om.sizeofReferenceAddress();
     }
 
     TR::LabelSymbol *startJNISequence = generateLabelSymbol(cg());
     startJNISequence->setStartInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, callNode, startJNISequence, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, startJNISequence, cg());
 
     if (isGPUHelper)
         callNode->setSymbolReference(gpuHelperSymRef);
@@ -1269,7 +1261,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     // TODO: will need an AOT relocation for this one at some point.
     // Lay down a label for the frame push to reference.
     //
-    generateLabelInstruction(callInstr, TR::InstOpCode::label, returnAddrLabel, cg());
+    Inst_Label(callInstr, TR::InstOpCode::label, returnAddrLabel, cg());
 
     if (_JNIDispatchInfo.JNIReturnRegister) {
         if (isGPUHelper)
@@ -1286,7 +1278,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
 
     // Restore the VMThread back from the C stack.
     //
-    generateRegInstruction(TR::InstOpCode::POPReg, callNode, vmThreadReg, cg());
+    Inst_Reg(TR::InstOpCode::POPReg, callNode, vmThreadReg, cg());
 
     if (dropVMAccess) {
 #ifdef J9VM_INTERP_ATOMIC_FREE_JNI
@@ -1303,18 +1295,17 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
         //
         TR::Register *targetReg = _JNIDispatchInfo.JNIReturnRegister;
         TR::LabelSymbol *nullLabel = generateLabelSymbol(cg());
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), callNode, targetReg, targetReg, cg());
-        generateLabelInstruction(TR::InstOpCode::JE4, callNode, nullLabel, cg());
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), callNode, targetReg, targetReg, cg());
+        Inst_Label(TR::InstOpCode::JE4, callNode, nullLabel, cg());
 
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, targetReg, MRef_Bdisp32(targetReg, 0, cg()),
-            cg());
+        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, targetReg, MRef_Bdisp32(targetReg, 0, cg()), cg());
 
-        generateLabelInstruction(TR::InstOpCode::label, callNode, nullLabel, cg());
+        Inst_Label(TR::InstOpCode::label, callNode, nullLabel, cg());
     }
 
     //    1) Store out the machine sp into the vm thread.  It has to be done as sometimes
     //       it gets tromped on by call backs.
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(), callNode,
+    Inst_MemReg(TR::InstOpCode::SMemReg(), callNode,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg()), espReal, cg());
 
     TR::J9LinkageUtils::switchToJavaStack(callNode, cg());
@@ -1325,11 +1316,11 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
          * For virtual threads, decrement the callOutCounter.  It is safe and most efficient to
          * do this unconditionally.  No need to check for underflow.
          */
-        generateMemInstruction(TR::InstOpCode::DEC8Mem, callNode,
+        Inst_Mem(TR::InstOpCode::DEC8Mem, callNode,
             MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
 #endif
 
-        generateRegMemInstruction(TR::InstOpCode::ADDRegMem(), callNode, espReal,
+        Inst_RegMem(TR::InstOpCode::ADDRegMem(), callNode, espReal,
             MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
     }
 
@@ -1340,7 +1331,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     // Clean up JNI callout frame.
     //
     if (createJNIFrame) {
-        TR::X86RegImmInstruction *instr = generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), callNode, espReal,
+        TR::X86RegImmInstruction *instr = Inst_RegImm(TR::InstOpCode::ADDRegImms(), callNode, espReal,
             _JNIDispatchInfo.numJNIFrameSlotsPushed * TR::Compiler->om.sizeofReferenceAddress(), cg());
     }
 
@@ -1348,11 +1339,11 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
         checkForJNIExceptions(callNode);
     }
 
-    generateVFPReleaseInstruction(vfpDedicateInstruction, callNode, cg());
+    Inst_VFPRelease(vfpDedicateInstruction, callNode, cg());
 
     TR::LabelSymbol *restartLabel = generateLabelSymbol(cg());
     restartLabel->setEndInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, callNode, restartLabel, _JNIDispatchInfo.mergeLabelPostDeps, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, restartLabel, _JNIDispatchInfo.mergeLabelPostDeps, cg());
 
     return _JNIDispatchInfo.JNIReturnRegister;
 }

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -625,8 +625,8 @@ void J9::X86::AMD64::JNILinkage::buildOutgoingJNIArgsAndDependencies(TR::Node *c
         + _systemLinkage->getProperties().getNumPreservedRegisters() + 1
         + (callNode->getDataType() == TR::NoType ? 0 : 1);
 
-    _JNIDispatchInfo.callPostDeps = generateRegisterDependencyConditions(callPre, callPost, cg());
-    _JNIDispatchInfo.mergeLabelPostDeps = generateRegisterDependencyConditions(0, labelPost, cg());
+    _JNIDispatchInfo.callPostDeps = RegDeps(callPre, callPost, cg());
+    _JNIDispatchInfo.mergeLabelPostDeps = RegDeps(0, labelPost, cg());
 
     // Evaluate outgoing arguments on the system stack and build pre-conditions.
     //
@@ -806,7 +806,7 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
     Inst_Label(TR::InstOpCode::JNE4, callNode, loopHeadLabel, cg());
 
     int8_t numDeps = scratchReg3 ? 3 : 2;
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(numDeps, numDeps, cg());
+    TR::RegisterDependencyConditions *deps = RegDeps(numDeps, numDeps, cg());
     deps->addPreCondition(scratchReg1, TR::RealRegister::eax, cg());
     deps->addPostCondition(scratchReg1, TR::RealRegister::eax, cg());
     cg()->stopUsingRegister(scratchReg1);
@@ -871,7 +871,7 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
         Inst_Label(TR::InstOpCode::JMP4, callNode, longReacquireRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(2, 2, cg());
+    TR::RegisterDependencyConditions *deps = RegDeps(2, 2, cg());
     deps->addPreCondition(scratchReg1, TR::RealRegister::eax, cg());
     deps->addPostCondition(scratchReg1, TR::RealRegister::eax, cg());
     cg()->stopUsingRegister(scratchReg1);

--- a/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64JNILinkage.cpp
@@ -85,10 +85,9 @@ TR::Register *J9::X86::AMD64::JNILinkage::processJNIReferenceArg(TR::Node *child
         }
 
         if (needsNullParameterCheck) {
-            generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), child, generateX86MemoryReference(refReg, 0, cg()),
-                0, cg());
+            generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), child, MRef_Bdisp32(refReg, 0, cg()), 0, cg());
             generateRegMemInstruction(TR::InstOpCode::CMOVERegMem(), child, refReg,
-                generateX86MemoryReference(cg()->findOrCreateConstantDataSnippet<intptr_t>(child, 0), cg()), cg());
+                MRef_const(cg()->findOrCreateConstantDataSnippet<intptr_t>(child, 0), cg()), cg());
         }
     } else {
         refReg = cg()->evaluate(child);
@@ -315,7 +314,7 @@ int32_t J9::X86::AMD64::JNILinkage::buildArgs(TR::Node *callNode, TR::RegisterDe
         } else {
             // Ideally, we would like to push rather than move
             generateMemRegInstruction(TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)), child,
-                generateX86MemoryReference(espReal, offset, cg()), vreg, cg());
+                MRef_Bdisp32(espReal, offset, cg()), vreg, cg());
 
             needsStackOffsetUpdate = true;
         }
@@ -444,7 +443,7 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
     // Mask out the magic bit that indicates JIT frames below.
     //
     generateMemImmInstruction(TR::InstOpCode::SMemImm4(), callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
 
     // Grab 5 slots in the frame.
     //
@@ -493,7 +492,7 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
 
     // Push the RAM method for the native.
     //
-    auto tempMR = generateX86MemoryReference(espReal, 0, cg());
+    auto tempMR = MRef_Bdisp32(espReal, 0, cg());
     uintptr_t methodAddr = (uintptr_t)resolvedMethod->resolvedMethodAddress();
     if (IS_32BIT_SIGNED(methodAddr) && !TR::Compiler->om.nativeAddressesCanChangeSize()) {
         generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, methodAddr, cg());
@@ -515,14 +514,13 @@ void J9::X86::AMD64::JNILinkage::buildJNICallOutFrame(TR::Node *callNode, TR::La
     static_assert(IS_32BIT_SIGNED(J9SF_FRAME_TYPE_JIT_JNI_CALLOUT),
         "J9SF_FRAME_TYPE_JIT_JNI_CALLOUT must fit in immediate");
     generateMemImmInstruction(TR::InstOpCode::SMemImm4(), callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetJavaPCOffset(), cg()),
-        J9SF_FRAME_TYPE_JIT_JNI_CALLOUT, cg());
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaPCOffset(), cg()), J9SF_FRAME_TYPE_JIT_JNI_CALLOUT, cg());
 
     if (scratchReg)
         cg()->stopUsingRegister(scratchReg);
 
     generateMemImmInstruction(TR::InstOpCode::SMemImm4(), callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
 }
 
 void J9::X86::AMD64::JNILinkage::buildJNIMergeLabelDependencies(TR::Node *callNode, bool killNonVolatileGPRs)
@@ -673,7 +671,7 @@ TR::Instruction *J9::X86::AMD64::JNILinkage::generateMethodDispatch(TR::Node *ca
     // Load machine bp esp + offsetof(J9CInterpreterStackFrame, machineBP) + argSize
     //
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, vmThreadReg,
-        generateX86MemoryReference(espReal, offsetof(J9CInterpreterStackFrame, machineBP) + argSize, cg()), cg());
+        MRef_Bdisp32(espReal, offsetof(J9CInterpreterStackFrame, machineBP) + argSize, cg()), cg());
 
     // Dispatch JNI method directly.
     //
@@ -757,7 +755,7 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg1,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), cg());
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), cg());
 
     TR::LabelSymbol *loopHeadLabel = generateLabelSymbol(cg());
 
@@ -806,8 +804,8 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccess(TR::Node *callNode)
     }
 
     op = comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg() : TR::InstOpCode::CMPXCHGMemReg(cg());
-    generateMemRegInstruction(op, callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), scratchReg2, cg());
+    generateMemRegInstruction(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
+        scratchReg2, cg());
 
     generateLabelInstruction(TR::InstOpCode::JNE4, callNode, loopHeadLabel, cg());
 
@@ -862,8 +860,8 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccess(TR::Node *callNode)
 
     TR::InstOpCode::Mnemonic op
         = comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg() : TR::InstOpCode::CMPXCHGMemReg(cg());
-    generateMemRegInstruction(op, callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), scratchReg2, cg());
+    generateMemRegInstruction(op, callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
+        scratchReg2, cg());
     generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longReacquireSnippetLabel, cg());
 
     // TODO: ecx may hold a reference across this snippet
@@ -900,11 +898,10 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccessAtomicFree(TR::Node *callNode)
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
     generateMemImmInstruction(TR::InstOpCode::S8MemImm4, callNode,
-        generateX86MemoryReference(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
+        MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-    TR::MemoryReference *mr
-        = generateX86MemoryReference(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
+    TR::MemoryReference *mr = MRef_Bdisp32(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
     mr->setRequiresLockPrefix();
     generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
@@ -913,10 +910,9 @@ void J9::X86::AMD64::JNILinkage::releaseVMAccessAtomicFree(TR::Node *callNode)
     TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
 
     static_assert(IS_32BIT_SIGNED(J9_PUBLIC_FLAGS_VM_ACCESS), "J9_PUBLIC_FLAGS_VM_ACCESS must fit in immediate");
-    generateMemImmInstruction(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms
-                                                              : TR::InstOpCode::CMP4MemImm4,
-        callNode, generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
-        J9_PUBLIC_FLAGS_VM_ACCESS, cg());
+    generateMemImmInstruction(
+        J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
     generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
     generateLabelInstruction(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
 
@@ -934,11 +930,10 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccessAtomicFree(TR::Node *callNode)
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
 
     generateMemImmInstruction(TR::InstOpCode::S8MemImm4, callNode,
-        generateX86MemoryReference(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
+        MRef_Bdisp32(vmThreadReg, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-    TR::MemoryReference *mr
-        = generateX86MemoryReference(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
+    TR::MemoryReference *mr = MRef_Bdisp32(cg()->machine()->getRealRegister(TR::RealRegister::esp), intptr_t(0), cg());
     mr->setRequiresLockPrefix();
     generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
@@ -947,10 +942,9 @@ void J9::X86::AMD64::JNILinkage::acquireVMAccessAtomicFree(TR::Node *callNode)
     TR::LabelSymbol *longAcquireRestartLabel = generateLabelSymbol(cg());
 
     static_assert(IS_32BIT_SIGNED(J9_PUBLIC_FLAGS_VM_ACCESS), "J9_PUBLIC_FLAGS_VM_ACCESS must fit in immediate");
-    generateMemImmInstruction(J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms
-                                                              : TR::InstOpCode::CMP4MemImm4,
-        callNode, generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()),
-        J9_PUBLIC_FLAGS_VM_ACCESS, cg());
+    generateMemImmInstruction(
+        J9_PUBLIC_FLAGS_VM_ACCESS < 128 ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4, callNode,
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
     generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
     generateLabelInstruction(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
 
@@ -1019,7 +1013,7 @@ void J9::X86::AMD64::JNILinkage::checkForJNIExceptions(TR::Node *callNode)
     // Check exceptions.
     //
     generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
 
     TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
     TR::Instruction *instr = generateLabelInstruction(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
@@ -1052,7 +1046,7 @@ void J9::X86::AMD64::JNILinkage::cleanupJNIRefPool(TR::Node *callNode)
 
     generateMemImmInstruction(J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS <= 255 ? TR::InstOpCode::TEST1MemImm1
                                                                         : TR::InstOpCode::TESTMemImm4(),
-        callNode, generateX86MemoryReference(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()),
+        callNode, MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()),
         J9_SSF_JIT_JNI_FRAME_COLLAPSE_BITS, cg());
 
     generateLabelInstruction(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
@@ -1222,7 +1216,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
          * do this unconditionally.  No need to check for overflow.
          */
         generateMemInstruction(TR::InstOpCode::INC8Mem, callNode,
-            generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
+            MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
 #endif
     }
 
@@ -1312,8 +1306,8 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
         generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), callNode, targetReg, targetReg, cg());
         generateLabelInstruction(TR::InstOpCode::JE4, callNode, nullLabel, cg());
 
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, targetReg,
-            generateX86MemoryReference(targetReg, 0, cg()), cg());
+        generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, targetReg, MRef_Bdisp32(targetReg, 0, cg()),
+            cg());
 
         generateLabelInstruction(TR::InstOpCode::label, callNode, nullLabel, cg());
     }
@@ -1321,7 +1315,7 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
     //    1) Store out the machine sp into the vm thread.  It has to be done as sometimes
     //       it gets tromped on by call backs.
     generateMemRegInstruction(TR::InstOpCode::SMemReg(), callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg()), espReal, cg());
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg()), espReal, cg());
 
     TR::J9LinkageUtils::switchToJavaStack(callNode, cg());
 
@@ -1332,11 +1326,11 @@ TR::Register *J9::X86::AMD64::JNILinkage::buildDirectJNIDispatch(TR::Node *callN
          * do this unconditionally.  No need to check for underflow.
          */
         generateMemInstruction(TR::InstOpCode::DEC8Mem, callNode,
-            generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
+            MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetCallOutCountOffset(), cg()), cg());
 #endif
 
         generateRegMemInstruction(TR::InstOpCode::ADDRegMem(), callNode, espReal,
-            generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
+            MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
     }
 
     if (createJNIFrame && tearDownJNIFrame) {

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -381,7 +381,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::generateFlushInstruction(TR::In
     //
     TR::Register *argReg = cg->allocateRegister(movRegisterKind(movType(dataType)));
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)2, 2, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)2, 2, cg);
     deps->addPreCondition(argReg, regIndex, cg);
     deps->addPostCondition(argReg, regIndex, cg);
     deps->addPreCondition(espReg, TR::RealRegister::esp, cg);

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -249,8 +249,8 @@ J9::X86::AMD64::PrivateLinkage::PrivateLinkage(TR::CodeGenerator *cg)
 // Argument manipulation
 //
 
-static uint8_t *flushArgument(uint8_t *cursor, TR::InstOpCode::Mnemonic op, TR::RealRegister::RegNum regIndex,
-    int32_t offset, TR::CodeGenerator *cg)
+static uint8_t *flushArgument(uint8_t *cursor, OP::Mnemonic op, TR::RealRegister::RegNum regIndex, int32_t offset,
+    TR::CodeGenerator *cg)
 {
     /* TODO:AMD64: Share code with the other flushArgument */
     cursor = TR::InstOpCode(op).binary(cursor, OMR::X86::Default);
@@ -280,7 +280,7 @@ static uint8_t *flushArgument(uint8_t *cursor, TR::InstOpCode::Mnemonic op, TR::
     return cursor;
 }
 
-static int32_t flushArgumentSize(TR::InstOpCode::Mnemonic op, int32_t offset)
+static int32_t flushArgumentSize(OP::Mnemonic op, int32_t offset)
 {
     int32_t size = TR::InstOpCode(op).length(OMR::X86::Default) + 1; // length including ModRM + 1 SIB
     return size + (((offset >= -128 && offset <= 127)) ? 1 : 4);
@@ -302,7 +302,7 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::flushArguments(TR::Node *callNode, uint
         offset += sizeof(intptr_t);
 
     TR::RealRegister::RegNum reg = TR::RealRegister::NoReg;
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
     TR::DataType dt = TR::NoType;
 
     if (calculateSizeOnly)
@@ -375,7 +375,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::generateFlushInstruction(TR::In
 
     // Opcode
     //
-    TR::InstOpCode::Mnemonic opCode = TR::Linkage::movOpcodes(operandType, movType(dataType));
+    OP::Mnemonic opCode = TR::Linkage::movOpcodes(operandType, movType(dataType));
 
     // Registers
     //
@@ -490,7 +490,7 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::generateVirtualIndirectThunk(TR::Node *
     TR::Compilation *comp = cg()->comp();
 
     (void)storeArguments(callNode, NULL, true, &codeSize);
-    codeSize += 12; // +10 TR::InstOpCode::MOV8RegImm64 +2 TR::InstOpCode::JMPReg
+    codeSize += 12; // +10 OP::MOV8RegImm64 +2 OP::JMPReg
 
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg()->fe());
 
@@ -537,14 +537,14 @@ uint8_t *J9::X86::AMD64::PrivateLinkage::generateVirtualIndirectThunk(TR::Node *
         *((int32_t *)thunk + 1) = cursor - thunkEntry;
     }
 
-    // TR::InstOpCode::MOV8RegImm64 rdi, glueAddress
+    // OP::MOV8RegImm64 rdi, glueAddress
     //
     *(uint16_t *)cursor = 0xbf48;
     cursor += 2;
     *(uint64_t *)cursor = (uintptr_t)glueSymRef->getMethodAddress();
     cursor += 8;
 
-    // TR::InstOpCode::JMPReg rdi
+    // OP::JMPReg rdi
     //
     *(uint8_t *)cursor++ = 0xff;
     *(uint8_t *)cursor++ = 0xe7;
@@ -566,13 +566,13 @@ TR_MHJ2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::N
     //
     int32_t codeSize;
     (void)storeArguments(callNode, NULL, true, &codeSize);
-    codeSize += 10; // TR::InstOpCode::MOV8RegImm64
+    codeSize += 10; // OP::MOV8RegImm64
     if (comp->getOption(TR_BreakOnJ2IThunk))
         codeSize += 1; // breakpoint opcode
     if (comp->getOptions()->getVerboseOption(TR_VerboseJ2IThunks))
         codeSize += 5; // JMPImm4
     else
-        codeSize += 2; // TR::InstOpCode::JMPReg
+        codeSize += 2; // OP::JMPReg
 
     TR_MHJ2IThunkTable *thunkTable = comp->getPersistentInfo()->getInvokeExactJ2IThunkTable();
     TR_MHJ2IThunk *thunk = TR_MHJ2IThunk::allocate(codeSize, signature, cg(), thunkTable);
@@ -606,7 +606,7 @@ TR_MHJ2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::N
     if (comp->getOption(TR_BreakOnJ2IThunk))
         *cursor++ = 0xcc;
 
-    // TR::InstOpCode::MOV8RegImm64 rdi, glueAddress
+    // OP::MOV8RegImm64 rdi, glueAddress
     //
     *(uint16_t *)cursor = 0xbf48;
     cursor += 2;
@@ -627,7 +627,7 @@ TR_MHJ2IThunk *J9::X86::AMD64::PrivateLinkage::generateInvokeExactJ2IThunk(TR::N
         *(int32_t *)(++cursor) = disp32;
         cursor += 4;
     } else {
-        // TR::InstOpCode::JMPReg rdi
+        // OP::JMPReg rdi
         //
         *(uint8_t *)cursor++ = 0xff;
         *(uint8_t *)cursor++ = 0xe7;
@@ -847,8 +847,8 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
                 parmAreaSize, alignedParmAreaSize);
         }
         if (alignedParmAreaSize > 0)
-            Inst_RegImm((alignedParmAreaSize <= 127 ? TR::InstOpCode::SUBRegImms() : TR::InstOpCode::SUBRegImm4()),
-                callNode, stackPointer, alignedParmAreaSize, cg());
+            Inst_RegImm((alignedParmAreaSize <= 127 ? OP::SUBRegImms() : OP::SUBRegImm4()), callNode, stackPointer,
+                alignedParmAreaSize, cg());
     }
 
     int32_t i;
@@ -928,7 +928,7 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
                 if (vreg->containsCollectedReference())
                     preCondReg->setContainsCollectedReference();
 
-                Inst_RegReg(needsZeroExtension ? TR::InstOpCode::MOVZXReg8Reg4
+                Inst_RegReg(needsZeroExtension ? OP::MOVZXReg8Reg4
                                                : TR::Linkage::movOpcodes(RegReg, movType(child->getDataType())),
                     child, preCondReg, vreg, cg());
                 vreg = preCondReg;
@@ -938,7 +938,7 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
             } else {
                 preCondReg = vreg;
                 if (needsZeroExtension)
-                    Inst_RegReg(TR::InstOpCode::MOVZXReg8Reg4, child, preCondReg, vreg, cg());
+                    Inst_RegReg(OP::MOVZXReg8Reg4, child, preCondReg, vreg, cg());
             }
 
             dependencies->addPreCondition(preCondReg, rregIndex, cg());
@@ -953,8 +953,8 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
                         MRef_Bdisp32(stackPointer, parmAreaSize - offset, cg()), vreg, cg());
                 else {
                     int32_t konst = child->getInt();
-                    Inst_MemImm(TR::InstOpCode::S8MemImm4, child,
-                        MRef_Bdisp32(stackPointer, parmAreaSize - offset, cg()), konst, cg());
+                    Inst_MemImm(OP::S8MemImm4, child, MRef_Bdisp32(stackPointer, parmAreaSize - offset, cg()), konst,
+                        cg());
                 }
             }
         }
@@ -1002,11 +1002,10 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
     TR::Instruction *firstInstruction;
     if (picSlot.getMethodAddress()) {
         addrToBeCompared = (uint64_t)picSlot.getMethodAddress();
-        firstInstruction
-            = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, cachedAddressRegister, addrToBeCompared, cg());
+        firstInstruction = Inst_RegImm64(OP::MOV8RegImm64, node, cachedAddressRegister, addrToBeCompared, cg());
     } else
-        firstInstruction = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, cachedAddressRegister,
-            (uint64_t)picSlot.getClassAddress(), cg());
+        firstInstruction
+            = Inst_RegImm64(OP::MOV8RegImm64, node, cachedAddressRegister, (uint64_t)picSlot.getClassAddress(), cg());
 
     firstInstruction->setNeedsGCMap(site.getPreservedRegisterMask());
 
@@ -1023,27 +1022,24 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
     // VFT register into the ModRM r/m field of the generated instruction.
     //
     if (picSlot.getMethodAddress())
-        Inst_MemReg(TR::InstOpCode::CMP8MemReg, node, MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()),
-            cachedAddressRegister, cg());
+        Inst_MemReg(OP::CMP8MemReg, node, MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()), cachedAddressRegister, cg());
     else
-        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, cachedAddressRegister, vftReg, cg());
+        Inst_RegReg(OP::CMP8RegReg, node, cachedAddressRegister, vftReg, cg());
 
     cg()->stopUsingRegister(cachedAddressRegister);
 
     if (picSlot.needsJumpOnNotEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            Inst_LongLabel(TR::InstOpCode::JNE4, node, mismatchLabel, cg());
+            Inst_LongLabel(OP::JNE4, node, mismatchLabel, cg());
         } else {
-            TR::InstOpCode::Mnemonic op
-                = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JNE1 : TR::InstOpCode::JNE4;
+            OP::Mnemonic op = picSlot.needsShortConditionalBranch() ? OP::JNE1 : OP::JNE4;
             Inst_Label(op, node, mismatchLabel, cg());
         }
     } else if (picSlot.needsJumpOnEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            Inst_LongLabel(TR::InstOpCode::JE4, node, mismatchLabel, cg());
+            Inst_LongLabel(OP::JE4, node, mismatchLabel, cg());
         } else {
-            TR::InstOpCode::Mnemonic op
-                = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JE1 : TR::InstOpCode::JE4;
+            OP::Mnemonic op = picSlot.needsShortConditionalBranch() ? OP::JE1 : OP::JE4;
             Inst_Label(op, node, mismatchLabel, cg());
         }
     }
@@ -1053,14 +1049,14 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
         TR::SymbolReference *callSymRef = comp()->getSymRefTab()->findOrCreateMethodSymbol(
             node->getSymbolReference()->getOwningMethodIndex(), -1, picSlot.getMethod(), TR::MethodSymbol::Virtual);
 
-        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, node,
-            (intptr_t)picSlot.getMethod()->startAddressForJittedMethod(), callSymRef, cg());
+        instr = Inst_ImmSym(OP::CALLImm4, node, (intptr_t)picSlot.getMethod()->startAddressForJittedMethod(),
+            callSymRef, cg());
     } else if (picSlot.getHelperMethodSymbolRef()) {
         TR::MethodSymbol *helperMethod = picSlot.getHelperMethodSymbolRef()->getSymbol()->castToMethodSymbol();
-        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uint32_t)(uintptr_t)helperMethod->getMethodAddress(),
+        instr = Inst_ImmSym(OP::CALLImm4, node, (uint32_t)(uintptr_t)helperMethod->getMethodAddress(),
             picSlot.getHelperMethodSymbolRef(), cg());
     } else {
-        instr = Inst_Imm(TR::InstOpCode::CALLImm4, node, 0, cg());
+        instr = Inst_Imm(OP::CALLImm4, node, 0, cg());
     }
 
     instr->setNeedsGCMap(site.getPreservedRegisterMask());
@@ -1071,12 +1067,12 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
     // TODO: Can we get rid of some of these?  Maybe they don't cost anything.
     //
     if (picSlot.needsJumpToDone()) {
-        instr = Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg());
+        instr = Inst_Label(OP::JMP4, node, doneLabel, cg());
         instr->setNeedsGCMap(site.getPreservedRegisterMask());
     }
 
     if (picSlot.generateNextSlotLabelInstruction()) {
-        Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg());
+        Inst_Label(OP::label, node, mismatchLabel, cg());
     }
 
     return firstInstruction;
@@ -1102,7 +1098,7 @@ void J9::X86::AMD64::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelS
     TR_ASSERT(doneLabel, "a doneLabel is required for PIC dispatches");
 
     if (entryLabel)
-        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(OP::label, site.getCallNode(), entryLabel, cg());
 
     int32_t numIPicSlots = IPicParameters.defaultNumberOfSlots;
 
@@ -1129,7 +1125,7 @@ void J9::X86::AMD64::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelS
             // let's just lay it down.  It's likely not worth the effort to get
             // this exactly right in all cases.
             //
-            Inst(TR::InstOpCode::INT3, site.getCallNode(), cg());
+            Inst(OP::INT3, site.getCallNode(), cg());
         }
     }
 
@@ -1195,7 +1191,7 @@ void J9::X86::AMD64::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite 
 {
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
     if (entryLabel)
-        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(OP::label, site.getCallNode(), entryLabel, cg());
 
     TR::SymbolReference *methodSymRef = site.getSymbolReference();
     logprintf(comp()->getOption(TR_TraceCG), comp()->log(), "buildVirtualOrComputedCall(%p), isComputed=%d\n",
@@ -1204,7 +1200,7 @@ void J9::X86::AMD64::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite 
     bool evaluateVftEarly = methodSymRef->isUnresolved() || !fej9->isResolvedVirtualDispatchGuaranteed(comp());
 
     if (methodSymRef->getSymbol()->castToMethodSymbol()->isComputed()) {
-        buildVFTCall(site, TR::InstOpCode::CALLReg, site.evaluateVFT(), NULL);
+        buildVFTCall(site, OP::CALLReg, site.evaluateVFT(), NULL);
     } else if (evaluateVftEarly) {
         site.evaluateVFT(); // We must evaluate the VFT here to avoid a later evaluation that pollutes the VPic shape.
         buildVPIC(site, entryLabel, doneLabel);
@@ -1227,8 +1223,7 @@ void J9::X86::AMD64::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite 
             comp()->getSymbolValidationManager()->addJ2IThunkFromMethodRecord(thunk, method);
         }
 
-        buildVFTCall(site, TR::InstOpCode::CALLMem, NULL,
-            MRef_Bdisp32(site.evaluateVFT(), methodSymRef->getOffset(), cg()));
+        buildVFTCall(site, OP::CALLMem, NULL, MRef_Bdisp32(site.evaluateVFT(), methodSymRef->getOffset(), cg()));
     } else {
         site.evaluateVFT(); // We must evaluate the VFT here to avoid a later evaluation that pollutes the VPic shape.
         buildVPIC(site, entryLabel, doneLabel);

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -658,7 +658,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::savePreservedRegisters(TR::Inst
         TR::RealRegister::RegNum r8 = TR::RealRegister::r8;
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod() && (reg->getState() != TR::RealRegister::Locked)) {
-            cursor = generateMemRegInstruction(cursor, TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(reg)),
+            cursor = Inst_MemReg(cursor, TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(reg)),
                 MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), reg, cg());
             offsetCursor -= pointerSize;
         }
@@ -682,7 +682,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::restorePreservedRegisters(TR::I
         TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod()) {
-            cursor = generateRegMemInstruction(cursor, TR::Linkage::movOpcodes(RegMem, fullRegisterMovType(reg)), reg,
+            cursor = Inst_RegMem(cursor, TR::Linkage::movOpcodes(RegMem, fullRegisterMovType(reg)), reg,
                 MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), cg());
             offsetCursor -= _properties.getPointerSize();
         }
@@ -847,9 +847,8 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
                 parmAreaSize, alignedParmAreaSize);
         }
         if (alignedParmAreaSize > 0)
-            generateRegImmInstruction(
-                (alignedParmAreaSize <= 127 ? TR::InstOpCode::SUBRegImms() : TR::InstOpCode::SUBRegImm4()), callNode,
-                stackPointer, alignedParmAreaSize, cg());
+            Inst_RegImm((alignedParmAreaSize <= 127 ? TR::InstOpCode::SUBRegImms() : TR::InstOpCode::SUBRegImm4()),
+                callNode, stackPointer, alignedParmAreaSize, cg());
     }
 
     int32_t i;
@@ -929,9 +928,8 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
                 if (vreg->containsCollectedReference())
                     preCondReg->setContainsCollectedReference();
 
-                generateRegRegInstruction(needsZeroExtension
-                        ? TR::InstOpCode::MOVZXReg8Reg4
-                        : TR::Linkage::movOpcodes(RegReg, movType(child->getDataType())),
+                Inst_RegReg(needsZeroExtension ? TR::InstOpCode::MOVZXReg8Reg4
+                                               : TR::Linkage::movOpcodes(RegReg, movType(child->getDataType())),
                     child, preCondReg, vreg, cg());
                 vreg = preCondReg;
 
@@ -940,7 +938,7 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
             } else {
                 preCondReg = vreg;
                 if (needsZeroExtension)
-                    generateRegRegInstruction(TR::InstOpCode::MOVZXReg8Reg4, child, preCondReg, vreg, cg());
+                    Inst_RegReg(TR::InstOpCode::MOVZXReg8Reg4, child, preCondReg, vreg, cg());
             }
 
             dependencies->addPreCondition(preCondReg, rregIndex, cg());
@@ -951,11 +949,11 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
 
             if ((rregIndex == noReg) || (rregIndex != noReg && createDummyLinkageRegisters)) {
                 if (vreg)
-                    generateMemRegInstruction(TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)), child,
+                    Inst_MemReg(TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)), child,
                         MRef_Bdisp32(stackPointer, parmAreaSize - offset, cg()), vreg, cg());
                 else {
                     int32_t konst = child->getInt();
-                    generateMemImmInstruction(TR::InstOpCode::S8MemImm4, child,
+                    Inst_MemImm(TR::InstOpCode::S8MemImm4, child,
                         MRef_Bdisp32(stackPointer, parmAreaSize - offset, cg()), konst, cg());
                 }
             }
@@ -1004,10 +1002,10 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
     TR::Instruction *firstInstruction;
     if (picSlot.getMethodAddress()) {
         addrToBeCompared = (uint64_t)picSlot.getMethodAddress();
-        firstInstruction = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, cachedAddressRegister,
-            addrToBeCompared, cg());
+        firstInstruction
+            = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, cachedAddressRegister, addrToBeCompared, cg());
     } else
-        firstInstruction = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, cachedAddressRegister,
+        firstInstruction = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, cachedAddressRegister,
             (uint64_t)picSlot.getClassAddress(), cg());
 
     firstInstruction->setNeedsGCMap(site.getPreservedRegisterMask());
@@ -1016,7 +1014,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
         site.setFirstPICSlotInstruction(firstInstruction);
 
     if (picSlot.needsPicSlotAlignment()) {
-        generateBoundaryAvoidanceInstruction(X86PicSlotAtomicRegion, 8, 8, firstInstruction, cg());
+        Inst_BoundaryAvoidance(X86PicSlotAtomicRegion, 8, 8, firstInstruction, cg());
     }
 
     TR::Register *vftReg = site.evaluateVFT();
@@ -1025,28 +1023,28 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
     // VFT register into the ModRM r/m field of the generated instruction.
     //
     if (picSlot.getMethodAddress())
-        generateMemRegInstruction(TR::InstOpCode::CMP8MemReg, node, MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()),
+        Inst_MemReg(TR::InstOpCode::CMP8MemReg, node, MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()),
             cachedAddressRegister, cg());
     else
-        generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, cachedAddressRegister, vftReg, cg());
+        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, cachedAddressRegister, vftReg, cg());
 
     cg()->stopUsingRegister(cachedAddressRegister);
 
     if (picSlot.needsJumpOnNotEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            generateLongLabelInstruction(TR::InstOpCode::JNE4, node, mismatchLabel, cg());
+            Inst_LongLabel(TR::InstOpCode::JNE4, node, mismatchLabel, cg());
         } else {
             TR::InstOpCode::Mnemonic op
                 = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JNE1 : TR::InstOpCode::JNE4;
-            generateLabelInstruction(op, node, mismatchLabel, cg());
+            Inst_Label(op, node, mismatchLabel, cg());
         }
     } else if (picSlot.needsJumpOnEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            generateLongLabelInstruction(TR::InstOpCode::JE4, node, mismatchLabel, cg());
+            Inst_LongLabel(TR::InstOpCode::JE4, node, mismatchLabel, cg());
         } else {
             TR::InstOpCode::Mnemonic op
                 = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JE1 : TR::InstOpCode::JE4;
-            generateLabelInstruction(op, node, mismatchLabel, cg());
+            Inst_Label(op, node, mismatchLabel, cg());
         }
     }
 
@@ -1055,14 +1053,14 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
         TR::SymbolReference *callSymRef = comp()->getSymRefTab()->findOrCreateMethodSymbol(
             node->getSymbolReference()->getOwningMethodIndex(), -1, picSlot.getMethod(), TR::MethodSymbol::Virtual);
 
-        instr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, node,
+        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, node,
             (intptr_t)picSlot.getMethod()->startAddressForJittedMethod(), callSymRef, cg());
     } else if (picSlot.getHelperMethodSymbolRef()) {
         TR::MethodSymbol *helperMethod = picSlot.getHelperMethodSymbolRef()->getSymbol()->castToMethodSymbol();
-        instr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, node,
-            (uint32_t)(uintptr_t)helperMethod->getMethodAddress(), picSlot.getHelperMethodSymbolRef(), cg());
+        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uint32_t)(uintptr_t)helperMethod->getMethodAddress(),
+            picSlot.getHelperMethodSymbolRef(), cg());
     } else {
-        instr = generateImmInstruction(TR::InstOpCode::CALLImm4, node, 0, cg());
+        instr = Inst_Imm(TR::InstOpCode::CALLImm4, node, 0, cg());
     }
 
     instr->setNeedsGCMap(site.getPreservedRegisterMask());
@@ -1073,12 +1071,12 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
     // TODO: Can we get rid of some of these?  Maybe they don't cost anything.
     //
     if (picSlot.needsJumpToDone()) {
-        instr = generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg());
+        instr = Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg());
         instr->setNeedsGCMap(site.getPreservedRegisterMask());
     }
 
     if (picSlot.generateNextSlotLabelInstruction()) {
-        generateLabelInstruction(TR::InstOpCode::label, node, mismatchLabel, cg());
+        Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg());
     }
 
     return firstInstruction;
@@ -1104,7 +1102,7 @@ void J9::X86::AMD64::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelS
     TR_ASSERT(doneLabel, "a doneLabel is required for PIC dispatches");
 
     if (entryLabel)
-        generateLabelInstruction(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
 
     int32_t numIPicSlots = IPicParameters.defaultNumberOfSlots;
 
@@ -1131,7 +1129,7 @@ void J9::X86::AMD64::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelS
             // let's just lay it down.  It's likely not worth the effort to get
             // this exactly right in all cases.
             //
-            generateInstruction(TR::InstOpCode::INT3, site.getCallNode(), cg());
+            Inst(TR::InstOpCode::INT3, site.getCallNode(), cg());
         }
     }
 
@@ -1197,7 +1195,7 @@ void J9::X86::AMD64::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite 
 {
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
     if (entryLabel)
-        generateLabelInstruction(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
 
     TR::SymbolReference *methodSymRef = site.getSymbolReference();
     logprintf(comp()->getOption(TR_TraceCG), comp()->log(), "buildVirtualOrComputedCall(%p), isComputed=%d\n",

--- a/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
+++ b/runtime/compiler/x/amd64/codegen/AMD64PrivateLinkage.cpp
@@ -389,7 +389,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::generateFlushInstruction(TR::In
 
     // Generate the instruction
     //
-    TR::MemoryReference *memRef = generateX86MemoryReference(espReg, offset, cg);
+    TR::MemoryReference *memRef = MRef_Bdisp32(espReg, offset, cg);
     switch (operandType) {
         case RegMem:
             result = new (cg->trHeapMemory()) TR::X86RegMemInstruction(prev, opCode, argReg, memRef, deps, cg);
@@ -659,8 +659,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::savePreservedRegisters(TR::Inst
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod() && (reg->getState() != TR::RealRegister::Locked)) {
             cursor = generateMemRegInstruction(cursor, TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(reg)),
-                generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), reg,
-                cg());
+                MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), reg, cg());
             offsetCursor -= pointerSize;
         }
     }
@@ -684,8 +683,7 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::restorePreservedRegisters(TR::I
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod()) {
             cursor = generateRegMemInstruction(cursor, TR::Linkage::movOpcodes(RegMem, fullRegisterMovType(reg)), reg,
-                generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
-                cg());
+                MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), cg());
             offsetCursor -= _properties.getPointerSize();
         }
     }
@@ -954,11 +952,11 @@ int32_t J9::X86::AMD64::PrivateLinkage::buildPrivateLinkageArgs(TR::Node *callNo
             if ((rregIndex == noReg) || (rregIndex != noReg && createDummyLinkageRegisters)) {
                 if (vreg)
                     generateMemRegInstruction(TR::Linkage::movOpcodes(MemReg, fullRegisterMovType(vreg)), child,
-                        generateX86MemoryReference(stackPointer, parmAreaSize - offset, cg()), vreg, cg());
+                        MRef_Bdisp32(stackPointer, parmAreaSize - offset, cg()), vreg, cg());
                 else {
                     int32_t konst = child->getInt();
                     generateMemImmInstruction(TR::InstOpCode::S8MemImm4, child,
-                        generateX86MemoryReference(stackPointer, parmAreaSize - offset, cg()), konst, cg());
+                        MRef_Bdisp32(stackPointer, parmAreaSize - offset, cg()), konst, cg());
                 }
             }
         }
@@ -1027,8 +1025,8 @@ TR::Instruction *J9::X86::AMD64::PrivateLinkage::buildPICSlot(TR::X86PICSlot pic
     // VFT register into the ModRM r/m field of the generated instruction.
     //
     if (picSlot.getMethodAddress())
-        generateMemRegInstruction(TR::InstOpCode::CMP8MemReg, node,
-            generateX86MemoryReference(vftReg, picSlot.getSlot(), cg()), cachedAddressRegister, cg());
+        generateMemRegInstruction(TR::InstOpCode::CMP8MemReg, node, MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()),
+            cachedAddressRegister, cg());
     else
         generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, cachedAddressRegister, vftReg, cg());
 
@@ -1232,7 +1230,7 @@ void J9::X86::AMD64::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite 
         }
 
         buildVFTCall(site, TR::InstOpCode::CALLMem, NULL,
-            generateX86MemoryReference(site.evaluateVFT(), methodSymRef->getOffset(), cg()));
+            MRef_Bdisp32(site.evaluateVFT(), methodSymRef->getOffset(), cg()));
     } else {
         site.evaluateVFT(); // We must evaluate the VFT here to avoid a later evaluation that pollutes the VPic shape.
         buildVPIC(site, entryLabel, doneLabel);

--- a/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
+++ b/runtime/compiler/x/codegen/AllocPrefetchSnippet.cpp
@@ -204,10 +204,10 @@ uint8_t *TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t *prefetchSnippetBuf
         prefetchSnippetBuffer += 3;
     }
 
-    // TR::InstOpCode::PREFETCHNTA [rcx + distance]
-    // TR::InstOpCode::PREFETCHNTA [rcx + distance + lineSize]
+    // OP::PREFETCHNTA [rcx + distance]
+    // OP::PREFETCHNTA [rcx + distance + lineSize]
     // ...
-    // TR::InstOpCode::PREFETCHNTA [rcx + distance + n*lineSize]
+    // OP::PREFETCHNTA [rcx + distance + n*lineSize]
     //
     for (int32_t lineOffset = 0; lineOffset < numLines; ++lineOffset) {
         prefetchSnippetBuffer[0] = 0x0F;
@@ -241,7 +241,7 @@ uint8_t *TR::X86AllocPrefetchSnippet::emitSharedBody(uint8_t *prefetchSnippetBuf
     //
     *prefetchSnippetBuffer++ = 0x59;
 
-    // TR::InstOpCode::RET
+    // OP::RET
     //
     *prefetchSnippetBuffer++ = 0xC3;
 

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -213,7 +213,7 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
             if (unresolvedDispatch() && _hasJ2IThunkInPicData)
                 cursor = encodeJ2IThunkPointer(cursor);
         } else {
-            // ModRM byte of TR::InstOpCode::CMPMemImm4 instruction
+            // ModRM byte of OP::CMPMemImm4 instruction
             //
             uint8_t *slotPatchInstructionBytes = _slotPatchInstruction->getBinaryEncoding();
             *cursor = *(slotPatchInstructionBytes + 1);
@@ -261,11 +261,11 @@ uint8_t *TR::X86PicDataSnippet::emitSnippetBody()
                 //
                 *cursor++ = *slotPatchInstructionBytes;
 
-                // REX prefix for the TR::InstOpCode::CALLMem instruction.
+                // REX prefix for the OP::CALLMem instruction.
                 //
                 *cursor++ = *(slotPatchInstructionBytes + 9);
 
-                // Convert the CMP ModRM byte into the ModRM byte for the TR::InstOpCode::CALLMem instruction.
+                // Convert the CMP ModRM byte into the ModRM byte for the OP::CALLMem instruction.
                 //
                 slotPatchInstructionBytes += 11;
                 callModRMByte = (*slotPatchInstructionBytes & 7) + 0x90;
@@ -478,7 +478,7 @@ void TR_Debug::print(OMR::Logger *log, TR::X86PicDataSnippet *snippet)
                     bufferPos += sizeof(uintptr_t);
                 }
             } else {
-                // ModRM of TR::InstOpCode::CMPRegImm4
+                // ModRM of OP::CMPRegImm4
                 //
                 printPrefix(log, NULL, bufferPos, 1);
                 log->printf("%s\t%s%02x%s\t\t\t\t\t\t\t\t%s ModRM of CMP", dbString(), hexPrefixString(), *bufferPos,
@@ -508,12 +508,12 @@ void TR_Debug::print(OMR::Logger *log, TR::X86PicDataSnippet *snippet)
 
                 callModRM = *bufferPos;
                 printPrefix(log, NULL, bufferPos, 1);
-                log->printf("%s\t%02x\t\t\t\t\t\t\t\t%s ModRM for TR::InstOpCode::CALLMem", dbString(), *bufferPos,
+                log->printf("%s\t%02x\t\t\t\t\t\t\t\t%s ModRM for OP::CALLMem", dbString(), *bufferPos,
                     commentString());
                 bufferPos += 1;
             } else {
                 printPrefix(log, NULL, bufferPos, 1);
-                log->printf("%s\t%02x\t\t\t\t\t\t\t\t%s ModRM for TR::InstOpCode::CMPRegImm4", dbString(), *bufferPos,
+                log->printf("%s\t%02x\t\t\t\t\t\t\t\t%s ModRM for OP::CMPRegImm4", dbString(), *bufferPos,
                     commentString());
                 bufferPos += 1;
             }

--- a/runtime/compiler/x/codegen/Instruction.hpp
+++ b/runtime/compiler/x/codegen/Instruction.hpp
@@ -35,47 +35,46 @@ public:
     /*
      * Generic constructors
      */
-    inline Instruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg,
+    inline Instruction(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg,
         OMR::X86::Encoding encoding = OMR::X86::Default);
 
-    inline Instruction(TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg,
+    inline Instruction(OP::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg,
         OMR::X86::Encoding encoding = OMR::X86::Default);
 
     /*
      * X86 specific constructors, need to call initializer to perform proper construction
      */
-    inline Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR::InstOpCode::Mnemonic op,
-        TR::CodeGenerator *cg, OMR::X86::Encoding encoding = OMR::X86::Default);
+    inline Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg,
+        OMR::X86::Encoding encoding = OMR::X86::Default);
 
-    inline Instruction(TR::RegisterDependencyConditions *cond, TR::InstOpCode::Mnemonic op,
-        TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, OMR::X86::Encoding encoding = OMR::X86::Default);
+    inline Instruction(TR::RegisterDependencyConditions *cond, OP::Mnemonic op, TR::Instruction *precedingInstruction,
+        TR::CodeGenerator *cg, OMR::X86::Encoding encoding = OMR::X86::Default);
 };
 
 } // namespace TR
 
 #include "codegen/J9Instruction_inlines.hpp"
 
-TR::Instruction::Instruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::CodeGenerator *cg,
-    OMR::X86::Encoding encoding)
-    : J9::InstructionConnector(cg, TR::InstOpCode::bad, node)
+TR::Instruction::Instruction(TR::Node *node, OP::Mnemonic op, TR::CodeGenerator *cg, OMR::X86::Encoding encoding)
+    : J9::InstructionConnector(cg, OP::bad, node)
 {
     self()->setOpCodeValue(op);
     self()->setEncodingMethod(encoding);
     self()->initialize();
 }
 
-TR::Instruction::Instruction(TR::InstOpCode::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg,
+TR::Instruction::Instruction(OP::Mnemonic op, TR::Instruction *precedingInstruction, TR::CodeGenerator *cg,
     OMR::X86::Encoding encoding)
-    : J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
+    : J9::InstructionConnector(cg, precedingInstruction, OP::bad)
 {
     self()->setOpCodeValue(op);
     self()->setEncodingMethod(encoding);
     self()->initialize();
 }
 
-TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, TR::InstOpCode::Mnemonic op,
+TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *node, OP::Mnemonic op,
     TR::CodeGenerator *cg, OMR::X86::Encoding encoding)
-    : J9::InstructionConnector(cg, TR::InstOpCode::bad, node)
+    : J9::InstructionConnector(cg, OP::bad, node)
 {
     self()->setOpCodeValue(op);
     self()->setEncodingMethod(encoding);
@@ -83,9 +82,9 @@ TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::Node *n
     self()->initialize(cg, cond, op, true);
 }
 
-TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, TR::InstOpCode::Mnemonic op,
+TR::Instruction::Instruction(TR::RegisterDependencyConditions *cond, OP::Mnemonic op,
     TR::Instruction *precedingInstruction, TR::CodeGenerator *cg, OMR::X86::Encoding encoding)
-    : J9::InstructionConnector(cg, precedingInstruction, TR::InstOpCode::bad)
+    : J9::InstructionConnector(cg, precedingInstruction, OP::bad)
 {
     self()->setOpCodeValue(op);
     self()->setEncodingMethod(encoding);

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -246,35 +246,35 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
         if (comp->target().is64Bit()) {
             // A copy of the first two bytes of the method, in case we need to un-patch them
             //
-            new (self()->trHeapMemory()) TR::X86ImmInstruction(cursor, TR::InstOpCode::DWImm2, 0xcccc, self());
+            new (self()->trHeapMemory()) TR::X86ImmInstruction(cursor, OP::DWImm2, 0xcccc, self());
         }
     } else if (methodSymbol->isJNI()) {
         intptr_t methodAddress = (intptr_t)methodSymbol->getResolvedMethod()->startAddressForJNIMethod(comp);
 
         if (comp->target().is64Bit())
             new (self()->trHeapMemory())
-                TR::AMD64Imm64Instruction((TR::Instruction *)NULL, TR::InstOpCode::DQImm64, methodAddress, self());
+                TR::AMD64Imm64Instruction((TR::Instruction *)NULL, OP::DQImm64, methodAddress, self());
         else
             new (self()->trHeapMemory())
-                TR::X86ImmInstruction((TR::Instruction *)NULL, TR::InstOpCode::DDImm4, methodAddress, self());
+                TR::X86ImmInstruction((TR::Instruction *)NULL, OP::DDImm4, methodAddress, self());
     }
 
     if (methodSymbol->getLinkageConvention() == TR_Private && !_returnTypeInfoInstruction) {
         // linkageInfo word
         if (self()->getAppendInstruction())
-            _returnTypeInfoInstruction = Inst_Imm(TR::InstOpCode::DDImm4, startNode, 0, self());
+            _returnTypeInfoInstruction = Inst_Imm(OP::DDImm4, startNode, 0, self());
         else
-            _returnTypeInfoInstruction = new (self()->trHeapMemory())
-                TR::X86ImmInstruction((TR::Instruction *)NULL, TR::InstOpCode::DDImm4, 0, self());
+            _returnTypeInfoInstruction
+                = new (self()->trHeapMemory()) TR::X86ImmInstruction((TR::Instruction *)NULL, OP::DDImm4, 0, self());
     }
 
     if (methodSymbol->getLinkageConvention() == TR_System && !_returnTypeInfoInstruction) {
         // linkageInfo word
         if (self()->getAppendInstruction())
-            _returnTypeInfoInstruction = Inst_Imm(TR::InstOpCode::DDImm4, startNode, 0, self());
+            _returnTypeInfoInstruction = Inst_Imm(OP::DDImm4, startNode, 0, self());
         else
-            _returnTypeInfoInstruction = new (self()->trHeapMemory())
-                TR::X86ImmInstruction((TR::Instruction *)NULL, TR::InstOpCode::DDImm4, 0, self());
+            _returnTypeInfoInstruction
+                = new (self()->trHeapMemory()) TR::X86ImmInstruction((TR::Instruction *)NULL, OP::DDImm4, 0, self());
     }
 
     TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)1, self());
@@ -285,15 +285,15 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
     deps->stopAddingPostConditions();
 
     if (self()->getAppendInstruction())
-        Inst(TR::InstOpCode::proc, startNode, deps, self());
+        Inst(OP::proc, startNode, deps, self());
     else
-        new (self()->trHeapMemory()) TR::Instruction(deps, TR::InstOpCode::proc, (TR::Instruction *)NULL, self());
+        new (self()->trHeapMemory()) TR::Instruction(deps, OP::proc, (TR::Instruction *)NULL, self());
 
     // Set the default FPCW to single precision mode if we are allowed to.
     //
     if (self()->enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
-        Inst_Mem(TR::InstOpCode::LDCWMem, startNode, MRef_const(cds, self()), self());
+        Inst_Mem(OP::LDCWMem, startNode, MRef_const(cds, self()), self());
     }
 }
 
@@ -315,7 +315,7 @@ void J9::X86::CodeGenerator::endInstructionSelection()
 
         auto cds = self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(),
             DOUBLE_PRECISION_ROUND_TO_NEAREST);
-        Inst_Mem(self()->getLastCatchAppendInstruction(), TR::InstOpCode::LDCWMem, MRef_const(cds, self()), self());
+        Inst_Mem(self()->getLastCatchAppendInstruction(), OP::LDCWMem, MRef_const(cds, self()), self());
     }
 }
 
@@ -379,12 +379,12 @@ TR::Instruction *J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
     if (comp->target().is32Bit()) {
         // Put the alignment before the interpreter jump so the jump's offset is fixed
         //
-        alignmentMargin += 6; // TR::InstOpCode::MOV4RegImm4 below
+        alignmentMargin += 6; // OP::MOV4RegImm4 below
         prev = Inst_Alignment(prev, alignment, alignmentMargin, self());
     }
 
     startLabel = generateLabelSymbol(self());
-    prev = Inst_Label(prev, TR::InstOpCode::label, startLabel, self());
+    prev = Inst_Label(prev, OP::label, startLabel, self());
     self()->setSwitchToInterpreterLabel(startLabel);
 
     TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)1, (uint8_t)0, self());
@@ -393,17 +393,17 @@ TR::Instruction *J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
     TR::SymbolReference *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition);
 
     if (comp->target().is64Bit()) {
-        prev = Inst_RegImm64(prev, TR::InstOpCode::MOV8RegImm64, ediRegister, feMethod, self(), TR_RamMethod);
+        prev = Inst_RegImm64(prev, OP::MOV8RegImm64, ediRegister, feMethod, self(), TR_RamMethod);
         if (comp->getOption(TR_EnableHCR))
             comp->getStaticHCRPICSites()->push_front(prev);
         prev = self()->getLinkage(methodSymbol->getLinkageConvention())->storeArguments(prev, methodSymbol);
     } else {
-        prev = Inst_RegImm(prev, TR::InstOpCode::MOV4RegImm4, ediRegister, feMethod, self(), TR_RamMethod);
+        prev = Inst_RegImm(prev, OP::MOV4RegImm4, ediRegister, feMethod, self(), TR_RamMethod);
         if (comp->getOption(TR_EnableHCR))
             comp->getStaticHCRPICSites()->push_front(prev);
     }
 
-    prev = new (self()->trHeapMemory()) TR::X86ImmSymInstruction(prev, TR::InstOpCode::JMP4,
+    prev = new (self()->trHeapMemory()) TR::X86ImmSymInstruction(prev, OP::JMP4,
         (uintptr_t)helperSymRef->getMethodAddress(), helperSymRef, deps, self());
     self()->stopUsingRegister(ediRegister);
 
@@ -411,13 +411,13 @@ TR::Instruction *J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
         // Generate a mini-trampoline jump to the start of the
         // SwitchToInterpreterPrePrologue.  This comes after the alignment
         // instruction so we know where it will be relative to startPC.  Note
-        // that it ought to be a TR::InstOpCode::JMP1 despite the fact that we're using a TR::InstOpCode::JMP4
+        // that it ought to be a OP::JMP1 despite the fact that we're using a OP::JMP4
         // opCode; otherwise, this instruction is not 2 bytes long, so it will
         // mess up alignment.
         //
         alignmentMargin += 2; // Size of the mini-trampoline
         prev = Inst_Alignment(prev, alignment, alignmentMargin, self());
-        prev = new (self()->trHeapMemory()) TR::X86LabelInstruction(prev, TR::InstOpCode::JMP4, startLabel, self());
+        prev = new (self()->trHeapMemory()) TR::X86LabelInstruction(prev, OP::JMP4, startLabel, self());
     }
 
     return prev;

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -277,7 +277,7 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
                 TR::X86ImmInstruction((TR::Instruction *)NULL, TR::InstOpCode::DDImm4, 0, self());
     }
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)1, self());
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)1, self());
     if (_linkageProperties->getMethodMetaDataRegister() != TR::RealRegister::NoReg) {
         deps->addPostCondition(self()->getVMThreadRegister(),
             (TR::RealRegister::RegNum)self()->getVMThreadRegister()->getAssociation(), self());
@@ -387,7 +387,7 @@ TR::Instruction *J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
     prev = Inst_Label(prev, TR::InstOpCode::label, startLabel, self());
     self()->setSwitchToInterpreterLabel(startLabel);
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)1, (uint8_t)0, self());
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)1, (uint8_t)0, self());
     deps->addPreCondition(ediRegister, TR::RealRegister::edi, self());
 
     TR::SymbolReference *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition);

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -262,7 +262,7 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
     if (methodSymbol->getLinkageConvention() == TR_Private && !_returnTypeInfoInstruction) {
         // linkageInfo word
         if (self()->getAppendInstruction())
-            _returnTypeInfoInstruction = generateImmInstruction(TR::InstOpCode::DDImm4, startNode, 0, self());
+            _returnTypeInfoInstruction = Inst_Imm(TR::InstOpCode::DDImm4, startNode, 0, self());
         else
             _returnTypeInfoInstruction = new (self()->trHeapMemory())
                 TR::X86ImmInstruction((TR::Instruction *)NULL, TR::InstOpCode::DDImm4, 0, self());
@@ -271,7 +271,7 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
     if (methodSymbol->getLinkageConvention() == TR_System && !_returnTypeInfoInstruction) {
         // linkageInfo word
         if (self()->getAppendInstruction())
-            _returnTypeInfoInstruction = generateImmInstruction(TR::InstOpCode::DDImm4, startNode, 0, self());
+            _returnTypeInfoInstruction = Inst_Imm(TR::InstOpCode::DDImm4, startNode, 0, self());
         else
             _returnTypeInfoInstruction = new (self()->trHeapMemory())
                 TR::X86ImmInstruction((TR::Instruction *)NULL, TR::InstOpCode::DDImm4, 0, self());
@@ -285,7 +285,7 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
     deps->stopAddingPostConditions();
 
     if (self()->getAppendInstruction())
-        generateInstruction(TR::InstOpCode::proc, startNode, deps, self());
+        Inst(TR::InstOpCode::proc, startNode, deps, self());
     else
         new (self()->trHeapMemory()) TR::Instruction(deps, TR::InstOpCode::proc, (TR::Instruction *)NULL, self());
 
@@ -293,7 +293,7 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
     //
     if (self()->enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
-        generateMemInstruction(TR::InstOpCode::LDCWMem, startNode, MRef_const(cds, self()), self());
+        Inst_Mem(TR::InstOpCode::LDCWMem, startNode, MRef_const(cds, self()), self());
     }
 }
 
@@ -315,8 +315,7 @@ void J9::X86::CodeGenerator::endInstructionSelection()
 
         auto cds = self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(),
             DOUBLE_PRECISION_ROUND_TO_NEAREST);
-        generateMemInstruction(self()->getLastCatchAppendInstruction(), TR::InstOpCode::LDCWMem,
-            MRef_const(cds, self()), self());
+        Inst_Mem(self()->getLastCatchAppendInstruction(), TR::InstOpCode::LDCWMem, MRef_const(cds, self()), self());
     }
 }
 
@@ -336,7 +335,7 @@ void J9::X86::CodeGenerator::preBinaryEncodingHook()
                     // address of the function may be beyond the body of this function. In this case, we must add
                     // padding to end of the function to prevent the stack walker from detecting an illegal return
                     // address.
-                    generatePaddingInstruction(lastInstruction, 1, self());
+                    Inst_Padding(lastInstruction, 1, self());
                 }
                 break;
             }
@@ -381,11 +380,11 @@ TR::Instruction *J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
         // Put the alignment before the interpreter jump so the jump's offset is fixed
         //
         alignmentMargin += 6; // TR::InstOpCode::MOV4RegImm4 below
-        prev = generateAlignmentInstruction(prev, alignment, alignmentMargin, self());
+        prev = Inst_Alignment(prev, alignment, alignmentMargin, self());
     }
 
     startLabel = generateLabelSymbol(self());
-    prev = generateLabelInstruction(prev, TR::InstOpCode::label, startLabel, self());
+    prev = Inst_Label(prev, TR::InstOpCode::label, startLabel, self());
     self()->setSwitchToInterpreterLabel(startLabel);
 
     TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)1, (uint8_t)0, self());
@@ -394,14 +393,12 @@ TR::Instruction *J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
     TR::SymbolReference *helperSymRef = self()->symRefTab()->findOrCreateRuntimeHelper(TR_j2iTransition);
 
     if (comp->target().is64Bit()) {
-        prev = generateRegImm64Instruction(prev, TR::InstOpCode::MOV8RegImm64, ediRegister, feMethod, self(),
-            TR_RamMethod);
+        prev = Inst_RegImm64(prev, TR::InstOpCode::MOV8RegImm64, ediRegister, feMethod, self(), TR_RamMethod);
         if (comp->getOption(TR_EnableHCR))
             comp->getStaticHCRPICSites()->push_front(prev);
         prev = self()->getLinkage(methodSymbol->getLinkageConvention())->storeArguments(prev, methodSymbol);
     } else {
-        prev
-            = generateRegImmInstruction(prev, TR::InstOpCode::MOV4RegImm4, ediRegister, feMethod, self(), TR_RamMethod);
+        prev = Inst_RegImm(prev, TR::InstOpCode::MOV4RegImm4, ediRegister, feMethod, self(), TR_RamMethod);
         if (comp->getOption(TR_EnableHCR))
             comp->getStaticHCRPICSites()->push_front(prev);
     }
@@ -419,7 +416,7 @@ TR::Instruction *J9::X86::CodeGenerator::generateSwitchToInterpreterPrePrologue(
         // mess up alignment.
         //
         alignmentMargin += 2; // Size of the mini-trampoline
-        prev = generateAlignmentInstruction(prev, alignment, alignmentMargin, self());
+        prev = Inst_Alignment(prev, alignment, alignmentMargin, self());
         prev = new (self()->trHeapMemory()) TR::X86LabelInstruction(prev, TR::InstOpCode::JMP4, startLabel, self());
     }
 

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -293,7 +293,7 @@ void J9::X86::CodeGenerator::beginInstructionSelection()
     //
     if (self()->enableSinglePrecisionMethods() && comp->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = self()->findOrCreate2ByteConstant(startNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
-        generateMemInstruction(TR::InstOpCode::LDCWMem, startNode, generateX86MemoryReference(cds, self()), self());
+        generateMemInstruction(TR::InstOpCode::LDCWMem, startNode, MRef_const(cds, self()), self());
     }
 }
 
@@ -316,7 +316,7 @@ void J9::X86::CodeGenerator::endInstructionSelection()
         auto cds = self()->findOrCreate2ByteConstant(self()->getLastCatchAppendInstruction()->getNode(),
             DOUBLE_PRECISION_ROUND_TO_NEAREST);
         generateMemInstruction(self()->getLastCatchAppendInstruction(), TR::InstOpCode::LDCWMem,
-            generateX86MemoryReference(cds, self()), self());
+            MRef_const(cds, self()), self());
     }
 }
 

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -93,12 +93,12 @@ void J9LinkageUtils::switchToMachineCStack(TR::Node *callNode, TR::CodeGenerator
     // Squirrel Java SP away into VM thread.
     //
     generateMemRegInstruction(TR::InstOpCode::SMemReg(), callNode,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg), espReal, cg);
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg), espReal, cg);
 
     // Load machine SP from VM thread.
     //
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, espReal,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg), cg);
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg), cg);
 }
 
 void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg)
@@ -110,7 +110,7 @@ void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg
     //  Load up the java sp so we have the callout frame on top of the java stack.
     //
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, espReal,
-        generateX86MemoryReference(vmThreadReg, cg->fej9()->thisThreadGetJavaSPOffset(), cg), cg);
+        MRef_Bdisp32(vmThreadReg, cg->fej9()->thisThreadGetJavaSPOffset(), cg), cg);
 }
 
 } // namespace TR

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -80,7 +80,7 @@ void J9LinkageUtils::cleanupReturnValue(TR::Node *callNode, TR::Register *linkag
         }
 
         if (op != TR::InstOpCode::bad)
-            generateRegRegInstruction(op, callNode, targetReg, linkageReturnReg, cg);
+            Inst_RegReg(op, callNode, targetReg, linkageReturnReg, cg);
     }
 }
 
@@ -92,12 +92,12 @@ void J9LinkageUtils::switchToMachineCStack(TR::Node *callNode, TR::CodeGenerator
 
     // Squirrel Java SP away into VM thread.
     //
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(), callNode,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg), espReal, cg);
+    Inst_MemReg(TR::InstOpCode::SMemReg(), callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg),
+        espReal, cg);
 
     // Load machine SP from VM thread.
     //
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, espReal,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, espReal,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg), cg);
 }
 
@@ -109,7 +109,7 @@ void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg
 
     //  Load up the java sp so we have the callout frame on top of the java stack.
     //
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, espReal,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, espReal,
         MRef_Bdisp32(vmThreadReg, cg->fej9()->thisThreadGetJavaSPOffset(), cg), cg);
 }
 

--- a/runtime/compiler/x/codegen/J9LinkageUtils.cpp
+++ b/runtime/compiler/x/codegen/J9LinkageUtils.cpp
@@ -51,7 +51,7 @@ void J9LinkageUtils::cleanupReturnValue(TR::Node *callNode, TR::Register *linkag
         // Native and JNI methods may not return a full register in some cases so we need to get the declared
         // type so that we sign and zero extend the narrower integer return types properly.
         //
-        TR::InstOpCode::Mnemonic op;
+        OP::Mnemonic op;
         TR::ResolvedMethodSymbol *callSymbol = callNode->getSymbol()->castToResolvedMethodSymbol();
         TR_ResolvedMethod *resolvedMethod = callSymbol->getResolvedMethod();
         TR::Compilation *comp = cg->comp();
@@ -60,26 +60,26 @@ void J9LinkageUtils::cleanupReturnValue(TR::Node *callNode, TR::Register *linkag
         switch (resolvedMethod->returnType()) {
             case TR::Int8:
                 if (isUnsigned) {
-                    op = comp->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Reg1 : TR::InstOpCode::MOVZXReg4Reg1;
+                    op = comp->target().is64Bit() ? OP::MOVZXReg8Reg1 : OP::MOVZXReg4Reg1;
                 } else {
-                    op = comp->target().is64Bit() ? TR::InstOpCode::MOVSXReg8Reg1 : TR::InstOpCode::MOVSXReg4Reg1;
+                    op = comp->target().is64Bit() ? OP::MOVSXReg8Reg1 : OP::MOVSXReg4Reg1;
                 }
                 break;
             case TR::Int16:
                 if (isUnsigned) {
-                    op = comp->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Reg2 : TR::InstOpCode::MOVZXReg4Reg2;
+                    op = comp->target().is64Bit() ? OP::MOVZXReg8Reg2 : OP::MOVZXReg4Reg2;
                 } else {
-                    op = comp->target().is64Bit() ? TR::InstOpCode::MOVSXReg8Reg2 : TR::InstOpCode::MOVSXReg4Reg2;
+                    op = comp->target().is64Bit() ? OP::MOVSXReg8Reg2 : OP::MOVSXReg4Reg2;
                 }
                 break;
             default:
                 // TR::Address, TR_[US]Int64, TR_[US]Int32
                 //
-                op = (linkageReturnReg != targetReg) ? TR::InstOpCode::MOVRegReg() : TR::InstOpCode::bad;
+                op = (linkageReturnReg != targetReg) ? OP::MOVRegReg() : OP::bad;
                 break;
         }
 
-        if (op != TR::InstOpCode::bad)
+        if (op != OP::bad)
             Inst_RegReg(op, callNode, targetReg, linkageReturnReg, cg);
     }
 }
@@ -92,13 +92,12 @@ void J9LinkageUtils::switchToMachineCStack(TR::Node *callNode, TR::CodeGenerator
 
     // Squirrel Java SP away into VM thread.
     //
-    Inst_MemReg(TR::InstOpCode::SMemReg(), callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg),
-        espReal, cg);
+    Inst_MemReg(OP::SMemReg(), callNode, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetJavaSPOffset(), cg), espReal, cg);
 
     // Load machine SP from VM thread.
     //
-    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, espReal,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg), cg);
+    Inst_RegMem(OP::LRegMem(), callNode, espReal, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetMachineSPOffset(), cg),
+        cg);
 }
 
 void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg)
@@ -109,7 +108,7 @@ void J9LinkageUtils::switchToJavaStack(TR::Node *callNode, TR::CodeGenerator *cg
 
     //  Load up the java sp so we have the callout frame on top of the java stack.
     //
-    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, espReal,
+    Inst_RegMem(OP::LRegMem(), callNode, espReal,
         MRef_Bdisp32(vmThreadReg, cg->fej9()->thisThreadGetJavaSPOffset(), cg), cg);
 }
 

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -95,7 +95,7 @@
 
 #define NUM_PICS 3
 
-// Minimum number of words for zero-initialization via REP TR::InstOpCode::STOSD
+// Minimum number of words for zero-initialization via REP OP::STOSD
 //
 #define MIN_REPSTOSD_WORDS 64
 static int32_t minRepstosdWords = 0;
@@ -152,7 +152,7 @@ inline void generateLoadJ9Class(TR::Node *node, TR::Register *j9class, TR::Regis
     }
 
     auto use64BitClasses = cg->comp()->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
-    auto instr = Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, j9class,
+    auto instr = Inst_RegMem(OP::LRegMem(use64BitClasses), node, j9class,
         MRef_Bdisp32(object, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
     if (needsNULLCHK) {
         cg->setImplicitExceptionPoint(instr);
@@ -163,9 +163,8 @@ inline void generateLoadJ9Class(TR::Node *node, TR::Register *j9class, TR::Regis
 
     auto mask = TR::Compiler->om.maskOfObjectVftField();
     if (~mask != 0) {
-        Inst_RegImm(~mask <= 127 ? TR::InstOpCode::ANDRegImms(use64BitClasses)
-                                 : TR::InstOpCode::ANDRegImm4(use64BitClasses),
-            node, j9class, mask, cg);
+        Inst_RegImm(~mask <= 127 ? OP::ANDRegImms(use64BitClasses) : OP::ANDRegImm4(use64BitClasses), node, j9class,
+            mask, cg);
     }
 }
 
@@ -194,7 +193,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
     arrayletRef->swapInstructionListsWithCompilation();
 
-    Inst_Label(NULL, TR::InstOpCode::label, arrayletRefLabel, cg)->setNode(node);
+    Inst_Label(NULL, OP::label, arrayletRefLabel, cg)->setNode(node);
 
     // TODO: REMOVE THIS!
     //
@@ -205,7 +204,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
     static char *forceArrayletInt = feGetEnv("TR_forceArrayletInt");
     if (forceArrayletInt) {
-        Inst(TR::InstOpCode::INT3, node, cg);
+        Inst(OP::INT3, node, cg);
     }
 
     // -----------------------------------------------------------------------------------
@@ -223,11 +222,11 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
         TR::MemoryReference *arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
 
-        Inst_MemImm(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
+        Inst_MemImm(OP::CMP4MemImms, node, arraySizeMR, 0, cg);
 
         TR::LabelSymbol *boundCheckFailureLabel = generateLabelSymbol(cg);
 
-        checkInstruction = Inst_Label(TR::InstOpCode::JNE4, node, boundCheckFailureLabel, cg);
+        checkInstruction = Inst_Label(OP::JNE4, node, boundCheckFailureLabel, cg);
 
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, node->getSymbolReference(),
             boundCheckFailureLabel, checkInstruction, false));
@@ -239,15 +238,14 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg);
 
         if (!indexReg) {
-            TR::InstOpCode::Mnemonic op
-                = (indexValue >= -128 && indexValue <= 127) ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4;
+            OP::Mnemonic op = (indexValue >= -128 && indexValue <= 127) ? OP::CMP4MemImms : OP::CMP4MemImm4;
             Inst_MemImm(op, node, arraySizeMR, indexValue, cg);
         } else {
-            Inst_MemReg(TR::InstOpCode::CMP4MemReg, node, arraySizeMR, indexReg, cg);
+            Inst_MemReg(OP::CMP4MemReg, node, arraySizeMR, indexReg, cg);
         }
 
         boundCheckFailureLabel = generateLabelSymbol(cg);
-        checkInstruction = Inst_Label(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
+        checkInstruction = Inst_Label(OP::JBE4, node, boundCheckFailureLabel, cg);
 
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, node->getSymbolReference(),
             boundCheckFailureLabel, checkInstruction, false));
@@ -298,12 +296,11 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     // Load the arraylet from the spine.
     //
     if (indexReg) {
-        TR::InstOpCode::Mnemonic op
-            = comp->target().is64Bit() ? TR::InstOpCode::MOVSXReg8Reg4 : TR::InstOpCode::MOVRegReg();
+        OP::Mnemonic op = comp->target().is64Bit() ? OP::MOVSXReg8Reg4 : OP::MOVRegReg();
         Inst_RegReg(op, node, scratchReg, indexReg, cg);
 
         int32_t spineShift = fej9->getArraySpineShift(elementSize);
-        Inst_RegImm(TR::InstOpCode::SARRegImm1(), node, scratchReg, spineShift, cg);
+        Inst_RegImm(OP::SARRegImm1(), node, scratchReg, spineShift, cg);
 
         spineMR = MRef_BISdisp32(baseArrayReg, scratchReg,
             TR::MemoryReference::convertMultiplierToStride(spinePointerSize), arrayHeaderSize, cg);
@@ -314,7 +311,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         spineMR = MRef_Bdisp32(baseArrayReg, spineDisp32, cg);
     }
 
-    TR::InstOpCode::Mnemonic op = (spinePointerSize == 8) ? TR::InstOpCode::L8RegMem : TR::InstOpCode::L4RegMem;
+    OP::Mnemonic op = (spinePointerSize == 8) ? OP::L8RegMem : OP::L4RegMem;
     Inst_RegMem(op, node, scratchReg, spineMR, cg);
 
     // Decompress the arraylet pointer from the spine.
@@ -323,7 +320,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     if (comp->target().is64Bit() && comp->useCompressedPointers()) {
         shiftOffset = TR::Compiler->om.compressedReferenceShiftOffset();
         if (shiftOffset > 0) {
-            Inst_RegImm(TR::InstOpCode::SHL8RegImm1, node, scratchReg, shiftOffset, cg);
+            Inst_RegImm(OP::SHL8RegImm1, node, scratchReg, shiftOffset, cg);
         }
     }
 
@@ -334,8 +331,8 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     if (indexReg) {
         TR::Register *scratchReg2 = cg->allocateRegister();
 
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, scratchReg2, indexReg, cg);
-        Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, scratchReg2, arrayletMask, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, scratchReg2, indexReg, cg);
+        Inst_RegImm(OP::ANDRegImm4(), node, scratchReg2, arrayletMask, cg);
         arrayletMR = MRef_BIS(scratchReg, scratchReg2, TR::MemoryReference::convertMultiplierToStride(elementSize), cg);
 
         cg->stopUsingRegister(scratchReg2);
@@ -347,7 +344,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     cg->stopUsingRegister(scratchReg);
 
     if (!actualLoadOrStoreOrArrayElementNode->getOpCode().isStore()) {
-        TR::InstOpCode::Mnemonic op;
+        OP::Mnemonic op;
 
         TR::MemoryReference *highArrayletMR = NULL;
         TR::Register *highRegister = NULL;
@@ -358,25 +355,25 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         if ((!actualLoadOrStoreOrArrayElementNode->getOpCode().hasSymbolReference()
                 || !actualLoadOrStoreOrArrayElementNode->getSymbolReference()->getSymbol()->isArrayShadowSymbol())
             && !node->isSpineCheckWithArrayElementChild()) {
-            op = TR::InstOpCode::LEARegMem();
+            op = OP::LEARegMem();
         } else {
             switch (dt) {
                 case TR::Int8:
-                    op = TR::InstOpCode::L1RegMem;
+                    op = OP::L1RegMem;
                     break;
                 case TR::Int16:
-                    op = TR::InstOpCode::L2RegMem;
+                    op = OP::L2RegMem;
                     break;
                 case TR::Int32:
-                    op = TR::InstOpCode::L4RegMem;
+                    op = OP::L4RegMem;
                     break;
                 case TR::Int64:
                     if (comp->target().is64Bit())
-                        op = TR::InstOpCode::L8RegMem;
+                        op = OP::L8RegMem;
                     else {
                         TR_ASSERT(loadOrStoreReg->getRegisterPair(), "expecting a register pair");
 
-                        op = TR::InstOpCode::L4RegMem;
+                        op = OP::L4RegMem;
                         highArrayletMR = MRef_MRefOff(*arrayletMR, 4, cg);
                         highRegister = loadOrStoreReg->getHighOrder();
                         loadOrStoreReg = loadOrStoreReg->getLowOrder();
@@ -384,22 +381,22 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
                     break;
 
                 case TR::Float:
-                    op = TR::InstOpCode::MOVSSRegMem;
+                    op = OP::MOVSSRegMem;
                     break;
                 case TR::Double:
-                    op = TR::InstOpCode::MOVSDRegMem;
+                    op = OP::MOVSDRegMem;
                     break;
 
                 case TR::Address:
                     if (comp->target().is32Bit() || comp->useCompressedPointers())
-                        op = TR::InstOpCode::L4RegMem;
+                        op = OP::L4RegMem;
                     else
-                        op = TR::InstOpCode::L8RegMem;
+                        op = OP::L8RegMem;
                     break;
 
                 default:
                     TR_ASSERT(0, "unsupported array element load type");
-                    op = TR::InstOpCode::bad;
+                    op = OP::bad;
             }
         }
 
@@ -414,7 +411,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         if (loadNeedsDecompression) {
             if (comp->target().is64Bit() && comp->useCompressedPointers()) {
                 if (shiftOffset > 0) {
-                    Inst_RegImm(TR::InstOpCode::SHL8RegImm1, node, loadOrStoreReg, shiftOffset, cg);
+                    Inst_RegImm(OP::SHL8RegImm1, node, loadOrStoreReg, shiftOffset, cg);
                 }
             }
         }
@@ -422,37 +419,37 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         if (dt != TR::Address) {
             // movE [S + S2], value
             //
-            TR::InstOpCode::Mnemonic op;
+            OP::Mnemonic op;
             bool needStore = true;
 
             switch (dt) {
                 case TR::Int8:
-                    op = valueReg ? TR::InstOpCode::S1MemReg : TR::InstOpCode::S1MemImm1;
+                    op = valueReg ? OP::S1MemReg : OP::S1MemImm1;
                     break;
                 case TR::Int16:
-                    op = valueReg ? TR::InstOpCode::S2MemReg : TR::InstOpCode::S2MemImm2;
+                    op = valueReg ? OP::S2MemReg : OP::S2MemImm2;
                     break;
                 case TR::Int32:
-                    op = valueReg ? TR::InstOpCode::S4MemReg : TR::InstOpCode::S4MemImm4;
+                    op = valueReg ? OP::S4MemReg : OP::S4MemImm4;
                     break;
                 case TR::Int64:
                     if (comp->target().is64Bit()) {
                         // The range of the immediate must be verified before this function to
                         // fall within a signed 32-bit integer.
                         //
-                        op = valueReg ? TR::InstOpCode::S8MemReg : TR::InstOpCode::S8MemImm4;
+                        op = valueReg ? OP::S8MemReg : OP::S8MemImm4;
                     } else {
                         if (valueReg) {
                             TR_ASSERT(valueReg->getRegisterPair(), "value must be a register pair");
-                            Inst_MemReg(TR::InstOpCode::S4MemReg, node, arrayletMR, valueReg->getLowOrder(), cg);
-                            Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_MRefOff(*arrayletMR, 4, cg),
-                                valueReg->getHighOrder(), cg);
+                            Inst_MemReg(OP::S4MemReg, node, arrayletMR, valueReg->getLowOrder(), cg);
+                            Inst_MemReg(OP::S4MemReg, node, MRef_MRefOff(*arrayletMR, 4, cg), valueReg->getHighOrder(),
+                                cg);
                         } else {
                             TR::Node *valueChild = actualLoadOrStoreOrArrayElementNode->getSecondChild();
                             TR_ASSERT(valueChild->getOpCode().isLoadConst(), "expecting a long constant child");
 
-                            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arrayletMR, valueChild->getLongIntLow(), cg);
-                            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, MRef_MRefOff(*arrayletMR, 4, cg),
+                            Inst_MemImm(OP::S4MemImm4, node, arrayletMR, valueChild->getLongIntLow(), cg);
+                            Inst_MemImm(OP::S4MemImm4, node, MRef_MRefOff(*arrayletMR, 4, cg),
                                 valueChild->getLongIntHigh(), cg);
                         }
 
@@ -461,15 +458,15 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
                     break;
 
                 case TR::Float:
-                    op = TR::InstOpCode::MOVSSMemReg;
+                    op = OP::MOVSSMemReg;
                     break;
                 case TR::Double:
-                    op = TR::InstOpCode::MOVSDMemReg;
+                    op = OP::MOVSDMemReg;
                     break;
 
                 default:
                     TR_ASSERT(0, "unsupported array element store type");
-                    op = TR::InstOpCode::bad;
+                    op = OP::bad;
             }
 
             if (needStore) {
@@ -486,7 +483,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         }
     }
 
-    Inst_Label(TR::InstOpCode::JMP4, node, restartLabel, cg);
+    Inst_Label(OP::JMP4, node, restartLabel, cg);
 
     // -----------------------------------------------------------------------------------
     // Stop tracking virtual register usage.
@@ -534,16 +531,16 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         // Attempt to convert a double in an XMM register to an integer using CVTTSD2SI.
         // If the conversion succeeds, put the integer in lowReg and sign-extend it to highReg.
         // If the conversion fails (the double is too large), call the helper.
-        Inst_RegReg(TR::InstOpCode::CVTTSD2SIReg4Reg, node, lowReg, doubleReg, cg);
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, lowReg, 0x80000000, cg);
+        Inst_RegReg(OP::CVTTSD2SIReg4Reg, node, lowReg, doubleReg, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, lowReg, 0x80000000, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, StartLabel, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, CallLabel, cg);
+        Inst_Label(OP::label, node, StartLabel, cg);
+        Inst_Label(OP::JE4, node, CallLabel, cg);
 
-        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highReg, lowReg, cg);
-        Inst_RegImm(TR::InstOpCode::SAR4RegImm1, node, highReg, 31, cg);
+        Inst_RegReg(OP::MOV4RegReg, node, highReg, lowReg, cg);
+        Inst_RegImm(OP::SAR4RegImm1, node, highReg, 31, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, reStartLabel, deps, cg);
+        Inst_Label(OP::label, node, reStartLabel, deps, cg);
 
         TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
         TR::SymbolReference *d2l = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_IA32double2LongSSE);
@@ -571,7 +568,7 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         startLabel->setStartInternalControlFlow();
         reStartLabel->setEndInternalControlFlow();
 
-        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(OP::label, node, startLabel, cg);
 
         // These instructions must be set appropriately prior to the creation
         // of the snippet near the end of this method. Also see warnings below.
@@ -580,27 +577,27 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         TR::X86RegMemInstruction *loadLowInstr; // loads the low dword of the converted long
 
         TR::MemoryReference *tempMR = cg->machine()->getDummyLocalMR(TR::Float);
-        Inst_MemReg(TR::InstOpCode::MOVSSMemReg, node, tempMR, floatReg, cg);
-        Inst_Mem(TR::InstOpCode::FLDMem, node, MRef_MRefOff(*tempMR, 0, cg), cg);
+        Inst_MemReg(OP::MOVSSMemReg, node, tempMR, floatReg, cg);
+        Inst_Mem(OP::FLDMem, node, MRef_MRefOff(*tempMR, 0, cg), cg);
 
-        Inst(TR::InstOpCode::FLDDUP, node, cg);
+        Inst(OP::FLDDUP, node, cg);
 
         // For slow conversion only, change the rounding mode on the FPU via its control word register.
         //
         TR::MemoryReference *convertedLongMR = (cg->machine())->getDummyLocalMR(TR::Int64);
 
         if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE3)) {
-            Inst_Mem(TR::InstOpCode::FLSTTPMem, node, convertedLongMR, cg);
+            Inst_Mem(OP::FLSTTPMem, node, convertedLongMR, cg);
         } else {
             int16_t fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ? SINGLE_PRECISION_ROUND_TO_ZERO
                                                                                     : DOUBLE_PRECISION_ROUND_TO_ZERO;
-            Inst_Mem(TR::InstOpCode::LDCWMem, node, MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
-            Inst_Mem(TR::InstOpCode::FLSTPMem, node, convertedLongMR, cg);
+            Inst_Mem(OP::LDCWMem, node, MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
+            Inst_Mem(OP::FLSTPMem, node, convertedLongMR, cg);
 
             fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ? SINGLE_PRECISION_ROUND_TO_NEAREST
                                                                             : DOUBLE_PRECISION_ROUND_TO_NEAREST;
 
-            Inst_Mem(TR::InstOpCode::LDCWMem, node, MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
+            Inst_Mem(OP::LDCWMem, node, MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
         }
 
         // WARNING:
@@ -608,16 +605,16 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         // The following load instructions are dissected in the snippet to determine the target registers.
         // If they or their format is changed, you may need to change the snippet also.
         //
-        loadHighInstr = Inst_RegMem(TR::InstOpCode::L4RegMem, node, highReg, MRef_MRefOff(*convertedLongMR, 4, cg), cg);
+        loadHighInstr = Inst_RegMem(OP::L4RegMem, node, highReg, MRef_MRefOff(*convertedLongMR, 4, cg), cg);
 
-        loadLowInstr = Inst_RegMem(TR::InstOpCode::L4RegMem, node, lowReg, MRef_MRefOff(*convertedLongMR, 0, cg), cg);
+        loadLowInstr = Inst_RegMem(OP::L4RegMem, node, lowReg, MRef_MRefOff(*convertedLongMR, 0, cg), cg);
 
         // Jump to the snippet if the converted value is an indefinite integer; otherwise continue.
         //
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, highReg, INT_MIN, cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, reStartLabel, cg);
-        Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, lowReg, lowReg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, highReg, INT_MIN, cg);
+        Inst_Label(OP::JNE4, node, reStartLabel, cg);
+        Inst_RegReg(OP::TEST4RegReg, node, lowReg, lowReg, cg);
+        Inst_Label(OP::JE4, node, snippetLabel, cg);
 
         // Create the conversion snippet.
         //
@@ -635,10 +632,10 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         deps->addPostCondition(lowReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(highReg, TR::RealRegister::NoReg, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, reStartLabel, deps, cg);
+        Inst_Label(OP::label, node, reStartLabel, deps, cg);
 
         cg->decReferenceCount(child);
-        Inst(TR::InstOpCode::FSTPST0, node, cg);
+        Inst(OP::FSTPST0, node, cg);
 
         TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
         node->setRegister(targetRegister);
@@ -652,26 +649,26 @@ TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGener
 {
     bool doubleSource;
     bool longTarget;
-    TR::InstOpCode::Mnemonic cvttOpCode;
+    OP::Mnemonic cvttOpCode;
 
     switch (node->getOpCodeValue()) {
         case TR::f2i:
-            cvttOpCode = TR::InstOpCode::CVTTSS2SIReg4Reg;
+            cvttOpCode = OP::CVTTSS2SIReg4Reg;
             doubleSource = false;
             longTarget = false;
             break;
         case TR::f2l:
-            cvttOpCode = TR::InstOpCode::CVTTSS2SIReg8Reg;
+            cvttOpCode = OP::CVTTSS2SIReg8Reg;
             doubleSource = false;
             longTarget = true;
             break;
         case TR::d2i:
-            cvttOpCode = TR::InstOpCode::CVTTSD2SIReg4Reg;
+            cvttOpCode = OP::CVTTSD2SIReg4Reg;
             doubleSource = true;
             longTarget = false;
             break;
         case TR::d2l:
-            cvttOpCode = TR::InstOpCode::CVTTSD2SIReg8Reg;
+            cvttOpCode = OP::CVTTSD2SIReg8Reg;
             doubleSource = true;
             longTarget = true;
             break;
@@ -694,18 +691,18 @@ TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGener
     startLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     if (longTarget) {
         TR_ASSERT_FATAL(cg->comp()->target().is64Bit(), "We should only get here on AMD64");
         // We can't compare with 0x8000000000000000.
         // Instead, rotate left 1 bit and compare with 0x0000000000000001.
-        Inst_Reg(TR::InstOpCode::ROL8Reg1, node, targetRegister, cg);
-        Inst_RegImm(TR::InstOpCode::CMP8RegImms, node, targetRegister, 1, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, exceptionLabel, cg);
+        Inst_Reg(OP::ROL8Reg1, node, targetRegister, cg);
+        Inst_RegImm(OP::CMP8RegImms, node, targetRegister, 1, cg);
+        Inst_Label(OP::JE4, node, exceptionLabel, cg);
     } else {
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, targetRegister, INT_MIN, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, exceptionLabel, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, targetRegister, INT_MIN, cg);
+        Inst_Label(OP::JE4, node, exceptionLabel, cg);
     }
 
     // TODO: (omr issue #4969): Remove once support for spills in OOL paths is added
@@ -717,30 +714,30 @@ TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGener
         TR_OutlinedInstructionsGenerator og(exceptionLabel, node, cg);
         // at this point, target is set to -INF and there can only be THREE possible results: -INF, +INF, NaN
         // compare source with ZERO
-        Inst_RegMem(doubleSource ? TR::InstOpCode::UCOMISDRegMem : TR::InstOpCode::UCOMISSRegMem, node, sourceRegister,
+        Inst_RegMem(doubleSource ? OP::UCOMISDRegMem : OP::UCOMISSRegMem, node, sourceRegister,
             MRef_const(doubleSource ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0),
                 cg),
             cg);
         // load max int if source is positive, note that for long case, LLONG_MAX << 1 is loaded as it will be shifted
         // right
-        Inst_RegMem(TR::InstOpCode::CMOVARegMem(longTarget), node, targetRegister,
+        Inst_RegMem(OP::CMOVARegMem(longTarget), node, targetRegister,
             MRef_const(longTarget ? cg->findOrCreate8ByteConstant(node, LLONG_MAX << 1)
                                   : cg->findOrCreate4ByteConstant(node, INT_MAX),
                 cg),
             cg);
         // load zero if source is NaN
-        Inst_RegMem(TR::InstOpCode::CMOVPRegMem(longTarget), node, targetRegister,
+        Inst_RegMem(OP::CMOVPRegMem(longTarget), node, targetRegister,
             MRef_const(longTarget ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0),
                 cg),
             cg);
 
-        Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+        Inst_Label(OP::JMP4, node, endLabel, cg);
         og.endOutlinedInstructionSequence();
     }
 
-    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(OP::label, node, endLabel, deps, cg);
     if (longTarget) {
-        Inst_Reg(TR::InstOpCode::ROR8Reg1, node, targetRegister, cg);
+        Inst_Reg(OP::ROR8Reg1, node, targetRegister, cg);
     }
 
     node->setRegister(targetRegister);
@@ -844,55 +841,52 @@ static void generateCommonLockNurseryCodes(TR::Node *node, TR::CodeGenerator *cg
     if (comp->getOption(TR_EnableMonitorCacheLookup)) {
         if (monent)
             lwOffset = 0;
-        Inst_Label(TR::InstOpCode::JLE4, node, monitorLookupCacheLabel, cg);
-        Inst_Label(TR::InstOpCode::JMP4, node, fallThruFromMonitorLookupCacheLabel, cg);
+        Inst_Label(OP::JLE4, node, monitorLookupCacheLabel, cg);
+        Inst_Label(OP::JMP4, node, fallThruFromMonitorLookupCacheLabel, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, monitorLookupCacheLabel, cg);
+        Inst_Label(OP::label, node, monitorLookupCacheLabel, cg);
 
         lookupOffsetReg = cg->allocateRegister();
         numDeps++;
 
         int32_t offsetOfMonitorLookupCache = offsetof(J9VMThread, objectMonitorLookupCache);
 
-        // Inst_RegMem(TR::InstOpCode::LRegMem(), node, objectClassReg,
+        // Inst_RegMem(OP::LRegMem(), node, objectClassReg,
         // MRef_Bdisp32(vmThreadReg, offsetOfMonitorLookupCache, cg), cg);
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, lookupOffsetReg, objectReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, lookupOffsetReg, objectReg, cg);
 
-        Inst_RegImm(TR::InstOpCode::SARRegImm1(comp->target().is64Bit()), node, lookupOffsetReg,
+        Inst_RegImm(OP::SARRegImm1(comp->target().is64Bit()), node, lookupOffsetReg,
             trailingZeroes(TR::Compiler->om.getObjectAlignmentInBytes()), cg);
 
         J9JavaVM *jvm = fej9->getJ9JITConfig()->javaVM;
-        Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, lookupOffsetReg, J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE - 1, cg);
-        Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, lookupOffsetReg,
-            trailingZeroes(TR::Compiler->om.sizeofReferenceField()), cg);
-        Inst_RegMem((comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? TR::InstOpCode::L4RegMem
-                                                                                     : TR::InstOpCode::LRegMem(),
+        Inst_RegImm(OP::ANDRegImms(), node, lookupOffsetReg, J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE - 1, cg);
+        Inst_RegImm(OP::SHLRegImm1(), node, lookupOffsetReg, trailingZeroes(TR::Compiler->om.sizeofReferenceField()),
+            cg);
+        Inst_RegMem((comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? OP::L4RegMem : OP::LRegMem(),
             node, objectClassReg, MRef_BISdisp32(vmThreadReg, lookupOffsetReg, 0, offsetOfMonitorLookupCache, cg), cg);
 
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, objectClassReg, objectClassReg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+        Inst_RegReg(OP::TESTRegReg(), node, objectClassReg, objectClassReg, cg);
+        Inst_Label(OP::JE4, node, snippetLabel, cg);
 
         int32_t offsetOfMonitor = offsetof(J9ObjectMonitor, monitor);
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, lookupOffsetReg, MRef_Bdisp32(objectClassReg, offsetOfMonitor, cg),
-            cg);
+        Inst_RegMem(OP::LRegMem(), node, lookupOffsetReg, MRef_Bdisp32(objectClassReg, offsetOfMonitor, cg), cg);
 
         int32_t offsetOfUserData = offsetof(J9ThreadAbstractMonitor, userData);
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
-            MRef_Bdisp32(lookupOffsetReg, offsetOfUserData, cg), cg);
+        Inst_RegMem(OP::LRegMem(), node, lookupOffsetReg, MRef_Bdisp32(lookupOffsetReg, offsetOfUserData, cg), cg);
 
-        Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, lookupOffsetReg, objectReg, cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_RegReg(OP::CMPRegReg(), node, lookupOffsetReg, objectReg, cg);
+        Inst_Label(OP::JNE4, node, snippetLabel, cg);
 
         int32_t offsetOfAlternateLockWord = offsetof(J9ObjectMonitor, alternateLockword);
-        // Inst_RegMem(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
+        // Inst_RegMem(OP::LRegMem(), node, lookupOffsetReg,
         // MRef_Bdisp32(objectClassReg, offsetOfAlternateLockWord, cg), cg);
-        Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, objectClassReg, offsetOfAlternateLockWord, cg);
-        // Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, objectClassReg, lookupOffsetReg, cg);
-        Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, objectClassReg, objectReg, cg);
+        Inst_RegImm(OP::ADDRegImms(), node, objectClassReg, offsetOfAlternateLockWord, cg);
+        // Inst_RegReg(OP::ADDRegReg(), node, objectClassReg, lookupOffsetReg, cg);
+        Inst_RegReg(OP::SUBRegReg(), node, objectClassReg, objectReg, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, fallThruFromMonitorLookupCacheLabel, cg);
+        Inst_Label(OP::label, node, fallThruFromMonitorLookupCacheLabel, cg);
     } else
-        Inst_Label(TR::InstOpCode::JLE4, node, snippetLabel, cg);
+        Inst_Label(OP::JLE4, node, snippetLabel, cg);
 }
 
 #ifdef TR_TARGET_32BIT
@@ -917,19 +911,18 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
     if (secondChild->getOpCode().isLoadConst() && secondChild->getRegister() == NULL) {
         int32_t value = secondChild->getInt();
         TR::Node *firstChild = testNode->getFirstChild();
-        TR::InstOpCode::Mnemonic opCode;
+        OP::Mnemonic opCode;
         if (value >= -128 && value <= 127)
-            opCode = TR::InstOpCode::CMP4MemImms;
+            opCode = OP::CMP4MemImms;
         else
-            opCode = TR::InstOpCode::CMP4MemImm4;
+            opCode = OP::CMP4MemImm4;
         TR::MemoryReference *memRef = MRef_node(firstChild, cg);
         Inst_MemImm(opCode, node, memRef, value, cg);
         memRef->decNodeReferenceCounts(cg);
         cg->decReferenceCount(secondChild);
     } else {
         TR_X86CompareAnalyser temp(cg);
-        temp.integerCompareAnalyser(testNode, TR::InstOpCode::CMP4RegReg, TR::InstOpCode::CMP4RegMem,
-            TR::InstOpCode::CMP4MemReg);
+        temp.integerCompareAnalyser(testNode, OP::CMP4RegReg, OP::CMP4RegMem, OP::CMP4MemReg);
     }
 
     TR::LabelSymbol *startLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
@@ -937,9 +930,8 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
     TR::LabelSymbol *snippetLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
     startLabel->setStartInternalControlFlow();
     reStartLabel->setEndInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
-    Inst_Label(testNode->getOpCodeValue() == TR::icmpeq ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node,
-        snippetLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
+    Inst_Label(testNode->getOpCodeValue() == TR::icmpeq ? OP::JE4 : OP::JNE4, node, snippetLabel, cg);
 
     TR::Snippet *snippet;
     if (node->getNumChildren() == 2)
@@ -951,7 +943,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
 
     cg->addSnippet(snippet);
 
-    Inst_Label(TR::InstOpCode::label, node, reStartLabel, cg);
+    Inst_Label(OP::label, node, reStartLabel, cg);
     cg->decReferenceCount(testNode);
     return NULL;
 }
@@ -1031,15 +1023,15 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         // Try to compare memory directly with immediate
         //
         TR::MemoryReference *memRef = MRef_node(testNode->getFirstChild(), cg);
-        TR::InstOpCode::Mnemonic op;
+        OP::Mnemonic op;
 
         if (testIs64Bit) {
             int64_t value = secondChild->getLongInt();
-            op = IS_8BIT_SIGNED(value) ? TR::InstOpCode::CMP8MemImms : TR::InstOpCode::CMP8MemImm4;
+            op = IS_8BIT_SIGNED(value) ? OP::CMP8MemImms : OP::CMP8MemImm4;
             Inst_MemImm(op, node, memRef, value, cg);
         } else {
             int32_t value = secondChild->getInt();
-            op = IS_8BIT_SIGNED(value) ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4;
+            op = IS_8BIT_SIGNED(value) ? OP::CMP4MemImms : OP::CMP4MemImm4;
             Inst_MemImm(op, node, memRef, value, cg);
         }
 
@@ -1047,8 +1039,8 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         cg->decReferenceCount(secondChild);
     } else {
         TR_X86CompareAnalyser temp(cg);
-        temp.integerCompareAnalyser(testNode, TR::InstOpCode::CMPRegReg(testIs64Bit),
-            TR::InstOpCode::CMPRegMem(testIs64Bit), TR::InstOpCode::CMPMemReg(testIs64Bit));
+        temp.integerCompareAnalyser(testNode, OP::CMPRegReg(testIs64Bit), OP::CMPRegMem(testIs64Bit),
+            OP::CMPMemReg(testIs64Bit));
     }
 
     TR::LabelSymbol *startLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
@@ -1057,7 +1049,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
     startLabel->setStartInternalControlFlow();
     reStartLabel->setEndInternalControlFlow();
 
-    TR::Instruction *startInstruction = Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    TR::Instruction *startInstruction = Inst_Label(OP::label, node, startLabel, cg);
 
     if (node->getOpCodeValue() == TR::MethodEnterHook || node->getOpCodeValue() == TR::MethodExitHook) {
         TR::Node *callNode = node->getSecondChild();
@@ -1065,7 +1057,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         // Generate an inverted jump around the call.  This is necessary because we want to do the call inline rather
         // than through the snippet.
         //
-        Inst_Label(testIsEQ ? TR::InstOpCode::JNE4 : TR::InstOpCode::JE4, node, reStartLabel, cg);
+        Inst_Label(testIsEQ ? OP::JNE4 : OP::JE4, node, reStartLabel, cg);
         TR::TreeEvaluator::performCall(callNode, false, false, cg);
 
         // Collect postconditions from the internal control flow region and put
@@ -1085,7 +1077,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         for (TR::Instruction *cursor = cg->getAppendInstruction(); cursor != startInstruction;
              cursor = cursor->getPrev()) {
             TR::RegisterDependencyConditions *cursorDeps = cursor->getDependencyConditions();
-            if (cursorDeps && cursor->getOpCodeValue() != TR::InstOpCode::assocreg) {
+            if (cursorDeps && cursor->getOpCodeValue() != OP::assocreg) {
                 for (int32_t i = 0; i < cursorDeps->getNumPostConditions(); i++) {
                     TR::RegisterDependency *cursorPostCondition
                         = cursorDeps->getPostConditions()->getRegisterDependency(i);
@@ -1096,9 +1088,9 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         }
         postConditions->stopAddingPostConditions();
 
-        Inst_Label(TR::InstOpCode::label, node, reStartLabel, postConditions, cg);
+        Inst_Label(OP::label, node, reStartLabel, postConditions, cg);
     } else {
-        Inst_Label(testIsEQ ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_Label(testIsEQ ? OP::JE4 : OP::JNE4, node, snippetLabel, cg);
 
         TR::Snippet *snippet;
         if (node->getNumChildren() == 2)
@@ -1109,7 +1101,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
                 TR::X86HelperCallSnippet(cg, node, reStartLabel, snippetLabel, node->getSymbolReference());
 
         cg->addSnippet(snippet);
-        Inst_Label(TR::InstOpCode::label, node, reStartLabel, cg);
+        Inst_Label(OP::label, node, reStartLabel, cg);
     }
 
     cg->decReferenceCount(testNode);
@@ -1133,8 +1125,7 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
     sourceMR->decNodeReferenceCounts(cg);
 
     TR::Register *object = cg->allocateRegister();
-    TR::Instruction *load
-        = Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
+    TR::Instruction *load = Inst_RegMem(OP::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
     cg->setImplicitExceptionPoint(load);
 
     switch (TR::Compiler->om.readBarrierType()) {
@@ -1142,10 +1133,10 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
             TR_ASSERT(false, "This path should only be reached when a read barrier is required.");
             break;
         case gc_modron_readbar_always:
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(OP::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
             Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
+            Inst_RegMem(OP::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
             break;
         case gc_modron_readbar_range_check: {
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg);
@@ -1160,25 +1151,25 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
             deps->addPostCondition(object, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(address, TR::RealRegister::NoReg, cg);
 
-            Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
-            Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
+            Inst_Label(OP::label, node, begLabel, cg);
+            Inst_RegMem(OP::CMPRegMem(use64BitClasses), node, object,
                 MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
                 cg);
-            Inst_Label(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
+            Inst_Label(OP::JAE4, node, rdbarLabel, cg);
             {
                 TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
-                Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
+                Inst_RegMem(OP::CMPRegMem(use64BitClasses), node, object,
                     MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
                     cg);
-                Inst_Label(TR::InstOpCode::JA4, node, endLabel, cg);
-                Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+                Inst_Label(OP::JA4, node, endLabel, cg);
+                Inst_MemReg(OP::SMemReg(), node,
                     MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
                 Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
-                Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
-                Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+                Inst_RegMem(OP::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
+                Inst_Label(OP::JMP4, node, endLabel, cg);
                 og.endOutlinedInstructionSequence();
             }
-            Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+            Inst_Label(OP::label, node, endLabel, deps, cg);
         } break;
         default:
             TR_ASSERT(false, "Unsupported Read Barrier Type.");
@@ -1274,11 +1265,10 @@ TR::Register *J9::X86::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::Co
             || (comp->target().is64Bit() && !IS_32BIT_SIGNED(secondChild->getLongInt()))) {
             TR::Register *valueReg = cg->evaluate(secondChild);
             TR::X86CheckAsyncMessagesMemRegInstruction *ins
-                = Inst_CheckAsyncMessages(node, TR::InstOpCode::CMPMemReg(), mr, valueReg, cg);
+                = Inst_CheckAsyncMessages(node, OP::CMPMemReg(), mr, valueReg, cg);
         } else {
             int32_t value = secondChild->getInt();
-            TR::InstOpCode::Mnemonic op
-                = (value < 127 && value >= -128) ? TR::InstOpCode::CMPMemImms() : TR::InstOpCode::CMPMemImm4();
+            OP::Mnemonic op = (value < 127 && value >= -128) ? OP::CMPMemImms() : OP::CMPMemImm4();
             TR::X86CheckAsyncMessagesMemImmInstruction *ins = Inst_CheckAsyncMessages(node, op, mr, value, cg);
         }
 
@@ -1294,21 +1284,21 @@ TR::Register *J9::X86::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::Co
     TR_ASSERT(testIsEqual, "unrecognized asynccheck test: test is not equal");
 
     startControlFlowLabel->setStartInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startControlFlowLabel, cg);
+    Inst_Label(OP::label, node, startControlFlowLabel, cg);
 
-    Inst_Label(testIsEqual ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node, snippetLabel, cg);
+    Inst_Label(testIsEqual ? OP::JE4 : OP::JNE4, node, snippetLabel, cg);
 
     {
         TR_OutlinedInstructionsGenerator og(snippetLabel, node, cg);
-        Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)node->getSymbolReference()->getMethodAddress(),
+        Inst_ImmSym(OP::CALLImm4, node, (uintptr_t)node->getSymbolReference()->getMethodAddress(),
             node->getSymbolReference(), cg)
             ->setNeedsGCMap(0xFF00FFFF);
-        Inst_Label(TR::InstOpCode::JMP4, node, endControlFlowLabel, cg);
+        Inst_Label(OP::JMP4, node, endControlFlowLabel, cg);
         og.endOutlinedInstructionSequence();
     }
 
     endControlFlowLabel->setEndInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, endControlFlowLabel, cg);
+    Inst_Label(OP::label, node, endControlFlowLabel, cg);
 
     cg->decReferenceCount(compareNode);
 
@@ -1524,129 +1514,124 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     // Calculate spine array size
 
     TR::Register *spineSizeReg = cg->allocateRegister();
-    Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, spineSizeReg, contiguousArrayHeaderSize, cg);
+    Inst_RegImm(OP::MOV8RegImm4, node, spineSizeReg, contiguousArrayHeaderSize, cg);
 
     int32_t zeroArraySizeAligned = OMR::align(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(), alignmentInBytes);
     TR::Register *tempReg = cg->allocateRegister();
-    Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, tempReg, zeroArraySizeAligned, cg);
+    Inst_RegImm(OP::MOV8RegImm4, node, tempReg, zeroArraySizeAligned, cg);
 
     TR::Register *firstDimReg = cg->allocateRegister();
-    Inst_RegMem(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
+    Inst_RegMem(OP::MOVSXReg8Mem4, node, firstDimReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
 
     // if first dim = 0 load the zero array size and skip over calculating the leaf block size
-    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
-    Inst_RegReg(TR::InstOpCode::CMOVE8RegReg, node, spineSizeReg, tempReg, cg);
+    Inst_RegReg(OP::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
+    Inst_RegReg(OP::CMOVE8RegReg, node, spineSizeReg, tempReg, cg);
     TR::LabelSymbol *startControlFlow = generateLabelSymbol(cg);
     startControlFlow->setStartInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startControlFlow, cg);
+    Inst_Label(OP::label, node, startControlFlow, cg);
     TR::LabelSymbol *allocateLabel = generateLabelSymbol(cg);
-    Inst_Label(TR::InstOpCode::JE4, node, allocateLabel, cg);
+    Inst_Label(OP::JE4, node, allocateLabel, cg);
 
     // if first dim < 0 go to OOL helper
-    Inst_Label(TR::InstOpCode::JL4, node, helperLabel, cg);
+    Inst_Label(OP::JL4, node, helperLabel, cg);
 
     // spine size += first dim * reference size
-    Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, spineSizeReg,
+    Inst_RegMem(OP::LEA8RegMem, node, spineSizeReg,
         MRef_BISdisp32(spineSizeReg, firstDimReg, trailingZeroes((int32_t)referenceSize), 0, cg), cg);
 
     // pad spine size so leaf arrays will be aligned
     if (needsAlignSpine) {
-        Inst_RegImm(TR::InstOpCode::ADD8RegImm4, node, spineSizeReg, alignmentInBytes - 1, cg);
-        Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, spineSizeReg, -alignmentInBytes, cg);
+        Inst_RegImm(OP::ADD8RegImm4, node, spineSizeReg, alignmentInBytes - 1, cg);
+        Inst_RegImm(OP::AND8RegImm4, node, spineSizeReg, -alignmentInBytes, cg);
     }
 
     // Calculate leaf array block size
 
     TR::Register *leafSizeReg = cg->allocateRegister();
-    Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, leafSizeReg, contiguousArrayHeaderSize, cg);
+    Inst_RegImm(OP::MOV8RegImm4, node, leafSizeReg, contiguousArrayHeaderSize, cg);
 
     // if second dim = 0 load the zero array size and skip over calculating the leaf size
     TR::Register *secondDimReg = cg->allocateRegister();
-    Inst_RegMem(TR::InstOpCode::MOVSXReg8Mem4, node, secondDimReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
+    Inst_RegMem(OP::MOVSXReg8Mem4, node, secondDimReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
 
-    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
-    Inst_RegReg(TR::InstOpCode::CMOVE8RegReg, node, leafSizeReg, tempReg, cg);
+    Inst_RegReg(OP::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
+    Inst_RegReg(OP::CMOVE8RegReg, node, leafSizeReg, tempReg, cg);
     TR::LabelSymbol *calculateLeafBlockSize = generateLabelSymbol(cg);
-    Inst_Label(TR::InstOpCode::JE4, node, calculateLeafBlockSize, cg);
+    Inst_Label(OP::JE4, node, calculateLeafBlockSize, cg);
 
     // if second dim < 0 go to OOL helper
-    Inst_Label(TR::InstOpCode::JL4, node, helperLabel, cg);
+    Inst_Label(OP::JL4, node, helperLabel, cg);
 
     // leaf size = header size + second dim * leaf element size
-    Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, leafSizeReg,
+    Inst_RegMem(OP::LEA8RegMem, node, leafSizeReg,
         MRef_BISdisp32(leafSizeReg, secondDimReg, trailingZeroes(leafArrayElementSize), 0, cg), cg);
 
     // pad leafSize for alignment
     if (needsAlignLeaf) {
-        Inst_RegImm(TR::InstOpCode::ADD8RegImm4, node, leafSizeReg, alignmentInBytes - 1, cg);
-        Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, leafSizeReg, -alignmentInBytes, cg);
+        Inst_RegImm(OP::ADD8RegImm4, node, leafSizeReg, alignmentInBytes - 1, cg);
+        Inst_RegImm(OP::AND8RegImm4, node, leafSizeReg, -alignmentInBytes, cg);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, calculateLeafBlockSize, cg);
+    Inst_Label(OP::label, node, calculateLeafBlockSize, cg);
 
-    Inst_RegReg(TR::InstOpCode::MOV8RegReg, node, tempReg, firstDimReg, cg);
-    Inst_RegReg(TR::InstOpCode::IMUL8RegReg, node, tempReg, leafSizeReg, cg);
+    Inst_RegReg(OP::MOV8RegReg, node, tempReg, firstDimReg, cg);
+    Inst_RegReg(OP::IMUL8RegReg, node, tempReg, leafSizeReg, cg);
 
     // spineSize += leafBlockSize
-    Inst_RegReg(TR::InstOpCode::ADD8RegReg, node, spineSizeReg, tempReg, cg);
+    Inst_RegReg(OP::ADD8RegReg, node, spineSizeReg, tempReg, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, allocateLabel, cg);
+    Inst_Label(OP::label, node, allocateLabel, cg);
 
     // spinePtrReg = vmThread->heapAlloc
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
-    Inst_RegMem(TR::InstOpCode::L8RegMem, node, spinePtrReg,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+    Inst_RegMem(OP::L8RegMem, node, spinePtrReg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
     // allocEnd = spinePtr + spineSize + leafBlockSize
     TR::Register *leafPtrReg = cg->allocateRegister();
-    Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, leafPtrReg, MRef_BISdisp32(spinePtrReg, spineSizeReg, 0, 0, cg), cg);
+    Inst_RegMem(OP::LEA8RegMem, node, leafPtrReg, MRef_BISdisp32(spinePtrReg, spineSizeReg, 0, 0, cg), cg);
 
     // if allocEnd > vmThread->heapTop go to helper
-    Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, leafPtrReg,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
-    Inst_Label(TR::InstOpCode::JA4, node, helperLabel, cg);
+    Inst_RegMem(OP::CMP8RegMem, node, leafPtrReg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+    Inst_Label(OP::JA4, node, helperLabel, cg);
 
     // bump vmThread->heapAlloc to allocate the memory needed
-    Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
-        leafPtrReg, cg);
+    Inst_MemReg(OP::S8MemReg, node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), leafPtrReg, cg);
 
     // load class into spine header
-    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node, MRef_Bdisp32(spinePtrReg, classOffset, cg), classReg,
-        cg);
+    Inst_MemReg(OP::SMemReg(use64BitClasses), node, MRef_Bdisp32(spinePtrReg, classOffset, cg), classReg, cg);
 
     // if first dim = 0 goto initialise zero length spine
     TR::LabelSymbol *initZeroLengthLabel = generateLabelSymbol(cg);
-    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, initZeroLengthLabel, cg);
+    Inst_RegReg(OP::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
+    Inst_Label(OP::JE4, node, initZeroLengthLabel, cg);
 
     // initialise zero length array
     TR_OutlinedInstructionsGenerator zeroLengthOOL(initZeroLengthLabel, node, cg);
 
     // init size and mustBeZero ('0') fields to 0
-    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
-        MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
-    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
-        MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
+    Inst_MemImm(OP::S4MemImm4, node, MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
+    Inst_MemImm(OP::S4MemImm4, node, MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0,
+        cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Init 1st dim dataAddr slot to 0
-        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
-            MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
+        Inst_MemImm(OP::S8MemImm4, node, MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg),
+            0, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
-    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(OP::JMP4, node, doneLabel, cg);
     zeroLengthOOL.endOutlinedInstructionSequence();
 
     // otherwise load first dim into spine header
-    Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(spinePtrReg, sizeOffset, cg), firstDimReg, cg);
+    Inst_MemReg(OP::S4MemReg, node, MRef_Bdisp32(spinePtrReg, sizeOffset, cg), firstDimReg, cg);
 
     // zero out the leaf portion of the allocation if necessary
     bool clearAllocation = !fej9->tlhHasBeenCleared();
     if (clearAllocation) {
         // adjust leafPtr to the beginning of the leaf array block
-        Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, tempReg, cg);
+        Inst_RegReg(OP::SUB8RegReg, node, leafPtrReg, tempReg, cg);
 
         // clear leafBlockSize bytes starting at leafPtr
         // leafBlockSize = m * (contiguousArrayHeaderSize + n * leafArrayElementSize + padding)
@@ -1657,23 +1642,21 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
             | static_cast<int32_t>(
                 needsAlignHeader ? alignmentInBytes : (contiguousArrayHeaderSize | leafArrayElementSize)));
 
-        static const TR::InstOpCode::Mnemonic xorOpCode[] = { TR::InstOpCode::XOR1RegReg, TR::InstOpCode::XOR2RegReg,
-            TR::InstOpCode::XOR4RegReg, TR::InstOpCode::XOR8RegReg };
+        static const OP::Mnemonic xorOpCode[] = { OP::XOR1RegReg, OP::XOR2RegReg, OP::XOR4RegReg, OP::XOR8RegReg };
 
         Inst_RegReg(xorOpCode[sizeShift], node, spineSizeReg, spineSizeReg, cg);
 
         if (sizeShift != 0)
-            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tempReg, sizeShift, cg);
+            Inst_RegImm(OP::SHRRegImm1(), node, tempReg, sizeShift, cg);
 
-        static const TR::InstOpCode::Mnemonic repstosOpCode[] = { TR::InstOpCode::REPSTOSB, TR::InstOpCode::REPSTOSW,
-            TR::InstOpCode::REPSTOSD, TR::InstOpCode::REPSTOSQ };
+        static const OP::Mnemonic repstosOpCode[] = { OP::REPSTOSB, OP::REPSTOSW, OP::REPSTOSD, OP::REPSTOSQ };
 
         Inst(repstosOpCode[sizeShift], node, cg);
         // leafPtrReg is pointing to the end of the allocation again
     }
 
     // load element class
-    Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
+    Inst_RegMem(OP::LRegMem(use64BitClasses), node, tempReg,
         MRef_Bdisp32(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
@@ -1681,15 +1664,15 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         /* Populate dataAddr slot of spine array. Arrays of non-zero size
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
+        Inst_RegMem(OP::LEARegMem(), node, spineSizeReg,
             MRef_Bdisp32(spinePtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg),
+            spineSizeReg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // adjust leafPtr to prepare for loop
-    Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
+    Inst_RegReg(OP::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     // for zero-length offheap arrays, the work to initialize zero length arrays is sufficiently different that a
@@ -1697,17 +1680,16 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     if (isOffHeapAllocationEnabled) {
         // if second dimension = 0, use OOL loop for initializing zero length arrays
         TR::LabelSymbol *initZeroLengthLoopLabel = generateLabelSymbol(cg);
-        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, initZeroLengthLoopLabel, cg);
+        Inst_RegReg(OP::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
+        Inst_Label(OP::JE4, node, initZeroLengthLoopLabel, cg);
 
         // initialise zero length arrays
         TR_OutlinedInstructionsGenerator zeroLengthLoopOOL(initZeroLengthLoopLabel, node, cg);
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+        Inst_Label(OP::label, node, loopLabel, cg);
 
         // initialise leaf array class
-        Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node, MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg,
-            cg);
+        Inst_MemReg(OP::SMemReg(use64BitClasses), node, MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg, cg);
         // length, mustBeZero, and dataAddr fields are already set to zero since the allocation is zeroed
 
         // insert leaf array reference into spine array
@@ -1717,21 +1699,21 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
             trailingZeroes((int32_t)referenceSize), contiguousArrayHeaderSize - referenceSize, cg);
         if (comp->useCompressedPointers()) {
             int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
-            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
+            Inst_RegReg(OP::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
             if (shiftAmount != 0) {
-                Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
+                Inst_RegImm(OP::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
             }
-            Inst_MemReg(TR::InstOpCode::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
+            Inst_MemReg(OP::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
         } else {
-            Inst_MemReg(TR::InstOpCode::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
+            Inst_MemReg(OP::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
         }
 
         // decrement firstDim and leafPtr and loop back
-        Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
-        Inst_Reg(TR::InstOpCode::DEC8Reg, node, firstDimReg, cg);
-        Inst_Label(TR::InstOpCode::JG4, node, loopLabel, cg);
+        Inst_RegReg(OP::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
+        Inst_Reg(OP::DEC8Reg, node, firstDimReg, cg);
+        Inst_Label(OP::JG4, node, loopLabel, cg);
 
-        Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+        Inst_Label(OP::JMP4, node, doneLabel, cg);
         zeroLengthLoopOOL.endOutlinedInstructionSequence();
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
@@ -1741,20 +1723,19 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     bool arrayHeaderFitsInGPR = !use64BitClasses && ((classOffset + 4) == sizeOffset);
 
     if (arrayHeaderFitsInGPR) {
-        Inst_RegImm(TR::InstOpCode::SHL8RegImm1, node, secondDimReg, 32, cg);
-        Inst_RegReg(TR::InstOpCode::OR8RegReg, node, secondDimReg, tempReg, cg);
+        Inst_RegImm(OP::SHL8RegImm1, node, secondDimReg, 32, cg);
+        Inst_RegReg(OP::OR8RegReg, node, secondDimReg, tempReg, cg);
     }
 
     TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(OP::label, node, loopLabel, cg);
 
     // initialise leaf array
     if (arrayHeaderFitsInGPR) {
-        Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(leafPtrReg, classOffset, cg), secondDimReg, cg);
+        Inst_MemReg(OP::S8MemReg, node, MRef_Bdisp32(leafPtrReg, classOffset, cg), secondDimReg, cg);
     } else {
-        Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node, MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg,
-            cg);
-        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(leafPtrReg, sizeOffset, cg), secondDimReg, cg);
+        Inst_MemReg(OP::SMemReg(use64BitClasses), node, MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg, cg);
+        Inst_MemReg(OP::S4MemReg, node, MRef_Bdisp32(leafPtrReg, sizeOffset, cg), secondDimReg, cg);
     }
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
@@ -1762,10 +1743,10 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         /* Populate dataAddr slot of leaf array. Arrays of non-zero size
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
+        Inst_RegMem(OP::LEARegMem(), node, spineSizeReg,
             MRef_Bdisp32(leafPtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(leafPtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(leafPtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg),
+            spineSizeReg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
@@ -1776,19 +1757,19 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         trailingZeroes((int32_t)referenceSize), contiguousArrayHeaderSize - referenceSize, cg);
     if (comp->useCompressedPointers()) {
         int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
         if (shiftAmount != 0) {
-            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
+            Inst_RegImm(OP::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
         }
-        Inst_MemReg(TR::InstOpCode::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
+        Inst_MemReg(OP::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
     } else {
-        Inst_MemReg(TR::InstOpCode::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
+        Inst_MemReg(OP::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
     }
 
     // decrement firstDim and leafPtr and loop back
-    Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
-    Inst_Reg(TR::InstOpCode::DEC8Reg, node, firstDimReg, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, loopLabel, cg);
+    Inst_RegReg(OP::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
+    Inst_Reg(OP::DEC8Reg, node, firstDimReg, cg);
+    Inst_Label(OP::JG4, node, loopLabel, cg);
 
     // done, OOL helper will return to this point
     TR::RegisterDependencyConditions *deps = RegDeps(0, 14, cg);
@@ -1835,7 +1816,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     }
 
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
+    Inst_Label(OP::label, node, doneLabel, deps, cg);
 
     cg->stopUsingRegister(spineSizeReg);
     cg->stopUsingRegister(firstDimReg);
@@ -1846,7 +1827,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // now that the array is properly allocated, move into a collected reference register
     TR::Register *returnReg = cg->allocateCollectedReferenceRegister();
-    Inst_RegReg(TR::InstOpCode::MOV8RegReg, node, returnReg, spinePtrReg, cg);
+    Inst_RegReg(OP::MOV8RegReg, node, returnReg, spinePtrReg, cg);
 
     cg->stopUsingRegister(spinePtrReg);
 
@@ -1912,7 +1893,7 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
     TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *oolJumpPoint = generateLabelSymbol(cg);
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     // Generate the heap allocation, and the snippet that will handle heap overflow.
     TR_OutlinedInstructions *outlinedHelperCall
@@ -1929,167 +1910,157 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
 
     // inlined code for allocating zero length arrays where the zero len is in either the first or second dimension
 
-    Inst_RegMem(TR::InstOpCode::L4RegMem, node, secondDimLenReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
+    Inst_RegMem(OP::L4RegMem, node, secondDimLenReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
     // Load the 32-bit length value as a 64-bit value so that the top half of the register
     // can be zeroed out. This will allow us to treat the value as 64-bit when performing
     // calculations later on.
-    Inst_RegMem(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
+    Inst_RegMem(OP::MOVSXReg8Mem4, node, firstDimLenReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
 
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, secondDimLenReg, 0, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, secondDimLenReg, 0, cg);
 
-    Inst_Label(TR::InstOpCode::JNE4, node, oolJumpPoint, cg);
+    Inst_Label(OP::JNE4, node, oolJumpPoint, cg);
     // Second Dim length is 0
 
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, firstDimLenReg, 0, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, nonZeroFirstDimLabel, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, firstDimLenReg, 0, cg);
+    Inst_Label(OP::JNE4, node, nonZeroFirstDimLabel, cg);
 
     // First Dim zero, only allocate 1 zero-length object array
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, targetReg,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+    Inst_RegMem(OP::LRegMem(), node, targetReg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
     // Take into account alignment requirements for the size of the zero-length array header
     int32_t zeroArraySizeAligned = OMR::align(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(),
         TR::Compiler->om.getObjectAlignmentInBytes());
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, temp1Reg, MRef_Bdisp32(targetReg, zeroArraySizeAligned, cg), cg);
+    Inst_RegMem(OP::LEARegMem(), node, temp1Reg, MRef_Bdisp32(targetReg, zeroArraySizeAligned, cg), cg);
 
-    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, temp1Reg,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
-    Inst_Label(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
-    Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
-        temp1Reg, cg);
+    Inst_RegMem(OP::CMPRegMem(), node, temp1Reg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+    Inst_Label(OP::JA4, node, oolJumpPoint, cg);
+    Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp1Reg, cg);
 
     // Init class
     bool use64BitClasses = comp->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
-    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node,
+    Inst_MemReg(OP::SMemReg(use64BitClasses), node,
         MRef_Bdisp32(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
 
     // Init size and mustBeZero ('0') fields to 0
-    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
-        MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
-    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
-        MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
+    Inst_MemImm(OP::S4MemImm4, node, MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
+    Inst_MemImm(OP::S4MemImm4, node, MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0,
+        cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Init 1st dim dataAddr slot to 0
-        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
-            MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
+        Inst_MemImm(OP::S8MemImm4, node, MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0,
+            cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
-    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(OP::JMP4, node, doneLabel, cg);
 
     // First dim length not 0
-    Inst_Label(TR::InstOpCode::label, node, nonZeroFirstDimLabel, cg);
+    Inst_Label(OP::label, node, nonZeroFirstDimLabel, cg);
 
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, componentClassReg,
+    Inst_RegMem(OP::LRegMem(), node, componentClassReg,
         MRef_Bdisp32(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
 
     int32_t elementSize = TR::Compiler->om.sizeofReferenceField();
 
     uintptr_t maxObjectSize = cg->getMaxObjectSizeGuaranteedNotToOverflow();
     uintptr_t maxObjectSizeInElements = maxObjectSize / elementSize;
-    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, firstDimLenReg, static_cast<int32_t>(maxObjectSizeInElements), cg);
+    Inst_RegImm(OP::CMPRegImm4(), node, firstDimLenReg, static_cast<int32_t>(maxObjectSizeInElements), cg);
 
     // Must be an unsigned comparison on sizes.
-    Inst_Label(TR::InstOpCode::JAE4, node, oolJumpPoint, cg);
+    Inst_Label(OP::JAE4, node, oolJumpPoint, cg);
 
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, temp1Reg, firstDimLenReg, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, temp1Reg, firstDimLenReg, cg);
 
     int32_t elementSizeAligned = OMR::align(elementSize, TR::Compiler->om.getObjectAlignmentInBytes());
     int32_t alignmentCompensation = (elementSize == elementSizeAligned) ? 0 : elementSizeAligned - 1;
 
     TR_ASSERT_FATAL(elementSize <= 8, "multianewArrayEvaluator - elementSize cannot be greater than 8!");
-    Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, temp1Reg,
-        TR::MemoryReference::convertMultiplierToStride(elementSize), cg);
-    Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, temp1Reg,
+    Inst_RegImm(OP::SHLRegImm1(), node, temp1Reg, TR::MemoryReference::convertMultiplierToStride(elementSize), cg);
+    Inst_RegImm(OP::ADDRegImm4(), node, temp1Reg,
         TR::Compiler->om.contiguousArrayHeaderSizeInBytes() + alignmentCompensation, cg);
 
     if (alignmentCompensation != 0) {
-        Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, temp1Reg, -elementSizeAligned, cg);
+        Inst_RegImm(OP::ANDRegImm4(), node, temp1Reg, -elementSizeAligned, cg);
     }
 
     TR_ASSERT_FATAL(zeroArraySizeAligned >= 0 && zeroArraySizeAligned <= 127,
         "discontiguousArrayHeaderSizeInBytes cannot be > 127 for IMulRegRegImms instruction");
-    Inst_RegRegImm(TR::InstOpCode::IMULRegRegImm4(), node, temp2Reg, firstDimLenReg, zeroArraySizeAligned, cg);
+    Inst_RegRegImm(OP::IMULRegRegImm4(), node, temp2Reg, firstDimLenReg, zeroArraySizeAligned, cg);
 
     // temp2Reg = temp2Reg + temp1Reg
-    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
+    Inst_RegReg(OP::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
 
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, targetReg,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+    Inst_RegMem(OP::LRegMem(), node, targetReg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
     // temp2Reg = temp2Reg + J9VMThread->heapAlloc
-    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, temp2Reg, targetReg, cg);
+    Inst_RegReg(OP::ADDRegReg(), node, temp2Reg, targetReg, cg);
 
-    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, temp2Reg,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
-    Inst_Label(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
-    Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
-        temp2Reg, cg);
+    Inst_RegMem(OP::CMPRegMem(), node, temp2Reg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+    Inst_Label(OP::JA4, node, oolJumpPoint, cg);
+    Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp2Reg, cg);
 
     // init 1st dim array class field
-    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node,
+    Inst_MemReg(OP::SMemReg(use64BitClasses), node,
         MRef_Bdisp32(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
     // Init 1st dim array size field
-    Inst_MemReg(TR::InstOpCode::S4MemReg, node,
-        MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), firstDimLenReg, cg);
+    Inst_MemReg(OP::S4MemReg, node, MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg),
+        firstDimLenReg, cg);
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         /* Populate dataAddr slot of 1st dimension array. Arrays of non-zero size
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, temp3Reg,
+        Inst_RegMem(OP::LEARegMem(), node, temp3Reg,
             MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg), temp3Reg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg),
+            temp3Reg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // temp2 point to end of 1st dim array i.e. start of 2nd dim
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, temp2Reg, targetReg, cg);
-    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, temp2Reg, targetReg, cg);
+    Inst_RegReg(OP::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
     // temp1 points to 1st dim array past header
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, temp1Reg,
+    Inst_RegMem(OP::LEARegMem(), node, temp1Reg,
         MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
 
     // loop start
-    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(OP::label, node, loopLabel, cg);
     // Init 2nd dim element's class
-    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node,
+    Inst_MemReg(OP::SMemReg(use64BitClasses), node,
         MRef_Bdisp32(temp2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), componentClassReg, cg);
     // Init 2nd dim element's size and mustBeZero ('0') fields to 0
-    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
-        MRef_Bdisp32(temp2Reg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
-    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
-        MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
+    Inst_MemImm(OP::S4MemImm4, node, MRef_Bdisp32(temp2Reg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
+    Inst_MemImm(OP::S4MemImm4, node, MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Populate dataAddr slot for 2nd dimension zero size array.
-        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
-            MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
+        Inst_MemImm(OP::S8MemImm4, node, MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0,
+            cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // Store 2nd dim element into 1st dim array slot, compress temp2 if needed
     if (comp->target().is64Bit() && comp->useCompressedPointers()) {
         int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, temp3Reg, temp2Reg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, temp3Reg, temp2Reg, cg);
         if (shiftAmount != 0) {
-            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, temp3Reg, shiftAmount, cg);
+            Inst_RegImm(OP::SHRRegImm1(), node, temp3Reg, shiftAmount, cg);
         }
-        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(temp1Reg, 0, cg), temp3Reg, cg);
+        Inst_MemReg(OP::S4MemReg, node, MRef_Bdisp32(temp1Reg, 0, cg), temp3Reg, cg);
     } else {
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(temp1Reg, 0, cg), temp2Reg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(temp1Reg, 0, cg), temp2Reg, cg);
     }
 
     // Advance cursors temp1 and temp2
-    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, temp2Reg, zeroArraySizeAligned, cg);
-    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, temp1Reg, elementSize, cg);
+    Inst_RegImm(OP::ADDRegImms(), node, temp2Reg, zeroArraySizeAligned, cg);
+    Inst_RegImm(OP::ADDRegImms(), node, temp1Reg, elementSize, cg);
 
-    Inst_Reg(TR::InstOpCode::DEC4Reg, node, firstDimLenReg, cg);
-    Inst_Label(TR::InstOpCode::JA4, node, loopLabel, cg);
+    Inst_Reg(OP::DEC4Reg, node, firstDimLenReg, cg);
+    Inst_Label(OP::JA4, node, loopLabel, cg);
 
-    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(OP::JMP4, node, doneLabel, cg);
 
     TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 13, cg);
 
@@ -2130,17 +2101,17 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
 
     deps->stopAddingConditions();
 
-    Inst_Label(TR::InstOpCode::label, node, oolJumpPoint, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, oolFailLabel, cg);
+    Inst_Label(OP::label, node, oolJumpPoint, cg);
+    Inst_Label(OP::JMP4, node, oolFailLabel, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
+    Inst_Label(OP::label, node, doneLabel, deps, cg);
 
     // Copy the newly allocated object into a collected reference register now that it is a valid object.
     //
     TR::Register *targetReg2 = cg->allocateCollectedReferenceRegister();
     TR::RegisterDependencyConditions *deps2 = RegDeps(0, 1, cg);
     deps2->addPostCondition(targetReg2, TR::RealRegister::eax, cg);
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
     cg->stopUsingRegister(targetReg);
     targetReg = targetReg2;
 
@@ -2227,7 +2198,7 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
     if (comp->target().is64Bit() && !TR::TreeEvaluator::getNodeIs64Bit(node->getChild(4), cg)) {
-        Inst_RegReg(TR::InstOpCode::MOVZXReg8Reg4, node, sizeReg, sizeReg, cg);
+        Inst_RegReg(OP::MOVZXReg8Reg4, node, sizeReg, sizeReg, cg);
     }
 
     if (!node->isNoArrayStoreCheckArrayCopy()) {
@@ -2240,14 +2211,14 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
         deps->addPostCondition(dstReg, TR::RealRegister::edi, cg);
         deps->addPostCondition(sizeReg, TR::RealRegister::ecx, cg);
 
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg, cg);
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg),
+            srcObjReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg),
+            dstObjReg, cg);
         Inst_HelperCall(node, TR_referenceArrayCopy, deps, cg)->setNeedsGCMap(0xFF00FFFF);
 
         auto snippetLabel = generateLabelSymbol(cg);
-        auto instr = Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel,
+        auto instr = Inst_Label(OP::JNE4, node, snippetLabel,
             cg); // ReferenceArrayCopy set ZF when succeed.
         auto snippet = new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg,
             cg->symRefTab()->findOrCreateRuntimeHelper(TR_arrayStoreException), snippetLabel, instr, false);
@@ -2288,9 +2259,9 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
             tmpXmmYmmReg2 = cg->allocateRegister(TR_VRF);
         }
 
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, RSI, srcReg, cg);
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, RDI, dstReg, cg);
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, RCX, sizeReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, RSI, srcReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, RDI, dstReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, RCX, sizeReg, cg);
 
         int8_t numDeps = enableInlineForSmallSize ? 9 : 5;
         TR::RegisterDependencyConditions *deps = RegDeps(numDeps, numDeps, cg);
@@ -2323,25 +2294,25 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
         begLabel->setStartInternalControlFlow();
         endLabel->setEndInternalControlFlow();
 
-        Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+        Inst_Label(OP::label, node, begLabel, cg);
 
         if (TR::Compiler->om.readBarrierType() != gc_modron_readbar_none) {
             bool use64BitClasses = comp->target().is64Bit() && !comp->useCompressedPointers();
 
             TR::LabelSymbol *rdbarLabel = generateLabelSymbol(cg);
             // EvacuateTopAddress == 0 means Concurrent Scavenge is inactive
-            Inst_MemImm(TR::InstOpCode::CMPMemImms(use64BitClasses), node,
+            Inst_MemImm(OP::CMPMemImms(use64BitClasses), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg), 0,
                 cg);
-            Inst_Label(TR::InstOpCode::JNE4, node, rdbarLabel, cg);
+            Inst_Label(OP::JNE4, node, rdbarLabel, cg);
 
             TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(OP::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg, cg);
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(OP::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg, cg);
             Inst_HelperCall(node, TR_referenceArrayCopy, NULL, cg)->setNeedsGCMap(0xFF00FFFF);
-            Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+            Inst_Label(OP::JMP4, node, endLabel, cg);
             og.endOutlinedInstructionSequence();
         }
 
@@ -2358,35 +2329,35 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
                     tmpXmmYmmReg2, cg, repMovsThresholdBytes, repMovsLabel, endLabel);
             }
 
-            Inst_Label(TR::InstOpCode::label, node, repMovsLabel, cg);
+            Inst_Label(OP::label, node, repMovsLabel, cg);
         }
 
         if (!node->isForwardArrayCopy()) {
             TR::LabelSymbol *backwardLabel = generateLabelSymbol(cg);
 
-            Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, RDI, RSI, cg); // dst = dst - src
-            Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, RDI, RCX, cg); // cmp dst, size
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, RDI, MRef_BIS(RDI, RSI, 0, cg),
+            Inst_RegReg(OP::SUBRegReg(), node, RDI, RSI, cg); // dst = dst - src
+            Inst_RegReg(OP::CMPRegReg(), node, RDI, RCX, cg); // cmp dst, size
+            Inst_RegMem(OP::LEARegMem(), node, RDI, MRef_BIS(RDI, RSI, 0, cg),
                 cg); // dst = dst + src
-            Inst_Label(TR::InstOpCode::JB4, node, backwardLabel, cg); // jb, skip backward copy setup
+            Inst_Label(OP::JB4, node, backwardLabel, cg); // jb, skip backward copy setup
 
             TR_OutlinedInstructionsGenerator og(backwardLabel, node, cg);
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, RSI,
+            Inst_RegMem(OP::LEARegMem(), node, RSI,
                 MRef_BISdisp32(RSI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, RDI,
+            Inst_RegMem(OP::LEARegMem(), node, RDI,
                 MRef_BISdisp32(RDI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
-            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
-            Inst(TR::InstOpCode::STD, node, cg);
-            Inst(use64BitClasses ? TR::InstOpCode::REPMOVSQ : TR::InstOpCode::REPMOVSD, node, cg);
-            Inst(TR::InstOpCode::CLD, node, cg);
-            Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+            Inst_RegImm(OP::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
+            Inst(OP::STD, node, cg);
+            Inst(use64BitClasses ? OP::REPMOVSQ : OP::REPMOVSD, node, cg);
+            Inst(OP::CLD, node, cg);
+            Inst_Label(OP::JMP4, node, endLabel, cg);
             og.endOutlinedInstructionSequence();
         }
 
-        Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
-        Inst(use64BitClasses ? TR::InstOpCode::REPMOVSQ : TR::InstOpCode::REPMOVSD, node, cg);
+        Inst_RegImm(OP::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
+        Inst(use64BitClasses ? OP::REPMOVSQ : OP::REPMOVSD, node, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+        Inst_Label(OP::label, node, endLabel, deps, cg);
 
         cg->stopUsingRegister(RSI);
         cg->stopUsingRegister(RDI);
@@ -2425,9 +2396,9 @@ TR::Register *J9::X86::TreeEvaluator::arraylengthEvaluator(TR::Node *node, TR::C
     TR::MemoryReference *discontiguousArraySizeMR
         = MRef_Bdisp32(objectReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg);
 
-    Inst_RegMem(TR::InstOpCode::L4RegMem, node, lengthReg, contiguousArraySizeMR, cg);
-    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, lengthReg, lengthReg, cg);
-    Inst_RegMem(TR::InstOpCode::CMOVE4RegMem, node, lengthReg, discontiguousArraySizeMR, cg);
+    Inst_RegMem(OP::L4RegMem, node, lengthReg, contiguousArraySizeMR, cg);
+    Inst_RegReg(OP::TEST4RegReg, node, lengthReg, lengthReg, cg);
+    Inst_RegMem(OP::CMOVE4RegMem, node, lengthReg, discontiguousArraySizeMR, cg);
 
     cg->decReferenceCount(node->getFirstChild());
     node->setRegister(lengthReg);
@@ -2436,7 +2407,7 @@ TR::Register *J9::X86::TreeEvaluator::arraylengthEvaluator(TR::Node *node, TR::C
 
 TR::Register *J9::X86::TreeEvaluator::exceptionRangeFenceEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    Inst_Fence(TR::InstOpCode::fence, node, node, cg);
+    Inst_Fence(OP::fence, node, node, cg);
     return NULL;
 }
 
@@ -2613,7 +2584,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
                 } else {
                     memRef = MRef_Bdisp32(refRegister, 0, cg);
                 }
-                appendTo = Inst_MemImm(appendTo, TR::InstOpCode::TEST1MemImm1, memRef, 0, cg);
+                appendTo = Inst_MemImm(appendTo, OP::TEST1MemImm1, memRef, 0, cg);
                 cg->setImplicitExceptionPoint(appendTo);
             }
         }
@@ -2640,7 +2611,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
             if (!appendTo)
                 appendTo = cg->getAppendInstruction();
 
-            TR::InstOpCode::Mnemonic op = TR::InstOpCode::CMPMemImms();
+            OP::Mnemonic op = OP::CMPMemImms();
             appendTo = Inst_MemImm(appendTo, op, tempMR, NULLVALUE, cg);
             tempMR->decNodeReferenceCounts(cg);
             needLateEvaluation = false;
@@ -2650,11 +2621,11 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
             if (!appendTo)
                 appendTo = cg->getAppendInstruction();
 
-            appendTo = Inst_RegReg(appendTo, TR::InstOpCode::TESTRegReg(), targetRegister, targetRegister, cg);
+            appendTo = Inst_RegReg(appendTo, OP::TESTRegReg(), targetRegister, targetRegister, cg);
         }
 
         TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
-        appendTo = Inst_Label(appendTo, TR::InstOpCode::JE4, snippetLabel, cg);
+        appendTo = Inst_Label(appendTo, OP::JE4, snippetLabel, cg);
         // the _node field should point to the current node
         appendTo->setNode(node);
         appendTo->setLiveLocals(cg->getLiveLocals());
@@ -2823,25 +2794,23 @@ TR::Register *J9::X86::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGe
         startLabel->setStartInternalControlFlow();
         restartLabel->setEndInternalControlFlow();
 
-        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(OP::label, node, startLabel, cg);
 
         if (useRegisterPairs) {
             TR::Register *tempReg = cg->allocateRegister(TR_GPR);
-            lowDivisorTestInstr = Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, tempReg, divisorReg->getLowOrder(), cg);
-            highDivisorTestInstr
-                = Inst_RegReg(TR::InstOpCode::OR4RegReg, node, tempReg, divisorReg->getHighOrder(), cg);
-            Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, tempReg, tempReg, cg);
+            lowDivisorTestInstr = Inst_RegReg(OP::MOV4RegReg, node, tempReg, divisorReg->getLowOrder(), cg);
+            highDivisorTestInstr = Inst_RegReg(OP::OR4RegReg, node, tempReg, divisorReg->getHighOrder(), cg);
+            Inst_RegReg(OP::TEST4RegReg, node, tempReg, tempReg, cg);
             cg->stopUsingRegister(tempReg);
         } else
-            lowDivisorTestInstr
-                = Inst_RegReg(TR::InstOpCode::TESTRegReg(use64BitRegisters), node, divisorReg, divisorReg, cg);
+            lowDivisorTestInstr = Inst_RegReg(OP::TESTRegReg(use64BitRegisters), node, divisorReg, divisorReg, cg);
 
-        Inst_Label(TR::InstOpCode::JE4, node, divideByZeroSnippetLabel, cg);
+        Inst_Label(OP::JE4, node, divideByZeroSnippetLabel, cg);
 
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, node->getSymbolReference(),
             divideByZeroSnippetLabel, cg->getAppendInstruction()));
 
-        Inst_Label(TR::InstOpCode::label, node, divisionLabel, cg);
+        Inst_Label(OP::label, node, divisionLabel, cg);
 
         TR::Register *resultRegister = cg->evaluate(divisionNode);
 
@@ -2879,7 +2848,7 @@ TR::Register *J9::X86::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGe
                     TR_ASSERT(0, "bad division opcode for DIVCHK\n");
             }
 
-        Inst_Label(TR::InstOpCode::label, node, restartLabel, deps, cg);
+        Inst_Label(OP::label, node, restartLabel, deps, cg);
 
         if (hasConversion) {
             cg->evaluate(node->getFirstChild());
@@ -2914,7 +2883,7 @@ static bool isInteger(TR::ILOpCode &op, TR::CodeGenerator *cg)
         return op.isIntegerOrAddress() && (op.getSize() <= 4);
 }
 
-static TR::InstOpCode::Mnemonic branchOpCodeForCompare(TR::ILOpCode &op, bool opposite = false)
+static OP::Mnemonic branchOpCodeForCompare(TR::ILOpCode &op, bool opposite = false)
 {
     int32_t index = 0;
     if (op.isCompareTrueIfLess())
@@ -2929,23 +2898,23 @@ static TR::InstOpCode::Mnemonic branchOpCodeForCompare(TR::ILOpCode &op, bool op
     if (opposite)
         index ^= 7;
 
-    static const TR::InstOpCode::Mnemonic opTable[] = {
-        TR::InstOpCode::bad,
-        TR::InstOpCode::JL4,
-        TR::InstOpCode::JG4,
-        TR::InstOpCode::JNE4,
-        TR::InstOpCode::JE4,
-        TR::InstOpCode::JLE4,
-        TR::InstOpCode::JGE4,
-        TR::InstOpCode::bad,
-        TR::InstOpCode::bad,
-        TR::InstOpCode::JB4,
-        TR::InstOpCode::JA4,
-        TR::InstOpCode::JNE4,
-        TR::InstOpCode::JE4,
-        TR::InstOpCode::JBE4,
-        TR::InstOpCode::JAE4,
-        TR::InstOpCode::bad,
+    static const OP::Mnemonic opTable[] = {
+        OP::bad,
+        OP::JL4,
+        OP::JG4,
+        OP::JNE4,
+        OP::JE4,
+        OP::JLE4,
+        OP::JGE4,
+        OP::bad,
+        OP::bad,
+        OP::JB4,
+        OP::JA4,
+        OP::JNE4,
+        OP::JE4,
+        OP::JBE4,
+        OP::JAE4,
+        OP::bad,
     };
     return opTable[index];
 }
@@ -3013,11 +2982,11 @@ TR::Register *J9::X86::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::CodeG
         Inst_Label(branchOpCodeForCompare(valueToCheck->getOpCode(), true), node, slowPathLabel, cg);
     } else {
         TR::Register *value = cg->evaluate(node->getFirstChild());
-        Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, value, value, cg);
+        Inst_RegReg(OP::TEST4RegReg, node, value, value, cg);
         cg->decReferenceCount(node->getFirstChild());
-        Inst_Label(TR::InstOpCode::JE4, node, slowPathLabel, cg);
+        Inst_Label(OP::JE4, node, slowPathLabel, cg);
     }
-    Inst_Label(TR::InstOpCode::label, node, restartLabel, cg);
+    Inst_Label(OP::label, node, restartLabel, cg);
 
     return NULL;
 }
@@ -3046,7 +3015,7 @@ bool isConditionCodeSetForCompare(TR::Node *node, bool *jumpOnOppositeCondition,
     //
     TR::Instruction *prevInstr;
     for (prevInstr = comp->cg()->getAppendInstruction(); prevInstr; prevInstr = prevInstr->getPrev()) {
-        if (prevInstr->getOpCodeValue() == TR::InstOpCode::CMP4RegReg) {
+        if (prevInstr->getOpCodeValue() == OP::CMP4RegReg) {
             TR::Register *prevInstrTargetRegister = prevInstr->getTargetRegister();
             TR::Register *prevInstrSourceRegister = prevInstr->getSourceRegister();
 
@@ -3062,7 +3031,7 @@ bool isConditionCodeSetForCompare(TR::Node *node, bool *jumpOnOppositeCondition,
             }
         }
 
-        if (prevInstr->getOpCodeValue() == TR::InstOpCode::label) {
+        if (prevInstr->getOpCodeValue() == OP::label) {
             // This instruction is a possible branch target.
             return false;
         }
@@ -3095,8 +3064,8 @@ void setImplicitNULLCHKExceptionInfo(TR::Node *node, TR::CodeGenerator *cg)
         //
         // The last instruction is a branch, the comparison is before.
         TR::Instruction *cmpInstruction = cg->getAppendInstruction()->getPrev();
-        TR::InstOpCode::Mnemonic mnemonic = cmpInstruction->getOpCodeValue();
-        bool isComparisonMemForm = mnemonic == TR::InstOpCode::CMP4MemReg || mnemonic == TR::InstOpCode::CMP4RegMem;
+        OP::Mnemonic mnemonic = cmpInstruction->getOpCodeValue();
+        bool isComparisonMemForm = mnemonic == OP::CMP4MemReg || mnemonic == OP::CMP4RegMem;
         if (comp->useCompressedPointers() && faultingInstruction != cmpInstruction && isComparisonMemForm) {
             logprintf(isTraceCG, comp->log(), "Faulting instruction (previously %p) updated to %p\n",
                 faultingInstruction, cmpInstruction);
@@ -3132,7 +3101,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKEvaluator(TR::Node *node, TR::CodeGe
     bool jumpOnOppositeCondition = false;
     if (firstChild->getOpCode().isLoadConst()) {
         if (secondChild->getOpCode().isLoadConst() && firstChild->getInt() <= secondChild->getInt()) {
-            instr = Inst_Label(TR::InstOpCode::JMP4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(OP::JMP4, node, boundCheckFailureLabel, cg);
             cg->decReferenceCount(firstChild);
             cg->decReferenceCount(secondChild);
         } else {
@@ -3140,23 +3109,23 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKEvaluator(TR::Node *node, TR::CodeGe
                 node->swapChildren();
                 TR::TreeEvaluator::compareIntegersForOrder(node, cg);
                 node->swapChildren();
-                instr = Inst_Label(TR::InstOpCode::JAE4, node, boundCheckFailureLabel, cg);
+                instr = Inst_Label(OP::JAE4, node, boundCheckFailureLabel, cg);
             } else
                 skippedComparison = true;
         }
     } else {
         if (!isConditionCodeSetForCompare(node, &jumpOnOppositeCondition, cg->comp())) {
             TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-            instr = Inst_Label(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(OP::JBE4, node, boundCheckFailureLabel, cg);
         } else
             skippedComparison = true;
     }
 
     if (skippedComparison) {
         if (jumpOnOppositeCondition)
-            instr = Inst_Label(TR::InstOpCode::JAE4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(OP::JAE4, node, boundCheckFailureLabel, cg);
         else
-            instr = Inst_Label(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(OP::JBE4, node, boundCheckFailureLabel, cg);
 
         cg->decReferenceCount(firstChild);
         cg->decReferenceCount(secondChild);
@@ -3189,7 +3158,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node, T
             if (firstChild->getInt() < secondChild->getInt()) {
                 // Check will always fail, just jump to failure snippet
                 //
-                instr = Inst_Label(TR::InstOpCode::JMP4, node, boundCheckFailureLabel, cg);
+                instr = Inst_Label(OP::JMP4, node, boundCheckFailureLabel, cg);
             } else {
                 // Check will always succeed, no need for an instruction
                 //
@@ -3201,11 +3170,11 @@ TR::Register *J9::X86::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node, T
             node->swapChildren();
             TR::TreeEvaluator::compareIntegersForOrder(node, cg);
             node->swapChildren();
-            instr = Inst_Label(TR::InstOpCode::JG4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(OP::JG4, node, boundCheckFailureLabel, cg);
         }
     } else {
         TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-        instr = Inst_Label(TR::InstOpCode::JL4, node, boundCheckFailureLabel, cg);
+        instr = Inst_Label(OP::JL4, node, boundCheckFailureLabel, cg);
     }
 
     if (instr)
@@ -3341,8 +3310,8 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             // valid for useShiftedOffsets
             compressedRegister = cg->evaluate(firstChild->getSecondChild());
             if (!usingLowMemHeap) {
-                Inst_RegReg(TR::InstOpCode::TESTRegReg(), firstChild, sourceRegister, sourceRegister, cg);
-                Inst_RegReg(TR::InstOpCode::CMOVERegReg(), firstChild, compressedRegister, sourceRegister, cg);
+                Inst_RegReg(OP::TESTRegReg(), firstChild, sourceRegister, sourceRegister, cg);
+                Inst_RegReg(OP::CMOVERegReg(), firstChild, compressedRegister, sourceRegister, cg);
             }
         }
     }
@@ -3358,13 +3327,13 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
 
     startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
-    Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
+    Inst_RegReg(OP::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
 
     TR::LabelSymbol *nullTargetLabel = isRealTimeGC ? startOfWrtbarLabel : doNullStoreLabel;
 
-    Inst_Label(TR::InstOpCode::JE4, node, nullTargetLabel, cg);
+    Inst_Label(OP::JE4, node, nullTargetLabel, cg);
 
     // -------------------------------------------------------------------------
     //
@@ -3402,7 +3371,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
                 = TR_VirtualGuard::createArrayStoreCheckGuard(comp, node, node->getArrayStoreClassInNode());
             Inst_VirtualGuardNOP(node, virtualGuard->addNOPSite(), NULL, oolASCLabel, cg);
         } else {
-            Inst_Label(TR::InstOpCode::JMP4, node, oolASCLabel, cg);
+            Inst_Label(OP::JMP4, node, oolASCLabel, cg);
         }
 
         // Restore the reference counts of the children created for the temporary vacll node above.
@@ -3423,7 +3392,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
     bool isSourceNonNull = sourceChild->isNonNull();
 
     if (generateWriteBarrier) {
-        Inst_Label(TR::InstOpCode::label, node, startOfWrtbarLabel, cg);
+        Inst_Label(OP::label, node, startOfWrtbarLabel, cg);
 
         if (!isRealTimeGC) {
             // HACK: set the nullness property on the source so that the write barrier
@@ -3442,7 +3411,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
     } else if (postASCLabel) {
         // Lay down a arestart label for OOL ASC if the write barrier was skipped
         //
-        Inst_Label(TR::InstOpCode::label, node, postASCLabel, cg);
+        Inst_Label(OP::label, node, postASCLabel, cg);
     }
 
     // -------------------------------------------------------------------------
@@ -3473,11 +3442,11 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             tempMR2 = MRef_MRefOff(*tempMR, 0, cg);
 
             if (usingCompressedPointers)
-                Inst_MemReg(TR::InstOpCode::S4MemReg, node, tempMR2, compressedRegister, cg);
+                Inst_MemReg(OP::S4MemReg, node, tempMR2, compressedRegister, cg);
             else
-                Inst_MemReg(TR::InstOpCode::SMemReg(), node, tempMR2, sourceRegister, cg);
+                Inst_MemReg(OP::SMemReg(), node, tempMR2, sourceRegister, cg);
 
-            Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+            Inst_Label(OP::JMP4, node, doneLabel, cg);
             og.endOutlinedInstructionSequence();
         } else if (!generateWriteBarrier) {
             // No write barrier emitted.  Evaluate the store here.
@@ -3494,9 +3463,9 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             TR::X86MemRegInstruction *storeInstr;
 
             if (usingCompressedPointers)
-                storeInstr = Inst_MemReg(TR::InstOpCode::S4MemReg, node, tempMR, compressedRegister, cg);
+                storeInstr = Inst_MemReg(OP::S4MemReg, node, tempMR, compressedRegister, cg);
             else
-                storeInstr = Inst_MemReg(TR::InstOpCode::SMemReg(), node, tempMR, sourceRegister, cg);
+                storeInstr = Inst_MemReg(OP::SMemReg(), node, tempMR, sourceRegister, cg);
 
             cg->setImplicitExceptionPoint(storeInstr);
 
@@ -3561,9 +3530,9 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
     scratchRegisterManager->stopUsingRegisters();
 
     if (dependencyAnchorInstruction) {
-        Inst_Label(dependencyAnchorInstruction, TR::InstOpCode::label, doneLabel, deps, cg);
+        Inst_Label(dependencyAnchorInstruction, OP::label, doneLabel, deps, cg);
     } else {
-        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
+        Inst_Label(OP::label, node, doneLabel, deps, cg);
     }
 
     if (usingCompressedPointers) {
@@ -3609,7 +3578,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
     // that the array bound is a constant, and lowered TR::arraylength into an
     // iconst.  In this case, make sure that the constant is the second child.
     //
-    TR::InstOpCode::Mnemonic branchOpCode;
+    OP::Mnemonic branchOpCode;
 
     // For primitive stores anchored under the check node, we must evaluate the source node
     // before the bound check branch so that its available to the snippet.  We can make
@@ -3642,7 +3611,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
                 // Create real check failure snippet if we can prove the
                 // bound check will always fail.
                 //
-                branchOpCode = TR::InstOpCode::JMP4;
+                branchOpCode = OP::JMP4;
                 cg->decReferenceCount(arrayLengthChild);
                 cg->decReferenceCount(indexChild);
             } else {
@@ -3654,7 +3623,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
                     // Create real check failure snippet if we can prove the spine check
                     // will always fail
                     //
-                    branchOpCode = TR::InstOpCode::JMP4;
+                    branchOpCode = OP::JMP4;
                     cg->decReferenceCount(arrayLengthChild);
                     if (!indexChild->getOpCode().isLoadConst()) {
                         cg->evaluate(indexChild);
@@ -3667,7 +3636,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
                     // Check the bounds.
                     //
                     TR::TreeEvaluator::compareIntegersForOrder(node, indexChild, arrayLengthChild, cg);
-                    branchOpCode = TR::InstOpCode::JAE4;
+                    branchOpCode = OP::JAE4;
                     faultingInstruction = cg->getImplicitExceptionPoint();
                 }
             }
@@ -3675,13 +3644,13 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
             // Check the bounds.
             //
             TR::TreeEvaluator::compareIntegersForOrder(node, arrayLengthChild, indexChild, cg);
-            branchOpCode = TR::InstOpCode::JBE4;
+            branchOpCode = OP::JBE4;
             faultingInstruction = cg->getImplicitExceptionPoint();
         }
 
         static char *forceArraylet = feGetEnv("TR_forceArraylet");
         if (forceArraylet) {
-            branchOpCode = TR::InstOpCode::JMP4;
+            branchOpCode = OP::JMP4;
         }
 
         checkInstr = Inst_Label(branchOpCode, node, boundCheckFailureLabel, cg);
@@ -3696,8 +3665,8 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
 
         TR::MemoryReference *arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
 
-        Inst_MemImm(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, boundCheckFailureLabel, cg);
+        Inst_MemImm(OP::CMP4MemImms, node, arraySizeMR, 0, cg);
+        Inst_Label(OP::JE4, node, boundCheckFailureLabel, cg);
     }
 
     // -----------------------------------------------------------------------------------
@@ -3775,7 +3744,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
 
     TR::LabelSymbol *mergeLabel = generateLabelSymbol(cg);
     mergeLabel->setInternalControlFlowMerge();
-    TR::X86LabelInstruction *restartInstr = Inst_Label(TR::InstOpCode::label, node, mergeLabel, deps, cg);
+    TR::X86LabelInstruction *restartInstr = Inst_Label(OP::label, node, mergeLabel, deps, cg);
 
     TR_OutlinedInstructions *arrayletOI
         = generateArrayletReference(node, loadOrStoreChild, checkInstr, boundCheckFailureLabel, mergeLabel,
@@ -3825,15 +3794,15 @@ TR::Register *J9::X86::TreeEvaluator::barrierFenceEvaluator(TR::Node *node, TR::
 {
     TR::ILOpCodes opCode = node->getOpCodeValue();
     if (opCode == TR::fullFence && node->canOmitSync()) {
-        Inst_Label(TR::InstOpCode::label, node, generateLabelSymbol(cg), cg);
+        Inst_Label(OP::label, node, generateLabelSymbol(cg), cg);
     } else if (cg->comp()->getOption(TR_X86UseMFENCE)) {
-        Inst(TR::InstOpCode::MFENCE, node, cg);
+        Inst(OP::MFENCE, node, cg);
     } else {
         TR::RealRegister *stackReg = cg->machine()->getRealRegister(TR::RealRegister::esp);
         TR::MemoryReference *mr = MRef_Bdisp32(stackReg, intptr_t(0), cg);
 
         mr->setRequiresLockPrefix();
-        Inst_MemImm(TR::InstOpCode::OR4MemImms, node, mr, 0, cg);
+        Inst_MemImm(OP::OR4MemImms, node, mr, 0, cg);
         cg->stopUsingRegister(stackReg);
     }
     return NULL;
@@ -3861,7 +3830,7 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
         startLabel = generateLabelSymbol(cg);
         doneLabel = generateLabelSymbol(cg);
 
-        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(OP::label, node, startLabel, cg);
         startLabel->setStartInternalControlFlow();
     }
 
@@ -3869,13 +3838,13 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
 
     if (needBranchAroundForNULL) {
         // if handle is NULL, then just branch around the redirection
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, handleRegister, handleRegister, cg);
-        Inst_Label(TR::InstOpCode::JE4, handleNode, doneLabel, cg);
+        Inst_RegReg(OP::TESTRegReg(), node, handleRegister, handleRegister, cg);
+        Inst_Label(OP::JE4, handleNode, doneLabel, cg);
     }
 
     // handle is not NULL or we're an implicit nullcheck, so go through forwarding pointer to get object
     TR::MemoryReference *handleMR = MRef_Bdisp32(handleRegister, node->getSymbolReference()->getOffset(), cg);
-    TR::Instruction *forwardingInstr = Inst_RegMem(TR::InstOpCode::L4RegMem, handleNode, handleRegister, handleMR, cg);
+    TR::Instruction *forwardingInstr = Inst_RegMem(OP::L4RegMem, handleNode, handleRegister, handleMR, cg);
     cg->setImplicitExceptionPoint(forwardingInstr);
 
     if (needBranchAroundForNULL) {
@@ -3883,7 +3852,7 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
         deps->addPostCondition(handleRegister, TR::RealRegister::NoReg, cg);
 
         // and we're done
-        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
+        Inst_Label(OP::label, node, doneLabel, deps, cg);
 
         doneLabel->setEndInternalControlFlow();
     }
@@ -3902,14 +3871,14 @@ static TR::Register *highestOneBit(TR::Node *node, TR::CodeGenerator *cg, TR::Re
     // shl r1, r2
     TR::Register *scratchReg = cg->allocateRegister();
     TR::Register *bsrReg = cg->allocateRegister();
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, scratchReg, scratchReg, cg);
-    Inst_RegReg(TR::InstOpCode::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
-    Inst_Reg(TR::InstOpCode::SETNE1Reg, node, scratchReg, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, scratchReg, scratchReg, cg);
+    Inst_RegReg(OP::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
+    Inst_Reg(OP::SETNE1Reg, node, scratchReg, cg);
     TR::RegisterDependencyConditions *shiftDependencies = RegDeps((uint8_t)1, 1, cg);
     shiftDependencies->addPreCondition(bsrReg, TR::RealRegister::ecx, cg);
     shiftDependencies->addPostCondition(bsrReg, TR::RealRegister::ecx, cg);
     shiftDependencies->stopAddingConditions();
-    Inst_RegReg(TR::InstOpCode::SHLRegCL(is64Bit), node, scratchReg, bsrReg, shiftDependencies, cg);
+    Inst_RegReg(OP::SHLRegCL(is64Bit), node, scratchReg, bsrReg, shiftDependencies, cg);
     cg->stopUsingRegister(bsrReg);
     return scratchReg;
 }
@@ -3946,11 +3915,11 @@ TR::Register *J9::X86::TreeEvaluator::longHighestOneBit(TR::Node *node, TR::Code
         TR::Register *maskReg = cg->allocateRegister();
         TR::Register *resultHigh = highestOneBit(node, cg, inputHigh, false);
         TR::Register *resultLow = highestOneBit(node, cg, inputLow, false);
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, inputHigh, 0, cg);
-        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
-        Inst_Reg(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
-        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, resultLow, maskReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, maskReg, maskReg, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, inputHigh, 0, cg);
+        Inst_Reg(OP::SETNE1Reg, node, maskReg, cg);
+        Inst_Reg(OP::DEC4Reg, node, maskReg, cg);
+        Inst_RegReg(OP::AND4RegReg, node, resultLow, maskReg, cg);
         resultReg = cg->allocateRegisterPair(resultLow, resultHigh);
         cg->stopUsingRegister(maskReg);
     }
@@ -3962,9 +3931,9 @@ TR::Register *J9::X86::TreeEvaluator::longHighestOneBit(TR::Node *node, TR::Code
 static TR::Register *lowestOneBit(TR::Node *node, TR::CodeGenerator *cg, TR::Register *reg, bool is64Bit)
 {
     TR::Register *resultReg = cg->allocateRegister();
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(is64Bit), node, resultReg, reg, cg);
-    Inst_Reg(TR::InstOpCode::NEGReg(is64Bit), node, resultReg, cg);
-    Inst_RegReg(TR::InstOpCode::ANDRegReg(is64Bit), node, resultReg, reg, cg);
+    Inst_RegReg(OP::MOVRegReg(is64Bit), node, resultReg, reg, cg);
+    Inst_Reg(OP::NEGReg(is64Bit), node, resultReg, cg);
+    Inst_RegReg(OP::ANDRegReg(is64Bit), node, resultReg, reg, cg);
     return resultReg;
 }
 
@@ -3999,11 +3968,11 @@ TR::Register *J9::X86::TreeEvaluator::longLowestOneBit(TR::Node *node, TR::CodeG
         TR::Register *inputHigh = inputReg->getHighOrder();
         TR::Register *inputLow = inputReg->getLowOrder();
         TR::Register *scratchReg = cg->allocateRegister();
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, scratchReg, scratchReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, scratchReg, scratchReg, cg);
         TR::Register *resultLow = lowestOneBit(node, cg, inputLow, false);
-        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, scratchReg, cg);
-        Inst_Reg(TR::InstOpCode::DEC4Reg, node, scratchReg, cg);
-        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, scratchReg, inputHigh, cg);
+        Inst_Reg(OP::SETNE1Reg, node, scratchReg, cg);
+        Inst_Reg(OP::DEC4Reg, node, scratchReg, cg);
+        Inst_RegReg(OP::AND4RegReg, node, scratchReg, inputHigh, cg);
         TR::Register *resultHigh = lowestOneBit(node, cg, scratchReg, false);
         cg->stopUsingRegister(scratchReg);
         resultReg = cg->allocateRegisterPair(resultLow, resultHigh);
@@ -4027,14 +3996,14 @@ static TR::Register *numberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg,
     // ret r1
     TR::Register *maskReg = cg->allocateRegister();
     TR::Register *bsrReg = cg->allocateRegister();
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-    Inst_RegReg(TR::InstOpCode::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
-    Inst_Reg(TR::InstOpCode::SETE1Reg, node, maskReg, cg);
-    Inst_Reg(TR::InstOpCode::DECReg(is64Bit), node, maskReg, cg);
-    Inst_Reg(TR::InstOpCode::INCReg(is64Bit), node, bsrReg, cg);
-    Inst_RegReg(TR::InstOpCode::ANDRegReg(is64Bit), node, bsrReg, maskReg, cg);
-    Inst_RegImm(TR::InstOpCode::MOVRegImm4(is64Bit), node, maskReg, isLong ? 64 : 32, cg);
-    Inst_RegReg(TR::InstOpCode::SUBRegReg(is64Bit), node, maskReg, bsrReg, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, maskReg, maskReg, cg);
+    Inst_RegReg(OP::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
+    Inst_Reg(OP::SETE1Reg, node, maskReg, cg);
+    Inst_Reg(OP::DECReg(is64Bit), node, maskReg, cg);
+    Inst_Reg(OP::INCReg(is64Bit), node, bsrReg, cg);
+    Inst_RegReg(OP::ANDRegReg(is64Bit), node, bsrReg, maskReg, cg);
+    Inst_RegImm(OP::MOVRegImm4(is64Bit), node, maskReg, isLong ? 64 : 32, cg);
+    Inst_RegReg(OP::SUBRegReg(is64Bit), node, maskReg, bsrReg, cg);
     cg->stopUsingRegister(bsrReg);
     return maskReg;
 }
@@ -4072,12 +4041,12 @@ TR::Register *J9::X86::TreeEvaluator::longNumberOfLeadingZeros(TR::Node *node, T
         TR::Register *resultHigh = numberOfLeadingZeros(node, cg, inputHigh, false, false);
         TR::Register *resultLow = numberOfLeadingZeros(node, cg, inputLow, false, false);
         TR::Register *maskReg = cg->allocateRegister();
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, inputHigh, 0, cg);
-        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
-        Inst_Reg(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
-        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, resultLow, maskReg, cg);
-        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, resultHigh, resultLow, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, maskReg, maskReg, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, inputHigh, 0, cg);
+        Inst_Reg(OP::SETNE1Reg, node, maskReg, cg);
+        Inst_Reg(OP::DEC4Reg, node, maskReg, cg);
+        Inst_RegReg(OP::AND4RegReg, node, resultLow, maskReg, cg);
+        Inst_RegReg(OP::ADD4RegReg, node, resultHigh, resultLow, cg);
         cg->stopUsingRegister(resultLow);
         cg->stopUsingRegister(maskReg);
         resultReg = resultHigh;
@@ -4103,14 +4072,14 @@ static TR::Register *numberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg
     TR::Register *bsfReg = cg->allocateRegister();
     TR::Register *tempReg = cg->allocateRegister();
     TR::Register *maskReg = cg->allocateRegister();
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
-    Inst_RegReg(TR::InstOpCode::BSFRegReg(is64Bit), node, bsfReg, reg, cg);
-    Inst_Reg(TR::InstOpCode::SETE1Reg, node, tempReg, cg);
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(is64Bit), node, maskReg, tempReg, cg);
-    Inst_Reg(TR::InstOpCode::DECReg(is64Bit), node, maskReg, cg);
-    Inst_RegImm(TR::InstOpCode::SHLRegImm1(is64Bit), node, tempReg, isLong ? 6 : 5, cg);
-    Inst_RegReg(TR::InstOpCode::ANDRegReg(is64Bit), node, bsfReg, maskReg, cg);
-    Inst_RegReg(TR::InstOpCode::ADDRegReg(is64Bit), node, bsfReg, tempReg, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, tempReg, tempReg, cg);
+    Inst_RegReg(OP::BSFRegReg(is64Bit), node, bsfReg, reg, cg);
+    Inst_Reg(OP::SETE1Reg, node, tempReg, cg);
+    Inst_RegReg(OP::MOVRegReg(is64Bit), node, maskReg, tempReg, cg);
+    Inst_Reg(OP::DECReg(is64Bit), node, maskReg, cg);
+    Inst_RegImm(OP::SHLRegImm1(is64Bit), node, tempReg, isLong ? 6 : 5, cg);
+    Inst_RegReg(OP::ANDRegReg(is64Bit), node, bsfReg, maskReg, cg);
+    Inst_RegReg(OP::ADDRegReg(is64Bit), node, bsfReg, tempReg, cg);
     cg->stopUsingRegister(tempReg);
     cg->stopUsingRegister(maskReg);
     return bsfReg;
@@ -4149,12 +4118,12 @@ TR::Register *J9::X86::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, 
         TR::Register *maskReg = cg->allocateRegister();
         TR::Register *resultLow = numberOfTrailingZeros(node, cg, inputLow, false, false);
         TR::Register *resultHigh = numberOfTrailingZeros(node, cg, inputHigh, false, false);
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, resultLow, 32, cg);
-        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
-        Inst_Reg(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
-        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, maskReg, resultHigh, cg);
-        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, resultLow, maskReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, maskReg, maskReg, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, resultLow, 32, cg);
+        Inst_Reg(OP::SETNE1Reg, node, maskReg, cg);
+        Inst_Reg(OP::DEC4Reg, node, maskReg, cg);
+        Inst_RegReg(OP::AND4RegReg, node, maskReg, resultHigh, cg);
+        Inst_RegReg(OP::ADD4RegReg, node, resultLow, maskReg, cg);
         cg->stopUsingRegister(resultHigh);
         cg->stopUsingRegister(maskReg);
         resultReg = resultLow;
@@ -4187,7 +4156,7 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     startLabel->setStartInternalControlFlow();
     fallThruLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     TR_OutlinedInstructions *outlinedHelperCall
         = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::call, NULL, outlinedCallLabel, fallThruLabel, cg);
@@ -4198,61 +4167,59 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
         generateLoadJ9Class(node, objClassReg, ObjReg, cg);
 
     // temp2Reg holds romClass of cast class, for testing array, interface class type
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp2Reg, MRef_Bdisp32(castClassReg, offsetof(J9Class, romClass), cg),
-        cg);
+    Inst_RegMem(OP::LRegMem(), node, temp2Reg, MRef_Bdisp32(castClassReg, offsetof(J9Class, romClass), cg), cg);
 
     // If cast class is array, call out of line helper
-    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg),
-        J9AccClassArray, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, outlinedCallLabel, cg);
+    Inst_MemImm(OP::TEST4MemImm4, node, MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray,
+        cg);
+    Inst_Label(OP::JNE4, node, outlinedCallLabel, cg);
 
     // objClassReg holds object class
     if (!isCheckCastAndNullCheck) {
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, ObjReg, ObjReg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+        Inst_RegReg(OP::TESTRegReg(), node, ObjReg, ObjReg, cg);
+        Inst_Label(OP::JE4, node, fallThruLabel, cg);
         generateLoadJ9Class(node, objClassReg, ObjReg, cg);
     }
 
     // Object not array, inline checks
     // Check cast class is interface
-    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg),
-        J9AccInterface, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, isClassLabel, cg);
+    Inst_MemImm(OP::TEST4MemImm4, node, MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccInterface,
+        cg);
+    Inst_Label(OP::JE4, node, isClassLabel, cg);
 
     // Obtain I-Table
     // temp1Reg holds head of J9Class->iTable of obj class
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp1Reg, MRef_Bdisp32(objClassReg, offsetof(J9Class, iTable), cg),
-        cg);
+    Inst_RegMem(OP::LRegMem(), node, temp1Reg, MRef_Bdisp32(objClassReg, offsetof(J9Class, iTable), cg), cg);
     // Loop through I-Table
     // temp1Reg holds iTable list element through the loop
-    Inst_Label(TR::InstOpCode::label, node, iTableLoopLabel, cg);
-    Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, temp1Reg, temp1Reg, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, throwLabel, cg);
+    Inst_Label(OP::label, node, iTableLoopLabel, cg);
+    Inst_RegReg(OP::TESTRegReg(), node, temp1Reg, temp1Reg, cg);
+    Inst_Label(OP::JE4, node, throwLabel, cg);
     auto interfaceMR = MRef_Bdisp32(temp1Reg, offsetof(J9ITable, interfaceClass), cg);
-    Inst_MemReg(TR::InstOpCode::CMPMemReg(), node, interfaceMR, castClassReg, cg);
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp1Reg, MRef_Bdisp32(temp1Reg, offsetof(J9ITable, next), cg), cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
+    Inst_MemReg(OP::CMPMemReg(), node, interfaceMR, castClassReg, cg);
+    Inst_RegMem(OP::LRegMem(), node, temp1Reg, MRef_Bdisp32(temp1Reg, offsetof(J9ITable, next), cg), cg);
+    Inst_Label(OP::JNE4, node, iTableLoopLabel, cg);
 
     // Found from I-Table
-    Inst_Label(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
+    Inst_Label(OP::JMP4, node, fallThruLabel, cg);
 
     // cast class is non-interface class
-    Inst_Label(TR::InstOpCode::label, node, isClassLabel, cg);
+    Inst_Label(OP::label, node, isClassLabel, cg);
     // equality test
-    Inst_RegReg(TR::InstOpCode::CMPRegReg(use64BitClasses), node, objClassReg, castClassReg, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+    Inst_RegReg(OP::CMPRegReg(use64BitClasses), node, objClassReg, castClassReg, cg);
+    Inst_Label(OP::JE4, node, fallThruLabel, cg);
 
     // class not equal
     // temp2 holds cast class depth
     // class depth mask must be low 16 bits to safely load without the mask.
     static_assert(J9AccClassDepthMask == 0xffff, "J9_JAVA_CLASS_DEPTH_MASK must be 0xffff");
-    Inst_RegMem(comp->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Mem2 : TR::InstOpCode::MOVZXReg4Mem2, node,
-        temp2Reg, MRef_Bdisp32(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+    Inst_RegMem(comp->target().is64Bit() ? OP::MOVZXReg8Mem2 : OP::MOVZXReg4Mem2, node, temp2Reg,
+        MRef_Bdisp32(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
 
     // cast class depth >= obj class depth, throw
-    Inst_RegMem(TR::InstOpCode::CMP2RegMem, node, temp2Reg,
-        MRef_Bdisp32(objClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-    Inst_Label(TR::InstOpCode::JAE4, node, throwLabel, cg);
+    Inst_RegMem(OP::CMP2RegMem, node, temp2Reg, MRef_Bdisp32(objClassReg, offsetof(J9Class, classDepthAndFlags), cg),
+        cg);
+    Inst_Label(OP::JAE4, node, throwLabel, cg);
 
     // check obj class's super class array entry
     // temp1Reg holds superClasses array of obj class
@@ -4263,17 +4230,16 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     // On 64 bit, the extra reg isn't likely to cause significant register pressure.
     // On 32 bit, it could put more register pressure due to limited number of regs.
     // Since 64-bit is more prevalent, we opt to optimize for 64bit in this case
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        MRef_Bdisp32(objClassReg, offsetof(J9Class, superclasses), cg), cg);
-    Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, castClassReg,
+    Inst_RegMem(OP::LRegMem(), node, temp1Reg, MRef_Bdisp32(objClassReg, offsetof(J9Class, superclasses), cg), cg);
+    Inst_RegMem(OP::CMPRegMem(use64BitClasses), node, castClassReg,
         MRef_BIS(temp1Reg, temp2Reg, comp->target().is64Bit() ? 3 : 2, cg), cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, throwLabel, cg);
+    Inst_Label(OP::JNE4, node, throwLabel, cg);
 
     // throw classCastException
     {
         TR_OutlinedInstructionsGenerator og(throwLabel, node, cg);
-        Inst_Reg(TR::InstOpCode::PUSHReg, node, objClassReg, cg);
-        Inst_Reg(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
+        Inst_Reg(OP::PUSHReg, node, objClassReg, cg);
+        Inst_Reg(OP::PUSHReg, node, castClassReg, cg);
         auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
         call->setNeedsGCMap(0xFF00FFFF);
         call->setAdjustsFramePointerBy(-2 * (int32_t)sizeof(J9Class *));
@@ -4305,7 +4271,7 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
 
     deps->stopAddingConditions();
 
-    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(OP::label, node, fallThruLabel, deps, cg);
 
     cg->stopUsingRegister(temp1Reg);
     cg->stopUsingRegister(temp2Reg);
@@ -4377,14 +4343,14 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
         cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     static char *breakOnInlineObjectArrayCheck = feGetEnv("TR_BreakOnInlineObjectArrayCheck");
     if (breakOnInlineObjectArrayCheck)
-        Inst(TR::InstOpCode::INT3, node, cg);
+        Inst(OP::INT3, node, cg);
 
     if (!isCheckCast) {
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, resultReg, resultReg, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4396,8 +4362,8 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
     // -----------------------------------------------------------------------
 
     if (!objectNode->isNonNull()) {
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, objectReg, objectReg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+        Inst_RegReg(OP::TESTRegReg(), node, objectReg, objectReg, cg);
+        Inst_Label(OP::JE4, node, fallThruLabel, cg);
     }
 
     // The cast class is an array of j/l/Objects. Check if the
@@ -4413,24 +4379,22 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
 
     // Check if romClass is an array
     //
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, romClassReg,
-        MRef_Bdisp32(objectClassReg, offsetof(J9Class, romClass), cg), cg);
-    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg),
-        J9AccClassArray, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, notCastableLabel, cg);
+    Inst_RegMem(OP::LRegMem(), node, romClassReg, MRef_Bdisp32(objectClassReg, offsetof(J9Class, romClass), cg), cg);
+    Inst_MemImm(OP::TEST4MemImm4, node, MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray,
+        cg);
+    Inst_Label(OP::JE4, node, notCastableLabel, cg);
 
     // Check if object class is a primitive array
     //
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, componentClassReg,
+    Inst_RegMem(OP::LRegMem(), node, componentClassReg,
         MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, componentType), cg), cg);
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, romClassReg,
-        MRef_Bdisp32(componentClassReg, offsetof(J9Class, romClass), cg), cg);
-    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg),
+    Inst_RegMem(OP::LRegMem(), node, romClassReg, MRef_Bdisp32(componentClassReg, offsetof(J9Class, romClass), cg), cg);
+    Inst_MemImm(OP::TEST4MemImm4, node, MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg),
         J9AccClassInternalPrimitiveType, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, notCastableLabel, cg);
+    Inst_Label(OP::JNE4, node, notCastableLabel, cg);
 
     if (!isCheckCast) {
-        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, resultReg, 1, cg);
+        Inst_RegImm(OP::MOV4RegImm4, node, resultReg, 1, cg);
     }
 
     // clang-format off
@@ -4472,7 +4436,7 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
     }
 
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(OP::label, node, fallThruLabel, deps, cg);
 
     cg->stopUsingRegister(scratchReg);
     if (objectReg != objectClassReg)
@@ -4547,12 +4511,12 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
 
     static char *breakOnInlineFinalArrayCastClass = feGetEnv("TR_BreakOnInlineFinalArrayCastClass");
     if (breakOnInlineFinalArrayCastClass)
-        Inst(TR::InstOpCode::INT3, node, cg);
+        Inst(OP::INT3, node, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     if (!isCheckCast) {
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, resultReg, resultReg, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4564,12 +4528,12 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
     // -----------------------------------------------------------------------
 
     if (!objectNode->isNonNull()) {
-        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, objectReg, objectReg, cg);
+        Inst_RegReg(OP::TEST8RegReg, node, objectReg, objectReg, cg);
 
         // checkcast leaves the operand stack unaffected
         // instanceof returns 0 if the objectRef is null
         //
-        Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+        Inst_Label(OP::JE4, node, fallThruLabel, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4588,11 +4552,11 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
     uintptr_t clazzAddress = (uintptr_t)clazz;
 
     if (IS_32BIT_SIGNED(clazzAddress) && !comp->compileRelocatableCode()) {
-        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
+        Inst_RegImm(OP::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
     } else {
         scratchReg = cg->allocateRegister();
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
-        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, objectClassReg, scratchReg, cg);
+        Inst_RegImm64(OP::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
+        Inst_RegReg(OP::CMP8RegReg, node, objectClassReg, scratchReg, cg);
     }
 
     if (isCheckCast) {
@@ -4604,9 +4568,9 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
             TR_OutlinedInstructions(node, TR::call, NULL, outlinedHelperCallLabel, fallThruLabel, cg);
         cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
 
-        Inst_Label(TR::InstOpCode::JNE4, node, outlinedHelperCallLabel, cg);
+        Inst_Label(OP::JNE4, node, outlinedHelperCallLabel, cg);
     } else {
-        Inst_Reg(TR::InstOpCode::SETE1Reg, node, resultReg, cg);
+        Inst_Reg(OP::SETE1Reg, node, resultReg, cg);
     }
 
     // ----------------------------------------------------------------------
@@ -4653,7 +4617,7 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
     }
 
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(OP::label, node, fallThruLabel, deps, cg);
 
     if (scratchReg)
         cg->stopUsingRegister(scratchReg);
@@ -4696,12 +4660,12 @@ static void generateCastClassCacheUpdate(TR::Register *objectClassReg, uintptr_t
         && (!use64BitClasses || (use64BitClasses && IS_32BIT_SIGNED(clazzAddress)));
 
     if (use32Bit) {
-        Inst_MemImm(TR::InstOpCode::S8MemImm4, node, castClassMR, (int32_t)clazzAddress, cg);
+        Inst_MemImm(OP::S8MemImm4, node, castClassMR, (int32_t)clazzAddress, cg);
     } else {
         if (!scratchReg)
             scratchReg = cg->allocateRegister();
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
-        Inst_MemReg(TR::InstOpCode::S8MemReg, node, castClassMR, scratchReg, cg);
+        Inst_RegImm64(OP::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
+        Inst_MemReg(OP::S8MemReg, node, castClassMR, scratchReg, cg);
     }
 }
 
@@ -4835,14 +4799,14 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
 
     static char *breakOnInlineArrayCastClass = feGetEnv("TR_BreakOnInlineArrayCastClass");
     if (breakOnInlineArrayCastClass)
-        Inst(TR::InstOpCode::INT3, node, cg);
+        Inst(OP::INT3, node, cg);
 
     TR::LabelSymbol *castableDoNotCacheLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *castableAndUpdateCacheLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *notCastableDoNotCacheLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *notCastableUpdateCacheLabel = generateLabelSymbol(cg);
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     // -----------------------------------------------------------------------
     // If the object is NULL, no exception is thrown for a checkcast and a 0
@@ -4853,13 +4817,13 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     // -----------------------------------------------------------------------
 
     if (!objectNode->isNonNull()) {
-        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, objectReg, objectReg, cg);
+        Inst_RegReg(OP::TEST8RegReg, node, objectReg, objectReg, cg);
 
         // checkcast leaves the operand stack unaffected
         // instanceof returns 0 if the objectRef is null
         //
         TR::LabelSymbol *nullTargetLabel = isCheckCast ? fallThruLabel : notCastableDoNotCacheLabel;
-        Inst_Label(TR::InstOpCode::JE4, node, nullTargetLabel, cg);
+        Inst_Label(OP::JE4, node, nullTargetLabel, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4875,14 +4839,14 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     uintptr_t clazzAddress = (uintptr_t)clazz;
 
     if (IS_32BIT_SIGNED(clazzAddress) && !comp->compileRelocatableCode()) {
-        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
+        Inst_RegImm(OP::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
     } else {
         scratchReg = cg->allocateRegister();
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
-        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, objectClassReg, scratchReg, cg);
+        Inst_RegImm64(OP::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
+        Inst_RegReg(OP::CMP8RegReg, node, objectClassReg, scratchReg, cg);
     }
 
-    Inst_Label(TR::InstOpCode::JE4, node, castableDoNotCacheLabel, cg);
+    Inst_Label(OP::JE4, node, castableDoNotCacheLabel, cg);
 
     // ----------------------------------------------------------------------
     // Next, check for a hit in the object's classCastCache
@@ -4891,34 +4855,34 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     if (!scratchReg)
         scratchReg = cg->allocateRegister();
 
-    Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
-        MRef_Bdisp32(objectClassReg, offsetof(J9Class, castClassCache), cg), cg);
+    Inst_RegMem(OP::L8RegMem, node, scratchReg, MRef_Bdisp32(objectClassReg, offsetof(J9Class, castClassCache), cg),
+        cg);
 
     if (use64BitClasses) {
         if (IS_32BIT_SIGNED(clazzAddress) && !comp->compileRelocatableCode()) {
-            Inst_RegImm(TR::InstOpCode::XOR8RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
+            Inst_RegImm(OP::XOR8RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
         } else {
             if (!scratchReg2)
                 scratchReg2 = cg->allocateRegister();
-            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg2, clazzAddress, cg, TR_ClassPointer);
-            Inst_RegReg(TR::InstOpCode::XOR8RegReg, node, scratchReg, scratchReg2, cg);
+            Inst_RegImm64(OP::MOV8RegImm64, node, scratchReg2, clazzAddress, cg, TR_ClassPointer);
+            Inst_RegReg(OP::XOR8RegReg, node, scratchReg, scratchReg2, cg);
         }
     } else {
-        Inst_RegImm(TR::InstOpCode::XOR4RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
+        Inst_RegImm(OP::XOR4RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
     }
 
-    Inst_RegImm(TR::InstOpCode::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_MASK, cg);
+    Inst_RegImm(OP::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_MASK, cg);
 
     TR::LabelSymbol *castClassCacheMissLabel = generateLabelSymbol(cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, castClassCacheMissLabel, cg);
+    Inst_Label(OP::JNE4, node, castClassCacheMissLabel, cg);
 
     // ----------------------------------------------------------------------
     // objectClass was found in the cache. Determine whether it was castable
     // or not and exit appropriately.
     // ----------------------------------------------------------------------
 
-    Inst_RegImm(TR::InstOpCode::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_UNCASTABLE, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, castableDoNotCacheLabel, cg);
+    Inst_RegImm(OP::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_UNCASTABLE, cg);
+    Inst_Label(OP::JE4, node, castableDoNotCacheLabel, cg);
 
     // ----------------------------------------------------------------------
     // If the cast class leaf component is not a reference array, the result
@@ -4927,31 +4891,31 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     if (fej9->isClassMixed((TR_OpaqueClassBlock *)castClassLeafJ9Class)) {
         // The JMP is required on this path to complete the above cache check
         //
-        Inst_Label(TR::InstOpCode::JMP4, node, notCastableDoNotCacheLabel, cg);
-        Inst_Label(TR::InstOpCode::label, node, castClassCacheMissLabel, cg);
+        Inst_Label(OP::JMP4, node, notCastableDoNotCacheLabel, cg);
+        Inst_Label(OP::label, node, castClassCacheMissLabel, cg);
 
         // ----------------------------------------------------------------------
         // Check if objectClass is an array. Not castable if it is not.
         // ----------------------------------------------------------------------
 
-        Inst_MemImm(IS_8BIT_SIGNED(J9AccClassRAMArray) ? TR::InstOpCode::TEST1MemImm1 : TR::InstOpCode::TEST4MemImm4,
-            node, MRef_Bdisp32(objectClassReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, notCastableUpdateCacheLabel, cg);
+        Inst_MemImm(IS_8BIT_SIGNED(J9AccClassRAMArray) ? OP::TEST1MemImm1 : OP::TEST4MemImm4, node,
+            MRef_Bdisp32(objectClassReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
+        Inst_Label(OP::JE4, node, notCastableUpdateCacheLabel, cg);
 
         // ----------------------------------------------------------------------
         // For an array objectClass, if objectClass->arity != castClass->arity
         // then perform cast check in helper
         // ----------------------------------------------------------------------
 
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
-            MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, arity), cg), cg);
+        Inst_RegMem(OP::L8RegMem, node, scratchReg, MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, arity), cg),
+            cg);
 
         UDATA arity = static_cast<TR_J9VM *>(fej9)->getArityFromArrayClass((TR_OpaqueClassBlock *)clazz);
-        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, scratchReg, arity, cg);
+        Inst_RegImm(OP::CMP8RegImm4, node, scratchReg, arity, cg);
 
         if (!oolHelperCallTrampolineLabel)
             oolHelperCallTrampolineLabel = generateLabelSymbol(cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, oolHelperCallTrampolineLabel, cg);
+        Inst_Label(OP::JNE4, node, oolHelperCallTrampolineLabel, cg);
 
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
         J9Class *castClassJ9Class = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
@@ -4959,14 +4923,12 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             static_assert(J9ClassArrayIsNullRestricted == 0x2000000,
                 "J9ClassArrayIsNullRestricted must be 0x2000000 for simple bit test");
 
-            Inst_MemImm(IS_8BIT_SIGNED(J9ClassArrayIsNullRestricted) ? TR::InstOpCode::TEST1MemImm1
-                                                                     : TR::InstOpCode::TEST4MemImm4,
-                node, MRef_Bdisp32(objectClassReg, offsetof(J9Class, classFlags), cg), J9ClassArrayIsNullRestricted,
-                cg);
+            Inst_MemImm(IS_8BIT_SIGNED(J9ClassArrayIsNullRestricted) ? OP::TEST1MemImm1 : OP::TEST4MemImm4, node,
+                MRef_Bdisp32(objectClassReg, offsetof(J9Class, classFlags), cg), J9ClassArrayIsNullRestricted, cg);
 
             // Fail, since a nullable array class cannot be cast to a null-restricted class
             //
-            Inst_Label(TR::InstOpCode::JE4, node, notCastableUpdateCacheLabel, cg);
+            Inst_Label(OP::JE4, node, notCastableUpdateCacheLabel, cg);
         }
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
@@ -4977,7 +4939,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         if (!objectClassLeafReg)
             objectClassLeafReg = cg->allocateRegister();
 
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, objectClassLeafReg,
+        Inst_RegMem(OP::L8RegMem, node, objectClassLeafReg,
             MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, leafComponentType), cg), cg);
 
         // ----------------------------------------------------------------------
@@ -4985,13 +4947,11 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // notCastableUpdateCache
         // ----------------------------------------------------------------------
 
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
+        Inst_RegMem(OP::L8RegMem, node, scratchReg,
             MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-        Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, scratchReg,
-            (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
-        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, scratchReg,
-            (OBJECT_HEADER_SHAPE_MIXED << J9AccClassRAMShapeShift), cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, notCastableUpdateCacheLabel, cg);
+        Inst_RegImm(OP::AND8RegImm4, node, scratchReg, (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
+        Inst_RegImm(OP::CMP8RegImm4, node, scratchReg, (OBJECT_HEADER_SHAPE_MIXED << J9AccClassRAMShapeShift), cg);
+        Inst_Label(OP::JNE4, node, notCastableUpdateCacheLabel, cg);
 
         // ----------------------------------------------------------------------
         // If objectClassLeafClass == castClassLeafClass then
@@ -5001,13 +4961,13 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         uintptr_t componentClazzAddress = (uintptr_t)castClassLeafJ9Class;
 
         if (IS_32BIT_SIGNED(componentClazzAddress) && !comp->compileRelocatableCode()) {
-            Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, objectClassLeafReg, (int32_t)componentClazzAddress, cg);
+            Inst_RegImm(OP::CMP8RegImm4, node, objectClassLeafReg, (int32_t)componentClazzAddress, cg);
         } else {
-            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, componentClazzAddress, cg, TR_ClassPointer);
-            Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, objectClassLeafReg, scratchReg, cg);
+            Inst_RegImm64(OP::MOV8RegImm64, node, scratchReg, componentClazzAddress, cg, TR_ClassPointer);
+            Inst_RegReg(OP::CMP8RegReg, node, objectClassLeafReg, scratchReg, cg);
         }
 
-        Inst_Label(TR::InstOpCode::JE4, node, castableAndUpdateCacheLabel, cg);
+        Inst_Label(OP::JE4, node, castableAndUpdateCacheLabel, cg);
 
         // ----------------------------------------------------------------------
         // Skip the subclass check if the castClassLeaf is final
@@ -5026,7 +4986,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             static_assert(J9AccClassDepthMask == 0xffff, "J9AccClassDepthMask must be 0xffff");
             TR::MemoryReference *objectClassLeafDepthMR
                 = MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg);
-            Inst_MemImm(TR::InstOpCode::CMP2MemImm2, node, objectClassLeafDepthMR, castClassLeafDepth, cg);
+            Inst_MemImm(OP::CMP2MemImm2, node, objectClassLeafDepthMR, castClassLeafDepth, cg);
 
             if (castClassLeafIsInterface) {
                 // Too complex for inline; perform cast check in helper.
@@ -5034,14 +4994,14 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
                 //
                 if (!oolHelperCallTrampolineLabel)
                     oolHelperCallTrampolineLabel = generateLabelSymbol(cg);
-                Inst_Label(TR::InstOpCode::JBE4, node, oolHelperCallTrampolineLabel, cg);
+                Inst_Label(OP::JBE4, node, oolHelperCallTrampolineLabel, cg);
             } else {
                 TR_ASSERT_FATAL(!TR::Compiler->cls.isClassArray(comp, castClassLeafClass),
                     "Expected cast class leaf component to be non-array");
-                Inst_Label(TR::InstOpCode::JBE4, node, notCastableUpdateCacheLabel, cg);
+                Inst_Label(OP::JBE4, node, notCastableUpdateCacheLabel, cg);
             }
 
-            Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
+            Inst_RegMem(OP::L8RegMem, node, scratchReg,
                 MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, superclasses), cg), cg);
             auto offset = castClassLeafDepth * sizeof(J9Class *);
             TR_ASSERT_FATAL(IS_32BIT_SIGNED(offset), "superclass array offset is unreasonably large");
@@ -5049,26 +5009,25 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             TR::MemoryReference *superclassMR2 = MRef_Bdisp32(scratchReg, offset, cg);
             if (use64BitClasses) {
                 if (IS_32BIT_SIGNED(componentClazzAddress) && !comp->compileRelocatableCode()) {
-                    Inst_MemImm(TR::InstOpCode::CMP8MemImm4, node, superclassMR2, (int32_t)componentClazzAddress, cg);
+                    Inst_MemImm(OP::CMP8MemImm4, node, superclassMR2, (int32_t)componentClazzAddress, cg);
                 } else {
                     if (!scratchReg3)
                         scratchReg3 = cg->allocateRegister();
 
-                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg3, componentClazzAddress, cg,
-                        TR_ClassPointer);
-                    Inst_MemReg(TR::InstOpCode::CMP8MemReg, node, superclassMR2, scratchReg3, cg);
+                    Inst_RegImm64(OP::MOV8RegImm64, node, scratchReg3, componentClazzAddress, cg, TR_ClassPointer);
+                    Inst_MemReg(OP::CMP8MemReg, node, superclassMR2, scratchReg3, cg);
                 }
             } else {
-                Inst_MemImm(TR::InstOpCode::CMP4MemImm4, node, superclassMR2, (int32_t)componentClazzAddress, cg);
+                Inst_MemImm(OP::CMP4MemImm4, node, superclassMR2, (int32_t)componentClazzAddress, cg);
             }
 
-            Inst_Label(TR::InstOpCode::JE4, node, castableAndUpdateCacheLabel, cg);
+            Inst_Label(OP::JE4, node, castableAndUpdateCacheLabel, cg);
         }
 
         if (castClassLeafIsInterface) {
             if (!oolHelperCallTrampolineLabel)
                 oolHelperCallTrampolineLabel = generateLabelSymbol(cg);
-            Inst_Label(TR::InstOpCode::JMP4, node, oolHelperCallTrampolineLabel, cg);
+            Inst_Label(OP::JMP4, node, oolHelperCallTrampolineLabel, cg);
         } else {
             TR_ASSERT_FATAL(!TR::Compiler->cls.isClassArray(comp, castClassLeafClass),
                 "Expected cast class leaf component to be non-array");
@@ -5077,17 +5036,17 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // Generated code will fall through to notCastableUpdateCacheLabel
 
     } else {
-        Inst_Label(TR::InstOpCode::label, node, castClassCacheMissLabel, cg);
+        Inst_Label(OP::label, node, castClassCacheMissLabel, cg);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, notCastableUpdateCacheLabel, cg);
+    Inst_Label(OP::label, node, notCastableUpdateCacheLabel, cg);
     generateCastClassCacheUpdate(objectClassReg, clazzAddress | 1, use64BitClasses, scratchReg, node, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, notCastableDoNotCacheLabel, cg);
+    Inst_Label(OP::label, node, notCastableDoNotCacheLabel, cg);
 
     if (!isCheckCast) {
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
-        Inst_Label(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, resultReg, resultReg, cg);
+        Inst_Label(OP::JMP4, node, fallThruLabel, cg);
     } else {
         // The out-of-line helper will throw the CastClassException
         //
@@ -5111,17 +5070,17 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // have not been fully determined, but until they are fully understood and that OOL
         // design is reworked, use a single branch to reach each unique OOL helper call.
         //
-        Inst_Label(TR::InstOpCode::label, node, oolHelperCallTrampolineLabel, cg);
-        Inst_Label(TR::InstOpCode::JMP4, node, outlinedHelperCallLabel, cg);
+        Inst_Label(OP::label, node, oolHelperCallTrampolineLabel, cg);
+        Inst_Label(OP::JMP4, node, outlinedHelperCallLabel, cg);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, castableAndUpdateCacheLabel, cg);
+    Inst_Label(OP::label, node, castableAndUpdateCacheLabel, cg);
     generateCastClassCacheUpdate(objectClassReg, clazzAddress, use64BitClasses, scratchReg, node, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, castableDoNotCacheLabel, cg);
+    Inst_Label(OP::label, node, castableDoNotCacheLabel, cg);
 
     if (!isCheckCast) {
-        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, resultReg, 1, cg);
+        Inst_RegImm(OP::MOV4RegImm4, node, resultReg, 1, cg);
     }
 
     // ----------------------------------------------------------------------
@@ -5176,7 +5135,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     }
 
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(OP::label, node, fallThruLabel, deps, cg);
 
     if (scratchReg)
         cg->stopUsingRegister(scratchReg);
@@ -5248,7 +5207,7 @@ static void generateInlinedCheckCastOrInstanceOfForArrayClass(TR::Node *node, TR
         // Just touch the memory in case this is a NULL pointer and we need to throw
         // the exception after the checkcast. If the checkcast was combined with nullpointer
         // there's nobody after the checkcast to throw the exception.
-        auto instr = Inst_MemImm(TR::InstOpCode::TEST1MemImm1, node,
+        auto instr = Inst_MemImm(OP::TEST1MemImm1, node,
             MRef_Bdisp32(object, TR::Compiler->om.offsetOfObjectVftField(), cg), 0, cg);
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
@@ -5277,23 +5236,23 @@ static void inlineInterfaceLookup(TR::Node *node, TR::CodeGenerator *cg, TR::Lab
     TR::LabelSymbol *iTableLoopLabel = generateLabelSymbol(cg);
 
     if (castClassReg) {
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, castClassReg, reinterpret_cast<uintptr_t>(castClass), cg,
+        Inst_RegImm64(OP::MOV8RegImm64, node, castClassReg, reinterpret_cast<uintptr_t>(castClass), cg,
             TR_ClassAddress);
     }
 
     // Loop through I-Table
-    Inst_Label(TR::InstOpCode::label, node, iTableLoopLabel, cg);
-    Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, itableReg, itableReg, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, iTableLookUpFailLabel, cg);
+    Inst_Label(OP::label, node, iTableLoopLabel, cg);
+    Inst_RegReg(OP::TESTRegReg(), node, itableReg, itableReg, cg);
+    Inst_Label(OP::JE4, node, iTableLookUpFailLabel, cg);
     auto interfaceMR = MRef_Bdisp32(itableReg, offsetof(J9ITable, interfaceClass), cg);
     if (castClassReg) {
-        Inst_MemReg(TR::InstOpCode::CMP8MemReg, node, interfaceMR, castClassReg, cg);
+        Inst_MemReg(OP::CMP8MemReg, node, interfaceMR, castClassReg, cg);
     } else {
-        Inst_MemImmSym(TR::InstOpCode::CMP4MemImm4, node, interfaceMR, reinterpret_cast<uintptr_t>(castClass),
+        Inst_MemImmSym(OP::CMP4MemImm4, node, interfaceMR, reinterpret_cast<uintptr_t>(castClass),
             node->getChild(1)->getSymbolReference(), cg);
     }
-    Inst_RegMem(TR::InstOpCode::LRegMem(), node, itableReg, MRef_Bdisp32(itableReg, offsetof(J9ITable, next), cg), cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
+    Inst_RegMem(OP::LRegMem(), node, itableReg, MRef_Bdisp32(itableReg, offsetof(J9ITable, next), cg), cg);
+    Inst_Label(OP::JNE4, node, iTableLoopLabel, cg);
 
     // If the loop does not iterate then a match was found
 }
@@ -5377,15 +5336,15 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
     TR::LabelSymbol *iTableLookUpPathLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *iTableLookUpFailLabel = generateLabelSymbol(cg);
 
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, instanceClassReg, node->getChild(0)->getRegister(), cg);
-    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, instanceClassReg, node->getChild(0)->getRegister(), cg);
+    Inst_Label(OP::label, node, begLabel, cg);
 
     // Null test
     if (!node->getChild(0)->isNonNull() && node->getOpCodeValue() != TR::checkcastAndNULLCHK) {
         // instanceClassReg contains the object at this point, reusing the register as object is no longer used after
         // this point.
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, instanceClassReg, instanceClassReg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, endLabel, cg);
+        Inst_RegReg(OP::TESTRegReg(), node, instanceClassReg, instanceClassReg, cg);
+        Inst_Label(OP::JE4, node, endLabel, cg);
     }
 
     // Load J9Class
@@ -5396,22 +5355,22 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
         auto cache = sizeof(J9Class *) == 4 ? cg->create4ByteData(node, (uint32_t)guessClass)
                                             : cg->create8ByteData(node, (uint64_t)guessClass);
         cache->setClassAddress(true);
-        Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, instanceClassReg, MRef_const(cache, cg), cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, iTableLookUpPathLabel, cg);
+        Inst_RegMem(OP::CMPRegMem(use64BitClasses), node, instanceClassReg, MRef_const(cache, cg), cg);
+        Inst_Label(OP::JNE4, node, iTableLookUpPathLabel, cg);
 
         // I-Table lookup out-of-line
         {
             TR_OutlinedInstructionsGenerator og(iTableLookUpPathLabel, node, cg);
 
             // Preserve the instance class before the register is reused
-            Inst_Reg(TR::InstOpCode::PUSHReg, node, instanceClassReg, cg);
+            Inst_Reg(OP::PUSHReg, node, instanceClassReg, cg);
 
             // Save VFP
             auto vfp = Inst_VFPSave(node, cg);
 
             // Obtain I-Table
             // Re-use the instanceClassReg register to perform itable lookup
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, instanceClassReg,
+            Inst_RegMem(OP::LRegMem(), node, instanceClassReg,
                 MRef_Bdisp32(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
 
             inlineInterfaceLookup(node, cg, iTableLookUpFailLabel, castClass, castClassReg, instanceClassReg);
@@ -5428,35 +5387,34 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
              */
             static bool updateCacheSlot = feGetEnv("TR_updateInterfaceCheckCastCacheSlot") != NULL;
             if (updateCacheSlot) {
-                Inst_Mem(TR::InstOpCode::POPMem, node, MRef_const(cache, cg),
+                Inst_Mem(OP::POPMem, node, MRef_const(cache, cg),
                     cg); // j9class
             } else {
-                Inst_Reg(TR::InstOpCode::POPReg, node, instanceClassReg, cg); // j9class
+                Inst_Reg(OP::POPReg, node, instanceClassReg, cg); // j9class
             }
 
             if (!isCheckCast) {
-                Inst(TR::InstOpCode::STC, node, cg);
+                Inst(OP::STC, node, cg);
             }
-            Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+            Inst_Label(OP::JMP4, node, endLabel, cg);
 
             // Not found
             Inst_VFPRestore(vfp, node, cg);
 
-            Inst_Label(TR::InstOpCode::label, node, iTableLookUpFailLabel, cg);
+            Inst_Label(OP::label, node, iTableLookUpFailLabel, cg);
 
             if (isCheckCast) {
                 if (castClassReg) {
-                    Inst_Reg(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
+                    Inst_Reg(OP::PUSHReg, node, castClassReg, cg);
                 } else {
-                    Inst_Imm(TR::InstOpCode::PUSHImm4, node,
-                        static_cast<int32_t>(reinterpret_cast<uintptr_t>(castClass)), cg);
+                    Inst_Imm(OP::PUSHImm4, node, static_cast<int32_t>(reinterpret_cast<uintptr_t>(castClass)), cg);
                 }
                 auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
                 call->setNeedsGCMap(0xFF00FFFF);
                 call->setAdjustsFramePointerBy(-2 * (int32_t)sizeof(J9Class *));
             } else {
-                Inst_Reg(TR::InstOpCode::POPReg, node, instanceClassReg, cg);
-                Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+                Inst_Reg(OP::POPReg, node, instanceClassReg, cg);
+                Inst_Label(OP::JMP4, node, endLabel, cg);
             }
 
             og.endOutlinedInstructionSequence();
@@ -5464,7 +5422,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
 
         // Succeed
         if (!isCheckCast) {
-            Inst(TR::InstOpCode::STC, node, cg);
+            Inst(OP::STC, node, cg);
         }
     } else {
         /**
@@ -5479,28 +5437,26 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
         TR::Register *itableReg = scratchReg ? scratchReg : instanceClassReg;
 
         // Obtain I-Table
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, itableReg,
-            MRef_Bdisp32(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
+        Inst_RegMem(OP::LRegMem(), node, itableReg, MRef_Bdisp32(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
 
         inlineInterfaceLookup(node, cg, isCheckCast ? iTableLookUpFailLabel : endLabel, castClass, castClassReg,
             itableReg);
 
         if (!isCheckCast) {
             // Class found in itable
-            Inst(TR::InstOpCode::STC, node, cg);
+            Inst(OP::STC, node, cg);
 
             // Fall through to endLabel
         } else {
             // CheckCast iTable fail lookup out-of-line
             TR_OutlinedInstructionsGenerator og(iTableLookUpFailLabel, node, cg);
 
-            Inst_Reg(TR::InstOpCode::PUSHReg, node, instanceClassReg, cg);
+            Inst_Reg(OP::PUSHReg, node, instanceClassReg, cg);
 
             if (castClassReg) {
-                Inst_Reg(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
+                Inst_Reg(OP::PUSHReg, node, castClassReg, cg);
             } else {
-                Inst_Imm(TR::InstOpCode::PUSHImm4, node, static_cast<int32_t>(reinterpret_cast<uintptr_t>(castClass)),
-                    cg);
+                Inst_Imm(OP::PUSHImm4, node, static_cast<int32_t>(reinterpret_cast<uintptr_t>(castClass)), cg);
             }
             auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
             call->setNeedsGCMap(0xFF00FFFF);
@@ -5510,7 +5466,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
         }
     }
 
-    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(OP::label, node, endLabel, deps, cg);
 
     cg->stopUsingRegister(instanceClassReg);
 
@@ -5564,14 +5520,14 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
     auto successLabel = isCheckCast ? endLabel : generateLabelSymbol(cg);
     auto failLabel = isCheckCast ? generateLabelSymbol(cg) : endLabel;
 
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, j9class, node->getChild(0)->getRegister(), cg);
-    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, j9class, node->getChild(0)->getRegister(), cg);
+    Inst_Label(OP::label, node, begLabel, cg);
 
     // Null test
     if (!node->getChild(0)->isNonNull() && node->getOpCodeValue() != TR::checkcastAndNULLCHK) {
         // j9class contains the object at this point, reusing the register as object is no longer used after this point.
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, j9class, j9class, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, endLabel, cg);
+        Inst_RegReg(OP::TESTRegReg(), node, j9class, j9class, cg);
+        Inst_Label(OP::JE4, node, endLabel, cg);
     }
 
     // Load J9Class
@@ -5584,12 +5540,12 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
         // However, LHS for TR_checkAssignable may be abstract or interface as it may be an arbitrary class, and
         // hence equality test is always needed.
         if (use64BitClasses) {
-            Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, j9class, MRef_const(clazzData, cg), cg);
+            Inst_RegMem(OP::CMP8RegMem, node, j9class, MRef_const(clazzData, cg), cg);
         } else {
-            Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, j9class, (uintptr_t)clazz, cg);
+            Inst_RegImm(OP::CMP4RegImm4, node, j9class, (uintptr_t)clazz, cg);
         }
         if (!fej9->isClassFinal(clazz)) {
-            Inst_Label(TR::InstOpCode::JE4, node, successLabel, cg);
+            Inst_Label(OP::JE4, node, successLabel, cg);
         }
     }
     // at this point, ZF == 1 indicates success
@@ -5600,56 +5556,55 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
         if (depth >= comp->getOptions()->_minimumSuperclassArraySize) {
             static_assert(J9AccClassDepthMask == 0xffff, "J9AccClassDepthMask must be 0xffff");
             auto depthMR = MRef_Bdisp32(j9class, offsetof(J9Class, classDepthAndFlags), cg);
-            Inst_MemImm(TR::InstOpCode::CMP2MemImm2, node, depthMR, depth, cg);
+            Inst_MemImm(OP::CMP2MemImm2, node, depthMR, depth, cg);
             if (!isCheckCast) {
                 // Need ensure CF is cleared before reaching to fail label
                 auto outlineLabel = generateLabelSymbol(cg);
-                Inst_Label(TR::InstOpCode::JBE4, node, outlineLabel, cg);
+                Inst_Label(OP::JBE4, node, outlineLabel, cg);
 
                 TR_OutlinedInstructionsGenerator og(outlineLabel, node, cg);
-                Inst(TR::InstOpCode::CLC, node, cg);
-                Inst_Label(TR::InstOpCode::JMP4, node, failLabel, cg);
+                Inst(OP::CLC, node, cg);
+                Inst_Label(OP::JMP4, node, failLabel, cg);
                 og.endOutlinedInstructionSequence();
             } else {
-                Inst_Label(TR::InstOpCode::JBE4, node, failLabel, cg);
+                Inst_Label(OP::JBE4, node, failLabel, cg);
             }
         }
 
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, tmp, MRef_Bdisp32(j9class, offsetof(J9Class, superclasses), cg),
-            cg);
+        Inst_RegMem(OP::LRegMem(), node, tmp, MRef_Bdisp32(j9class, offsetof(J9Class, superclasses), cg), cg);
         auto offset = depth * sizeof(J9Class *);
         TR_ASSERT(IS_32BIT_SIGNED(offset), "The offset to superclass is unreasonably large.");
         auto superclass = MRef_Bdisp32(tmp, offset, cg);
         if (use64BitClasses) {
-            Inst_RegMem(TR::InstOpCode::L8RegMem, node, tmp, superclass, cg);
-            Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, tmp, MRef_const(clazzData, cg), cg);
+            Inst_RegMem(OP::L8RegMem, node, tmp, superclass, cg);
+            Inst_RegMem(OP::CMP8RegMem, node, tmp, MRef_const(clazzData, cg), cg);
         } else {
-            Inst_MemImm(TR::InstOpCode::CMP4MemImm4, node, superclass, (int32_t)(uintptr_t)clazz, cg);
+            Inst_MemImm(OP::CMP4MemImm4, node, superclass, (int32_t)(uintptr_t)clazz, cg);
         }
     }
     // at this point, ZF == 1 indicates success
 
     // Branch to success/fail path
     if (!isCheckCast) {
-        Inst(TR::InstOpCode::CLC, node, cg);
+        Inst(OP::CLC, node, cg);
     }
-    Inst_Label(TR::InstOpCode::JNE4, node, failLabel, cg);
+    Inst_Label(OP::JNE4, node, failLabel, cg);
 
     // Set CF to report success
     if (!isCheckCast) {
-        Inst_Label(TR::InstOpCode::label, node, successLabel, cg);
-        Inst(TR::InstOpCode::STC, node, cg);
+        Inst_Label(OP::label, node, successLabel, cg);
+        Inst(OP::STC, node, cg);
     }
 
     // Throw exception for CheckCast
     if (isCheckCast) {
         TR_OutlinedInstructionsGenerator og(failLabel, node, cg);
 
-        Inst_Reg(TR::InstOpCode::PUSHReg, node, j9class, cg);
+        Inst_Reg(OP::PUSHReg, node, j9class, cg);
         if (use64BitClasses) {
-            Inst_Mem(TR::InstOpCode::PUSHMem, node, MRef_const(clazzData, cg), cg);
+            Inst_Mem(OP::PUSHMem, node, MRef_const(clazzData, cg), cg);
         } else {
-            Inst_Imm(TR::InstOpCode::PUSHImm4, node, (int32_t)(uintptr_t)clazz, cg);
+            Inst_Imm(OP::PUSHImm4, node, (int32_t)(uintptr_t)clazz, cg);
         }
         auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
         call->setNeedsGCMap(0xFF00FFFF);
@@ -5659,7 +5614,7 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
     }
 
     // Succeed
-    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(OP::label, node, endLabel, deps, cg);
 
     cg->stopUsingRegister(j9class);
     cg->stopUsingRegister(tmp);
@@ -5697,8 +5652,8 @@ TR::Register *J9::X86::TreeEvaluator::checkcastinstanceofEvaluator(TR::Node *nod
         }
         if (!isCheckCast) {
             auto result = cg->allocateRegister();
-            Inst_Reg(TR::InstOpCode::SETB1Reg, node, result, cg);
-            Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, result, result, cg);
+            Inst_Reg(OP::SETB1Reg, node, result, cg);
+            Inst_RegReg(OP::MOVZXReg4Reg1, node, result, result, cg);
             node->setRegister(result);
         }
         cg->decReferenceCount(node->getChild(0));
@@ -5744,33 +5699,32 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         outlinedStartLabel->setStartInternalControlFlow();
         outlinedEndLabel->setEndInternalControlFlow();
 
-        // Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg);
+        // Inst_Label(OP::CALLImm4, node, gcMapPatchingLabel, cg);
         Inst_PatchableCodeAlignment(TR::X86PatchableCodeAlignmentInstruction::CALLImm4AtomicRegions,
-            Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
+            Inst_Label(OP::CALLImm4, node, gcMapPatchingLabel, cg), cg);
 
         TR_OutlinedInstructionsGenerator og(gcMapPatchingLabel, node, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, outlinedStartLabel, cg);
+        Inst_Label(OP::label, node, outlinedStartLabel, cg);
         // Load the address that we are going to patch and clean up the stack
         //
-        Inst_Reg(TR::InstOpCode::POPReg, node, patchableAddrReg, cg);
+        Inst_Reg(OP::POPReg, node, patchableAddrReg, cg);
 
         // check if there is already an async even pending
         //
-        Inst_MemImm(TR::InstOpCode::CMP8MemImm4, node, SOMmr, -1, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, asyncWithoutPatch, cg);
+        Inst_MemImm(OP::CMP8MemImm4, node, SOMmr, -1, cg);
+        Inst_Label(OP::JE4, node, asyncWithoutPatch, cg);
 
         // Signal the async event
         //
         static char *d = feGetEnv("TR_GCOnAsyncBREAK");
         if (d)
-            Inst(TR::InstOpCode::INT3, node, cg);
+            Inst(OP::INT3, node, cg);
 
-        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
+        Inst_MemImm(OP::S8MemImm4, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
-        Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, tempReg,
-            1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(), cg);
-        Inst_MemReg(TR::InstOpCode::LOR8MemReg, node,
+        Inst_RegImm(OP::MOV8RegImm4, node, tempReg, 1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(), cg);
+        Inst_MemReg(OP::LOR8MemReg, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg), tempReg, cg);
 
         // Populate the code we are going to patch in
@@ -5786,11 +5740,11 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         // Load the original value
         //
 
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, patchValReg, MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
-        Inst_RegReg(TR::InstOpCode::OR8RegReg, node, patchValReg, tempReg, cg);
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
-        Inst_RegReg(TR::InstOpCode::AND8RegReg, node, patchValReg, tempReg, cg);
+        Inst_RegMem(OP::L8RegMem, node, patchValReg, MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
+        Inst_RegImm64(OP::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
+        Inst_RegReg(OP::OR8RegReg, node, patchValReg, tempReg, cg);
+        Inst_RegImm64(OP::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
+        Inst_RegReg(OP::AND8RegReg, node, patchValReg, tempReg, cg);
 
         TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 4, cg);
         deps->addPostCondition(patchableAddrReg, TR::RealRegister::NoReg, cg);
@@ -5799,14 +5753,14 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
         deps->stopAddingConditions();
 
-        Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(patchableAddrReg, -5, cg), patchValReg, deps, cg);
-        Inst_Label(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
-        Inst_Label(TR::InstOpCode::JMP4, node, snippetLabel, cg);
+        Inst_MemReg(OP::S8MemReg, node, MRef_Bdisp32(patchableAddrReg, -5, cg), patchValReg, deps, cg);
+        Inst_Label(OP::label, node, asyncWithoutPatch, cg);
+        Inst_Label(OP::JMP4, node, snippetLabel, cg);
 
         cg->stopUsingRegister(patchableAddrReg);
         cg->stopUsingRegister(patchValReg);
         cg->stopUsingRegister(tempReg);
-        Inst_Label(TR::InstOpCode::label, node, outlinedEndLabel, cg);
+        Inst_Label(OP::label, node, outlinedEndLabel, cg);
 
         og.endOutlinedInstructionSequence();
     } else {
@@ -5833,31 +5787,31 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         outlinedEndLabel->setEndInternalControlFlow();
 
         // Inst_BoundaryAvoidance(TR::X86BoundaryAvoidanceInstruction::CALLImm4AtomicRegions, 8,
-        // 8,Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
+        // 8,Inst_Label(OP::CALLImm4, node, gcMapPatchingLabel, cg), cg);
         TR::Instruction *callInst
             = Inst_PatchableCodeAlignment(TR::X86PatchableCodeAlignmentInstruction::CALLImm4AtomicRegions,
-                Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
+                Inst_Label(OP::CALLImm4, node, gcMapPatchingLabel, cg), cg);
         TR::X86VFPSaveInstruction *vfpSaveInst = Inst_VFPSave(callInst->getPrev(), cg);
 
         TR_OutlinedInstructionsGenerator og(gcMapPatchingLabel, node, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, outlinedStartLabel, cg);
+        Inst_Label(OP::label, node, outlinedStartLabel, cg);
         // Load the address that we are going to patch and clean up the stack
         //
-        Inst_Reg(TR::InstOpCode::POPReg, node, patchableAddrReg, cg);
+        Inst_Reg(OP::POPReg, node, patchableAddrReg, cg);
 
         // check if there is already an async even pending
         //
-        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, node, SOMmr, -1, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, asyncWithoutPatch, cg);
+        Inst_MemImm(OP::CMP4MemImm4, node, SOMmr, -1, cg);
+        Inst_Label(OP::JE4, node, asyncWithoutPatch, cg);
 
         // Signal the async event
         //
-        Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
+        Inst_MemImm(OP::S4MemImm4, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
-        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, lowPatchValReg,
-            1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(), cg);
-        Inst_MemReg(TR::InstOpCode::LOR4MemReg, node,
+        Inst_RegImm(OP::MOV4RegImm4, node, lowPatchValReg, 1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(),
+            cg);
+        Inst_MemReg(OP::LOR4MemReg, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg), lowPatchValReg, cg);
 
         // Populate the registers we are going to use in the lock cmp xchg
@@ -5865,12 +5819,12 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
 
         static char *d = feGetEnv("TR_GCOnAsyncBREAK");
         if (d)
-            Inst(TR::InstOpCode::INT3, node, cg);
+            Inst(OP::INT3, node, cg);
 
         // Populate the existing inline code
         //
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, lowExistingValReg, MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, highExistingValReg, MRef_Bdisp32(patchableAddrReg, -1, cg), cg);
+        Inst_RegMem(OP::L4RegMem, node, lowExistingValReg, MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
+        Inst_RegMem(OP::L4RegMem, node, highExistingValReg, MRef_Bdisp32(patchableAddrReg, -1, cg), cg);
 
         // Populate the code we are going to patch in
         // 837d28ff        cmp     dword ptr [ebp+28h],0FFFFFFFFh <--- patching in
@@ -5878,9 +5832,9 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         //*******************
         //                 call imm4                              <---- patching over
         //
-        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, lowPatchValReg, (uint32_t)0x287d8390, cg);
-        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highPatchValReg, highExistingValReg, cg);
-        Inst_RegImm(TR::InstOpCode::OR4RegImm4, node, highPatchValReg, (uint32_t)0x000000ff, cg);
+        Inst_RegImm(OP::MOV4RegImm4, node, lowPatchValReg, (uint32_t)0x287d8390, cg);
+        Inst_RegReg(OP::MOV4RegReg, node, highPatchValReg, highExistingValReg, cg);
+        Inst_RegImm(OP::OR4RegImm4, node, highPatchValReg, (uint32_t)0x000000ff, cg);
 
         TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 6, cg);
 
@@ -5891,16 +5845,16 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         deps->addPostCondition(highExistingValReg, TR::RealRegister::edx, cg);
         deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
         deps->stopAddingConditions();
-        Inst_Mem(TR::InstOpCode::LCMPXCHG8BMem, node, MRef_Bdisp32(patchableAddrReg, -5, cg), deps, cg);
-        Inst_Label(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
-        Inst_VFPRestore(Inst_Label(TR::InstOpCode::JMP4, node, snippetLabel, cg), vfpSaveInst, cg);
+        Inst_Mem(OP::LCMPXCHG8BMem, node, MRef_Bdisp32(patchableAddrReg, -5, cg), deps, cg);
+        Inst_Label(OP::label, node, asyncWithoutPatch, cg);
+        Inst_VFPRestore(Inst_Label(OP::JMP4, node, snippetLabel, cg), vfpSaveInst, cg);
 
         cg->stopUsingRegister(patchableAddrReg);
         cg->stopUsingRegister(lowPatchValReg);
         cg->stopUsingRegister(highPatchValReg);
         cg->stopUsingRegister(lowExistingValReg);
         cg->stopUsingRegister(highExistingValReg);
-        Inst_Label(TR::InstOpCode::label, node, outlinedEndLabel, cg);
+        Inst_Label(OP::label, node, outlinedEndLabel, cg);
 
         og.endOutlinedInstructionSequence();
     }
@@ -5939,7 +5893,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
 
     TR_OutlinedInstructionsGenerator og(inlineRecursiveSnippetLabel, node, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, outlinedStartLabel, cg);
+    Inst_Label(OP::label, node, outlinedStartLabel, cg);
     TR::Register *lockWordReg = cg->allocateRegister();
     TR::Register *lockWordMaskedReg = cg->allocateRegister();
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
@@ -5948,15 +5902,14 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
         = node->getSymbolReference() == cg->comp()->getSymRefTab()->findOrCreateMethodMonitorEntrySymbolRef(NULL)
         || node->getSymbolReference() == cg->comp()->getSymRefTab()->findOrCreateMonitorEntrySymbolRef(NULL);
 
-    Inst_RegMem(TR::InstOpCode::LRegMem(use64bitOp), node, lockWordReg, MRef_Bdisp32(objectReg, lwOffset, cg), cg);
-    Inst_RegImm(TR::InstOpCode::ADDRegImm4(use64bitOp), node, lockWordReg,
-        isMonitorEnter ? INC_DEC_VALUE : -INC_DEC_VALUE, cg);
-    Inst_RegImm(TR::InstOpCode::MOVRegImm4(use64bitOp), node, lockWordMaskedReg, NON_INC_DEC_MASK - RES_BIT, cg);
-    Inst_RegReg(TR::InstOpCode::ANDRegReg(use64bitOp), node, lockWordMaskedReg, lockWordReg, cg);
-    Inst_RegReg(TR::InstOpCode::CMPRegReg(use64bitOp), node, lockWordMaskedReg, vmThreadReg, cg);
+    Inst_RegMem(OP::LRegMem(use64bitOp), node, lockWordReg, MRef_Bdisp32(objectReg, lwOffset, cg), cg);
+    Inst_RegImm(OP::ADDRegImm4(use64bitOp), node, lockWordReg, isMonitorEnter ? INC_DEC_VALUE : -INC_DEC_VALUE, cg);
+    Inst_RegImm(OP::MOVRegImm4(use64bitOp), node, lockWordMaskedReg, NON_INC_DEC_MASK - RES_BIT, cg);
+    Inst_RegReg(OP::ANDRegReg(use64bitOp), node, lockWordMaskedReg, lockWordReg, cg);
+    Inst_RegReg(OP::CMPRegReg(use64bitOp), node, lockWordMaskedReg, vmThreadReg, cg);
 
-    Inst_Label(TR::InstOpCode::JNE4, node, jitMonitorEnterOrExitSnippetLabel, cg);
-    Inst_MemReg(TR::InstOpCode::SMemReg(use64bitOp), node, MRef_Bdisp32(objectReg, lwOffset, cg), lockWordReg, cg);
+    Inst_Label(OP::JNE4, node, jitMonitorEnterOrExitSnippetLabel, cg);
+    Inst_MemReg(OP::SMemReg(use64bitOp), node, MRef_Bdisp32(objectReg, lwOffset, cg), lockWordReg, cg);
 
 #if defined(TR_TARGET_64BIT) && (JAVA_SPEC_VERSION >= 19)
     // Adjust J9VMThread ownedMonitorCount for execution paths that do not
@@ -5964,7 +5917,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     // this unconditionally.  There is no need to check for overflow or
     // underflow.
     //
-    Inst_Mem(isMonitorEnter ? TR::InstOpCode::INC8Mem : TR::InstOpCode::DEC8Mem, node,
+    Inst_Mem(isMonitorEnter ? OP::INC8Mem : OP::DEC8Mem, node,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
@@ -5974,9 +5927,9 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     restartDeps->addPostCondition(lockWordMaskedReg, TR::RealRegister::NoReg, cg);
     restartDeps->addPostCondition(lockWordReg, TR::RealRegister::NoReg, cg);
     restartDeps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, snippetRestartLabel, restartDeps, cg);
+    Inst_Label(OP::label, node, snippetRestartLabel, restartDeps, cg);
 
-    Inst_Label(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
+    Inst_Label(OP::JMP4, node, fallThruLabel, cg);
 
     cg->stopUsingRegister(lockWordReg);
     cg->stopUsingRegister(lockWordMaskedReg);
@@ -5984,7 +5937,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 1, cg);
     deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, outlinedEndLabel, deps, cg);
+    Inst_Label(OP::label, node, outlinedEndLabel, deps, cg);
 
     og.endOutlinedInstructionSequence();
 }
@@ -5998,14 +5951,14 @@ void J9::X86::TreeEvaluator::generateCheckForValueMonitorEnterOrExit(TR::Node *n
     auto fej9 = (TR_J9VMBase *)(cg->fe());
     TR::MemoryReference *classFlagsMR = MRef_Bdisp32(j9classReg, (uintptr_t)(fej9->getOffsetOfClassFlags()), cg);
 
-    TR::InstOpCode::Mnemonic testOpCode;
+    OP::Mnemonic testOpCode;
     if ((uint32_t)classFlag <= USHRT_MAX)
-        testOpCode = TR::InstOpCode::TEST2MemImm2;
+        testOpCode = OP::TEST2MemImm2;
     else
-        testOpCode = TR::InstOpCode::TEST4MemImm4;
+        testOpCode = OP::TEST4MemImm4;
 
     Inst_MemImm(testOpCode, node, classFlagsMR, classFlag, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+    Inst_Label(OP::JNE4, node, snippetLabel, cg);
 }
 
 TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -6074,7 +6027,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
 
     startLabel->setStartInternalControlFlow();
     fallThruLabel->setEndInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
 
@@ -6182,13 +6135,13 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
     //    label   restartLabel
     //
     TR::Register *lockedReg = NULL;
-    TR::InstOpCode::Mnemonic op = TR::InstOpCode::bad;
+    OP::Mnemonic op = OP::bad;
 
     bool isSMP = comp->target().isSMP();
     if (is64Bit && !fej9->generateCompressedLockWord()) {
-        op = isSMP ? TR::InstOpCode::LCMPXCHG8MemReg : TR::InstOpCode::CMPXCHG8MemReg;
+        op = isSMP ? OP::LCMPXCHG8MemReg : OP::CMPXCHG8MemReg;
     } else {
-        op = isSMP ? TR::InstOpCode::LCMPXCHG4MemReg : TR::InstOpCode::CMPXCHG4MemReg;
+        op = isSMP ? OP::LCMPXCHG4MemReg : OP::CMPXCHG4MemReg;
     }
 
     TR::Register *objectClassReg = NULL;
@@ -6199,8 +6152,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
         objectClassReg = cg->allocateRegister();
         numDeps++;
 
-        TR::InstOpCode::Mnemonic loadOp
-            = (TR::Compiler->om.compressObjectReferences()) ? TR::InstOpCode::L4RegMem : TR::InstOpCode::LRegMem();
+        OP::Mnemonic loadOp = (TR::Compiler->om.compressObjectReferences()) ? OP::L4RegMem : OP::LRegMem();
         TR::X86RegMemInstruction *instr = Inst_RegMem(loadOp, node, objectClassReg, objectClassMR, cg);
 
         // This instruction may try to dereference a null memory address
@@ -6211,9 +6163,8 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
 
         TR::TreeEvaluator::generateVFTMaskInstruction(node, objectClassReg, cg);
         int32_t offsetOfLockOffset = offsetof(J9Class, lockOffset);
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, objectClassReg,
-            MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
-        Inst_RegImm(TR::InstOpCode::CMPRegImms(), node, objectClassReg, 0, cg);
+        Inst_RegMem(OP::LRegMem(), node, objectClassReg, MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
+        Inst_RegImm(OP::CMPRegImms(), node, objectClassReg, 0, cg);
 
         generateCommonLockNurseryCodes(node, cg,
             true, // true for VMmonentEvaluator, false for VMmonexitEvaluator
@@ -6225,53 +6176,49 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
         TR::LabelSymbol *mismatchLabel
             = TR::Options::_aggressiveLockReservation ? snippetLabel : generateLabelSymbol(cg);
 
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, RES_BIT, cg), cg);
+        Inst_RegMem(OP::LEARegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, RES_BIT, cg), cg);
 
-        TR::InstOpCode::Mnemonic cmpMemRegOp = (is64Bit && fej9->generateCompressedLockWord())
-            ? TR::InstOpCode::CMP4MemReg
-            : TR::InstOpCode::CMPMemReg(is64Bit);
+        OP::Mnemonic cmpMemRegOp
+            = (is64Bit && fej9->generateCompressedLockWord()) ? OP::CMP4MemReg : OP::CMPMemReg(is64Bit);
         TR::X86MemRegInstruction *instr
             = Inst_MemReg(cmpMemRegOp, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), eaxReal, cg);
 
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
 
-        Inst_Label(TR::InstOpCode::JNE4, node, mismatchLabel, cg);
+        Inst_Label(OP::JNE4, node, mismatchLabel, cg);
 
         if (!node->isPrimitiveLockedRegion()) {
-            TR::InstOpCode::Mnemonic addMemImmOp = (is64Bit && fej9->generateCompressedLockWord())
-                ? TR::InstOpCode::ADD4MemImms
-                : TR::InstOpCode::ADDMemImms();
+            OP::Mnemonic addMemImmOp
+                = (is64Bit && fej9->generateCompressedLockWord()) ? OP::ADD4MemImms : OP::ADDMemImms();
             Inst_MemImm(addMemImmOp, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), REC_BIT, cg);
         }
 
         if (!TR::Options::_aggressiveLockReservation) {
             // Jump over the non-reservable path
-            Inst_Label(TR::InstOpCode::JMP4, node, inlinedMonEnterFallThruLabel, cg);
+            Inst_Label(OP::JMP4, node, inlinedMonEnterFallThruLabel, cg);
 
             // It's possible that the lock may be available, but not reservable. In
             // that case we should try the usual cmpxchg for non-reserving enter.
             // Otherwise we'll necessarily call the helper.
-            Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg);
+            Inst_Label(OP::label, node, mismatchLabel, cg);
 
-            TR::InstOpCode::Mnemonic cmpMemImmOp = (is64Bit && fej9->generateCompressedLockWord())
-                ? TR::InstOpCode::CMP4MemImms
-                : TR::InstOpCode::CMPMemImms();
+            OP::Mnemonic cmpMemImmOp
+                = (is64Bit && fej9->generateCompressedLockWord()) ? OP::CMP4MemImms : OP::CMPMemImms();
 
             auto lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
             Inst_MemImm(cmpMemImmOp, node, lwMR, 0, cg);
-            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
-            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_Label(OP::JNE4, node, snippetLabel, cg);
+            Inst_RegReg(OP::XOR4RegReg, node, eaxReal, eaxReal, cg);
             lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
             Inst_MemReg(op, node, lwMR, vmThreadReg, cg);
-            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_Label(OP::JNE4, node, snippetLabel, cg);
         }
     } else {
         if (TR::Options::_aggressiveLockReservation) {
             if (comp->getOption(TR_ReservingLocks) && normalLockPreservingReservation) {
-                TR::InstOpCode::Mnemonic cmpMemImmOp = (is64Bit && fej9->generateCompressedLockWord())
-                    ? TR::InstOpCode::CMP4MemImms
-                    : TR::InstOpCode::CMPMemImms();
+                OP::Mnemonic cmpMemImmOp
+                    = (is64Bit && fej9->generateCompressedLockWord()) ? OP::CMP4MemImms : OP::CMPMemImms();
 
                 TR::X86MemImmInstruction *instr = Inst_MemImm(cmpMemImmOp, node,
                     getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
@@ -6279,18 +6226,18 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
                 cg->setImplicitExceptionPoint(instr);
                 instr->setNeedsGCMap(0xFF00FFFF);
 
-                Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+                Inst_Label(OP::JNE4, node, snippetLabel, cg);
             }
 
-            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_RegReg(OP::XOR4RegReg, node, eaxReal, eaxReal, cg);
         } else if (!comp->getOption(TR_ReservingLocks)) {
-            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_RegReg(OP::XOR4RegReg, node, eaxReal, eaxReal, cg);
         } else {
-            TR::InstOpCode::Mnemonic loadOp = TR::InstOpCode::LRegMem();
-            TR::InstOpCode::Mnemonic testOp = TR::InstOpCode::TESTRegImm4();
+            OP::Mnemonic loadOp = OP::LRegMem();
+            OP::Mnemonic testOp = OP::TESTRegImm4();
             if (is64Bit && fej9->generateCompressedLockWord()) {
-                loadOp = TR::InstOpCode::L4RegMem;
-                testOp = TR::InstOpCode::TEST4RegImm4;
+                loadOp = OP::L4RegMem;
+                testOp = OP::TEST4RegImm4;
             }
 
             auto lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
@@ -6299,15 +6246,15 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
             instr->setNeedsGCMap(0xFF00FFFF);
 
             Inst_RegImm(testOp, node, eaxReal, (int32_t)~RES_BIT, cg);
-            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_Label(OP::JNE4, node, snippetLabel, cg);
         }
 
         if (node->isReadMonitor()) {
             lockedReg = cg->allocateRegister();
             if (is64Bit && fej9->generateCompressedLockWord())
-                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, lockedReg, lockedReg,
+                Inst_RegReg(OP::XOR4RegReg, node, lockedReg, lockedReg,
                     cg); // After lockedReg is allocated zero it out.
-            Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, lockedReg, INC_DEC_VALUE, cg);
+            Inst_RegImm(OP::MOVRegImm4(), node, lockedReg, INC_DEC_VALUE, cg);
             ++numDeps;
         } else {
             bool conditionallyReserve = false;
@@ -6340,11 +6287,11 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
                 // prevent any future reservation of the same lock.
 
                 bool b64 = is64Bit && !fej9->generateCompressedLockWord();
-                Inst_RegReg(TR::InstOpCode::MOVRegReg(b64), node, lockedReg, eaxReal, cg);
-                Inst_RegImm(TR::InstOpCode::SHRRegImm1(b64), node, lockedReg, RES_BIT_POSITION, cg);
-                Inst_Reg(TR::InstOpCode::NEGReg(b64), node, lockedReg, cg);
-                Inst_RegImm(TR::InstOpCode::ANDRegImms(b64), node, lockedReg, RES_BIT | INC_DEC_VALUE, cg);
-                Inst_RegReg(TR::InstOpCode::ADDRegReg(b64), node, lockedReg, vmThreadReg, cg);
+                Inst_RegReg(OP::MOVRegReg(b64), node, lockedReg, eaxReal, cg);
+                Inst_RegImm(OP::SHRRegImm1(b64), node, lockedReg, RES_BIT_POSITION, cg);
+                Inst_Reg(OP::NEGReg(b64), node, lockedReg, cg);
+                Inst_RegImm(OP::ANDRegImms(b64), node, lockedReg, RES_BIT | INC_DEC_VALUE, cg);
+                Inst_RegReg(OP::ADDRegReg(b64), node, lockedReg, vmThreadReg, cg);
             }
         }
 
@@ -6354,18 +6301,17 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
 
-        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_Label(OP::JNE4, node, snippetLabel, cg);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, inlinedMonEnterFallThruLabel, cg);
+    Inst_Label(OP::label, node, inlinedMonEnterFallThruLabel, cg);
 
 #if defined(TR_TARGET_64BIT) && (JAVA_SPEC_VERSION >= 19)
     // Adjust J9VMThread ownedMonitorCount for execution paths that do not
     // go out of line to acquire the lock.  It is safe and efficient to do
     // this unconditionally.  There is no need to check for overflow..
     //
-    Inst_Mem(TR::InstOpCode::INC8Mem, node, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg),
-        cg);
+    Inst_Mem(OP::INC8Mem, node, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
     // Create dependencies for the registers used.
@@ -6393,7 +6339,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
 
     deps->stopAddingConditions();
 
-    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(OP::label, node, fallThruLabel, deps, cg);
 
     cg->decReferenceCount(objectRef);
     cg->stopUsingRegister(eaxReal);
@@ -6482,7 +6428,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     startLabel->setStartInternalControlFlow();
     TR::LabelSymbol *snippetFallThruLabel = inlineRecursive ? generateLabelSymbol(cg) : fallThruLabel;
     fallThruLabel->setEndInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     TR::Register *eaxReal = NULL;
     TR::Register *unlockedReg = NULL;
@@ -6496,8 +6442,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
 
     if (lwOffset <= 0) {
         TR::MemoryReference *objectClassMR = MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_CLAZZ, cg);
-        TR::InstOpCode::Mnemonic op
-            = TR::Compiler->om.compressObjectReferences() ? TR::InstOpCode::L4RegMem : TR::InstOpCode::LRegMem();
+        OP::Mnemonic op = TR::Compiler->om.compressObjectReferences() ? OP::L4RegMem : OP::LRegMem();
         objectClassReg = cg->allocateRegister();
 
         TR::Instruction *instr = Inst_RegMem(op, node, objectClassReg, objectClassMR, cg);
@@ -6509,12 +6454,11 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
 
         TR::TreeEvaluator::generateVFTMaskInstruction(node, objectClassReg, cg);
         int32_t offsetOfLockOffset = offsetof(J9Class, lockOffset);
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, objectClassReg,
-            MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
+        Inst_RegMem(OP::LRegMem(), node, objectClassReg, MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
 
         numDeps++;
 
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, objectClassReg, 0, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, objectClassReg, 0, cg);
 
         generateCommonLockNurseryCodes(node, cg,
             false, // true for VMmonentEvaluator, false for VMmonexitEvaluator
@@ -6580,33 +6524,32 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     if (node->isReadMonitor()) {
         unlockedReg = cg->allocateRegister();
         eaxReal = cg->allocateRegister();
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, unlockedReg, unlockedReg, cg);
-        Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, eaxReal, INC_DEC_VALUE, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, unlockedReg, unlockedReg, cg);
+        Inst_RegImm(OP::MOVRegImm4(), node, eaxReal, INC_DEC_VALUE, cg);
 
-        TR::InstOpCode::Mnemonic op = cg->comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg(gen64BitInstr)
-                                                                   : TR::InstOpCode::CMPXCHGMemReg(gen64BitInstr);
+        OP::Mnemonic op
+            = cg->comp()->target().isSMP() ? OP::LCMPXCHGMemReg(gen64BitInstr) : OP::CMPXCHGMemReg(gen64BitInstr);
         cg->setImplicitExceptionPoint(
             Inst_MemReg(op, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), unlockedReg, cg));
         numDeps += 2;
     } else {
         if (reservingLock) {
             if (node->isPrimitiveLockedRegion()) {
-                cg->setImplicitExceptionPoint(Inst_RegMem(TR::InstOpCode::LRegMem(gen64BitInstr), node, tempReg,
+                cg->setImplicitExceptionPoint(Inst_RegMem(OP::LRegMem(gen64BitInstr), node, tempReg,
                     getMemoryReference(objectClassReg, objectReg, lwOffset, cg), cg));
 
                 // Mask out the thread ID and reservation count
-                Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, tempReg, FLAGS_MASK, cg);
+                Inst_RegImm(OP::ANDRegImms(), node, tempReg, FLAGS_MASK, cg);
                 // If only the RES flag is set and no other we can continue
-                Inst_RegImm(TR::InstOpCode::XORRegImms(), node, tempReg, RES_BIT, cg);
+                Inst_RegImm(OP::XORRegImms(), node, tempReg, RES_BIT, cg);
             } else {
                 reservingDecrementNeeded = true;
-                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
-                    MRef_Bdisp32(vmThreadReg, (REC_BIT | RES_BIT), cg), cg);
-                cg->setImplicitExceptionPoint(Inst_MemReg(TR::InstOpCode::CMPMemReg(gen64BitInstr), node,
+                Inst_RegMem(OP::LEARegMem(), node, tempReg, MRef_Bdisp32(vmThreadReg, (REC_BIT | RES_BIT), cg), cg);
+                cg->setImplicitExceptionPoint(Inst_MemReg(OP::CMPMemReg(gen64BitInstr), node,
                     getMemoryReference(objectClassReg, objectReg, lwOffset, cg), tempReg, cg));
             }
         } else {
-            cg->setImplicitExceptionPoint(Inst_RegMem(TR::InstOpCode::CMPRegMem(gen64BitInstr), node, vmThreadReg,
+            cg->setImplicitExceptionPoint(Inst_RegMem(OP::CMPRegMem(gen64BitInstr), node, vmThreadReg,
                 getMemoryReference(objectClassReg, objectReg, lwOffset, cg), cg));
         }
     }
@@ -6614,41 +6557,40 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     TR::LabelSymbol *mismatchLabel
         = (reservingLock && !TR::Options::_aggressiveLockReservation) ? generateLabelSymbol(cg) : snippetLabel;
 
-    Inst_Label(TR::InstOpCode::JNE4, node, mismatchLabel, cg);
+    Inst_Label(OP::JNE4, node, mismatchLabel, cg);
 
     if (reservingDecrementNeeded) {
         // Subtract the reservation count
-        Inst_MemImm(TR::InstOpCode::SUBMemImms(gen64BitInstr), node,
-            getMemoryReference(objectClassReg, objectReg, lwOffset, cg), REC_BIT,
-            cg); // I'm not sure TR::InstOpCode::SUB4MemImms will work.
+        Inst_MemImm(OP::SUBMemImms(gen64BitInstr), node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg),
+            REC_BIT,
+            cg); // I'm not sure OP::SUB4MemImms will work.
     }
 
     if (!node->isReadMonitor() && !reservingLock) {
-        Inst_MemImm(TR::InstOpCode::SMemImm4(gen64BitInstr), node,
-            getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
+        Inst_MemImm(OP::SMemImm4(gen64BitInstr), node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0,
+            cg);
     }
 
     if (reservingLock && !TR::Options::_aggressiveLockReservation) {
-        Inst_Label(TR::InstOpCode::JMP4, node, inlinedMonExitFallThruLabel, cg);
+        Inst_Label(OP::JMP4, node, inlinedMonExitFallThruLabel, cg);
 
         // Avoid the helper for non-recursive exit in case it isn't reserved
-        Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg);
+        Inst_Label(OP::label, node, mismatchLabel, cg);
         auto lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
-        Inst_MemReg(TR::InstOpCode::CMPMemReg(gen64BitInstr), node, lwMR, vmThreadReg, cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_MemReg(OP::CMPMemReg(gen64BitInstr), node, lwMR, vmThreadReg, cg);
+        Inst_Label(OP::JNE4, node, snippetLabel, cg);
         lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
-        Inst_MemImm(TR::InstOpCode::SMemImm4(gen64BitInstr), node, lwMR, 0, cg);
+        Inst_MemImm(OP::SMemImm4(gen64BitInstr), node, lwMR, 0, cg);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, inlinedMonExitFallThruLabel, cg);
+    Inst_Label(OP::label, node, inlinedMonExitFallThruLabel, cg);
 
 #if defined(TR_TARGET_64BIT) && (JAVA_SPEC_VERSION >= 19)
     // Adjust J9VMThread ownedMonitorCount for execution paths that do not
     // go out of line to release the lock.  It is safe and efficient to do
     // this unconditionally.  There is no need to check for underflow.
     //
-    Inst_Mem(TR::InstOpCode::DEC8Mem, node, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg),
-        cg);
+    Inst_Mem(OP::DEC8Mem, node, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
     // Create dependencies for the registers used.
@@ -6676,7 +6618,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
         deps->addPostCondition(objectClassReg, TR::RealRegister::NoReg, cg);
 
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(OP::label, node, fallThruLabel, deps, cg);
 
     if (eaxReal)
         cg->stopUsingRegister(eaxReal);
@@ -6758,7 +6700,7 @@ static void insertAllocationPrefetch(TR::Node *node, int32_t numPrefetches, TR::
     TR::CodeGenerator *cg)
 {
     for (int32_t i = 0; i < numPrefetches; i++) {
-        Inst_Mem(TR::InstOpCode::PREFETCHNTA, node, MRef_Bdisp32(allocationReg, offset, cg), cg);
+        Inst_Mem(OP::PREFETCHNTA, node, MRef_Bdisp32(allocationReg, offset, cg), cg);
         offset += 64;
     }
 }
@@ -6794,24 +6736,24 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         UDATA sizeClass = fej9->getObjectSizeClass(allocationSizeOrDataOffset);
 
         if (comp->getOption(TR_BreakOnNew))
-            Inst(TR::InstOpCode::INT3, node, cg);
+            Inst(OP::INT3, node, cg);
 
         // heap allocation, so proceed
         if (sizeReg) {
-            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_RegReg(OP::XOR4RegReg, node, eaxReal, eaxReal, cg);
 
             // make sure size isn't too big
             // convert max object size to num elements because computing an object size from num elements may overflow
             TR_ASSERT(fej9->getMaxObjectSizeForSizeClass() <= UINT_MAX, "assertion failure");
-            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, sizeReg,
+            Inst_RegImm(OP::CMPRegImm4(), node, sizeReg,
                 (fej9->getMaxObjectSizeForSizeClass() - allocationSizeOrDataOffset) / elementSize, cg);
-            Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
+            Inst_Label(OP::JA4, node, failLabel, cg);
 
             // Hybrid arraylets need a zero length test if the size is unknown.
             //
             if (!generateArraylets) {
-                Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-                Inst_Label(TR::InstOpCode::JE4, node, failLabel, cg);
+                Inst_RegReg(OP::TEST4RegReg, node, sizeReg, sizeReg, cg);
+                Inst_Label(OP::JE4, node, failLabel, cg);
             }
 
             // need to round up to sizeof(UDATA) so we can use it to index into size class index array
@@ -6821,28 +6763,28 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 round = sizeof(UDATA) - 1;
 
             // now compute size of object in bytes
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
+            Inst_RegMem(OP::LEARegMem(), node, segmentReg,
                 MRef_BISdisp32(eaxReal, sizeReg, TR::MemoryReference::convertMultiplierToStride(elementSize),
                     allocationSizeOrDataOffset + round, cg),
                 cg);
 
             if (elementSize < sizeof(UDATA))
-                Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, segmentReg, -(int32_t)sizeof(UDATA), cg);
+                Inst_RegImm(OP::ANDRegImms(), node, segmentReg, -(int32_t)sizeof(UDATA), cg);
 
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
-            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+            Inst_RegImm(OP::CMPRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
             TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-            Inst_Label(TR::InstOpCode::JAE4, node, doneLabel, cg);
-            Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
-            Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
+            Inst_Label(OP::JAE4, node, doneLabel, cg);
+            Inst_RegImm(OP::MOVRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+            Inst_Label(OP::label, node, doneLabel, cg);
 #endif
 
             // get size class
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
-                MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
-                MRef_Bdisp32(tempReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(OP::LRegMem(), node, tempReg, MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg),
+                cg);
+            Inst_RegMem(OP::LRegMem(), node, tempReg, MRef_Bdisp32(tempReg, fej9->getRealtimeSizeClassesOffset(), cg),
+                cg);
+            Inst_RegMem(OP::LRegMem(), node, tempReg,
                 MRef_BISdisp32(tempReg, segmentReg, TR::MemoryReference::convertMultiplierToStride(1),
                     fej9->getSizeClassesIndexOffset(), cg),
                 cg);
@@ -6860,7 +6802,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 //   We need a shift instruction to be able to do stride 16
                 //   To avoid two shifts, only do one for stride sizeof(UDATA) and use a multiplier in memory ref for 16
                 //   64-bit, so shift 3 times for sizeof(UDATA) and use multiplier stride 2 in memory references
-                Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, tempReg, 3, cg);
+                Inst_RegImm(OP::SHLRegImm1(), node, tempReg, 3, cg);
                 currentMemRef = MRef_BISdisp32(vmThreadReg, tempReg, TR::MemoryReference::convertMultiplierToStride(2),
                     fej9->thisThreadAllocationCacheCurrentOffset(0), cg);
                 topMemRef = MRef_BISdisp32(vmThreadReg, tempReg, TR::MemoryReference::convertMultiplierToStride(2),
@@ -6888,26 +6830,26 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             // (64-bit)
 
             // get next cell for this size class
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal, currentMemRef, cg);
+            Inst_RegMem(OP::LRegMem(), node, eaxReal, currentMemRef, cg);
 
             // if null, then no cell available, use slow path
-            Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, eaxReal, topMemRef, cg);
-            Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
+            Inst_RegMem(OP::CMPRegMem(), node, eaxReal, topMemRef, cg);
+            Inst_Label(OP::JAE4, node, failLabel, cg);
 
             // have a valid cell, need to update current cell pointer
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
-                MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
+            Inst_RegMem(OP::LRegMem(), node, segmentReg, MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg),
+                cg);
+            Inst_RegMem(OP::LRegMem(), node, segmentReg,
                 MRef_Bdisp32(segmentReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
             if (cg->comp()->target().is64Bit()) {
                 // tempReg already has already been shifted for sizeof(UDATA)
-                Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
+                Inst_RegMem(OP::LRegMem(), node, segmentReg,
                     MRef_BISdisp32(segmentReg, tempReg, TR::MemoryReference::convertMultiplierToStride(1),
                         fej9->getSmallCellSizesOffset(), cg),
                     cg);
             } else {
                 // tempReg needs to be shifted for sizeof(UDATA)
-                Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
+                Inst_RegMem(OP::LRegMem(), node, segmentReg,
                     MRef_BISdisp32(segmentReg, tempReg, TR::MemoryReference::convertMultiplierToStride(sizeof(UDATA)),
                         fej9->getSmallCellSizesOffset(), cg),
                     cg);
@@ -6915,26 +6857,26 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             // segmentReg now holds cell size
 
             // update current cell by cell size
-            Inst_MemReg(TR::InstOpCode::ADDMemReg(), node, currentMemRefBump, segmentReg, cg);
+            Inst_MemReg(OP::ADDMemReg(), node, currentMemRefBump, segmentReg, cg);
         } else {
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal,
+            Inst_RegMem(OP::LRegMem(), node, eaxReal,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg), cg);
 
-            Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, eaxReal,
+            Inst_RegMem(OP::CMPRegMem(), node, eaxReal,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheTopOffset(sizeClass), cg), cg);
 
-            Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
+            Inst_Label(OP::JAE4, node, failLabel, cg);
 
             // we have an object in eaxReal, now bump the current updatepointer
-            TR::InstOpCode::Mnemonic opcode;
+            OP::Mnemonic opcode;
             uint32_t cellSize = fej9->getCellSizeForSizeClass(sizeClass);
             if (cellSize <= 127)
-                opcode = TR::InstOpCode::ADDMemImms();
+                opcode = OP::ADDMemImms();
             else if (cellSize == 128) {
-                opcode = TR::InstOpCode::SUBMemImms();
+                opcode = OP::SUBMemImms();
                 cellSize = (uint32_t)-128;
             } else
-                opcode = TR::InstOpCode::ADDMemImm4();
+                opcode = OP::ADDMemImm4();
 
             Inst_MemImm(opcode, node,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg), cellSize, cg);
@@ -6961,7 +6903,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         // minimal because the helper will be called in that case.  It is necessary to insert this load here so that it
         // dominates all control paths through this internal control flow region.
         //
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), cg);
+        Inst_RegMem(OP::LRegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), cg);
 
         bool canSkipOverflowCheck = false;
 
@@ -6970,7 +6912,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         //
         if (generateArraylets && (node->getOpCodeValue() == TR::anewarray || node->getOpCodeValue() == TR::newarray)) {
             if (comp->getOption(TR_DisableTarokInlineArrayletAllocation))
-                Inst_Label(TR::InstOpCode::JMP4, node, failLabel, cg);
+                Inst_Label(OP::JMP4, node, failLabel, cg);
 
             if (sizeReg) {
                 uint32_t maxContiguousArrayletLeafSizeInBytes
@@ -6980,11 +6922,11 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
                 // Hybrid arraylets need a zero length test if the size is unknown.
                 //
-                Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-                Inst_Label(TR::InstOpCode::JE4, node, failLabel, cg);
+                Inst_RegReg(OP::TEST4RegReg, node, sizeReg, sizeReg, cg);
+                Inst_Label(OP::JE4, node, failLabel, cg);
 
-                Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, maxArrayletSizeInElements, cg);
-                Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
+                Inst_RegImm(OP::CMP4RegImm4, node, sizeReg, maxArrayletSizeInElements, cg);
+                Inst_Label(OP::JAE4, node, failLabel, cg);
 
                 // If the max arraylet leaf size is less than the amount of free space available on
                 // the stack, there is no need to check for an overflow scenario.
@@ -6998,7 +6940,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 // Actually, we should never get here because we've already checked
                 // constant lengths for discontiguity...
                 //
-                Inst_Label(TR::InstOpCode::JMP4, node, failLabel, cg);
+                Inst_Label(OP::JMP4, node, failLabel, cg);
             }
         }
 
@@ -7007,8 +6949,8 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             // The length could be zero.
             //
             if (!generateArraylets) {
-                Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-                Inst_Label(TR::InstOpCode::JE4, node, failLabel, cg);
+                Inst_RegReg(OP::TEST4RegReg, node, sizeReg, sizeReg, cg);
+                Inst_Label(OP::JE4, node, failLabel, cg);
             }
 
             // The GC will guarantee that at least 'maxObjectSizeGuaranteedNotToOverflow' bytes
@@ -7019,22 +6961,22 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
             if (cg->comp()->target().is64Bit()
                 && !(maxObjectSizeInElements > 0 && maxObjectSizeInElements <= (uintptr_t)INT_MAX)) {
-                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, maxObjectSizeInElements, cg);
-                Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, sizeReg, tempReg, cg);
+                Inst_RegImm64(OP::MOV8RegImm64, node, tempReg, maxObjectSizeInElements, cg);
+                Inst_RegReg(OP::CMP8RegReg, node, sizeReg, tempReg, cg);
             } else {
-                Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
+                Inst_RegImm(OP::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
             }
 
             // Must be an unsigned comparison on sizes.
             //
-            Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
+            Inst_Label(OP::JAE4, node, failLabel, cg);
         }
 
 #if !defined(J9VM_GC_THREAD_LOCAL_HEAP)
         // Establish a loop label in case the new heap pointer cannot be committed.
         //
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+        Inst_Label(OP::label, node, loopLabel, cg);
 #endif
 
         if (sizeReg) {
@@ -7072,22 +7014,22 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                     "Expecting a minimum indexable object size >= 8 (actual minimum is %d)\n",
                     J9_GC_MINIMUM_OBJECT_SIZE);
 
-                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
+                Inst_RegMem(OP::LEARegMem(), node, tempReg,
                     MRef_BISdisp32(eaxReal, sizeReg, TR::MemoryReference::convertMultiplierToStride(elementSize),
                         allocationSizeOrDataOffset + disp32, cg),
                     cg);
 
                 if (round) {
-                    Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg, -round, cg);
+                    Inst_RegImm(OP::ANDRegImm4(), node, tempReg, -round, cg);
                 }
             } else
 #endif
             {
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
-                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
+                Inst_RegReg(OP::XOR4RegReg, node, tempReg, tempReg, cg);
 #endif
 
-                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
+                Inst_RegMem(OP::LEARegMem(), node, tempReg,
                     MRef_BISdisp32(
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
                         tempReg,
@@ -7099,16 +7041,16 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                     cg);
 
                 if (round) {
-                    Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg, -round, cg);
+                    Inst_RegImm(OP::ANDRegImm4(), node, tempReg, -round, cg);
                 }
 
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
-                Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+                Inst_RegImm(OP::CMPRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-                Inst_Label(TR::InstOpCode::JAE4, node, doneLabel, cg);
-                Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
-                Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
-                Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, tempReg, eaxReal, cg);
+                Inst_Label(OP::JAE4, node, doneLabel, cg);
+                Inst_RegImm(OP::MOVRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+                Inst_Label(OP::label, node, doneLabel, cg);
+                Inst_RegReg(OP::ADDRegReg(), node, tempReg, eaxReal, cg);
 #endif
             }
         } else {
@@ -7117,42 +7059,39 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 & (-TR::Compiler->om.getObjectAlignmentInBytes());
 
             if ((uint32_t)allocationSizeOrDataOffset > cg->getMaxObjectSizeGuaranteedNotToOverflow()) {
-                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, eaxReal, cg);
+                Inst_RegReg(OP::MOVRegReg(), node, tempReg, eaxReal, cg);
                 if (allocationSizeOrDataOffset <= 127)
-                    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, tempReg, allocationSizeOrDataOffset, cg);
+                    Inst_RegImm(OP::ADDRegImms(), node, tempReg, allocationSizeOrDataOffset, cg);
                 else if (allocationSizeOrDataOffset == 128)
-                    Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, tempReg, (unsigned)-128, cg);
+                    Inst_RegImm(OP::SUBRegImms(), node, tempReg, (unsigned)-128, cg);
                 else
-                    Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, tempReg, allocationSizeOrDataOffset, cg);
+                    Inst_RegImm(OP::ADDRegImm4(), node, tempReg, allocationSizeOrDataOffset, cg);
 
                 // Check for overflow
-                Inst_Label(TR::InstOpCode::JB4, node, failLabel, cg);
+                Inst_Label(OP::JB4, node, failLabel, cg);
             } else {
-                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
-                    MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg), cg);
+                Inst_RegMem(OP::LEARegMem(), node, tempReg, MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg), cg);
             }
         }
 
-        Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, MRef_Bdisp32(vmThreadReg, heapTop_offset, cg), cg);
+        Inst_RegMem(OP::CMPRegMem(), node, tempReg, MRef_Bdisp32(vmThreadReg, heapTop_offset, cg), cg);
 
-        Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
+        Inst_Label(OP::JA4, node, failLabel, cg);
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 
         // Make sure that the arraylet is aligned properly.
         //
         if (generateArraylets && (node->getOpCodeValue() == TR::anewarray || node->getOpCodeValue() == TR::newarray)) {
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
+            Inst_RegMem(OP::LEARegMem(), node, tempReg,
                 MRef_Bdisp32(tempReg, TR::Compiler->om.getObjectAlignmentInBytes() - 1, cg), cg);
             if (cg->comp()->target().is64Bit())
-                Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, tempReg, -TR::Compiler->om.getObjectAlignmentInBytes(),
-                    cg);
+                Inst_RegImm(OP::AND8RegImm4, node, tempReg, -TR::Compiler->om.getObjectAlignmentInBytes(), cg);
             else
-                Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, tempReg, -TR::Compiler->om.getObjectAlignmentInBytes(),
-                    cg);
+                Inst_RegImm(OP::AND4RegImm4, node, tempReg, -TR::Compiler->om.getObjectAlignmentInBytes(), cg);
         }
 
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
 
         if (!isSmallAllocation && cg->enableTLHPrefetching()) {
             TR::LabelSymbol *prefetchSnippetLabel = generateLabelSymbol(cg);
@@ -7176,14 +7115,13 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 useDirectPrefetchCall = true;
             }
 
-            Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, tempReg, eaxReal, cg);
+            Inst_RegReg(OP::SUB4RegReg, node, tempReg, eaxReal, cg);
 
-            Inst_MemReg(TR::InstOpCode::SUB4MemReg, node, MRef_Bdisp32(vmThreadReg, tlhPrefetchFTA_offset, cg), tempReg,
-                cg);
+            Inst_MemReg(OP::SUB4MemReg, node, MRef_Bdisp32(vmThreadReg, tlhPrefetchFTA_offset, cg), tempReg, cg);
             if (!useDirectPrefetchCall)
-                Inst_Label(TR::InstOpCode::JLE4, node, prefetchSnippetLabel, cg);
+                Inst_Label(OP::JLE4, node, prefetchSnippetLabel, cg);
             else {
-                Inst_Label(TR::InstOpCode::JG4, node, restartLabel, cg);
+                Inst_Label(OP::JG4, node, restartLabel, cg);
                 TR::SymbolReference *helperSymRef
                     = cg->getSymRefTab()->findOrCreateRuntimeHelper(TR_X86CodeCachePrefetchHelper);
                 TR::MethodSymbol *helperSymbol = helperSymRef->getSymbol()->castToMethodSymbol();
@@ -7196,17 +7134,15 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 #else
                 helperSymbol->setMethodAddress(fej9->getAllocationPrefetchCodeSnippetAddress(comp));
 #endif
-                Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)helperSymbol->getMethodAddress(), helperSymRef,
-                    cg);
+                Inst_ImmSym(OP::CALLImm4, node, (uintptr_t)helperSymbol->getMethodAddress(), helperSymRef, cg);
             }
 
-            Inst_Label(TR::InstOpCode::label, node, restartLabel, cg);
+            Inst_Label(OP::label, node, restartLabel, cg);
         }
 
 #else // J9VM_GC_THREAD_LOCAL_HEAP
-        Inst_MemReg(TR::InstOpCode::CMPXCHGMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg,
-            cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, loopLabel, cg);
+        Inst_MemReg(OP::CMPXCHGMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
+        Inst_Label(OP::JNE4, node, loopLabel, cg);
 #endif // !J9VM_GC_THREAD_LOCAL_HEAP
     }
 }
@@ -7248,20 +7184,19 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
             && !(maxObjectSizeInElements > 0 && maxObjectSizeInElements <= (uintptr_t)INT_MAX)) {
             // nextTLHAllocReg can be used as a scratch register until it is defined below
             //
-            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, nextTLHAllocReg, maxObjectSizeInElements, cg);
-            Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, sizeReg, nextTLHAllocReg, cg);
+            Inst_RegImm64(OP::MOV8RegImm64, node, nextTLHAllocReg, maxObjectSizeInElements, cg);
+            Inst_RegReg(OP::CMP8RegReg, node, sizeReg, nextTLHAllocReg, cg);
         } else {
-            Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
+            Inst_RegImm(OP::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
         }
 
         // Must be an unsigned comparison on sizes.
         //
-        Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
+        Inst_Label(OP::JAE4, node, failLabel, cg);
 
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal,
-            MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+        Inst_RegMem(OP::LRegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
-        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, nextTLHAllocReg, sizeReg, cg);
+        Inst_RegReg(OP::MOV4RegReg, node, nextTLHAllocReg, sizeReg, cg);
 
         // Artificially adjust the number of elements by 1 if the array is zero length.  This works
         // because either the array is zero length and needs a discontiguous array length field
@@ -7271,13 +7206,13 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
         // contiguous and discontiguous array headers are the same size.
         //
         if (comp->target().is32Bit() || (comp->target().is64Bit() && comp->useCompressedPointers())) {
-            Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, nextTLHAllocReg, 1, cg);
-            Inst_RegImm(TR::InstOpCode::ADC4RegImm4, node, nextTLHAllocReg, 0, cg);
+            Inst_RegImm(OP::CMP4RegImm4, node, nextTLHAllocReg, 1, cg);
+            Inst_RegImm(OP::ADC4RegImm4, node, nextTLHAllocReg, 0, cg);
         }
 
         uint8_t shiftVal = TR::MemoryReference::convertMultiplierToStride(elementSize);
         if (shiftVal > 0) {
-            Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, nextTLHAllocReg, shiftVal, cg);
+            Inst_RegImm(OP::SHLRegImm1(), node, nextTLHAllocReg, shiftVal, cg);
         }
 
         // calculate variable size, rounding up if necessary to a intptr_t multiple boundary
@@ -7289,24 +7224,23 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
             : TR::Compiler->om.getObjectAlignmentInBytes();
         int32_t disp32 = round ? (round - 1) : 0;
 
-        Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, nextTLHAllocReg, allocationSizeOrDataOffset + disp32, cg);
+        Inst_RegImm(OP::ADDRegImm4(), node, nextTLHAllocReg, allocationSizeOrDataOffset + disp32, cg);
 
         if (round) {
-            Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, nextTLHAllocReg, -round, cg);
+            Inst_RegImm(OP::ANDRegImm4(), node, nextTLHAllocReg, -round, cg);
         }
 
-        // Copy full object size in bytes to RCX for zero init via REP TR::InstOpCode::STOSQ
+        // Copy full object size in bytes to RCX for zero init via REP OP::STOSQ
         //
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, nextTLHAllocReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, tempReg, nextTLHAllocReg, cg);
 
-        Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, nextTLHAllocReg, eaxReal, cg);
+        Inst_RegReg(OP::ADDRegReg(), node, nextTLHAllocReg, eaxReal, cg);
     } else {
         // ----------
         // FIXED SIZE
         // ----------
 
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal,
-            MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+        Inst_RegMem(OP::LRegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
         if (comp->getOptLevel() < hot)
             isTooSmallToPrefetch = allocationSizeOrDataOffset <= 0x40 ? true : false;
@@ -7315,19 +7249,19 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
             & (-TR::Compiler->om.getObjectAlignmentInBytes());
 
         if ((uint32_t)allocationSizeOrDataOffset > cg->getMaxObjectSizeGuaranteedNotToOverflow()) {
-            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, nextTLHAllocReg, eaxReal, cg);
+            Inst_RegReg(OP::MOVRegReg(), node, nextTLHAllocReg, eaxReal, cg);
             if (allocationSizeOrDataOffset <= 127)
-                Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, nextTLHAllocReg, allocationSizeOrDataOffset, cg);
+                Inst_RegImm(OP::ADDRegImms(), node, nextTLHAllocReg, allocationSizeOrDataOffset, cg);
             else if (allocationSizeOrDataOffset == 128)
-                Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, nextTLHAllocReg, (unsigned)-128, cg);
+                Inst_RegImm(OP::SUBRegImms(), node, nextTLHAllocReg, (unsigned)-128, cg);
             else
-                Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, nextTLHAllocReg, allocationSizeOrDataOffset, cg);
+                Inst_RegImm(OP::ADDRegImm4(), node, nextTLHAllocReg, allocationSizeOrDataOffset, cg);
 
             // Check for overflow
-            Inst_Label(TR::InstOpCode::JB4, node, failLabel, cg);
+            Inst_Label(OP::JB4, node, failLabel, cg);
         } else {
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, nextTLHAllocReg,
-                MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg), cg);
+            Inst_RegMem(OP::LEARegMem(), node, nextTLHAllocReg, MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg),
+                cg);
         }
     }
 
@@ -7335,17 +7269,17 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
     // MERGED PATH
     // -----------
 
-    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, nextTLHAllocReg,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+    Inst_RegMem(OP::CMPRegMem(), node, nextTLHAllocReg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg),
+        cg);
 
-    Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
+    Inst_Label(OP::JA4, node, failLabel, cg);
 
     if (!isTooSmallToPrefetch && cg->enableTLHPrefetching()) {
         insertAllocationPrefetch(node, 1, nextTLHAllocReg, 0xc0, cg);
     }
 
-    Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
-        nextTLHAllocReg, cg);
+    Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), nextTLHAllocReg,
+        cg);
 
     if (!isTooSmallToPrefetch && node->getOpCodeValue() != TR::New && cg->enableTLHPrefetching()) {
         insertAllocationPrefetch(node, 3, nextTLHAllocReg, 0x100, cg);
@@ -7374,7 +7308,7 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
     //
     // --------------------------------------------------------------------------------
     //
-    TR::InstOpCode::Mnemonic opSMemReg = TR::InstOpCode::SMemReg(use64BitClasses);
+    OP::Mnemonic opSMemReg = OP::SMemReg(use64BitClasses);
 
     TR::Register *clzReg = classReg;
 
@@ -7384,16 +7318,14 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
             "Dynamic allocation currently only supports reference arrays");
         TR_ASSERT(classReg, "must have a classReg for dynamic allocation");
         clzReg = tempReg;
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, clzReg, MRef_Bdisp32(classReg, offsetof(J9Class, arrayClass), cg),
-            cg);
+        Inst_RegMem(OP::LRegMem(), node, clzReg, MRef_Bdisp32(classReg, offsetof(J9Class, arrayClass), cg), cg);
     }
     // TODO: should be able to use a TR_ClassPointer relocation without this stuff (along with class validation)
     else if (cg->needClassAndMethodPointerRelocations() && !comp->getOption(TR_UseSymbolValidationManager)) {
         TR::Register *vmThreadReg = cg->getVMThreadRegister();
         if (node->getOpCodeValue() == TR::newarray) {
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
-                MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(OP::LRegMem(), node, tempReg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+            Inst_RegMem(OP::LRegMem(), node, tempReg,
                 MRef_Bdisp32(tempReg,
                     offsetof(J9JavaVM, booleanArrayClass) + (node->getSecondChild()->getInt() - 4) * sizeof(J9Class *),
                     cg),
@@ -7417,22 +7349,20 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
         TR::Instruction *instr = NULL;
         if (use64BitClasses) {
             if (cg->needClassAndMethodPointerRelocations() && comp->getOption(TR_UseSymbolValidationManager))
-                instr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, ((intptr_t)clazz | orFlagsClass), cg,
+                instr = Inst_RegImm64(OP::MOV8RegImm64, node, tempReg, ((intptr_t)clazz | orFlagsClass), cg,
                     TR_ClassPointer);
             else
-                instr
-                    = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, ((intptr_t)clazz | orFlagsClass), cg);
-            Inst_MemReg(TR::InstOpCode::S8MemReg, node,
-                MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), tempReg, cg);
+                instr = Inst_RegImm64(OP::MOV8RegImm64, node, tempReg, ((intptr_t)clazz | orFlagsClass), cg);
+            Inst_MemReg(OP::S8MemReg, node, MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg),
+                tempReg, cg);
         } else {
-            instr = Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
+            instr = Inst_MemImm(OP::S4MemImm4, node,
                 MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg),
                 (int32_t)((uintptr_t)clazz | orFlagsClass), cg);
         }
     } else {
         if (orFlagsClass != 0)
-            Inst_RegImm(use64BitClasses ? TR::InstOpCode::OR8RegImm4 : TR::InstOpCode::OR4RegImm4, node, clzReg,
-                orFlagsClass, cg);
+            Inst_RegImm(use64BitClasses ? OP::OR8RegImm4 : OP::OR4RegImm4, node, clzReg, orFlagsClass, cg);
         Inst_MemReg(opSMemReg, node, MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), clzReg,
             cg);
     }
@@ -7456,8 +7386,7 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
 
 #if defined(J9VM_OPT_NEW_OBJECT_HASH)
         // put orFlags or 0 into header if needed
-        Inst_MemImm(TR::InstOpCode::S4MemImm4, node, MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_FLAGS, cg), orFlags,
-            cg);
+        Inst_MemImm(OP::S4MemImm4, node, MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_FLAGS, cg), orFlags, cg);
 
 #endif /* !J9VM_OPT_NEW_OBJECT_HASH */
     }
@@ -7474,13 +7403,12 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
     // 0 will force the locking to go to the slow locking path.
     if (isDynamicAllocation) {
         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
-            MRef_Bdisp32(clzReg, offsetof(J9ArrayClass, lockOffset), cg), cg);
-        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)-1, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
-        Inst_MemImm(TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
+        Inst_RegMem(OP::LRegMem(), node, tempReg, MRef_Bdisp32(clzReg, offsetof(J9ArrayClass, lockOffset), cg), cg);
+        Inst_RegImm(OP::CMPRegImm4(), node, tempReg, (int32_t)-1, cg);
+        Inst_Label(OP::JE4, node, doneLabel, cg);
+        Inst_MemImm(OP::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
             MRef_BIS(objectReg, tempReg, 0, cg), 0, cg);
-        Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
+        Inst_Label(OP::label, node, doneLabel, cg);
     } else {
         bool initReservable = TR::Compiler->cls.classFlagReservableWordInitValue(clazz);
         if (!isZeroInitialized || initReservable) {
@@ -7494,8 +7422,8 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
                 if (initReservable)
                     initialLwValue = OBJECT_HEADER_LOCK_RESERVED;
 
-                Inst_MemImm(TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()),
-                    node, MRef_Bdisp32(objectReg, lwOffset, cg), initialLwValue, cg);
+                Inst_MemImm(OP::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
+                    MRef_Bdisp32(objectReg, lwOffset, cg), initialLwValue, cg);
             }
         }
     }
@@ -7550,16 +7478,15 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
         if (canUseFastInlineAllocation) {
             // Native 64-bit needs to cover the discontiguous size field
             //
-            TR::InstOpCode::Mnemonic storeOp = (comp->target().is64Bit() && !comp->useCompressedPointers())
-                ? TR::InstOpCode::S8MemReg
-                : TR::InstOpCode::S4MemReg;
+            OP::Mnemonic storeOp
+                = (comp->target().is64Bit() && !comp->useCompressedPointers()) ? OP::S8MemReg : OP::S4MemReg;
             Inst_MemReg(storeOp, node, arraySizeMR, sizeReg, cg);
         } else {
-            Inst_MemReg(TR::InstOpCode::S4MemReg, node, arraySizeMR, sizeReg, cg);
+            Inst_MemReg(OP::S4MemReg, node, arraySizeMR, sizeReg, cg);
         }
         // Take care of zero sized arrays as they are discontiguous and not contiguous
         if (shouldInitZeroSizedArrayHeader) {
-            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
+            Inst_MemImm(OP::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
         }
     } else {
         // Fixed size
@@ -7568,18 +7495,17 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
         if (canUseFastInlineAllocation) {
             // Native 64-bit needs to cover the discontiguous size field
             //
-            TR::InstOpCode::Mnemonic storeOp = (comp->target().is64Bit() && !comp->useCompressedPointers())
-                ? TR::InstOpCode::S8MemImm4
-                : TR::InstOpCode::S4MemImm4;
+            OP::Mnemonic storeOp
+                = (comp->target().is64Bit() && !comp->useCompressedPointers()) ? OP::S8MemImm4 : OP::S4MemImm4;
             instanceSize = node->getFirstChild()->getInt();
             Inst_MemImm(storeOp, node, arraySizeMR, instanceSize, cg);
         } else {
             instanceSize = node->getFirstChild()->getInt();
-            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arraySizeMR, instanceSize, cg);
+            Inst_MemImm(OP::S4MemImm4, node, arraySizeMR, instanceSize, cg);
         }
         // Take care of zero sized arrays as they are discontiguous and not contiguous
         if (shouldInitZeroSizedArrayHeader && (instanceSize == 0)) {
-            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
+            Inst_MemImm(OP::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
         }
     }
 
@@ -7587,20 +7513,19 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
 
     if (generateArraylets) {
         // write arraylet pointer
-        TR::InstOpCode::Mnemonic storeOp;
+        OP::Mnemonic storeOp;
 
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg, MRef_Bdisp32(objectReg, arrayletDataOffset, cg), cg);
+        Inst_RegMem(OP::LEARegMem(), node, tempReg, MRef_Bdisp32(objectReg, arrayletDataOffset, cg), cg);
 
         if (comp->useCompressedPointers()) {
-            storeOp = TR::InstOpCode::S4MemReg;
+            storeOp = OP::S4MemReg;
 
             // Compress the arraylet pointer.
             //
             if (TR::Compiler->om.compressedReferenceShiftOffset() > 0)
-                Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg,
-                    TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+                Inst_RegImm(OP::SHR8RegImm1, node, tempReg, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         } else {
-            storeOp = TR::InstOpCode::SMemReg();
+            storeOp = OP::SMemReg();
         }
 
         TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
@@ -7656,7 +7581,7 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
     }
 
     if (sizeReg || objectSizeInBytes >= minRepstosdWords) {
-        // Zero-initialize by using REP TR::InstOpCode::STOSB.
+        // Zero-initialize by using REP OP::STOSB.
         //
         if (sizeReg) {
             // -------------
@@ -7668,16 +7593,16 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
             // When the size is in a register, the numBytesToZeroInitReg contains the
             // rounded object size including the header
             //
-            Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, numBytesToZeroInitReg, headerSizeInBytes, cg);
+            Inst_RegImm(OP::SUBRegImms(), node, numBytesToZeroInitReg, headerSizeInBytes, cg);
         } else {
             // ----------
             // FIXED SIZE
             // ----------
 
             if (comp->target().is64Bit() && !IS_32BIT_SIGNED(objectSizeInBytes)) {
-                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, numBytesToZeroInitReg, objectSizeInBytes, cg);
+                Inst_RegImm64(OP::MOV8RegImm64, node, numBytesToZeroInitReg, objectSizeInBytes, cg);
             } else {
-                Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, numBytesToZeroInitReg, objectSizeInBytes, cg);
+                Inst_RegImm(OP::MOVRegImm4(), node, numBytesToZeroInitReg, objectSizeInBytes, cg);
             }
         }
 
@@ -7716,26 +7641,26 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
             TR::LabelSymbol *repStosInitLabelSym = generateLabelSymbol(cg);
             TR::LabelSymbol *mergeInitLabelSym = generateLabelSymbol(cg);
 
-            Inst_RegImm(TR::InstOpCode::CMPRegImms(), node, numBytesToZeroInitReg,
+            Inst_RegImm(OP::CMPRegImms(), node, numBytesToZeroInitReg,
                 repStosZeroInitThresholdBytes + repSTOSThresholdAdjustment, cg);
-            Inst_Label(TR::InstOpCode::JG4, node, repStosInitLabelSym, cg);
+            Inst_Label(OP::JG4, node, repStosInitLabelSym, cg);
 
             // Begin zero initialization after the header, adjusting for header size
             // if necessary
             //
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
+            Inst_RegMem(OP::LEARegMem(), node, segmentReg,
                 MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + startingAddressAdjustment, cg), cg);
 
-            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, zeroInitScratchReg, zeroInitScratchReg, cg);
+            Inst_RegReg(OP::XOR4RegReg, node, zeroInitScratchReg, zeroInitScratchReg, cg);
 
             // Generate mainline zero initialization with stores
             //
             TR::LabelSymbol *zeroInitLoopLabelSym = generateLabelSymbol(cg);
-            Inst_Label(TR::InstOpCode::label, node, zeroInitLoopLabelSym, cg);
-            Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(segmentReg, 0, cg), zeroInitScratchReg, cg);
-            Inst_RegImm(TR::InstOpCode::ADD8RegImms, node, segmentReg, 8, cg);
-            Inst_RegImm(TR::InstOpCode::SUB8RegImms, node, numBytesToZeroInitReg, 8, cg);
-            Inst_Label(TR::InstOpCode::JG4, node, zeroInitLoopLabelSym, cg);
+            Inst_Label(OP::label, node, zeroInitLoopLabelSym, cg);
+            Inst_MemReg(OP::S8MemReg, node, MRef_Bdisp32(segmentReg, 0, cg), zeroInitScratchReg, cg);
+            Inst_RegImm(OP::ADD8RegImms, node, segmentReg, 8, cg);
+            Inst_RegImm(OP::SUB8RegImms, node, numBytesToZeroInitReg, 8, cg);
+            Inst_Label(OP::JG4, node, zeroInitLoopLabelSym, cg);
 
             {
                 // Generate out-of-line REP STOS initialization
@@ -7748,14 +7673,14 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
 
                 // Begin zero initialization after the header
                 //
-                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
-                    MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg), cg);
+                Inst_RegMem(OP::LEARegMem(), node, segmentReg, MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg),
+                    cg);
 
-                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg, cg);
-                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg, cg);
-                Inst(TR::InstOpCode::REPSTOSB, node, cg);
-                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg, cg);
-                Inst_Label(TR::InstOpCode::JMP4, node, mergeInitLabelSym, cg);
+                Inst_RegReg(OP::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg, cg);
+                Inst_RegReg(OP::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg, cg);
+                Inst(OP::REPSTOSB, node, cg);
+                Inst_RegReg(OP::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg, cg);
+                Inst_Label(OP::JMP4, node, mergeInitLabelSym, cg);
                 og.endOutlinedInstructionSequence();
             }
 
@@ -7763,26 +7688,26 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
 
             // Merge
             //
-            Inst_Label(TR::InstOpCode::label, node, mergeInitLabelSym, cg);
+            Inst_Label(OP::label, node, mergeInitLabelSym, cg);
         } else {
 #endif
             // Begin zero initialization after the header
             //
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
-                MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg), cg);
+            Inst_RegMem(OP::LEARegMem(), node, segmentReg, MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg),
+                cg);
 
             if (comp->target().is64Bit()) {
-                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg, cg);
+                Inst_RegReg(OP::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg, cg);
             } else {
-                Inst_Reg(TR::InstOpCode::PUSHReg, node, newObjectAddressReg, cg);
+                Inst_Reg(OP::PUSHReg, node, newObjectAddressReg, cg);
             }
-            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg, cg);
-            Inst(TR::InstOpCode::REPSTOSB, node, cg);
+            Inst_RegReg(OP::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg, cg);
+            Inst(OP::REPSTOSB, node, cg);
             if (comp->target().is64Bit()) {
-                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg, cg);
+                Inst_RegReg(OP::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg, cg);
                 srm->reclaimScratchRegister(zeroInitScratchReg);
             } else {
-                Inst_Reg(TR::InstOpCode::POPReg, node, newObjectAddressReg, cg);
+                Inst_Reg(OP::POPReg, node, newObjectAddressReg, cg);
             }
 #ifdef TR_TARGET_64BIT
         }
@@ -7797,23 +7722,23 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
         }
 
         TR::Register *scratchReg = srm->findOrCreateScratchRegister(TR_FPR);
-        Inst_RegReg(TR::InstOpCode::PXORRegReg, node, scratchReg, scratchReg, cg);
+        Inst_RegReg(OP::PXORRegReg, node, scratchReg, scratchReg, cg);
         int32_t offset = 0;
         while (objectSizeInBytes >= 16) {
-            Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
-                MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
+            Inst_MemReg(OP::MOVDQUMemReg, node, MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg),
+                scratchReg, cg);
             objectSizeInBytes -= 16;
             offset += 16;
         }
 
         switch (objectSizeInBytes) {
             case 8:
-                Inst_MemReg(TR::InstOpCode::MOVQMemReg, node,
-                    MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
+                Inst_MemReg(OP::MOVQMemReg, node, MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg),
+                    scratchReg, cg);
                 break;
             case 4:
-                Inst_MemReg(TR::InstOpCode::MOVDMemReg, node,
-                    MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
+                Inst_MemReg(OP::MOVDMemReg, node, MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg),
+                    scratchReg, cg);
                 break;
             case 0:
                 break;
@@ -7923,15 +7848,14 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             minRepstosdWords = MIN_REPSTOSD_WORDS; // Use default value
     }
 
-    int32_t alignmentDelta
-        = 0; // for aligning properly to get best performance from REP TR::InstOpCode::STOSD/TR::InstOpCode::STOSQ
+    int32_t alignmentDelta = 0; // for aligning properly to get best performance from REP OP::STOSD/OP::STOSQ
 
     if (sizeReg || (numSlots + alignmentDelta) >= minRepstosdWords) {
-        // Zero-initialize by using REP TR::InstOpCode::STOSD/TR::InstOpCode::STOSQ.
+        // Zero-initialize by using REP OP::STOSD/OP::STOSQ.
         //
         // startOffset will be monitorSlot only for arrays
 
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg, MRef_Bdisp32(targetReg, startOfZeroInits, cg), cg);
+        Inst_RegMem(OP::LEARegMem(), node, segmentReg, MRef_Bdisp32(targetReg, startOfZeroInits, cg), cg);
 
         if (sizeReg) {
             int32_t additionalSlots = 0;
@@ -7948,42 +7872,40 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
                 //
                 case 1:
                     if (comp->target().is64Bit()) {
-                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            MRef_Bdisp32(sizeReg, (additionalSlots * 8) + 7, cg), cg);
-                        Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg, 3, cg);
+                        Inst_RegMem(OP::LEA8RegMem, node, tempReg, MRef_Bdisp32(sizeReg, (additionalSlots * 8) + 7, cg),
+                            cg);
+                        Inst_RegImm(OP::SHR8RegImm1, node, tempReg, 3, cg);
                     } else {
-                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
-                            MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg), cg);
-                        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, tempReg, 2, cg);
+                        Inst_RegMem(OP::LEA4RegMem, node, tempReg, MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg),
+                            cg);
+                        Inst_RegImm(OP::SHR4RegImm1, node, tempReg, 2, cg);
                     }
                     break;
                 case 2:
                     if (comp->target().is64Bit()) {
-                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg), cg);
-                        Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg, 2, cg);
+                        Inst_RegMem(OP::LEA8RegMem, node, tempReg, MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg),
+                            cg);
+                        Inst_RegImm(OP::SHR8RegImm1, node, tempReg, 2, cg);
                     } else {
-                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
-                            MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg), cg);
-                        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, tempReg, 1, cg);
+                        Inst_RegMem(OP::LEA4RegMem, node, tempReg, MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg),
+                            cg);
+                        Inst_RegImm(OP::SHR4RegImm1, node, tempReg, 1, cg);
                     }
                     break;
                 case 4:
                     if (comp->target().is64Bit()) {
-                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg), cg);
-                        Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg, 1, cg);
+                        Inst_RegMem(OP::LEA8RegMem, node, tempReg, MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg),
+                            cg);
+                        Inst_RegImm(OP::SHR8RegImm1, node, tempReg, 1, cg);
                     } else {
-                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
-                            MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
+                        Inst_RegMem(OP::LEA4RegMem, node, tempReg, MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
                     }
                     break;
                 case 8:
                     if (comp->target().is64Bit()) {
-                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
+                        Inst_RegMem(OP::LEA8RegMem, node, tempReg, MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
                     } else {
-                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
+                        Inst_RegMem(OP::LEA4RegMem, node, tempReg,
                             MRef_BISdisp32(NULL, sizeReg, TR::MemoryReference::convertMultiplierToStride(2),
                                 additionalSlots, cg),
                             cg);
@@ -7993,23 +7915,23 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         } else {
             // Fixed size
             //
-            Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, tempReg, numSlots + alignmentDelta, cg);
+            Inst_RegImm(OP::MOVRegImm4(), node, tempReg, numSlots + alignmentDelta, cg);
             if (comp->target().is64Bit()) {
                 // TODO AMD64: replace both instructions with a LEA tempReg, [disp32]
                 //
-                Inst_RegReg(TR::InstOpCode::MOVSXReg8Reg4, node, tempReg, tempReg, cg);
+                Inst_RegReg(OP::MOVSXReg8Reg4, node, tempReg, tempReg, cg);
             }
         }
 
         TR::Register *scratchReg = NULL;
         if (comp->target().is64Bit()) {
             scratchReg = srm->findOrCreateScratchRegister();
-            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, scratchReg, targetReg, cg);
+            Inst_RegReg(OP::MOVRegReg(), node, scratchReg, targetReg, cg);
         } else {
-            Inst_Reg(TR::InstOpCode::PUSHReg, node, targetReg, cg);
+            Inst_Reg(OP::PUSHReg, node, targetReg, cg);
         }
 
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, targetReg, targetReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, targetReg, targetReg, cg);
 
         // We just pushed targetReg on the stack and zeroed it out. targetReg contained the address of the
         // beginning of the header. We want to use the 0-reg to initialize the monitor slot, so we use
@@ -8020,36 +7942,34 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         initLw = false;
 
         if (initLw) {
-            TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
-                ? TR::InstOpCode::S4MemReg
-                : TR::InstOpCode::SMemReg();
+            OP::Mnemonic op
+                = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? OP::S4MemReg : OP::SMemReg();
             Inst_MemReg(op, node, MRef_Bdisp32(segmentReg, lwOffset - startOfZeroInits, cg), targetReg, cg);
         }
 
-        TR::InstOpCode::Mnemonic op = comp->target().is64Bit() ? TR::InstOpCode::REPSTOSQ : TR::InstOpCode::REPSTOSD;
+        OP::Mnemonic op = comp->target().is64Bit() ? OP::REPSTOSQ : OP::REPSTOSD;
         Inst(op, node, cg);
 
         if (comp->target().is64Bit()) {
-            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg, scratchReg, cg);
+            Inst_RegReg(OP::MOVRegReg(), node, targetReg, scratchReg, cg);
             srm->reclaimScratchRegister(scratchReg);
         } else {
-            Inst_Reg(TR::InstOpCode::POPReg, node, targetReg, cg);
+            Inst_Reg(OP::POPReg, node, targetReg, cg);
         }
 
         return true;
     }
 
     if (numSlots > 0) {
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, tempReg, tempReg, cg);
 
         bool initLw = (node->getOpCodeValue() != TR::New);
         int lwOffset = fej9->getByteOffsetToLockword(clazz);
         initLw = false;
 
         if (initLw) {
-            TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
-                ? TR::InstOpCode::S4MemReg
-                : TR::InstOpCode::SMemReg();
+            OP::Mnemonic op
+                = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? OP::S4MemReg : OP::SMemReg();
             Inst_MemReg(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), tempReg, cg);
         }
     } else {
@@ -8058,9 +7978,8 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         initLw = false;
 
         if (initLw) {
-            TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
-                ? TR::InstOpCode::S4MemImm4
-                : TR::InstOpCode::SMemImm4();
+            OP::Mnemonic op
+                = (comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? OP::S4MemImm4 : OP::SMemImm4();
             Inst_MemImm(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), 0, cg);
         }
         return false;
@@ -8075,28 +7994,27 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
 
         endOffset = (int32_t)(numLoopSlots * TR::Compiler->om.sizeofReferenceAddress() + startOfZeroInits);
 
-        Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, segmentReg,
-            -((numIterations - 1) * maxZeroInitWordsPerIteration), cg);
+        Inst_RegImm(OP::MOVRegImm4(), node, segmentReg, -((numIterations - 1) * maxZeroInitWordsPerIteration), cg);
 
         if (comp->target().is64Bit())
-            Inst_RegReg(TR::InstOpCode::MOVSXReg8Reg4, node, segmentReg, segmentReg, cg);
+            Inst_RegReg(OP::MOVSXReg8Reg4, node, segmentReg, segmentReg, cg);
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+        Inst_Label(OP::label, node, loopLabel, cg);
         for (i = maxZeroInitWordsPerIteration; i > 0; i--) {
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(OP::SMemReg(), node,
                 MRef_BISdisp32(targetReg, segmentReg,
                     TR::MemoryReference::convertMultiplierToStride((int32_t)TR::Compiler->om.sizeofReferenceAddress()),
                     endOffset - TR::Compiler->om.sizeofReferenceAddress() * i, cg),
                 tempReg, cg);
         }
-        Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, segmentReg, maxZeroInitWordsPerIteration, cg);
-        Inst_Label(TR::InstOpCode::JLE4, node, loopLabel, cg);
+        Inst_RegImm(OP::ADDRegImms(), node, segmentReg, maxZeroInitWordsPerIteration, cg);
+        Inst_Label(OP::JLE4, node, loopLabel, cg);
 
         // Generate the left-over initializations
         //
         for (i = 0; i < numSlots % maxZeroInitWordsPerIteration; i++) {
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(OP::SMemReg(), node,
                 MRef_Bdisp32(targetReg, endOffset + TR::Compiler->om.sizeofReferenceAddress() * i, cg), tempReg, cg);
         }
     } else {
@@ -8105,7 +8023,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         for (i = 0; i < numSlots; i++) {
             // Don't bother initializing the array-size slot
             //
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(OP::SMemReg(), node,
                 MRef_Bdisp32(targetReg, i * TR::Compiler->om.sizeofReferenceAddress() + startOfZeroInits, cg), tempReg,
                 cg);
         }
@@ -8157,36 +8075,35 @@ static void handleOffHeapDataForArrays(TR::Node *node, TR::Register *sizeReg, TR
             fej9->getOffsetOfDiscontiguousDataAddrField(), fej9->getOffsetOfContiguousDataAddrField());
 
         TR::Register *discontiguousDataAddrOffsetReg = srm->findOrCreateScratchRegister();
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, discontiguousDataAddrOffsetReg, discontiguousDataAddrOffsetReg,
-            cg);
+        Inst_RegReg(OP::XOR4RegReg, node, discontiguousDataAddrOffsetReg, discontiguousDataAddrOffsetReg, cg);
         // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of sizeReg.
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, 1, cg);
-        Inst_RegImm(TR::InstOpCode::ADCRegImm4(), node, discontiguousDataAddrOffsetReg, 0, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, sizeReg, 1, cg);
+        Inst_RegImm(OP::ADCRegImm4(), node, discontiguousDataAddrOffsetReg, 0, cg);
 
         dataAddrMR = MRef_BISdisp32(targetReg, discontiguousDataAddrOffsetReg, 3,
             TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
         dataAddrSlotMR = MRef_BISdisp32(targetReg, discontiguousDataAddrOffsetReg, 3,
             fej9->getOffsetOfContiguousDataAddrField(), cg);
         // Load first data element address
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
+        Inst_RegMem(OP::LEARegMem(), node, tempReg, dataAddrMR, cg);
 
         // Clear out tempReg if dealing with 0 length array
         zeroReg = srm->findOrCreateScratchRegister();
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, zeroReg, zeroReg, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, zeroReg, zeroReg, cg);
         // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of sizeReg.
-        Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-        Inst_RegReg(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
+        Inst_RegReg(OP::TEST4RegReg, node, sizeReg, sizeReg, cg);
+        Inst_RegReg(OP::CMOVERegReg(), node, tempReg, zeroReg, cg);
         srm->reclaimScratchRegister(zeroReg);
 
         // Write first data element address to dataAddr slot
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
         srm->reclaimScratchRegister(discontiguousDataAddrOffsetReg);
     } else if (NULL == sizeReg && node->getFirstChild()->getOpCode().isLoadConst()
         && node->getFirstChild()->getInt() == 0) {
         logprintf(trace, log, "Node (%p): Dealing with full/compressed refs fixed length zero size array.\n", node);
 
         dataAddrSlotMR = MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg);
-        Inst_MemImm(TR::InstOpCode::SMemImm4(), node, dataAddrSlotMR, 0, cg);
+        Inst_MemImm(OP::SMemImm4(), node, dataAddrSlotMR, 0, cg);
     } else {
         logprintf(trace, log,
             "Node (%p): Dealing with either full/compressed refs fixed length non-zero size array or full refs "
@@ -8205,19 +8122,19 @@ static void handleOffHeapDataForArrays(TR::Node *node, TR::Register *sizeReg, TR
         dataAddrMR = MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
         dataAddrSlotMR = MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg);
         // Load first data element address
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
+        Inst_RegMem(OP::LEARegMem(), node, tempReg, dataAddrMR, cg);
 
         if (!TR::Compiler->om.compressObjectReferences() && NULL != sizeReg) {
             // Clear out tempReg if dealing with 0 length array
             zeroReg = srm->findOrCreateScratchRegister();
-            Inst_RegReg(TR::InstOpCode::XORRegReg(), node, zeroReg, zeroReg, cg);
+            Inst_RegReg(OP::XORRegReg(), node, zeroReg, zeroReg, cg);
             // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of sizeReg.
-            Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-            Inst_RegReg(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
+            Inst_RegReg(OP::TEST4RegReg, node, sizeReg, sizeReg, cg);
+            Inst_RegReg(OP::CMOVERegReg(), node, tempReg, zeroReg, cg);
             srm->reclaimScratchRegister(zeroReg);
         }
         // Write first data element address to dataAddr slot
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
     }
 }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
@@ -8454,7 +8371,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     // Generate the helper call for out-of-line allocation
     //
@@ -8525,10 +8442,10 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
             TR_BitVectorIterator bvi(*initInfo->zeroInitSlots);
             static bool UseOldBVI = feGetEnv("TR_UseOldBVI");
             if (UseOldBVI) {
-                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
+                Inst_RegReg(OP::XOR4RegReg, node, tempReg, tempReg, cg);
                 while (bvi.hasMoreElements()) {
-                    Inst_MemReg(TR::InstOpCode::S4MemReg, node,
-                        MRef_Bdisp32(targetReg, bvi.getNextElement() * 4 + dataOffset, cg), tempReg, cg);
+                    Inst_MemReg(OP::S4MemReg, node, MRef_Bdisp32(targetReg, bvi.getNextElement() * 4 + dataOffset, cg),
+                        tempReg, cg);
                 }
             } else {
                 int32_t lastElementIndex = -1;
@@ -8536,7 +8453,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 int32_t span = 0;
                 int32_t lastSpan = -1;
                 scratchReg = srm->findOrCreateScratchRegister(TR_FPR);
-                Inst_RegReg(TR::InstOpCode::PXORRegReg, node, scratchReg, scratchReg, cg);
+                Inst_RegReg(OP::PXORRegReg, node, scratchReg, scratchReg, cg);
                 while (bvi.hasMoreElements()) {
                     nextE = bvi.getNextElement();
                     if (-1 == lastElementIndex)
@@ -8547,18 +8464,18 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                         lastSpan = span;
                         continue;
                     } else if (span == 3) {
-                        Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
+                        Inst_MemReg(OP::MOVDQUMemReg, node,
                             MRef_Bdisp32(targetReg, lastElementIndex * 4 + dataOffset, cg), scratchReg, cg);
                         lastSpan = -1;
                         lastElementIndex = -1;
                     } else if (span > 3) {
-                        TR::InstOpCode::Mnemonic storeOpCode;
+                        OP::Mnemonic storeOpCode;
                         if (lastSpan == 0) {
-                            storeOpCode = TR::InstOpCode::MOVDMemReg;
+                            storeOpCode = OP::MOVDMemReg;
                         } else if (lastSpan == 1) {
-                            storeOpCode = TR::InstOpCode::MOVQMemReg;
+                            storeOpCode = OP::MOVQMemReg;
                         } else {
-                            storeOpCode = TR::InstOpCode::MOVDQUMemReg;
+                            storeOpCode = OP::MOVDQUMemReg;
                         }
 
                         Inst_MemReg(storeOpCode, node, MRef_Bdisp32(targetReg, lastElementIndex * 4 + dataOffset, cg),
@@ -8570,25 +8487,25 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 }
 
                 int32_t adjustedDataOffset = dataOffset;
-                TR::InstOpCode::Mnemonic storeOpCode = TR::InstOpCode::bad;
+                OP::Mnemonic storeOpCode = OP::bad;
 
                 switch (lastSpan) {
                     case 0:
-                        storeOpCode = TR::InstOpCode::MOVDMemReg;
+                        storeOpCode = OP::MOVDMemReg;
                         break;
                     case 1:
-                        storeOpCode = TR::InstOpCode::MOVQMemReg;
+                        storeOpCode = OP::MOVQMemReg;
                         break;
                     case 2:
                         TR_ASSERT(dataOffset >= 4, "dataOffset must be >= 4.");
-                        storeOpCode = TR::InstOpCode::MOVDQUMemReg;
+                        storeOpCode = OP::MOVDQUMemReg;
                         adjustedDataOffset -= 4;
                         break;
                     default:
                         break;
                 }
 
-                if (storeOpCode != TR::InstOpCode::bad) {
+                if (storeOpCode != OP::bad) {
                     Inst_MemReg(storeOpCode, node,
                         MRef_Bdisp32(targetReg, lastElementIndex * 4 + adjustedDataOffset, cg), scratchReg, cg);
                 }
@@ -8625,7 +8542,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 // via the contiguous length slot.
                 //
                 if (node->getOpCodeValue() != TR::New && (comp->target().is32Bit() || comp->useCompressedPointers())) {
-                    Inst_MemImm(TR::InstOpCode::SMemImm4(), node,
+                    Inst_MemImm(OP::SMemImm4(), node,
                         MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
                     shouldInitZeroSizedArrayHeader = false;
                 }
@@ -8739,7 +8656,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
 
     deps->stopAddingConditions();
 
-    Inst_Label(TR::InstOpCode::label, node, fallThru, deps, cg);
+    Inst_Label(OP::label, node, fallThru, deps, cg);
 
     // Copy the newly allocated object into a collected reference register
     // now that it is a valid object.
@@ -8747,7 +8664,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
     TR::Register *targetReg2 = cg->allocateCollectedReferenceRegister();
     TR::RegisterDependencyConditions *deps2 = RegDeps(0, 1, cg);
     deps2->addPostCondition(targetReg2, TR::RealRegister::eax, cg);
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
     cg->stopUsingRegister(targetReg);
     targetReg = targetReg2;
 
@@ -8793,7 +8710,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR::MemoryReference *destTypeMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
 
-            Inst_RegMem(TR::InstOpCode::L4RegMem, node, destComponentClassReg, destTypeMR,
+            Inst_RegMem(OP::L4RegMem, node, destComponentClassReg, destTypeMR,
                 cg); // class pointer is 32 bits
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
 
@@ -8807,10 +8724,9 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR_ASSERT((((uintptr_t)objectClass) >> 32) == 0,
                 "TR_OpaqueClassBlock must fit on 32 bits when using class pointer compression");
-            instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
-                (uint32_t)((uint64_t)objectClass), cg);
+            instr = Inst_RegImm(OP::CMP4RegImm4, node, destComponentClassReg, (uint32_t)((uint64_t)objectClass), cg);
 
-            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_Label(OP::JE4, node, wrtbarLabel, cg);
 
             // here we may have to convert the TR_OpaqueClassBlock into a J9Class pointer
             // and store it in destComponentClassReg
@@ -8818,7 +8734,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR::MemoryReference *destCompTypeMR
                 = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
 
             // here we may have to convert the J9Class pointer from destComponentClassReg into
             // a TR_OpaqueClassBlock and store it back into destComponentClassReg
@@ -8826,35 +8742,35 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR::MemoryReference *sourceRegClassMR
                 = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            Inst_RegMem(TR::InstOpCode::L4RegMem, node, sourceClassReg, sourceRegClassMR, cg);
+            Inst_RegMem(OP::L4RegMem, node, sourceClassReg, sourceRegClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
 
-            Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, destComponentClassReg, sourceClassReg,
+            Inst_RegReg(OP::CMP4RegReg, node, destComponentClassReg, sourceClassReg,
                 cg); // compare only 32 bits
-            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_Label(OP::JE4, node, wrtbarLabel, cg);
 
             // -------------------------------------------------------------------------
             //          // Check the source class cast cache
             //
             // -------------------------------------------------------------------------
 
-            Inst_MemReg(TR::InstOpCode::CMP4MemReg, node,
-                MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg), destComponentClassReg, cg);
+            Inst_MemReg(OP::CMP4MemReg, node, MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg),
+                destComponentClassReg, cg);
         } else // no class pointer compression
         {
             TR::MemoryReference *sourceClassMR = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
 
             TR::MemoryReference *destClassMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, destComponentClassReg, destClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
             TR::MemoryReference *destCompTypeMR
                 = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
 
-            Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, destComponentClassReg, sourceClassReg, cg);
-            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_RegReg(OP::CMPRegReg(), node, destComponentClassReg, sourceClassReg, cg);
+            Inst_Label(OP::JE4, node, wrtbarLabel, cg);
 
             // -------------------------------------------------------------------------
             //
@@ -8862,10 +8778,10 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             //
             // -------------------------------------------------------------------------
 
-            Inst_MemReg(TR::InstOpCode::CMPMemReg(), node,
-                MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg), destComponentClassReg, cg);
+            Inst_MemReg(OP::CMPMemReg(), node, MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg),
+                destComponentClassReg, cg);
         }
-        Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+        Inst_Label(OP::JE4, node, wrtbarLabel, cg);
 
         instr = NULL;
         /*
@@ -8885,32 +8801,32 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
               if (TR::Compiler->om.compressObjectReferences())
                  {
                  TR_ASSERT((((uintptr_t)objectClass) >> 32) == 0, "TR_OpaqueClassBlock must fit on 32 bits when using
-        class pointer compression"); instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node,
+        class pointer compression"); instr = Inst_RegImm(OP::CMP4RegImm4, node,
         destComponentClassReg, (uint32_t) ((uint64_t) objectClass), cg);
                  }
               else // 64 bit but no class pointer compression
                  {
                  if ((uintptr_t)objectClass <= (uintptr_t)0x7fffffff)
                     {
-                    instr = Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, destComponentClassReg,
+                    instr = Inst_RegImm(OP::CMP8RegImm4, node, destComponentClassReg,
         (uintptr_t) objectClass, cg);
                     }
                  else
                     {
                     TR::Register *objectClassReg = scratchRegisterManager->findOrCreateScratchRegister();
-                    instr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, objectClassReg, (uintptr_t)
-        objectClass, cg); Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, destComponentClassReg,
+                    instr = Inst_RegImm64(OP::MOV8RegImm64, node, objectClassReg, (uintptr_t)
+        objectClass, cg); Inst_RegReg(OP::CMP8RegReg, node, destComponentClassReg,
         objectClassReg, cg); scratchRegisterManager->reclaimScratchRegister(objectClassReg);
                     }
                  }
            }
         else
            {
-           instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
+           instr = Inst_RegImm(OP::CMP4RegImm4, node, destComponentClassReg,
         (int32_t)(uintptr_t) objectClass, cg);
            }
 
-        Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+        Inst_Label(OP::JE4, node, wrtbarLabel, cg);
         */
 
         // ---------------------------------------------
@@ -8926,7 +8842,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
                 if (TR::Compiler->om.compressObjectReferences()) {
                     TR_ASSERT((((uintptr_t)arrayComponentClass) >> 32) == 0,
                         "TR_OpaqueClassBlock must fit on 32 bits when using class pointer compression");
-                    instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
+                    instr = Inst_RegImm(OP::CMP4RegImm4, node, destComponentClassReg,
                         (uint32_t)((uint64_t)arrayComponentClass), cg);
 
                     if (fej9->isUnloadAssumptionRequired(arrayComponentClass, comp->getCurrentMethod()))
@@ -8935,28 +8851,27 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
                 } else // 64 bit but no class pointer compression
                 {
                     if ((uintptr_t)arrayComponentClass <= (uintptr_t)0x7fffffff) {
-                        instr = Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, destComponentClassReg,
+                        instr = Inst_RegImm(OP::CMP8RegImm4, node, destComponentClassReg,
                             (uintptr_t)arrayComponentClass, cg);
                         if (fej9->isUnloadAssumptionRequired(arrayComponentClass, comp->getCurrentMethod()))
                             comp->getStaticPICSites()->push_front(instr);
 
                     } else {
                         TR::Register *arrayComponentClassReg = scratchRegisterManager->findOrCreateScratchRegister();
-                        instr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, arrayComponentClassReg,
+                        instr = Inst_RegImm64(OP::MOV8RegImm64, node, arrayComponentClassReg,
                             (uintptr_t)arrayComponentClass, cg);
-                        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, destComponentClassReg, arrayComponentClassReg,
-                            cg);
+                        Inst_RegReg(OP::CMP8RegReg, node, destComponentClassReg, arrayComponentClassReg, cg);
                         scratchRegisterManager->reclaimScratchRegister(arrayComponentClassReg);
                     }
                 }
             } else {
-                instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
+                instr = Inst_RegImm(OP::CMP4RegImm4, node, destComponentClassReg,
                     (int32_t)(uintptr_t)arrayComponentClass, cg);
                 if (fej9->isUnloadAssumptionRequired(arrayComponentClass, comp->getCurrentMethod()))
                     comp->getStaticPICSites()->push_front(instr);
             }
 
-            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_Label(OP::JE4, node, wrtbarLabel, cg);
         }
 
         // For compressed references:
@@ -8984,22 +8899,20 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
         if (eliminateDepthMask) {
             if (comp->target().is64Bit())
-                Inst_RegMem(TR::InstOpCode::MOVZXReg8Mem2, node, destComponentClassDepthReg, destComponentClassDepthMR,
-                    cg);
+                Inst_RegMem(OP::MOVZXReg8Mem2, node, destComponentClassDepthReg, destComponentClassDepthMR, cg);
             else
-                Inst_RegMem(TR::InstOpCode::MOVZXReg4Mem2, node, destComponentClassDepthReg, destComponentClassDepthMR,
-                    cg);
+                Inst_RegMem(OP::MOVZXReg4Mem2, node, destComponentClassDepthReg, destComponentClassDepthMR, cg);
         } else {
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassDepthReg, destComponentClassDepthMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, destComponentClassDepthReg, destComponentClassDepthMR, cg);
         }
 
         if (!eliminateDepthMask) {
             if (comp->target().is64Bit()) {
                 TR_ASSERT(!(J9AccClassDepthMask & 0x80000000), "AMD64: need to use a second register for AND mask");
                 if (!(J9AccClassDepthMask & 0x80000000))
-                    Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, destComponentClassDepthReg, J9AccClassDepthMask, cg);
+                    Inst_RegImm(OP::AND8RegImm4, node, destComponentClassDepthReg, J9AccClassDepthMask, cg);
             } else {
-                Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, destComponentClassDepthReg, J9AccClassDepthMask, cg);
+                Inst_RegImm(OP::AND4RegImm4, node, destComponentClassDepthReg, J9AccClassDepthMask, cg);
             }
         }
 
@@ -9022,24 +8935,24 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
         TR::Register *sourceClassDepthReg = NULL;
         if (eliminateDepthMask) {
-            Inst_MemReg(TR::InstOpCode::CMP2MemReg, node, mr, destComponentClassDepthReg, cg);
+            Inst_MemReg(OP::CMP2MemReg, node, mr, destComponentClassDepthReg, cg);
         } else {
             sourceClassDepthReg = scratchRegisterManager->findOrCreateScratchRegister();
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceClassDepthReg, mr, cg);
+            Inst_RegMem(OP::LRegMem(), node, sourceClassDepthReg, mr, cg);
 
             if (comp->target().is64Bit()) {
                 TR_ASSERT(!(J9AccClassDepthMask & 0x80000000), "AMD64: need to use a second register for AND mask");
                 if (!(J9AccClassDepthMask & 0x80000000))
-                    Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
+                    Inst_RegImm(OP::AND8RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
             } else {
-                Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
+                Inst_RegImm(OP::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
             }
-            Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg, cg);
+            Inst_RegReg(OP::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg, cg);
         }
 
         /*TR::Register *sourceClassDepthReg = scratchRegisterManager->findOrCreateScratchRegister();
         Inst_RegMem(
-           TR::InstOpCode::LRegMem(),
+           OP::LRegMem(),
            node,
            sourceClassDepthReg,
            mr, cg);
@@ -9048,18 +8961,18 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
            {
            TR_ASSERT(!(J9AccClassDepthMask & 0x80000000), "AMD64: need to use a second register for AND mask");
            if (!(J9AccClassDepthMask & 0x80000000))
-              Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask,
+              Inst_RegImm(OP::AND8RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask,
         cg);
            }
         else
            {
-           Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
+           Inst_RegImm(OP::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
            }
 
-        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg,
+        Inst_RegReg(OP::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg,
         cg);*/
 
-        Inst_Label(TR::InstOpCode::JBE4, node, helperCallLabel, cg);
+        Inst_Label(OP::JBE4, node, helperCallLabel, cg);
         if (sourceClassDepthReg != NULL)
             scratchRegisterManager->reclaimScratchRegister(sourceClassDepthReg);
 
@@ -9072,7 +8985,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             //
             sourceClassReg = scratchRegisterManager->findOrCreateScratchRegister();
             TR::MemoryReference *sourceClassMR = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
         }
 
@@ -9084,7 +8997,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
         TR::Register *sourceSuperClassReg = scratchRegisterManager->findOrCreateScratchRegister();
 
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceSuperClassReg, tempMR, cg);
+        Inst_RegMem(OP::LRegMem(), node, sourceSuperClassReg, tempMR, cg);
 
         TR::MemoryReference *leaMR
             = MRef_BISdisp32(sourceSuperClassReg, destComponentClassDepthReg, logBase2(sizeof(uintptr_t)), 0, cg);
@@ -9095,20 +9008,20 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
         // We may need to convert superClass to a class offset before doing the comparison
 
         if (comp->target().is32Bit()) {
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceSuperClassReg, leaMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, sourceSuperClassReg, leaMR, cg);
 
             // Rematerialize destination component class
             //
             TR::MemoryReference *destClassMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
 
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
+            Inst_RegMem(OP::LRegMem(), node, destComponentClassReg, destClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
             TR::MemoryReference *destCompTypeMR
                 = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
 
-            Inst_MemReg(TR::InstOpCode::CMPMemReg(), node, destCompTypeMR, sourceSuperClassReg, cg);
+            Inst_MemReg(OP::CMPMemReg(), node, destCompTypeMR, sourceSuperClassReg, cg);
         } else {
-            Inst_RegMem(TR::InstOpCode::CMP4RegMem, node, destComponentClassReg, leaMR, cg);
+            Inst_RegMem(OP::CMP4RegMem, node, destComponentClassReg, leaMR, cg);
         }
 
         scratchRegisterManager->reclaimScratchRegister(destComponentClassReg);
@@ -9116,7 +9029,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
         scratchRegisterManager->reclaimScratchRegister(sourceClassReg);
         scratchRegisterManager->reclaimScratchRegister(sourceSuperClassReg);
 
-        Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+        Inst_Label(OP::JE4, node, wrtbarLabel, cg);
     }
 
     // The fast paths failed; execute the type-check helper call.
@@ -9125,11 +9038,11 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
     TR::Node *helperCallNode
         = TR::Node::createWithSymRef(TR::call, 2, 2, sourceChild, destinationChild, node->getSymbolReference());
     helperCallNode->copyByteCodeInfo(node);
-    Inst_Label(TR::InstOpCode::JMP4, helperCallNode, helperCallLabel, cg);
+    Inst_Label(OP::JMP4, helperCallNode, helperCallLabel, cg);
     TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory())
         TR_OutlinedInstructions(helperCallNode, TR::call, NULL, helperCallLabel, helperReturnLabel, cg);
     cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
-    Inst_Label(TR::InstOpCode::label, helperCallNode, helperReturnLabel, cg);
+    Inst_Label(OP::label, helperCallNode, helperReturnLabel, cg);
     cg->decReferenceCount(sourceChild);
     cg->decReferenceCount(destinationChild);
 }
@@ -9156,32 +9069,32 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
 
     startLabel->setStartInternalControlFlow();
     fallThrough->setEndInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     // If the objects are the same and one of them is known to be an array, they
     // are compatible.
     //
     if (node->isArrayChkPrimitiveArray1() || node->isArrayChkReferenceArray1() || node->isArrayChkPrimitiveArray2()
         || node->isArrayChkReferenceArray2()) {
-        Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, object1Reg, object2Reg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, fallThrough, cg);
+        Inst_RegReg(OP::CMPRegReg(), node, object1Reg, object2Reg, cg);
+        Inst_Label(OP::JE4, node, fallThrough, cg);
     }
 
     else {
         // Neither object is known to be an array
         // Check that object 1 is an array. If not, throw exception.
         //
-        TR::InstOpCode::Mnemonic testOpCode;
+        OP::Mnemonic testOpCode;
         if ((J9AccClassRAMArray >= CHAR_MIN) && (J9AccClassRAMArray <= CHAR_MAX))
-            testOpCode = TR::InstOpCode::TEST1MemImm1;
+            testOpCode = OP::TEST1MemImm1;
         else
-            testOpCode = TR::InstOpCode::TEST4MemImm4;
+            testOpCode = OP::TEST4MemImm4;
 
         if (TR::Compiler->om.compressObjectReferences())
-            Inst_RegMem(TR::InstOpCode::L4RegMem, node, tempReg,
+            Inst_RegMem(OP::L4RegMem, node, tempReg,
                 MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
         else
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(OP::LRegMem(), node, tempReg,
                 MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
 
         TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
@@ -9189,19 +9102,19 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
             J9AccClassRAMArray, cg);
         if (!snippetLabel) {
             snippetLabel = generateLabelSymbol(cg);
-            instr = Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+            instr = Inst_Label(OP::JE4, node, snippetLabel, cg);
             snippet = new (cg->trHeapMemory())
                 TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
             cg->addSnippet(snippet);
         } else
-            Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+            Inst_Label(OP::JE4, node, snippetLabel, cg);
     }
 
     // Test equality of the object classes.
     //
-    Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
+    Inst_RegMem(OP::LRegMem(use64BitClasses), node, tempReg,
         MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
-    Inst_RegMem(TR::InstOpCode::XORRegMem(use64BitClasses), node, tempReg,
+    Inst_RegMem(OP::XORRegMem(use64BitClasses), node, tempReg,
         MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
     TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
 
@@ -9212,19 +9125,19 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
     if (node->isArrayChkPrimitiveArray1() || node->isArrayChkPrimitiveArray2()) {
         if (!snippetLabel) {
             snippetLabel = generateLabelSymbol(cg);
-            instr = Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            instr = Inst_Label(OP::JNE4, node, snippetLabel, cg);
             snippet = new (cg->trHeapMemory())
                 TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
             cg->addSnippet(snippet);
         } else
-            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_Label(OP::JNE4, node, snippetLabel, cg);
     }
 
     // Otherwise, there is more testing to do. If the classes are equal we
     // are done, and branch to the fallThrough label.
     //
     else {
-        Inst_Label(TR::InstOpCode::JE4, node, fallThrough, cg);
+        Inst_Label(OP::JE4, node, fallThrough, cg);
 
         // If either object is not known to be a reference array type, check it
         // We already know that object1 is an array type but we may have to now
@@ -9232,69 +9145,65 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
         //
         if (!node->isArrayChkReferenceArray1()) {
             if (TR::Compiler->om.compressObjectReferences())
-                Inst_RegMem(TR::InstOpCode::L4RegMem, node, tempReg,
+                Inst_RegMem(OP::L4RegMem, node, tempReg,
                     MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             else
-                Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
+                Inst_RegMem(OP::LRegMem(), node, tempReg,
                     MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
 
             TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
-                MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+            Inst_RegMem(OP::LRegMem(), node, tempReg, MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg),
+                cg);
             // X = (ramclass->ClassDepthAndFlags)>>J9AccClassRAMShapeShift
 
             // X & OBJECT_HEADER_SHAPE_MASK
-            Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg,
-                (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
-            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg,
-                (OBJECT_HEADER_SHAPE_POINTERS << J9AccClassRAMShapeShift), cg);
+            Inst_RegImm(OP::ANDRegImm4(), node, tempReg, (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
+            Inst_RegImm(OP::CMPRegImm4(), node, tempReg, (OBJECT_HEADER_SHAPE_POINTERS << J9AccClassRAMShapeShift), cg);
 
             if (!snippetLabel) {
                 snippetLabel = generateLabelSymbol(cg);
-                instr = Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+                instr = Inst_Label(OP::JNE4, node, snippetLabel, cg);
                 snippet = new (cg->trHeapMemory())
                     TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
                 cg->addSnippet(snippet);
             } else
-                Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+                Inst_Label(OP::JNE4, node, snippetLabel, cg);
         }
         if (!node->isArrayChkReferenceArray2()) {
             // Check that object 2 is an array. If not, throw exception.
             //
-            TR::InstOpCode::Mnemonic testOpCode;
+            OP::Mnemonic testOpCode;
             if ((J9AccClassRAMArray >= CHAR_MIN) && (J9AccClassRAMArray <= CHAR_MAX))
-                testOpCode = TR::InstOpCode::TEST1MemImm1;
+                testOpCode = OP::TEST1MemImm1;
             else
-                testOpCode = TR::InstOpCode::TEST4MemImm4;
+                testOpCode = OP::TEST4MemImm4;
 
             // Check that object 2 is an array. If not, throw exception.
             //
             if (TR::Compiler->om.compressObjectReferences())
-                Inst_RegMem(TR::InstOpCode::L4RegMem, node, tempReg,
+                Inst_RegMem(OP::L4RegMem, node, tempReg,
                     MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             else
-                Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
+                Inst_RegMem(OP::LRegMem(), node, tempReg,
                     MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
             Inst_MemImm(testOpCode, node, MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg),
                 J9AccClassRAMArray, cg);
             if (!snippetLabel) {
                 snippetLabel = generateLabelSymbol(cg);
-                instr = Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+                instr = Inst_Label(OP::JE4, node, snippetLabel, cg);
                 snippet = new (cg->trHeapMemory())
                     TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
                 cg->addSnippet(snippet);
             } else
-                Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+                Inst_Label(OP::JE4, node, snippetLabel, cg);
 
-            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
-                MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-            Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg,
-                (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
-            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg,
-                (OBJECT_HEADER_SHAPE_POINTERS << J9AccClassRAMShapeShift), cg);
+            Inst_RegMem(OP::LRegMem(), node, tempReg, MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg),
+                cg);
+            Inst_RegImm(OP::ANDRegImm4(), node, tempReg, (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
+            Inst_RegImm(OP::CMPRegImm4(), node, tempReg, (OBJECT_HEADER_SHAPE_POINTERS << J9AccClassRAMShapeShift), cg);
 
-            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_Label(OP::JNE4, node, snippetLabel, cg);
         }
 
         // Now both objects are known to be reference arrays, so they are
@@ -9309,7 +9218,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
     deps->addPostCondition(tempReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, fallThrough, deps, cg);
+    Inst_Label(OP::label, node, fallThrough, deps, cg);
 
     cg->stopUsingRegister(tempReg);
     cg->decReferenceCount(object1);
@@ -9373,25 +9282,22 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         // result = tv_sec * 1,000,000,000 (converts seconds to nanoseconds)
 
         tv_sec = MRef_node(timevalNode, cg, false);
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, result, tv_sec, cg);
-        Inst_RegRegImm(TR::InstOpCode::IMUL8RegRegImm4, node, result, result, J9TIME_NANOSECONDS_PER_SECOND, cg);
+        Inst_RegMem(OP::L8RegMem, node, result, tv_sec, cg);
+        Inst_RegRegImm(OP::IMUL8RegRegImm4, node, result, result, J9TIME_NANOSECONDS_PER_SECOND, cg);
 
         // reg = tv_usec
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, reg, MRef_MRefOff(*tv_sec, offsetof(struct timespec, tv_nsec), cg),
-            cg);
+        Inst_RegMem(OP::L8RegMem, node, reg, MRef_MRefOff(*tv_sec, offsetof(struct timespec, tv_nsec), cg), cg);
 
         // result = reg + result
-        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, result, MRef_BIS(reg, result, 0, cg), cg);
+        Inst_RegMem(OP::LEA8RegMem, node, result, MRef_BIS(reg, result, 0, cg), cg);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
         if (fej9->isSnapshotModeEnabled()) {
             // result = result - nanoTimeMonotonicClockDelta
             TR::Register *vmThreadReg = cg->getVMThreadRegister();
-            Inst_RegMem(TR::InstOpCode::L8RegMem, node, reg,
-                MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
-            Inst_RegMem(TR::InstOpCode::L8RegMem, node, reg, MRef_Bdisp32(reg, offsetof(J9JavaVM, portLibrary), cg),
-                cg);
-            Inst_RegMem(TR::InstOpCode::SUB8RegMem, node, result,
+            Inst_RegMem(OP::L8RegMem, node, reg, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+            Inst_RegMem(OP::L8RegMem, node, reg, MRef_Bdisp32(reg, offsetof(J9JavaVM, portLibrary), cg), cg);
+            Inst_RegMem(OP::SUB8RegMem, node, result,
                 MRef_Bdisp32(reg, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
         }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
@@ -9400,7 +9306,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // Store the result to memory if necessary
         if (resultAddress) {
-            Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), result, cg);
+            Inst_MemReg(OP::S8MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), result, cg);
 
             cg->decReferenceCount(node->getFirstChild());
             if (node->getReferenceCount() == 1
@@ -9433,19 +9339,19 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         TR::Register *resultAddress;
         if (node->getNumChildren() == 1) {
             resultAddress = cg->evaluate(node->getFirstChild());
-            Inst_Reg(TR::InstOpCode::PUSHReg, node, resultAddress, cg);
-            Inst_Imm(TR::InstOpCode::PUSHImm4, node, CLOCK_MONOTONIC, cg);
+            Inst_Reg(OP::PUSHReg, node, resultAddress, cg);
+            Inst_Imm(OP::PUSHImm4, node, CLOCK_MONOTONIC, cg);
         } else {
             // Leave space on the stack for the 64-bit result
             //
 
-            Inst_RegImm(TR::InstOpCode::SUB4RegImms, node, espReal, 8, cg);
+            Inst_RegImm(OP::SUB4RegImms, node, espReal, 8, cg);
 
             resultAddress = cg->allocateRegister();
-            Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, resultAddress, espReal,
+            Inst_RegReg(OP::MOV4RegReg, node, resultAddress, espReal,
                 cg); // save away esp before the push
-            Inst_Reg(TR::InstOpCode::PUSHReg, node, resultAddress, cg);
-            Inst_Imm(TR::InstOpCode::PUSHImm4, node, CLOCK_MONOTONIC, cg);
+            Inst_Reg(OP::PUSHReg, node, resultAddress, cg);
+            Inst_Imm(OP::PUSHImm4, node, CLOCK_MONOTONIC, cg);
             cg->stopUsingRegister(resultAddress);
             resultAddress = espReal;
         }
@@ -9472,16 +9378,16 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         addFPXMMDependencies(cg, deps);
         deps->stopAddingConditions();
 
-        TR::X86ImmInstruction *callInstr = Inst_Imm(TR::InstOpCode::CALLImm4, node, (int32_t)&clock_gettime, deps, cg);
+        TR::X86ImmInstruction *callInstr = Inst_Imm(OP::CALLImm4, node, (int32_t)&clock_gettime, deps, cg);
 
-        Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, espReal, 8, cg);
+        Inst_RegImm(OP::ADD4RegImms, node, espReal, 8, cg);
 
         TR::Register *eaxReal = cg->allocateRegister();
         TR::Register *edxReal = cg->allocateRegister();
 
         // load usec to a register
         TR::Register *reglow = cg->allocateRegister();
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, reglow, MRef_Bdisp32(resultAddress, 4, cg), cg);
+        Inst_RegMem(OP::L4RegMem, node, reglow, MRef_Bdisp32(resultAddress, 4, cg), cg);
 
         TR::RegisterDependencyConditions *dep1 = RegDeps((uint8_t)2, 2, cg);
         dep1->addPreCondition(eaxReal, TR::RealRegister::eax, cg);
@@ -9491,32 +9397,30 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // load second to eax then multiply by 1,000,000,000
 
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, edxReal, MRef_Bdisp32(resultAddress, 0, cg), cg);
-        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, eaxReal, J9TIME_NANOSECONDS_PER_SECOND, cg);
-        Inst_RegReg(TR::InstOpCode::IMUL4AccReg, node, eaxReal, edxReal, dep1, cg);
+        Inst_RegMem(OP::L4RegMem, node, edxReal, MRef_Bdisp32(resultAddress, 0, cg), cg);
+        Inst_RegImm(OP::MOV4RegImm4, node, eaxReal, J9TIME_NANOSECONDS_PER_SECOND, cg);
+        Inst_RegReg(OP::IMUL4AccReg, node, eaxReal, edxReal, dep1, cg);
 
         // add the two parts
-        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, eaxReal, reglow, cg);
-        Inst_RegImm(TR::InstOpCode::ADC4RegImm4, node, edxReal, 0x0, cg);
+        Inst_RegReg(OP::ADD4RegReg, node, eaxReal, reglow, cg);
+        Inst_RegImm(OP::ADC4RegImm4, node, edxReal, 0x0, cg);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
         if (fej9->isSnapshotModeEnabled()) {
             // subtract nanoTimeMonotonicClockDelta from the result
             TR::Register *vmThreadReg = cg->getVMThreadRegister();
-            Inst_RegMem(TR::InstOpCode::L4RegMem, node, regLow,
-                MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
-            Inst_RegMem(TR::InstOpCode::L4RegMem, node, regLow,
-                MRef_Bdisp32(regLow, offsetof(J9JavaVM, portLibrary), cg), cg);
-            Inst_RegMem(TR::InstOpCode::SUB4RegMem, node, eaxReal,
+            Inst_RegMem(OP::L4RegMem, node, regLow, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+            Inst_RegMem(OP::L4RegMem, node, regLow, MRef_Bdisp32(regLow, offsetof(J9JavaVM, portLibrary), cg), cg);
+            Inst_RegMem(OP::SUB4RegMem, node, eaxReal,
                 MRef_Bdisp32(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
-            Inst_RegMem(TR::InstOpCode::SBB4RegMem, node, edxReal,
+            Inst_RegMem(OP::SBB4RegMem, node, edxReal,
                 MRef_Bdisp32(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta) + 4, cg), cg);
         }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
         // store it back
-        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), eaxReal, cg);
-        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 4, cg), edxReal, cg);
+        Inst_MemReg(OP::S4MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), eaxReal, cg);
+        Inst_MemReg(OP::S4MemReg, node, MRef_Bdisp32(resultAddress, 4, cg), edxReal, cg);
 
         cg->stopUsingRegister(eaxReal);
         cg->stopUsingRegister(edxReal);
@@ -9528,8 +9432,8 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         if (node->getNumChildren() == 1) {
             if (node->getReferenceCount() > 1
                 || cg->getCurrentEvaluationTreeTop()->getNode()->getOpCodeValue() != TR::treetop) {
-                Inst_RegMem(TR::InstOpCode::L4RegMem, node, lowReg, MRef_Bdisp32(resultAddress, 0, cg), cg);
-                Inst_RegMem(TR::InstOpCode::L4RegMem, node, highReg, MRef_Bdisp32(resultAddress, 4, cg), cg);
+                Inst_RegMem(OP::L4RegMem, node, lowReg, MRef_Bdisp32(resultAddress, 0, cg), cg);
+                Inst_RegMem(OP::L4RegMem, node, highReg, MRef_Bdisp32(resultAddress, 4, cg), cg);
 
                 TR::RegisterPair *result = cg->allocateRegisterPair(lowReg, highReg);
                 node->setRegister(result);
@@ -9538,8 +9442,8 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         } else {
             // The result of the call is now on the stack. Get it into registers.
             //
-            Inst_Reg(TR::InstOpCode::POPReg, node, lowReg, cg);
-            Inst_Reg(TR::InstOpCode::POPReg, node, highReg, cg);
+            Inst_Reg(OP::POPReg, node, lowReg, cg);
+            Inst_Reg(OP::POPReg, node, highReg, cg);
             TR::RegisterPair *result = cg->allocateRegisterPair(lowReg, highReg);
             node->setRegister(result);
         }
@@ -9554,12 +9458,10 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         // Leave space on the stack for the 64-bit result
         //
         temp2 = cg->allocateRegister();
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, temp2, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg),
-            cg);
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, temp2, MRef_Bdisp32(temp2, offsetof(J9JavaVM, portLibrary), cg),
-            cg);
-        Inst_Reg(TR::InstOpCode::PUSHReg, node, espReal, cg);
-        Inst_Reg(TR::InstOpCode::PUSHReg, node, temp2, cg);
+        Inst_RegMem(OP::L4RegMem, node, temp2, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+        Inst_RegMem(OP::L4RegMem, node, temp2, MRef_Bdisp32(temp2, offsetof(J9JavaVM, portLibrary), cg), cg);
+        Inst_Reg(OP::PUSHReg, node, espReal, cg);
+        Inst_Reg(OP::PUSHReg, node, temp2, cg);
 
         int32_t extraFPDeps = (uint8_t)(cg->machine()->getLastXMMR() - cg->machine()->getFirstXMMR() + 1);
 
@@ -9583,11 +9485,10 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         addFPXMMDependencies(cg, deps);
         deps->stopAddingConditions();
 
-        Inst_CallMem(TR::InstOpCode::CALLMem, node, MRef_Bdisp32(temp2, offsetof(OMRPortLibrary, time_hires_clock), cg),
-            deps, cg);
+        Inst_CallMem(OP::CALLMem, node, MRef_Bdisp32(temp2, offsetof(OMRPortLibrary, time_hires_clock), cg), deps, cg);
         cg->stopUsingRegister(temp2);
 
-        Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, espReal, 8, cg);
+        Inst_RegImm(OP::ADD4RegImms, node, espReal, 8, cg);
 
         TR::RegisterPair *result = cg->allocateRegisterPair(lowReg, highReg);
         node->setRegister(result);
@@ -9620,7 +9521,7 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
 
     bool is64Bit = node->getDataType().isDouble();
 
-    TR::InstOpCode::Mnemonic fpMovRegRegOpcode = is64Bit ? TR::InstOpCode::MOVSDRegReg : TR::InstOpCode::MOVSSRegReg;
+    OP::Mnemonic fpMovRegRegOpcode = is64Bit ? OP::MOVSDRegReg : OP::MOVSSRegReg;
     result->setIsSinglePrecision(!is64Bit);
 
     TR_ASSERT_FATAL(cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_FMA),
@@ -9628,26 +9529,25 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
 
     // Choose fma instruction carefully, based on operand form, to reduce number of copies
     if (memLoadLhs) {
-        TR::InstOpCode::Mnemonic opcode
-            = is64Bit ? TR::InstOpCode::VFMADD231SDRegRegMem : TR::InstOpCode::VFMADD231SSRegRegMem;
+        OP::Mnemonic opcode = is64Bit ? OP::VFMADD231SDRegRegMem : OP::VFMADD231SSRegRegMem;
         TR::MemoryReference *lhsMR = MRef_node(firstChild, cg);
 
         if (memLoadRhs) {
             // a (2) * b (3) + c (1)
             TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
-            Inst_RegMem(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, rhsMR, cg);
+            Inst_RegMem(OP::MOVSRegMem(is64Bit), node, result, rhsMR, cg);
 
             midReg = cg->evaluate(secondChild);
             memLoadMiddle = false; // No choice but to evaluate;
             Inst_RegRegMem(opcode, node, result, midReg, lhsMR, cg);
         } else if (memLoadMiddle) {
             // fma = a (1) * b (3) + c (2)
-            opcode = is64Bit ? TR::InstOpCode::VFMADD132SDRegRegMem : TR::InstOpCode::VFMADD132SSRegRegMem;
+            opcode = is64Bit ? OP::VFMADD132SDRegRegMem : OP::VFMADD132SSRegRegMem;
 
             TR::MemoryReference *midMR = MRef_node(secondChild, cg);
             rhsReg = cg->evaluate(thirdChild);
 
-            Inst_RegMem(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, lhsMR, cg);
+            Inst_RegMem(OP::MOVSRegMem(is64Bit), node, result, lhsMR, cg);
             Inst_RegRegMem(opcode, node, result, rhsReg, midMR, cg);
         } else {
             // fma = a (2) * b (3) + c (1)
@@ -9662,16 +9562,14 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
 
         if (memLoadRhs) {
             // fma = a (2) * b (1) + c (3)
-            TR::InstOpCode::Mnemonic opcode
-                = is64Bit ? TR::InstOpCode::VFMADD213SDRegRegMem : TR::InstOpCode::VFMADD213SSRegRegMem;
+            OP::Mnemonic opcode = is64Bit ? OP::VFMADD213SDRegRegMem : OP::VFMADD213SSRegRegMem;
             TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
 
-            Inst_RegMem(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, midMR, cg);
+            Inst_RegMem(OP::MOVSRegMem(is64Bit), node, result, midMR, cg);
             Inst_RegRegMem(opcode, node, result, lhsReg, rhsMR, cg);
         } else {
             // fma = a (1) * b (3) + c (2)
-            TR::InstOpCode::Mnemonic opcode
-                = is64Bit ? TR::InstOpCode::VFMADD132SDRegRegMem : TR::InstOpCode::VFMADD132SSRegRegMem;
+            OP::Mnemonic opcode = is64Bit ? OP::VFMADD132SDRegRegMem : OP::VFMADD132SSRegRegMem;
             rhsReg = cg->evaluate(thirdChild);
 
             Inst_RegReg(fpMovRegRegOpcode, node, result, lhsReg, cg);
@@ -9679,8 +9577,7 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
         }
     } else if (memLoadRhs) {
         // fma = a (2) * b (1) + c (3)
-        TR::InstOpCode::Mnemonic opcode
-            = is64Bit ? TR::InstOpCode::VFMADD213SDRegRegMem : TR::InstOpCode::VFMADD213SSRegRegMem;
+        OP::Mnemonic opcode = is64Bit ? OP::VFMADD213SDRegRegMem : OP::VFMADD213SSRegRegMem;
 
         TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
         lhsReg = cg->evaluate(firstChild);
@@ -9690,8 +9587,7 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
         Inst_RegRegMem(opcode, node, result, midReg, rhsMR, cg);
     } else {
         // fma = a (2) * b (1) + c (3)
-        TR::InstOpCode::Mnemonic opcode
-            = is64Bit ? TR::InstOpCode::VFMADD213SDRegRegReg : TR::InstOpCode::VFMADD213SSRegRegReg;
+        OP::Mnemonic opcode = is64Bit ? OP::VFMADD213SDRegRegReg : OP::VFMADD213SSRegRegReg;
 
         lhsReg = cg->evaluate(firstChild);
         midReg = cg->evaluate(secondChild);
@@ -9852,10 +9748,9 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
     deps->addPostCondition(tmpXMM, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(hashXMM, TR::RealRegister::NoReg, cg);
 
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, index, length, cg);
-    Inst_RegImm(TR::InstOpCode::AND4RegImms, node, index, size - 1, cg); // mod size
-    Inst_RegMem(TR::InstOpCode::CMOVE4RegMem, node, index, MRef_const(cg->findOrCreate4ByteConstant(node, size), cg),
-        cg);
+    Inst_RegReg(OP::MOV4RegReg, node, index, length, cg);
+    Inst_RegImm(OP::AND4RegImms, node, index, size - 1, cg); // mod size
+    Inst_RegMem(OP::CMOVE4RegMem, node, index, MRef_const(cg->findOrCreate4ByteConstant(node, size), cg), cg);
 
     // Prepend zeros
     {
@@ -9863,55 +9758,54 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
 
         static uint64_t MASKDECOMPRESSED[] = { 0x0000000000000000ULL, 0xffffffffffffffffULL };
         static uint64_t MASKCOMPRESSED[] = { 0xffffffff00000000ULL, 0x0000000000000000ULL };
-        Inst_RegMem(isCompressed ? TR::InstOpCode::MOVDRegMem : TR::InstOpCode::MOVQRegMem, node, hashXMM,
+        Inst_RegMem(isCompressed ? OP::MOVDRegMem : OP::MOVQRegMem, node, hashXMM,
             MRef_BISdisp32(address, index, shift,
                 -(size << shift) + TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg),
             cg);
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmp,
+        Inst_RegMem(OP::LEARegMem(), node, tmp,
             MRef_const(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
         auto mr = MRef_BISdisp32(tmp, index, shift, 0, cg);
         if (comp->target().cpu.supportsAVX()) {
-            Inst_RegMem(TR::InstOpCode::PANDRegMem, node, hashXMM, mr, cg);
+            Inst_RegMem(OP::PANDRegMem, node, hashXMM, mr, cg);
         } else {
-            Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, tmpXMM, mr, cg);
-            Inst_RegReg(TR::InstOpCode::PANDRegReg, node, hashXMM, tmpXMM, cg);
+            Inst_RegMem(OP::MOVDQURegMem, node, tmpXMM, mr, cg);
+            Inst_RegReg(OP::PANDRegReg, node, hashXMM, tmpXMM, cg);
         }
-        Inst_RegReg(isCompressed ? TR::InstOpCode::PMOVZXBDRegReg : TR::InstOpCode::PMOVZXWDRegReg, node, hashXMM,
-            hashXMM, cg);
+        Inst_RegReg(isCompressed ? OP::PMOVZXBDRegReg : OP::PMOVZXWDRegReg, node, hashXMM, hashXMM, cg);
     }
 
     // Reduction Loop
     {
         static uint32_t multiplier[] = { 31 * 31 * 31 * 31, 31 * 31 * 31 * 31, 31 * 31 * 31 * 31, 31 * 31 * 31 * 31 };
-        Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
-        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        Inst_Label(TR::InstOpCode::JGE4, node, endLabel, cg);
-        Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, multiplierXMM,
+        Inst_Label(OP::label, node, begLabel, cg);
+        Inst_RegReg(OP::CMP4RegReg, node, index, length, cg);
+        Inst_Label(OP::JGE4, node, endLabel, cg);
+        Inst_RegMem(OP::MOVDQURegMem, node, multiplierXMM,
             MRef_const(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
-        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
-        Inst_RegReg(TR::InstOpCode::PMULLDRegReg, node, hashXMM, multiplierXMM, cg);
-        Inst_RegMem(isCompressed ? TR::InstOpCode::PMOVZXBDRegMem : TR::InstOpCode::PMOVZXWDRegMem, node, tmpXMM,
+        Inst_Label(OP::label, node, loopLabel, cg);
+        Inst_RegReg(OP::PMULLDRegReg, node, hashXMM, multiplierXMM, cg);
+        Inst_RegMem(isCompressed ? OP::PMOVZXBDRegMem : OP::PMOVZXWDRegMem, node, tmpXMM,
             MRef_BISdisp32(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, index, 4, cg);
-        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
-        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        Inst_Label(TR::InstOpCode::JL4, node, loopLabel, cg);
-        Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+        Inst_RegImm(OP::ADD4RegImms, node, index, 4, cg);
+        Inst_RegReg(OP::PADDDRegReg, node, hashXMM, tmpXMM, cg);
+        Inst_RegReg(OP::CMP4RegReg, node, index, length, cg);
+        Inst_Label(OP::JL4, node, loopLabel, cg);
+        Inst_Label(OP::label, node, endLabel, deps, cg);
     }
 
     // Finalization
     {
         static uint32_t multiplier[] = { 31 * 31 * 31, 31 * 31, 31, 1 };
-        Inst_RegMem(TR::InstOpCode::PMULLDRegMem, node, hashXMM,
-            MRef_const(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
-        Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x0e, cg);
-        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
-        Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x01, cg);
-        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
+        Inst_RegMem(OP::PMULLDRegMem, node, hashXMM, MRef_const(cg->findOrCreate16ByteConstant(node, multiplier), cg),
+            cg);
+        Inst_RegRegImm(OP::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x0e, cg);
+        Inst_RegReg(OP::PADDDRegReg, node, hashXMM, tmpXMM, cg);
+        Inst_RegRegImm(OP::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x01, cg);
+        Inst_RegReg(OP::PADDDRegReg, node, hashXMM, tmpXMM, cg);
     }
 
-    Inst_RegReg(TR::InstOpCode::MOVDReg4Reg, node, hash, hashXMM, cg);
+    Inst_RegReg(OP::MOVDReg4Reg, node, hash, hashXMM, cg);
 
     cg->stopUsingRegister(index);
     cg->stopUsingRegister(tmp);
@@ -9964,14 +9858,14 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeReductionHelper(TR::Node
     int32_t numVectors, TR::Register *tmpVectorRegVRF, TR::Register *result, TR::VectorLength vl, TR::DataType dt,
     TR::CodeGenerator *cg)
 {
-    TR::InstOpCode opcode = TR::InstOpCode::PADDDRegReg;
+    TR::InstOpCode opcode = OP::PADDDRegReg;
     TR::Register *vectorRegVRF = vectorRegisters[0];
 
     // If we unrolled the main loop, vertically add the vectors together first
     // then proceed to do horizontal reduction
     for (int32_t i = 1; i < numVectors; i++) {
         OMR::X86::Encoding opcodeEncoding = opcode.getSIMDEncoding(&cg->comp()->target().cpu, vl);
-        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, vectorRegisters[i], cg, opcodeEncoding);
+        Inst_RegReg(OP::PADDDRegReg, node, vectorRegVRF, vectorRegisters[i], cg, opcodeEncoding);
     }
 
     // Reduce lanes -> horizontally add all vector elements together
@@ -9980,27 +9874,27 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeReductionHelper(TR::Node
     switch (vl) {
         case TR::VectorLength512:
             // extract 256-bits from zmm and store in ymm, then perform vertical operation
-            Inst_RegRegImm(TR::InstOpCode::VEXTRACTF64X4YmmZmmImm1, node, tmpVectorRegVRF, vectorRegVRF, 0xFF, cg);
+            Inst_RegRegImm(OP::VEXTRACTF64X4YmmZmmImm1, node, tmpVectorRegVRF, vectorRegVRF, 0xFF, cg);
             Inst_RegReg(opcode.getMnemonic(), node, vectorRegVRF, tmpVectorRegVRF, cg,
                 opcode.getSIMDEncoding(&cg->comp()->target().cpu, TR::VectorLength256));
             // Fallthrough to treat remaining result as 256-bit vector
         case TR::VectorLength256:
             // extract 128 bits from ymm and store in xmm, then perform vertical operation
-            Inst_RegRegImm(TR::InstOpCode::VEXTRACTF128RegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0xFF, cg);
+            Inst_RegRegImm(OP::VEXTRACTF128RegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0xFF, cg);
             Inst_RegReg(opcode.getMnemonic(), node, vectorRegVRF, tmpVectorRegVRF, cg,
                 opcode.getSIMDEncoding(&cg->comp()->target().cpu, TR::VectorLength128));
             // Fallthrough to treat remaining result as 128-bit vector
         case TR::VectorLength128:
-            Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x0e, cg);
-            Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
-            Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x01, cg);
-            Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
+            Inst_RegRegImm(OP::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x0e, cg);
+            Inst_RegReg(OP::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
+            Inst_RegRegImm(OP::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x01, cg);
+            Inst_RegReg(OP::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
             break;
         default:
             TR_ASSERT_FATAL(false, "Unsupported vector length");
     }
 
-    Inst_RegReg(TR::InstOpCode::MOVDReg4Reg, node, result, vectorRegVRF, cg);
+    Inst_RegReg(OP::MOVDReg4Reg, node, result, vectorRegVRF, cg);
     return result;
 }
 
@@ -10082,25 +9976,25 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, result, initialHash, cg);
-    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tmp, length, cg);
-    Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, tmp, ~(numElements - 1), cg);
+    Inst_RegReg(OP::MOVRegReg(), node, result, initialHash, cg);
+    Inst_Label(OP::label, node, begLabel, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, tmp, length, cg);
+    Inst_RegImm(OP::AND4RegImm4, node, tmp, ~(numElements - 1), cg);
 
     {
-        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, tmp, cg);
-        Inst_Label(TR::InstOpCode::JGE4, node, endLabel, cg);
+        Inst_RegReg(OP::CMP4RegReg, node, index, tmp, cg);
+        Inst_Label(OP::JGE4, node, endLabel, cg);
 
         // Initialize Constants outside of loop body but after the first compare
         for (int32_t i = 0; i < unrollCount; i++)
-            Inst_RegReg(TR::InstOpCode::PXORRegReg, node, hashRegsVRF[i], hashRegsVRF[i], cg, vectorEncoding);
+            Inst_RegReg(OP::PXORRegReg, node, hashRegsVRF[i], hashRegsVRF[i], cg, vectorEncoding);
 
-        Inst_RegReg(TR::InstOpCode::MOVDRegReg4, node, hashRegsVRF[0], initialHash, cg);
+        Inst_RegReg(OP::MOVDRegReg4, node, hashRegsVRF[0], initialHash, cg);
 
         int32_t multiplier31PowNData[16];
         // Fill multiplier array with 31^numElements
         std::fill_n(multiplier31PowNData, 16, powersOf31[64 - numElements]);
-        Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, multiplierVRF,
+        Inst_RegMem(OP::MOVDQURegMem, node, multiplierVRF,
             MRef_const(
                 cg->findOrCreateConstantDataSnippet(node, multiplier31PowNData, vectorSizeElements * sizeof(int32_t)),
                 cg),
@@ -10127,31 +10021,31 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
             int32_t *multiplier = const_cast<int32_t *>(powersOf31 + offset);
             TR::MemoryReference *mr = MRef_const(cg->findOrCreateConstantDataSnippet(node, multiplier, vectorSize), cg);
 
-            Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, multiplier31PowN_i, mr, cg, vectorEncoding);
+            Inst_RegMem(OP::MOVDQURegMem, node, multiplier31PowN_i, mr, cg, vectorEncoding);
         }
     }
 
-    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(OP::label, node, loopLabel, cg);
 
     {
         // Main loop body;
 
         for (int32_t i = 0; i < unrollCount; i++) {
             // Load in the next batch of elements. (sign/zero) extend i8, i16 to i32
-            TR::InstOpCode::Mnemonic loadOpcode = TR::InstOpCode::bad;
+            OP::Mnemonic loadOpcode = OP::bad;
             int32_t elementSize;
 
             switch (dt) {
                 case TR::Int8:
-                    loadOpcode = isSigned ? TR::InstOpCode::PMOVSXBDRegMem : TR::InstOpCode::PMOVZXBDRegMem;
+                    loadOpcode = isSigned ? OP::PMOVSXBDRegMem : OP::PMOVZXBDRegMem;
                     elementSize = 1;
                     break;
                 case TR::Int16:
-                    loadOpcode = isSigned ? TR::InstOpCode::PMOVSXWDRegMem : TR::InstOpCode::PMOVZXWDRegMem;
+                    loadOpcode = isSigned ? OP::PMOVSXWDRegMem : OP::PMOVZXWDRegMem;
                     elementSize = 2;
                     break;
                 case TR::Int32:
-                    loadOpcode = TR::InstOpCode::MOVDQURegMem;
+                    loadOpcode = OP::MOVDQURegMem;
                     elementSize = 4;
                     break;
                 default:
@@ -10166,21 +10060,21 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
             Inst_RegMem(loadOpcode, node, tmpVRF, mr, cg, vectorEncoding);
 
             // tmpVRF = tmpVRF * multiplierVRF
-            Inst_RegReg(TR::InstOpCode::PMULLDRegReg, node, tmpVRF, multiplier31PowNRegsVRF[i], cg, vectorEncoding);
+            Inst_RegReg(OP::PMULLDRegReg, node, tmpVRF, multiplier31PowNRegsVRF[i], cg, vectorEncoding);
             // hashRegsVRF = ( hashRegsVRF * {31^vl, ..., 31^vl} ) + tmpVRF
-            Inst_RegReg(TR::InstOpCode::PMULLDRegReg, node, hashRegsVRF[i], multiplierVRF, cg, vectorEncoding);
-            Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashRegsVRF[i], tmpVRF, cg, vectorEncoding);
+            Inst_RegReg(OP::PMULLDRegReg, node, hashRegsVRF[i], multiplierVRF, cg, vectorEncoding);
+            Inst_RegReg(OP::PADDDRegReg, node, hashRegsVRF[i], tmpVRF, cg, vectorEncoding);
         }
     }
 
     // Increase loop index by the number of processed elements
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, index, numElements, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, index, numElements, cg);
     // Compare index with numElements and loop back if necessary
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, tmp, cg);
-    Inst_Label(TR::InstOpCode::JL4, node, loopLabel, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, index, tmp, cg);
+    Inst_Label(OP::JL4, node, loopLabel, cg);
 
     vectorizedHashCodeReductionHelper(node, hashRegsVRF, unrollCount, tmpVRF, result, vl, dt, cg);
-    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(OP::label, node, endLabel, deps, cg);
 
     cg->stopUsingRegister(tmp);
     cg->stopUsingRegister(tmpVRF);
@@ -10274,16 +10168,16 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
     if (nonZeroOffset) {
         TR::Register *offset = cg->evaluate(node->getChild(1));
         TR::MemoryReference *memRef = MRef_BISdisp32(address, offset, shift, 0, cg);
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, address, memRef, cg);
+        Inst_RegMem(OP::LEARegMem(), node, address, memRef, cg);
     }
 
     if (!nodeHash) {
         // If nodeHash is not provided, assume initial hash value of 0.
-        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, initHash, initHash, cg);
+        Inst_RegReg(OP::XOR4RegReg, node, initHash, initHash, cg);
     }
 
     // Set index ptr to 0
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, index, index, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, index, index, cg);
 
     // Generate Main Loop; 4x Unrolled seems to yield the best performance for large arrays
     static char *unrollVar = feGetEnv("TR_setInlineVectorHashCodeUnrollCount");
@@ -10300,7 +10194,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
 
     // Generate a second vectorized loop if not disabled and Vl/unrollCount are not the same as the first loop
     if (!disableSecondLoop && (unrollCount != 1 || vl != TR::VectorLength128)) {
-        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, initHash, result, cg);
+        Inst_RegReg(OP::MOV4RegReg, node, initHash, result, cg);
         vectorizedHashCodeLoopHelper(node, dt, TR::VectorLength128, isSigned, result, initHash, index, length, address,
             1, cg);
     }
@@ -10315,32 +10209,29 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
         residueBeginLoopLabel->setStartInternalControlFlow();
         residueEndLoopLabel->setEndInternalControlFlow();
 
-        Inst_Label(TR::InstOpCode::label, node, residueBeginLoopLabel, cg);
-        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        Inst_Label(TR::InstOpCode::JGE4, node, residueEndLoopLabel, cg);
-        Inst_Label(TR::InstOpCode::label, node, residueLoopLabel, cg);
+        Inst_Label(OP::label, node, residueBeginLoopLabel, cg);
+        Inst_RegReg(OP::CMP4RegReg, node, index, length, cg);
+        Inst_Label(OP::JGE4, node, residueEndLoopLabel, cg);
+        Inst_Label(OP::label, node, residueLoopLabel, cg);
 
         // hash = 31 * hash + arr[index] = tmp * hash + arr[index]
-        Inst_RegRegImm(TR::InstOpCode::IMUL4RegRegImm4, node, result, result, 31, cg);
+        Inst_RegRegImm(OP::IMUL4RegRegImm4, node, result, result, 31, cg);
 
-        static TR::InstOpCode::Mnemonic signedLoadOpcode[3]
-            = { TR::InstOpCode::MOVSXReg4Mem1, TR::InstOpCode::MOVSXReg4Mem2, TR::InstOpCode::L4RegMem };
-        static TR::InstOpCode::Mnemonic unsignedLoadOpcode[3]
-            = { TR::InstOpCode::MOVZXReg4Mem1, TR::InstOpCode::MOVZXReg4Mem2, TR::InstOpCode::L4RegMem };
-        TR::InstOpCode::Mnemonic loadOpcode
-            = isSigned ? signedLoadOpcode[dt - TR::Int8] : unsignedLoadOpcode[dt - TR::Int8];
+        static OP::Mnemonic signedLoadOpcode[3] = { OP::MOVSXReg4Mem1, OP::MOVSXReg4Mem2, OP::L4RegMem };
+        static OP::Mnemonic unsignedLoadOpcode[3] = { OP::MOVZXReg4Mem1, OP::MOVZXReg4Mem2, OP::L4RegMem };
+        OP::Mnemonic loadOpcode = isSigned ? signedLoadOpcode[dt - TR::Int8] : unsignedLoadOpcode[dt - TR::Int8];
 
         Inst_RegMem(loadOpcode, node, tmp,
             MRef_BISdisp32(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, result, tmp, cg);
+        Inst_RegReg(OP::ADDRegReg(), node, result, tmp, cg);
 
         // Increase loop index by the number of processed elements
-        Inst_Reg(TR::InstOpCode::INCReg(), node, index, cg);
+        Inst_Reg(OP::INCReg(), node, index, cg);
 
         // Compare index with numElements and loop back if necessary
-        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        Inst_Label(TR::InstOpCode::JL4, node, residueLoopLabel, cg);
-        Inst_Label(TR::InstOpCode::label, node, residueEndLoopLabel, deps, cg);
+        Inst_RegReg(OP::CMP4RegReg, node, index, length, cg);
+        Inst_Label(OP::JL4, node, residueLoopLabel, cg);
+        Inst_Label(OP::label, node, residueEndLoopLabel, deps, cg);
     }
 
     if (nonZeroOffset) {
@@ -10448,14 +10339,14 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
     uint8_t width = 16;
     uint8_t shift = 0;
     uint8_t *shuffleMask = NULL;
-    auto compareOp = TR::InstOpCode::bad;
+    auto compareOp = OP::bad;
     if (isLatin1) {
         shuffleMask = MASKOFSIZEONE;
-        compareOp = TR::InstOpCode::PCMPEQBRegReg;
+        compareOp = OP::PCMPEQBRegReg;
         shift = 0;
     } else {
         shuffleMask = MASKOFSIZETWO;
-        compareOp = TR::InstOpCode::PCMPEQWRegReg;
+        compareOp = OP::PCMPEQWRegReg;
         shift = 1;
     }
 
@@ -10496,53 +10387,53 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    Inst_RegReg(TR::InstOpCode::MOVDRegReg4, node, valueXMM, ch, cg);
-    Inst_RegMem(TR::InstOpCode::PSHUFBRegMem, node, valueXMM,
-        MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
+    Inst_RegReg(OP::MOVDRegReg4, node, valueXMM, ch, cg);
+    Inst_RegMem(OP::PSHUFBRegMem, node, valueXMM, MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg),
+        cg);
 
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, result, offset, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, result, offset, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, scratch,
+    Inst_Label(OP::label, node, begLabel, cg);
+    Inst_RegMem(OP::LEARegMem(), node, scratch,
         MRef_BISdisp32(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, ECX, scratch, cg);
-    Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, scratch, ~(width - 1), cg);
-    Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, ECX, width - 1, cg);
-    Inst_Label(TR::InstOpCode::JE1, node, loopLabel, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, ECX, scratch, cg);
+    Inst_RegImm(OP::ANDRegImms(), node, scratch, ~(width - 1), cg);
+    Inst_RegImm(OP::ANDRegImms(), node, ECX, width - 1, cg);
+    Inst_Label(OP::JE1, node, loopLabel, cg);
 
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, scratchXMM, MRef_Bdisp32(scratch, 0, cg), cg);
+    Inst_RegMem(OP::MOVDQURegMem, node, scratchXMM, MRef_Bdisp32(scratch, 0, cg), cg);
     Inst_RegReg(compareOp, node, scratchXMM, valueXMM, cg);
-    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
-    Inst_Reg(TR::InstOpCode::SHR4RegCL, node, scratch, cg);
-    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, scratch, scratch, cg);
-    Inst_Label(TR::InstOpCode::JNE1, node, endLabel, cg);
+    Inst_RegReg(OP::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
+    Inst_Reg(OP::SHR4RegCL, node, scratch, cg);
+    Inst_RegReg(OP::TEST4RegReg, node, scratch, scratch, cg);
+    Inst_Label(OP::JNE1, node, endLabel, cg);
     if (shift) {
-        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, ECX, shift, cg);
+        Inst_RegImm(OP::SHR4RegImm1, node, ECX, shift, cg);
     }
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, result, width >> shift, cg);
-    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, result, ECX, cg);
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, result, length, cg);
-    Inst_Label(TR::InstOpCode::JGE1, node, endLabel, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, result, width >> shift, cg);
+    Inst_RegReg(OP::SUB4RegReg, node, result, ECX, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, result, length, cg);
+    Inst_Label(OP::JGE1, node, endLabel, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, scratchXMM,
+    Inst_Label(OP::label, node, loopLabel, cg);
+    Inst_RegMem(OP::MOVDQURegMem, node, scratchXMM,
         MRef_BISdisp32(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
     Inst_RegReg(compareOp, node, scratchXMM, valueXMM, cg);
-    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
-    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, scratch, scratch, cg);
-    Inst_Label(TR::InstOpCode::JNE1, node, endLabel, cg);
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, result, width >> shift, cg);
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, result, length, cg);
-    Inst_Label(TR::InstOpCode::JL1, node, loopLabel, cg);
-    Inst_Label(TR::InstOpCode::label, node, endLabel, dependencies, cg);
+    Inst_RegReg(OP::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
+    Inst_RegReg(OP::TEST4RegReg, node, scratch, scratch, cg);
+    Inst_Label(OP::JNE1, node, endLabel, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, result, width >> shift, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, result, length, cg);
+    Inst_Label(OP::JL1, node, loopLabel, cg);
+    Inst_Label(OP::label, node, endLabel, dependencies, cg);
 
-    Inst_RegReg(TR::InstOpCode::BSF4RegReg, node, scratch, scratch, cg);
+    Inst_RegReg(OP::BSF4RegReg, node, scratch, scratch, cg);
     if (shift) {
-        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, scratch, shift, cg);
+        Inst_RegImm(OP::SHR4RegImm1, node, scratch, shift, cg);
     }
-    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, result, scratch, cg);
-    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, result, length, cg);
-    Inst_RegMem(TR::InstOpCode::CMOVGERegMem(), node, result,
+    Inst_RegReg(OP::ADDRegReg(), node, result, scratch, cg);
+    Inst_RegReg(OP::CMPRegReg(), node, result, length, cg);
+    Inst_RegMem(OP::CMOVGERegMem(), node, result,
         MRef_const(cg->comp()->target().is32Bit() ? cg->findOrCreate4ByteConstant(node, -1)
                                                   : cg->findOrCreate8ByteConstant(node, -1),
             cg),
@@ -10610,7 +10501,7 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
         maxReg = s1lenReg;
     } else {
         maxReg = cg->allocateRegister(TR_GPR);
-        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, maxReg, s1lenReg, cg);
+        Inst_RegReg(OP::MOV4RegReg, node, maxReg, s1lenReg, cg);
     }
 
     TR::Register *resultReg;
@@ -10618,7 +10509,7 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
         resultReg = offsetReg;
     } else {
         resultReg = cg->allocateRegister(TR_GPR);
-        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, resultReg, offsetReg, cg);
+        Inst_RegReg(OP::MOV4RegReg, node, resultReg, offsetReg, cg);
     }
 
     static uint8_t MASKOFSIZEONE[] = {
@@ -10661,14 +10552,14 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     const uint8_t width = 16;
     uint8_t shift = 0;
     uint8_t *shuffleMask = NULL;
-    TR::InstOpCode::Mnemonic compareOp = TR::InstOpCode::bad;
+    OP::Mnemonic compareOp = OP::bad;
     if (isLatin1) {
         shuffleMask = MASKOFSIZEONE;
-        compareOp = TR::InstOpCode::PCMPEQBRegReg;
+        compareOp = OP::PCMPEQBRegReg;
         shift = 0;
     } else {
         shuffleMask = MASKOFSIZETWO;
-        compareOp = TR::InstOpCode::PCMPEQWRegReg;
+        compareOp = OP::PCMPEQWRegReg;
         shift = 1;
     }
 
@@ -10721,116 +10612,114 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     int32_t hdrSize = static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
 
     // load first char of s2
-    Inst_RegMem(isLatin1 ? TR::InstOpCode::MOVZXReg4Mem1 : TR::InstOpCode::MOVZXReg4Mem2, node, tmpReg,
-        MRef_Bdisp32(s2Reg, hdrSize, cg), cg);
-    Inst_RegReg(TR::InstOpCode::MOVDRegReg4, node, xmmReg2, tmpReg, cg);
-    Inst_RegMem(TR::InstOpCode::PSHUFBRegMem, node, xmmReg2,
-        MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
+    Inst_RegMem(isLatin1 ? OP::MOVZXReg4Mem1 : OP::MOVZXReg4Mem2, node, tmpReg, MRef_Bdisp32(s2Reg, hdrSize, cg), cg);
+    Inst_RegReg(OP::MOVDRegReg4, node, xmmReg2, tmpReg, cg);
+    Inst_RegMem(OP::PSHUFBRegMem, node, xmmReg2, MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
 
     // calculate max
-    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, maxReg, s2lenReg, cg); // s1len - s2len
+    Inst_RegReg(OP::SUB4RegReg, node, maxReg, s2lenReg, cg); // s1len - s2len
 
     // outer loop
-    Inst_Label(TR::InstOpCode::label, node, outerLoopLabel, cg);
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+    Inst_Label(OP::label, node, outerLoopLabel, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(OP::JG4, node, notFoundLabel, cg);
 
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmpReg, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, ECX, tmpReg, cg);
-    Inst_RegImm(TR::InstOpCode::AND4RegImms, node, ECX, width - 1, cg);
-    Inst_Label(TR::InstOpCode::JE1, node, firstCharLoopLabel, cg);
+    Inst_RegMem(OP::LEARegMem(), node, tmpReg, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
+    Inst_RegReg(OP::MOV4RegReg, node, ECX, tmpReg, cg);
+    Inst_RegImm(OP::AND4RegImms, node, ECX, width - 1, cg);
+    Inst_Label(OP::JE1, node, firstCharLoopLabel, cg);
 
-    Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, tmpReg, ~(width - 1), cg);
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_Bdisp32(tmpReg, 0, cg), cg);
+    Inst_RegImm(OP::ANDRegImms(), node, tmpReg, ~(width - 1), cg);
+    Inst_RegMem(OP::MOVDQURegMem, node, xmmReg1, MRef_Bdisp32(tmpReg, 0, cg), cg);
     Inst_RegReg(compareOp, node, xmmReg1, xmmReg2, cg);
-    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
-    Inst_Reg(TR::InstOpCode::SHR4RegCL, node, tmpReg, cg);
-    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
-    Inst_Label(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
+    Inst_RegReg(OP::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+    Inst_Reg(OP::SHR4RegCL, node, tmpReg, cg);
+    Inst_RegReg(OP::TEST4RegReg, node, tmpReg, tmpReg, cg);
+    Inst_Label(OP::JNE1, node, firstCharMatchedLabel, cg);
     if (!isLatin1) {
-        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, ECX, 1, cg);
+        Inst_RegImm(OP::SHR4RegImm1, node, ECX, 1, cg);
     }
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, resultReg, width >> shift, cg);
-    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, resultReg, ECX, cg);
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, resultReg, width >> shift, cg);
+    Inst_RegReg(OP::SUB4RegReg, node, resultReg, ECX, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(OP::JG4, node, notFoundLabel, cg);
 
     // loop for finding the first char
-    Inst_Label(TR::InstOpCode::label, node, firstCharLoopLabel, cg);
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
+    Inst_Label(OP::label, node, firstCharLoopLabel, cg);
+    Inst_RegMem(OP::MOVDQURegMem, node, xmmReg1, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
     Inst_RegReg(compareOp, node, xmmReg1, xmmReg2, cg);
-    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
-    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
-    Inst_Label(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, resultReg, width >> shift, cg);
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    Inst_Label(TR::InstOpCode::JLE1, node, firstCharLoopLabel, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, notFoundLabel, cg);
+    Inst_RegReg(OP::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+    Inst_RegReg(OP::TEST4RegReg, node, tmpReg, tmpReg, cg);
+    Inst_Label(OP::JNE1, node, firstCharMatchedLabel, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, resultReg, width >> shift, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(OP::JLE1, node, firstCharLoopLabel, cg);
+    Inst_Label(OP::JMP4, node, notFoundLabel, cg);
 
     // first char matched
-    Inst_Label(TR::InstOpCode::label, node, firstCharMatchedLabel, cg);
+    Inst_Label(OP::label, node, firstCharMatchedLabel, cg);
 
-    Inst_RegReg(TR::InstOpCode::BSF4RegReg, node, tmpReg, tmpReg, cg);
+    Inst_RegReg(OP::BSF4RegReg, node, tmpReg, tmpReg, cg);
     if (!isLatin1) {
-        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, tmpReg, 1, cg);
+        Inst_RegImm(OP::SHR4RegImm1, node, tmpReg, 1, cg);
     }
-    Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, resultReg, tmpReg, cg);
+    Inst_RegReg(OP::ADD4RegReg, node, resultReg, tmpReg, cg);
 
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(OP::JG4, node, notFoundLabel, cg);
 
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, s1addrReg, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg),
+    Inst_RegMem(OP::LEARegMem(), node, s1addrReg, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg),
         cg); // s1addr = &(s1[resultReg << shift])
-    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, s2idxReg, 1, cg); // s2idx = 1
+    Inst_RegImm(OP::MOV4RegImm4, node, s2idxReg, 1, cg); // s2idx = 1
 
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, ECX, MRef_Bdisp32(s2lenReg, -1, cg),
+    Inst_RegMem(OP::LEARegMem(), node, ECX, MRef_Bdisp32(s2lenReg, -1, cg),
         cg); // ECX = s2len - 1: 1st char has already matched
-    Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, ECX, 4 - shift, cg); // div by 16 or 8
-    Inst_Label(TR::InstOpCode::JE1, node, byteLoopLabel, cg);
+    Inst_RegImm(OP::SHR4RegImm1, node, ECX, 4 - shift, cg); // div by 16 or 8
+    Inst_Label(OP::JE1, node, byteLoopLabel, cg);
 
     // Compare by 16 bytes
-    Inst_Label(TR::InstOpCode::label, node, qwordLoopLabel, cg);
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), cg);
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg3, MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
-    Inst_RegReg(TR::InstOpCode::PCMPEQBRegReg, node, xmmReg1, xmmReg3, cg);
-    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, tmpReg, 0xffff, cg);
-    Inst_Label(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
+    Inst_Label(OP::label, node, qwordLoopLabel, cg);
+    Inst_RegMem(OP::MOVDQURegMem, node, xmmReg1, MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), cg);
+    Inst_RegMem(OP::MOVDQURegMem, node, xmmReg3, MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
+    Inst_RegReg(OP::PCMPEQBRegReg, node, xmmReg1, xmmReg3, cg);
+    Inst_RegReg(OP::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, tmpReg, 0xffff, cg);
+    Inst_Label(OP::JNE1, node, unmatchedLabel, cg);
 
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, s2idxReg, width >> shift, cg);
-    Inst_RegImm(TR::InstOpCode::SUB4RegImms, node, ECX, 1, cg);
-    Inst_Label(TR::InstOpCode::JG1, node, qwordLoopLabel, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, s2idxReg, width >> shift, cg);
+    Inst_RegImm(OP::SUB4RegImms, node, ECX, 1, cg);
+    Inst_Label(OP::JG1, node, qwordLoopLabel, cg);
 
     // Compare each byte
-    Inst_Label(TR::InstOpCode::label, node, byteLoopLabel, cg);
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, s2lenReg, s2idxReg, cg);
-    Inst_Label(TR::InstOpCode::JLE1, node, doneLabel, cg); // resultReg has the result
+    Inst_Label(OP::label, node, byteLoopLabel, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, s2lenReg, s2idxReg, cg);
+    Inst_Label(OP::JLE1, node, doneLabel, cg); // resultReg has the result
 
-    Inst_RegMem(isLatin1 ? TR::InstOpCode::L1RegMem : TR::InstOpCode::L2RegMem, node, tmpReg,
+    Inst_RegMem(isLatin1 ? OP::L1RegMem : OP::L2RegMem, node, tmpReg,
         MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
-    Inst_MemReg(isLatin1 ? TR::InstOpCode::CMP1MemReg : TR::InstOpCode::CMP2MemReg, node,
-        MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), tmpReg, cg);
-    Inst_Label(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
+    Inst_MemReg(isLatin1 ? OP::CMP1MemReg : OP::CMP2MemReg, node, MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg),
+        tmpReg, cg);
+    Inst_Label(OP::JNE1, node, unmatchedLabel, cg);
 
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, s2idxReg, 1, cg);
-    Inst_Label(TR::InstOpCode::JMP1, node, byteLoopLabel, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, s2idxReg, 1, cg);
+    Inst_Label(OP::JMP1, node, byteLoopLabel, cg);
 
     // substring did not match
-    Inst_Label(TR::InstOpCode::label, node, unmatchedLabel, cg);
-    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, resultReg, 1, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, outerLoopLabel, cg);
+    Inst_Label(OP::label, node, unmatchedLabel, cg);
+    Inst_RegImm(OP::ADD4RegImms, node, resultReg, 1, cg);
+    Inst_Label(OP::JMP4, node, outerLoopLabel, cg);
 
     // not found
-    Inst_Label(TR::InstOpCode::label, node, notFoundLabel, cg);
-    Inst_RegImm(TR::InstOpCode::OR4RegImms, node, resultReg, -1, cg);
+    Inst_Label(OP::label, node, notFoundLabel, cg);
+    Inst_RegImm(OP::OR4RegImms, node, resultReg, -1, cg);
     // fall through to doneLabel
 
-    Inst_Label(TR::InstOpCode::label, node, doneLabel, dependencies, cg);
+    Inst_Label(OP::label, node, doneLabel, dependencies, cg);
 
     cg->stopUsingRegister(ECX);
     cg->stopUsingRegister(tmpReg);
@@ -10901,13 +10790,13 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
         case gc_modron_readbar_none:
             break;
         case gc_modron_readbar_always:
-            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+            Inst_RegMem(OP::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
+            Inst_MemReg(OP::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
             Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
             break;
         case gc_modron_readbar_range_check: {
-            Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
+            Inst_RegMem(OP::LRegMem(use64BitClasses), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
 
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg);
             TR::LabelSymbol *endLabel = generateLabelSymbol(cg);
@@ -10919,29 +10808,29 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
             deps->addPreCondition(tmp, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(tmp, TR::RealRegister::NoReg, cg);
 
-            Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+            Inst_Label(OP::label, node, begLabel, cg);
 
-            Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
+            Inst_RegMem(OP::CMPRegMem(use64BitClasses), node, tmp,
                 MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
                 cg);
-            Inst_Label(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
+            Inst_Label(OP::JAE4, node, rdbarLabel, cg);
 
             {
                 TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
-                Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
+                Inst_RegMem(OP::CMPRegMem(use64BitClasses), node, tmp,
                     MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
                     cg);
-                Inst_Label(TR::InstOpCode::JA4, node, endLabel, cg);
-                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
-                Inst_MemReg(TR::InstOpCode::SMemReg(), node,
+                Inst_Label(OP::JA4, node, endLabel, cg);
+                Inst_RegMem(OP::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
+                Inst_MemReg(OP::SMemReg(), node,
                     MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
                 Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
-                Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+                Inst_Label(OP::JMP4, node, endLabel, cg);
 
                 og.endOutlinedInstructionSequence();
             }
 
-            Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+            Inst_Label(OP::label, node, endLabel, deps, cg);
         } break;
         default:
             TR_ASSERT(false, "Unsupported Read Barrier Type.");
@@ -10949,32 +10838,32 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
     }
 #endif
 
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, EAX, oldValue, cg);
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tmp, newValue, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, EAX, oldValue, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, tmp, newValue, cg);
     if (TR::Compiler->om.compressedReferenceShiftOffset() != 0) {
         if (!oldValueNode->isNull()) {
-            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, EAX, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+            Inst_RegImm(OP::SHRRegImm1(), node, EAX, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         }
         if (!newValueNode->isNull()) {
-            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tmp, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+            Inst_RegImm(OP::SHRRegImm1(), node, tmp, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         }
     }
 
     TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)1, 1, cg);
     deps->addPreCondition(EAX, TR::RealRegister::eax, cg);
     deps->addPostCondition(EAX, TR::RealRegister::eax, cg);
-    Inst_MemReg(use64BitClasses ? TR::InstOpCode::LCMPXCHG8MemReg : TR::InstOpCode::LCMPXCHG4MemReg, node,
-        MRef_BIS(object, offset, 0, cg), tmp, deps, cg);
+    Inst_MemReg(use64BitClasses ? OP::LCMPXCHG8MemReg : OP::LCMPXCHG4MemReg, node, MRef_BIS(object, offset, 0, cg), tmp,
+        deps, cg);
 
     if (isExchange) {
         result = EAX;
         result->setContainsCollectedReference();
         if (TR::Compiler->om.compressedReferenceShiftOffset() != 0) {
-            Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, EAX, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+            Inst_RegImm(OP::SHLRegImm1(), node, EAX, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         }
     } else {
-        Inst_Reg(TR::InstOpCode::SETE1Reg, node, result, cg);
-        Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, result, result, cg);
+        Inst_Reg(OP::SETE1Reg, node, result, cg);
+        Inst_RegReg(OP::MOVZXReg4Reg1, node, result, result, cg);
     }
 
     // Non-realtime: Generate a write barrier for this kind of object.
@@ -11018,7 +10907,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
     TR::Compilation *comp = cg->comp();
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp->fe());
 
-    TR::InstOpCode::Mnemonic op;
+    OP::Mnemonic op;
 
     if (TR::Compiler->om.canGenerateArraylets() && !node->isUnsafeGetPutCASCallOnNonArray())
         return false;
@@ -11032,13 +10921,13 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
     //
     switch (size) {
         case 4:
-            op = TR::InstOpCode::LCMPXCHG4MemReg;
+            op = OP::LCMPXCHG4MemReg;
             break;
         case 8:
             if (comp->target().is64Bit()) {
-                op = TR::InstOpCode::LCMPXCHG8MemReg;
+                op = OP::LCMPXCHG8MemReg;
             } else if (comp->target().cpu.supportsFeature(OMR_FEATURE_X86_CX8)) {
-                op = TR::InstOpCode::LCMPXCHG8BMem;
+                op = OP::LCMPXCHG8BMem;
             } else {
                 return false;
             }
@@ -11141,7 +11030,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         //   beforehand
         // For simplicity, just evaluate the store address into storeAddressRegForRealTime right now
         storeAddressRegForRealTime = scratchRegisterManagerForRealTime->findOrCreateScratchRegister();
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, storeAddressRegForRealTime, mr, cg);
+        Inst_RegMem(OP::LEARegMem(), node, storeAddressRegForRealTime, mr, cg);
         if (node->getSymbolReference()->isUnresolved()) {
             TR::TreeEvaluator::padUnresolvedDataReferences(node, *node->getSymbolReference(), cg);
 
@@ -11161,7 +11050,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
     TR::MemoryReference *cmpxchgMR = mr;
 
     TR::Register *resultReg;
-    if (op == TR::InstOpCode::LCMPXCHG8BMem) {
+    if (op == OP::LCMPXCHG8BMem) {
         int numDeps = 4;
         if (storeAddressRegForRealTime != NULL) {
             numDeps++;
@@ -11215,8 +11104,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         if (isObject) {
             resultReg->setContainsCollectedReference();
             if (TR::Compiler->om.compressedReferenceShiftOffset() != 0) {
-                Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, resultReg,
-                    TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+                Inst_RegImm(OP::SHLRegImm1(), node, resultReg, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
             }
         }
     }
@@ -11229,8 +11117,8 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
 
     if (!isExchange) {
         resultReg = cg->allocateRegister();
-        Inst_Reg(TR::InstOpCode::SETE1Reg, node, resultReg, cg);
-        Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, resultReg, resultReg, cg);
+        Inst_Reg(OP::SETE1Reg, node, resultReg, cg);
+        Inst_RegReg(OP::MOVZXReg4Reg1, node, resultReg, resultReg, cg);
     }
 
     // Non-realtime: Generate a write barrier for this kind of object.
@@ -11299,7 +11187,7 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     // A key part of the main loop of this algorithm is the pmovmskb instruction,
     // which extracts the sign bits from a source register and collects them into a destination register
     // We need to specify the encoding of this instruction so that the code generator knows we want the 16 byte version
-    TR::InstOpCode pmovmskb = TR::InstOpCode::PMOVMSKB4RegReg;
+    TR::InstOpCode pmovmskb = OP::PMOVMSKB4RegReg;
     OMR::X86::Encoding pmovmskbEncoding = pmovmskb.getSIMDEncoding(&cg->comp()->target().cpu, TR::VectorLength128);
     static bool disableSIMDHasNegativesCountPositives = feGetEnv("TR_disableSIMDHasNegativesCountPositives") != NULL;
     bool useVectorInstructions
@@ -11360,13 +11248,13 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_Label(OP::label, node, begLabel, cg);
 
     // If offheap is enabled, we will update bufReg to point to the actual start of the array data
     // and set offsetToDataElements to zero
 #ifdef J9VM_GC_SPARSE_HEAP_ALLOCATION
     if (TR::Compiler->om.isOffHeapAllocationEnabled()) {
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, bufReg,
+        Inst_RegMem(OP::L8RegMem, node, bufReg,
             MRef_Bdisp32(bufReg, cg->comp()->fej9()->getOffsetOfContiguousDataAddrField(), cg), cg);
 
         // We'll be loading first data element address from array header so no need for offset
@@ -11375,65 +11263,64 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // index = offset
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, indexReg, offsetReg, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, indexReg, offsetReg, cg);
 
     // limit = offset + length
-    Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, limitReg, MRef_BISdisp32(offsetReg, lengthReg, 0, 0, cg), cg);
+    Inst_RegMem(OP::LEA4RegMem, node, limitReg, MRef_BISdisp32(offsetReg, lengthReg, 0, 0, cg), cg);
 
     // loopLimit = (length & -16) + offset
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, loopLimitReg, lengthReg, cg);
-    Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, loopLimitReg, -16, cg);
-    Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, loopLimitReg, offsetReg, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, loopLimitReg, lengthReg, cg);
+    Inst_RegImm(OP::AND4RegImm4, node, loopLimitReg, -16, cg);
+    Inst_RegReg(OP::ADD4RegReg, node, loopLimitReg, offsetReg, cg);
 
     // If the 16 byte encoding of the pmovmskb instruction is not supported on this architecture,
     // Prepare an 8 byte sign bit mask so we can run an alternate version of the algorithm
     if (!useVectorInstructions) {
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
+        Inst_RegImm64(OP::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(OP::label, node, loopLabel, cg);
 
     // if index >= loopLimit, jump to handling the residual bytes
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, indexReg, loopLimitReg, cg);
-    Inst_Label(TR::InstOpCode::JGE4, node, residualLabel, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, indexReg, loopLimitReg, cg);
+    Inst_Label(OP::JGE4, node, residualLabel, cg);
 
     // If the 16 byte version of pmovmskb is supported on this architecture,
     // we can proceed to generate code for the loop
     if (useVectorInstructions) {
         // Load 16 bytes from address [buf + index]
-        Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmChunkReg,
-            MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+        Inst_RegMem(OP::MOVDQURegMem, node, xmmChunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
+            cg);
 
         // Extract bitmask of sign bits
-        Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, maskReg, xmmChunkReg, cg, pmovmskbEncoding);
+        Inst_RegReg(OP::PMOVMSKB4RegReg, node, maskReg, xmmChunkReg, cg, pmovmskbEncoding);
 
         // Check if any negative values exist
-        Inst_RegReg(TR::InstOpCode::TEST2RegReg, node, maskReg, maskReg, cg);
+        Inst_RegReg(OP::TEST2RegReg, node, maskReg, maskReg, cg);
     }
     // If the 16 byte version of pmovmskb is not supported,
     // run an alternate version of the loop with an 8 byte chunk instead of a 16 byte chunk
     else {
         // Load 8 bytes from address [buf + index]
-        Inst_RegMem(TR::InstOpCode::L8RegMem, node, chunkReg,
-            MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+        Inst_RegMem(OP::L8RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
 
         // Check if any negative values exist
-        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, chunkReg, maskReg, cg);
+        Inst_RegReg(OP::TEST8RegReg, node, chunkReg, maskReg, cg);
     }
 
     // If the result is nonzero, we found at least one negative byte
-    Inst_Label(TR::InstOpCode::JNE4, node, isHasNegatives ? returnBooleanLabel : returnHasNegativesLabel, cg);
+    Inst_Label(OP::JNE4, node, isHasNegatives ? returnBooleanLabel : returnHasNegativesLabel, cg);
 
     // increment index by the appropriate amount and jump back to the top of the loop
-    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, indexReg, useVectorInstructions ? 16 : 8, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, loopLabel, cg);
+    Inst_RegImm(OP::ADD4RegImm4, node, indexReg, useVectorInstructions ? 16 : 8, cg);
+    Inst_Label(OP::JMP4, node, loopLabel, cg);
 
     // Deal with the residual (last 15 or fewer) bytes
-    Inst_Label(TR::InstOpCode::label, node, residualLabel, cg);
+    Inst_Label(OP::label, node, residualLabel, cg);
 
     // Calculate bytes remaining: loopLimit = -(loopLimit - limit)
-    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, loopLimitReg, limitReg, cg);
-    Inst_Reg(TR::InstOpCode::NEG4Reg, node, loopLimitReg, cg);
+    Inst_RegReg(OP::SUB4RegReg, node, loopLimitReg, limitReg, cg);
+    Inst_Reg(OP::NEG4Reg, node, loopLimitReg, cg);
 
     /*
      *    if loopLimit == 0
@@ -11467,102 +11354,94 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
      */
 
     // if loopLimit = 0, we did not find any negative bytes
-    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, loopLimitReg, loopLimitReg, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, isHasNegatives ? returnBooleanLabel : returnNoNegativesLabel, cg);
+    Inst_RegReg(OP::TEST4RegReg, node, loopLimitReg, loopLimitReg, cg);
+    Inst_Label(OP::JE4, node, isHasNegatives ? returnBooleanLabel : returnNoNegativesLabel, cg);
 
     // Prepare an 8 byte sign bit mask
     // (if the 16 byte pmovmskb instruction above isn't supported, we already did this at the start)
     if (useVectorInstructions) {
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
+        Inst_RegImm64(OP::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
     }
 
     // if loopLimit > 8, jump to nineOrMoreBytesLabel
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 8, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, nineOrMoreBytesLabel, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, loopLimitReg, 8, cg);
+    Inst_Label(OP::JG4, node, nineOrMoreBytesLabel, cg);
 
     // Zero out the chunk register
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, chunkReg, chunkReg, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, chunkReg, chunkReg, cg);
 
     // if loopLimit > 2, jump to threeOrMoreBytesLabel
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 2, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, threeOrMoreBytesLabel, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, loopLimitReg, 2, cg);
+    Inst_Label(OP::JG4, node, threeOrMoreBytesLabel, cg);
 
     // Case in which there are one or two residual bytes
     // Load the byte at address [buf + index] into the chunk register
-    Inst_RegMem(TR::InstOpCode::L1RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
-        cg);
+    Inst_RegMem(OP::L1RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second byte (which is the same byte again in the 1 byte case)
-    Inst_RegMem(TR::InstOpCode::OR1RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 1, cg), cg);
+    Inst_RegMem(OP::OR1RegMem, node, chunkReg, MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 1, cg), cg);
 
-    Inst_Label(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
+    Inst_Label(OP::JMP4, node, residualTestLabel, cg);
 
     // Case in which there are three or more residual bytes
-    Inst_Label(TR::InstOpCode::label, node, threeOrMoreBytesLabel, cg);
+    Inst_Label(OP::label, node, threeOrMoreBytesLabel, cg);
 
     // if loopLimit > 4, jump to fiveOrMoreBytesLabel
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 4, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, fiveOrMoreBytesLabel, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, loopLimitReg, 4, cg);
+    Inst_Label(OP::JG4, node, fiveOrMoreBytesLabel, cg);
 
     // Load the first two bytes at address [buf + index] into the chunk register
-    Inst_RegMem(TR::InstOpCode::L2RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
-        cg);
+    Inst_RegMem(OP::L2RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second two bytes at address [buf + (limit - 2)] into the chunk register
-    Inst_RegMem(TR::InstOpCode::OR2RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 2, cg), cg);
+    Inst_RegMem(OP::OR2RegMem, node, chunkReg, MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 2, cg), cg);
 
-    Inst_Label(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
+    Inst_Label(OP::JMP4, node, residualTestLabel, cg);
 
     // Case in which there are five or more residual bytes
-    Inst_Label(TR::InstOpCode::label, node, fiveOrMoreBytesLabel, cg);
+    Inst_Label(OP::label, node, fiveOrMoreBytesLabel, cg);
 
     // Load the first four bytes at address [buf + index] into the chunk register
-    Inst_RegMem(TR::InstOpCode::L4RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
-        cg);
+    Inst_RegMem(OP::L4RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second four bytes at address [buf + (limit - 4)] into the chunk register
-    Inst_RegMem(TR::InstOpCode::OR4RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 4, cg), cg);
+    Inst_RegMem(OP::OR4RegMem, node, chunkReg, MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 4, cg), cg);
 
-    Inst_Label(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
+    Inst_Label(OP::JMP4, node, residualTestLabel, cg);
 
     // Case in which there are nine or more residual bytes
-    Inst_Label(TR::InstOpCode::label, node, nineOrMoreBytesLabel, cg);
+    Inst_Label(OP::label, node, nineOrMoreBytesLabel, cg);
 
     // Load the first eight bytes at address [buf + index] into the chunk register
-    Inst_RegMem(TR::InstOpCode::L8RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
-        cg);
+    Inst_RegMem(OP::L8RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second eight bytes at address [buf + (limit - 8)] into the chunk register
-    Inst_RegMem(TR::InstOpCode::OR8RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 8, cg), cg);
+    Inst_RegMem(OP::OR8RegMem, node, chunkReg, MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 8, cg), cg);
 
     // Examine the chunk register now that all of the residual bytes have been ORed into it
-    Inst_Label(TR::InstOpCode::label, node, residualTestLabel, cg);
+    Inst_Label(OP::label, node, residualTestLabel, cg);
     // AND the residual bytes with the new mask
-    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, chunkReg, maskReg, cg);
+    Inst_RegReg(OP::TEST8RegReg, node, chunkReg, maskReg, cg);
     if (!isHasNegatives) {
         // If the result is nonzero (i.e. at least one of the sign bits is set), jump to returnHasNegativesLabel
-        Inst_Label(TR::InstOpCode::JNE4, node, returnHasNegativesLabel, cg);
+        Inst_Label(OP::JNE4, node, returnHasNegativesLabel, cg);
     }
 
     // Return result
     if (isHasNegatives) {
-        Inst_Label(TR::InstOpCode::label, node, returnBooleanLabel, cg);
+        Inst_Label(OP::label, node, returnBooleanLabel, cg);
         // If the result of the previous comparison is nonzero, a negative byte has been found somewhere, so return true
         // Otherwise, return false
-        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, indexReg, cg);
-        Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, indexReg, indexReg, cg);
+        Inst_Reg(OP::SETNE1Reg, node, indexReg, cg);
+        Inst_RegReg(OP::MOVZXReg4Reg1, node, indexReg, indexReg, cg);
     } else {
         // no negatives found case, result = length
-        Inst_Label(TR::InstOpCode::label, node, returnNoNegativesLabel, cg);
-        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, indexReg, lengthReg, cg);
-        Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+        Inst_Label(OP::label, node, returnNoNegativesLabel, cg);
+        Inst_RegReg(OP::MOV4RegReg, node, indexReg, lengthReg, cg);
+        Inst_Label(OP::JMP4, node, endLabel, cg);
 
         // negative(s) found case, result = index - offset
-        Inst_Label(TR::InstOpCode::label, node, returnHasNegativesLabel, cg);
-        Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, indexReg, offsetReg, cg);
+        Inst_Label(OP::label, node, returnHasNegativesLabel, cg);
+        Inst_RegReg(OP::SUB4RegReg, node, indexReg, offsetReg, cg);
     }
 
-    Inst_Label(TR::InstOpCode::label, node, endLabel, dependencies, cg);
+    Inst_Label(OP::label, node, endLabel, dependencies, cg);
 
     cg->stopUsingRegister(bufReg);
     cg->stopUsingRegister(loopLimitReg);
@@ -11627,14 +11506,14 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
                         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
                         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
                         startLabel->setStartInternalControlFlow();
-                        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+                        Inst_Label(OP::label, node, startLabel, cg);
 
-                        Inst_RegMem(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
+                        Inst_RegMem(OP::LRegMem(), node, nativeThreadReg,
                             MRef_Bdisp32(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg), cg);
-                        Inst_RegMem(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
+                        Inst_RegMem(OP::LRegMem(), node, nativeThreadReg,
                             MRef_Bdisp32(nativeThreadReg, offsetof(J9Thread, handle), cg), cg);
                         doneLabel->setEndInternalControlFlow();
-                        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
+                        Inst_Label(OP::label, node, doneLabel, deps, cg);
                     } else {
                         TR::MemoryReference *lowMR = MRef_Bdisp32(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg);
                         TR::MemoryReference *highMR = MRef_MRefOff(*lowMR, 4, cg);
@@ -11642,20 +11521,20 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
                         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
                         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
                         startLabel->setStartInternalControlFlow();
-                        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+                        Inst_Label(OP::label, node, startLabel, cg);
 
-                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadReg, lowMR, cg);
-                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highMR, cg);
+                        Inst_RegMem(OP::L4RegMem, node, nativeThreadReg, lowMR, cg);
+                        Inst_RegMem(OP::L4RegMem, node, nativeThreadRegHigh, highMR, cg);
 
                         TR::MemoryReference *lowHandleMR
                             = MRef_Bdisp32(nativeThreadReg, offsetof(J9Thread, handle), cg);
                         TR::MemoryReference *highHandleMR = MRef_MRefOff(*lowMR, 4, cg);
 
-                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadReg, lowHandleMR, cg);
-                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highHandleMR, cg);
+                        Inst_RegMem(OP::L4RegMem, node, nativeThreadReg, lowHandleMR, cg);
+                        Inst_RegMem(OP::L4RegMem, node, nativeThreadRegHigh, highHandleMR, cg);
 
                         doneLabel->setEndInternalControlFlow();
-                        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
+                        Inst_Label(OP::label, node, doneLabel, deps, cg);
                     }
 
                     if (comp->target().is32Bit()) {
@@ -11766,7 +11645,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
  *
  * Note that RealTimeGC is handled separately in a different method.
  */
-static void generateWriteBarrierCall(TR::InstOpCode::Mnemonic branchOp, TR::Node *node, MM_GCWriteBarrierType gcMode,
+static void generateWriteBarrierCall(OP::Mnemonic branchOp, TR::Node *node, MM_GCWriteBarrierType gcMode,
     TR::Register *owningObjectReg, TR::Register *sourceReg, TR::LabelSymbol *doneLabel, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
@@ -11801,14 +11680,14 @@ static void generateWriteBarrierCall(TR::InstOpCode::Mnemonic branchOp, TR::Node
 
     TR_OutlinedInstructionsGenerator og(wrtBarLabel, node, cg);
 
-    Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-        MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), owningObjectReg, cg);
+    Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg),
+        owningObjectReg, cg);
     if (helperArgCount > 1) {
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceReg, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg),
+            sourceReg, cg);
     }
-    Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_ImmSym(OP::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef, cg);
+    Inst_Label(OP::JMP4, node, doneLabel, cg);
 
     og.endOutlinedInstructionSequence();
 }
@@ -11916,12 +11795,12 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
     if (doInternalControlFlow) {
         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
         startLabel->setStartInternalControlFlow();
-        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(OP::label, node, startLabel, cg);
         doneLabel->setEndInternalControlFlow();
     }
 
     if (comp->getOption(TR_BreakOnWriteBarrier)) {
-        Inst(TR::InstOpCode::INT3, node, cg);
+        Inst(OP::INT3, node, cg);
     }
 
     TR::SymbolReference *wrtBarSymRef = NULL;
@@ -11962,7 +11841,7 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
         if (comp->getOption(TR_CountWriteBarriersRT)) {
             TR::MemoryReference *barrierCountMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, debugEventData6), cg);
-            Inst_Mem(TR::InstOpCode::INCMem(comp->target().is64Bit()), node, barrierCountMR, cg);
+            Inst_Mem(OP::INCMem(comp->target().is64Bit()), node, barrierCountMR, cg);
         }
 
         tempReg = srm->findOrCreateScratchRegister();
@@ -11970,27 +11849,27 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
         // if barrier not enabled, nothing to do
         TR::MemoryReference *fragmentParentMR = MRef_Bdisp32(cg->getVMThreadRegister(),
             fej9->thisThreadRememberedSetFragmentOffset() + fej9->getFragmentParentOffset(), cg);
-        Inst_RegMem(TR::InstOpCode::LRegMem(comp->target().is64Bit()), node, tempReg, fragmentParentMR, cg);
+        Inst_RegMem(OP::LRegMem(comp->target().is64Bit()), node, tempReg, fragmentParentMR, cg);
         TR::MemoryReference *globalFragmentIDMR
             = MRef_Bdisp32(tempReg, fej9->getRememberedSetGlobalFragmentOffset(), cg);
-        Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, globalFragmentIDMR, 0, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
+        Inst_MemImm(OP::CMPMemImms(), node, globalFragmentIDMR, 0, cg);
+        Inst_Label(OP::JE4, node, doneLabel, cg);
 
         // now check if double barrier is enabled and definitely execute the barrier if it is
         // if (vmThread->localFragmentIndex == 0) goto snippetLabel
         TR::MemoryReference *localFragmentIndexMR = MRef_Bdisp32(cg->getVMThreadRegister(),
             fej9->thisThreadRememberedSetFragmentOffset() + fej9->getLocalFragmentOffset(), cg);
-        Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, localFragmentIndexMR, 0, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+        Inst_MemImm(OP::CMPMemImms(), node, localFragmentIndexMR, 0, cg);
+        Inst_Label(OP::JE4, node, snippetLabel, cg);
 
         // null test on the reference we're about to store over: if it is null goto doneLabel
         // if (destObject->field == null) goto doneLabel
         TR::MemoryReference *nullTestMR = MRef_Bdisp32(storeAddressRegForRealTime, 0, cg);
         if (comp->target().is64Bit() && comp->useCompressedPointers())
-            Inst_MemImm(TR::InstOpCode::CMP4MemImms, node, nullTestMR, 0, cg);
+            Inst_MemImm(OP::CMP4MemImms, node, nullTestMR, 0, cg);
         else
-            Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, nullTestMR, 0, cg);
-        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_MemImm(OP::CMPMemImms(), node, nullTestMR, 0, cg);
+        Inst_Label(OP::JNE4, node, snippetLabel, cg);
 
         // fall-through means write barrier not needed, just do the store
     }
@@ -12034,12 +11913,12 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
         srm->addScratchRegistersToDependencyList(conditions);
         conditions->stopAddingConditions();
 
-        Inst_Label(TR::InstOpCode::label, node, doneLabel, conditions, cg);
+        Inst_Label(OP::label, node, doneLabel, conditions, cg);
 
         srm->stopUsingRegisters();
     } else {
         TR_ASSERT(node->getOpCodeValue() == TR::ArrayStoreCHK, "assertion failure");
-        Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
+        Inst_Label(OP::label, node, doneLabel, cg);
     }
 }
 
@@ -12219,12 +12098,12 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
     if (doInternalControlFlow) {
         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
         startLabel->setStartInternalControlFlow();
-        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(OP::label, node, startLabel, cg);
         doneLabel->setEndInternalControlFlow();
     }
 
     if (comp->getOption(TR_BreakOnWriteBarrier)) {
-        Inst(TR::InstOpCode::INT3, node, cg);
+        Inst(OP::INT3, node, cg);
     }
 
     TR::MemoryReference *fragmentParentMR = MRef_Bdisp32(cg->getVMThreadRegister(),
@@ -12235,38 +12114,36 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
     if (doInlineCardMarkingWithoutOldSpaceCheck && doCheckConcurrentMarkActive) {
         TR::MemoryReference *vmThreadPrivateFlagsMR
             = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
-        Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR, J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE,
-            cg);
+        Inst_MemImm(OP::TEST4MemImm4, node, vmThreadPrivateFlagsMR, J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
 
         // Branch to outlined instructions to inline card dirtying.
         //
         TR::LabelSymbol *inlineCardMarkLabel = generateLabelSymbol(cg);
 
-        Inst_Label(TR::InstOpCode::JNE4, node, inlineCardMarkLabel, cg);
+        Inst_Label(OP::JNE4, node, inlineCardMarkLabel, cg);
 
         // Dirty the card table.
         //
         TR_OutlinedInstructionsGenerator og(inlineCardMarkLabel, node, cg);
         TR::Register *tempReg = srm->findOrCreateScratchRegister();
 
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, tempReg, owningObjectReg, cg);
 
         if (comp->getOptions()->isVariableHeapBaseForBarrierRange0()) {
             TR::MemoryReference *vhbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
-            Inst_RegMem(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
+            Inst_RegMem(OP::SUBRegMem(), node, tempReg, vhbMR, cg);
         } else {
             uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
 
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
+                Inst_RegImm64(OP::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                Inst_RegReg(OP::SUBRegReg(), node, tempReg, chbReg, cg);
                 srm->reclaimScratchRegister(chbReg);
             } else {
-                Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
-                    TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                Inst_RegImm(OP::SUBRegImm4(), node, tempReg, (int32_t)chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
             }
         }
 
@@ -12276,27 +12153,25 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->getOptions()->isVariableHeapSizeForBarrierRange0()) {
                 TR::MemoryReference *vhsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
+                Inst_RegMem(OP::CMPRegMem(), node, tempReg, vhsMR, cg);
             } else {
                 uintptr_t chs = comp->getOptions()->getHeapSizeForBarrierRange0();
 
                 if (comp->target().is64Bit()
                     && (!IS_32BIT_SIGNED(chs) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                     TR::Register *chsReg = srm->findOrCreateScratchRegister();
-                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chsReg, chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
-                    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, tempReg, chsReg, cg);
+                    Inst_RegImm64(OP::MOV8RegImm64, node, chsReg, chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
+                    Inst_RegReg(OP::CMPRegReg(), node, tempReg, chsReg, cg);
                     srm->reclaimScratchRegister(chsReg);
                 } else {
-                    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)chs, cg,
-                        TR_HEAP_SIZE_FOR_BARRIER_RANGE);
+                    Inst_RegImm(OP::CMPRegImm4(), node, tempReg, (int32_t)chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
                 }
             }
 
-            Inst_Label(TR::InstOpCode::JAE4, node, cardMarkDoneLabel, cg);
+            Inst_Label(OP::JAE4, node, cardMarkDoneLabel, cg);
         }
 
-        Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tempReg, comp->getOptions()->getHeapAddressToCardAddressShift(),
-            cg);
+        Inst_RegImm(OP::SHRRegImm1(), node, tempReg, comp->getOptions()->getHeapAddressToCardAddressShift(), cg);
 
         // Mark the card
         //
@@ -12307,7 +12182,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         if (comp->getOptions()->isVariableActiveCardTableBase()) {
             TR::MemoryReference *actbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
-            Inst_RegMem(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
+            Inst_RegMem(OP::ADDRegMem(), node, tempReg, actbMR, cg);
             cardTableMR = MRef_Bdisp32(tempReg, 0, cg);
         } else {
             uintptr_t actb = comp->getOptions()->getActiveCardTableBase();
@@ -12315,7 +12190,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(actb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *tempReg3 = srm->findOrCreateScratchRegister();
-                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg, TR_ACTIVE_CARD_TABLE_BASE);
+                Inst_RegImm64(OP::MOV8RegImm64, node, tempReg3, actb, cg, TR_ACTIVE_CARD_TABLE_BASE);
                 cardTableMR = MRef_BIS(tempReg3, tempReg, 0, cg);
                 srm->reclaimScratchRegister(tempReg3);
             } else {
@@ -12324,9 +12199,9 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             }
         }
 
-        Inst_MemImm(TR::InstOpCode::S1MemImm1, node, cardTableMR, dirtyCard, cg);
+        Inst_MemImm(OP::S1MemImm1, node, cardTableMR, dirtyCard, cg);
         srm->reclaimScratchRegister(tempReg);
-        Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+        Inst_Label(OP::JMP4, node, doneLabel, cg);
 
         og.endOutlinedInstructionSequence();
     } else if (doInlineCardMarkingWithoutOldSpaceCheck && !dirtyCardTableOutOfLine) {
@@ -12334,24 +12209,23 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         //
         TR::Register *tempReg = srm->findOrCreateScratchRegister();
 
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
+        Inst_RegReg(OP::MOVRegReg(), node, tempReg, owningObjectReg, cg);
 
         if (comp->getOptions()->isVariableHeapBaseForBarrierRange0()) {
             TR::MemoryReference *vhbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
-            Inst_RegMem(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
+            Inst_RegMem(OP::SUBRegMem(), node, tempReg, vhbMR, cg);
         } else {
             uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
 
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
+                Inst_RegImm64(OP::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                Inst_RegReg(OP::SUBRegReg(), node, tempReg, chbReg, cg);
                 srm->reclaimScratchRegister(chbReg);
             } else {
-                Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
-                    TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                Inst_RegImm(OP::SUBRegImm4(), node, tempReg, (int32_t)chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
             }
         }
 
@@ -12361,27 +12235,25 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->getOptions()->isVariableHeapSizeForBarrierRange0()) {
                 TR::MemoryReference *vhsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
+                Inst_RegMem(OP::CMPRegMem(), node, tempReg, vhsMR, cg);
             } else {
                 uintptr_t chs = comp->getOptions()->getHeapSizeForBarrierRange0();
 
                 if (comp->target().is64Bit()
                     && (!IS_32BIT_SIGNED(chs) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                     TR::Register *chsReg = srm->findOrCreateScratchRegister();
-                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chsReg, chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
-                    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, tempReg, chsReg, cg);
+                    Inst_RegImm64(OP::MOV8RegImm64, node, chsReg, chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
+                    Inst_RegReg(OP::CMPRegReg(), node, tempReg, chsReg, cg);
                     srm->reclaimScratchRegister(chsReg);
                 } else {
-                    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)chs, cg,
-                        TR_HEAP_SIZE_FOR_BARRIER_RANGE);
+                    Inst_RegImm(OP::CMPRegImm4(), node, tempReg, (int32_t)chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
                 }
             }
 
-            Inst_Label(TR::InstOpCode::JAE4, node, cardMarkDoneLabel, cg);
+            Inst_Label(OP::JAE4, node, cardMarkDoneLabel, cg);
         }
 
-        Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tempReg, comp->getOptions()->getHeapAddressToCardAddressShift(),
-            cg);
+        Inst_RegImm(OP::SHRRegImm1(), node, tempReg, comp->getOptions()->getHeapAddressToCardAddressShift(), cg);
 
         // Mark the card
         //
@@ -12392,7 +12264,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         if (comp->getOptions()->isVariableActiveCardTableBase()) {
             TR::MemoryReference *actbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
-            Inst_RegMem(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
+            Inst_RegMem(OP::ADDRegMem(), node, tempReg, actbMR, cg);
             cardTableMR = MRef_Bdisp32(tempReg, 0, cg);
         } else {
             uintptr_t actb = comp->getOptions()->getActiveCardTableBase();
@@ -12400,7 +12272,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(actb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *tempReg3 = srm->findOrCreateScratchRegister();
-                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg, TR_ACTIVE_CARD_TABLE_BASE);
+                Inst_RegImm64(OP::MOV8RegImm64, node, tempReg3, actb, cg, TR_ACTIVE_CARD_TABLE_BASE);
                 cardTableMR = MRef_BIS(tempReg3, tempReg, 0, cg);
                 srm->reclaimScratchRegister(tempReg3);
             } else {
@@ -12409,24 +12281,24 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             }
         }
 
-        Inst_MemImm(TR::InstOpCode::S1MemImm1, node, cardTableMR, dirtyCard, cg);
+        Inst_MemImm(OP::S1MemImm1, node, cardTableMR, dirtyCard, cg);
 
         srm->reclaimScratchRegister(tempReg);
     }
 
     if (doIsDestAHeapObjectCheck && doIsDestInOldSpaceCheck) {
-        Inst_Label(TR::InstOpCode::label, node, cardMarkDoneLabel, cg);
+        Inst_Label(OP::label, node, cardMarkDoneLabel, cg);
     }
 
     if (doSrcIsNullCheck) {
-        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, srcReg, srcReg, cg);
-        Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
+        Inst_RegReg(OP::TESTRegReg(), node, srcReg, srcReg, cg);
+        Inst_Label(OP::JE4, node, doneLabel, cg);
     }
 
     if (doIsDestInOldSpaceCheck) {
         static char *disableWrtbarOpt = feGetEnv("TR_DisableWrtbarOpt");
 
-        TR::InstOpCode::Mnemonic branchOp;
+        OP::Mnemonic branchOp;
         auto gcModeForSnippet = gcMode;
 
         bool skipSnippetIfSrcNotOld = false;
@@ -12440,7 +12312,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             //
             // TODO: this should be an inline call.
             //
-            branchOp = TR::InstOpCode::JMP4;
+            branchOp = OP::JMP4;
         } else if (doCheckConcurrentMarkActive) {
             // TR_ASSERT(wrtbarNode, "Must not be an arraycopy");
 
@@ -12461,56 +12333,55 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                     uintptr_t che = comp->getOptions()->getHeapBaseForBarrierRange0()
                         + comp->getOptions()->getHeapSizeForBarrierRange0();
                     if (comp->target().is64Bit() && !IS_32BIT_SIGNED(che)) {
-                        Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, owningObjectReg,
+                        Inst_RegMem(OP::CMP8RegMem, node, owningObjectReg,
                             MRef_const(cg->findOrCreate8ByteConstant(node, che), cg), cg);
                     } else {
-                        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, owningObjectReg, (int32_t)che, cg);
+                        Inst_RegImm(OP::CMPRegImm4(), node, owningObjectReg, (int32_t)che, cg);
                     }
                 } else {
                     uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
                     TR::Register *tempOwningObjReg = srm->findOrCreateScratchRegister();
-                    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempOwningObjReg, owningObjectReg, cg);
+                    Inst_RegReg(OP::MOVRegReg(), node, tempOwningObjReg, owningObjectReg, cg);
                     if (comp->target().is64Bit()
                         && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                         TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg,
-                            TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                        Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempOwningObjReg, chbReg, cg);
+                        Inst_RegImm64(OP::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                        Inst_RegReg(OP::SUBRegReg(), node, tempOwningObjReg, chbReg, cg);
                         srm->reclaimScratchRegister(chbReg);
                     } else {
-                        Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempOwningObjReg, (int32_t)chb, cg,
+                        Inst_RegImm(OP::SUBRegImm4(), node, tempOwningObjReg, (int32_t)chb, cg,
                             TR_HEAP_BASE_FOR_BARRIER_RANGE);
                     }
                     TR::MemoryReference *vhsMR1
                         = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempOwningObjReg, vhsMR1, cg);
+                    Inst_RegMem(OP::CMPRegMem(), node, tempOwningObjReg, vhsMR1, cg);
                     srm->reclaimScratchRegister(tempOwningObjReg);
                 }
 
-                Inst_Label(TR::InstOpCode::JAE1, node, doneLabel, cg);
+                Inst_Label(OP::JAE1, node, doneLabel, cg);
 
                 skipSnippetIfSrcNotOld = true;
             } else {
                 skipSnippetIfDestOld = true;
             }
 
-            // See if we can do a TR::InstOpCode::TEST1MemImm1
+            // See if we can do a OP::TEST1MemImm1
             //
             int32_t byteOffset = byteOffsetForMask(J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
             if (byteOffset != -1) {
                 TR::MemoryReference *vmThreadPrivateFlagsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), byteOffset + offsetof(J9VMThread, privateFlags), cg);
-                Inst_MemImm(TR::InstOpCode::TEST1MemImm1, node, vmThreadPrivateFlagsMR,
+                Inst_MemImm(OP::TEST1MemImm1, node, vmThreadPrivateFlagsMR,
                     J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >> (8 * byteOffset), cg);
             } else {
                 TR::MemoryReference *vmThreadPrivateFlagsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
-                Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR,
-                    J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
+                Inst_MemImm(OP::TEST4MemImm4, node, vmThreadPrivateFlagsMR, J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE,
+                    cg);
             }
 
-            generateWriteBarrierCall(TR::InstOpCode::JNE4, node, gc_modron_wrtbar_cardmark_and_oldcheck,
-                owningObjectReg, srcReg, doneLabel, cg);
+            generateWriteBarrierCall(OP::JNE4, node, gc_modron_wrtbar_cardmark_and_oldcheck, owningObjectReg, srcReg,
+                doneLabel, cg);
 
             // If the destination object is old and not remembered then process the remembered
             // set update out-of-line with the generational helper.
@@ -12545,34 +12416,31 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                 uintptr_t che = comp->getOptions()->getHeapBaseForBarrierRange0()
                     + comp->getOptions()->getHeapSizeForBarrierRange0();
                 if (comp->target().is64Bit() && !IS_32BIT_SIGNED(che)) {
-                    Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, checkDest ? owningObjectReg : srcReg,
+                    Inst_RegMem(OP::CMP8RegMem, node, checkDest ? owningObjectReg : srcReg,
                         MRef_const(cg->findOrCreate8ByteConstant(node, che), cg), cg);
                 } else {
-                    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, checkDest ? owningObjectReg : srcReg, (int32_t)che,
-                        cg);
+                    Inst_RegImm(OP::CMPRegImm4(), node, checkDest ? owningObjectReg : srcReg, (int32_t)che, cg);
                 }
             } else {
                 uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
                 TR::Register *tempReg = srm->findOrCreateScratchRegister();
-                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, checkDest ? owningObjectReg : srcReg, cg);
+                Inst_RegReg(OP::MOVRegReg(), node, tempReg, checkDest ? owningObjectReg : srcReg, cg);
                 if (comp->target().is64Bit()
                     && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                     TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                    Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
+                    Inst_RegImm64(OP::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                    Inst_RegReg(OP::SUBRegReg(), node, tempReg, chbReg, cg);
                     srm->reclaimScratchRegister(chbReg);
                 } else {
-                    Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
-                        TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                    Inst_RegImm(OP::SUBRegImm4(), node, tempReg, (int32_t)chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
                 }
                 TR::MemoryReference *vhsMR1
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR1, cg);
+                Inst_RegMem(OP::CMPRegMem(), node, tempReg, vhsMR1, cg);
             }
 
-            branchOp = skipSnippetIfOld ? TR::InstOpCode::JB4 : TR::InstOpCode::JAE4; // For branch to snippet
-            TR::InstOpCode::Mnemonic reverseBranchOp
-                = skipSnippetIfOld ? TR::InstOpCode::JAE4 : TR::InstOpCode::JB4; // For branch past snippet
+            branchOp = skipSnippetIfOld ? OP::JB4 : OP::JAE4; // For branch to snippet
+            OP::Mnemonic reverseBranchOp = skipSnippetIfOld ? OP::JAE4 : OP::JB4; // For branch past snippet
 
             // Now performing check for remembered
             if (skipSnippetIfDestRemembered) {
@@ -12583,20 +12451,20 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                 if (byteOffset != -1) {
                     TR::MemoryReference *MR
                         = MRef_Bdisp32(owningObjectReg, byteOffset + TR::Compiler->om.offsetOfHeaderFlags(), cg);
-                    Inst_MemImm(TR::InstOpCode::TEST1MemImm1, node, MR,
+                    Inst_MemImm(OP::TEST1MemImm1, node, MR,
                         J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST >> (8 * byteOffset), cg);
                 } else {
                     TR::MemoryReference *MR = MRef_Bdisp32(owningObjectReg, TR::Compiler->om.offsetOfHeaderFlags(), cg);
-                    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MR, J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST, cg);
+                    Inst_MemImm(OP::TEST4MemImm4, node, MR, J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST, cg);
                 }
-                branchOp = TR::InstOpCode::JE4;
+                branchOp = OP::JE4;
             }
         }
 
         generateWriteBarrierCall(branchOp, node, gcModeForSnippet, owningObjectReg, srcReg, doneLabel, cg);
 
         if (labelAfterBranchToSnippet)
-            Inst_Label(TR::InstOpCode::label, node, labelAfterBranchToSnippet, cg);
+            Inst_Label(OP::label, node, labelAfterBranchToSnippet, cg);
     }
 
     int32_t numPostConditions = 2 + srm->numAvailableRegisters();
@@ -12617,7 +12485,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
     srm->addScratchRegistersToDependencyList(conditions);
     conditions->stopAddingConditions();
 
-    Inst_Label(TR::InstOpCode::label, node, doneLabel, conditions, cg);
+    Inst_Label(OP::label, node, doneLabel, conditions, cg);
 
     srm->stopUsingRegisters();
 }
@@ -12626,7 +12494,7 @@ static TR::Instruction *doReferenceStore(TR::Node *node, TR::MemoryReference *st
     bool usingCompressedPointers, TR::CodeGenerator *cg)
 {
     TR::Compilation *comp = cg->comp();
-    TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? TR::InstOpCode::S4MemReg : TR::InstOpCode::SMemReg();
+    OP::Mnemonic storeOp = usingCompressedPointers ? OP::S4MemReg : OP::SMemReg();
     TR::Instruction *instr = Inst_MemReg(storeOp, node, storeMR, sourceReg, cg);
 
     // for real-time GC, the data reference has already been resolved into an earlier LEA instruction so this padding
@@ -12685,8 +12553,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
         else {
             translatedSourceReg = cg->evaluate(translatedStore->getSecondChild());
             if (!usingLowMemHeap) {
-                Inst_RegReg(TR::InstOpCode::TESTRegReg(), translatedStore, sourceRegister, sourceRegister, cg);
-                Inst_RegReg(TR::InstOpCode::CMOVERegReg(), translatedStore, translatedSourceReg, sourceRegister, cg);
+                Inst_RegReg(OP::TESTRegReg(), translatedStore, sourceRegister, sourceRegister, cg);
+                Inst_RegReg(OP::CMOVERegReg(), translatedStore, translatedSourceReg, sourceRegister, cg);
             }
         }
     }
@@ -12703,7 +12571,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
         //   beforehand
         // For simplicity, just evaluate the store address into storeAddressRegForRealTime right now
         storeAddressRegForRealTime = scratchRegisterManager->findOrCreateScratchRegister();
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, storeAddressRegForRealTime, storeMR, cg);
+        Inst_RegMem(OP::LEARegMem(), node, storeAddressRegForRealTime, storeMR, cg);
         if (node->getSymbolReference()->isUnresolved()) {
             TR::TreeEvaluator::padUnresolvedDataReferences(node, *node->getSymbolReference(), cg);
 
@@ -12730,9 +12598,9 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
             startLabel->setStartInternalControlFlow();
             doneWrtBarLabel->setEndInternalControlFlow();
 
-            Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
-            Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
-            Inst_Label(TR::InstOpCode::JE4, node, doneWrtBarLabel, cg);
+            Inst_Label(OP::label, node, startLabel, cg);
+            Inst_RegReg(OP::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
+            Inst_Label(OP::JE4, node, doneWrtBarLabel, cg);
 
             deps = RegDeps(0, 3, cg);
             deps->addPostCondition(sourceRegister, TR::RealRegister::NoReg, cg);
@@ -12741,15 +12609,15 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
             deps->stopAddingConditions();
         }
 
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), owningObjectRegister, cg);
-        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
-            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceRegister, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg),
+            owningObjectRegister, cg);
+        Inst_MemReg(OP::SMemReg(), node, MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg),
+            sourceRegister, cg);
 
         TR::SymbolReference *wrtBarSymRef = comp->getSymRefTab()->findOrCreateWriteBarrierStoreSymbolRef();
-        Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef, cg);
+        Inst_ImmSym(OP::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef, cg);
 
-        Inst_Label(TR::InstOpCode::label, node, doneWrtBarLabel, deps, cg);
+        Inst_Label(OP::label, node, doneWrtBarLabel, deps, cg);
     } else {
         if (isRealTimeGC) {
             TR::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(node, storeMR, storeAddressRegForRealTime,
@@ -12788,9 +12656,9 @@ void J9::X86::TreeEvaluator::generateVFTMaskInstruction(TR::Node *node, TR::Regi
     if (~mask == 0) {
         // no mask instruction required
     } else if (~mask <= 127) {
-        Inst_RegImm(TR::InstOpCode::ANDRegImms(is64Bit), node, reg, TR::Compiler->om.maskOfObjectVftField(), cg);
+        Inst_RegImm(OP::ANDRegImms(is64Bit), node, reg, TR::Compiler->om.maskOfObjectVftField(), cg);
     } else {
-        Inst_RegImm(TR::InstOpCode::ANDRegImm4(is64Bit), node, reg, TR::Compiler->om.maskOfObjectVftField(), cg);
+        Inst_RegImm(OP::ANDRegImm4(is64Bit), node, reg, TR::Compiler->om.maskOfObjectVftField(), cg);
     }
 }
 
@@ -12810,9 +12678,9 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
         TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
         TR::LabelSymbol *restartLabel = generateLabelSymbol(cg);
 
-        Inst_Mem(TR::InstOpCode::DEC4Mem, node, MRef_sym(comp->getRecompilationInfo()->getCounterSymRef(), cg), cg);
-        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
-        Inst_Label(TR::InstOpCode::label, node, restartLabel, cg);
+        Inst_Mem(OP::DEC4Mem, node, MRef_sym(comp->getRecompilationInfo()->getCounterSymRef(), cg), cg);
+        Inst_Label(OP::JE4, node, snippetLabel, cg);
+        Inst_Label(OP::label, node, restartLabel, cg);
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86ForceRecompilationSnippet(cg, node, restartLabel, snippetLabel));
         cg->comp()->getRecompilationInfo()->getJittedBodyInfo()->setHasEdoSnippet();
     }
@@ -12901,103 +12769,103 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     startLabelConditions->addPostCondition(dummyReg, TR::RealRegister::eax, cg);
     startLabelConditions->stopAddingConditions();
     cg->stopUsingRegister(dummyReg);
-    Inst_Label(TR::InstOpCode::label, node, startLabel, startLabelConditions, cg);
+    Inst_Label(OP::label, node, startLabel, startLabelConditions, cg);
 
     // xbegin fall_back_path
-    Inst_LongLabel(TR::InstOpCode::XBEGIN4, node, fallBackPathLabel, cg);
+    Inst_LongLabel(OP::XBEGIN4, node, fallBackPathLabel, cg);
     // mov monReg, obj+offset
     int32_t lwOffset = cg->fej9()->getByteOffsetToLockword((TR_OpaqueClassBlock *)cg->getMonClass(node));
     TR::MemoryReference *objLockRef = MRef_Bdisp32(objReg, lwOffset, cg);
     if (comp->target().is64Bit() && cg->fej9()->generateCompressedLockWord()) {
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, monReg, objLockRef, cg);
+        Inst_RegMem(OP::L4RegMem, node, monReg, objLockRef, cg);
     } else {
-        Inst_RegMem(TR::InstOpCode::LRegMem(), node, monReg, objLockRef, cg);
+        Inst_RegMem(OP::LRegMem(), node, monReg, objLockRef, cg);
     }
 
     if (comp->target().is64Bit() && cg->fej9()->generateCompressedLockWord()) {
-        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, monReg, 0, cg);
+        Inst_RegImm(OP::CMP4RegImm4, node, monReg, 0, cg);
     } else {
-        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, monReg, 0, cg);
+        Inst_RegImm(OP::CMPRegImm4(), node, monReg, 0, cg);
     }
 
     if (fallThroughConditions)
-        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, fallThroughConditions, cg);
+        Inst_Label(OP::JE4, node, fallThroughLabel, fallThroughConditions, cg);
     else
-        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, cg);
+        Inst_Label(OP::JE4, node, fallThroughLabel, cg);
 
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
     if (comp->target().is64Bit() && cg->fej9()->generateCompressedLockWord()) {
-        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, monReg, vmThreadReg, cg);
+        Inst_RegReg(OP::CMP4RegReg, node, monReg, vmThreadReg, cg);
     } else {
-        Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, monReg, vmThreadReg, cg);
+        Inst_RegReg(OP::CMPRegReg(), node, monReg, vmThreadReg, cg);
     }
 
     if (fallThroughConditions)
-        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, fallThroughConditions, cg);
+        Inst_Label(OP::JE4, node, fallThroughLabel, fallThroughConditions, cg);
     else
-        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, cg);
+        Inst_Label(OP::JE4, node, fallThroughLabel, cg);
 
     // xabort
-    Inst_Imm(TR::InstOpCode::XABORT, node, 0x01, cg);
+    Inst_Imm(OP::XABORT, node, 0x01, cg);
 
     cg->stopUsingRegister(monReg);
     // fall_back_path:
-    Inst_Label(TR::InstOpCode::label, node, fallBackPathLabel, cg);
+    Inst_Label(OP::label, node, fallBackPathLabel, cg);
 
     endLabelConditions = RegDeps((uint8_t)0, 1, cg);
     endLabelConditions->addPostCondition(accReg, TR::RealRegister::eax, cg);
     endLabelConditions->stopAddingConditions();
 
     // test eax, 0x2
-    Inst_RegImm(TR::InstOpCode::TEST1AccImm1, node, accReg, 0x2, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, gotoTransientFailure, cg);
+    Inst_RegImm(OP::TEST1AccImm1, node, accReg, 0x2, cg);
+    Inst_Label(OP::JNE4, node, gotoTransientFailure, cg);
 
     // abort because of nonzero lockword is also transient failure
-    Inst_RegImm(TR::InstOpCode::TEST4AccImm4, node, accReg, 0x00000001, cg);
+    Inst_RegImm(OP::TEST4AccImm4, node, accReg, 0x00000001, cg);
     if (persistentConditions)
-        Inst_Label(TR::InstOpCode::JE4, node, persistentFailureLabel, persistentConditions, cg);
+        Inst_Label(OP::JE4, node, persistentFailureLabel, persistentConditions, cg);
     else
-        Inst_Label(TR::InstOpCode::JE4, node, persistentFailureLabel, cg);
+        Inst_Label(OP::JE4, node, persistentFailureLabel, cg);
 
-    Inst_RegImm(TR::InstOpCode::TEST4AccImm4, node, accReg, 0x01000000, cg);
+    Inst_RegImm(OP::TEST4AccImm4, node, accReg, 0x01000000, cg);
     // je gotransientFailureNodeLabel
-    Inst_Label(TR::InstOpCode::JNE4, node, gotoTransientFailure, cg);
+    Inst_Label(OP::JNE4, node, gotoTransientFailure, cg);
 
     if (persistentConditions)
-        Inst_Label(TR::InstOpCode::JMP4, node, persistentFailureLabel, persistentConditions, cg);
+        Inst_Label(OP::JMP4, node, persistentFailureLabel, persistentConditions, cg);
     else
-        Inst_Label(TR::InstOpCode::JMP4, node, persistentFailureLabel, cg);
+        Inst_Label(OP::JMP4, node, persistentFailureLabel, cg);
     cg->stopUsingRegister(accReg);
 
     // gotoTransientFailureLabel:
     if (transientConditions)
-        Inst_Label(TR::InstOpCode::label, node, gotoTransientFailure, transientConditions, cg);
+        Inst_Label(OP::label, node, gotoTransientFailure, transientConditions, cg);
     else
-        Inst_Label(TR::InstOpCode::label, node, gotoTransientFailure, cg);
+        Inst_Label(OP::label, node, gotoTransientFailure, cg);
 
     // delay
     TR::Register *counterReg = cg->allocateRegister();
-    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, counterReg, 100, cg);
+    Inst_RegImm(OP::MOV4RegImm4, node, counterReg, 100, cg);
     TR::LabelSymbol *spinLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-    Inst_Label(TR::InstOpCode::label, node, spinLabel, cg);
-    Inst(TR::InstOpCode::PAUSE, node, cg);
-    Inst(TR::InstOpCode::PAUSE, node, cg);
-    Inst(TR::InstOpCode::PAUSE, node, cg);
-    Inst(TR::InstOpCode::PAUSE, node, cg);
-    Inst(TR::InstOpCode::PAUSE, node, cg);
-    Inst_Reg(TR::InstOpCode::DEC4Reg, node, counterReg, cg);
+    Inst_Label(OP::label, node, spinLabel, cg);
+    Inst(OP::PAUSE, node, cg);
+    Inst(OP::PAUSE, node, cg);
+    Inst(OP::PAUSE, node, cg);
+    Inst(OP::PAUSE, node, cg);
+    Inst(OP::PAUSE, node, cg);
+    Inst_Reg(OP::DEC4Reg, node, counterReg, cg);
     TR::RegisterDependencyConditions *loopConditions = RegDeps((uint8_t)0, 1, cg);
     loopConditions->addPostCondition(counterReg, TR::RealRegister::NoReg, cg);
     loopConditions->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::JNE4, node, spinLabel, loopConditions, cg);
+    Inst_Label(OP::JNE4, node, spinLabel, loopConditions, cg);
     cg->stopUsingRegister(counterReg);
 
     if (transientConditions)
-        Inst_Label(TR::InstOpCode::JMP4, node, transientFailureLabel, transientConditions, cg);
+        Inst_Label(OP::JMP4, node, transientFailureLabel, transientConditions, cg);
     else
-        Inst_Label(TR::InstOpCode::JMP4, node, transientFailureLabel, cg);
+        Inst_Label(OP::JMP4, node, transientFailureLabel, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, endLabel, endLabelConditions, cg);
+    Inst_Label(OP::label, node, endLabel, endLabelConditions, cg);
     cg->decReferenceCount(objNode);
     cg->decReferenceCount(persistentFailureNode);
     cg->decReferenceCount(transientFailureNode);
@@ -13006,13 +12874,13 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *J9::X86::TreeEvaluator::tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    Inst(TR::InstOpCode::XEND, node, cg);
+    Inst(OP::XEND, node, cg);
     return NULL;
 }
 
 TR::Register *J9::X86::TreeEvaluator::tabortEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    Inst_Imm(TR::InstOpCode::XABORT, node, 0x04, cg);
+    Inst_Imm(OP::XABORT, node, 0x04, cg);
     return NULL;
 }
 
@@ -13112,7 +12980,7 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
         case TR::java_lang_Thread_onSpinWait: {
             static char *disableOSW = feGetEnv("TR_noPauseOnSpinWait");
             if (!disableOSW) {
-                Inst(TR::InstOpCode::PAUSE, node, cg);
+                Inst(OP::PAUSE, node, cg);
 
                 static char *printIt = feGetEnv("TR_showPauseOnSpinWait");
                 if (printIt && comp->getOption(TR_TraceCG)) {
@@ -13151,8 +13019,7 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)1, (uint8_t)1, cg);
             deps->addPreCondition(valueToKeepAlive, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(valueToKeepAlive, TR::RealRegister::NoReg, cg);
-            new (cg->trHeapMemory())
-                TR::X86LabelInstruction(TR::InstOpCode::label, node, generateLabelSymbol(cg), deps, cg);
+            new (cg->trHeapMemory()) TR::X86LabelInstruction(OP::label, node, generateLabelSymbol(cg), deps, cg);
             cg->decReferenceCount(node->getFirstChild());
 
             return NULL; // keepAlive has no return value
@@ -13245,10 +13112,10 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     uint8_t vectorLengthConst = 16;
 
     TR::Register *srcBufferReg = cg->evaluate(node->getChild(0));
-    TR::Register *srcOffsetReg = cg->gprClobberEvaluate(node->getChild(1), TR::InstOpCode::MOV4RegReg);
+    TR::Register *srcOffsetReg = cg->gprClobberEvaluate(node->getChild(1), OP::MOV4RegReg);
     TR::Register *destBufferReg = cg->evaluate(node->getChild(2));
-    TR::Register *destOffsetReg = cg->gprClobberEvaluate(node->getChild(3), TR::InstOpCode::MOV4RegReg);
-    TR::Register *lengthReg = cg->gprClobberEvaluate(node->getChild(4), TR::InstOpCode::MOV4RegReg);
+    TR::Register *destOffsetReg = cg->gprClobberEvaluate(node->getChild(3), OP::MOV4RegReg);
+    TR::Register *lengthReg = cg->gprClobberEvaluate(node->getChild(4), OP::MOV4RegReg);
 
     TR::Register *xmmHighReg = cg->allocateRegister(TR_VRF);
     TR::Register *xmmLowReg = cg->allocateRegister(TR_VRF);
@@ -13273,23 +13140,23 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     TR::Node *destOffsetNode = node->getChild(3);
 
     if (!destOffsetNode->isConstZeroValue()) {
         // dest offset measured in characters, convert it to bytes
-        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, destOffsetReg, destOffsetReg, cg);
+        Inst_RegReg(OP::ADD4RegReg, node, destOffsetReg, destOffsetReg, cg);
     }
 
-    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, lengthReg, lengthReg, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
+    Inst_RegReg(OP::TEST4RegReg, node, lengthReg, lengthReg, cg);
+    Inst_Label(OP::JE4, node, doneLabel, cg);
 
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, lengthReg, 8, cg);
-    Inst_Label(TR::InstOpCode::JL4, node, afterCopy8Label, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, lengthReg, 8, cg);
+    Inst_Label(OP::JL4, node, afterCopy8Label, cg);
 
     // make sure the register is zero before interleaving
-    Inst_RegReg(TR::InstOpCode::PXORRegReg, node, zeroReg, zeroReg, cg);
+    Inst_RegReg(OP::PXORRegReg, node, zeroReg, zeroReg, cg);
 
     TR::LabelSymbol *startLoop = generateLabelSymbol(cg);
     TR::LabelSymbol *endLoop = generateLabelSymbol(cg);
@@ -13297,52 +13164,52 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     // vectorized add in loop, 16 bytes per iteration
     // use srcOffsetReg for loop counter, add starting offset to lengthReg, subtract 16 (xmm register size)
     // to prevent reading/writing beyond the end of the array
-    Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, scratchReg,
-        MRef_BISdisp32(lengthReg, srcOffsetReg, 0, -vectorLengthConst, cg), cg);
+    Inst_RegMem(OP::LEA4RegMem, node, scratchReg, MRef_BISdisp32(lengthReg, srcOffsetReg, 0, -vectorLengthConst, cg),
+        cg);
 
-    Inst_Label(TR::InstOpCode::label, node, startLoop, cg);
-    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, srcOffsetReg, scratchReg, cg);
-    Inst_Label(TR::InstOpCode::JG4, node, endLoop, cg);
+    Inst_Label(OP::label, node, startLoop, cg);
+    Inst_RegReg(OP::CMP4RegReg, node, srcOffsetReg, scratchReg, cg);
+    Inst_Label(OP::JG4, node, endLoop, cg);
 
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmHighReg,
+    Inst_RegMem(OP::MOVDQURegMem, node, xmmHighReg,
         MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
 
-    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmLowReg, xmmHighReg, cg);
-    Inst_RegReg(TR::InstOpCode::PUNPCKHBWRegReg, node, xmmLowReg, zeroReg, cg);
-    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
+    Inst_RegReg(OP::MOVDQURegReg, node, xmmLowReg, xmmHighReg, cg);
+    Inst_RegReg(OP::PUNPCKHBWRegReg, node, xmmLowReg, zeroReg, cg);
+    Inst_MemReg(OP::MOVDQUMemReg, node,
         MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst + vectorLengthConst, cg), xmmLowReg, cg);
 
-    Inst_RegReg(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmHighReg, zeroReg, cg);
-    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
-        MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmHighReg, cg);
+    Inst_RegReg(OP::PUNPCKLBWRegReg, node, xmmHighReg, zeroReg, cg);
+    Inst_MemReg(OP::MOVDQUMemReg, node, MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg),
+        xmmHighReg, cg);
 
     // increase src offset by size of imm register
     // increase dest offset by double, to account for the byte->char inflation
-    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, srcOffsetReg, vectorLengthConst, cg);
-    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, destOffsetReg, 2 * vectorLengthConst, cg);
+    Inst_RegImm(OP::ADD4RegImm4, node, srcOffsetReg, vectorLengthConst, cg);
+    Inst_RegImm(OP::ADD4RegImm4, node, destOffsetReg, 2 * vectorLengthConst, cg);
 
     // LOOP BACK
-    Inst_Label(TR::InstOpCode::JMP4, node, startLoop, cg);
-    Inst_Label(TR::InstOpCode::label, node, endLoop, cg);
+    Inst_Label(OP::JMP4, node, startLoop, cg);
+    Inst_Label(OP::label, node, endLoop, cg);
 
     // AND length with 15 to compute residual remainder
     // then copy and interleave 8 bytes from src buffer with 0s into dest buffer if possible
-    Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, lengthReg, vectorLengthConst - 1, cg);
+    Inst_RegImm(OP::AND4RegImm4, node, lengthReg, vectorLengthConst - 1, cg);
 
-    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, lengthReg, 8, cg);
-    Inst_Label(TR::InstOpCode::JL1, node, afterCopy8Label, cg);
+    Inst_RegImm(OP::CMP4RegImm4, node, lengthReg, 8, cg);
+    Inst_Label(OP::JL1, node, afterCopy8Label, cg);
 
-    Inst_RegMem(TR::InstOpCode::MOVQRegMem, node, xmmLowReg,
-        MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
-    Inst_RegReg(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmLowReg, zeroReg, cg);
-    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
-        MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmLowReg, cg);
-    Inst_RegImm(TR::InstOpCode::SUB4RegImm4, node, lengthReg, 8, cg);
+    Inst_RegMem(OP::MOVQRegMem, node, xmmLowReg, MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg),
+        cg);
+    Inst_RegReg(OP::PUNPCKLBWRegReg, node, xmmLowReg, zeroReg, cg);
+    Inst_MemReg(OP::MOVDQUMemReg, node, MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg),
+        xmmLowReg, cg);
+    Inst_RegImm(OP::SUB4RegImm4, node, lengthReg, 8, cg);
 
-    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, srcOffsetReg, 8, cg);
-    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, destOffsetReg, 16, cg);
+    Inst_RegImm(OP::ADD4RegImm4, node, srcOffsetReg, 8, cg);
+    Inst_RegImm(OP::ADD4RegImm4, node, destOffsetReg, 16, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, afterCopy8Label, cg);
+    Inst_Label(OP::label, node, afterCopy8Label, cg);
 
     // handle residual (< 8 bytes left) & jump to copy instructions based on the number of bytes left
     // calculate how many bytes to skip based on length;
@@ -13353,8 +13220,8 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     // since copy_instruction_size could change depending on which registers are allocated to scratchReg, srcOffsetReg
     // and destOffsetReg we reserve them to be eax, ecx, edx, respectively
 
-    Inst_RegRegImm(TR::InstOpCode::IMUL4RegRegImm4, node, lengthReg, lengthReg, -copy_instruction_size, cg);
-    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, lengthReg, copy_instruction_size * 7, cg);
+    Inst_RegRegImm(OP::IMUL4RegRegImm4, node, lengthReg, lengthReg, -copy_instruction_size, cg);
+    Inst_RegImm(OP::ADD4RegImm4, node, lengthReg, copy_instruction_size * 7, cg);
 
     bool is64bit = cg->comp()->target().is64Bit();
     // calculate address to jump too
@@ -13365,27 +13232,25 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
         deps->addPostCondition(residueLabelMR->getAddressRegister(), TR::RealRegister::NoReg, cg);
     }
 
-    Inst_RegMem(TR::InstOpCode::LEARegMem(is64bit), node, scratchReg, residueLabelMR, cg);
-    Inst_RegReg(TR::InstOpCode::ADDRegReg(is64bit), node, lengthReg, scratchReg, cg);
+    Inst_RegMem(OP::LEARegMem(is64bit), node, scratchReg, residueLabelMR, cg);
+    Inst_RegReg(OP::ADDRegReg(is64bit), node, lengthReg, scratchReg, cg);
 
-    Inst_RegMem(TR::InstOpCode::LEARegMem(is64bit), node, srcOffsetReg,
-        MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, 0, cg), cg);
-    Inst_RegMem(TR::InstOpCode::LEARegMem(is64bit), node, destOffsetReg,
-        MRef_BISdisp32(destBufferReg, destOffsetReg, 0, 0, cg), cg);
+    Inst_RegMem(OP::LEARegMem(is64bit), node, srcOffsetReg, MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, 0, cg), cg);
+    Inst_RegMem(OP::LEARegMem(is64bit), node, destOffsetReg, MRef_BISdisp32(destBufferReg, destOffsetReg, 0, 0, cg),
+        cg);
 
-    Inst_Reg(TR::InstOpCode::JMPReg, node, lengthReg, cg);
+    Inst_Reg(OP::JMPReg, node, lengthReg, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, copyResidueLabel, cg);
+    Inst_Label(OP::label, node, copyResidueLabel, cg);
 
     for (int i = 0; i < 7; i++) {
-        Inst_RegMem(TR::InstOpCode::MOVZXReg2Mem1, node, scratchReg,
-            MRef_Bdisp32(srcOffsetReg, headerOffsetConst + 6 - i, cg), cg);
-        Inst_MemReg(TR::InstOpCode::S2MemReg, node, MRef_Bdisp32(destOffsetReg, headerOffsetConst + 2 * (6 - i), cg),
-            scratchReg, cg);
+        Inst_RegMem(OP::MOVZXReg2Mem1, node, scratchReg, MRef_Bdisp32(srcOffsetReg, headerOffsetConst + 6 - i, cg), cg);
+        Inst_MemReg(OP::S2MemReg, node, MRef_Bdisp32(destOffsetReg, headerOffsetConst + 2 * (6 - i), cg), scratchReg,
+            cg);
     }
 
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
+    Inst_Label(OP::label, node, doneLabel, deps, cg);
     doneLabel->setEndInternalControlFlow();
 
     cg->stopUsingRegister(srcOffsetReg);
@@ -13725,41 +13590,41 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
     // Under decompressed string case for 32bits platforms, bail out if string is larger than INT_MAX32/2 since #
     // character to # byte conversion will cause overflow.
     if (!cg->comp()->target().is64Bit() && !manager.isCompressedString()) {
-        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, length, (uint16_t)0x8000, cg);
-        Inst_Label(TR::InstOpCode::JGE4, node, failLabel, cg);
+        Inst_RegImm(OP::CMPRegImm4(), node, length, (uint16_t)0x8000, cg);
+        Inst_Label(OP::JGE4, node, failLabel, cg);
     }
 
     // 1. preparation (load value into registers, calculate length etc)
     auto lowerBndMinus1 = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getLowerBndMinus1()), cg);
-    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegLowerBndMinus1, lowerBndMinus1, cg);
+    cursor = Inst_RegMem(OP::MOVDQURegMem, node, xmmRegLowerBndMinus1, lowerBndMinus1, cg);
     iComment("lower bound ascii value minus one");
 
     auto upperBnd = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getUpperBnd()), cg);
-    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegUpperBnd, upperBnd, cg);
+    cursor = Inst_RegMem(OP::MOVDQURegMem, node, xmmRegUpperBnd, upperBnd, cg);
     iComment("upper bound ascii value");
 
     auto conversionDiff = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getConversionDiff()), cg);
-    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegConversionDiff, conversionDiff, cg);
+    cursor = Inst_RegMem(OP::MOVDQURegMem, node, xmmRegConversionDiff, conversionDiff, cg);
     iComment("case conversion diff value");
 
     auto minus1 = MRef_const(cg->findOrCreate16ByteConstant(node, MINUS1), cg);
-    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegMinus1, minus1, cg);
+    cursor = Inst_RegMem(OP::MOVDQURegMem, node, xmmRegMinus1, minus1, cg);
     iComment("-1");
 
     auto asciiUpperBnd = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getAsciiMax()), cg);
-    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegAsciiUpperBnd, asciiUpperBnd, cg);
+    cursor = Inst_RegMem(OP::MOVDQURegMem, node, xmmRegAsciiUpperBnd, asciiUpperBnd, cg);
     iComment("maximum ascii value ");
 
-    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, result, 1, cg);
+    Inst_RegImm(OP::MOV4RegImm4, node, result, 1, cg);
 
     // initialize the loop counter
-    cursor = Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, counter, counter, cg);
+    cursor = Inst_RegReg(OP::XOR4RegReg, node, counter, counter, cg);
     iComment("initialize loop counter");
 
     // calculate the residueStartLength. Later instructions compare the counter with this length and decide when to jump
     // to the residue handling sequence
-    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, residueStartLength, length, cg);
-    Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, residueStartLength, strideSize - 1, cg);
+    Inst_RegReg(OP::MOVRegReg(), node, residueStartLength, length, cg);
+    Inst_RegImm(OP::SUBRegImms(), node, residueStartLength, strideSize - 1, cg);
 
     // 2. vectorized case conversion loop
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
@@ -13769,95 +13634,94 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
 
     startLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     TR::LabelSymbol *caseConversionMainLoopLabel = generateLabelSymbol(cg);
-    Inst_Label(TR::InstOpCode::label, node, caseConversionMainLoopLabel, cg);
-    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, counter, residueStartLength, cg);
-    Inst_Label(TR::InstOpCode::JGE4, node, residueStartLabel, cg);
+    Inst_Label(OP::label, node, caseConversionMainLoopLabel, cg);
+    Inst_RegReg(OP::CMPRegReg(), node, counter, residueStartLength, cg);
+    Inst_Label(OP::JGE4, node, residueStartLabel, cg);
 
     auto srcArrayMemRef = MRef_BISdisp32(srcArray, counter, 0, headerSize, cg);
-    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegArrayContentCopy0, srcArrayMemRef, cg);
+    Inst_RegMem(OP::MOVDQURegMem, node, xmmRegArrayContentCopy0, srcArrayMemRef, cg);
 
     // detect invalid characters
-    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
-    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
-    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
-        node, xmmRegArrayContentCopy1, xmmRegMinus1, cg);
+    Inst_RegReg(OP::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
+    Inst_RegReg(OP::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
+    cursor = Inst_RegReg(manager.isCompressedString() ? OP::PCMPGTBRegReg : OP::PCMPGTWRegReg, node,
+        xmmRegArrayContentCopy1, xmmRegMinus1, cg);
     iComment(" > -1");
-    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
-        node, xmmRegArrayContentCopy2, xmmRegAsciiUpperBnd, cg);
+    cursor = Inst_RegReg(manager.isCompressedString() ? OP::PCMPGTBRegReg : OP::PCMPGTWRegReg, node,
+        xmmRegArrayContentCopy2, xmmRegAsciiUpperBnd, cg);
     iComment(" > maximum ascii value");
-    cursor = Inst_RegReg(TR::InstOpCode::PANDNRegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
+    cursor = Inst_RegReg(OP::PANDNRegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
     iComment(" >-1 && !(> maximum ascii value) valid when all bits are set");
-    cursor = Inst_RegReg(TR::InstOpCode::PXORRegReg, node, xmmRegArrayContentCopy2, xmmRegMinus1, cg);
+    cursor = Inst_RegReg(OP::PXORRegReg, node, xmmRegArrayContentCopy2, xmmRegMinus1, cg);
     iComment("reverse all bits");
-    Inst_RegReg(TR::InstOpCode::PTESTRegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy2, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, failLabel, cg);
+    Inst_RegReg(OP::PTESTRegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy2, cg);
+    Inst_Label(OP::JNE4, node, failLabel, cg);
     iComment("jump out if invalid chars are detected");
 
     // calculate case conversion with vector registers
-    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
-    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
-    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
-        node, xmmRegArrayContentCopy0, xmmRegLowerBndMinus1, cg);
+    Inst_RegReg(OP::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
+    Inst_RegReg(OP::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
+    cursor = Inst_RegReg(manager.isCompressedString() ? OP::PCMPGTBRegReg : OP::PCMPGTWRegReg, node,
+        xmmRegArrayContentCopy0, xmmRegLowerBndMinus1, cg);
     iComment(manager.toLowerCase() ? " > 'A-1'" : "> 'a-1'");
-    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
-        node, xmmRegArrayContentCopy1, xmmRegUpperBnd, cg);
+    cursor = Inst_RegReg(manager.isCompressedString() ? OP::PCMPGTBRegReg : OP::PCMPGTWRegReg, node,
+        xmmRegArrayContentCopy1, xmmRegUpperBnd, cg);
     iComment(manager.toLowerCase() ? " > 'Z'" : " > 'z'");
-    cursor = Inst_RegReg(TR::InstOpCode::PANDNRegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
+    cursor = Inst_RegReg(OP::PANDNRegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
     iComment(const_cast<char *>(manager.toLowerCase() ? " >='A' && !( >'Z')" : " >='a' && !( >'z')"));
-    Inst_RegReg(TR::InstOpCode::PANDRegReg, node, xmmRegArrayContentCopy1, xmmRegConversionDiff, cg);
+    Inst_RegReg(OP::PANDRegReg, node, xmmRegArrayContentCopy1, xmmRegConversionDiff, cg);
 
     if (manager.toLowerCase())
-        Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PADDBRegReg : TR::InstOpCode::PADDWRegReg, node,
-            xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
+        Inst_RegReg(manager.isCompressedString() ? OP::PADDBRegReg : OP::PADDWRegReg, node, xmmRegArrayContentCopy2,
+            xmmRegArrayContentCopy1, cg);
     else
-        Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PSUBBRegReg : TR::InstOpCode::PSUBWRegReg, node,
-            xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
+        Inst_RegReg(manager.isCompressedString() ? OP::PSUBBRegReg : OP::PSUBWRegReg, node, xmmRegArrayContentCopy2,
+            xmmRegArrayContentCopy1, cg);
 
     auto dstArrayMemRef = MRef_BISdisp32(dstArray, counter, 0, headerSize, cg);
-    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node, dstArrayMemRef, xmmRegArrayContentCopy2, cg);
-    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, counter, strideSize, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, caseConversionMainLoopLabel, cg);
+    Inst_MemReg(OP::MOVDQUMemReg, node, dstArrayMemRef, xmmRegArrayContentCopy2, cg);
+    Inst_RegImm(OP::ADDRegImms(), node, counter, strideSize, cg);
+    Inst_Label(OP::JMP4, node, caseConversionMainLoopLabel, cg);
 
     // 3. handle residue with non vectorized case conversion loop
-    Inst_Label(TR::InstOpCode::label, node, residueStartLabel, cg);
-    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, counter, length, cg);
-    Inst_Label(TR::InstOpCode::JGE4, node, endLabel, cg);
+    Inst_Label(OP::label, node, residueStartLabel, cg);
+    Inst_RegReg(OP::CMPRegReg(), node, counter, length, cg);
+    Inst_Label(OP::JGE4, node, endLabel, cg);
     srcArrayMemRef = MRef_BISdisp32(srcArray, counter, 0, headerSize, cg);
-    Inst_RegMem(manager.isCompressedString() ? TR::InstOpCode::MOVZXReg4Mem1 : TR::InstOpCode::MOVZXReg4Mem2, node,
-        singleChar, srcArrayMemRef, cg);
+    Inst_RegMem(manager.isCompressedString() ? OP::MOVZXReg4Mem1 : OP::MOVZXReg4Mem2, node, singleChar, srcArrayMemRef,
+        cg);
 
     // use unsigned compare to detect invalid range
-    Inst_RegImm(TR::InstOpCode::CMP4RegImms, node, singleChar, 0x7F, cg);
-    Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
+    Inst_RegImm(OP::CMP4RegImms, node, singleChar, 0x7F, cg);
+    Inst_Label(OP::JA4, node, failLabel, cg);
 
-    Inst_RegImm(TR::InstOpCode::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'A' : 'a', cg);
-    Inst_Label(TR::InstOpCode::JB4, node, storeToArrayLabel, cg);
+    Inst_RegImm(OP::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'A' : 'a', cg);
+    Inst_Label(OP::JB4, node, storeToArrayLabel, cg);
 
-    Inst_RegImm(TR::InstOpCode::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'Z' : 'z', cg);
-    Inst_Label(TR::InstOpCode::JA4, node, storeToArrayLabel, cg);
+    Inst_RegImm(OP::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'Z' : 'z', cg);
+    Inst_Label(OP::JA4, node, storeToArrayLabel, cg);
 
     if (manager.toLowerCase())
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, singleChar, MRef_Bdisp32(singleChar, 0x20, cg), cg);
+        Inst_RegMem(OP::LEARegMem(), node, singleChar, MRef_Bdisp32(singleChar, 0x20, cg), cg);
 
     else
-        Inst_RegImm(TR::InstOpCode::SUB4RegImms, node, singleChar, 0x20, cg);
+        Inst_RegImm(OP::SUB4RegImms, node, singleChar, 0x20, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, storeToArrayLabel, cg);
+    Inst_Label(OP::label, node, storeToArrayLabel, cg);
 
     dstArrayMemRef = MRef_BISdisp32(dstArray, counter, 0, headerSize, cg);
-    Inst_MemReg(manager.isCompressedString() ? TR::InstOpCode::S1MemReg : TR::InstOpCode::S2MemReg, node,
-        dstArrayMemRef, singleChar, cg);
-    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, counter, manager.isCompressedString() ? 1 : 2, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, residueStartLabel, cg);
+    Inst_MemReg(manager.isCompressedString() ? OP::S1MemReg : OP::S2MemReg, node, dstArrayMemRef, singleChar, cg);
+    Inst_RegImm(OP::ADDRegImms(), node, counter, manager.isCompressedString() ? 1 : 2, cg);
+    Inst_Label(OP::JMP4, node, residueStartLabel, cg);
 
     // 4. handle invalid case
-    Inst_Label(TR::InstOpCode::label, node, failLabel, cg);
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, result, result, cg);
+    Inst_Label(OP::label, node, failLabel, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, result, result, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(OP::label, node, endLabel, deps, cg);
     node->setRegister(result);
 
     cg->stopUsingRegister(length);
@@ -13933,10 +13797,10 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
     deps->addPreCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, dataBlockReg, MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
-    Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), -1, cg);
-    Inst_Label(TR::InstOpCode::JE4, node, unresolveLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
+    Inst_RegMem(OP::LEARegMem(), node, dataBlockReg, MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
+    Inst_MemImm(OP::CMPMemImms(), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), -1, cg);
+    Inst_Label(OP::JE4, node, unresolveLabel, cg);
 
     {
         TR_OutlinedInstructionsGenerator og(unresolveLabel, node, cg);
@@ -13945,12 +13809,12 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
             TR::Register *fieldClassReg;
             if (isWrite) {
                 fieldClassReg = cg->allocateRegister();
-                Inst_RegMem(TR::InstOpCode::LRegMem(), node, fieldClassReg,
+                Inst_RegMem(OP::LRegMem(), node, fieldClassReg,
                     MRef_Bdisp32(sideEffectRegister, comp->fej9()->getOffsetOfClassFromJavaLangClassField(), cg), cg);
             } else {
                 fieldClassReg = sideEffectRegister;
             }
-            Inst_MemReg(TR::InstOpCode::SMemReg(is64Bit), node,
+            Inst_MemReg(OP::SMemReg(is64Bit), node,
                 MRef_Bdisp32(dataBlockReg, (intptr_t)(offsetof(J9JITWatchedStaticFieldData, fieldClass)), cg),
                 fieldClassReg, cg);
             deps->addPreCondition(fieldClassReg, TR::RealRegister::NoReg, cg);
@@ -13966,10 +13830,10 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
         if (is64Bit) {
             TR::Register *cpAddressReg = cg->allocateRegister();
             TR::Register *cpIndexReg = cg->allocateRegister();
-            Inst_RegImm64Sym(TR::InstOpCode::MOV8RegImm64, node, cpAddressReg,
+            Inst_RegImm64Sym(OP::MOV8RegImm64, node, cpAddressReg,
                 (uintptr_t)methodSymbol->getResolvedMethod()->constantPool(),
                 comp->getSymRefTab()->findOrCreateConstantPoolAddressSymbolRef(methodSymbol), cg);
-            Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, cpIndexReg, symRef->getCPIndex(), cg);
+            Inst_RegImm(OP::MOV8RegImm4, node, cpIndexReg, symRef->getCPIndex(), cg);
             deps->addPreCondition(cpAddressReg, linkageProperties.getArgumentRegister(0, false /* isFloat */), cg);
             deps->addPostCondition(cpAddressReg, linkageProperties.getArgumentRegister(0, false /* isFloat */), cg);
             deps->addPreCondition(cpIndexReg, linkageProperties.getArgumentRegister(1, false /* isFloat */), cg);
@@ -13978,8 +13842,8 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
             resultReg
                 = cpAddressReg; // for 64bit private linkage both the first argument reg and the return reg are rax
         } else {
-            Inst_Imm(TR::InstOpCode::PUSHImm4, node, symRef->getCPIndex(), cg);
-            Inst_ImmSym(TR::InstOpCode::PUSHImm4, node, (uintptr_t)methodSymbol->getResolvedMethod()->constantPool(),
+            Inst_Imm(OP::PUSHImm4, node, symRef->getCPIndex(), cg);
+            Inst_ImmSym(OP::PUSHImm4, node, (uintptr_t)methodSymbol->getResolvedMethod()->constantPool(),
                 comp->getSymRefTab()->findOrCreateConstantPoolAddressSymbolRef(methodSymbol), cg);
             resultReg = cg->allocateRegister();
             deps->addPreCondition(resultReg, linkageProperties.getIntegerReturnRegister(), cg);
@@ -13993,20 +13857,19 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
         subtract the header size to get the offset needed by field watch helpers
         */
         if (!isStatic) {
-            Inst_RegImm(TR::InstOpCode::SubRegImm4(is64Bit, false /*isWithBorrow*/), node, resultReg,
+            Inst_RegImm(OP::SubRegImm4(is64Bit, false /*isWithBorrow*/), node, resultReg,
                 TR::Compiler->om.objectHeaderSizeInBytes(), cg);
         }
 
         // store result into J9JITWatchedStaticFieldData.fieldAddress / J9JITWatchedInstanceFieldData.offset
-        Inst_MemReg(TR::InstOpCode::SMemReg(is64Bit), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg),
-            resultReg, cg);
-        Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+        Inst_MemReg(OP::SMemReg(is64Bit), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), resultReg, cg);
+        Inst_Label(OP::JMP4, node, endLabel, cg);
 
         og.endOutlinedInstructionSequence();
     }
 
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(OP::label, node, endLabel, deps, cg);
     cg->stopUsingRegister(dataBlockReg);
     cg->stopUsingRegister(resultReg);
 }
@@ -14061,18 +13924,18 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
         if (!valueReg->getRegisterPair()) {
             if (valueReg->getKind() == TR_GPR) {
                 TR::AutomaticSymbol *autoSymbol = valueMR->getSymbolReference().getSymbol()->getAutoSymbol();
-                Inst_MemReg(TR::InstOpCode::SMemReg(autoSymbol->getRoundedSize() == 8), node, valueMR, valueReg, cg);
+                Inst_MemReg(OP::SMemReg(autoSymbol->getRoundedSize() == 8), node, valueMR, valueReg, cg);
             } else if (valueReg->isSinglePrecision())
-                Inst_MemReg(TR::InstOpCode::MOVSSMemReg, node, valueMR, valueReg, cg);
+                Inst_MemReg(OP::MOVSSMemReg, node, valueMR, valueReg, cg);
             else
-                Inst_MemReg(TR::InstOpCode::MOVSDMemReg, node, valueMR, valueReg, cg);
+                Inst_MemReg(OP::MOVSDMemReg, node, valueMR, valueReg, cg);
             // valueReg and valueReferenceReg are different. Add conditions for valueReg here
             deps->addPreCondition(valueReg, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(valueReg, TR::RealRegister::NoReg, cg);
             valueReferenceReg = cg->allocateRegister();
         } else { // 32bit long
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node, valueMR, valueReg->getLowOrder(), cg);
-            Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_MRefOff(*valueMR, 4, cg), valueReg->getHighOrder(), cg);
+            Inst_MemReg(OP::SMemReg(), node, valueMR, valueReg->getLowOrder(), cg);
+            Inst_MemReg(OP::SMemReg(), node, MRef_MRefOff(*valueMR, 4, cg), valueReg->getHighOrder(), cg);
 
             // Add the dependency for higher half register here
             deps->addPostCondition(valueReg->getHighOrder(), TR::RealRegister::NoReg, cg);
@@ -14086,10 +13949,10 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
         }
 
         // store the stack location into a register
-        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, valueReferenceReg, valueMR, cg);
+        Inst_RegMem(OP::LEARegMem(), node, valueReferenceReg, valueMR, cg);
     }
 
-    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, dataBlockReg, MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
+    Inst_RegMem(OP::LEARegMem(), node, dataBlockReg, MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
     int numArgs = 0;
     if (is64Bit) {
         deps->addPreCondition(dataBlockReg, linkageProperties.getArgumentRegister(numArgs, false /* isFloat */), cg);
@@ -14112,17 +13975,17 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
         }
     } else {
         if (isWrite) {
-            Inst_Reg(TR::InstOpCode::PUSHReg, node, valueReferenceReg, cg);
+            Inst_Reg(OP::PUSHReg, node, valueReferenceReg, cg);
             deps->addPostCondition(valueReferenceReg, TR::RealRegister::NoReg, cg);
             deps->addPreCondition(valueReferenceReg, TR::RealRegister::NoReg, cg);
         }
 
         if (isInstanceField) {
-            Inst_Reg(TR::InstOpCode::PUSHReg, node, sideEffectRegister, cg);
+            Inst_Reg(OP::PUSHReg, node, sideEffectRegister, cg);
             deps->addPreCondition(sideEffectRegister, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(sideEffectRegister, TR::RealRegister::NoReg, cg);
         }
-        Inst_Reg(TR::InstOpCode::PUSHReg, node, dataBlockReg, cg);
+        Inst_Reg(OP::PUSHReg, node, dataBlockReg, cg);
         deps->addPreCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
     }
@@ -14131,10 +13994,10 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
     call->setNeedsGCMap(0xFF00FFFF);
     // Restore the value of lower part register
     if (isWrite && valueReg->getRegisterPair() && valueReg->getKind() == TR_GPR)
-        Inst_RegMem(TR::InstOpCode::L4RegMem, node, valueReg->getLowOrder(), valueMR, cg);
+        Inst_RegMem(OP::L4RegMem, node, valueReg->getLowOrder(), valueMR, cg);
     if (!reuseValueReg)
         cg->stopUsingRegister(valueReferenceReg);
-    Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
+    Inst_Label(OP::JMP4, node, endLabel, cg);
     cg->stopUsingRegister(dataBlockReg);
 }
 
@@ -14175,7 +14038,7 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
     startLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
     TR::Register *fieldClassReg = NULL;
     TR::MemoryReference *classFlagsMemRef = NULL;
@@ -14200,16 +14063,15 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
                 // because the fieldClass in an AOT body will be invalid if we load using the dataSnippet's helper query
                 // at compile time.
                 fieldClassReg = cg->allocateRegister();
-                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, fieldClassReg,
-                    MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
-                Inst_RegMem(TR::InstOpCode::LRegMem(), node, fieldClassReg,
+                Inst_RegMem(OP::LEARegMem(), node, fieldClassReg, MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
+                Inst_RegMem(OP::LRegMem(), node, fieldClassReg,
                     MRef_Bdisp32(fieldClassReg, offsetof(J9JITWatchedStaticFieldData, fieldClass), cg), cg);
                 classFlagsMemRef = MRef_Bdisp32(fieldClassReg, fej9->getOffsetOfClassFlags(), cg);
             }
         } else {
             if (isWrite) {
                 fieldClassReg = cg->allocateRegister();
-                Inst_RegMem(TR::InstOpCode::LRegMem(), node, fieldClassReg,
+                Inst_RegMem(OP::LRegMem(), node, fieldClassReg,
                     MRef_Bdisp32(sideEffectRegister, fej9->getOffsetOfClassFromJavaLangClassField(), cg), cg);
             } else {
                 fieldClassReg = sideEffectRegister;
@@ -14218,8 +14080,8 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
         }
     }
 
-    Inst_MemImm(TR::InstOpCode::TEST2MemImm2, node, classFlagsMemRef, J9ClassHasWatchedFields, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, fieldReportLabel, cg);
+    Inst_MemImm(OP::TEST2MemImm2, node, classFlagsMemRef, J9ClassHasWatchedFields, cg);
+    Inst_Label(OP::JNE4, node, fieldReportLabel, cg);
 
     uint8_t numOfConditions = getNumOfConditionsForReportFieldAccess(node, !node->getSymbolReference()->isUnresolved(),
         isWrite, isInstanceField, cg);
@@ -14236,7 +14098,7 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
         og.endOutlinedInstructionSequence();
     }
     deps->stopAddingConditions();
-    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(OP::label, node, endLabel, deps, cg);
 
     if (isInstanceField || (!isResolved && isWrite) || fieldClassNeedsRelocation) {
         cg->stopUsingRegister(fieldClassReg);
@@ -14256,7 +14118,7 @@ TR::Register *J9::X86::TreeEvaluator::generateConcurrentScavengeSequence(TR::Nod
                                     ->fieldSignatureChars(node->getSymbolReference()->getCPIndex(), len);
 
         if (fieldName && strstr(fieldName, "Ljava/lang/String;")) {
-            Inst_Mem(TR::InstOpCode::PREFETCHT0, node, MRef_Bdisp32(object, 0, cg), cg);
+            Inst_Mem(OP::PREFETCHT0, node, MRef_Bdisp32(object, 0, cg), cg);
         }
     }
     return object;
@@ -14469,16 +14331,15 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highRegister, secondHigh, cg);
-    Inst_RegReg(TR::InstOpCode::OR4RegReg, node, highRegister, firstHigh, cg);
-    // Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, highRegister, highRegister, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, callLabel, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, highRegister, secondHigh, cg);
+    Inst_RegReg(OP::OR4RegReg, node, highRegister, firstHigh, cg);
+    // Inst_RegReg(OP::TEST4RegReg, node, highRegister, highRegister, cg);
+    Inst_Label(OP::JNE4, node, callLabel, cg);
 
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
-    divInstr = Inst_RegReg(TR::InstOpCode::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(),
-        idivDependencies, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
+    divInstr = Inst_RegReg(OP::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(), idivDependencies, cg);
 
     cg->setImplicitExceptionPoint(divInstr);
     divInstr->setNeedsGCMap(0xFF00FFF6);
@@ -14488,11 +14349,11 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     xorDependencies1->addPreCondition(highRegister, TR::RealRegister::edx, cg);
     xorDependencies1->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
     xorDependencies1->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, highRegister, highRegister, xorDependencies1, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, highRegister, highRegister, xorDependencies1, cg);
 
-    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(OP::JMP4, node, doneLabel, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, callLabel, cg);
+    Inst_Label(OP::label, node, callLabel, cg);
 
     TR::RegisterDependencyConditions *dependencies = RegDeps((uint8_t)0, 2, cg);
     dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
@@ -14523,7 +14384,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     labelDependencies->addPostCondition(firstRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
     labelDependencies->addPostCondition(secondRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, doneLabel, labelDependencies, cg);
+    Inst_Label(OP::label, node, doneLabel, labelDependencies, cg);
 
     TR::Register *targetRegister = cg->allocateRegisterPair(lowRegister, highRegister);
     node->setRegister(targetRegister);
@@ -14568,27 +14429,26 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(OP::label, node, startLabel, cg);
 
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highRegister, secondHigh, cg);
-    Inst_RegReg(TR::InstOpCode::OR4RegReg, node, highRegister, firstHigh, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, highRegister, secondHigh, cg);
+    Inst_RegReg(OP::OR4RegReg, node, highRegister, firstHigh, cg);
     // it doesn't need the test instruction, OR will set the flags properly
-    // Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, highRegister, highRegister, cg);
-    Inst_Label(TR::InstOpCode::JNE4, node, callLabel, cg);
+    // Inst_RegReg(OP::TEST4RegReg, node, highRegister, highRegister, cg);
+    Inst_Label(OP::JNE4, node, callLabel, cg);
 
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
-    divInstr = Inst_RegReg(TR::InstOpCode::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(),
-        idivDependencies, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
+    divInstr = Inst_RegReg(OP::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(), idivDependencies, cg);
 
     cg->setImplicitExceptionPoint(divInstr);
     divInstr->setNeedsGCMap(0xFF00FFF6);
 
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, lowRegister, highRegister, cg);
+    Inst_RegReg(OP::MOV4RegReg, node, lowRegister, highRegister, cg);
 
-    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, highRegister, highRegister, cg);
-    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_RegReg(OP::XOR4RegReg, node, highRegister, highRegister, cg);
+    Inst_Label(OP::JMP4, node, doneLabel, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, callLabel, cg);
+    Inst_Label(OP::label, node, callLabel, cg);
 
     TR::RegisterDependencyConditions *dependencies = RegDeps((uint8_t)4, 6, cg);
 
@@ -14629,7 +14489,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
     movDependencies->addPostCondition(firstRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
     movDependencies->addPostCondition(secondRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
 
-    Inst_Label(TR::InstOpCode::label, node, doneLabel, movDependencies, cg);
+    Inst_Label(OP::label, node, doneLabel, movDependencies, cg);
 
     TR::Register *targetRegister = cg->allocateRegisterPair(lowRegister, highRegister);
     node->setRegister(targetRegister);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -517,7 +517,7 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         TR::Register *highReg = cg->allocateRegister(TR_GPR);
         TR::RealRegister *espReal = cg->machine()->getRealRegister(TR::RealRegister::esp);
 
-        deps = generateRegisterDependencyConditions((uint8_t)0, 3, cg);
+        deps = RegDeps((uint8_t)0, 3, cg);
         deps->addPostCondition(lowReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(highReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(doubleReg, TR::RealRegister::NoReg, cg);
@@ -624,7 +624,7 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86FPConvertToLongSnippet(reStartLabel, snippetLabel, helperSymRef,
             node, loadHighInstr, loadLowInstr, cg));
 
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, accReg ? 3 : 2, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, accReg ? 3 : 2, cg);
 
         // Make sure the high and low long registers are assigned to something.
         //
@@ -709,7 +709,7 @@ TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGener
     }
 
     // TODO: (omr issue #4969): Remove once support for spills in OOL paths is added
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)2, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)2, cg);
     deps->addPostCondition(targetRegister, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(sourceRegister, TR::RealRegister::NoReg, cg);
 
@@ -1154,7 +1154,7 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
             begLabel->setStartInternalControlFlow();
             endLabel->setEndInternalControlFlow();
 
-            TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)2, 2, cg);
+            TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)2, 2, cg);
             deps->addPreCondition(object, TR::RealRegister::NoReg, cg);
             deps->addPreCondition(address, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(object, TR::RealRegister::NoReg, cg);
@@ -1791,7 +1791,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     Inst_Label(TR::InstOpCode::JG4, node, loopLabel, cg);
 
     // done, OOL helper will return to this point
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 14, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 14, cg);
     deps->addPostCondition(spinePtrReg, TR::RealRegister::NoReg, cg);
 
     deps->addPostCondition(nDimsReg, TR::RealRegister::NoReg, cg);
@@ -2091,7 +2091,7 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
 
     Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 13, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 13, cg);
 
     deps->addPostCondition(dimsPtrReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(dimReg, TR::RealRegister::NoReg, cg);
@@ -2138,7 +2138,7 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
     // Copy the newly allocated object into a collected reference register now that it is a valid object.
     //
     TR::Register *targetReg2 = cg->allocateCollectedReferenceRegister();
-    TR::RegisterDependencyConditions *deps2 = generateRegisterDependencyConditions(0, 1, cg);
+    TR::RegisterDependencyConditions *deps2 = RegDeps(0, 1, cg);
     deps2->addPostCondition(targetReg2, TR::RealRegister::eax, cg);
     Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
     cg->stopUsingRegister(targetReg);
@@ -2232,7 +2232,7 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
 
     if (!node->isNoArrayStoreCheckArrayCopy()) {
         // Nothing to optimize, simply call jitReferenceArrayCopy helper
-        auto deps = generateRegisterDependencyConditions((uint8_t)3, 3, cg);
+        auto deps = RegDeps((uint8_t)3, 3, cg);
         deps->addPreCondition(srcReg, TR::RealRegister::esi, cg);
         deps->addPreCondition(dstReg, TR::RealRegister::edi, cg);
         deps->addPreCondition(sizeReg, TR::RealRegister::ecx, cg);
@@ -2293,7 +2293,7 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
         Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, RCX, sizeReg, cg);
 
         int8_t numDeps = enableInlineForSmallSize ? 9 : 5;
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(numDeps, numDeps, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps(numDeps, numDeps, cg);
 
         deps->addPreCondition(RSI, TR::RealRegister::esi, cg);
         deps->addPreCondition(RDI, TR::RealRegister::edi, cg);
@@ -2851,7 +2851,7 @@ TR::Register *J9::X86::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGe
         // We need to make sure that any spilling occurs only after restartLabel,
         // otherwise the divide check snippet may store into the wrong register.
         //
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 2, cg);
         TR::Register *scratchRegister;
 
         if (useRegisterPairs) {
@@ -3513,7 +3513,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
     //
     // -------------------------------------------------------------------------
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(13, 13, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps(13, 13, cg);
     deps->unionPostCondition(destinationRegister, TR::RealRegister::NoReg, cg);
     deps->unionPostCondition(sourceRegister, TR::RealRegister::NoReg, cg);
 
@@ -3766,7 +3766,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
 
     // TODO: don't always require the VM thread
     //
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 1, cg);
 
     deps->addPostCondition(cg->getVMThreadRegister(),
         (TR::RealRegister::RegNum)cg->getVMThreadRegister()->getAssociation(), cg);
@@ -3879,7 +3879,7 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
     cg->setImplicitExceptionPoint(forwardingInstr);
 
     if (needBranchAroundForNULL) {
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 1, cg);
         deps->addPostCondition(handleRegister, TR::RealRegister::NoReg, cg);
 
         // and we're done
@@ -3905,7 +3905,7 @@ static TR::Register *highestOneBit(TR::Node *node, TR::CodeGenerator *cg, TR::Re
     Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, scratchReg, scratchReg, cg);
     Inst_RegReg(TR::InstOpCode::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
     Inst_Reg(TR::InstOpCode::SETNE1Reg, node, scratchReg, cg);
-    TR::RegisterDependencyConditions *shiftDependencies = generateRegisterDependencyConditions((uint8_t)1, 1, cg);
+    TR::RegisterDependencyConditions *shiftDependencies = RegDeps((uint8_t)1, 1, cg);
     shiftDependencies->addPreCondition(bsrReg, TR::RealRegister::ecx, cg);
     shiftDependencies->addPostCondition(bsrReg, TR::RealRegister::ecx, cg);
     shiftDependencies->stopAddingConditions();
@@ -4280,7 +4280,7 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
         og.endOutlinedInstructionSequence();
     }
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 8, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 8, cg);
 
     deps->addPostCondition(ObjReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(castClassReg, TR::RealRegister::NoReg, cg);
@@ -4442,7 +4442,7 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
         + (outlinedHelperCall ? 2 : 0);  // 2 helper args: objectRef + castClass
     // clang-format on
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, numRegDeps, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, numRegDeps, cg);
 
     deps->addPostCondition(objectReg, TR::RealRegister::NoReg, cg);
 
@@ -4622,7 +4622,7 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
         + (scratchReg ? 1 : 0);
     // clang-format on
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, numRegDeps, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, numRegDeps, cg);
 
     deps->addPostCondition(objectReg, TR::RealRegister::NoReg, cg);
 
@@ -5139,7 +5139,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         + (scratchReg3 ? 1 : 0);
     // clang-format on
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, numRegDeps, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, numRegDeps, cg);
 
     deps->addPostCondition(objectReg, TR::RealRegister::NoReg, cg);
 
@@ -5356,7 +5356,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
     TR::Register *scratchReg = (!doClassCache && isCheckCast) ? cg->allocateRegister() : NULL;
 
     uint8_t numDeps = 1 + (castClassReg != NULL) + (scratchReg != NULL);
-    auto deps = generateRegisterDependencyConditions(numDeps, numDeps, cg);
+    auto deps = RegDeps(numDeps, numDeps, cg);
     deps->addPreCondition(instanceClassReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(instanceClassReg, TR::RealRegister::NoReg, cg);
     if (castClassReg) {
@@ -5550,7 +5550,7 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
     auto j9class = cg->allocateRegister();
     auto tmp = cg->allocateRegister();
 
-    auto deps = generateRegisterDependencyConditions((uint8_t)2, (uint8_t)2, cg);
+    auto deps = RegDeps((uint8_t)2, (uint8_t)2, cg);
     deps->addPreCondition(tmp, TR::RealRegister::NoReg, cg);
     deps->addPreCondition(j9class, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(tmp, TR::RealRegister::NoReg, cg);
@@ -5792,7 +5792,7 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
         Inst_RegReg(TR::InstOpCode::AND8RegReg, node, patchValReg, tempReg, cg);
 
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 4, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 4, cg);
         deps->addPostCondition(patchableAddrReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(patchValReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(tempReg, TR::RealRegister::NoReg, cg);
@@ -5882,7 +5882,7 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highPatchValReg, highExistingValReg, cg);
         Inst_RegImm(TR::InstOpCode::OR4RegImm4, node, highPatchValReg, (uint32_t)0x000000ff, cg);
 
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 6, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 6, cg);
 
         deps->addPostCondition(patchableAddrReg, TR::RealRegister::edi, cg);
         deps->addPostCondition(lowPatchValReg, TR::RealRegister::ebx, cg);
@@ -5968,7 +5968,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
-    TR::RegisterDependencyConditions *restartDeps = generateRegisterDependencyConditions((uint8_t)0, 4, cg);
+    TR::RegisterDependencyConditions *restartDeps = RegDeps((uint8_t)0, 4, cg);
     restartDeps->addPostCondition(objectReg, TR::RealRegister::NoReg, cg);
     restartDeps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
     restartDeps->addPostCondition(lockWordMaskedReg, TR::RealRegister::NoReg, cg);
@@ -5981,7 +5981,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     cg->stopUsingRegister(lockWordReg);
     cg->stopUsingRegister(lockWordMaskedReg);
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 1, cg);
     deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
     deps->stopAddingConditions();
     Inst_Label(TR::InstOpCode::label, node, outlinedEndLabel, deps, cg);
@@ -6373,7 +6373,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
     //      objectReg, eaxReal, vmThreadReg
     // since the snippet needs to find them to grab the real registers from them.
     //
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)numDeps, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)numDeps, cg);
     deps->addPostCondition(objectReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(eaxReal, TR::RealRegister::eax, cg);
     deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
@@ -6656,7 +6656,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     // Or, for readmonitors they must be objectReg, vmThreadReg, unlockedReg, eaxReal
     // snippet needs to find them to grab the real registers from them.
     //
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)numDeps, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)numDeps, cg);
     deps->addPostCondition(objectReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
 
@@ -8698,7 +8698,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
 
     numDeps += srm->numAvailableRegisters();
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, numDeps, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, numDeps, cg);
 
     if (sizeReg)
         deps->addPostCondition(sizeReg, TR::RealRegister::NoReg, cg);
@@ -8745,7 +8745,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
     // now that it is a valid object.
     //
     TR::Register *targetReg2 = cg->allocateCollectedReferenceRegister();
-    TR::RegisterDependencyConditions *deps2 = generateRegisterDependencyConditions(0, 1, cg);
+    TR::RegisterDependencyConditions *deps2 = RegDeps(0, 1, cg);
     deps2->addPostCondition(targetReg2, TR::RealRegister::eax, cg);
     Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
     cg->stopUsingRegister(targetReg);
@@ -9303,7 +9303,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
 
     // Now generate the fall-through label
     //
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)4, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)4, cg);
     deps->addPostCondition(object1Reg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(object2Reg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(tempReg, TR::RealRegister::NoReg, cg);
@@ -9456,8 +9456,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         // directly. Since this is a "C"-style call, ebx, esi and edi are preserved
         //
         int32_t extraFPDeps = (uint8_t)(cg->machine()->getLastXMMR() - cg->machine()->getFirstXMMR() + 1);
-        TR::RegisterDependencyConditions *deps
-            = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)4 + extraFPDeps, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)4 + extraFPDeps, cg);
         TR::Register *temp1 = cg->allocateRegister();
         deps->addPostCondition(temp1, TR::RealRegister::eax, cg);
         cg->stopUsingRegister(temp1);
@@ -9484,7 +9483,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         TR::Register *reglow = cg->allocateRegister();
         Inst_RegMem(TR::InstOpCode::L4RegMem, node, reglow, MRef_Bdisp32(resultAddress, 4, cg), cg);
 
-        TR::RegisterDependencyConditions *dep1 = generateRegisterDependencyConditions((uint8_t)2, 2, cg);
+        TR::RegisterDependencyConditions *dep1 = RegDeps((uint8_t)2, 2, cg);
         dep1->addPreCondition(eaxReal, TR::RealRegister::eax, cg);
         dep1->addPreCondition(edxReal, TR::RealRegister::edx, cg);
         dep1->addPostCondition(eaxReal, TR::RealRegister::eax, cg);
@@ -9567,8 +9566,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         // Build register dependencies and call the method in the port library
         // directly. Since this is a "C"-style call, ebx, esi and edi are preserved
         //
-        TR::RegisterDependencyConditions *deps
-            = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)4 + extraFPDeps, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)4 + extraFPDeps, cg);
         TR::Register *temp1 = cg->allocateRegister();
         deps->addPostCondition(temp1, TR::RealRegister::ecx, cg);
         cg->stopUsingRegister(temp1);
@@ -9840,7 +9838,7 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
     auto loopLabel = generateLabelSymbol(cg);
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
-    auto deps = generateRegisterDependencyConditions((uint8_t)6, (uint8_t)6, cg);
+    auto deps = RegDeps((uint8_t)6, (uint8_t)6, cg);
     deps->addPreCondition(address, TR::RealRegister::NoReg, cg);
     deps->addPreCondition(index, TR::RealRegister::NoReg, cg);
     deps->addPreCondition(length, TR::RealRegister::NoReg, cg);
@@ -10055,7 +10053,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
     int32_t vectorSizeElements = vectorSizes[vl - TR::VectorLength128];
     int32_t numElements = vectorSizeElements * unrollCount;
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)11, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)11, cg);
     TR::Register *tmp = cg->allocateRegister(TR_GPR);
     TR::Register *tmpVRF = cg->allocateRegister(TR_VRF);
     TR::Register *multiplierVRF = cg->allocateRegister(TR_VRF);
@@ -10263,7 +10261,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
     TR::Register *result = cg->allocateRegister();
     TR::Register *tmp = cg->allocateRegister();
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 6, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps(0, 6, cg);
 
     deps->addPostCondition(result, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(address, TR::RealRegister::NoReg, cg);
@@ -10476,7 +10474,7 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
     auto scratchXMM = cg->allocateRegister(TR_VRF);
     auto valueXMM = cg->allocateRegister(TR_VRF);
 
-    auto dependencies = generateRegisterDependencyConditions((uint8_t)7, (uint8_t)7, cg);
+    auto dependencies = RegDeps((uint8_t)7, (uint8_t)7, cg);
     dependencies->addPreCondition(ECX, TR::RealRegister::ecx, cg);
     dependencies->addPreCondition(array, TR::RealRegister::NoReg, cg);
     dependencies->addPreCondition(length, TR::RealRegister::NoReg, cg);
@@ -10682,7 +10680,7 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     TR::Register *s1addrReg = cg->allocateRegister(TR_GPR);
     TR::Register *s2idxReg = cg->allocateRegister(TR_GPR);
 
-    TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions((uint8_t)12, (uint8_t)12, cg);
+    TR::RegisterDependencyConditions *dependencies = RegDeps((uint8_t)12, (uint8_t)12, cg);
     dependencies->addPreCondition(s1Reg, TR::RealRegister::NoReg, cg);
     dependencies->addPreCondition(s2Reg, TR::RealRegister::NoReg, cg);
     dependencies->addPreCondition(s2lenReg, TR::RealRegister::NoReg, cg);
@@ -10917,7 +10915,7 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
             begLabel->setStartInternalControlFlow();
             endLabel->setEndInternalControlFlow();
 
-            TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)1, 1, cg);
+            TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)1, 1, cg);
             deps->addPreCondition(tmp, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(tmp, TR::RealRegister::NoReg, cg);
 
@@ -10962,7 +10960,7 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
         }
     }
 
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)1, 1, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)1, 1, cg);
     deps->addPreCondition(EAX, TR::RealRegister::eax, cg);
     deps->addPostCondition(EAX, TR::RealRegister::eax, cg);
     Inst_MemReg(use64BitClasses ? TR::InstOpCode::LCMPXCHG8MemReg : TR::InstOpCode::LCMPXCHG4MemReg, node,
@@ -11173,7 +11171,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         if (scratchRegisterManagerForRealTime)
             numDeps += scratchRegisterManagerForRealTime->numAvailableRegisters();
 
-        deps = generateRegisterDependencyConditions(numDeps, numDeps, cg);
+        deps = RegDeps(numDeps, numDeps, cg);
         deps->addPreCondition(oldValueRegister->getLowOrder(), TR::RealRegister::eax, cg);
         deps->addPreCondition(oldValueRegister->getHighOrder(), TR::RealRegister::edx, cg);
         deps->addPreCondition(newValueRegister->getLowOrder(), TR::RealRegister::ebx, cg);
@@ -11199,7 +11197,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         if (scratchRegisterManagerForRealTime)
             numDeps += scratchRegisterManagerForRealTime->numAvailableRegisters();
 
-        deps = generateRegisterDependencyConditions(numDeps, numDeps, cg);
+        deps = RegDeps(numDeps, numDeps, cg);
         deps->addPreCondition(oldValueRegister, TR::RealRegister::eax, cg);
         deps->addPostCondition(oldValueRegister, TR::RealRegister::eax, cg);
 
@@ -11318,8 +11316,7 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     }
 
     uint8_t numDependencies = useVectorInstructions ? 9 : 8;
-    TR::RegisterDependencyConditions *dependencies
-        = generateRegisterDependencyConditions(numDependencies, numDependencies, cg);
+    TR::RegisterDependencyConditions *dependencies = RegDeps(numDependencies, numDependencies, cg);
     dependencies->addPreCondition(bufReg, TR::RealRegister::NoReg, cg);
     dependencies->addPreCondition(offsetReg, TR::RealRegister::NoReg, cg);
     dependencies->addPreCondition(lengthReg, TR::RealRegister::NoReg, cg);
@@ -11619,8 +11616,7 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
                         numDeps++;
                     }
 
-                    TR::RegisterDependencyConditions *deps
-                        = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)numDeps, cg);
+                    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, (uint8_t)numDeps, cg);
                     deps->addPostCondition(nativeThreadReg, TR::RealRegister::NoReg, cg);
                     if (comp->target().is32Bit()) {
                         deps->addPostCondition(nativeThreadRegHigh, TR::RealRegister::NoReg, cg);
@@ -12008,8 +12004,7 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
             numPostConditions++;
         }
 
-        TR::RegisterDependencyConditions *conditions
-            = generateRegisterDependencyConditions((uint8_t)0, numPostConditions, cg);
+        TR::RegisterDependencyConditions *conditions = RegDeps((uint8_t)0, numPostConditions, cg);
 
         conditions->addPostCondition(owningObjectReg, TR::RealRegister::NoReg, cg);
         if (srcReg) {
@@ -12610,8 +12605,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         numPostConditions++;
     }
 
-    TR::RegisterDependencyConditions *conditions
-        = generateRegisterDependencyConditions((uint8_t)0, numPostConditions, cg);
+    TR::RegisterDependencyConditions *conditions = RegDeps((uint8_t)0, numPostConditions, cg);
 
     conditions->addPostCondition(owningObjectReg, TR::RealRegister::NoReg, cg);
     if (srcReg) {
@@ -12740,7 +12734,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
             Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
             Inst_Label(TR::InstOpCode::JE4, node, doneWrtBarLabel, cg);
 
-            deps = generateRegisterDependencyConditions(0, 3, cg);
+            deps = RegDeps(0, 3, cg);
             deps->addPostCondition(sourceRegister, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(owningObjectRegister, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
@@ -12872,7 +12866,7 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     TR::Register *objReg = cg->evaluate(objNode);
     TR::Register *accReg = cg->allocateRegister();
     TR::Register *monReg = cg->allocateRegister();
-    TR::RegisterDependencyConditions *fallBackConditions = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
+    TR::RegisterDependencyConditions *fallBackConditions = RegDeps((uint8_t)0, 2, cg);
     TR::RegisterDependencyConditions *endLabelConditions;
     TR::RegisterDependencyConditions *fallThroughConditions = NULL;
     TR::RegisterDependencyConditions *persistentConditions = NULL;
@@ -12881,24 +12875,21 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     if (fallThroughNode->getNumChildren() != 0) {
         GRANode = fallThroughNode->getFirstChild();
         cg->evaluate(GRANode);
-        List<TR::Register> popRegisters(cg->trMemory());
-        fallThroughConditions = generateRegisterDependencyConditions(GRANode, cg, 0, &popRegisters);
+        fallThroughConditions = RegDeps(GRANode, cg, 0);
         cg->decReferenceCount(GRANode);
     }
 
     if (persistentFailureNode->getNumChildren() != 0) {
         GRANode = persistentFailureNode->getFirstChild();
         cg->evaluate(GRANode);
-        List<TR::Register> popRegisters(cg->trMemory());
-        persistentConditions = generateRegisterDependencyConditions(GRANode, cg, 0, &popRegisters);
+        persistentConditions = RegDeps(GRANode, cg, 0);
         cg->decReferenceCount(GRANode);
     }
 
     if (transientFailureNode->getNumChildren() != 0) {
         GRANode = transientFailureNode->getFirstChild();
         cg->evaluate(GRANode);
-        List<TR::Register> popRegisters(cg->trMemory());
-        transientConditions = generateRegisterDependencyConditions(GRANode, cg, 0, &popRegisters);
+        transientConditions = RegDeps(GRANode, cg, 0);
         cg->decReferenceCount(GRANode);
     }
 
@@ -12906,7 +12897,7 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     // add place holder register so that eax would not contain any useful value before xbegin
     TR::Register *dummyReg = cg->allocateRegister();
     dummyReg->setPlaceholderReg();
-    TR::RegisterDependencyConditions *startLabelConditions = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
+    TR::RegisterDependencyConditions *startLabelConditions = RegDeps((uint8_t)0, 1, cg);
     startLabelConditions->addPostCondition(dummyReg, TR::RealRegister::eax, cg);
     startLabelConditions->stopAddingConditions();
     cg->stopUsingRegister(dummyReg);
@@ -12953,7 +12944,7 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     // fall_back_path:
     Inst_Label(TR::InstOpCode::label, node, fallBackPathLabel, cg);
 
-    endLabelConditions = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
+    endLabelConditions = RegDeps((uint8_t)0, 1, cg);
     endLabelConditions->addPostCondition(accReg, TR::RealRegister::eax, cg);
     endLabelConditions->stopAddingConditions();
 
@@ -12995,7 +12986,7 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     Inst(TR::InstOpCode::PAUSE, node, cg);
     Inst(TR::InstOpCode::PAUSE, node, cg);
     Inst_Reg(TR::InstOpCode::DEC4Reg, node, counterReg, cg);
-    TR::RegisterDependencyConditions *loopConditions = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
+    TR::RegisterDependencyConditions *loopConditions = RegDeps((uint8_t)0, 1, cg);
     loopConditions->addPostCondition(counterReg, TR::RealRegister::NoReg, cg);
     loopConditions->stopAddingConditions();
     Inst_Label(TR::InstOpCode::JNE4, node, spinLabel, loopConditions, cg);
@@ -13157,7 +13148,7 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
             // cases, this label will have no effect on the generated code, and
             // will only affect GC maps.
             //
-            TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)1, (uint8_t)1, cg);
+            TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)1, (uint8_t)1, cg);
             deps->addPreCondition(valueToKeepAlive, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(valueToKeepAlive, TR::RealRegister::NoReg, cg);
             new (cg->trHeapMemory())
@@ -13265,7 +13256,7 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     TR::Register *scratchReg = cg->allocateRegister(TR_GPR);
 
     int maxDepCount = 10;
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, maxDepCount, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps(0, maxDepCount, cg);
     deps->addPostCondition(xmmHighReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(xmmLowReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(zeroReg, TR::RealRegister::NoReg, cg);
@@ -13441,7 +13432,7 @@ TR::Register *J9::X86::TreeEvaluator::encodeUTF16Evaluator(TR::Node *node, TR::C
         fprClobbers[i] = cg->allocateRegister(TR_FPR);
 
     int depCount = 11;
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, depCount, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, depCount, cg);
 
     deps->addPostCondition(srcPtrReg, TR::RealRegister::esi, cg);
     deps->addPostCondition(dstPtrReg, TR::RealRegister::edi, cg);
@@ -13684,7 +13675,7 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
 #define iComment(str) \
     if (debug)        \
         debug->addInstructionComment(cursor, (const_cast<char *>(str)));
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)14, (uint8_t)14, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)14, (uint8_t)14, cg);
     TR::Register *srcArray = cg->evaluate(node->getChild(1));
     deps->addPostCondition(srcArray, TR::RealRegister::NoReg, cg);
     deps->addPreCondition(srcArray, TR::RealRegister::NoReg, cg);
@@ -13936,7 +13927,7 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
     {
         numOfConditions++;
     }
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(numOfConditions, numOfConditions, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps(numOfConditions, numOfConditions, cg);
     TR::Register *resultReg = NULL;
     TR::Register *dataBlockReg = cg->allocateRegister();
     deps->addPreCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
@@ -14232,7 +14223,7 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
 
     uint8_t numOfConditions = getNumOfConditionsForReportFieldAccess(node, !node->getSymbolReference()->isUnresolved(),
         isWrite, isInstanceField, cg);
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(numOfConditions, numOfConditions, cg);
+    TR::RegisterDependencyConditions *deps = RegDeps(numOfConditions, numOfConditions, cg);
     if (isInstanceField || !isResolved || fieldClassNeedsRelocation) {
         deps->addPreCondition(fieldClassReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(fieldClassReg, TR::RealRegister::NoReg, cg);
@@ -14457,7 +14448,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
 
     TR::Instruction *divInstr = NULL;
 
-    TR::RegisterDependencyConditions *idivDependencies = generateRegisterDependencyConditions((uint8_t)6, 6, cg);
+    TR::RegisterDependencyConditions *idivDependencies = RegDeps((uint8_t)6, 6, cg);
     idivDependencies->addPreCondition(lowRegister, TR::RealRegister::eax, cg);
     idivDependencies->addPreCondition(highRegister, TR::RealRegister::edx, cg);
     idivDependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
@@ -14492,7 +14483,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     cg->setImplicitExceptionPoint(divInstr);
     divInstr->setNeedsGCMap(0xFF00FFF6);
 
-    TR::RegisterDependencyConditions *xorDependencies1 = generateRegisterDependencyConditions((uint8_t)2, 2, cg);
+    TR::RegisterDependencyConditions *xorDependencies1 = RegDeps((uint8_t)2, 2, cg);
     xorDependencies1->addPreCondition(lowRegister, TR::RealRegister::eax, cg);
     xorDependencies1->addPreCondition(highRegister, TR::RealRegister::edx, cg);
     xorDependencies1->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
@@ -14503,7 +14494,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
 
     Inst_Label(TR::InstOpCode::label, node, callLabel, cg);
 
-    TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
+    TR::RegisterDependencyConditions *dependencies = RegDeps((uint8_t)0, 2, cg);
     dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
     dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
     J9::IA32PrivateLinkage *linkage = static_cast<J9::IA32PrivateLinkage *>(cg->getLinkage(TR_Private));
@@ -14518,7 +14509,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     //
     instr->setNeedsGCMap(0xFF00FFF6);
 
-    TR::RegisterDependencyConditions *labelDependencies = generateRegisterDependencyConditions((uint8_t)6, 6, cg);
+    TR::RegisterDependencyConditions *labelDependencies = RegDeps((uint8_t)6, 6, cg);
     labelDependencies->addPreCondition(lowRegister, TR::RealRegister::eax, cg);
     labelDependencies->addPreCondition(highRegister, TR::RealRegister::edx, cg);
     labelDependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
@@ -14556,7 +14547,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
 
     TR::Instruction *divInstr = NULL;
 
-    TR::RegisterDependencyConditions *idivDependencies = generateRegisterDependencyConditions((uint8_t)6, 6, cg);
+    TR::RegisterDependencyConditions *idivDependencies = RegDeps((uint8_t)6, 6, cg);
     idivDependencies->addPreCondition(lowRegister, TR::RealRegister::eax, cg);
     idivDependencies->addPreCondition(highRegister, TR::RealRegister::edx, cg);
     idivDependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
@@ -14599,7 +14590,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
 
     Inst_Label(TR::InstOpCode::label, node, callLabel, cg);
 
-    TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions((uint8_t)4, 6, cg);
+    TR::RegisterDependencyConditions *dependencies = RegDeps((uint8_t)4, 6, cg);
 
     dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
     dependencies->addPostCondition(highRegister, TR::RealRegister::edx, cg);
@@ -14624,7 +14615,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
     //
     instr->setNeedsGCMap(0xFF00FFF6);
 
-    TR::RegisterDependencyConditions *movDependencies = generateRegisterDependencyConditions((uint8_t)6, 6, cg);
+    TR::RegisterDependencyConditions *movDependencies = RegDeps((uint8_t)6, 6, cg);
     movDependencies->addPreCondition(lowRegister, TR::RealRegister::eax, cg);
     movDependencies->addPreCondition(highRegister, TR::RealRegister::edx, cg);
     movDependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -152,7 +152,7 @@ inline void generateLoadJ9Class(TR::Node *node, TR::Register *j9class, TR::Regis
     }
 
     auto use64BitClasses = cg->comp()->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
-    auto instr = generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, j9class,
+    auto instr = Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, j9class,
         MRef_Bdisp32(object, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
     if (needsNULLCHK) {
         cg->setImplicitExceptionPoint(instr);
@@ -163,8 +163,8 @@ inline void generateLoadJ9Class(TR::Node *node, TR::Register *j9class, TR::Regis
 
     auto mask = TR::Compiler->om.maskOfObjectVftField();
     if (~mask != 0) {
-        generateRegImmInstruction(~mask <= 127 ? TR::InstOpCode::ANDRegImms(use64BitClasses)
-                                               : TR::InstOpCode::ANDRegImm4(use64BitClasses),
+        Inst_RegImm(~mask <= 127 ? TR::InstOpCode::ANDRegImms(use64BitClasses)
+                                 : TR::InstOpCode::ANDRegImm4(use64BitClasses),
             node, j9class, mask, cg);
     }
 }
@@ -194,7 +194,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
     arrayletRef->swapInstructionListsWithCompilation();
 
-    generateLabelInstruction(NULL, TR::InstOpCode::label, arrayletRefLabel, cg)->setNode(node);
+    Inst_Label(NULL, TR::InstOpCode::label, arrayletRefLabel, cg)->setNode(node);
 
     // TODO: REMOVE THIS!
     //
@@ -205,7 +205,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
     static char *forceArrayletInt = feGetEnv("TR_forceArrayletInt");
     if (forceArrayletInt) {
-        generateInstruction(TR::InstOpCode::INT3, node, cg);
+        Inst(TR::InstOpCode::INT3, node, cg);
     }
 
     // -----------------------------------------------------------------------------------
@@ -223,11 +223,11 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
         TR::MemoryReference *arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
 
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
+        Inst_MemImm(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
 
         TR::LabelSymbol *boundCheckFailureLabel = generateLabelSymbol(cg);
 
-        checkInstruction = generateLabelInstruction(TR::InstOpCode::JNE4, node, boundCheckFailureLabel, cg);
+        checkInstruction = Inst_Label(TR::InstOpCode::JNE4, node, boundCheckFailureLabel, cg);
 
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, node->getSymbolReference(),
             boundCheckFailureLabel, checkInstruction, false));
@@ -241,13 +241,13 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         if (!indexReg) {
             TR::InstOpCode::Mnemonic op
                 = (indexValue >= -128 && indexValue <= 127) ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4;
-            generateMemImmInstruction(op, node, arraySizeMR, indexValue, cg);
+            Inst_MemImm(op, node, arraySizeMR, indexValue, cg);
         } else {
-            generateMemRegInstruction(TR::InstOpCode::CMP4MemReg, node, arraySizeMR, indexReg, cg);
+            Inst_MemReg(TR::InstOpCode::CMP4MemReg, node, arraySizeMR, indexReg, cg);
         }
 
         boundCheckFailureLabel = generateLabelSymbol(cg);
-        checkInstruction = generateLabelInstruction(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
+        checkInstruction = Inst_Label(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
 
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, node->getSymbolReference(),
             boundCheckFailureLabel, checkInstruction, false));
@@ -300,10 +300,10 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     if (indexReg) {
         TR::InstOpCode::Mnemonic op
             = comp->target().is64Bit() ? TR::InstOpCode::MOVSXReg8Reg4 : TR::InstOpCode::MOVRegReg();
-        generateRegRegInstruction(op, node, scratchReg, indexReg, cg);
+        Inst_RegReg(op, node, scratchReg, indexReg, cg);
 
         int32_t spineShift = fej9->getArraySpineShift(elementSize);
-        generateRegImmInstruction(TR::InstOpCode::SARRegImm1(), node, scratchReg, spineShift, cg);
+        Inst_RegImm(TR::InstOpCode::SARRegImm1(), node, scratchReg, spineShift, cg);
 
         spineMR = MRef_BISdisp32(baseArrayReg, scratchReg,
             TR::MemoryReference::convertMultiplierToStride(spinePointerSize), arrayHeaderSize, cg);
@@ -315,7 +315,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     }
 
     TR::InstOpCode::Mnemonic op = (spinePointerSize == 8) ? TR::InstOpCode::L8RegMem : TR::InstOpCode::L4RegMem;
-    generateRegMemInstruction(op, node, scratchReg, spineMR, cg);
+    Inst_RegMem(op, node, scratchReg, spineMR, cg);
 
     // Decompress the arraylet pointer from the spine.
     int32_t shiftOffset = 0;
@@ -323,7 +323,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     if (comp->target().is64Bit() && comp->useCompressedPointers()) {
         shiftOffset = TR::Compiler->om.compressedReferenceShiftOffset();
         if (shiftOffset > 0) {
-            generateRegImmInstruction(TR::InstOpCode::SHL8RegImm1, node, scratchReg, shiftOffset, cg);
+            Inst_RegImm(TR::InstOpCode::SHL8RegImm1, node, scratchReg, shiftOffset, cg);
         }
     }
 
@@ -334,8 +334,8 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
     if (indexReg) {
         TR::Register *scratchReg2 = cg->allocateRegister();
 
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, scratchReg2, indexReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, scratchReg2, arrayletMask, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, scratchReg2, indexReg, cg);
+        Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, scratchReg2, arrayletMask, cg);
         arrayletMR = MRef_BIS(scratchReg, scratchReg2, TR::MemoryReference::convertMultiplierToStride(elementSize), cg);
 
         cg->stopUsingRegister(scratchReg2);
@@ -403,10 +403,10 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
             }
         }
 
-        generateRegMemInstruction(op, node, loadOrStoreReg, arrayletMR, cg);
+        Inst_RegMem(op, node, loadOrStoreReg, arrayletMR, cg);
 
         if (highArrayletMR) {
-            generateRegMemInstruction(op, node, highRegister, highArrayletMR, cg);
+            Inst_RegMem(op, node, highRegister, highArrayletMR, cg);
         }
 
         // Decompress the loaded address if necessary.
@@ -414,7 +414,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         if (loadNeedsDecompression) {
             if (comp->target().is64Bit() && comp->useCompressedPointers()) {
                 if (shiftOffset > 0) {
-                    generateRegImmInstruction(TR::InstOpCode::SHL8RegImm1, node, loadOrStoreReg, shiftOffset, cg);
+                    Inst_RegImm(TR::InstOpCode::SHL8RegImm1, node, loadOrStoreReg, shiftOffset, cg);
                 }
             }
         }
@@ -444,17 +444,15 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
                     } else {
                         if (valueReg) {
                             TR_ASSERT(valueReg->getRegisterPair(), "value must be a register pair");
-                            generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, arrayletMR,
-                                valueReg->getLowOrder(), cg);
-                            generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_MRefOff(*arrayletMR, 4, cg),
+                            Inst_MemReg(TR::InstOpCode::S4MemReg, node, arrayletMR, valueReg->getLowOrder(), cg);
+                            Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_MRefOff(*arrayletMR, 4, cg),
                                 valueReg->getHighOrder(), cg);
                         } else {
                             TR::Node *valueChild = actualLoadOrStoreOrArrayElementNode->getSecondChild();
                             TR_ASSERT(valueChild->getOpCode().isLoadConst(), "expecting a long constant child");
 
-                            generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, arrayletMR,
-                                valueChild->getLongIntLow(), cg);
-                            generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, MRef_MRefOff(*arrayletMR, 4, cg),
+                            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arrayletMR, valueChild->getLongIntLow(), cg);
+                            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, MRef_MRefOff(*arrayletMR, 4, cg),
                                 valueChild->getLongIntHigh(), cg);
                         }
 
@@ -476,10 +474,10 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
             if (needStore) {
                 if (valueReg)
-                    generateMemRegInstruction(op, node, arrayletMR, valueReg, cg);
+                    Inst_MemReg(op, node, arrayletMR, valueReg, cg);
                 else {
                     int32_t value = actualLoadOrStoreOrArrayElementNode->getSecondChild()->getInt();
-                    generateMemImmInstruction(op, node, arrayletMR, value, cg);
+                    Inst_MemImm(op, node, arrayletMR, value, cg);
                 }
             }
         } else {
@@ -488,7 +486,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         }
     }
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, restartLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, restartLabel, cg);
 
     // -----------------------------------------------------------------------------------
     // Stop tracking virtual register usage.
@@ -536,16 +534,16 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         // Attempt to convert a double in an XMM register to an integer using CVTTSD2SI.
         // If the conversion succeeds, put the integer in lowReg and sign-extend it to highReg.
         // If the conversion fails (the double is too large), call the helper.
-        generateRegRegInstruction(TR::InstOpCode::CVTTSD2SIReg4Reg, node, lowReg, doubleReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, lowReg, 0x80000000, cg);
+        Inst_RegReg(TR::InstOpCode::CVTTSD2SIReg4Reg, node, lowReg, doubleReg, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, lowReg, 0x80000000, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, StartLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, CallLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, StartLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, CallLabel, cg);
 
-        generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, highReg, lowReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::SAR4RegImm1, node, highReg, 31, cg);
+        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highReg, lowReg, cg);
+        Inst_RegImm(TR::InstOpCode::SAR4RegImm1, node, highReg, 31, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, reStartLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, reStartLabel, deps, cg);
 
         TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
         TR::SymbolReference *d2l = comp->getSymRefTab()->findOrCreateRuntimeHelper(TR_IA32double2LongSSE);
@@ -573,7 +571,7 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         startLabel->setStartInternalControlFlow();
         reStartLabel->setEndInternalControlFlow();
 
-        generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
         // These instructions must be set appropriately prior to the creation
         // of the snippet near the end of this method. Also see warnings below.
@@ -582,29 +580,27 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         TR::X86RegMemInstruction *loadLowInstr; // loads the low dword of the converted long
 
         TR::MemoryReference *tempMR = cg->machine()->getDummyLocalMR(TR::Float);
-        generateMemRegInstruction(TR::InstOpCode::MOVSSMemReg, node, tempMR, floatReg, cg);
-        generateMemInstruction(TR::InstOpCode::FLDMem, node, MRef_MRefOff(*tempMR, 0, cg), cg);
+        Inst_MemReg(TR::InstOpCode::MOVSSMemReg, node, tempMR, floatReg, cg);
+        Inst_Mem(TR::InstOpCode::FLDMem, node, MRef_MRefOff(*tempMR, 0, cg), cg);
 
-        generateInstruction(TR::InstOpCode::FLDDUP, node, cg);
+        Inst(TR::InstOpCode::FLDDUP, node, cg);
 
         // For slow conversion only, change the rounding mode on the FPU via its control word register.
         //
         TR::MemoryReference *convertedLongMR = (cg->machine())->getDummyLocalMR(TR::Int64);
 
         if (cg->comp()->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE3)) {
-            generateMemInstruction(TR::InstOpCode::FLSTTPMem, node, convertedLongMR, cg);
+            Inst_Mem(TR::InstOpCode::FLSTTPMem, node, convertedLongMR, cg);
         } else {
             int16_t fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ? SINGLE_PRECISION_ROUND_TO_ZERO
                                                                                     : DOUBLE_PRECISION_ROUND_TO_ZERO;
-            generateMemInstruction(TR::InstOpCode::LDCWMem, node,
-                MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
-            generateMemInstruction(TR::InstOpCode::FLSTPMem, node, convertedLongMR, cg);
+            Inst_Mem(TR::InstOpCode::LDCWMem, node, MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
+            Inst_Mem(TR::InstOpCode::FLSTPMem, node, convertedLongMR, cg);
 
             fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ? SINGLE_PRECISION_ROUND_TO_NEAREST
                                                                             : DOUBLE_PRECISION_ROUND_TO_NEAREST;
 
-            generateMemInstruction(TR::InstOpCode::LDCWMem, node,
-                MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
+            Inst_Mem(TR::InstOpCode::LDCWMem, node, MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
         }
 
         // WARNING:
@@ -612,18 +608,16 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         // The following load instructions are dissected in the snippet to determine the target registers.
         // If they or their format is changed, you may need to change the snippet also.
         //
-        loadHighInstr = generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, highReg,
-            MRef_MRefOff(*convertedLongMR, 4, cg), cg);
+        loadHighInstr = Inst_RegMem(TR::InstOpCode::L4RegMem, node, highReg, MRef_MRefOff(*convertedLongMR, 4, cg), cg);
 
-        loadLowInstr = generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lowReg,
-            MRef_MRefOff(*convertedLongMR, 0, cg), cg);
+        loadLowInstr = Inst_RegMem(TR::InstOpCode::L4RegMem, node, lowReg, MRef_MRefOff(*convertedLongMR, 0, cg), cg);
 
         // Jump to the snippet if the converted value is an indefinite integer; otherwise continue.
         //
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, highReg, INT_MIN, cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, reStartLabel, cg);
-        generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, lowReg, lowReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, highReg, INT_MIN, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, reStartLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, lowReg, lowReg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
 
         // Create the conversion snippet.
         //
@@ -641,10 +635,10 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         deps->addPostCondition(lowReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(highReg, TR::RealRegister::NoReg, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, reStartLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, reStartLabel, deps, cg);
 
         cg->decReferenceCount(child);
-        generateInstruction(TR::InstOpCode::FSTPST0, node, cg);
+        Inst(TR::InstOpCode::FSTPST0, node, cg);
 
         TR::Register *targetRegister = cg->allocateRegisterPair(lowReg, highReg);
         node->setRegister(targetRegister);
@@ -695,23 +689,23 @@ TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGener
     TR::LabelSymbol *exceptionLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
 
     sourceRegister = cg->evaluate(child);
-    generateRegRegInstruction(cvttOpCode, node, targetRegister, sourceRegister, cg);
+    Inst_RegReg(cvttOpCode, node, targetRegister, sourceRegister, cg);
 
     startLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     if (longTarget) {
         TR_ASSERT_FATAL(cg->comp()->target().is64Bit(), "We should only get here on AMD64");
         // We can't compare with 0x8000000000000000.
         // Instead, rotate left 1 bit and compare with 0x0000000000000001.
-        generateRegInstruction(TR::InstOpCode::ROL8Reg1, node, targetRegister, cg);
-        generateRegImmInstruction(TR::InstOpCode::CMP8RegImms, node, targetRegister, 1, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, exceptionLabel, cg);
+        Inst_Reg(TR::InstOpCode::ROL8Reg1, node, targetRegister, cg);
+        Inst_RegImm(TR::InstOpCode::CMP8RegImms, node, targetRegister, 1, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, exceptionLabel, cg);
     } else {
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, targetRegister, INT_MIN, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, exceptionLabel, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, targetRegister, INT_MIN, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, exceptionLabel, cg);
     }
 
     // TODO: (omr issue #4969): Remove once support for spills in OOL paths is added
@@ -723,31 +717,30 @@ TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGener
         TR_OutlinedInstructionsGenerator og(exceptionLabel, node, cg);
         // at this point, target is set to -INF and there can only be THREE possible results: -INF, +INF, NaN
         // compare source with ZERO
-        generateRegMemInstruction(doubleSource ? TR::InstOpCode::UCOMISDRegMem : TR::InstOpCode::UCOMISSRegMem, node,
-            sourceRegister,
+        Inst_RegMem(doubleSource ? TR::InstOpCode::UCOMISDRegMem : TR::InstOpCode::UCOMISSRegMem, node, sourceRegister,
             MRef_const(doubleSource ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0),
                 cg),
             cg);
         // load max int if source is positive, note that for long case, LLONG_MAX << 1 is loaded as it will be shifted
         // right
-        generateRegMemInstruction(TR::InstOpCode::CMOVARegMem(longTarget), node, targetRegister,
+        Inst_RegMem(TR::InstOpCode::CMOVARegMem(longTarget), node, targetRegister,
             MRef_const(longTarget ? cg->findOrCreate8ByteConstant(node, LLONG_MAX << 1)
                                   : cg->findOrCreate4ByteConstant(node, INT_MAX),
                 cg),
             cg);
         // load zero if source is NaN
-        generateRegMemInstruction(TR::InstOpCode::CMOVPRegMem(longTarget), node, targetRegister,
+        Inst_RegMem(TR::InstOpCode::CMOVPRegMem(longTarget), node, targetRegister,
             MRef_const(longTarget ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0),
                 cg),
             cg);
 
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
         og.endOutlinedInstructionSequence();
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
     if (longTarget) {
-        generateRegInstruction(TR::InstOpCode::ROR8Reg1, node, targetRegister, cg);
+        Inst_Reg(TR::InstOpCode::ROR8Reg1, node, targetRegister, cg);
     }
 
     node->setRegister(targetRegister);
@@ -851,57 +844,55 @@ static void generateCommonLockNurseryCodes(TR::Node *node, TR::CodeGenerator *cg
     if (comp->getOption(TR_EnableMonitorCacheLookup)) {
         if (monent)
             lwOffset = 0;
-        generateLabelInstruction(TR::InstOpCode::JLE4, node, monitorLookupCacheLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThruFromMonitorLookupCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::JLE4, node, monitorLookupCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, fallThruFromMonitorLookupCacheLabel, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, monitorLookupCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, monitorLookupCacheLabel, cg);
 
         lookupOffsetReg = cg->allocateRegister();
         numDeps++;
 
         int32_t offsetOfMonitorLookupCache = offsetof(J9VMThread, objectMonitorLookupCache);
 
-        // generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, objectClassReg,
+        // Inst_RegMem(TR::InstOpCode::LRegMem(), node, objectClassReg,
         // MRef_Bdisp32(vmThreadReg, offsetOfMonitorLookupCache, cg), cg);
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, lookupOffsetReg, objectReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, lookupOffsetReg, objectReg, cg);
 
-        generateRegImmInstruction(TR::InstOpCode::SARRegImm1(comp->target().is64Bit()), node, lookupOffsetReg,
+        Inst_RegImm(TR::InstOpCode::SARRegImm1(comp->target().is64Bit()), node, lookupOffsetReg,
             trailingZeroes(TR::Compiler->om.getObjectAlignmentInBytes()), cg);
 
         J9JavaVM *jvm = fej9->getJ9JITConfig()->javaVM;
-        generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, lookupOffsetReg,
-            J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE - 1, cg);
-        generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(), node, lookupOffsetReg,
+        Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, lookupOffsetReg, J9VMTHREAD_OBJECT_MONITOR_CACHE_SIZE - 1, cg);
+        Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, lookupOffsetReg,
             trailingZeroes(TR::Compiler->om.sizeofReferenceField()), cg);
-        generateRegMemInstruction((comp->target().is64Bit() && fej9->generateCompressedLockWord())
-                ? TR::InstOpCode::L4RegMem
-                : TR::InstOpCode::LRegMem(),
+        Inst_RegMem((comp->target().is64Bit() && fej9->generateCompressedLockWord()) ? TR::InstOpCode::L4RegMem
+                                                                                     : TR::InstOpCode::LRegMem(),
             node, objectClassReg, MRef_BISdisp32(vmThreadReg, lookupOffsetReg, 0, offsetOfMonitorLookupCache, cg), cg);
 
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, objectClassReg, objectClassReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, objectClassReg, objectClassReg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
 
         int32_t offsetOfMonitor = offsetof(J9ObjectMonitor, monitor);
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
-            MRef_Bdisp32(objectClassReg, offsetOfMonitor, cg), cg);
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, lookupOffsetReg, MRef_Bdisp32(objectClassReg, offsetOfMonitor, cg),
+            cg);
 
         int32_t offsetOfUserData = offsetof(J9ThreadAbstractMonitor, userData);
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
             MRef_Bdisp32(lookupOffsetReg, offsetOfUserData, cg), cg);
 
-        generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, lookupOffsetReg, objectReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, lookupOffsetReg, objectReg, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
 
         int32_t offsetOfAlternateLockWord = offsetof(J9ObjectMonitor, alternateLockword);
-        // generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
+        // Inst_RegMem(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
         // MRef_Bdisp32(objectClassReg, offsetOfAlternateLockWord, cg), cg);
-        generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, objectClassReg, offsetOfAlternateLockWord, cg);
-        // generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, objectClassReg, lookupOffsetReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, objectClassReg, objectReg, cg);
+        Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, objectClassReg, offsetOfAlternateLockWord, cg);
+        // Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, objectClassReg, lookupOffsetReg, cg);
+        Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, objectClassReg, objectReg, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, fallThruFromMonitorLookupCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, fallThruFromMonitorLookupCacheLabel, cg);
     } else
-        generateLabelInstruction(TR::InstOpCode::JLE4, node, snippetLabel, cg);
+        Inst_Label(TR::InstOpCode::JLE4, node, snippetLabel, cg);
 }
 
 #ifdef TR_TARGET_32BIT
@@ -932,7 +923,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
         else
             opCode = TR::InstOpCode::CMP4MemImm4;
         TR::MemoryReference *memRef = MRef_node(firstChild, cg);
-        generateMemImmInstruction(opCode, node, memRef, value, cg);
+        Inst_MemImm(opCode, node, memRef, value, cg);
         memRef->decNodeReferenceCounts(cg);
         cg->decReferenceCount(secondChild);
     } else {
@@ -946,9 +937,9 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
     TR::LabelSymbol *snippetLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
     startLabel->setStartInternalControlFlow();
     reStartLabel->setEndInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
-    generateLabelInstruction(testNode->getOpCodeValue() == TR::icmpeq ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4,
-        node, snippetLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(testNode->getOpCodeValue() == TR::icmpeq ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node,
+        snippetLabel, cg);
 
     TR::Snippet *snippet;
     if (node->getNumChildren() == 2)
@@ -960,7 +951,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
 
     cg->addSnippet(snippet);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, reStartLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, reStartLabel, cg);
     cg->decReferenceCount(testNode);
     return NULL;
 }
@@ -1045,11 +1036,11 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         if (testIs64Bit) {
             int64_t value = secondChild->getLongInt();
             op = IS_8BIT_SIGNED(value) ? TR::InstOpCode::CMP8MemImms : TR::InstOpCode::CMP8MemImm4;
-            generateMemImmInstruction(op, node, memRef, value, cg);
+            Inst_MemImm(op, node, memRef, value, cg);
         } else {
             int32_t value = secondChild->getInt();
             op = IS_8BIT_SIGNED(value) ? TR::InstOpCode::CMP4MemImms : TR::InstOpCode::CMP4MemImm4;
-            generateMemImmInstruction(op, node, memRef, value, cg);
+            Inst_MemImm(op, node, memRef, value, cg);
         }
 
         memRef->decNodeReferenceCounts(cg);
@@ -1066,7 +1057,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
     startLabel->setStartInternalControlFlow();
     reStartLabel->setEndInternalControlFlow();
 
-    TR::Instruction *startInstruction = generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    TR::Instruction *startInstruction = Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     if (node->getOpCodeValue() == TR::MethodEnterHook || node->getOpCodeValue() == TR::MethodExitHook) {
         TR::Node *callNode = node->getSecondChild();
@@ -1074,7 +1065,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         // Generate an inverted jump around the call.  This is necessary because we want to do the call inline rather
         // than through the snippet.
         //
-        generateLabelInstruction(testIsEQ ? TR::InstOpCode::JNE4 : TR::InstOpCode::JE4, node, reStartLabel, cg);
+        Inst_Label(testIsEQ ? TR::InstOpCode::JNE4 : TR::InstOpCode::JE4, node, reStartLabel, cg);
         TR::TreeEvaluator::performCall(callNode, false, false, cg);
 
         // Collect postconditions from the internal control flow region and put
@@ -1105,9 +1096,9 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         }
         postConditions->stopAddingPostConditions();
 
-        generateLabelInstruction(TR::InstOpCode::label, node, reStartLabel, postConditions, cg);
+        Inst_Label(TR::InstOpCode::label, node, reStartLabel, postConditions, cg);
     } else {
-        generateLabelInstruction(testIsEQ ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_Label(testIsEQ ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node, snippetLabel, cg);
 
         TR::Snippet *snippet;
         if (node->getNumChildren() == 2)
@@ -1118,7 +1109,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
                 TR::X86HelperCallSnippet(cg, node, reStartLabel, snippetLabel, node->getSymbolReference());
 
         cg->addSnippet(snippet);
-        generateLabelInstruction(TR::InstOpCode::label, node, reStartLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, reStartLabel, cg);
     }
 
     cg->decReferenceCount(testNode);
@@ -1142,8 +1133,8 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
     sourceMR->decNodeReferenceCounts(cg);
 
     TR::Register *object = cg->allocateRegister();
-    TR::Instruction *load = generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, object,
-        MRef_Bdisp32(address, 0, cg), cg);
+    TR::Instruction *load
+        = Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
     cg->setImplicitExceptionPoint(load);
 
     switch (TR::Compiler->om.readBarrierType()) {
@@ -1151,11 +1142,10 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
             TR_ASSERT(false, "This path should only be reached when a read barrier is required.");
             break;
         case gc_modron_readbar_always:
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
-            generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, object,
-                MRef_Bdisp32(address, 0, cg), cg);
+            Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
             break;
         case gc_modron_readbar_range_check: {
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg);
@@ -1170,26 +1160,25 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
             deps->addPostCondition(object, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(address, TR::RealRegister::NoReg, cg);
 
-            generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
-            generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
+            Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+            Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
                 MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
                 cg);
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
             {
                 TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
-                generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
+                Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
                     MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
                     cg);
-                generateLabelInstruction(TR::InstOpCode::JA4, node, endLabel, cg);
-                generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+                Inst_Label(TR::InstOpCode::JA4, node, endLabel, cg);
+                Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                     MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
-                generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, object,
-                    MRef_Bdisp32(address, 0, cg), cg);
-                generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+                Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
+                Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, object, MRef_Bdisp32(address, 0, cg), cg);
+                Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
                 og.endOutlinedInstructionSequence();
             }
-            generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+            Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
         } break;
         default:
             TR_ASSERT(false, "Unsupported Read Barrier Type.");
@@ -1285,13 +1274,12 @@ TR::Register *J9::X86::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::Co
             || (comp->target().is64Bit() && !IS_32BIT_SIGNED(secondChild->getLongInt()))) {
             TR::Register *valueReg = cg->evaluate(secondChild);
             TR::X86CheckAsyncMessagesMemRegInstruction *ins
-                = generateCheckAsyncMessagesInstruction(node, TR::InstOpCode::CMPMemReg(), mr, valueReg, cg);
+                = Inst_CheckAsyncMessages(node, TR::InstOpCode::CMPMemReg(), mr, valueReg, cg);
         } else {
             int32_t value = secondChild->getInt();
             TR::InstOpCode::Mnemonic op
                 = (value < 127 && value >= -128) ? TR::InstOpCode::CMPMemImms() : TR::InstOpCode::CMPMemImm4();
-            TR::X86CheckAsyncMessagesMemImmInstruction *ins
-                = generateCheckAsyncMessagesInstruction(node, op, mr, value, cg);
+            TR::X86CheckAsyncMessagesMemImmInstruction *ins = Inst_CheckAsyncMessages(node, op, mr, value, cg);
         }
 
         mr->decNodeReferenceCounts(cg);
@@ -1306,21 +1294,21 @@ TR::Register *J9::X86::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::Co
     TR_ASSERT(testIsEqual, "unrecognized asynccheck test: test is not equal");
 
     startControlFlowLabel->setStartInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startControlFlowLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startControlFlowLabel, cg);
 
-    generateLabelInstruction(testIsEqual ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node, snippetLabel, cg);
+    Inst_Label(testIsEqual ? TR::InstOpCode::JE4 : TR::InstOpCode::JNE4, node, snippetLabel, cg);
 
     {
         TR_OutlinedInstructionsGenerator og(snippetLabel, node, cg);
-        generateImmSymInstruction(TR::InstOpCode::CALLImm4, node,
-            (uintptr_t)node->getSymbolReference()->getMethodAddress(), node->getSymbolReference(), cg)
+        Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)node->getSymbolReference()->getMethodAddress(),
+            node->getSymbolReference(), cg)
             ->setNeedsGCMap(0xFF00FFFF);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, endControlFlowLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, endControlFlowLabel, cg);
         og.endOutlinedInstructionSequence();
     }
 
     endControlFlowLabel->setEndInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, endControlFlowLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, endControlFlowLabel, cg);
 
     cg->decReferenceCount(compareNode);
 
@@ -1536,131 +1524,129 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     // Calculate spine array size
 
     TR::Register *spineSizeReg = cg->allocateRegister();
-    generateRegImmInstruction(TR::InstOpCode::MOV8RegImm4, node, spineSizeReg, contiguousArrayHeaderSize, cg);
+    Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, spineSizeReg, contiguousArrayHeaderSize, cg);
 
     int32_t zeroArraySizeAligned = OMR::align(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(), alignmentInBytes);
     TR::Register *tempReg = cg->allocateRegister();
-    generateRegImmInstruction(TR::InstOpCode::MOV8RegImm4, node, tempReg, zeroArraySizeAligned, cg);
+    Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, tempReg, zeroArraySizeAligned, cg);
 
     TR::Register *firstDimReg = cg->allocateRegister();
-    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
+    Inst_RegMem(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
 
     // if first dim = 0 load the zero array size and skip over calculating the leaf block size
-    generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMOVE8RegReg, node, spineSizeReg, tempReg, cg);
+    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
+    Inst_RegReg(TR::InstOpCode::CMOVE8RegReg, node, spineSizeReg, tempReg, cg);
     TR::LabelSymbol *startControlFlow = generateLabelSymbol(cg);
     startControlFlow->setStartInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startControlFlow, cg);
+    Inst_Label(TR::InstOpCode::label, node, startControlFlow, cg);
     TR::LabelSymbol *allocateLabel = generateLabelSymbol(cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, allocateLabel, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, allocateLabel, cg);
 
     // if first dim < 0 go to OOL helper
-    generateLabelInstruction(TR::InstOpCode::JL4, node, helperLabel, cg);
+    Inst_Label(TR::InstOpCode::JL4, node, helperLabel, cg);
 
     // spine size += first dim * reference size
-    generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, spineSizeReg,
+    Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, spineSizeReg,
         MRef_BISdisp32(spineSizeReg, firstDimReg, trailingZeroes((int32_t)referenceSize), 0, cg), cg);
 
     // pad spine size so leaf arrays will be aligned
     if (needsAlignSpine) {
-        generateRegImmInstruction(TR::InstOpCode::ADD8RegImm4, node, spineSizeReg, alignmentInBytes - 1, cg);
-        generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, spineSizeReg, -alignmentInBytes, cg);
+        Inst_RegImm(TR::InstOpCode::ADD8RegImm4, node, spineSizeReg, alignmentInBytes - 1, cg);
+        Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, spineSizeReg, -alignmentInBytes, cg);
     }
 
     // Calculate leaf array block size
 
     TR::Register *leafSizeReg = cg->allocateRegister();
-    generateRegImmInstruction(TR::InstOpCode::MOV8RegImm4, node, leafSizeReg, contiguousArrayHeaderSize, cg);
+    Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, leafSizeReg, contiguousArrayHeaderSize, cg);
 
     // if second dim = 0 load the zero array size and skip over calculating the leaf size
     TR::Register *secondDimReg = cg->allocateRegister();
-    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, secondDimReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
+    Inst_RegMem(TR::InstOpCode::MOVSXReg8Mem4, node, secondDimReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
 
-    generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMOVE8RegReg, node, leafSizeReg, tempReg, cg);
+    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
+    Inst_RegReg(TR::InstOpCode::CMOVE8RegReg, node, leafSizeReg, tempReg, cg);
     TR::LabelSymbol *calculateLeafBlockSize = generateLabelSymbol(cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, calculateLeafBlockSize, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, calculateLeafBlockSize, cg);
 
     // if second dim < 0 go to OOL helper
-    generateLabelInstruction(TR::InstOpCode::JL4, node, helperLabel, cg);
+    Inst_Label(TR::InstOpCode::JL4, node, helperLabel, cg);
 
     // leaf size = header size + second dim * leaf element size
-    generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, leafSizeReg,
+    Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, leafSizeReg,
         MRef_BISdisp32(leafSizeReg, secondDimReg, trailingZeroes(leafArrayElementSize), 0, cg), cg);
 
     // pad leafSize for alignment
     if (needsAlignLeaf) {
-        generateRegImmInstruction(TR::InstOpCode::ADD8RegImm4, node, leafSizeReg, alignmentInBytes - 1, cg);
-        generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, leafSizeReg, -alignmentInBytes, cg);
+        Inst_RegImm(TR::InstOpCode::ADD8RegImm4, node, leafSizeReg, alignmentInBytes - 1, cg);
+        Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, leafSizeReg, -alignmentInBytes, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, calculateLeafBlockSize, cg);
+    Inst_Label(TR::InstOpCode::label, node, calculateLeafBlockSize, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV8RegReg, node, tempReg, firstDimReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::IMUL8RegReg, node, tempReg, leafSizeReg, cg);
+    Inst_RegReg(TR::InstOpCode::MOV8RegReg, node, tempReg, firstDimReg, cg);
+    Inst_RegReg(TR::InstOpCode::IMUL8RegReg, node, tempReg, leafSizeReg, cg);
 
     // spineSize += leafBlockSize
-    generateRegRegInstruction(TR::InstOpCode::ADD8RegReg, node, spineSizeReg, tempReg, cg);
+    Inst_RegReg(TR::InstOpCode::ADD8RegReg, node, spineSizeReg, tempReg, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, allocateLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, allocateLabel, cg);
 
     // spinePtrReg = vmThread->heapAlloc
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
-    generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, spinePtrReg,
+    Inst_RegMem(TR::InstOpCode::L8RegMem, node, spinePtrReg,
         MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
     // allocEnd = spinePtr + spineSize + leafBlockSize
     TR::Register *leafPtrReg = cg->allocateRegister();
-    generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, leafPtrReg,
-        MRef_BISdisp32(spinePtrReg, spineSizeReg, 0, 0, cg), cg);
+    Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, leafPtrReg, MRef_BISdisp32(spinePtrReg, spineSizeReg, 0, 0, cg), cg);
 
     // if allocEnd > vmThread->heapTop go to helper
-    generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, leafPtrReg,
+    Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, leafPtrReg,
         MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JA4, node, helperLabel, cg);
+    Inst_Label(TR::InstOpCode::JA4, node, helperLabel, cg);
 
     // bump vmThread->heapAlloc to allocate the memory needed
-    generateMemRegInstruction(TR::InstOpCode::S8MemReg, node,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), leafPtrReg, cg);
+    Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
+        leafPtrReg, cg);
 
     // load class into spine header
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-        MRef_Bdisp32(spinePtrReg, classOffset, cg), classReg, cg);
+    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node, MRef_Bdisp32(spinePtrReg, classOffset, cg), classReg,
+        cg);
 
     // if first dim = 0 goto initialise zero length spine
     TR::LabelSymbol *initZeroLengthLabel = generateLabelSymbol(cg);
-    generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, initZeroLengthLabel, cg);
+    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, initZeroLengthLabel, cg);
 
     // initialise zero length array
     TR_OutlinedInstructionsGenerator zeroLengthOOL(initZeroLengthLabel, node, cg);
 
     // init size and mustBeZero ('0') fields to 0
-    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
         MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
-    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
         MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Init 1st dim dataAddr slot to 0
-        generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
+        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
             MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
     zeroLengthOOL.endOutlinedInstructionSequence();
 
     // otherwise load first dim into spine header
-    generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(spinePtrReg, sizeOffset, cg), firstDimReg,
-        cg);
+    Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(spinePtrReg, sizeOffset, cg), firstDimReg, cg);
 
     // zero out the leaf portion of the allocation if necessary
     bool clearAllocation = !fej9->tlhHasBeenCleared();
     if (clearAllocation) {
         // adjust leafPtr to the beginning of the leaf array block
-        generateRegRegInstruction(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, tempReg, cg);
+        Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, tempReg, cg);
 
         // clear leafBlockSize bytes starting at leafPtr
         // leafBlockSize = m * (contiguousArrayHeaderSize + n * leafArrayElementSize + padding)
@@ -1674,20 +1660,20 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         static const TR::InstOpCode::Mnemonic xorOpCode[] = { TR::InstOpCode::XOR1RegReg, TR::InstOpCode::XOR2RegReg,
             TR::InstOpCode::XOR4RegReg, TR::InstOpCode::XOR8RegReg };
 
-        generateRegRegInstruction(xorOpCode[sizeShift], node, spineSizeReg, spineSizeReg, cg);
+        Inst_RegReg(xorOpCode[sizeShift], node, spineSizeReg, spineSizeReg, cg);
 
         if (sizeShift != 0)
-            generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, tempReg, sizeShift, cg);
+            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tempReg, sizeShift, cg);
 
         static const TR::InstOpCode::Mnemonic repstosOpCode[] = { TR::InstOpCode::REPSTOSB, TR::InstOpCode::REPSTOSW,
             TR::InstOpCode::REPSTOSD, TR::InstOpCode::REPSTOSQ };
 
-        generateInstruction(repstosOpCode[sizeShift], node, cg);
+        Inst(repstosOpCode[sizeShift], node, cg);
         // leafPtrReg is pointing to the end of the allocation again
     }
 
     // load element class
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
         MRef_Bdisp32(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
@@ -1695,15 +1681,15 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         /* Populate dataAddr slot of spine array. Arrays of non-zero size
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
             MRef_Bdisp32(spinePtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // adjust leafPtr to prepare for loop
-    generateRegRegInstruction(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
+    Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     // for zero-length offheap arrays, the work to initialize zero length arrays is sufficiently different that a
@@ -1711,17 +1697,17 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     if (isOffHeapAllocationEnabled) {
         // if second dimension = 0, use OOL loop for initializing zero length arrays
         TR::LabelSymbol *initZeroLengthLoopLabel = generateLabelSymbol(cg);
-        generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, initZeroLengthLoopLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, initZeroLengthLoopLabel, cg);
 
         // initialise zero length arrays
         TR_OutlinedInstructionsGenerator zeroLengthLoopOOL(initZeroLengthLoopLabel, node, cg);
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
 
         // initialise leaf array class
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-            MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg, cg);
+        Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node, MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg,
+            cg);
         // length, mustBeZero, and dataAddr fields are already set to zero since the allocation is zeroed
 
         // insert leaf array reference into spine array
@@ -1731,21 +1717,21 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
             trailingZeroes((int32_t)referenceSize), contiguousArrayHeaderSize - referenceSize, cg);
         if (comp->useCompressedPointers()) {
             int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
-            generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
+            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
             if (shiftAmount != 0) {
-                generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
+                Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
             }
-            generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
+            Inst_MemReg(TR::InstOpCode::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
         } else {
-            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
+            Inst_MemReg(TR::InstOpCode::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
         }
 
         // decrement firstDim and leafPtr and loop back
-        generateRegRegInstruction(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
-        generateRegInstruction(TR::InstOpCode::DEC8Reg, node, firstDimReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JG4, node, loopLabel, cg);
+        Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
+        Inst_Reg(TR::InstOpCode::DEC8Reg, node, firstDimReg, cg);
+        Inst_Label(TR::InstOpCode::JG4, node, loopLabel, cg);
 
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
         zeroLengthLoopOOL.endOutlinedInstructionSequence();
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
@@ -1755,22 +1741,20 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     bool arrayHeaderFitsInGPR = !use64BitClasses && ((classOffset + 4) == sizeOffset);
 
     if (arrayHeaderFitsInGPR) {
-        generateRegImmInstruction(TR::InstOpCode::SHL8RegImm1, node, secondDimReg, 32, cg);
-        generateRegRegInstruction(TR::InstOpCode::OR8RegReg, node, secondDimReg, tempReg, cg);
+        Inst_RegImm(TR::InstOpCode::SHL8RegImm1, node, secondDimReg, 32, cg);
+        Inst_RegReg(TR::InstOpCode::OR8RegReg, node, secondDimReg, tempReg, cg);
     }
 
     TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
 
     // initialise leaf array
     if (arrayHeaderFitsInGPR) {
-        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(leafPtrReg, classOffset, cg),
-            secondDimReg, cg);
+        Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(leafPtrReg, classOffset, cg), secondDimReg, cg);
     } else {
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-            MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg, cg);
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(leafPtrReg, sizeOffset, cg),
-            secondDimReg, cg);
+        Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node, MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg,
+            cg);
+        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(leafPtrReg, sizeOffset, cg), secondDimReg, cg);
     }
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
@@ -1778,9 +1762,9 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         /* Populate dataAddr slot of leaf array. Arrays of non-zero size
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
             MRef_Bdisp32(leafPtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(leafPtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
@@ -1792,19 +1776,19 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
         trailingZeroes((int32_t)referenceSize), contiguousArrayHeaderSize - referenceSize, cg);
     if (comp->useCompressedPointers()) {
         int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, spineSizeReg, leafPtrReg, cg);
         if (shiftAmount != 0) {
-            generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
+            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, spineSizeReg, shiftAmount, cg);
         }
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
+        Inst_MemReg(TR::InstOpCode::S4MemReg, node, spineSlotMemRef, spineSizeReg, cg);
     } else {
-        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
+        Inst_MemReg(TR::InstOpCode::S8MemReg, node, spineSlotMemRef, leafPtrReg, cg);
     }
 
     // decrement firstDim and leafPtr and loop back
-    generateRegRegInstruction(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
-    generateRegInstruction(TR::InstOpCode::DEC8Reg, node, firstDimReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, loopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::SUB8RegReg, node, leafPtrReg, leafSizeReg, cg);
+    Inst_Reg(TR::InstOpCode::DEC8Reg, node, firstDimReg, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, loopLabel, cg);
 
     // done, OOL helper will return to this point
     TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 14, cg);
@@ -1851,7 +1835,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     }
 
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
 
     cg->stopUsingRegister(spineSizeReg);
     cg->stopUsingRegister(firstDimReg);
@@ -1862,7 +1846,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // now that the array is properly allocated, move into a collected reference register
     TR::Register *returnReg = cg->allocateCollectedReferenceRegister();
-    generateRegRegInstruction(TR::InstOpCode::MOV8RegReg, node, returnReg, spinePtrReg, cg);
+    Inst_RegReg(TR::InstOpCode::MOV8RegReg, node, returnReg, spinePtrReg, cg);
 
     cg->stopUsingRegister(spinePtrReg);
 
@@ -1928,7 +1912,7 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
     TR::LabelSymbol *oolFailLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *oolJumpPoint = generateLabelSymbol(cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     // Generate the heap allocation, and the snippet that will handle heap overflow.
     TR_OutlinedInstructions *outlinedHelperCall
@@ -1945,146 +1929,143 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
 
     // inlined code for allocating zero length arrays where the zero len is in either the first or second dimension
 
-    generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, secondDimLenReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
+    Inst_RegMem(TR::InstOpCode::L4RegMem, node, secondDimLenReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
     // Load the 32-bit length value as a 64-bit value so that the top half of the register
     // can be zeroed out. This will allow us to treat the value as 64-bit when performing
     // calculations later on.
-    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
+    Inst_RegMem(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
 
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, secondDimLenReg, 0, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, secondDimLenReg, 0, cg);
 
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, oolJumpPoint, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, oolJumpPoint, cg);
     // Second Dim length is 0
 
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, firstDimLenReg, 0, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, nonZeroFirstDimLabel, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, firstDimLenReg, 0, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, nonZeroFirstDimLabel, cg);
 
     // First Dim zero, only allocate 1 zero-length object array
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, targetReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, targetReg,
         MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
     // Take into account alignment requirements for the size of the zero-length array header
     int32_t zeroArraySizeAligned = OMR::align(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(),
         TR::Compiler->om.getObjectAlignmentInBytes());
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, temp1Reg,
-        MRef_Bdisp32(targetReg, zeroArraySizeAligned, cg), cg);
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, temp1Reg, MRef_Bdisp32(targetReg, zeroArraySizeAligned, cg), cg);
 
-    generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, temp1Reg,
+    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, temp1Reg,
         MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp1Reg, cg);
+    Inst_Label(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
+    Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
+        temp1Reg, cg);
 
     // Init class
     bool use64BitClasses = comp->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
+    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node,
         MRef_Bdisp32(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
 
     // Init size and mustBeZero ('0') fields to 0
-    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
         MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
-    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
         MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Init 1st dim dataAddr slot to 0
-        generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
+        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
             MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
 
     // First dim length not 0
-    generateLabelInstruction(TR::InstOpCode::label, node, nonZeroFirstDimLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, nonZeroFirstDimLabel, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, componentClassReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, componentClassReg,
         MRef_Bdisp32(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
 
     int32_t elementSize = TR::Compiler->om.sizeofReferenceField();
 
     uintptr_t maxObjectSize = cg->getMaxObjectSizeGuaranteedNotToOverflow();
     uintptr_t maxObjectSizeInElements = maxObjectSize / elementSize;
-    generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, firstDimLenReg,
-        static_cast<int32_t>(maxObjectSizeInElements), cg);
+    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, firstDimLenReg, static_cast<int32_t>(maxObjectSizeInElements), cg);
 
     // Must be an unsigned comparison on sizes.
-    generateLabelInstruction(TR::InstOpCode::JAE4, node, oolJumpPoint, cg);
+    Inst_Label(TR::InstOpCode::JAE4, node, oolJumpPoint, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, temp1Reg, firstDimLenReg, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, temp1Reg, firstDimLenReg, cg);
 
     int32_t elementSizeAligned = OMR::align(elementSize, TR::Compiler->om.getObjectAlignmentInBytes());
     int32_t alignmentCompensation = (elementSize == elementSizeAligned) ? 0 : elementSizeAligned - 1;
 
     TR_ASSERT_FATAL(elementSize <= 8, "multianewArrayEvaluator - elementSize cannot be greater than 8!");
-    generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(), node, temp1Reg,
+    Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, temp1Reg,
         TR::MemoryReference::convertMultiplierToStride(elementSize), cg);
-    generateRegImmInstruction(TR::InstOpCode::ADDRegImm4(), node, temp1Reg,
+    Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, temp1Reg,
         TR::Compiler->om.contiguousArrayHeaderSizeInBytes() + alignmentCompensation, cg);
 
     if (alignmentCompensation != 0) {
-        generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, temp1Reg, -elementSizeAligned, cg);
+        Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, temp1Reg, -elementSizeAligned, cg);
     }
 
     TR_ASSERT_FATAL(zeroArraySizeAligned >= 0 && zeroArraySizeAligned <= 127,
         "discontiguousArrayHeaderSizeInBytes cannot be > 127 for IMulRegRegImms instruction");
-    generateRegRegImmInstruction(TR::InstOpCode::IMULRegRegImm4(), node, temp2Reg, firstDimLenReg, zeroArraySizeAligned,
-        cg);
+    Inst_RegRegImm(TR::InstOpCode::IMULRegRegImm4(), node, temp2Reg, firstDimLenReg, zeroArraySizeAligned, cg);
 
     // temp2Reg = temp2Reg + temp1Reg
-    generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
+    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, targetReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, targetReg,
         MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
     // temp2Reg = temp2Reg + J9VMThread->heapAlloc
-    generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, temp2Reg, targetReg, cg);
+    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, temp2Reg, targetReg, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, temp2Reg,
+    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, temp2Reg,
         MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp2Reg, cg);
+    Inst_Label(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
+    Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
+        temp2Reg, cg);
 
     // init 1st dim array class field
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
+    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node,
         MRef_Bdisp32(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
     // Init 1st dim array size field
-    generateMemRegInstruction(TR::InstOpCode::S4MemReg, node,
+    Inst_MemReg(TR::InstOpCode::S4MemReg, node,
         MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), firstDimLenReg, cg);
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         /* Populate dataAddr slot of 1st dimension array. Arrays of non-zero size
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, temp3Reg,
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, temp3Reg,
             MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg), temp3Reg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // temp2 point to end of 1st dim array i.e. start of 2nd dim
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, temp2Reg, targetReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, temp2Reg, targetReg, cg);
+    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
     // temp1 points to 1st dim array past header
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, temp1Reg,
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, temp1Reg,
         MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
 
     // loop start
-    generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
     // Init 2nd dim element's class
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
+    Inst_MemReg(TR::InstOpCode::SMemReg(use64BitClasses), node,
         MRef_Bdisp32(temp2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), componentClassReg, cg);
     // Init 2nd dim element's size and mustBeZero ('0') fields to 0
-    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
         MRef_Bdisp32(temp2Reg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
-    generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+    Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
         MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Populate dataAddr slot for 2nd dimension zero size array.
-        generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
+        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
             MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
@@ -2092,23 +2073,23 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
     // Store 2nd dim element into 1st dim array slot, compress temp2 if needed
     if (comp->target().is64Bit() && comp->useCompressedPointers()) {
         int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, temp3Reg, temp2Reg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, temp3Reg, temp2Reg, cg);
         if (shiftAmount != 0) {
-            generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, temp3Reg, shiftAmount, cg);
+            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, temp3Reg, shiftAmount, cg);
         }
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(temp1Reg, 0, cg), temp3Reg, cg);
+        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(temp1Reg, 0, cg), temp3Reg, cg);
     } else {
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(temp1Reg, 0, cg), temp2Reg, cg);
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(temp1Reg, 0, cg), temp2Reg, cg);
     }
 
     // Advance cursors temp1 and temp2
-    generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, temp2Reg, zeroArraySizeAligned, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, temp1Reg, elementSize, cg);
+    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, temp2Reg, zeroArraySizeAligned, cg);
+    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, temp1Reg, elementSize, cg);
 
-    generateRegInstruction(TR::InstOpCode::DEC4Reg, node, firstDimLenReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JA4, node, loopLabel, cg);
+    Inst_Reg(TR::InstOpCode::DEC4Reg, node, firstDimLenReg, cg);
+    Inst_Label(TR::InstOpCode::JA4, node, loopLabel, cg);
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
 
     TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 13, cg);
 
@@ -2149,17 +2130,17 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
 
     deps->stopAddingConditions();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, oolJumpPoint, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, oolFailLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, oolJumpPoint, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, oolFailLabel, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
 
     // Copy the newly allocated object into a collected reference register now that it is a valid object.
     //
     TR::Register *targetReg2 = cg->allocateCollectedReferenceRegister();
     TR::RegisterDependencyConditions *deps2 = generateRegisterDependencyConditions(0, 1, cg);
     deps2->addPostCondition(targetReg2, TR::RealRegister::eax, cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
     cg->stopUsingRegister(targetReg);
     targetReg = targetReg2;
 
@@ -2246,7 +2227,7 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
 
     if (comp->target().is64Bit() && !TR::TreeEvaluator::getNodeIs64Bit(node->getChild(4), cg)) {
-        generateRegRegInstruction(TR::InstOpCode::MOVZXReg8Reg4, node, sizeReg, sizeReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVZXReg8Reg4, node, sizeReg, sizeReg, cg);
     }
 
     if (!node->isNoArrayStoreCheckArrayCopy()) {
@@ -2259,14 +2240,14 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
         deps->addPostCondition(dstReg, TR::RealRegister::edi, cg);
         deps->addPostCondition(sizeReg, TR::RealRegister::ecx, cg);
 
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg, cg);
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg, cg);
-        generateHelperCallInstruction(node, TR_referenceArrayCopy, deps, cg)->setNeedsGCMap(0xFF00FFFF);
+        Inst_HelperCall(node, TR_referenceArrayCopy, deps, cg)->setNeedsGCMap(0xFF00FFFF);
 
         auto snippetLabel = generateLabelSymbol(cg);
-        auto instr = generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel,
+        auto instr = Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel,
             cg); // ReferenceArrayCopy set ZF when succeed.
         auto snippet = new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg,
             cg->symRefTab()->findOrCreateRuntimeHelper(TR_arrayStoreException), snippetLabel, instr, false);
@@ -2307,9 +2288,9 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
             tmpXmmYmmReg2 = cg->allocateRegister(TR_VRF);
         }
 
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, RSI, srcReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, RDI, dstReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, RCX, sizeReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, RSI, srcReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, RDI, dstReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, RCX, sizeReg, cg);
 
         int8_t numDeps = enableInlineForSmallSize ? 9 : 5;
         TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(numDeps, numDeps, cg);
@@ -2342,25 +2323,25 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
         begLabel->setStartInternalControlFlow();
         endLabel->setEndInternalControlFlow();
 
-        generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
 
         if (TR::Compiler->om.readBarrierType() != gc_modron_readbar_none) {
             bool use64BitClasses = comp->target().is64Bit() && !comp->useCompressedPointers();
 
             TR::LabelSymbol *rdbarLabel = generateLabelSymbol(cg);
             // EvacuateTopAddress == 0 means Concurrent Scavenge is inactive
-            generateMemImmInstruction(TR::InstOpCode::CMPMemImms(use64BitClasses), node,
+            Inst_MemImm(TR::InstOpCode::CMPMemImms(use64BitClasses), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg), 0,
                 cg);
-            generateLabelInstruction(TR::InstOpCode::JNE4, node, rdbarLabel, cg);
+            Inst_Label(TR::InstOpCode::JNE4, node, rdbarLabel, cg);
 
             TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg, cg);
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg, cg);
-            generateHelperCallInstruction(node, TR_referenceArrayCopy, NULL, cg)->setNeedsGCMap(0xFF00FFFF);
-            generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+            Inst_HelperCall(node, TR_referenceArrayCopy, NULL, cg)->setNeedsGCMap(0xFF00FFFF);
+            Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
             og.endOutlinedInstructionSequence();
         }
 
@@ -2377,35 +2358,35 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
                     tmpXmmYmmReg2, cg, repMovsThresholdBytes, repMovsLabel, endLabel);
             }
 
-            generateLabelInstruction(TR::InstOpCode::label, node, repMovsLabel, cg);
+            Inst_Label(TR::InstOpCode::label, node, repMovsLabel, cg);
         }
 
         if (!node->isForwardArrayCopy()) {
             TR::LabelSymbol *backwardLabel = generateLabelSymbol(cg);
 
-            generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, RDI, RSI, cg); // dst = dst - src
-            generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, RDI, RCX, cg); // cmp dst, size
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, RDI, MRef_BIS(RDI, RSI, 0, cg),
+            Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, RDI, RSI, cg); // dst = dst - src
+            Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, RDI, RCX, cg); // cmp dst, size
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, RDI, MRef_BIS(RDI, RSI, 0, cg),
                 cg); // dst = dst + src
-            generateLabelInstruction(TR::InstOpCode::JB4, node, backwardLabel, cg); // jb, skip backward copy setup
+            Inst_Label(TR::InstOpCode::JB4, node, backwardLabel, cg); // jb, skip backward copy setup
 
             TR_OutlinedInstructionsGenerator og(backwardLabel, node, cg);
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, RSI,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, RSI,
                 MRef_BISdisp32(RSI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, RDI,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, RDI,
                 MRef_BISdisp32(RDI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
-            generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
-            generateInstruction(TR::InstOpCode::STD, node, cg);
-            generateInstruction(use64BitClasses ? TR::InstOpCode::REPMOVSQ : TR::InstOpCode::REPMOVSD, node, cg);
-            generateInstruction(TR::InstOpCode::CLD, node, cg);
-            generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
+            Inst(TR::InstOpCode::STD, node, cg);
+            Inst(use64BitClasses ? TR::InstOpCode::REPMOVSQ : TR::InstOpCode::REPMOVSD, node, cg);
+            Inst(TR::InstOpCode::CLD, node, cg);
+            Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
             og.endOutlinedInstructionSequence();
         }
 
-        generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
-        generateInstruction(use64BitClasses ? TR::InstOpCode::REPMOVSQ : TR::InstOpCode::REPMOVSD, node, cg);
+        Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
+        Inst(use64BitClasses ? TR::InstOpCode::REPMOVSQ : TR::InstOpCode::REPMOVSD, node, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
 
         cg->stopUsingRegister(RSI);
         cg->stopUsingRegister(RDI);
@@ -2444,9 +2425,9 @@ TR::Register *J9::X86::TreeEvaluator::arraylengthEvaluator(TR::Node *node, TR::C
     TR::MemoryReference *discontiguousArraySizeMR
         = MRef_Bdisp32(objectReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg);
 
-    generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lengthReg, contiguousArraySizeMR, cg);
-    generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, lengthReg, lengthReg, cg);
-    generateRegMemInstruction(TR::InstOpCode::CMOVE4RegMem, node, lengthReg, discontiguousArraySizeMR, cg);
+    Inst_RegMem(TR::InstOpCode::L4RegMem, node, lengthReg, contiguousArraySizeMR, cg);
+    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, lengthReg, lengthReg, cg);
+    Inst_RegMem(TR::InstOpCode::CMOVE4RegMem, node, lengthReg, discontiguousArraySizeMR, cg);
 
     cg->decReferenceCount(node->getFirstChild());
     node->setRegister(lengthReg);
@@ -2455,7 +2436,7 @@ TR::Register *J9::X86::TreeEvaluator::arraylengthEvaluator(TR::Node *node, TR::C
 
 TR::Register *J9::X86::TreeEvaluator::exceptionRangeFenceEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    generateFenceInstruction(TR::InstOpCode::fence, node, node, cg);
+    Inst_Fence(TR::InstOpCode::fence, node, node, cg);
     return NULL;
 }
 
@@ -2632,7 +2613,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
                 } else {
                     memRef = MRef_Bdisp32(refRegister, 0, cg);
                 }
-                appendTo = generateMemImmInstruction(appendTo, TR::InstOpCode::TEST1MemImm1, memRef, 0, cg);
+                appendTo = Inst_MemImm(appendTo, TR::InstOpCode::TEST1MemImm1, memRef, 0, cg);
                 cg->setImplicitExceptionPoint(appendTo);
             }
         }
@@ -2660,7 +2641,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
                 appendTo = cg->getAppendInstruction();
 
             TR::InstOpCode::Mnemonic op = TR::InstOpCode::CMPMemImms();
-            appendTo = generateMemImmInstruction(appendTo, op, tempMR, NULLVALUE, cg);
+            appendTo = Inst_MemImm(appendTo, op, tempMR, NULLVALUE, cg);
             tempMR->decNodeReferenceCounts(cg);
             needLateEvaluation = false;
         } else {
@@ -2669,12 +2650,11 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
             if (!appendTo)
                 appendTo = cg->getAppendInstruction();
 
-            appendTo
-                = generateRegRegInstruction(appendTo, TR::InstOpCode::TESTRegReg(), targetRegister, targetRegister, cg);
+            appendTo = Inst_RegReg(appendTo, TR::InstOpCode::TESTRegReg(), targetRegister, targetRegister, cg);
         }
 
         TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
-        appendTo = generateLabelInstruction(appendTo, TR::InstOpCode::JE4, snippetLabel, cg);
+        appendTo = Inst_Label(appendTo, TR::InstOpCode::JE4, snippetLabel, cg);
         // the _node field should point to the current node
         appendTo->setNode(node);
         appendTo->setLiveLocals(cg->getLiveLocals());
@@ -2843,26 +2823,25 @@ TR::Register *J9::X86::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGe
         startLabel->setStartInternalControlFlow();
         restartLabel->setEndInternalControlFlow();
 
-        generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
         if (useRegisterPairs) {
             TR::Register *tempReg = cg->allocateRegister(TR_GPR);
-            lowDivisorTestInstr
-                = generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, tempReg, divisorReg->getLowOrder(), cg);
+            lowDivisorTestInstr = Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, tempReg, divisorReg->getLowOrder(), cg);
             highDivisorTestInstr
-                = generateRegRegInstruction(TR::InstOpCode::OR4RegReg, node, tempReg, divisorReg->getHighOrder(), cg);
-            generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, tempReg, tempReg, cg);
+                = Inst_RegReg(TR::InstOpCode::OR4RegReg, node, tempReg, divisorReg->getHighOrder(), cg);
+            Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, tempReg, tempReg, cg);
             cg->stopUsingRegister(tempReg);
         } else
-            lowDivisorTestInstr = generateRegRegInstruction(TR::InstOpCode::TESTRegReg(use64BitRegisters), node,
-                divisorReg, divisorReg, cg);
+            lowDivisorTestInstr
+                = Inst_RegReg(TR::InstOpCode::TESTRegReg(use64BitRegisters), node, divisorReg, divisorReg, cg);
 
-        generateLabelInstruction(TR::InstOpCode::JE4, node, divideByZeroSnippetLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, divideByZeroSnippetLabel, cg);
 
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86CheckFailureSnippet(cg, node->getSymbolReference(),
             divideByZeroSnippetLabel, cg->getAppendInstruction()));
 
-        generateLabelInstruction(TR::InstOpCode::label, node, divisionLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, divisionLabel, cg);
 
         TR::Register *resultRegister = cg->evaluate(divisionNode);
 
@@ -2900,7 +2879,7 @@ TR::Register *J9::X86::TreeEvaluator::DIVCHKEvaluator(TR::Node *node, TR::CodeGe
                     TR_ASSERT(0, "bad division opcode for DIVCHK\n");
             }
 
-        generateLabelInstruction(TR::InstOpCode::label, node, restartLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, restartLabel, deps, cg);
 
         if (hasConversion) {
             cg->evaluate(node->getFirstChild());
@@ -3031,14 +3010,14 @@ TR::Register *J9::X86::TreeEvaluator::ZEROCHKEvaluator(TR::Node *node, TR::CodeG
                 "Compare opcode must either be compare for order or for equality");
             TR::TreeEvaluator::compareIntegersForEquality(valueToCheck, cg);
         }
-        generateLabelInstruction(branchOpCodeForCompare(valueToCheck->getOpCode(), true), node, slowPathLabel, cg);
+        Inst_Label(branchOpCodeForCompare(valueToCheck->getOpCode(), true), node, slowPathLabel, cg);
     } else {
         TR::Register *value = cg->evaluate(node->getFirstChild());
-        generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, value, value, cg);
+        Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, value, value, cg);
         cg->decReferenceCount(node->getFirstChild());
-        generateLabelInstruction(TR::InstOpCode::JE4, node, slowPathLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, slowPathLabel, cg);
     }
-    generateLabelInstruction(TR::InstOpCode::label, node, restartLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, restartLabel, cg);
 
     return NULL;
 }
@@ -3153,7 +3132,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKEvaluator(TR::Node *node, TR::CodeGe
     bool jumpOnOppositeCondition = false;
     if (firstChild->getOpCode().isLoadConst()) {
         if (secondChild->getOpCode().isLoadConst() && firstChild->getInt() <= secondChild->getInt()) {
-            instr = generateLabelInstruction(TR::InstOpCode::JMP4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(TR::InstOpCode::JMP4, node, boundCheckFailureLabel, cg);
             cg->decReferenceCount(firstChild);
             cg->decReferenceCount(secondChild);
         } else {
@@ -3161,23 +3140,23 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKEvaluator(TR::Node *node, TR::CodeGe
                 node->swapChildren();
                 TR::TreeEvaluator::compareIntegersForOrder(node, cg);
                 node->swapChildren();
-                instr = generateLabelInstruction(TR::InstOpCode::JAE4, node, boundCheckFailureLabel, cg);
+                instr = Inst_Label(TR::InstOpCode::JAE4, node, boundCheckFailureLabel, cg);
             } else
                 skippedComparison = true;
         }
     } else {
         if (!isConditionCodeSetForCompare(node, &jumpOnOppositeCondition, cg->comp())) {
             TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-            instr = generateLabelInstruction(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
         } else
             skippedComparison = true;
     }
 
     if (skippedComparison) {
         if (jumpOnOppositeCondition)
-            instr = generateLabelInstruction(TR::InstOpCode::JAE4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(TR::InstOpCode::JAE4, node, boundCheckFailureLabel, cg);
         else
-            instr = generateLabelInstruction(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(TR::InstOpCode::JBE4, node, boundCheckFailureLabel, cg);
 
         cg->decReferenceCount(firstChild);
         cg->decReferenceCount(secondChild);
@@ -3210,7 +3189,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node, T
             if (firstChild->getInt() < secondChild->getInt()) {
                 // Check will always fail, just jump to failure snippet
                 //
-                instr = generateLabelInstruction(TR::InstOpCode::JMP4, node, boundCheckFailureLabel, cg);
+                instr = Inst_Label(TR::InstOpCode::JMP4, node, boundCheckFailureLabel, cg);
             } else {
                 // Check will always succeed, no need for an instruction
                 //
@@ -3222,11 +3201,11 @@ TR::Register *J9::X86::TreeEvaluator::ArrayCopyBNDCHKEvaluator(TR::Node *node, T
             node->swapChildren();
             TR::TreeEvaluator::compareIntegersForOrder(node, cg);
             node->swapChildren();
-            instr = generateLabelInstruction(TR::InstOpCode::JG4, node, boundCheckFailureLabel, cg);
+            instr = Inst_Label(TR::InstOpCode::JG4, node, boundCheckFailureLabel, cg);
         }
     } else {
         TR::TreeEvaluator::compareIntegersForOrder(node, cg);
-        instr = generateLabelInstruction(TR::InstOpCode::JL4, node, boundCheckFailureLabel, cg);
+        instr = Inst_Label(TR::InstOpCode::JL4, node, boundCheckFailureLabel, cg);
     }
 
     if (instr)
@@ -3362,9 +3341,8 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             // valid for useShiftedOffsets
             compressedRegister = cg->evaluate(firstChild->getSecondChild());
             if (!usingLowMemHeap) {
-                generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), firstChild, sourceRegister, sourceRegister, cg);
-                generateRegRegInstruction(TR::InstOpCode::CMOVERegReg(), firstChild, compressedRegister, sourceRegister,
-                    cg);
+                Inst_RegReg(TR::InstOpCode::TESTRegReg(), firstChild, sourceRegister, sourceRegister, cg);
+                Inst_RegReg(TR::InstOpCode::CMOVERegReg(), firstChild, compressedRegister, sourceRegister, cg);
             }
         }
     }
@@ -3380,13 +3358,13 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
 
     startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
+    Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
 
     TR::LabelSymbol *nullTargetLabel = isRealTimeGC ? startOfWrtbarLabel : doNullStoreLabel;
 
-    generateLabelInstruction(TR::InstOpCode::JE4, node, nullTargetLabel, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, nullTargetLabel, cg);
 
     // -------------------------------------------------------------------------
     //
@@ -3422,10 +3400,9 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
         if (!alwaysDoOOLASC) {
             TR_VirtualGuard *virtualGuard
                 = TR_VirtualGuard::createArrayStoreCheckGuard(comp, node, node->getArrayStoreClassInNode());
-            TR::Instruction *pachable
-                = generateVirtualGuardNOPInstruction(node, virtualGuard->addNOPSite(), NULL, oolASCLabel, cg);
+            Inst_VirtualGuardNOP(node, virtualGuard->addNOPSite(), NULL, oolASCLabel, cg);
         } else {
-            generateLabelInstruction(TR::InstOpCode::JMP4, node, oolASCLabel, cg);
+            Inst_Label(TR::InstOpCode::JMP4, node, oolASCLabel, cg);
         }
 
         // Restore the reference counts of the children created for the temporary vacll node above.
@@ -3446,7 +3423,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
     bool isSourceNonNull = sourceChild->isNonNull();
 
     if (generateWriteBarrier) {
-        generateLabelInstruction(TR::InstOpCode::label, node, startOfWrtbarLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, startOfWrtbarLabel, cg);
 
         if (!isRealTimeGC) {
             // HACK: set the nullness property on the source so that the write barrier
@@ -3465,7 +3442,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
     } else if (postASCLabel) {
         // Lay down a arestart label for OOL ASC if the write barrier was skipped
         //
-        generateLabelInstruction(TR::InstOpCode::label, node, postASCLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, postASCLabel, cg);
     }
 
     // -------------------------------------------------------------------------
@@ -3496,11 +3473,11 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             tempMR2 = MRef_MRefOff(*tempMR, 0, cg);
 
             if (usingCompressedPointers)
-                generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, tempMR2, compressedRegister, cg);
+                Inst_MemReg(TR::InstOpCode::S4MemReg, node, tempMR2, compressedRegister, cg);
             else
-                generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, tempMR2, sourceRegister, cg);
+                Inst_MemReg(TR::InstOpCode::SMemReg(), node, tempMR2, sourceRegister, cg);
 
-            generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+            Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
             og.endOutlinedInstructionSequence();
         } else if (!generateWriteBarrier) {
             // No write barrier emitted.  Evaluate the store here.
@@ -3517,9 +3494,9 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             TR::X86MemRegInstruction *storeInstr;
 
             if (usingCompressedPointers)
-                storeInstr = generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, tempMR, compressedRegister, cg);
+                storeInstr = Inst_MemReg(TR::InstOpCode::S4MemReg, node, tempMR, compressedRegister, cg);
             else
-                storeInstr = generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, tempMR, sourceRegister, cg);
+                storeInstr = Inst_MemReg(TR::InstOpCode::SMemReg(), node, tempMR, sourceRegister, cg);
 
             cg->setImplicitExceptionPoint(storeInstr);
 
@@ -3584,9 +3561,9 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
     scratchRegisterManager->stopUsingRegisters();
 
     if (dependencyAnchorInstruction) {
-        generateLabelInstruction(dependencyAnchorInstruction, TR::InstOpCode::label, doneLabel, deps, cg);
+        Inst_Label(dependencyAnchorInstruction, TR::InstOpCode::label, doneLabel, deps, cg);
     } else {
-        generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
     }
 
     if (usingCompressedPointers) {
@@ -3707,7 +3684,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
             branchOpCode = TR::InstOpCode::JMP4;
         }
 
-        checkInstr = generateLabelInstruction(branchOpCode, node, boundCheckFailureLabel, cg);
+        checkInstr = Inst_Label(branchOpCode, node, boundCheckFailureLabel, cg);
     } else {
         // -------------------------------------------------------------------------
         // Check if the base array has a spine.  If so, process out of line.
@@ -3719,8 +3696,8 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
 
         TR::MemoryReference *arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
 
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, boundCheckFailureLabel, cg);
+        Inst_MemImm(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, boundCheckFailureLabel, cg);
     }
 
     // -----------------------------------------------------------------------------------
@@ -3798,7 +3775,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
 
     TR::LabelSymbol *mergeLabel = generateLabelSymbol(cg);
     mergeLabel->setInternalControlFlowMerge();
-    TR::X86LabelInstruction *restartInstr = generateLabelInstruction(TR::InstOpCode::label, node, mergeLabel, deps, cg);
+    TR::X86LabelInstruction *restartInstr = Inst_Label(TR::InstOpCode::label, node, mergeLabel, deps, cg);
 
     TR_OutlinedInstructions *arrayletOI
         = generateArrayletReference(node, loadOrStoreChild, checkInstr, boundCheckFailureLabel, mergeLabel,
@@ -3848,15 +3825,15 @@ TR::Register *J9::X86::TreeEvaluator::barrierFenceEvaluator(TR::Node *node, TR::
 {
     TR::ILOpCodes opCode = node->getOpCodeValue();
     if (opCode == TR::fullFence && node->canOmitSync()) {
-        generateLabelInstruction(TR::InstOpCode::label, node, generateLabelSymbol(cg), cg);
+        Inst_Label(TR::InstOpCode::label, node, generateLabelSymbol(cg), cg);
     } else if (cg->comp()->getOption(TR_X86UseMFENCE)) {
-        generateInstruction(TR::InstOpCode::MFENCE, node, cg);
+        Inst(TR::InstOpCode::MFENCE, node, cg);
     } else {
         TR::RealRegister *stackReg = cg->machine()->getRealRegister(TR::RealRegister::esp);
         TR::MemoryReference *mr = MRef_Bdisp32(stackReg, intptr_t(0), cg);
 
         mr->setRequiresLockPrefix();
-        generateMemImmInstruction(TR::InstOpCode::OR4MemImms, node, mr, 0, cg);
+        Inst_MemImm(TR::InstOpCode::OR4MemImms, node, mr, 0, cg);
         cg->stopUsingRegister(stackReg);
     }
     return NULL;
@@ -3884,7 +3861,7 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
         startLabel = generateLabelSymbol(cg);
         doneLabel = generateLabelSymbol(cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
         startLabel->setStartInternalControlFlow();
     }
 
@@ -3892,14 +3869,13 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
 
     if (needBranchAroundForNULL) {
         // if handle is NULL, then just branch around the redirection
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, handleRegister, handleRegister, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, handleNode, doneLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, handleRegister, handleRegister, cg);
+        Inst_Label(TR::InstOpCode::JE4, handleNode, doneLabel, cg);
     }
 
     // handle is not NULL or we're an implicit nullcheck, so go through forwarding pointer to get object
     TR::MemoryReference *handleMR = MRef_Bdisp32(handleRegister, node->getSymbolReference()->getOffset(), cg);
-    TR::Instruction *forwardingInstr
-        = generateRegMemInstruction(TR::InstOpCode::L4RegMem, handleNode, handleRegister, handleMR, cg);
+    TR::Instruction *forwardingInstr = Inst_RegMem(TR::InstOpCode::L4RegMem, handleNode, handleRegister, handleMR, cg);
     cg->setImplicitExceptionPoint(forwardingInstr);
 
     if (needBranchAroundForNULL) {
@@ -3907,7 +3883,7 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
         deps->addPostCondition(handleRegister, TR::RealRegister::NoReg, cg);
 
         // and we're done
-        generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
 
         doneLabel->setEndInternalControlFlow();
     }
@@ -3926,14 +3902,14 @@ static TR::Register *highestOneBit(TR::Node *node, TR::CodeGenerator *cg, TR::Re
     // shl r1, r2
     TR::Register *scratchReg = cg->allocateRegister();
     TR::Register *bsrReg = cg->allocateRegister();
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, scratchReg, scratchReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
-    generateRegInstruction(TR::InstOpCode::SETNE1Reg, node, scratchReg, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, scratchReg, scratchReg, cg);
+    Inst_RegReg(TR::InstOpCode::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
+    Inst_Reg(TR::InstOpCode::SETNE1Reg, node, scratchReg, cg);
     TR::RegisterDependencyConditions *shiftDependencies = generateRegisterDependencyConditions((uint8_t)1, 1, cg);
     shiftDependencies->addPreCondition(bsrReg, TR::RealRegister::ecx, cg);
     shiftDependencies->addPostCondition(bsrReg, TR::RealRegister::ecx, cg);
     shiftDependencies->stopAddingConditions();
-    generateRegRegInstruction(TR::InstOpCode::SHLRegCL(is64Bit), node, scratchReg, bsrReg, shiftDependencies, cg);
+    Inst_RegReg(TR::InstOpCode::SHLRegCL(is64Bit), node, scratchReg, bsrReg, shiftDependencies, cg);
     cg->stopUsingRegister(bsrReg);
     return scratchReg;
 }
@@ -3970,11 +3946,11 @@ TR::Register *J9::X86::TreeEvaluator::longHighestOneBit(TR::Node *node, TR::Code
         TR::Register *maskReg = cg->allocateRegister();
         TR::Register *resultHigh = highestOneBit(node, cg, inputHigh, false);
         TR::Register *resultLow = highestOneBit(node, cg, inputLow, false);
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, inputHigh, 0, cg);
-        generateRegInstruction(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
-        generateRegInstruction(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::AND4RegReg, node, resultLow, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, inputHigh, 0, cg);
+        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
+        Inst_Reg(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, resultLow, maskReg, cg);
         resultReg = cg->allocateRegisterPair(resultLow, resultHigh);
         cg->stopUsingRegister(maskReg);
     }
@@ -3986,9 +3962,9 @@ TR::Register *J9::X86::TreeEvaluator::longHighestOneBit(TR::Node *node, TR::Code
 static TR::Register *lowestOneBit(TR::Node *node, TR::CodeGenerator *cg, TR::Register *reg, bool is64Bit)
 {
     TR::Register *resultReg = cg->allocateRegister();
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(is64Bit), node, resultReg, reg, cg);
-    generateRegInstruction(TR::InstOpCode::NEGReg(is64Bit), node, resultReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::ANDRegReg(is64Bit), node, resultReg, reg, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(is64Bit), node, resultReg, reg, cg);
+    Inst_Reg(TR::InstOpCode::NEGReg(is64Bit), node, resultReg, cg);
+    Inst_RegReg(TR::InstOpCode::ANDRegReg(is64Bit), node, resultReg, reg, cg);
     return resultReg;
 }
 
@@ -4023,11 +3999,11 @@ TR::Register *J9::X86::TreeEvaluator::longLowestOneBit(TR::Node *node, TR::CodeG
         TR::Register *inputHigh = inputReg->getHighOrder();
         TR::Register *inputLow = inputReg->getLowOrder();
         TR::Register *scratchReg = cg->allocateRegister();
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, scratchReg, scratchReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, scratchReg, scratchReg, cg);
         TR::Register *resultLow = lowestOneBit(node, cg, inputLow, false);
-        generateRegInstruction(TR::InstOpCode::SETNE1Reg, node, scratchReg, cg);
-        generateRegInstruction(TR::InstOpCode::DEC4Reg, node, scratchReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::AND4RegReg, node, scratchReg, inputHigh, cg);
+        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, scratchReg, cg);
+        Inst_Reg(TR::InstOpCode::DEC4Reg, node, scratchReg, cg);
+        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, scratchReg, inputHigh, cg);
         TR::Register *resultHigh = lowestOneBit(node, cg, scratchReg, false);
         cg->stopUsingRegister(scratchReg);
         resultReg = cg->allocateRegisterPair(resultLow, resultHigh);
@@ -4051,14 +4027,14 @@ static TR::Register *numberOfLeadingZeros(TR::Node *node, TR::CodeGenerator *cg,
     // ret r1
     TR::Register *maskReg = cg->allocateRegister();
     TR::Register *bsrReg = cg->allocateRegister();
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
-    generateRegInstruction(TR::InstOpCode::SETE1Reg, node, maskReg, cg);
-    generateRegInstruction(TR::InstOpCode::DECReg(is64Bit), node, maskReg, cg);
-    generateRegInstruction(TR::InstOpCode::INCReg(is64Bit), node, bsrReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::ANDRegReg(is64Bit), node, bsrReg, maskReg, cg);
-    generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(is64Bit), node, maskReg, isLong ? 64 : 32, cg);
-    generateRegRegInstruction(TR::InstOpCode::SUBRegReg(is64Bit), node, maskReg, bsrReg, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
+    Inst_RegReg(TR::InstOpCode::BSRRegReg(is64Bit), node, bsrReg, reg, cg);
+    Inst_Reg(TR::InstOpCode::SETE1Reg, node, maskReg, cg);
+    Inst_Reg(TR::InstOpCode::DECReg(is64Bit), node, maskReg, cg);
+    Inst_Reg(TR::InstOpCode::INCReg(is64Bit), node, bsrReg, cg);
+    Inst_RegReg(TR::InstOpCode::ANDRegReg(is64Bit), node, bsrReg, maskReg, cg);
+    Inst_RegImm(TR::InstOpCode::MOVRegImm4(is64Bit), node, maskReg, isLong ? 64 : 32, cg);
+    Inst_RegReg(TR::InstOpCode::SUBRegReg(is64Bit), node, maskReg, bsrReg, cg);
     cg->stopUsingRegister(bsrReg);
     return maskReg;
 }
@@ -4096,12 +4072,12 @@ TR::Register *J9::X86::TreeEvaluator::longNumberOfLeadingZeros(TR::Node *node, T
         TR::Register *resultHigh = numberOfLeadingZeros(node, cg, inputHigh, false, false);
         TR::Register *resultLow = numberOfLeadingZeros(node, cg, inputLow, false, false);
         TR::Register *maskReg = cg->allocateRegister();
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, inputHigh, 0, cg);
-        generateRegInstruction(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
-        generateRegInstruction(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::AND4RegReg, node, resultLow, maskReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, resultHigh, resultLow, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, inputHigh, 0, cg);
+        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
+        Inst_Reg(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, resultLow, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, resultHigh, resultLow, cg);
         cg->stopUsingRegister(resultLow);
         cg->stopUsingRegister(maskReg);
         resultReg = resultHigh;
@@ -4127,14 +4103,14 @@ static TR::Register *numberOfTrailingZeros(TR::Node *node, TR::CodeGenerator *cg
     TR::Register *bsfReg = cg->allocateRegister();
     TR::Register *tempReg = cg->allocateRegister();
     TR::Register *maskReg = cg->allocateRegister();
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::BSFRegReg(is64Bit), node, bsfReg, reg, cg);
-    generateRegInstruction(TR::InstOpCode::SETE1Reg, node, tempReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(is64Bit), node, maskReg, tempReg, cg);
-    generateRegInstruction(TR::InstOpCode::DECReg(is64Bit), node, maskReg, cg);
-    generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(is64Bit), node, tempReg, isLong ? 6 : 5, cg);
-    generateRegRegInstruction(TR::InstOpCode::ANDRegReg(is64Bit), node, bsfReg, maskReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::ADDRegReg(is64Bit), node, bsfReg, tempReg, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
+    Inst_RegReg(TR::InstOpCode::BSFRegReg(is64Bit), node, bsfReg, reg, cg);
+    Inst_Reg(TR::InstOpCode::SETE1Reg, node, tempReg, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(is64Bit), node, maskReg, tempReg, cg);
+    Inst_Reg(TR::InstOpCode::DECReg(is64Bit), node, maskReg, cg);
+    Inst_RegImm(TR::InstOpCode::SHLRegImm1(is64Bit), node, tempReg, isLong ? 6 : 5, cg);
+    Inst_RegReg(TR::InstOpCode::ANDRegReg(is64Bit), node, bsfReg, maskReg, cg);
+    Inst_RegReg(TR::InstOpCode::ADDRegReg(is64Bit), node, bsfReg, tempReg, cg);
     cg->stopUsingRegister(tempReg);
     cg->stopUsingRegister(maskReg);
     return bsfReg;
@@ -4173,12 +4149,12 @@ TR::Register *J9::X86::TreeEvaluator::longNumberOfTrailingZeros(TR::Node *node, 
         TR::Register *maskReg = cg->allocateRegister();
         TR::Register *resultLow = numberOfTrailingZeros(node, cg, inputLow, false, false);
         TR::Register *resultHigh = numberOfTrailingZeros(node, cg, inputHigh, false, false);
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, resultLow, 32, cg);
-        generateRegInstruction(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
-        generateRegInstruction(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::AND4RegReg, node, maskReg, resultHigh, cg);
-        generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, resultLow, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, maskReg, maskReg, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, resultLow, 32, cg);
+        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, maskReg, cg);
+        Inst_Reg(TR::InstOpCode::DEC4Reg, node, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::AND4RegReg, node, maskReg, resultHigh, cg);
+        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, resultLow, maskReg, cg);
         cg->stopUsingRegister(resultHigh);
         cg->stopUsingRegister(maskReg);
         resultReg = resultLow;
@@ -4211,7 +4187,7 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     startLabel->setStartInternalControlFlow();
     fallThruLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     TR_OutlinedInstructions *outlinedHelperCall
         = new (cg->trHeapMemory()) TR_OutlinedInstructions(node, TR::call, NULL, outlinedCallLabel, fallThruLabel, cg);
@@ -4222,62 +4198,61 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
         generateLoadJ9Class(node, objClassReg, ObjReg, cg);
 
     // temp2Reg holds romClass of cast class, for testing array, interface class type
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp2Reg,
-        MRef_Bdisp32(castClassReg, offsetof(J9Class, romClass), cg), cg);
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp2Reg, MRef_Bdisp32(castClassReg, offsetof(J9Class, romClass), cg),
+        cg);
 
     // If cast class is array, call out of line helper
-    generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, outlinedCallLabel, cg);
+    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg),
+        J9AccClassArray, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, outlinedCallLabel, cg);
 
     // objClassReg holds object class
     if (!isCheckCastAndNullCheck) {
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, ObjReg, ObjReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, ObjReg, ObjReg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
         generateLoadJ9Class(node, objClassReg, ObjReg, cg);
     }
 
     // Object not array, inline checks
     // Check cast class is interface
-    generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccInterface, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, isClassLabel, cg);
+    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg),
+        J9AccInterface, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, isClassLabel, cg);
 
     // Obtain I-Table
     // temp1Reg holds head of J9Class->iTable of obj class
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        MRef_Bdisp32(objClassReg, offsetof(J9Class, iTable), cg), cg);
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp1Reg, MRef_Bdisp32(objClassReg, offsetof(J9Class, iTable), cg),
+        cg);
     // Loop through I-Table
     // temp1Reg holds iTable list element through the loop
-    generateLabelInstruction(TR::InstOpCode::label, node, iTableLoopLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, temp1Reg, temp1Reg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, throwLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, iTableLoopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, temp1Reg, temp1Reg, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, throwLabel, cg);
     auto interfaceMR = MRef_Bdisp32(temp1Reg, offsetof(J9ITable, interfaceClass), cg);
-    generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), node, interfaceMR, castClassReg, cg);
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        MRef_Bdisp32(temp1Reg, offsetof(J9ITable, next), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
+    Inst_MemReg(TR::InstOpCode::CMPMemReg(), node, interfaceMR, castClassReg, cg);
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp1Reg, MRef_Bdisp32(temp1Reg, offsetof(J9ITable, next), cg), cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
 
     // Found from I-Table
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
 
     // cast class is non-interface class
-    generateLabelInstruction(TR::InstOpCode::label, node, isClassLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, isClassLabel, cg);
     // equality test
-    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(use64BitClasses), node, objClassReg, castClassReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMPRegReg(use64BitClasses), node, objClassReg, castClassReg, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
 
     // class not equal
     // temp2 holds cast class depth
     // class depth mask must be low 16 bits to safely load without the mask.
     static_assert(J9AccClassDepthMask == 0xffff, "J9_JAVA_CLASS_DEPTH_MASK must be 0xffff");
-    generateRegMemInstruction(comp->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Mem2 : TR::InstOpCode::MOVZXReg4Mem2,
-        node, temp2Reg, MRef_Bdisp32(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+    Inst_RegMem(comp->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Mem2 : TR::InstOpCode::MOVZXReg4Mem2, node,
+        temp2Reg, MRef_Bdisp32(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
 
     // cast class depth >= obj class depth, throw
-    generateRegMemInstruction(TR::InstOpCode::CMP2RegMem, node, temp2Reg,
+    Inst_RegMem(TR::InstOpCode::CMP2RegMem, node, temp2Reg,
         MRef_Bdisp32(objClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JAE4, node, throwLabel, cg);
+    Inst_Label(TR::InstOpCode::JAE4, node, throwLabel, cg);
 
     // check obj class's super class array entry
     // temp1Reg holds superClasses array of obj class
@@ -4288,18 +4263,18 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     // On 64 bit, the extra reg isn't likely to cause significant register pressure.
     // On 32 bit, it could put more register pressure due to limited number of regs.
     // Since 64-bit is more prevalent, we opt to optimize for 64bit in this case
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, temp1Reg,
         MRef_Bdisp32(objClassReg, offsetof(J9Class, superclasses), cg), cg);
-    generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, castClassReg,
+    Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, castClassReg,
         MRef_BIS(temp1Reg, temp2Reg, comp->target().is64Bit() ? 3 : 2, cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, throwLabel, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, throwLabel, cg);
 
     // throw classCastException
     {
         TR_OutlinedInstructionsGenerator og(throwLabel, node, cg);
-        generateRegInstruction(TR::InstOpCode::PUSHReg, node, objClassReg, cg);
-        generateRegInstruction(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
-        auto call = generateHelperCallInstruction(node, TR_throwClassCastException, NULL, cg);
+        Inst_Reg(TR::InstOpCode::PUSHReg, node, objClassReg, cg);
+        Inst_Reg(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
+        auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
         call->setNeedsGCMap(0xFF00FFFF);
         call->setAdjustsFramePointerBy(-2 * (int32_t)sizeof(J9Class *));
         og.endOutlinedInstructionSequence();
@@ -4330,7 +4305,7 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
 
     deps->stopAddingConditions();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
 
     cg->stopUsingRegister(temp1Reg);
     cg->stopUsingRegister(temp2Reg);
@@ -4402,14 +4377,14 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
         cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     static char *breakOnInlineObjectArrayCheck = feGetEnv("TR_BreakOnInlineObjectArrayCheck");
     if (breakOnInlineObjectArrayCheck)
-        generateInstruction(TR::InstOpCode::INT3, node, cg);
+        Inst(TR::InstOpCode::INT3, node, cg);
 
     if (!isCheckCast) {
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4421,8 +4396,8 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
     // -----------------------------------------------------------------------
 
     if (!objectNode->isNonNull()) {
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, objectReg, objectReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, objectReg, objectReg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
     }
 
     // The cast class is an array of j/l/Objects. Check if the
@@ -4438,24 +4413,24 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
 
     // Check if romClass is an array
     //
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, romClassReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, romClassReg,
         MRef_Bdisp32(objectClassReg, offsetof(J9Class, romClass), cg), cg);
-    generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, notCastableLabel, cg);
+    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg),
+        J9AccClassArray, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, notCastableLabel, cg);
 
     // Check if object class is a primitive array
     //
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, componentClassReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, componentClassReg,
         MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, componentType), cg), cg);
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, romClassReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, romClassReg,
         MRef_Bdisp32(componentClassReg, offsetof(J9Class, romClass), cg), cg);
-    generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassInternalPrimitiveType, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, notCastableLabel, cg);
+    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg),
+        J9AccClassInternalPrimitiveType, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, notCastableLabel, cg);
 
     if (!isCheckCast) {
-        generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, resultReg, 1, cg);
+        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, resultReg, 1, cg);
     }
 
     // clang-format off
@@ -4497,7 +4472,7 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
     }
 
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
 
     cg->stopUsingRegister(scratchReg);
     if (objectReg != objectClassReg)
@@ -4572,12 +4547,12 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
 
     static char *breakOnInlineFinalArrayCastClass = feGetEnv("TR_BreakOnInlineFinalArrayCastClass");
     if (breakOnInlineFinalArrayCastClass)
-        generateInstruction(TR::InstOpCode::INT3, node, cg);
+        Inst(TR::InstOpCode::INT3, node, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     if (!isCheckCast) {
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4589,12 +4564,12 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
     // -----------------------------------------------------------------------
 
     if (!objectNode->isNonNull()) {
-        generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, objectReg, objectReg, cg);
+        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, objectReg, objectReg, cg);
 
         // checkcast leaves the operand stack unaffected
         // instanceof returns 0 if the objectRef is null
         //
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThruLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThruLabel, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4613,11 +4588,11 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
     uintptr_t clazzAddress = (uintptr_t)clazz;
 
     if (IS_32BIT_SIGNED(clazzAddress) && !comp->compileRelocatableCode()) {
-        generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
+        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
     } else {
         scratchReg = cg->allocateRegister();
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
-        generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, objectClassReg, scratchReg, cg);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
+        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, objectClassReg, scratchReg, cg);
     }
 
     if (isCheckCast) {
@@ -4629,9 +4604,9 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
             TR_OutlinedInstructions(node, TR::call, NULL, outlinedHelperCallLabel, fallThruLabel, cg);
         cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
 
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, outlinedHelperCallLabel, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, outlinedHelperCallLabel, cg);
     } else {
-        generateRegInstruction(TR::InstOpCode::SETE1Reg, node, resultReg, cg);
+        Inst_Reg(TR::InstOpCode::SETE1Reg, node, resultReg, cg);
     }
 
     // ----------------------------------------------------------------------
@@ -4678,7 +4653,7 @@ static void inlineCheckCastOrInstanceOfFinalArrayCastClass(TR::Node *node, TR_Op
     }
 
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
 
     if (scratchReg)
         cg->stopUsingRegister(scratchReg);
@@ -4721,12 +4696,12 @@ static void generateCastClassCacheUpdate(TR::Register *objectClassReg, uintptr_t
         && (!use64BitClasses || (use64BitClasses && IS_32BIT_SIGNED(clazzAddress)));
 
     if (use32Bit) {
-        generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node, castClassMR, (int32_t)clazzAddress, cg);
+        Inst_MemImm(TR::InstOpCode::S8MemImm4, node, castClassMR, (int32_t)clazzAddress, cg);
     } else {
         if (!scratchReg)
             scratchReg = cg->allocateRegister();
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
-        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, castClassMR, scratchReg, cg);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
+        Inst_MemReg(TR::InstOpCode::S8MemReg, node, castClassMR, scratchReg, cg);
     }
 }
 
@@ -4860,14 +4835,14 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
 
     static char *breakOnInlineArrayCastClass = feGetEnv("TR_BreakOnInlineArrayCastClass");
     if (breakOnInlineArrayCastClass)
-        generateInstruction(TR::InstOpCode::INT3, node, cg);
+        Inst(TR::InstOpCode::INT3, node, cg);
 
     TR::LabelSymbol *castableDoNotCacheLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *castableAndUpdateCacheLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *notCastableDoNotCacheLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *notCastableUpdateCacheLabel = generateLabelSymbol(cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     // -----------------------------------------------------------------------
     // If the object is NULL, no exception is thrown for a checkcast and a 0
@@ -4878,13 +4853,13 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     // -----------------------------------------------------------------------
 
     if (!objectNode->isNonNull()) {
-        generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, objectReg, objectReg, cg);
+        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, objectReg, objectReg, cg);
 
         // checkcast leaves the operand stack unaffected
         // instanceof returns 0 if the objectRef is null
         //
         TR::LabelSymbol *nullTargetLabel = isCheckCast ? fallThruLabel : notCastableDoNotCacheLabel;
-        generateLabelInstruction(TR::InstOpCode::JE4, node, nullTargetLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, nullTargetLabel, cg);
     }
 
     // -----------------------------------------------------------------------
@@ -4900,14 +4875,14 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     uintptr_t clazzAddress = (uintptr_t)clazz;
 
     if (IS_32BIT_SIGNED(clazzAddress) && !comp->compileRelocatableCode()) {
-        generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
+        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, objectClassReg, (int32_t)clazzAddress, cg);
     } else {
         scratchReg = cg->allocateRegister();
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
-        generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, objectClassReg, scratchReg, cg);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, clazzAddress, cg, TR_ClassPointer);
+        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, objectClassReg, scratchReg, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::JE4, node, castableDoNotCacheLabel, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, castableDoNotCacheLabel, cg);
 
     // ----------------------------------------------------------------------
     // Next, check for a hit in the object's classCastCache
@@ -4916,35 +4891,34 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     if (!scratchReg)
         scratchReg = cg->allocateRegister();
 
-    generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
+    Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
         MRef_Bdisp32(objectClassReg, offsetof(J9Class, castClassCache), cg), cg);
 
     if (use64BitClasses) {
         if (IS_32BIT_SIGNED(clazzAddress) && !comp->compileRelocatableCode()) {
-            generateRegImmInstruction(TR::InstOpCode::XOR8RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
+            Inst_RegImm(TR::InstOpCode::XOR8RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
         } else {
             if (!scratchReg2)
                 scratchReg2 = cg->allocateRegister();
-            generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, scratchReg2, clazzAddress, cg,
-                TR_ClassPointer);
-            generateRegRegInstruction(TR::InstOpCode::XOR8RegReg, node, scratchReg, scratchReg2, cg);
+            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg2, clazzAddress, cg, TR_ClassPointer);
+            Inst_RegReg(TR::InstOpCode::XOR8RegReg, node, scratchReg, scratchReg2, cg);
         }
     } else {
-        generateRegImmInstruction(TR::InstOpCode::XOR4RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
+        Inst_RegImm(TR::InstOpCode::XOR4RegImm4, node, scratchReg, (int32_t)clazzAddress, cg);
     }
 
-    generateRegImmInstruction(TR::InstOpCode::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_MASK, cg);
+    Inst_RegImm(TR::InstOpCode::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_MASK, cg);
 
     TR::LabelSymbol *castClassCacheMissLabel = generateLabelSymbol(cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, castClassCacheMissLabel, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, castClassCacheMissLabel, cg);
 
     // ----------------------------------------------------------------------
     // objectClass was found in the cache. Determine whether it was castable
     // or not and exit appropriately.
     // ----------------------------------------------------------------------
 
-    generateRegImmInstruction(TR::InstOpCode::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_UNCASTABLE, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, castableDoNotCacheLabel, cg);
+    Inst_RegImm(TR::InstOpCode::TEST8RegImm4, node, scratchReg, CAST_CLASS_CACHE_UNCASTABLE, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, castableDoNotCacheLabel, cg);
 
     // ----------------------------------------------------------------------
     // If the cast class leaf component is not a reference array, the result
@@ -4953,32 +4927,31 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     if (fej9->isClassMixed((TR_OpaqueClassBlock *)castClassLeafJ9Class)) {
         // The JMP is required on this path to complete the above cache check
         //
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, notCastableDoNotCacheLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, castClassCacheMissLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, notCastableDoNotCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, castClassCacheMissLabel, cg);
 
         // ----------------------------------------------------------------------
         // Check if objectClass is an array. Not castable if it is not.
         // ----------------------------------------------------------------------
 
-        generateMemImmInstruction(IS_8BIT_SIGNED(J9AccClassRAMArray) ? TR::InstOpCode::TEST1MemImm1
-                                                                     : TR::InstOpCode::TEST4MemImm4,
+        Inst_MemImm(IS_8BIT_SIGNED(J9AccClassRAMArray) ? TR::InstOpCode::TEST1MemImm1 : TR::InstOpCode::TEST4MemImm4,
             node, MRef_Bdisp32(objectClassReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, notCastableUpdateCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, notCastableUpdateCacheLabel, cg);
 
         // ----------------------------------------------------------------------
         // For an array objectClass, if objectClass->arity != castClass->arity
         // then perform cast check in helper
         // ----------------------------------------------------------------------
 
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
             MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, arity), cg), cg);
 
         UDATA arity = static_cast<TR_J9VM *>(fej9)->getArityFromArrayClass((TR_OpaqueClassBlock *)clazz);
-        generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, scratchReg, arity, cg);
+        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, scratchReg, arity, cg);
 
         if (!oolHelperCallTrampolineLabel)
             oolHelperCallTrampolineLabel = generateLabelSymbol(cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, oolHelperCallTrampolineLabel, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, oolHelperCallTrampolineLabel, cg);
 
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
         J9Class *castClassJ9Class = TR::Compiler->cls.convertClassOffsetToClassPtr(clazz);
@@ -4986,14 +4959,14 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             static_assert(J9ClassArrayIsNullRestricted == 0x2000000,
                 "J9ClassArrayIsNullRestricted must be 0x2000000 for simple bit test");
 
-            generateMemImmInstruction(IS_8BIT_SIGNED(J9ClassArrayIsNullRestricted) ? TR::InstOpCode::TEST1MemImm1
-                                                                                   : TR::InstOpCode::TEST4MemImm4,
+            Inst_MemImm(IS_8BIT_SIGNED(J9ClassArrayIsNullRestricted) ? TR::InstOpCode::TEST1MemImm1
+                                                                     : TR::InstOpCode::TEST4MemImm4,
                 node, MRef_Bdisp32(objectClassReg, offsetof(J9Class, classFlags), cg), J9ClassArrayIsNullRestricted,
                 cg);
 
             // Fail, since a nullable array class cannot be cast to a null-restricted class
             //
-            generateLabelInstruction(TR::InstOpCode::JE4, node, notCastableUpdateCacheLabel, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, notCastableUpdateCacheLabel, cg);
         }
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
@@ -5004,7 +4977,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         if (!objectClassLeafReg)
             objectClassLeafReg = cg->allocateRegister();
 
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, objectClassLeafReg,
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, objectClassLeafReg,
             MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, leafComponentType), cg), cg);
 
         // ----------------------------------------------------------------------
@@ -5012,13 +4985,13 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // notCastableUpdateCache
         // ----------------------------------------------------------------------
 
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
             MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-        generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, scratchReg,
+        Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, scratchReg,
             (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
-        generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, scratchReg,
+        Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, scratchReg,
             (OBJECT_HEADER_SHAPE_MIXED << J9AccClassRAMShapeShift), cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, notCastableUpdateCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, notCastableUpdateCacheLabel, cg);
 
         // ----------------------------------------------------------------------
         // If objectClassLeafClass == castClassLeafClass then
@@ -5028,15 +5001,13 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         uintptr_t componentClazzAddress = (uintptr_t)castClassLeafJ9Class;
 
         if (IS_32BIT_SIGNED(componentClazzAddress) && !comp->compileRelocatableCode()) {
-            generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, objectClassLeafReg,
-                (int32_t)componentClazzAddress, cg);
+            Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, objectClassLeafReg, (int32_t)componentClazzAddress, cg);
         } else {
-            generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, scratchReg, componentClazzAddress, cg,
-                TR_ClassPointer);
-            generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, objectClassLeafReg, scratchReg, cg);
+            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg, componentClazzAddress, cg, TR_ClassPointer);
+            Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, objectClassLeafReg, scratchReg, cg);
         }
 
-        generateLabelInstruction(TR::InstOpCode::JE4, node, castableAndUpdateCacheLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, castableAndUpdateCacheLabel, cg);
 
         // ----------------------------------------------------------------------
         // Skip the subclass check if the castClassLeaf is final
@@ -5055,8 +5026,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             static_assert(J9AccClassDepthMask == 0xffff, "J9AccClassDepthMask must be 0xffff");
             TR::MemoryReference *objectClassLeafDepthMR
                 = MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg);
-            generateMemImmInstruction(TR::InstOpCode::CMP2MemImm2, node, objectClassLeafDepthMR, castClassLeafDepth,
-                cg);
+            Inst_MemImm(TR::InstOpCode::CMP2MemImm2, node, objectClassLeafDepthMR, castClassLeafDepth, cg);
 
             if (castClassLeafIsInterface) {
                 // Too complex for inline; perform cast check in helper.
@@ -5064,14 +5034,14 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
                 //
                 if (!oolHelperCallTrampolineLabel)
                     oolHelperCallTrampolineLabel = generateLabelSymbol(cg);
-                generateLabelInstruction(TR::InstOpCode::JBE4, node, oolHelperCallTrampolineLabel, cg);
+                Inst_Label(TR::InstOpCode::JBE4, node, oolHelperCallTrampolineLabel, cg);
             } else {
                 TR_ASSERT_FATAL(!TR::Compiler->cls.isClassArray(comp, castClassLeafClass),
                     "Expected cast class leaf component to be non-array");
-                generateLabelInstruction(TR::InstOpCode::JBE4, node, notCastableUpdateCacheLabel, cg);
+                Inst_Label(TR::InstOpCode::JBE4, node, notCastableUpdateCacheLabel, cg);
             }
 
-            generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
+            Inst_RegMem(TR::InstOpCode::L8RegMem, node, scratchReg,
                 MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, superclasses), cg), cg);
             auto offset = castClassLeafDepth * sizeof(J9Class *);
             TR_ASSERT_FATAL(IS_32BIT_SIGNED(offset), "superclass array offset is unreasonably large");
@@ -5079,28 +5049,26 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             TR::MemoryReference *superclassMR2 = MRef_Bdisp32(scratchReg, offset, cg);
             if (use64BitClasses) {
                 if (IS_32BIT_SIGNED(componentClazzAddress) && !comp->compileRelocatableCode()) {
-                    generateMemImmInstruction(TR::InstOpCode::CMP8MemImm4, node, superclassMR2,
-                        (int32_t)componentClazzAddress, cg);
+                    Inst_MemImm(TR::InstOpCode::CMP8MemImm4, node, superclassMR2, (int32_t)componentClazzAddress, cg);
                 } else {
                     if (!scratchReg3)
                         scratchReg3 = cg->allocateRegister();
 
-                    generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, scratchReg3, componentClazzAddress,
-                        cg, TR_ClassPointer);
-                    generateMemRegInstruction(TR::InstOpCode::CMP8MemReg, node, superclassMR2, scratchReg3, cg);
+                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, scratchReg3, componentClazzAddress, cg,
+                        TR_ClassPointer);
+                    Inst_MemReg(TR::InstOpCode::CMP8MemReg, node, superclassMR2, scratchReg3, cg);
                 }
             } else {
-                generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, node, superclassMR2,
-                    (int32_t)componentClazzAddress, cg);
+                Inst_MemImm(TR::InstOpCode::CMP4MemImm4, node, superclassMR2, (int32_t)componentClazzAddress, cg);
             }
 
-            generateLabelInstruction(TR::InstOpCode::JE4, node, castableAndUpdateCacheLabel, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, castableAndUpdateCacheLabel, cg);
         }
 
         if (castClassLeafIsInterface) {
             if (!oolHelperCallTrampolineLabel)
                 oolHelperCallTrampolineLabel = generateLabelSymbol(cg);
-            generateLabelInstruction(TR::InstOpCode::JMP4, node, oolHelperCallTrampolineLabel, cg);
+            Inst_Label(TR::InstOpCode::JMP4, node, oolHelperCallTrampolineLabel, cg);
         } else {
             TR_ASSERT_FATAL(!TR::Compiler->cls.isClassArray(comp, castClassLeafClass),
                 "Expected cast class leaf component to be non-array");
@@ -5109,17 +5077,17 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // Generated code will fall through to notCastableUpdateCacheLabel
 
     } else {
-        generateLabelInstruction(TR::InstOpCode::label, node, castClassCacheMissLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, castClassCacheMissLabel, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, notCastableUpdateCacheLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, notCastableUpdateCacheLabel, cg);
     generateCastClassCacheUpdate(objectClassReg, clazzAddress | 1, use64BitClasses, scratchReg, node, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, notCastableDoNotCacheLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, notCastableDoNotCacheLabel, cg);
 
     if (!isCheckCast) {
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, resultReg, resultReg, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
     } else {
         // The out-of-line helper will throw the CastClassException
         //
@@ -5143,17 +5111,17 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // have not been fully determined, but until they are fully understood and that OOL
         // design is reworked, use a single branch to reach each unique OOL helper call.
         //
-        generateLabelInstruction(TR::InstOpCode::label, node, oolHelperCallTrampolineLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, outlinedHelperCallLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, oolHelperCallTrampolineLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, outlinedHelperCallLabel, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, castableAndUpdateCacheLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, castableAndUpdateCacheLabel, cg);
     generateCastClassCacheUpdate(objectClassReg, clazzAddress, use64BitClasses, scratchReg, node, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, castableDoNotCacheLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, castableDoNotCacheLabel, cg);
 
     if (!isCheckCast) {
-        generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, resultReg, 1, cg);
+        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, resultReg, 1, cg);
     }
 
     // ----------------------------------------------------------------------
@@ -5208,7 +5176,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
     }
 
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
 
     if (scratchReg)
         cg->stopUsingRegister(scratchReg);
@@ -5280,7 +5248,7 @@ static void generateInlinedCheckCastOrInstanceOfForArrayClass(TR::Node *node, TR
         // Just touch the memory in case this is a NULL pointer and we need to throw
         // the exception after the checkcast. If the checkcast was combined with nullpointer
         // there's nobody after the checkcast to throw the exception.
-        auto instr = generateMemImmInstruction(TR::InstOpCode::TEST1MemImm1, node,
+        auto instr = Inst_MemImm(TR::InstOpCode::TEST1MemImm1, node,
             MRef_Bdisp32(object, TR::Compiler->om.offsetOfObjectVftField(), cg), 0, cg);
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
@@ -5309,24 +5277,23 @@ static void inlineInterfaceLookup(TR::Node *node, TR::CodeGenerator *cg, TR::Lab
     TR::LabelSymbol *iTableLoopLabel = generateLabelSymbol(cg);
 
     if (castClassReg) {
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, castClassReg,
-            reinterpret_cast<uintptr_t>(castClass), cg, TR_ClassAddress);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, castClassReg, reinterpret_cast<uintptr_t>(castClass), cg,
+            TR_ClassAddress);
     }
 
     // Loop through I-Table
-    generateLabelInstruction(TR::InstOpCode::label, node, iTableLoopLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, itableReg, itableReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, iTableLookUpFailLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, iTableLoopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, itableReg, itableReg, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, iTableLookUpFailLabel, cg);
     auto interfaceMR = MRef_Bdisp32(itableReg, offsetof(J9ITable, interfaceClass), cg);
     if (castClassReg) {
-        generateMemRegInstruction(TR::InstOpCode::CMP8MemReg, node, interfaceMR, castClassReg, cg);
+        Inst_MemReg(TR::InstOpCode::CMP8MemReg, node, interfaceMR, castClassReg, cg);
     } else {
-        generateMemImmSymInstruction(TR::InstOpCode::CMP4MemImm4, node, interfaceMR,
-            reinterpret_cast<uintptr_t>(castClass), node->getChild(1)->getSymbolReference(), cg);
+        Inst_MemImmSym(TR::InstOpCode::CMP4MemImm4, node, interfaceMR, reinterpret_cast<uintptr_t>(castClass),
+            node->getChild(1)->getSymbolReference(), cg);
     }
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, itableReg,
-        MRef_Bdisp32(itableReg, offsetof(J9ITable, next), cg), cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
+    Inst_RegMem(TR::InstOpCode::LRegMem(), node, itableReg, MRef_Bdisp32(itableReg, offsetof(J9ITable, next), cg), cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
 
     // If the loop does not iterate then a match was found
 }
@@ -5410,16 +5377,15 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
     TR::LabelSymbol *iTableLookUpPathLabel = generateLabelSymbol(cg);
     TR::LabelSymbol *iTableLookUpFailLabel = generateLabelSymbol(cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, instanceClassReg, node->getChild(0)->getRegister(),
-        cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, instanceClassReg, node->getChild(0)->getRegister(), cg);
+    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
 
     // Null test
     if (!node->getChild(0)->isNonNull() && node->getOpCodeValue() != TR::checkcastAndNULLCHK) {
         // instanceClassReg contains the object at this point, reusing the register as object is no longer used after
         // this point.
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, instanceClassReg, instanceClassReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, endLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, instanceClassReg, instanceClassReg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, endLabel, cg);
     }
 
     // Load J9Class
@@ -5430,23 +5396,22 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
         auto cache = sizeof(J9Class *) == 4 ? cg->create4ByteData(node, (uint32_t)guessClass)
                                             : cg->create8ByteData(node, (uint64_t)guessClass);
         cache->setClassAddress(true);
-        generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, instanceClassReg,
-            MRef_const(cache, cg), cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLookUpPathLabel, cg);
+        Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, instanceClassReg, MRef_const(cache, cg), cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, iTableLookUpPathLabel, cg);
 
         // I-Table lookup out-of-line
         {
             TR_OutlinedInstructionsGenerator og(iTableLookUpPathLabel, node, cg);
 
             // Preserve the instance class before the register is reused
-            generateRegInstruction(TR::InstOpCode::PUSHReg, node, instanceClassReg, cg);
+            Inst_Reg(TR::InstOpCode::PUSHReg, node, instanceClassReg, cg);
 
             // Save VFP
-            auto vfp = generateVFPSaveInstruction(node, cg);
+            auto vfp = Inst_VFPSave(node, cg);
 
             // Obtain I-Table
             // Re-use the instanceClassReg register to perform itable lookup
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, instanceClassReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, instanceClassReg,
                 MRef_Bdisp32(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
 
             inlineInterfaceLookup(node, cg, iTableLookUpFailLabel, castClass, castClassReg, instanceClassReg);
@@ -5463,35 +5428,35 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
              */
             static bool updateCacheSlot = feGetEnv("TR_updateInterfaceCheckCastCacheSlot") != NULL;
             if (updateCacheSlot) {
-                generateMemInstruction(TR::InstOpCode::POPMem, node, MRef_const(cache, cg),
+                Inst_Mem(TR::InstOpCode::POPMem, node, MRef_const(cache, cg),
                     cg); // j9class
             } else {
-                generateRegInstruction(TR::InstOpCode::POPReg, node, instanceClassReg, cg); // j9class
+                Inst_Reg(TR::InstOpCode::POPReg, node, instanceClassReg, cg); // j9class
             }
 
             if (!isCheckCast) {
-                generateInstruction(TR::InstOpCode::STC, node, cg);
+                Inst(TR::InstOpCode::STC, node, cg);
             }
-            generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+            Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
 
             // Not found
-            generateVFPRestoreInstruction(vfp, node, cg);
+            Inst_VFPRestore(vfp, node, cg);
 
-            generateLabelInstruction(TR::InstOpCode::label, node, iTableLookUpFailLabel, cg);
+            Inst_Label(TR::InstOpCode::label, node, iTableLookUpFailLabel, cg);
 
             if (isCheckCast) {
                 if (castClassReg) {
-                    generateRegInstruction(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
+                    Inst_Reg(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
                 } else {
-                    generateImmInstruction(TR::InstOpCode::PUSHImm4, node,
+                    Inst_Imm(TR::InstOpCode::PUSHImm4, node,
                         static_cast<int32_t>(reinterpret_cast<uintptr_t>(castClass)), cg);
                 }
-                auto call = generateHelperCallInstruction(node, TR_throwClassCastException, NULL, cg);
+                auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
                 call->setNeedsGCMap(0xFF00FFFF);
                 call->setAdjustsFramePointerBy(-2 * (int32_t)sizeof(J9Class *));
             } else {
-                generateRegInstruction(TR::InstOpCode::POPReg, node, instanceClassReg, cg);
-                generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+                Inst_Reg(TR::InstOpCode::POPReg, node, instanceClassReg, cg);
+                Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
             }
 
             og.endOutlinedInstructionSequence();
@@ -5499,7 +5464,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
 
         // Succeed
         if (!isCheckCast) {
-            generateInstruction(TR::InstOpCode::STC, node, cg);
+            Inst(TR::InstOpCode::STC, node, cg);
         }
     } else {
         /**
@@ -5514,7 +5479,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
         TR::Register *itableReg = scratchReg ? scratchReg : instanceClassReg;
 
         // Obtain I-Table
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, itableReg,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, itableReg,
             MRef_Bdisp32(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
 
         inlineInterfaceLookup(node, cg, isCheckCast ? iTableLookUpFailLabel : endLabel, castClass, castClassReg,
@@ -5522,22 +5487,22 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
 
         if (!isCheckCast) {
             // Class found in itable
-            generateInstruction(TR::InstOpCode::STC, node, cg);
+            Inst(TR::InstOpCode::STC, node, cg);
 
             // Fall through to endLabel
         } else {
             // CheckCast iTable fail lookup out-of-line
             TR_OutlinedInstructionsGenerator og(iTableLookUpFailLabel, node, cg);
 
-            generateRegInstruction(TR::InstOpCode::PUSHReg, node, instanceClassReg, cg);
+            Inst_Reg(TR::InstOpCode::PUSHReg, node, instanceClassReg, cg);
 
             if (castClassReg) {
-                generateRegInstruction(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
+                Inst_Reg(TR::InstOpCode::PUSHReg, node, castClassReg, cg);
             } else {
-                generateImmInstruction(TR::InstOpCode::PUSHImm4, node,
-                    static_cast<int32_t>(reinterpret_cast<uintptr_t>(castClass)), cg);
+                Inst_Imm(TR::InstOpCode::PUSHImm4, node, static_cast<int32_t>(reinterpret_cast<uintptr_t>(castClass)),
+                    cg);
             }
-            auto call = generateHelperCallInstruction(node, TR_throwClassCastException, NULL, cg);
+            auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
             call->setNeedsGCMap(0xFF00FFFF);
             call->setAdjustsFramePointerBy(-2 * (int32_t)sizeof(J9Class *));
 
@@ -5545,7 +5510,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
         }
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
 
     cg->stopUsingRegister(instanceClassReg);
 
@@ -5599,14 +5564,14 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
     auto successLabel = isCheckCast ? endLabel : generateLabelSymbol(cg);
     auto failLabel = isCheckCast ? generateLabelSymbol(cg) : endLabel;
 
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, j9class, node->getChild(0)->getRegister(), cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, j9class, node->getChild(0)->getRegister(), cg);
+    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
 
     // Null test
     if (!node->getChild(0)->isNonNull() && node->getOpCodeValue() != TR::checkcastAndNULLCHK) {
         // j9class contains the object at this point, reusing the register as object is no longer used after this point.
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, j9class, j9class, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, endLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, j9class, j9class, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, endLabel, cg);
     }
 
     // Load J9Class
@@ -5619,12 +5584,12 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
         // However, LHS for TR_checkAssignable may be abstract or interface as it may be an arbitrary class, and
         // hence equality test is always needed.
         if (use64BitClasses) {
-            generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, j9class, MRef_const(clazzData, cg), cg);
+            Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, j9class, MRef_const(clazzData, cg), cg);
         } else {
-            generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, j9class, (uintptr_t)clazz, cg);
+            Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, j9class, (uintptr_t)clazz, cg);
         }
         if (!fej9->isClassFinal(clazz)) {
-            generateLabelInstruction(TR::InstOpCode::JE4, node, successLabel, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, successLabel, cg);
         }
     }
     // at this point, ZF == 1 indicates success
@@ -5635,58 +5600,58 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
         if (depth >= comp->getOptions()->_minimumSuperclassArraySize) {
             static_assert(J9AccClassDepthMask == 0xffff, "J9AccClassDepthMask must be 0xffff");
             auto depthMR = MRef_Bdisp32(j9class, offsetof(J9Class, classDepthAndFlags), cg);
-            generateMemImmInstruction(TR::InstOpCode::CMP2MemImm2, node, depthMR, depth, cg);
+            Inst_MemImm(TR::InstOpCode::CMP2MemImm2, node, depthMR, depth, cg);
             if (!isCheckCast) {
                 // Need ensure CF is cleared before reaching to fail label
                 auto outlineLabel = generateLabelSymbol(cg);
-                generateLabelInstruction(TR::InstOpCode::JBE4, node, outlineLabel, cg);
+                Inst_Label(TR::InstOpCode::JBE4, node, outlineLabel, cg);
 
                 TR_OutlinedInstructionsGenerator og(outlineLabel, node, cg);
-                generateInstruction(TR::InstOpCode::CLC, node, cg);
-                generateLabelInstruction(TR::InstOpCode::JMP4, node, failLabel, cg);
+                Inst(TR::InstOpCode::CLC, node, cg);
+                Inst_Label(TR::InstOpCode::JMP4, node, failLabel, cg);
                 og.endOutlinedInstructionSequence();
             } else {
-                generateLabelInstruction(TR::InstOpCode::JBE4, node, failLabel, cg);
+                Inst_Label(TR::InstOpCode::JBE4, node, failLabel, cg);
             }
         }
 
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tmp,
-            MRef_Bdisp32(j9class, offsetof(J9Class, superclasses), cg), cg);
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, tmp, MRef_Bdisp32(j9class, offsetof(J9Class, superclasses), cg),
+            cg);
         auto offset = depth * sizeof(J9Class *);
         TR_ASSERT(IS_32BIT_SIGNED(offset), "The offset to superclass is unreasonably large.");
         auto superclass = MRef_Bdisp32(tmp, offset, cg);
         if (use64BitClasses) {
-            generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, tmp, superclass, cg);
-            generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, tmp, MRef_const(clazzData, cg), cg);
+            Inst_RegMem(TR::InstOpCode::L8RegMem, node, tmp, superclass, cg);
+            Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, tmp, MRef_const(clazzData, cg), cg);
         } else {
-            generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, node, superclass, (int32_t)(uintptr_t)clazz, cg);
+            Inst_MemImm(TR::InstOpCode::CMP4MemImm4, node, superclass, (int32_t)(uintptr_t)clazz, cg);
         }
     }
     // at this point, ZF == 1 indicates success
 
     // Branch to success/fail path
     if (!isCheckCast) {
-        generateInstruction(TR::InstOpCode::CLC, node, cg);
+        Inst(TR::InstOpCode::CLC, node, cg);
     }
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, failLabel, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, failLabel, cg);
 
     // Set CF to report success
     if (!isCheckCast) {
-        generateLabelInstruction(TR::InstOpCode::label, node, successLabel, cg);
-        generateInstruction(TR::InstOpCode::STC, node, cg);
+        Inst_Label(TR::InstOpCode::label, node, successLabel, cg);
+        Inst(TR::InstOpCode::STC, node, cg);
     }
 
     // Throw exception for CheckCast
     if (isCheckCast) {
         TR_OutlinedInstructionsGenerator og(failLabel, node, cg);
 
-        generateRegInstruction(TR::InstOpCode::PUSHReg, node, j9class, cg);
+        Inst_Reg(TR::InstOpCode::PUSHReg, node, j9class, cg);
         if (use64BitClasses) {
-            generateMemInstruction(TR::InstOpCode::PUSHMem, node, MRef_const(clazzData, cg), cg);
+            Inst_Mem(TR::InstOpCode::PUSHMem, node, MRef_const(clazzData, cg), cg);
         } else {
-            generateImmInstruction(TR::InstOpCode::PUSHImm4, node, (int32_t)(uintptr_t)clazz, cg);
+            Inst_Imm(TR::InstOpCode::PUSHImm4, node, (int32_t)(uintptr_t)clazz, cg);
         }
-        auto call = generateHelperCallInstruction(node, TR_throwClassCastException, NULL, cg);
+        auto call = Inst_HelperCall(node, TR_throwClassCastException, NULL, cg);
         call->setNeedsGCMap(0xFF00FFFF);
         call->setAdjustsFramePointerBy(-2 * (int32_t)sizeof(J9Class *));
 
@@ -5694,7 +5659,7 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
     }
 
     // Succeed
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
 
     cg->stopUsingRegister(j9class);
     cg->stopUsingRegister(tmp);
@@ -5732,8 +5697,8 @@ TR::Register *J9::X86::TreeEvaluator::checkcastinstanceofEvaluator(TR::Node *nod
         }
         if (!isCheckCast) {
             auto result = cg->allocateRegister();
-            generateRegInstruction(TR::InstOpCode::SETB1Reg, node, result, cg);
-            generateRegRegInstruction(TR::InstOpCode::MOVZXReg4Reg1, node, result, result, cg);
+            Inst_Reg(TR::InstOpCode::SETB1Reg, node, result, cg);
+            Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, result, result, cg);
             node->setRegister(result);
         }
         cg->decReferenceCount(node->getChild(0));
@@ -5779,33 +5744,33 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         outlinedStartLabel->setStartInternalControlFlow();
         outlinedEndLabel->setEndInternalControlFlow();
 
-        // generateLabelInstruction(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg);
-        generatePatchableCodeAlignmentInstruction(TR::X86PatchableCodeAlignmentInstruction::CALLImm4AtomicRegions,
-            generateLabelInstruction(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
+        // Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg);
+        Inst_PatchableCodeAlignment(TR::X86PatchableCodeAlignmentInstruction::CALLImm4AtomicRegions,
+            Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
 
         TR_OutlinedInstructionsGenerator og(gcMapPatchingLabel, node, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, outlinedStartLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, outlinedStartLabel, cg);
         // Load the address that we are going to patch and clean up the stack
         //
-        generateRegInstruction(TR::InstOpCode::POPReg, node, patchableAddrReg, cg);
+        Inst_Reg(TR::InstOpCode::POPReg, node, patchableAddrReg, cg);
 
         // check if there is already an async even pending
         //
-        generateMemImmInstruction(TR::InstOpCode::CMP8MemImm4, node, SOMmr, -1, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, asyncWithoutPatch, cg);
+        Inst_MemImm(TR::InstOpCode::CMP8MemImm4, node, SOMmr, -1, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, asyncWithoutPatch, cg);
 
         // Signal the async event
         //
         static char *d = feGetEnv("TR_GCOnAsyncBREAK");
         if (d)
-            generateInstruction(TR::InstOpCode::INT3, node, cg);
+            Inst(TR::InstOpCode::INT3, node, cg);
 
-        generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
+        Inst_MemImm(TR::InstOpCode::S8MemImm4, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
-        generateRegImmInstruction(TR::InstOpCode::MOV8RegImm4, node, tempReg,
+        Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, tempReg,
             1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(), cg);
-        generateMemRegInstruction(TR::InstOpCode::LOR8MemReg, node,
+        Inst_MemReg(TR::InstOpCode::LOR8MemReg, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg), tempReg, cg);
 
         // Populate the code we are going to patch in
@@ -5821,12 +5786,11 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         // Load the original value
         //
 
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, patchValReg, MRef_Bdisp32(patchableAddrReg, -5, cg),
-            cg);
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
-        generateRegRegInstruction(TR::InstOpCode::OR8RegReg, node, patchValReg, tempReg, cg);
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
-        generateRegRegInstruction(TR::InstOpCode::AND8RegReg, node, patchValReg, tempReg, cg);
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, patchValReg, MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
+        Inst_RegReg(TR::InstOpCode::OR8RegReg, node, patchValReg, tempReg, cg);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
+        Inst_RegReg(TR::InstOpCode::AND8RegReg, node, patchValReg, tempReg, cg);
 
         TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 4, cg);
         deps->addPostCondition(patchableAddrReg, TR::RealRegister::NoReg, cg);
@@ -5835,15 +5799,14 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
         deps->stopAddingConditions();
 
-        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(patchableAddrReg, -5, cg), patchValReg,
-            deps, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, snippetLabel, cg);
+        Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(patchableAddrReg, -5, cg), patchValReg, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, snippetLabel, cg);
 
         cg->stopUsingRegister(patchableAddrReg);
         cg->stopUsingRegister(patchValReg);
         cg->stopUsingRegister(tempReg);
-        generateLabelInstruction(TR::InstOpCode::label, node, outlinedEndLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, outlinedEndLabel, cg);
 
         og.endOutlinedInstructionSequence();
     } else {
@@ -5869,32 +5832,32 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         outlinedStartLabel->setStartInternalControlFlow();
         outlinedEndLabel->setEndInternalControlFlow();
 
-        // generateBoundaryAvoidanceInstruction(TR::X86BoundaryAvoidanceInstruction::CALLImm4AtomicRegions, 8,
-        // 8,generateLabelInstruction(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
+        // Inst_BoundaryAvoidance(TR::X86BoundaryAvoidanceInstruction::CALLImm4AtomicRegions, 8,
+        // 8,Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
         TR::Instruction *callInst
-            = generatePatchableCodeAlignmentInstruction(TR::X86PatchableCodeAlignmentInstruction::CALLImm4AtomicRegions,
-                generateLabelInstruction(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
-        TR::X86VFPSaveInstruction *vfpSaveInst = generateVFPSaveInstruction(callInst->getPrev(), cg);
+            = Inst_PatchableCodeAlignment(TR::X86PatchableCodeAlignmentInstruction::CALLImm4AtomicRegions,
+                Inst_Label(TR::InstOpCode::CALLImm4, node, gcMapPatchingLabel, cg), cg);
+        TR::X86VFPSaveInstruction *vfpSaveInst = Inst_VFPSave(callInst->getPrev(), cg);
 
         TR_OutlinedInstructionsGenerator og(gcMapPatchingLabel, node, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, outlinedStartLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, outlinedStartLabel, cg);
         // Load the address that we are going to patch and clean up the stack
         //
-        generateRegInstruction(TR::InstOpCode::POPReg, node, patchableAddrReg, cg);
+        Inst_Reg(TR::InstOpCode::POPReg, node, patchableAddrReg, cg);
 
         // check if there is already an async even pending
         //
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, node, SOMmr, -1, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, asyncWithoutPatch, cg);
+        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, node, SOMmr, -1, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, asyncWithoutPatch, cg);
 
         // Signal the async event
         //
-        generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+        Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
-        generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, lowPatchValReg,
+        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, lowPatchValReg,
             1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(), cg);
-        generateMemRegInstruction(TR::InstOpCode::LOR4MemReg, node,
+        Inst_MemReg(TR::InstOpCode::LOR4MemReg, node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg), lowPatchValReg, cg);
 
         // Populate the registers we are going to use in the lock cmp xchg
@@ -5902,14 +5865,12 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
 
         static char *d = feGetEnv("TR_GCOnAsyncBREAK");
         if (d)
-            generateInstruction(TR::InstOpCode::INT3, node, cg);
+            Inst(TR::InstOpCode::INT3, node, cg);
 
         // Populate the existing inline code
         //
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lowExistingValReg,
-            MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, highExistingValReg,
-            MRef_Bdisp32(patchableAddrReg, -1, cg), cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, lowExistingValReg, MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, highExistingValReg, MRef_Bdisp32(patchableAddrReg, -1, cg), cg);
 
         // Populate the code we are going to patch in
         // 837d28ff        cmp     dword ptr [ebp+28h],0FFFFFFFFh <--- patching in
@@ -5917,9 +5878,9 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         //*******************
         //                 call imm4                              <---- patching over
         //
-        generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, lowPatchValReg, (uint32_t)0x287d8390, cg);
-        generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, highPatchValReg, highExistingValReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::OR4RegImm4, node, highPatchValReg, (uint32_t)0x000000ff, cg);
+        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, lowPatchValReg, (uint32_t)0x287d8390, cg);
+        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highPatchValReg, highExistingValReg, cg);
+        Inst_RegImm(TR::InstOpCode::OR4RegImm4, node, highPatchValReg, (uint32_t)0x000000ff, cg);
 
         TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 6, cg);
 
@@ -5930,17 +5891,16 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         deps->addPostCondition(highExistingValReg, TR::RealRegister::edx, cg);
         deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
         deps->stopAddingConditions();
-        generateMemInstruction(TR::InstOpCode::LCMPXCHG8BMem, node, MRef_Bdisp32(patchableAddrReg, -5, cg), deps, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
-        generateVFPRestoreInstruction(generateLabelInstruction(TR::InstOpCode::JMP4, node, snippetLabel, cg),
-            vfpSaveInst, cg);
+        Inst_Mem(TR::InstOpCode::LCMPXCHG8BMem, node, MRef_Bdisp32(patchableAddrReg, -5, cg), deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
+        Inst_VFPRestore(Inst_Label(TR::InstOpCode::JMP4, node, snippetLabel, cg), vfpSaveInst, cg);
 
         cg->stopUsingRegister(patchableAddrReg);
         cg->stopUsingRegister(lowPatchValReg);
         cg->stopUsingRegister(highPatchValReg);
         cg->stopUsingRegister(lowExistingValReg);
         cg->stopUsingRegister(highExistingValReg);
-        generateLabelInstruction(TR::InstOpCode::label, node, outlinedEndLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, outlinedEndLabel, cg);
 
         og.endOutlinedInstructionSequence();
     }
@@ -5979,7 +5939,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
 
     TR_OutlinedInstructionsGenerator og(inlineRecursiveSnippetLabel, node, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, outlinedStartLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, outlinedStartLabel, cg);
     TR::Register *lockWordReg = cg->allocateRegister();
     TR::Register *lockWordMaskedReg = cg->allocateRegister();
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
@@ -5988,18 +5948,15 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
         = node->getSymbolReference() == cg->comp()->getSymRefTab()->findOrCreateMethodMonitorEntrySymbolRef(NULL)
         || node->getSymbolReference() == cg->comp()->getSymRefTab()->findOrCreateMonitorEntrySymbolRef(NULL);
 
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(use64bitOp), node, lockWordReg,
-        MRef_Bdisp32(objectReg, lwOffset, cg), cg);
-    generateRegImmInstruction(TR::InstOpCode::ADDRegImm4(use64bitOp), node, lockWordReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(use64bitOp), node, lockWordReg, MRef_Bdisp32(objectReg, lwOffset, cg), cg);
+    Inst_RegImm(TR::InstOpCode::ADDRegImm4(use64bitOp), node, lockWordReg,
         isMonitorEnter ? INC_DEC_VALUE : -INC_DEC_VALUE, cg);
-    generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(use64bitOp), node, lockWordMaskedReg,
-        NON_INC_DEC_MASK - RES_BIT, cg);
-    generateRegRegInstruction(TR::InstOpCode::ANDRegReg(use64bitOp), node, lockWordMaskedReg, lockWordReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(use64bitOp), node, lockWordMaskedReg, vmThreadReg, cg);
+    Inst_RegImm(TR::InstOpCode::MOVRegImm4(use64bitOp), node, lockWordMaskedReg, NON_INC_DEC_MASK - RES_BIT, cg);
+    Inst_RegReg(TR::InstOpCode::ANDRegReg(use64bitOp), node, lockWordMaskedReg, lockWordReg, cg);
+    Inst_RegReg(TR::InstOpCode::CMPRegReg(use64bitOp), node, lockWordMaskedReg, vmThreadReg, cg);
 
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, jitMonitorEnterOrExitSnippetLabel, cg);
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64bitOp), node, MRef_Bdisp32(objectReg, lwOffset, cg),
-        lockWordReg, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, jitMonitorEnterOrExitSnippetLabel, cg);
+    Inst_MemReg(TR::InstOpCode::SMemReg(use64bitOp), node, MRef_Bdisp32(objectReg, lwOffset, cg), lockWordReg, cg);
 
 #if defined(TR_TARGET_64BIT) && (JAVA_SPEC_VERSION >= 19)
     // Adjust J9VMThread ownedMonitorCount for execution paths that do not
@@ -6007,7 +5964,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     // this unconditionally.  There is no need to check for overflow or
     // underflow.
     //
-    generateMemInstruction(isMonitorEnter ? TR::InstOpCode::INC8Mem : TR::InstOpCode::DEC8Mem, node,
+    Inst_Mem(isMonitorEnter ? TR::InstOpCode::INC8Mem : TR::InstOpCode::DEC8Mem, node,
         MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
@@ -6017,9 +5974,9 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     restartDeps->addPostCondition(lockWordMaskedReg, TR::RealRegister::NoReg, cg);
     restartDeps->addPostCondition(lockWordReg, TR::RealRegister::NoReg, cg);
     restartDeps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, snippetRestartLabel, restartDeps, cg);
+    Inst_Label(TR::InstOpCode::label, node, snippetRestartLabel, restartDeps, cg);
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, fallThruLabel, cg);
 
     cg->stopUsingRegister(lockWordReg);
     cg->stopUsingRegister(lockWordMaskedReg);
@@ -6027,7 +5984,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
     deps->addPostCondition(vmThreadReg, TR::RealRegister::ebp, cg);
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, outlinedEndLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, outlinedEndLabel, deps, cg);
 
     og.endOutlinedInstructionSequence();
 }
@@ -6047,8 +6004,8 @@ void J9::X86::TreeEvaluator::generateCheckForValueMonitorEnterOrExit(TR::Node *n
     else
         testOpCode = TR::InstOpCode::TEST4MemImm4;
 
-    generateMemImmInstruction(testOpCode, node, classFlagsMR, classFlag, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+    Inst_MemImm(testOpCode, node, classFlagsMR, classFlag, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
 }
 
 TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::CodeGenerator *cg)
@@ -6117,7 +6074,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
 
     startLabel->setStartInternalControlFlow();
     fallThruLabel->setEndInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
 
@@ -6244,7 +6201,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
 
         TR::InstOpCode::Mnemonic loadOp
             = (TR::Compiler->om.compressObjectReferences()) ? TR::InstOpCode::L4RegMem : TR::InstOpCode::LRegMem();
-        TR::X86RegMemInstruction *instr = generateRegMemInstruction(loadOp, node, objectClassReg, objectClassMR, cg);
+        TR::X86RegMemInstruction *instr = Inst_RegMem(loadOp, node, objectClassReg, objectClassMR, cg);
 
         // This instruction may try to dereference a null memory address
         // add an implicit exception point for it.
@@ -6254,9 +6211,9 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
 
         TR::TreeEvaluator::generateVFTMaskInstruction(node, objectClassReg, cg);
         int32_t offsetOfLockOffset = offsetof(J9Class, lockOffset);
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, objectClassReg,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, objectClassReg,
             MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
-        generateRegImmInstruction(TR::InstOpCode::CMPRegImms(), node, objectClassReg, 0, cg);
+        Inst_RegImm(TR::InstOpCode::CMPRegImms(), node, objectClassReg, 0, cg);
 
         generateCommonLockNurseryCodes(node, cg,
             true, // true for VMmonentEvaluator, false for VMmonexitEvaluator
@@ -6268,48 +6225,46 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
         TR::LabelSymbol *mismatchLabel
             = TR::Options::_aggressiveLockReservation ? snippetLabel : generateLabelSymbol(cg);
 
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, RES_BIT, cg),
-            cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, RES_BIT, cg), cg);
 
         TR::InstOpCode::Mnemonic cmpMemRegOp = (is64Bit && fej9->generateCompressedLockWord())
             ? TR::InstOpCode::CMP4MemReg
             : TR::InstOpCode::CMPMemReg(is64Bit);
-        TR::X86MemRegInstruction *instr = generateMemRegInstruction(cmpMemRegOp, node,
-            getMemoryReference(objectClassReg, objectReg, lwOffset, cg), eaxReal, cg);
+        TR::X86MemRegInstruction *instr
+            = Inst_MemReg(cmpMemRegOp, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), eaxReal, cg);
 
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
 
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, mismatchLabel, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, mismatchLabel, cg);
 
         if (!node->isPrimitiveLockedRegion()) {
             TR::InstOpCode::Mnemonic addMemImmOp = (is64Bit && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::ADD4MemImms
                 : TR::InstOpCode::ADDMemImms();
-            generateMemImmInstruction(addMemImmOp, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg),
-                REC_BIT, cg);
+            Inst_MemImm(addMemImmOp, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), REC_BIT, cg);
         }
 
         if (!TR::Options::_aggressiveLockReservation) {
             // Jump over the non-reservable path
-            generateLabelInstruction(TR::InstOpCode::JMP4, node, inlinedMonEnterFallThruLabel, cg);
+            Inst_Label(TR::InstOpCode::JMP4, node, inlinedMonEnterFallThruLabel, cg);
 
             // It's possible that the lock may be available, but not reservable. In
             // that case we should try the usual cmpxchg for non-reserving enter.
             // Otherwise we'll necessarily call the helper.
-            generateLabelInstruction(TR::InstOpCode::label, node, mismatchLabel, cg);
+            Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg);
 
             TR::InstOpCode::Mnemonic cmpMemImmOp = (is64Bit && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::CMP4MemImms
                 : TR::InstOpCode::CMPMemImms();
 
             auto lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
-            generateMemImmInstruction(cmpMemImmOp, node, lwMR, 0, cg);
-            generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
-            generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_MemImm(cmpMemImmOp, node, lwMR, 0, cg);
+            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
             lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
-            generateMemRegInstruction(op, node, lwMR, vmThreadReg, cg);
-            generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_MemReg(op, node, lwMR, vmThreadReg, cg);
+            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
         }
     } else {
         if (TR::Options::_aggressiveLockReservation) {
@@ -6318,18 +6273,18 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
                     ? TR::InstOpCode::CMP4MemImms
                     : TR::InstOpCode::CMPMemImms();
 
-                TR::X86MemImmInstruction *instr = generateMemImmInstruction(cmpMemImmOp, node,
+                TR::X86MemImmInstruction *instr = Inst_MemImm(cmpMemImmOp, node,
                     getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
 
                 cg->setImplicitExceptionPoint(instr);
                 instr->setNeedsGCMap(0xFF00FFFF);
 
-                generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+                Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
             }
 
-            generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
         } else if (!comp->getOption(TR_ReservingLocks)) {
-            generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
         } else {
             TR::InstOpCode::Mnemonic loadOp = TR::InstOpCode::LRegMem();
             TR::InstOpCode::Mnemonic testOp = TR::InstOpCode::TESTRegImm4();
@@ -6339,20 +6294,20 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
             }
 
             auto lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
-            auto instr = generateRegMemInstruction(loadOp, node, eaxReal, lwMR, cg);
+            auto instr = Inst_RegMem(loadOp, node, eaxReal, lwMR, cg);
             cg->setImplicitExceptionPoint(instr);
             instr->setNeedsGCMap(0xFF00FFFF);
 
-            generateRegImmInstruction(testOp, node, eaxReal, (int32_t)~RES_BIT, cg);
-            generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_RegImm(testOp, node, eaxReal, (int32_t)~RES_BIT, cg);
+            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
         }
 
         if (node->isReadMonitor()) {
             lockedReg = cg->allocateRegister();
             if (is64Bit && fej9->generateCompressedLockWord())
-                generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, lockedReg, lockedReg,
+                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, lockedReg, lockedReg,
                     cg); // After lockedReg is allocated zero it out.
-            generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(), node, lockedReg, INC_DEC_VALUE, cg);
+            Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, lockedReg, INC_DEC_VALUE, cg);
             ++numDeps;
         } else {
             bool conditionallyReserve = false;
@@ -6385,33 +6340,32 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
                 // prevent any future reservation of the same lock.
 
                 bool b64 = is64Bit && !fej9->generateCompressedLockWord();
-                generateRegRegInstruction(TR::InstOpCode::MOVRegReg(b64), node, lockedReg, eaxReal, cg);
-                generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(b64), node, lockedReg, RES_BIT_POSITION, cg);
-                generateRegInstruction(TR::InstOpCode::NEGReg(b64), node, lockedReg, cg);
-                generateRegImmInstruction(TR::InstOpCode::ANDRegImms(b64), node, lockedReg, RES_BIT | INC_DEC_VALUE,
-                    cg);
-                generateRegRegInstruction(TR::InstOpCode::ADDRegReg(b64), node, lockedReg, vmThreadReg, cg);
+                Inst_RegReg(TR::InstOpCode::MOVRegReg(b64), node, lockedReg, eaxReal, cg);
+                Inst_RegImm(TR::InstOpCode::SHRRegImm1(b64), node, lockedReg, RES_BIT_POSITION, cg);
+                Inst_Reg(TR::InstOpCode::NEGReg(b64), node, lockedReg, cg);
+                Inst_RegImm(TR::InstOpCode::ANDRegImms(b64), node, lockedReg, RES_BIT | INC_DEC_VALUE, cg);
+                Inst_RegReg(TR::InstOpCode::ADDRegReg(b64), node, lockedReg, vmThreadReg, cg);
             }
         }
 
         // try to swap into lock word
-        TR::X86MemRegInstruction *instr = generateMemRegInstruction(op, node,
-            getMemoryReference(objectClassReg, objectReg, lwOffset, cg), lockedReg, cg);
+        TR::X86MemRegInstruction *instr
+            = Inst_MemReg(op, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), lockedReg, cg);
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
 
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, inlinedMonEnterFallThruLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, inlinedMonEnterFallThruLabel, cg);
 
 #if defined(TR_TARGET_64BIT) && (JAVA_SPEC_VERSION >= 19)
     // Adjust J9VMThread ownedMonitorCount for execution paths that do not
     // go out of line to acquire the lock.  It is safe and efficient to do
     // this unconditionally.  There is no need to check for overflow..
     //
-    generateMemInstruction(TR::InstOpCode::INC8Mem, node,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
+    Inst_Mem(TR::InstOpCode::INC8Mem, node, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg),
+        cg);
 #endif
 
     // Create dependencies for the registers used.
@@ -6439,7 +6393,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
 
     deps->stopAddingConditions();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
 
     cg->decReferenceCount(objectRef);
     cg->stopUsingRegister(eaxReal);
@@ -6528,7 +6482,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     startLabel->setStartInternalControlFlow();
     TR::LabelSymbol *snippetFallThruLabel = inlineRecursive ? generateLabelSymbol(cg) : fallThruLabel;
     fallThruLabel->setEndInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     TR::Register *eaxReal = NULL;
     TR::Register *unlockedReg = NULL;
@@ -6546,7 +6500,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
             = TR::Compiler->om.compressObjectReferences() ? TR::InstOpCode::L4RegMem : TR::InstOpCode::LRegMem();
         objectClassReg = cg->allocateRegister();
 
-        TR::Instruction *instr = generateRegMemInstruction(op, node, objectClassReg, objectClassMR, cg);
+        TR::Instruction *instr = Inst_RegMem(op, node, objectClassReg, objectClassMR, cg);
 
         // this instruction may try to dereference a null memory address
         // add an implicit exception point for it.
@@ -6555,12 +6509,12 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
 
         TR::TreeEvaluator::generateVFTMaskInstruction(node, objectClassReg, cg);
         int32_t offsetOfLockOffset = offsetof(J9Class, lockOffset);
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, objectClassReg,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, objectClassReg,
             MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
 
         numDeps++;
 
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, objectClassReg, 0, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, objectClassReg, 0, cg);
 
         generateCommonLockNurseryCodes(node, cg,
             false, // true for VMmonentEvaluator, false for VMmonexitEvaluator
@@ -6626,75 +6580,75 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     if (node->isReadMonitor()) {
         unlockedReg = cg->allocateRegister();
         eaxReal = cg->allocateRegister();
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, unlockedReg, unlockedReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(), node, eaxReal, INC_DEC_VALUE, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, unlockedReg, unlockedReg, cg);
+        Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, eaxReal, INC_DEC_VALUE, cg);
 
         TR::InstOpCode::Mnemonic op = cg->comp()->target().isSMP() ? TR::InstOpCode::LCMPXCHGMemReg(gen64BitInstr)
                                                                    : TR::InstOpCode::CMPXCHGMemReg(gen64BitInstr);
-        cg->setImplicitExceptionPoint(generateMemRegInstruction(op, node,
-            getMemoryReference(objectClassReg, objectReg, lwOffset, cg), unlockedReg, cg));
+        cg->setImplicitExceptionPoint(
+            Inst_MemReg(op, node, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), unlockedReg, cg));
         numDeps += 2;
     } else {
         if (reservingLock) {
             if (node->isPrimitiveLockedRegion()) {
-                cg->setImplicitExceptionPoint(generateRegMemInstruction(TR::InstOpCode::LRegMem(gen64BitInstr), node,
-                    tempReg, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), cg));
+                cg->setImplicitExceptionPoint(Inst_RegMem(TR::InstOpCode::LRegMem(gen64BitInstr), node, tempReg,
+                    getMemoryReference(objectClassReg, objectReg, lwOffset, cg), cg));
 
                 // Mask out the thread ID and reservation count
-                generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, tempReg, FLAGS_MASK, cg);
+                Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, tempReg, FLAGS_MASK, cg);
                 // If only the RES flag is set and no other we can continue
-                generateRegImmInstruction(TR::InstOpCode::XORRegImms(), node, tempReg, RES_BIT, cg);
+                Inst_RegImm(TR::InstOpCode::XORRegImms(), node, tempReg, RES_BIT, cg);
             } else {
                 reservingDecrementNeeded = true;
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
+                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
                     MRef_Bdisp32(vmThreadReg, (REC_BIT | RES_BIT), cg), cg);
-                cg->setImplicitExceptionPoint(generateMemRegInstruction(TR::InstOpCode::CMPMemReg(gen64BitInstr), node,
+                cg->setImplicitExceptionPoint(Inst_MemReg(TR::InstOpCode::CMPMemReg(gen64BitInstr), node,
                     getMemoryReference(objectClassReg, objectReg, lwOffset, cg), tempReg, cg));
             }
         } else {
-            cg->setImplicitExceptionPoint(generateRegMemInstruction(TR::InstOpCode::CMPRegMem(gen64BitInstr), node,
-                vmThreadReg, getMemoryReference(objectClassReg, objectReg, lwOffset, cg), cg));
+            cg->setImplicitExceptionPoint(Inst_RegMem(TR::InstOpCode::CMPRegMem(gen64BitInstr), node, vmThreadReg,
+                getMemoryReference(objectClassReg, objectReg, lwOffset, cg), cg));
         }
     }
 
     TR::LabelSymbol *mismatchLabel
         = (reservingLock && !TR::Options::_aggressiveLockReservation) ? generateLabelSymbol(cg) : snippetLabel;
 
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, mismatchLabel, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, mismatchLabel, cg);
 
     if (reservingDecrementNeeded) {
         // Subtract the reservation count
-        generateMemImmInstruction(TR::InstOpCode::SUBMemImms(gen64BitInstr), node,
+        Inst_MemImm(TR::InstOpCode::SUBMemImms(gen64BitInstr), node,
             getMemoryReference(objectClassReg, objectReg, lwOffset, cg), REC_BIT,
             cg); // I'm not sure TR::InstOpCode::SUB4MemImms will work.
     }
 
     if (!node->isReadMonitor() && !reservingLock) {
-        generateMemImmInstruction(TR::InstOpCode::SMemImm4(gen64BitInstr), node,
+        Inst_MemImm(TR::InstOpCode::SMemImm4(gen64BitInstr), node,
             getMemoryReference(objectClassReg, objectReg, lwOffset, cg), 0, cg);
     }
 
     if (reservingLock && !TR::Options::_aggressiveLockReservation) {
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, inlinedMonExitFallThruLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, inlinedMonExitFallThruLabel, cg);
 
         // Avoid the helper for non-recursive exit in case it isn't reserved
-        generateLabelInstruction(TR::InstOpCode::label, node, mismatchLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg);
         auto lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
-        generateMemRegInstruction(TR::InstOpCode::CMPMemReg(gen64BitInstr), node, lwMR, vmThreadReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+        Inst_MemReg(TR::InstOpCode::CMPMemReg(gen64BitInstr), node, lwMR, vmThreadReg, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
         lwMR = getMemoryReference(objectClassReg, objectReg, lwOffset, cg);
-        generateMemImmInstruction(TR::InstOpCode::SMemImm4(gen64BitInstr), node, lwMR, 0, cg);
+        Inst_MemImm(TR::InstOpCode::SMemImm4(gen64BitInstr), node, lwMR, 0, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, inlinedMonExitFallThruLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, inlinedMonExitFallThruLabel, cg);
 
 #if defined(TR_TARGET_64BIT) && (JAVA_SPEC_VERSION >= 19)
     // Adjust J9VMThread ownedMonitorCount for execution paths that do not
     // go out of line to release the lock.  It is safe and efficient to do
     // this unconditionally.  There is no need to check for underflow.
     //
-    generateMemInstruction(TR::InstOpCode::DEC8Mem, node,
-        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
+    Inst_Mem(TR::InstOpCode::DEC8Mem, node, MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg),
+        cg);
 #endif
 
     // Create dependencies for the registers used.
@@ -6722,7 +6676,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
         deps->addPostCondition(objectClassReg, TR::RealRegister::NoReg, cg);
 
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThruLabel, deps, cg);
 
     if (eaxReal)
         cg->stopUsingRegister(eaxReal);
@@ -6804,7 +6758,7 @@ static void insertAllocationPrefetch(TR::Node *node, int32_t numPrefetches, TR::
     TR::CodeGenerator *cg)
 {
     for (int32_t i = 0; i < numPrefetches; i++) {
-        generateMemInstruction(TR::InstOpCode::PREFETCHNTA, node, MRef_Bdisp32(allocationReg, offset, cg), cg);
+        Inst_Mem(TR::InstOpCode::PREFETCHNTA, node, MRef_Bdisp32(allocationReg, offset, cg), cg);
         offset += 64;
     }
 }
@@ -6840,24 +6794,24 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         UDATA sizeClass = fej9->getObjectSizeClass(allocationSizeOrDataOffset);
 
         if (comp->getOption(TR_BreakOnNew))
-            generateInstruction(TR::InstOpCode::INT3, node, cg);
+            Inst(TR::InstOpCode::INT3, node, cg);
 
         // heap allocation, so proceed
         if (sizeReg) {
-            generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
+            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, eaxReal, eaxReal, cg);
 
             // make sure size isn't too big
             // convert max object size to num elements because computing an object size from num elements may overflow
             TR_ASSERT(fej9->getMaxObjectSizeForSizeClass() <= UINT_MAX, "assertion failure");
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, sizeReg,
+            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, sizeReg,
                 (fej9->getMaxObjectSizeForSizeClass() - allocationSizeOrDataOffset) / elementSize, cg);
-            generateLabelInstruction(TR::InstOpCode::JA4, node, failLabel, cg);
+            Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
 
             // Hybrid arraylets need a zero length test if the size is unknown.
             //
             if (!generateArraylets) {
-                generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-                generateLabelInstruction(TR::InstOpCode::JE4, node, failLabel, cg);
+                Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
+                Inst_Label(TR::InstOpCode::JE4, node, failLabel, cg);
             }
 
             // need to round up to sizeof(UDATA) so we can use it to index into size class index array
@@ -6867,28 +6821,28 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 round = sizeof(UDATA) - 1;
 
             // now compute size of object in bytes
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
                 MRef_BISdisp32(eaxReal, sizeReg, TR::MemoryReference::convertMultiplierToStride(elementSize),
                     allocationSizeOrDataOffset + round, cg),
                 cg);
 
             if (elementSize < sizeof(UDATA))
-                generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, segmentReg, -(int32_t)sizeof(UDATA), cg);
+                Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, segmentReg, -(int32_t)sizeof(UDATA), cg);
 
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
             TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, doneLabel, cg);
-            generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
-            generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, doneLabel, cg);
+            Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, segmentReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+            Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
 #endif
 
             // get size class
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_Bdisp32(tempReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_BISdisp32(tempReg, segmentReg, TR::MemoryReference::convertMultiplierToStride(1),
                     fej9->getSizeClassesIndexOffset(), cg),
                 cg);
@@ -6906,7 +6860,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 //   We need a shift instruction to be able to do stride 16
                 //   To avoid two shifts, only do one for stride sizeof(UDATA) and use a multiplier in memory ref for 16
                 //   64-bit, so shift 3 times for sizeof(UDATA) and use multiplier stride 2 in memory references
-                generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(), node, tempReg, 3, cg);
+                Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, tempReg, 3, cg);
                 currentMemRef = MRef_BISdisp32(vmThreadReg, tempReg, TR::MemoryReference::convertMultiplierToStride(2),
                     fej9->thisThreadAllocationCacheCurrentOffset(0), cg);
                 topMemRef = MRef_BISdisp32(vmThreadReg, tempReg, TR::MemoryReference::convertMultiplierToStride(2),
@@ -6934,26 +6888,26 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             // (64-bit)
 
             // get next cell for this size class
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal, currentMemRef, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal, currentMemRef, cg);
 
             // if null, then no cell available, use slow path
-            generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, eaxReal, topMemRef, cg);
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
+            Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, eaxReal, topMemRef, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
 
             // have a valid cell, need to update current cell pointer
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
                 MRef_Bdisp32(segmentReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
             if (cg->comp()->target().is64Bit()) {
                 // tempReg already has already been shifted for sizeof(UDATA)
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
+                Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
                     MRef_BISdisp32(segmentReg, tempReg, TR::MemoryReference::convertMultiplierToStride(1),
                         fej9->getSmallCellSizesOffset(), cg),
                     cg);
             } else {
                 // tempReg needs to be shifted for sizeof(UDATA)
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
+                Inst_RegMem(TR::InstOpCode::LRegMem(), node, segmentReg,
                     MRef_BISdisp32(segmentReg, tempReg, TR::MemoryReference::convertMultiplierToStride(sizeof(UDATA)),
                         fej9->getSmallCellSizesOffset(), cg),
                     cg);
@@ -6961,15 +6915,15 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             // segmentReg now holds cell size
 
             // update current cell by cell size
-            generateMemRegInstruction(TR::InstOpCode::ADDMemReg(), node, currentMemRefBump, segmentReg, cg);
+            Inst_MemReg(TR::InstOpCode::ADDMemReg(), node, currentMemRefBump, segmentReg, cg);
         } else {
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg), cg);
 
-            generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, eaxReal,
+            Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, eaxReal,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheTopOffset(sizeClass), cg), cg);
 
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
 
             // we have an object in eaxReal, now bump the current updatepointer
             TR::InstOpCode::Mnemonic opcode;
@@ -6982,7 +6936,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             } else
                 opcode = TR::InstOpCode::ADDMemImm4();
 
-            generateMemImmInstruction(opcode, node,
+            Inst_MemImm(opcode, node,
                 MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg), cellSize, cg);
         }
 
@@ -7007,8 +6961,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         // minimal because the helper will be called in that case.  It is necessary to insert this load here so that it
         // dominates all control paths through this internal control flow region.
         //
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
-            MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), cg);
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), cg);
 
         bool canSkipOverflowCheck = false;
 
@@ -7017,7 +6970,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         //
         if (generateArraylets && (node->getOpCodeValue() == TR::anewarray || node->getOpCodeValue() == TR::newarray)) {
             if (comp->getOption(TR_DisableTarokInlineArrayletAllocation))
-                generateLabelInstruction(TR::InstOpCode::JMP4, node, failLabel, cg);
+                Inst_Label(TR::InstOpCode::JMP4, node, failLabel, cg);
 
             if (sizeReg) {
                 uint32_t maxContiguousArrayletLeafSizeInBytes
@@ -7027,11 +6980,11 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
                 // Hybrid arraylets need a zero length test if the size is unknown.
                 //
-                generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-                generateLabelInstruction(TR::InstOpCode::JE4, node, failLabel, cg);
+                Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
+                Inst_Label(TR::InstOpCode::JE4, node, failLabel, cg);
 
-                generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, maxArrayletSizeInElements, cg);
-                generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
+                Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, maxArrayletSizeInElements, cg);
+                Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
 
                 // If the max arraylet leaf size is less than the amount of free space available on
                 // the stack, there is no need to check for an overflow scenario.
@@ -7045,7 +6998,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 // Actually, we should never get here because we've already checked
                 // constant lengths for discontiguity...
                 //
-                generateLabelInstruction(TR::InstOpCode::JMP4, node, failLabel, cg);
+                Inst_Label(TR::InstOpCode::JMP4, node, failLabel, cg);
             }
         }
 
@@ -7054,8 +7007,8 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             // The length could be zero.
             //
             if (!generateArraylets) {
-                generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-                generateLabelInstruction(TR::InstOpCode::JE4, node, failLabel, cg);
+                Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
+                Inst_Label(TR::InstOpCode::JE4, node, failLabel, cg);
             }
 
             // The GC will guarantee that at least 'maxObjectSizeGuaranteedNotToOverflow' bytes
@@ -7066,23 +7019,22 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
             if (cg->comp()->target().is64Bit()
                 && !(maxObjectSizeInElements > 0 && maxObjectSizeInElements <= (uintptr_t)INT_MAX)) {
-                generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg, maxObjectSizeInElements, cg);
-                generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, sizeReg, tempReg, cg);
+                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, maxObjectSizeInElements, cg);
+                Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, sizeReg, tempReg, cg);
             } else {
-                generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements,
-                    cg);
+                Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
             }
 
             // Must be an unsigned comparison on sizes.
             //
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
         }
 
 #if !defined(J9VM_GC_THREAD_LOCAL_HEAP)
         // Establish a loop label in case the new heap pointer cannot be committed.
         //
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
 #endif
 
         if (sizeReg) {
@@ -7120,22 +7072,22 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                     "Expecting a minimum indexable object size >= 8 (actual minimum is %d)\n",
                     J9_GC_MINIMUM_OBJECT_SIZE);
 
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
+                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
                     MRef_BISdisp32(eaxReal, sizeReg, TR::MemoryReference::convertMultiplierToStride(elementSize),
                         allocationSizeOrDataOffset + disp32, cg),
                     cg);
 
                 if (round) {
-                    generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, tempReg, -round, cg);
+                    Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg, -round, cg);
                 }
             } else
 #endif
             {
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
-                generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
+                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
 #endif
 
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
+                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
                     MRef_BISdisp32(
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
                         tempReg,
@@ -7147,16 +7099,16 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                     cg);
 
                 if (round) {
-                    generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, tempReg, -round, cg);
+                    Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg, -round, cg);
                 }
 
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
-                generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+                Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
                 TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-                generateLabelInstruction(TR::InstOpCode::JAE4, node, doneLabel, cg);
-                generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
-                generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, cg);
-                generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, tempReg, eaxReal, cg);
+                Inst_Label(TR::InstOpCode::JAE4, node, doneLabel, cg);
+                Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, tempReg, J9_GC_MINIMUM_OBJECT_SIZE, cg);
+                Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
+                Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, tempReg, eaxReal, cg);
 #endif
             }
         } else {
@@ -7165,46 +7117,42 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 & (-TR::Compiler->om.getObjectAlignmentInBytes());
 
             if ((uint32_t)allocationSizeOrDataOffset > cg->getMaxObjectSizeGuaranteedNotToOverflow()) {
-                generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg, eaxReal, cg);
+                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, eaxReal, cg);
                 if (allocationSizeOrDataOffset <= 127)
-                    generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, tempReg, allocationSizeOrDataOffset,
-                        cg);
+                    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, tempReg, allocationSizeOrDataOffset, cg);
                 else if (allocationSizeOrDataOffset == 128)
-                    generateRegImmInstruction(TR::InstOpCode::SUBRegImms(), node, tempReg, (unsigned)-128, cg);
+                    Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, tempReg, (unsigned)-128, cg);
                 else
-                    generateRegImmInstruction(TR::InstOpCode::ADDRegImm4(), node, tempReg, allocationSizeOrDataOffset,
-                        cg);
+                    Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, tempReg, allocationSizeOrDataOffset, cg);
 
                 // Check for overflow
-                generateLabelInstruction(TR::InstOpCode::JB4, node, failLabel, cg);
+                Inst_Label(TR::InstOpCode::JB4, node, failLabel, cg);
             } else {
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
+                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
                     MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg), cg);
             }
         }
 
-        generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg,
-            MRef_Bdisp32(vmThreadReg, heapTop_offset, cg), cg);
+        Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, MRef_Bdisp32(vmThreadReg, heapTop_offset, cg), cg);
 
-        generateLabelInstruction(TR::InstOpCode::JA4, node, failLabel, cg);
+        Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
 
 #if defined(J9VM_GC_THREAD_LOCAL_HEAP)
 
         // Make sure that the arraylet is aligned properly.
         //
         if (generateArraylets && (node->getOpCodeValue() == TR::anewarray || node->getOpCodeValue() == TR::newarray)) {
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg,
                 MRef_Bdisp32(tempReg, TR::Compiler->om.getObjectAlignmentInBytes() - 1, cg), cg);
             if (cg->comp()->target().is64Bit())
-                generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, tempReg,
-                    -TR::Compiler->om.getObjectAlignmentInBytes(), cg);
+                Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, tempReg, -TR::Compiler->om.getObjectAlignmentInBytes(),
+                    cg);
             else
-                generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, tempReg,
-                    -TR::Compiler->om.getObjectAlignmentInBytes(), cg);
+                Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, tempReg, -TR::Compiler->om.getObjectAlignmentInBytes(),
+                    cg);
         }
 
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg),
-            tempReg, cg);
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
 
         if (!isSmallAllocation && cg->enableTLHPrefetching()) {
             TR::LabelSymbol *prefetchSnippetLabel = generateLabelSymbol(cg);
@@ -7228,14 +7176,14 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 useDirectPrefetchCall = true;
             }
 
-            generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, tempReg, eaxReal, cg);
+            Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, tempReg, eaxReal, cg);
 
-            generateMemRegInstruction(TR::InstOpCode::SUB4MemReg, node,
-                MRef_Bdisp32(vmThreadReg, tlhPrefetchFTA_offset, cg), tempReg, cg);
+            Inst_MemReg(TR::InstOpCode::SUB4MemReg, node, MRef_Bdisp32(vmThreadReg, tlhPrefetchFTA_offset, cg), tempReg,
+                cg);
             if (!useDirectPrefetchCall)
-                generateLabelInstruction(TR::InstOpCode::JLE4, node, prefetchSnippetLabel, cg);
+                Inst_Label(TR::InstOpCode::JLE4, node, prefetchSnippetLabel, cg);
             else {
-                generateLabelInstruction(TR::InstOpCode::JG4, node, restartLabel, cg);
+                Inst_Label(TR::InstOpCode::JG4, node, restartLabel, cg);
                 TR::SymbolReference *helperSymRef
                     = cg->getSymRefTab()->findOrCreateRuntimeHelper(TR_X86CodeCachePrefetchHelper);
                 TR::MethodSymbol *helperSymbol = helperSymRef->getSymbol()->castToMethodSymbol();
@@ -7248,17 +7196,17 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 #else
                 helperSymbol->setMethodAddress(fej9->getAllocationPrefetchCodeSnippetAddress(comp));
 #endif
-                generateImmSymInstruction(TR::InstOpCode::CALLImm4, node, (uintptr_t)helperSymbol->getMethodAddress(),
-                    helperSymRef, cg);
+                Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)helperSymbol->getMethodAddress(), helperSymRef,
+                    cg);
             }
 
-            generateLabelInstruction(TR::InstOpCode::label, node, restartLabel, cg);
+            Inst_Label(TR::InstOpCode::label, node, restartLabel, cg);
         }
 
 #else // J9VM_GC_THREAD_LOCAL_HEAP
-        generateMemRegInstruction(TR::InstOpCode::CMPXCHGMemReg(), node,
-            MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, loopLabel, cg);
+        Inst_MemReg(TR::InstOpCode::CMPXCHGMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg,
+            cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, loopLabel, cg);
 #endif // !J9VM_GC_THREAD_LOCAL_HEAP
     }
 }
@@ -7300,21 +7248,20 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
             && !(maxObjectSizeInElements > 0 && maxObjectSizeInElements <= (uintptr_t)INT_MAX)) {
             // nextTLHAllocReg can be used as a scratch register until it is defined below
             //
-            generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, nextTLHAllocReg, maxObjectSizeInElements,
-                cg);
-            generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, sizeReg, nextTLHAllocReg, cg);
+            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, nextTLHAllocReg, maxObjectSizeInElements, cg);
+            Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, sizeReg, nextTLHAllocReg, cg);
         } else {
-            generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
+            Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, (int32_t)maxObjectSizeInElements, cg);
         }
 
         // Must be an unsigned comparison on sizes.
         //
-        generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
+        Inst_Label(TR::InstOpCode::JAE4, node, failLabel, cg);
 
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal,
             MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
-        generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, nextTLHAllocReg, sizeReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, nextTLHAllocReg, sizeReg, cg);
 
         // Artificially adjust the number of elements by 1 if the array is zero length.  This works
         // because either the array is zero length and needs a discontiguous array length field
@@ -7324,13 +7271,13 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
         // contiguous and discontiguous array headers are the same size.
         //
         if (comp->target().is32Bit() || (comp->target().is64Bit() && comp->useCompressedPointers())) {
-            generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, nextTLHAllocReg, 1, cg);
-            generateRegImmInstruction(TR::InstOpCode::ADC4RegImm4, node, nextTLHAllocReg, 0, cg);
+            Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, nextTLHAllocReg, 1, cg);
+            Inst_RegImm(TR::InstOpCode::ADC4RegImm4, node, nextTLHAllocReg, 0, cg);
         }
 
         uint8_t shiftVal = TR::MemoryReference::convertMultiplierToStride(elementSize);
         if (shiftVal > 0) {
-            generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(), node, nextTLHAllocReg, shiftVal, cg);
+            Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, nextTLHAllocReg, shiftVal, cg);
         }
 
         // calculate variable size, rounding up if necessary to a intptr_t multiple boundary
@@ -7342,24 +7289,23 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
             : TR::Compiler->om.getObjectAlignmentInBytes();
         int32_t disp32 = round ? (round - 1) : 0;
 
-        generateRegImmInstruction(TR::InstOpCode::ADDRegImm4(), node, nextTLHAllocReg,
-            allocationSizeOrDataOffset + disp32, cg);
+        Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, nextTLHAllocReg, allocationSizeOrDataOffset + disp32, cg);
 
         if (round) {
-            generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, nextTLHAllocReg, -round, cg);
+            Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, nextTLHAllocReg, -round, cg);
         }
 
         // Copy full object size in bytes to RCX for zero init via REP TR::InstOpCode::STOSQ
         //
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg, nextTLHAllocReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, nextTLHAllocReg, cg);
 
-        generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, nextTLHAllocReg, eaxReal, cg);
+        Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, nextTLHAllocReg, eaxReal, cg);
     } else {
         // ----------
         // FIXED SIZE
         // ----------
 
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, eaxReal,
             MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
         if (comp->getOptLevel() < hot)
@@ -7369,20 +7315,18 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
             & (-TR::Compiler->om.getObjectAlignmentInBytes());
 
         if ((uint32_t)allocationSizeOrDataOffset > cg->getMaxObjectSizeGuaranteedNotToOverflow()) {
-            generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, nextTLHAllocReg, eaxReal, cg);
+            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, nextTLHAllocReg, eaxReal, cg);
             if (allocationSizeOrDataOffset <= 127)
-                generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, nextTLHAllocReg,
-                    allocationSizeOrDataOffset, cg);
+                Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, nextTLHAllocReg, allocationSizeOrDataOffset, cg);
             else if (allocationSizeOrDataOffset == 128)
-                generateRegImmInstruction(TR::InstOpCode::SUBRegImms(), node, nextTLHAllocReg, (unsigned)-128, cg);
+                Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, nextTLHAllocReg, (unsigned)-128, cg);
             else
-                generateRegImmInstruction(TR::InstOpCode::ADDRegImm4(), node, nextTLHAllocReg,
-                    allocationSizeOrDataOffset, cg);
+                Inst_RegImm(TR::InstOpCode::ADDRegImm4(), node, nextTLHAllocReg, allocationSizeOrDataOffset, cg);
 
             // Check for overflow
-            generateLabelInstruction(TR::InstOpCode::JB4, node, failLabel, cg);
+            Inst_Label(TR::InstOpCode::JB4, node, failLabel, cg);
         } else {
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, nextTLHAllocReg,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, nextTLHAllocReg,
                 MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg), cg);
         }
     }
@@ -7391,17 +7335,17 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
     // MERGED PATH
     // -----------
 
-    generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, nextTLHAllocReg,
+    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, nextTLHAllocReg,
         MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
 
-    generateLabelInstruction(TR::InstOpCode::JA4, node, failLabel, cg);
+    Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
 
     if (!isTooSmallToPrefetch && cg->enableTLHPrefetching()) {
         insertAllocationPrefetch(node, 1, nextTLHAllocReg, 0xc0, cg);
     }
 
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), nextTLHAllocReg, cg);
+    Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg),
+        nextTLHAllocReg, cg);
 
     if (!isTooSmallToPrefetch && node->getOpCodeValue() != TR::New && cg->enableTLHPrefetching()) {
         insertAllocationPrefetch(node, 3, nextTLHAllocReg, 0x100, cg);
@@ -7440,23 +7384,23 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
             "Dynamic allocation currently only supports reference arrays");
         TR_ASSERT(classReg, "must have a classReg for dynamic allocation");
         clzReg = tempReg;
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, clzReg,
-            MRef_Bdisp32(classReg, offsetof(J9Class, arrayClass), cg), cg);
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, clzReg, MRef_Bdisp32(classReg, offsetof(J9Class, arrayClass), cg),
+            cg);
     }
     // TODO: should be able to use a TR_ClassPointer relocation without this stuff (along with class validation)
     else if (cg->needClassAndMethodPointerRelocations() && !comp->getOption(TR_UseSymbolValidationManager)) {
         TR::Register *vmThreadReg = cg->getVMThreadRegister();
         if (node->getOpCodeValue() == TR::newarray) {
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_Bdisp32(tempReg,
                     offsetof(J9JavaVM, booleanArrayClass) + (node->getSecondChild()->getInt() - 4) * sizeof(J9Class *),
                     cg),
                 cg);
             // tempReg should contain a 32 bit pointer.
-            generateMemRegInstruction(opSMemReg, node,
-                MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), tempReg, cg);
+            Inst_MemReg(opSMemReg, node, MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg),
+                tempReg, cg);
             clzReg = tempReg;
         } else {
             TR_ASSERT_FATAL((node->getOpCodeValue() == TR::New) && classReg,
@@ -7473,24 +7417,24 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
         TR::Instruction *instr = NULL;
         if (use64BitClasses) {
             if (cg->needClassAndMethodPointerRelocations() && comp->getOption(TR_UseSymbolValidationManager))
-                instr = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg,
-                    ((intptr_t)clazz | orFlagsClass), cg, TR_ClassPointer);
+                instr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, ((intptr_t)clazz | orFlagsClass), cg,
+                    TR_ClassPointer);
             else
-                instr = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg,
-                    ((intptr_t)clazz | orFlagsClass), cg);
-            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node,
+                instr
+                    = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg, ((intptr_t)clazz | orFlagsClass), cg);
+            Inst_MemReg(TR::InstOpCode::S8MemReg, node,
                 MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), tempReg, cg);
         } else {
-            instr = generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
+            instr = Inst_MemImm(TR::InstOpCode::S4MemImm4, node,
                 MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg),
                 (int32_t)((uintptr_t)clazz | orFlagsClass), cg);
         }
     } else {
         if (orFlagsClass != 0)
-            generateRegImmInstruction(use64BitClasses ? TR::InstOpCode::OR8RegImm4 : TR::InstOpCode::OR4RegImm4, node,
-                clzReg, orFlagsClass, cg);
-        generateMemRegInstruction(opSMemReg, node,
-            MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), clzReg, cg);
+            Inst_RegImm(use64BitClasses ? TR::InstOpCode::OR8RegImm4 : TR::InstOpCode::OR4RegImm4, node, clzReg,
+                orFlagsClass, cg);
+        Inst_MemReg(opSMemReg, node, MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), clzReg,
+            cg);
     }
 
     // --------------------------------------------------------------------------------
@@ -7512,8 +7456,8 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
 
 #if defined(J9VM_OPT_NEW_OBJECT_HASH)
         // put orFlags or 0 into header if needed
-        generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-            MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_FLAGS, cg), orFlags, cg);
+        Inst_MemImm(TR::InstOpCode::S4MemImm4, node, MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_FLAGS, cg), orFlags,
+            cg);
 
 #endif /* !J9VM_OPT_NEW_OBJECT_HASH */
     }
@@ -7530,14 +7474,13 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
     // 0 will force the locking to go to the slow locking path.
     if (isDynamicAllocation) {
         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
             MRef_Bdisp32(clzReg, offsetof(J9ArrayClass, lockOffset), cg), cg);
-        generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)-1, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, doneLabel, cg);
-        generateMemImmInstruction(
-            TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
+        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)-1, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
+        Inst_MemImm(TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
             MRef_BIS(objectReg, tempReg, 0, cg), 0, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
     } else {
         bool initReservable = TR::Compiler->cls.classFlagReservableWordInitValue(clazz);
         if (!isZeroInitialized || initReservable) {
@@ -7551,9 +7494,8 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
                 if (initReservable)
                     initialLwValue = OBJECT_HEADER_LOCK_RESERVED;
 
-                generateMemImmInstruction(
-                    TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
-                    MRef_Bdisp32(objectReg, lwOffset, cg), initialLwValue, cg);
+                Inst_MemImm(TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()),
+                    node, MRef_Bdisp32(objectReg, lwOffset, cg), initialLwValue, cg);
             }
         }
     }
@@ -7611,13 +7553,13 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
             TR::InstOpCode::Mnemonic storeOp = (comp->target().is64Bit() && !comp->useCompressedPointers())
                 ? TR::InstOpCode::S8MemReg
                 : TR::InstOpCode::S4MemReg;
-            generateMemRegInstruction(storeOp, node, arraySizeMR, sizeReg, cg);
+            Inst_MemReg(storeOp, node, arraySizeMR, sizeReg, cg);
         } else {
-            generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, arraySizeMR, sizeReg, cg);
+            Inst_MemReg(TR::InstOpCode::S4MemReg, node, arraySizeMR, sizeReg, cg);
         }
         // Take care of zero sized arrays as they are discontiguous and not contiguous
         if (shouldInitZeroSizedArrayHeader) {
-            generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
+            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
         }
     } else {
         // Fixed size
@@ -7630,14 +7572,14 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
                 ? TR::InstOpCode::S8MemImm4
                 : TR::InstOpCode::S4MemImm4;
             instanceSize = node->getFirstChild()->getInt();
-            generateMemImmInstruction(storeOp, node, arraySizeMR, instanceSize, cg);
+            Inst_MemImm(storeOp, node, arraySizeMR, instanceSize, cg);
         } else {
             instanceSize = node->getFirstChild()->getInt();
-            generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, arraySizeMR, instanceSize, cg);
+            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arraySizeMR, instanceSize, cg);
         }
         // Take care of zero sized arrays as they are discontiguous and not contiguous
         if (shouldInitZeroSizedArrayHeader && (instanceSize == 0)) {
-            generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
+            Inst_MemImm(TR::InstOpCode::S4MemImm4, node, arrayDiscontiguousSizeMR, 0, cg);
         }
     }
 
@@ -7647,8 +7589,7 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
         // write arraylet pointer
         TR::InstOpCode::Mnemonic storeOp;
 
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
-            MRef_Bdisp32(objectReg, arrayletDataOffset, cg), cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg, MRef_Bdisp32(objectReg, arrayletDataOffset, cg), cg);
 
         if (comp->useCompressedPointers()) {
             storeOp = TR::InstOpCode::S4MemReg;
@@ -7656,15 +7597,14 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
             // Compress the arraylet pointer.
             //
             if (TR::Compiler->om.compressedReferenceShiftOffset() > 0)
-                generateRegImmInstruction(TR::InstOpCode::SHR8RegImm1, node, tempReg,
+                Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg,
                     TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         } else {
             storeOp = TR::InstOpCode::SMemReg();
         }
 
         TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
-        generateMemRegInstruction(storeOp, node, MRef_Bdisp32(objectReg, fej9->getFirstArrayletPointerOffset(comp), cg),
-            tempReg, cg);
+        Inst_MemReg(storeOp, node, MRef_Bdisp32(objectReg, fej9->getFirstArrayletPointerOffset(comp), cg), tempReg, cg);
     }
 }
 
@@ -7728,18 +7668,16 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
             // When the size is in a register, the numBytesToZeroInitReg contains the
             // rounded object size including the header
             //
-            generateRegImmInstruction(TR::InstOpCode::SUBRegImms(), node, numBytesToZeroInitReg, headerSizeInBytes, cg);
+            Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, numBytesToZeroInitReg, headerSizeInBytes, cg);
         } else {
             // ----------
             // FIXED SIZE
             // ----------
 
             if (comp->target().is64Bit() && !IS_32BIT_SIGNED(objectSizeInBytes)) {
-                generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, numBytesToZeroInitReg,
-                    objectSizeInBytes, cg);
+                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, numBytesToZeroInitReg, objectSizeInBytes, cg);
             } else {
-                generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(), node, numBytesToZeroInitReg, objectSizeInBytes,
-                    cg);
+                Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, numBytesToZeroInitReg, objectSizeInBytes, cg);
             }
         }
 
@@ -7778,27 +7716,26 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
             TR::LabelSymbol *repStosInitLabelSym = generateLabelSymbol(cg);
             TR::LabelSymbol *mergeInitLabelSym = generateLabelSymbol(cg);
 
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImms(), node, numBytesToZeroInitReg,
+            Inst_RegImm(TR::InstOpCode::CMPRegImms(), node, numBytesToZeroInitReg,
                 repStosZeroInitThresholdBytes + repSTOSThresholdAdjustment, cg);
-            generateLabelInstruction(TR::InstOpCode::JG4, node, repStosInitLabelSym, cg);
+            Inst_Label(TR::InstOpCode::JG4, node, repStosInitLabelSym, cg);
 
             // Begin zero initialization after the header, adjusting for header size
             // if necessary
             //
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
                 MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + startingAddressAdjustment, cg), cg);
 
-            generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, zeroInitScratchReg, zeroInitScratchReg, cg);
+            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, zeroInitScratchReg, zeroInitScratchReg, cg);
 
             // Generate mainline zero initialization with stores
             //
             TR::LabelSymbol *zeroInitLoopLabelSym = generateLabelSymbol(cg);
-            generateLabelInstruction(TR::InstOpCode::label, node, zeroInitLoopLabelSym, cg);
-            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(segmentReg, 0, cg),
-                zeroInitScratchReg, cg);
-            generateRegImmInstruction(TR::InstOpCode::ADD8RegImms, node, segmentReg, 8, cg);
-            generateRegImmInstruction(TR::InstOpCode::SUB8RegImms, node, numBytesToZeroInitReg, 8, cg);
-            generateLabelInstruction(TR::InstOpCode::JG4, node, zeroInitLoopLabelSym, cg);
+            Inst_Label(TR::InstOpCode::label, node, zeroInitLoopLabelSym, cg);
+            Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(segmentReg, 0, cg), zeroInitScratchReg, cg);
+            Inst_RegImm(TR::InstOpCode::ADD8RegImms, node, segmentReg, 8, cg);
+            Inst_RegImm(TR::InstOpCode::SUB8RegImms, node, numBytesToZeroInitReg, 8, cg);
+            Inst_Label(TR::InstOpCode::JG4, node, zeroInitLoopLabelSym, cg);
 
             {
                 // Generate out-of-line REP STOS initialization
@@ -7811,17 +7748,14 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
 
                 // Begin zero initialization after the header
                 //
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
+                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
                     MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg), cg);
 
-                generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg,
-                    cg);
-                generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg,
-                    cg);
-                generateInstruction(TR::InstOpCode::REPSTOSB, node, cg);
-                generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg,
-                    cg);
-                generateLabelInstruction(TR::InstOpCode::JMP4, node, mergeInitLabelSym, cg);
+                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg, cg);
+                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg, cg);
+                Inst(TR::InstOpCode::REPSTOSB, node, cg);
+                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg, cg);
+                Inst_Label(TR::InstOpCode::JMP4, node, mergeInitLabelSym, cg);
                 og.endOutlinedInstructionSequence();
             }
 
@@ -7829,28 +7763,26 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
 
             // Merge
             //
-            generateLabelInstruction(TR::InstOpCode::label, node, mergeInitLabelSym, cg);
+            Inst_Label(TR::InstOpCode::label, node, mergeInitLabelSym, cg);
         } else {
 #endif
             // Begin zero initialization after the header
             //
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg,
                 MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg), cg);
 
             if (comp->target().is64Bit()) {
-                generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg,
-                    cg);
+                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg, cg);
             } else {
-                generateRegInstruction(TR::InstOpCode::PUSHReg, node, newObjectAddressReg, cg);
+                Inst_Reg(TR::InstOpCode::PUSHReg, node, newObjectAddressReg, cg);
             }
-            generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg, cg);
-            generateInstruction(TR::InstOpCode::REPSTOSB, node, cg);
+            Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, newObjectAddressReg, newObjectAddressReg, cg);
+            Inst(TR::InstOpCode::REPSTOSB, node, cg);
             if (comp->target().is64Bit()) {
-                generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg,
-                    cg);
+                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, newObjectAddressReg, zeroInitScratchReg, cg);
                 srm->reclaimScratchRegister(zeroInitScratchReg);
             } else {
-                generateRegInstruction(TR::InstOpCode::POPReg, node, newObjectAddressReg, cg);
+                Inst_Reg(TR::InstOpCode::POPReg, node, newObjectAddressReg, cg);
             }
 #ifdef TR_TARGET_64BIT
         }
@@ -7865,10 +7797,10 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
         }
 
         TR::Register *scratchReg = srm->findOrCreateScratchRegister(TR_FPR);
-        generateRegRegInstruction(TR::InstOpCode::PXORRegReg, node, scratchReg, scratchReg, cg);
+        Inst_RegReg(TR::InstOpCode::PXORRegReg, node, scratchReg, scratchReg, cg);
         int32_t offset = 0;
         while (objectSizeInBytes >= 16) {
-            generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
+            Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
                 MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
             objectSizeInBytes -= 16;
             offset += 16;
@@ -7876,11 +7808,11 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
 
         switch (objectSizeInBytes) {
             case 8:
-                generateMemRegInstruction(TR::InstOpCode::MOVQMemReg, node,
+                Inst_MemReg(TR::InstOpCode::MOVQMemReg, node,
                     MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
                 break;
             case 4:
-                generateMemRegInstruction(TR::InstOpCode::MOVDMemReg, node,
+                Inst_MemReg(TR::InstOpCode::MOVDMemReg, node,
                     MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
                 break;
             case 0:
@@ -7999,8 +7931,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         //
         // startOffset will be monitorSlot only for arrays
 
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
-            MRef_Bdisp32(targetReg, startOfZeroInits, cg), cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, segmentReg, MRef_Bdisp32(targetReg, startOfZeroInits, cg), cg);
 
         if (sizeReg) {
             int32_t additionalSlots = 0;
@@ -8017,42 +7948,42 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
                 //
                 case 1:
                     if (comp->target().is64Bit()) {
-                        generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
                             MRef_Bdisp32(sizeReg, (additionalSlots * 8) + 7, cg), cg);
-                        generateRegImmInstruction(TR::InstOpCode::SHR8RegImm1, node, tempReg, 3, cg);
+                        Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg, 3, cg);
                     } else {
-                        generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
                             MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg), cg);
-                        generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, tempReg, 2, cg);
+                        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, tempReg, 2, cg);
                     }
                     break;
                 case 2:
                     if (comp->target().is64Bit()) {
-                        generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
                             MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg), cg);
-                        generateRegImmInstruction(TR::InstOpCode::SHR8RegImm1, node, tempReg, 2, cg);
+                        Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg, 2, cg);
                     } else {
-                        generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
                             MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg), cg);
-                        generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, tempReg, 1, cg);
+                        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, tempReg, 1, cg);
                     }
                     break;
                 case 4:
                     if (comp->target().is64Bit()) {
-                        generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
                             MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg), cg);
-                        generateRegImmInstruction(TR::InstOpCode::SHR8RegImm1, node, tempReg, 1, cg);
+                        Inst_RegImm(TR::InstOpCode::SHR8RegImm1, node, tempReg, 1, cg);
                     } else {
-                        generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
                             MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
                     }
                     break;
                 case 8:
                     if (comp->target().is64Bit()) {
-                        generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, tempReg,
                             MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
                     } else {
-                        generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
+                        Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, tempReg,
                             MRef_BISdisp32(NULL, sizeReg, TR::MemoryReference::convertMultiplierToStride(2),
                                 additionalSlots, cg),
                             cg);
@@ -8062,23 +7993,23 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         } else {
             // Fixed size
             //
-            generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(), node, tempReg, numSlots + alignmentDelta, cg);
+            Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, tempReg, numSlots + alignmentDelta, cg);
             if (comp->target().is64Bit()) {
                 // TODO AMD64: replace both instructions with a LEA tempReg, [disp32]
                 //
-                generateRegRegInstruction(TR::InstOpCode::MOVSXReg8Reg4, node, tempReg, tempReg, cg);
+                Inst_RegReg(TR::InstOpCode::MOVSXReg8Reg4, node, tempReg, tempReg, cg);
             }
         }
 
         TR::Register *scratchReg = NULL;
         if (comp->target().is64Bit()) {
             scratchReg = srm->findOrCreateScratchRegister();
-            generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, scratchReg, targetReg, cg);
+            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, scratchReg, targetReg, cg);
         } else {
-            generateRegInstruction(TR::InstOpCode::PUSHReg, node, targetReg, cg);
+            Inst_Reg(TR::InstOpCode::PUSHReg, node, targetReg, cg);
         }
 
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, targetReg, targetReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, targetReg, targetReg, cg);
 
         // We just pushed targetReg on the stack and zeroed it out. targetReg contained the address of the
         // beginning of the header. We want to use the 0-reg to initialize the monitor slot, so we use
@@ -8092,25 +8023,24 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::S4MemReg
                 : TR::InstOpCode::SMemReg();
-            generateMemRegInstruction(op, node, MRef_Bdisp32(segmentReg, lwOffset - startOfZeroInits, cg), targetReg,
-                cg);
+            Inst_MemReg(op, node, MRef_Bdisp32(segmentReg, lwOffset - startOfZeroInits, cg), targetReg, cg);
         }
 
         TR::InstOpCode::Mnemonic op = comp->target().is64Bit() ? TR::InstOpCode::REPSTOSQ : TR::InstOpCode::REPSTOSD;
-        generateInstruction(op, node, cg);
+        Inst(op, node, cg);
 
         if (comp->target().is64Bit()) {
-            generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, targetReg, scratchReg, cg);
+            Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg, scratchReg, cg);
             srm->reclaimScratchRegister(scratchReg);
         } else {
-            generateRegInstruction(TR::InstOpCode::POPReg, node, targetReg, cg);
+            Inst_Reg(TR::InstOpCode::POPReg, node, targetReg, cg);
         }
 
         return true;
     }
 
     if (numSlots > 0) {
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
 
         bool initLw = (node->getOpCodeValue() != TR::New);
         int lwOffset = fej9->getByteOffsetToLockword(clazz);
@@ -8120,7 +8050,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::S4MemReg
                 : TR::InstOpCode::SMemReg();
-            generateMemRegInstruction(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), tempReg, cg);
+            Inst_MemReg(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), tempReg, cg);
         }
     } else {
         bool initLw = (node->getOpCodeValue() != TR::New);
@@ -8131,7 +8061,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::S4MemImm4
                 : TR::InstOpCode::SMemImm4();
-            generateMemImmInstruction(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), 0, cg);
+            Inst_MemImm(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), 0, cg);
         }
         return false;
     }
@@ -8145,28 +8075,28 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
 
         endOffset = (int32_t)(numLoopSlots * TR::Compiler->om.sizeofReferenceAddress() + startOfZeroInits);
 
-        generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(), node, segmentReg,
+        Inst_RegImm(TR::InstOpCode::MOVRegImm4(), node, segmentReg,
             -((numIterations - 1) * maxZeroInitWordsPerIteration), cg);
 
         if (comp->target().is64Bit())
-            generateRegRegInstruction(TR::InstOpCode::MOVSXReg8Reg4, node, segmentReg, segmentReg, cg);
+            Inst_RegReg(TR::InstOpCode::MOVSXReg8Reg4, node, segmentReg, segmentReg, cg);
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
         for (i = maxZeroInitWordsPerIteration; i > 0; i--) {
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                 MRef_BISdisp32(targetReg, segmentReg,
                     TR::MemoryReference::convertMultiplierToStride((int32_t)TR::Compiler->om.sizeofReferenceAddress()),
                     endOffset - TR::Compiler->om.sizeofReferenceAddress() * i, cg),
                 tempReg, cg);
         }
-        generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, segmentReg, maxZeroInitWordsPerIteration, cg);
-        generateLabelInstruction(TR::InstOpCode::JLE4, node, loopLabel, cg);
+        Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, segmentReg, maxZeroInitWordsPerIteration, cg);
+        Inst_Label(TR::InstOpCode::JLE4, node, loopLabel, cg);
 
         // Generate the left-over initializations
         //
         for (i = 0; i < numSlots % maxZeroInitWordsPerIteration; i++) {
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                 MRef_Bdisp32(targetReg, endOffset + TR::Compiler->om.sizeofReferenceAddress() * i, cg), tempReg, cg);
         }
     } else {
@@ -8175,7 +8105,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         for (i = 0; i < numSlots; i++) {
             // Don't bother initializing the array-size slot
             //
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                 MRef_Bdisp32(targetReg, i * TR::Compiler->om.sizeofReferenceAddress() + startOfZeroInits, cg), tempReg,
                 cg);
         }
@@ -8227,36 +8157,36 @@ static void handleOffHeapDataForArrays(TR::Node *node, TR::Register *sizeReg, TR
             fej9->getOffsetOfDiscontiguousDataAddrField(), fej9->getOffsetOfContiguousDataAddrField());
 
         TR::Register *discontiguousDataAddrOffsetReg = srm->findOrCreateScratchRegister();
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, discontiguousDataAddrOffsetReg,
-            discontiguousDataAddrOffsetReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, discontiguousDataAddrOffsetReg, discontiguousDataAddrOffsetReg,
+            cg);
         // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of sizeReg.
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, 1, cg);
-        generateRegImmInstruction(TR::InstOpCode::ADCRegImm4(), node, discontiguousDataAddrOffsetReg, 0, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, sizeReg, 1, cg);
+        Inst_RegImm(TR::InstOpCode::ADCRegImm4(), node, discontiguousDataAddrOffsetReg, 0, cg);
 
         dataAddrMR = MRef_BISdisp32(targetReg, discontiguousDataAddrOffsetReg, 3,
             TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
         dataAddrSlotMR = MRef_BISdisp32(targetReg, discontiguousDataAddrOffsetReg, 3,
             fej9->getOffsetOfContiguousDataAddrField(), cg);
         // Load first data element address
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
 
         // Clear out tempReg if dealing with 0 length array
         zeroReg = srm->findOrCreateScratchRegister();
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, zeroReg, zeroReg, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, zeroReg, zeroReg, cg);
         // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of sizeReg.
-        generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
+        Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
+        Inst_RegReg(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
         srm->reclaimScratchRegister(zeroReg);
 
         // Write first data element address to dataAddr slot
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
         srm->reclaimScratchRegister(discontiguousDataAddrOffsetReg);
     } else if (NULL == sizeReg && node->getFirstChild()->getOpCode().isLoadConst()
         && node->getFirstChild()->getInt() == 0) {
         logprintf(trace, log, "Node (%p): Dealing with full/compressed refs fixed length zero size array.\n", node);
 
         dataAddrSlotMR = MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg);
-        generateMemImmInstruction(TR::InstOpCode::SMemImm4(), node, dataAddrSlotMR, 0, cg);
+        Inst_MemImm(TR::InstOpCode::SMemImm4(), node, dataAddrSlotMR, 0, cg);
     } else {
         logprintf(trace, log,
             "Node (%p): Dealing with either full/compressed refs fixed length non-zero size array or full refs "
@@ -8275,19 +8205,19 @@ static void handleOffHeapDataForArrays(TR::Node *node, TR::Register *sizeReg, TR
         dataAddrMR = MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
         dataAddrSlotMR = MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg);
         // Load first data element address
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
 
         if (!TR::Compiler->om.compressObjectReferences() && NULL != sizeReg) {
             // Clear out tempReg if dealing with 0 length array
             zeroReg = srm->findOrCreateScratchRegister();
-            generateRegRegInstruction(TR::InstOpCode::XORRegReg(), node, zeroReg, zeroReg, cg);
+            Inst_RegReg(TR::InstOpCode::XORRegReg(), node, zeroReg, zeroReg, cg);
             // Since array size is capped at 32 bits, we only need to check lower half (0-31 bits) of sizeReg.
-            generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
-            generateRegRegInstruction(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
+            Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, sizeReg, sizeReg, cg);
+            Inst_RegReg(TR::InstOpCode::CMOVERegReg(), node, tempReg, zeroReg, cg);
             srm->reclaimScratchRegister(zeroReg);
         }
         // Write first data element address to dataAddr slot
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node, dataAddrSlotMR, tempReg, cg);
     }
 }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
@@ -8524,7 +8454,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     // Generate the helper call for out-of-line allocation
     //
@@ -8595,9 +8525,9 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
             TR_BitVectorIterator bvi(*initInfo->zeroInitSlots);
             static bool UseOldBVI = feGetEnv("TR_UseOldBVI");
             if (UseOldBVI) {
-                generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
+                Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
                 while (bvi.hasMoreElements()) {
-                    generateMemRegInstruction(TR::InstOpCode::S4MemReg, node,
+                    Inst_MemReg(TR::InstOpCode::S4MemReg, node,
                         MRef_Bdisp32(targetReg, bvi.getNextElement() * 4 + dataOffset, cg), tempReg, cg);
                 }
             } else {
@@ -8606,7 +8536,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 int32_t span = 0;
                 int32_t lastSpan = -1;
                 scratchReg = srm->findOrCreateScratchRegister(TR_FPR);
-                generateRegRegInstruction(TR::InstOpCode::PXORRegReg, node, scratchReg, scratchReg, cg);
+                Inst_RegReg(TR::InstOpCode::PXORRegReg, node, scratchReg, scratchReg, cg);
                 while (bvi.hasMoreElements()) {
                     nextE = bvi.getNextElement();
                     if (-1 == lastElementIndex)
@@ -8617,7 +8547,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                         lastSpan = span;
                         continue;
                     } else if (span == 3) {
-                        generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
+                        Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
                             MRef_Bdisp32(targetReg, lastElementIndex * 4 + dataOffset, cg), scratchReg, cg);
                         lastSpan = -1;
                         lastElementIndex = -1;
@@ -8631,8 +8561,8 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                             storeOpCode = TR::InstOpCode::MOVDQUMemReg;
                         }
 
-                        generateMemRegInstruction(storeOpCode, node,
-                            MRef_Bdisp32(targetReg, lastElementIndex * 4 + dataOffset, cg), scratchReg, cg);
+                        Inst_MemReg(storeOpCode, node, MRef_Bdisp32(targetReg, lastElementIndex * 4 + dataOffset, cg),
+                            scratchReg, cg);
 
                         lastElementIndex = nextE;
                         lastSpan = 0;
@@ -8659,7 +8589,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 }
 
                 if (storeOpCode != TR::InstOpCode::bad) {
-                    generateMemRegInstruction(storeOpCode, node,
+                    Inst_MemReg(storeOpCode, node,
                         MRef_Bdisp32(targetReg, lastElementIndex * 4 + adjustedDataOffset, cg), scratchReg, cg);
                 }
 
@@ -8695,7 +8625,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 // via the contiguous length slot.
                 //
                 if (node->getOpCodeValue() != TR::New && (comp->target().is32Bit() || comp->useCompressedPointers())) {
-                    generateMemImmInstruction(TR::InstOpCode::SMemImm4(), node,
+                    Inst_MemImm(TR::InstOpCode::SMemImm4(), node,
                         MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
                     shouldInitZeroSizedArrayHeader = false;
                 }
@@ -8809,7 +8739,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
 
     deps->stopAddingConditions();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThru, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThru, deps, cg);
 
     // Copy the newly allocated object into a collected reference register
     // now that it is a valid object.
@@ -8817,7 +8747,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
     TR::Register *targetReg2 = cg->allocateCollectedReferenceRegister();
     TR::RegisterDependencyConditions *deps2 = generateRegisterDependencyConditions(0, 1, cg);
     deps2->addPostCondition(targetReg2, TR::RealRegister::eax, cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, targetReg2, targetReg, deps2, cg);
     cg->stopUsingRegister(targetReg);
     targetReg = targetReg2;
 
@@ -8863,7 +8793,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR::MemoryReference *destTypeMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
 
-            generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, destComponentClassReg, destTypeMR,
+            Inst_RegMem(TR::InstOpCode::L4RegMem, node, destComponentClassReg, destTypeMR,
                 cg); // class pointer is 32 bits
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
 
@@ -8877,10 +8807,10 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR_ASSERT((((uintptr_t)objectClass) >> 32) == 0,
                 "TR_OpaqueClassBlock must fit on 32 bits when using class pointer compression");
-            instr = generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
+            instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
                 (uint32_t)((uint64_t)objectClass), cg);
 
-            generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
 
             // here we may have to convert the TR_OpaqueClassBlock into a J9Class pointer
             // and store it in destComponentClassReg
@@ -8888,7 +8818,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR::MemoryReference *destCompTypeMR
                 = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
 
             // here we may have to convert the J9Class pointer from destComponentClassReg into
             // a TR_OpaqueClassBlock and store it back into destComponentClassReg
@@ -8896,35 +8826,35 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             TR::MemoryReference *sourceRegClassMR
                 = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, sourceClassReg, sourceRegClassMR, cg);
+            Inst_RegMem(TR::InstOpCode::L4RegMem, node, sourceClassReg, sourceRegClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
 
-            generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, destComponentClassReg, sourceClassReg,
+            Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, destComponentClassReg, sourceClassReg,
                 cg); // compare only 32 bits
-            generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
 
             // -------------------------------------------------------------------------
             //          // Check the source class cast cache
             //
             // -------------------------------------------------------------------------
 
-            generateMemRegInstruction(TR::InstOpCode::CMP4MemReg, node,
+            Inst_MemReg(TR::InstOpCode::CMP4MemReg, node,
                 MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg), destComponentClassReg, cg);
         } else // no class pointer compression
         {
             TR::MemoryReference *sourceClassMR = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
 
             TR::MemoryReference *destClassMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
             TR::MemoryReference *destCompTypeMR
                 = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
 
-            generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, destComponentClassReg, sourceClassReg, cg);
-            generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, destComponentClassReg, sourceClassReg, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
 
             // -------------------------------------------------------------------------
             //
@@ -8932,10 +8862,10 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             //
             // -------------------------------------------------------------------------
 
-            generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), node,
+            Inst_MemReg(TR::InstOpCode::CMPMemReg(), node,
                 MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg), destComponentClassReg, cg);
         }
-        generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
 
         instr = NULL;
         /*
@@ -8955,32 +8885,32 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
               if (TR::Compiler->om.compressObjectReferences())
                  {
                  TR_ASSERT((((uintptr_t)objectClass) >> 32) == 0, "TR_OpaqueClassBlock must fit on 32 bits when using
-        class pointer compression"); instr = generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node,
+        class pointer compression"); instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node,
         destComponentClassReg, (uint32_t) ((uint64_t) objectClass), cg);
                  }
               else // 64 bit but no class pointer compression
                  {
                  if ((uintptr_t)objectClass <= (uintptr_t)0x7fffffff)
                     {
-                    instr = generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, destComponentClassReg,
+                    instr = Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, destComponentClassReg,
         (uintptr_t) objectClass, cg);
                     }
                  else
                     {
                     TR::Register *objectClassReg = scratchRegisterManager->findOrCreateScratchRegister();
-                    instr = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, objectClassReg, (uintptr_t)
-        objectClass, cg); generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, destComponentClassReg,
+                    instr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, objectClassReg, (uintptr_t)
+        objectClass, cg); Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, destComponentClassReg,
         objectClassReg, cg); scratchRegisterManager->reclaimScratchRegister(objectClassReg);
                     }
                  }
            }
         else
            {
-           instr = generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
+           instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
         (int32_t)(uintptr_t) objectClass, cg);
            }
 
-        generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
         */
 
         // ---------------------------------------------
@@ -8996,7 +8926,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
                 if (TR::Compiler->om.compressObjectReferences()) {
                     TR_ASSERT((((uintptr_t)arrayComponentClass) >> 32) == 0,
                         "TR_OpaqueClassBlock must fit on 32 bits when using class pointer compression");
-                    instr = generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
+                    instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
                         (uint32_t)((uint64_t)arrayComponentClass), cg);
 
                     if (fej9->isUnloadAssumptionRequired(arrayComponentClass, comp->getCurrentMethod()))
@@ -9005,28 +8935,28 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
                 } else // 64 bit but no class pointer compression
                 {
                     if ((uintptr_t)arrayComponentClass <= (uintptr_t)0x7fffffff) {
-                        instr = generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, destComponentClassReg,
+                        instr = Inst_RegImm(TR::InstOpCode::CMP8RegImm4, node, destComponentClassReg,
                             (uintptr_t)arrayComponentClass, cg);
                         if (fej9->isUnloadAssumptionRequired(arrayComponentClass, comp->getCurrentMethod()))
                             comp->getStaticPICSites()->push_front(instr);
 
                     } else {
                         TR::Register *arrayComponentClassReg = scratchRegisterManager->findOrCreateScratchRegister();
-                        instr = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, arrayComponentClassReg,
+                        instr = Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, arrayComponentClassReg,
                             (uintptr_t)arrayComponentClass, cg);
-                        generateRegRegInstruction(TR::InstOpCode::CMP8RegReg, node, destComponentClassReg,
-                            arrayComponentClassReg, cg);
+                        Inst_RegReg(TR::InstOpCode::CMP8RegReg, node, destComponentClassReg, arrayComponentClassReg,
+                            cg);
                         scratchRegisterManager->reclaimScratchRegister(arrayComponentClassReg);
                     }
                 }
             } else {
-                instr = generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
+                instr = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, destComponentClassReg,
                     (int32_t)(uintptr_t)arrayComponentClass, cg);
                 if (fej9->isUnloadAssumptionRequired(arrayComponentClass, comp->getCurrentMethod()))
                     comp->getStaticPICSites()->push_front(instr);
             }
 
-            generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
         }
 
         // For compressed references:
@@ -9054,25 +8984,22 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
         if (eliminateDepthMask) {
             if (comp->target().is64Bit())
-                generateRegMemInstruction(TR::InstOpCode::MOVZXReg8Mem2, node, destComponentClassDepthReg,
-                    destComponentClassDepthMR, cg);
+                Inst_RegMem(TR::InstOpCode::MOVZXReg8Mem2, node, destComponentClassDepthReg, destComponentClassDepthMR,
+                    cg);
             else
-                generateRegMemInstruction(TR::InstOpCode::MOVZXReg4Mem2, node, destComponentClassDepthReg,
-                    destComponentClassDepthMR, cg);
+                Inst_RegMem(TR::InstOpCode::MOVZXReg4Mem2, node, destComponentClassDepthReg, destComponentClassDepthMR,
+                    cg);
         } else {
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassDepthReg,
-                destComponentClassDepthMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassDepthReg, destComponentClassDepthMR, cg);
         }
 
         if (!eliminateDepthMask) {
             if (comp->target().is64Bit()) {
                 TR_ASSERT(!(J9AccClassDepthMask & 0x80000000), "AMD64: need to use a second register for AND mask");
                 if (!(J9AccClassDepthMask & 0x80000000))
-                    generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, destComponentClassDepthReg,
-                        J9AccClassDepthMask, cg);
+                    Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, destComponentClassDepthReg, J9AccClassDepthMask, cg);
             } else {
-                generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, destComponentClassDepthReg,
-                    J9AccClassDepthMask, cg);
+                Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, destComponentClassDepthReg, J9AccClassDepthMask, cg);
             }
         }
 
@@ -9095,26 +9022,23 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
         TR::Register *sourceClassDepthReg = NULL;
         if (eliminateDepthMask) {
-            generateMemRegInstruction(TR::InstOpCode::CMP2MemReg, node, mr, destComponentClassDepthReg, cg);
+            Inst_MemReg(TR::InstOpCode::CMP2MemReg, node, mr, destComponentClassDepthReg, cg);
         } else {
             sourceClassDepthReg = scratchRegisterManager->findOrCreateScratchRegister();
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceClassDepthReg, mr, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceClassDepthReg, mr, cg);
 
             if (comp->target().is64Bit()) {
                 TR_ASSERT(!(J9AccClassDepthMask & 0x80000000), "AMD64: need to use a second register for AND mask");
                 if (!(J9AccClassDepthMask & 0x80000000))
-                    generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, sourceClassDepthReg,
-                        J9AccClassDepthMask, cg);
+                    Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
             } else {
-                generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask,
-                    cg);
+                Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
             }
-            generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg,
-                cg);
+            Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg, cg);
         }
 
         /*TR::Register *sourceClassDepthReg = scratchRegisterManager->findOrCreateScratchRegister();
-        generateRegMemInstruction(
+        Inst_RegMem(
            TR::InstOpCode::LRegMem(),
            node,
            sourceClassDepthReg,
@@ -9124,18 +9048,18 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
            {
            TR_ASSERT(!(J9AccClassDepthMask & 0x80000000), "AMD64: need to use a second register for AND mask");
            if (!(J9AccClassDepthMask & 0x80000000))
-              generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask,
+              Inst_RegImm(TR::InstOpCode::AND8RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask,
         cg);
            }
         else
            {
-           generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
+           Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, sourceClassDepthReg, J9AccClassDepthMask, cg);
            }
 
-        generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg,
+        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, sourceClassDepthReg, destComponentClassDepthReg,
         cg);*/
 
-        generateLabelInstruction(TR::InstOpCode::JBE4, node, helperCallLabel, cg);
+        Inst_Label(TR::InstOpCode::JBE4, node, helperCallLabel, cg);
         if (sourceClassDepthReg != NULL)
             scratchRegisterManager->reclaimScratchRegister(sourceClassDepthReg);
 
@@ -9148,7 +9072,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             //
             sourceClassReg = scratchRegisterManager->findOrCreateScratchRegister();
             TR::MemoryReference *sourceClassMR = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
         }
 
@@ -9160,7 +9084,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
         TR::Register *sourceSuperClassReg = scratchRegisterManager->findOrCreateScratchRegister();
 
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceSuperClassReg, tempMR, cg);
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceSuperClassReg, tempMR, cg);
 
         TR::MemoryReference *leaMR
             = MRef_BISdisp32(sourceSuperClassReg, destComponentClassDepthReg, logBase2(sizeof(uintptr_t)), 0, cg);
@@ -9171,20 +9095,20 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
         // We may need to convert superClass to a class offset before doing the comparison
 
         if (comp->target().is32Bit()) {
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceSuperClassReg, leaMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, sourceSuperClassReg, leaMR, cg);
 
             // Rematerialize destination component class
             //
             TR::MemoryReference *destClassMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
 
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
             TR::MemoryReference *destCompTypeMR
                 = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
 
-            generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), node, destCompTypeMR, sourceSuperClassReg, cg);
+            Inst_MemReg(TR::InstOpCode::CMPMemReg(), node, destCompTypeMR, sourceSuperClassReg, cg);
         } else {
-            generateRegMemInstruction(TR::InstOpCode::CMP4RegMem, node, destComponentClassReg, leaMR, cg);
+            Inst_RegMem(TR::InstOpCode::CMP4RegMem, node, destComponentClassReg, leaMR, cg);
         }
 
         scratchRegisterManager->reclaimScratchRegister(destComponentClassReg);
@@ -9192,7 +9116,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
         scratchRegisterManager->reclaimScratchRegister(sourceClassReg);
         scratchRegisterManager->reclaimScratchRegister(sourceSuperClassReg);
 
-        generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
     }
 
     // The fast paths failed; execute the type-check helper call.
@@ -9201,11 +9125,11 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
     TR::Node *helperCallNode
         = TR::Node::createWithSymRef(TR::call, 2, 2, sourceChild, destinationChild, node->getSymbolReference());
     helperCallNode->copyByteCodeInfo(node);
-    generateLabelInstruction(TR::InstOpCode::JMP4, helperCallNode, helperCallLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, helperCallNode, helperCallLabel, cg);
     TR_OutlinedInstructions *outlinedHelperCall = new (cg->trHeapMemory())
         TR_OutlinedInstructions(helperCallNode, TR::call, NULL, helperCallLabel, helperReturnLabel, cg);
     cg->getOutlinedInstructionsList().push_front(outlinedHelperCall);
-    generateLabelInstruction(TR::InstOpCode::label, helperCallNode, helperReturnLabel, cg);
+    Inst_Label(TR::InstOpCode::label, helperCallNode, helperReturnLabel, cg);
     cg->decReferenceCount(sourceChild);
     cg->decReferenceCount(destinationChild);
 }
@@ -9232,15 +9156,15 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
 
     startLabel->setStartInternalControlFlow();
     fallThrough->setEndInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     // If the objects are the same and one of them is known to be an array, they
     // are compatible.
     //
     if (node->isArrayChkPrimitiveArray1() || node->isArrayChkReferenceArray1() || node->isArrayChkPrimitiveArray2()
         || node->isArrayChkReferenceArray2()) {
-        generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, object1Reg, object2Reg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThrough, cg);
+        Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, object1Reg, object2Reg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThrough, cg);
     }
 
     else {
@@ -9254,30 +9178,30 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
             testOpCode = TR::InstOpCode::TEST4MemImm4;
 
         if (TR::Compiler->om.compressObjectReferences())
-            generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, tempReg,
+            Inst_RegMem(TR::InstOpCode::L4RegMem, node, tempReg,
                 MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
         else
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
 
         TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
-        generateMemImmInstruction(testOpCode, node, MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg),
+        Inst_MemImm(testOpCode, node, MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg),
             J9AccClassRAMArray, cg);
         if (!snippetLabel) {
             snippetLabel = generateLabelSymbol(cg);
-            instr = generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
+            instr = Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
             snippet = new (cg->trHeapMemory())
                 TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
             cg->addSnippet(snippet);
         } else
-            generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
     }
 
     // Test equality of the object classes.
     //
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
+    Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
         MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
-    generateRegMemInstruction(TR::InstOpCode::XORRegMem(use64BitClasses), node, tempReg,
+    Inst_RegMem(TR::InstOpCode::XORRegMem(use64BitClasses), node, tempReg,
         MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
     TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
 
@@ -9288,19 +9212,19 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
     if (node->isArrayChkPrimitiveArray1() || node->isArrayChkPrimitiveArray2()) {
         if (!snippetLabel) {
             snippetLabel = generateLabelSymbol(cg);
-            instr = generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            instr = Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
             snippet = new (cg->trHeapMemory())
                 TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
             cg->addSnippet(snippet);
         } else
-            generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
     }
 
     // Otherwise, there is more testing to do. If the classes are equal we
     // are done, and branch to the fallThrough label.
     //
     else {
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThrough, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThrough, cg);
 
         // If either object is not known to be a reference array type, check it
         // We already know that object1 is an array type but we may have to now
@@ -9308,31 +9232,31 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
         //
         if (!node->isArrayChkReferenceArray1()) {
             if (TR::Compiler->om.compressObjectReferences())
-                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, tempReg,
+                Inst_RegMem(TR::InstOpCode::L4RegMem, node, tempReg,
                     MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             else
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+                Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                     MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
 
             TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
             // X = (ramclass->ClassDepthAndFlags)>>J9AccClassRAMShapeShift
 
             // X & OBJECT_HEADER_SHAPE_MASK
-            generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, tempReg,
+            Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg,
                 (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg,
+            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg,
                 (OBJECT_HEADER_SHAPE_POINTERS << J9AccClassRAMShapeShift), cg);
 
             if (!snippetLabel) {
                 snippetLabel = generateLabelSymbol(cg);
-                instr = generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+                instr = Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
                 snippet = new (cg->trHeapMemory())
                     TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
                 cg->addSnippet(snippet);
             } else
-                generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+                Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
         }
         if (!node->isArrayChkReferenceArray2()) {
             // Check that object 2 is an array. If not, throw exception.
@@ -9346,31 +9270,31 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
             // Check that object 2 is an array. If not, throw exception.
             //
             if (TR::Compiler->om.compressObjectReferences())
-                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, tempReg,
+                Inst_RegMem(TR::InstOpCode::L4RegMem, node, tempReg,
                     MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             else
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+                Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                     MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
-            generateMemImmInstruction(testOpCode, node,
-                MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
+            Inst_MemImm(testOpCode, node, MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg),
+                J9AccClassRAMArray, cg);
             if (!snippetLabel) {
                 snippetLabel = generateLabelSymbol(cg);
-                instr = generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
+                instr = Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
                 snippet = new (cg->trHeapMemory())
                     TR::X86CheckFailureSnippet(cg, node->getSymbolReference(), snippetLabel, instr);
                 cg->addSnippet(snippet);
             } else
-                generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
+                Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
 
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
+            Inst_RegMem(TR::InstOpCode::LRegMem(), node, tempReg,
                 MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
-            generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, tempReg,
+            Inst_RegImm(TR::InstOpCode::ANDRegImm4(), node, tempReg,
                 (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
-            generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg,
+            Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg,
                 (OBJECT_HEADER_SHAPE_POINTERS << J9AccClassRAMShapeShift), cg);
 
-            generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
         }
 
         // Now both objects are known to be reference arrays, so they are
@@ -9385,7 +9309,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
     deps->addPostCondition(tempReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, fallThrough, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallThrough, deps, cg);
 
     cg->stopUsingRegister(tempReg);
     cg->decReferenceCount(object1);
@@ -9449,26 +9373,25 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         // result = tv_sec * 1,000,000,000 (converts seconds to nanoseconds)
 
         tv_sec = MRef_node(timevalNode, cg, false);
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, result, tv_sec, cg);
-        generateRegRegImmInstruction(TR::InstOpCode::IMUL8RegRegImm4, node, result, result,
-            J9TIME_NANOSECONDS_PER_SECOND, cg);
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, result, tv_sec, cg);
+        Inst_RegRegImm(TR::InstOpCode::IMUL8RegRegImm4, node, result, result, J9TIME_NANOSECONDS_PER_SECOND, cg);
 
         // reg = tv_usec
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg,
-            MRef_MRefOff(*tv_sec, offsetof(struct timespec, tv_nsec), cg), cg);
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, reg, MRef_MRefOff(*tv_sec, offsetof(struct timespec, tv_nsec), cg),
+            cg);
 
         // result = reg + result
-        generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, result, MRef_BIS(reg, result, 0, cg), cg);
+        Inst_RegMem(TR::InstOpCode::LEA8RegMem, node, result, MRef_BIS(reg, result, 0, cg), cg);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
         if (fej9->isSnapshotModeEnabled()) {
             // result = result - nanoTimeMonotonicClockDelta
             TR::Register *vmThreadReg = cg->getVMThreadRegister();
-            generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg,
+            Inst_RegMem(TR::InstOpCode::L8RegMem, node, reg,
                 MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg,
-                MRef_Bdisp32(reg, offsetof(J9JavaVM, portLibrary), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::SUB8RegMem, node, result,
+            Inst_RegMem(TR::InstOpCode::L8RegMem, node, reg, MRef_Bdisp32(reg, offsetof(J9JavaVM, portLibrary), cg),
+                cg);
+            Inst_RegMem(TR::InstOpCode::SUB8RegMem, node, result,
                 MRef_Bdisp32(reg, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
         }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
@@ -9477,7 +9400,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // Store the result to memory if necessary
         if (resultAddress) {
-            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), result, cg);
+            Inst_MemReg(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), result, cg);
 
             cg->decReferenceCount(node->getFirstChild());
             if (node->getReferenceCount() == 1
@@ -9510,19 +9433,19 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         TR::Register *resultAddress;
         if (node->getNumChildren() == 1) {
             resultAddress = cg->evaluate(node->getFirstChild());
-            generateRegInstruction(TR::InstOpCode::PUSHReg, node, resultAddress, cg);
-            generateImmInstruction(TR::InstOpCode::PUSHImm4, node, CLOCK_MONOTONIC, cg);
+            Inst_Reg(TR::InstOpCode::PUSHReg, node, resultAddress, cg);
+            Inst_Imm(TR::InstOpCode::PUSHImm4, node, CLOCK_MONOTONIC, cg);
         } else {
             // Leave space on the stack for the 64-bit result
             //
 
-            generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, node, espReal, 8, cg);
+            Inst_RegImm(TR::InstOpCode::SUB4RegImms, node, espReal, 8, cg);
 
             resultAddress = cg->allocateRegister();
-            generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, resultAddress, espReal,
+            Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, resultAddress, espReal,
                 cg); // save away esp before the push
-            generateRegInstruction(TR::InstOpCode::PUSHReg, node, resultAddress, cg);
-            generateImmInstruction(TR::InstOpCode::PUSHImm4, node, CLOCK_MONOTONIC, cg);
+            Inst_Reg(TR::InstOpCode::PUSHReg, node, resultAddress, cg);
+            Inst_Imm(TR::InstOpCode::PUSHImm4, node, CLOCK_MONOTONIC, cg);
             cg->stopUsingRegister(resultAddress);
             resultAddress = espReal;
         }
@@ -9550,17 +9473,16 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         addFPXMMDependencies(cg, deps);
         deps->stopAddingConditions();
 
-        TR::X86ImmInstruction *callInstr
-            = generateImmInstruction(TR::InstOpCode::CALLImm4, node, (int32_t)&clock_gettime, deps, cg);
+        TR::X86ImmInstruction *callInstr = Inst_Imm(TR::InstOpCode::CALLImm4, node, (int32_t)&clock_gettime, deps, cg);
 
-        generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, espReal, 8, cg);
+        Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, espReal, 8, cg);
 
         TR::Register *eaxReal = cg->allocateRegister();
         TR::Register *edxReal = cg->allocateRegister();
 
         // load usec to a register
         TR::Register *reglow = cg->allocateRegister();
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, reglow, MRef_Bdisp32(resultAddress, 4, cg), cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, reglow, MRef_Bdisp32(resultAddress, 4, cg), cg);
 
         TR::RegisterDependencyConditions *dep1 = generateRegisterDependencyConditions((uint8_t)2, 2, cg);
         dep1->addPreCondition(eaxReal, TR::RealRegister::eax, cg);
@@ -9570,32 +9492,32 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // load second to eax then multiply by 1,000,000,000
 
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, edxReal, MRef_Bdisp32(resultAddress, 0, cg), cg);
-        generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, eaxReal, J9TIME_NANOSECONDS_PER_SECOND, cg);
-        generateRegRegInstruction(TR::InstOpCode::IMUL4AccReg, node, eaxReal, edxReal, dep1, cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, edxReal, MRef_Bdisp32(resultAddress, 0, cg), cg);
+        Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, eaxReal, J9TIME_NANOSECONDS_PER_SECOND, cg);
+        Inst_RegReg(TR::InstOpCode::IMUL4AccReg, node, eaxReal, edxReal, dep1, cg);
 
         // add the two parts
-        generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, eaxReal, reglow, cg);
-        generateRegImmInstruction(TR::InstOpCode::ADC4RegImm4, node, edxReal, 0x0, cg);
+        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, eaxReal, reglow, cg);
+        Inst_RegImm(TR::InstOpCode::ADC4RegImm4, node, edxReal, 0x0, cg);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
         if (fej9->isSnapshotModeEnabled()) {
             // subtract nanoTimeMonotonicClockDelta from the result
             TR::Register *vmThreadReg = cg->getVMThreadRegister();
-            generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, regLow,
+            Inst_RegMem(TR::InstOpCode::L4RegMem, node, regLow,
                 MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, regLow,
+            Inst_RegMem(TR::InstOpCode::L4RegMem, node, regLow,
                 MRef_Bdisp32(regLow, offsetof(J9JavaVM, portLibrary), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::SUB4RegMem, node, eaxReal,
+            Inst_RegMem(TR::InstOpCode::SUB4RegMem, node, eaxReal,
                 MRef_Bdisp32(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
-            generateRegMemInstruction(TR::InstOpCode::SBB4RegMem, node, edxReal,
+            Inst_RegMem(TR::InstOpCode::SBB4RegMem, node, edxReal,
                 MRef_Bdisp32(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta) + 4, cg), cg);
         }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
         // store it back
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), eaxReal, cg);
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 4, cg), edxReal, cg);
+        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), eaxReal, cg);
+        Inst_MemReg(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 4, cg), edxReal, cg);
 
         cg->stopUsingRegister(eaxReal);
         cg->stopUsingRegister(edxReal);
@@ -9607,10 +9529,8 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         if (node->getNumChildren() == 1) {
             if (node->getReferenceCount() > 1
                 || cg->getCurrentEvaluationTreeTop()->getNode()->getOpCodeValue() != TR::treetop) {
-                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lowReg, MRef_Bdisp32(resultAddress, 0, cg),
-                    cg);
-                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, highReg, MRef_Bdisp32(resultAddress, 4, cg),
-                    cg);
+                Inst_RegMem(TR::InstOpCode::L4RegMem, node, lowReg, MRef_Bdisp32(resultAddress, 0, cg), cg);
+                Inst_RegMem(TR::InstOpCode::L4RegMem, node, highReg, MRef_Bdisp32(resultAddress, 4, cg), cg);
 
                 TR::RegisterPair *result = cg->allocateRegisterPair(lowReg, highReg);
                 node->setRegister(result);
@@ -9619,8 +9539,8 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         } else {
             // The result of the call is now on the stack. Get it into registers.
             //
-            generateRegInstruction(TR::InstOpCode::POPReg, node, lowReg, cg);
-            generateRegInstruction(TR::InstOpCode::POPReg, node, highReg, cg);
+            Inst_Reg(TR::InstOpCode::POPReg, node, lowReg, cg);
+            Inst_Reg(TR::InstOpCode::POPReg, node, highReg, cg);
             TR::RegisterPair *result = cg->allocateRegisterPair(lowReg, highReg);
             node->setRegister(result);
         }
@@ -9635,12 +9555,12 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         // Leave space on the stack for the 64-bit result
         //
         temp2 = cg->allocateRegister();
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, temp2,
-            MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, temp2,
-            MRef_Bdisp32(temp2, offsetof(J9JavaVM, portLibrary), cg), cg);
-        generateRegInstruction(TR::InstOpCode::PUSHReg, node, espReal, cg);
-        generateRegInstruction(TR::InstOpCode::PUSHReg, node, temp2, cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, temp2, MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg),
+            cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, temp2, MRef_Bdisp32(temp2, offsetof(J9JavaVM, portLibrary), cg),
+            cg);
+        Inst_Reg(TR::InstOpCode::PUSHReg, node, espReal, cg);
+        Inst_Reg(TR::InstOpCode::PUSHReg, node, temp2, cg);
 
         int32_t extraFPDeps = (uint8_t)(cg->machine()->getLastXMMR() - cg->machine()->getFirstXMMR() + 1);
 
@@ -9665,11 +9585,11 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         addFPXMMDependencies(cg, deps);
         deps->stopAddingConditions();
 
-        generateCallMemInstruction(TR::InstOpCode::CALLMem, node,
-            MRef_Bdisp32(temp2, offsetof(OMRPortLibrary, time_hires_clock), cg), deps, cg);
+        Inst_CallMem(TR::InstOpCode::CALLMem, node, MRef_Bdisp32(temp2, offsetof(OMRPortLibrary, time_hires_clock), cg),
+            deps, cg);
         cg->stopUsingRegister(temp2);
 
-        generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, espReal, 8, cg);
+        Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, espReal, 8, cg);
 
         TR::RegisterPair *result = cg->allocateRegisterPair(lowReg, highReg);
         node->setRegister(result);
@@ -9717,11 +9637,11 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
         if (memLoadRhs) {
             // a (2) * b (3) + c (1)
             TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
-            generateRegMemInstruction(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, rhsMR, cg);
+            Inst_RegMem(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, rhsMR, cg);
 
             midReg = cg->evaluate(secondChild);
             memLoadMiddle = false; // No choice but to evaluate;
-            generateRegRegMemInstruction(opcode, node, result, midReg, lhsMR, cg);
+            Inst_RegRegMem(opcode, node, result, midReg, lhsMR, cg);
         } else if (memLoadMiddle) {
             // fma = a (1) * b (3) + c (2)
             opcode = is64Bit ? TR::InstOpCode::VFMADD132SDRegRegMem : TR::InstOpCode::VFMADD132SSRegRegMem;
@@ -9729,14 +9649,14 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
             TR::MemoryReference *midMR = MRef_node(secondChild, cg);
             rhsReg = cg->evaluate(thirdChild);
 
-            generateRegMemInstruction(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, lhsMR, cg);
-            generateRegRegMemInstruction(opcode, node, result, rhsReg, midMR, cg);
+            Inst_RegMem(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, lhsMR, cg);
+            Inst_RegRegMem(opcode, node, result, rhsReg, midMR, cg);
         } else {
             // fma = a (2) * b (3) + c (1)
             midReg = cg->evaluate(secondChild);
             rhsReg = cg->evaluate(thirdChild);
-            generateRegRegInstruction(fpMovRegRegOpcode, node, result, rhsReg, cg);
-            generateRegRegMemInstruction(opcode, node, result, midReg, lhsMR, cg);
+            Inst_RegReg(fpMovRegRegOpcode, node, result, rhsReg, cg);
+            Inst_RegRegMem(opcode, node, result, midReg, lhsMR, cg);
         }
     } else if (memLoadMiddle) {
         TR::MemoryReference *midMR = MRef_node(secondChild, cg);
@@ -9748,16 +9668,16 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
                 = is64Bit ? TR::InstOpCode::VFMADD213SDRegRegMem : TR::InstOpCode::VFMADD213SSRegRegMem;
             TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
 
-            generateRegMemInstruction(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, midMR, cg);
-            generateRegRegMemInstruction(opcode, node, result, lhsReg, rhsMR, cg);
+            Inst_RegMem(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, midMR, cg);
+            Inst_RegRegMem(opcode, node, result, lhsReg, rhsMR, cg);
         } else {
             // fma = a (1) * b (3) + c (2)
             TR::InstOpCode::Mnemonic opcode
                 = is64Bit ? TR::InstOpCode::VFMADD132SDRegRegMem : TR::InstOpCode::VFMADD132SSRegRegMem;
             rhsReg = cg->evaluate(thirdChild);
 
-            generateRegRegInstruction(fpMovRegRegOpcode, node, result, lhsReg, cg);
-            generateRegRegMemInstruction(opcode, node, result, rhsReg, midMR, cg);
+            Inst_RegReg(fpMovRegRegOpcode, node, result, lhsReg, cg);
+            Inst_RegRegMem(opcode, node, result, rhsReg, midMR, cg);
         }
     } else if (memLoadRhs) {
         // fma = a (2) * b (1) + c (3)
@@ -9768,8 +9688,8 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
         lhsReg = cg->evaluate(firstChild);
         midReg = cg->evaluate(secondChild);
 
-        generateRegRegInstruction(fpMovRegRegOpcode, node, result, lhsReg, cg);
-        generateRegRegMemInstruction(opcode, node, result, midReg, rhsMR, cg);
+        Inst_RegReg(fpMovRegRegOpcode, node, result, lhsReg, cg);
+        Inst_RegRegMem(opcode, node, result, midReg, rhsMR, cg);
     } else {
         // fma = a (2) * b (1) + c (3)
         TR::InstOpCode::Mnemonic opcode
@@ -9779,8 +9699,8 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
         midReg = cg->evaluate(secondChild);
         rhsReg = cg->evaluate(thirdChild);
 
-        generateRegRegInstruction(fpMovRegRegOpcode, node, result, lhsReg, cg);
-        generateRegRegRegInstruction(opcode, node, result, midReg, rhsReg, cg);
+        Inst_RegReg(fpMovRegRegOpcode, node, result, lhsReg, cg);
+        Inst_RegRegReg(opcode, node, result, midReg, rhsReg, cg);
     }
 
     if (memLoadLhs) {
@@ -9934,10 +9854,10 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
     deps->addPostCondition(tmpXMM, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(hashXMM, TR::RealRegister::NoReg, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, index, length, cg);
-    generateRegImmInstruction(TR::InstOpCode::AND4RegImms, node, index, size - 1, cg); // mod size
-    generateRegMemInstruction(TR::InstOpCode::CMOVE4RegMem, node, index,
-        MRef_const(cg->findOrCreate4ByteConstant(node, size), cg), cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, index, length, cg);
+    Inst_RegImm(TR::InstOpCode::AND4RegImms, node, index, size - 1, cg); // mod size
+    Inst_RegMem(TR::InstOpCode::CMOVE4RegMem, node, index, MRef_const(cg->findOrCreate4ByteConstant(node, size), cg),
+        cg);
 
     // Prepend zeros
     {
@@ -9945,55 +9865,55 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
 
         static uint64_t MASKDECOMPRESSED[] = { 0x0000000000000000ULL, 0xffffffffffffffffULL };
         static uint64_t MASKCOMPRESSED[] = { 0xffffffff00000000ULL, 0x0000000000000000ULL };
-        generateRegMemInstruction(isCompressed ? TR::InstOpCode::MOVDRegMem : TR::InstOpCode::MOVQRegMem, node, hashXMM,
+        Inst_RegMem(isCompressed ? TR::InstOpCode::MOVDRegMem : TR::InstOpCode::MOVQRegMem, node, hashXMM,
             MRef_BISdisp32(address, index, shift,
                 -(size << shift) + TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg),
             cg);
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp,
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmp,
             MRef_const(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
         auto mr = MRef_BISdisp32(tmp, index, shift, 0, cg);
         if (comp->target().cpu.supportsAVX()) {
-            generateRegMemInstruction(TR::InstOpCode::PANDRegMem, node, hashXMM, mr, cg);
+            Inst_RegMem(TR::InstOpCode::PANDRegMem, node, hashXMM, mr, cg);
         } else {
-            generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, tmpXMM, mr, cg);
-            generateRegRegInstruction(TR::InstOpCode::PANDRegReg, node, hashXMM, tmpXMM, cg);
+            Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, tmpXMM, mr, cg);
+            Inst_RegReg(TR::InstOpCode::PANDRegReg, node, hashXMM, tmpXMM, cg);
         }
-        generateRegRegInstruction(isCompressed ? TR::InstOpCode::PMOVZXBDRegReg : TR::InstOpCode::PMOVZXWDRegReg, node,
-            hashXMM, hashXMM, cg);
+        Inst_RegReg(isCompressed ? TR::InstOpCode::PMOVZXBDRegReg : TR::InstOpCode::PMOVZXWDRegReg, node, hashXMM,
+            hashXMM, cg);
     }
 
     // Reduction Loop
     {
         static uint32_t multiplier[] = { 31 * 31 * 31 * 31, 31 * 31 * 31 * 31, 31 * 31 * 31 * 31, 31 * 31 * 31 * 31 };
-        generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
-        generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        generateLabelInstruction(TR::InstOpCode::JGE4, node, endLabel, cg);
-        generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, multiplierXMM,
+        Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
+        Inst_Label(TR::InstOpCode::JGE4, node, endLabel, cg);
+        Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, multiplierXMM,
             MRef_const(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
-        generateRegRegInstruction(TR::InstOpCode::PMULLDRegReg, node, hashXMM, multiplierXMM, cg);
-        generateRegMemInstruction(isCompressed ? TR::InstOpCode::PMOVZXBDRegMem : TR::InstOpCode::PMOVZXWDRegMem, node,
-            tmpXMM, MRef_BISdisp32(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, index, 4, cg);
-        generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
-        generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        generateLabelInstruction(TR::InstOpCode::JL4, node, loopLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+        Inst_RegReg(TR::InstOpCode::PMULLDRegReg, node, hashXMM, multiplierXMM, cg);
+        Inst_RegMem(isCompressed ? TR::InstOpCode::PMOVZXBDRegMem : TR::InstOpCode::PMOVZXWDRegMem, node, tmpXMM,
+            MRef_BISdisp32(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+        Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, index, 4, cg);
+        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
+        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
+        Inst_Label(TR::InstOpCode::JL4, node, loopLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
     }
 
     // Finalization
     {
         static uint32_t multiplier[] = { 31 * 31 * 31, 31 * 31, 31, 1 };
-        generateRegMemInstruction(TR::InstOpCode::PMULLDRegMem, node, hashXMM,
+        Inst_RegMem(TR::InstOpCode::PMULLDRegMem, node, hashXMM,
             MRef_const(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
-        generateRegRegImmInstruction(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x0e, cg);
-        generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
-        generateRegRegImmInstruction(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x01, cg);
-        generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
+        Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x0e, cg);
+        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
+        Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x01, cg);
+        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
     }
 
-    generateRegRegInstruction(TR::InstOpCode::MOVDReg4Reg, node, hash, hashXMM, cg);
+    Inst_RegReg(TR::InstOpCode::MOVDReg4Reg, node, hash, hashXMM, cg);
 
     cg->stopUsingRegister(index);
     cg->stopUsingRegister(tmp);
@@ -10053,8 +9973,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeReductionHelper(TR::Node
     // then proceed to do horizontal reduction
     for (int32_t i = 1; i < numVectors; i++) {
         OMR::X86::Encoding opcodeEncoding = opcode.getSIMDEncoding(&cg->comp()->target().cpu, vl);
-        generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, vectorRegisters[i], cg,
-            opcodeEncoding);
+        Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, vectorRegisters[i], cg, opcodeEncoding);
     }
 
     // Reduce lanes -> horizontally add all vector elements together
@@ -10063,31 +9982,27 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeReductionHelper(TR::Node
     switch (vl) {
         case TR::VectorLength512:
             // extract 256-bits from zmm and store in ymm, then perform vertical operation
-            generateRegRegImmInstruction(TR::InstOpCode::VEXTRACTF64X4YmmZmmImm1, node, tmpVectorRegVRF, vectorRegVRF,
-                0xFF, cg);
-            generateRegRegInstruction(opcode.getMnemonic(), node, vectorRegVRF, tmpVectorRegVRF, cg,
+            Inst_RegRegImm(TR::InstOpCode::VEXTRACTF64X4YmmZmmImm1, node, tmpVectorRegVRF, vectorRegVRF, 0xFF, cg);
+            Inst_RegReg(opcode.getMnemonic(), node, vectorRegVRF, tmpVectorRegVRF, cg,
                 opcode.getSIMDEncoding(&cg->comp()->target().cpu, TR::VectorLength256));
             // Fallthrough to treat remaining result as 256-bit vector
         case TR::VectorLength256:
             // extract 128 bits from ymm and store in xmm, then perform vertical operation
-            generateRegRegImmInstruction(TR::InstOpCode::VEXTRACTF128RegRegImm1, node, tmpVectorRegVRF, vectorRegVRF,
-                0xFF, cg);
-            generateRegRegInstruction(opcode.getMnemonic(), node, vectorRegVRF, tmpVectorRegVRF, cg,
+            Inst_RegRegImm(TR::InstOpCode::VEXTRACTF128RegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0xFF, cg);
+            Inst_RegReg(opcode.getMnemonic(), node, vectorRegVRF, tmpVectorRegVRF, cg,
                 opcode.getSIMDEncoding(&cg->comp()->target().cpu, TR::VectorLength128));
             // Fallthrough to treat remaining result as 128-bit vector
         case TR::VectorLength128:
-            generateRegRegImmInstruction(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x0e,
-                cg);
-            generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
-            generateRegRegImmInstruction(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x01,
-                cg);
-            generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
+            Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x0e, cg);
+            Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
+            Inst_RegRegImm(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpVectorRegVRF, vectorRegVRF, 0x01, cg);
+            Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, vectorRegVRF, tmpVectorRegVRF, cg);
             break;
         default:
             TR_ASSERT_FATAL(false, "Unsupported vector length");
     }
 
-    generateRegRegInstruction(TR::InstOpCode::MOVDReg4Reg, node, result, vectorRegVRF, cg);
+    Inst_RegReg(TR::InstOpCode::MOVDReg4Reg, node, result, vectorRegVRF, cg);
     return result;
 }
 
@@ -10169,26 +10084,25 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, result, initialHash, cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tmp, length, cg);
-    generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, tmp, ~(numElements - 1), cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, result, initialHash, cg);
+    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tmp, length, cg);
+    Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, tmp, ~(numElements - 1), cg);
 
     {
-        generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, tmp, cg);
-        generateLabelInstruction(TR::InstOpCode::JGE4, node, endLabel, cg);
+        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, tmp, cg);
+        Inst_Label(TR::InstOpCode::JGE4, node, endLabel, cg);
 
         // Initialize Constants outside of loop body but after the first compare
         for (int32_t i = 0; i < unrollCount; i++)
-            generateRegRegInstruction(TR::InstOpCode::PXORRegReg, node, hashRegsVRF[i], hashRegsVRF[i], cg,
-                vectorEncoding);
+            Inst_RegReg(TR::InstOpCode::PXORRegReg, node, hashRegsVRF[i], hashRegsVRF[i], cg, vectorEncoding);
 
-        generateRegRegInstruction(TR::InstOpCode::MOVDRegReg4, node, hashRegsVRF[0], initialHash, cg);
+        Inst_RegReg(TR::InstOpCode::MOVDRegReg4, node, hashRegsVRF[0], initialHash, cg);
 
         int32_t multiplier31PowNData[16];
         // Fill multiplier array with 31^numElements
         std::fill_n(multiplier31PowNData, 16, powersOf31[64 - numElements]);
-        generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, multiplierVRF,
+        Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, multiplierVRF,
             MRef_const(
                 cg->findOrCreateConstantDataSnippet(node, multiplier31PowNData, vectorSizeElements * sizeof(int32_t)),
                 cg),
@@ -10215,11 +10129,11 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
             int32_t *multiplier = const_cast<int32_t *>(powersOf31 + offset);
             TR::MemoryReference *mr = MRef_const(cg->findOrCreateConstantDataSnippet(node, multiplier, vectorSize), cg);
 
-            generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, multiplier31PowN_i, mr, cg, vectorEncoding);
+            Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, multiplier31PowN_i, mr, cg, vectorEncoding);
         }
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
 
     {
         // Main loop body;
@@ -10251,26 +10165,24 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
                 = TR::Compiler->om.contiguousArrayHeaderSizeInBytes() + i * (vectorSizeElements * elementSize);
             TR::MemoryReference *mr = MRef_BISdisp32(arrayAddress, index, shift, displacement, cg);
             // load next batch of data
-            generateRegMemInstruction(loadOpcode, node, tmpVRF, mr, cg, vectorEncoding);
+            Inst_RegMem(loadOpcode, node, tmpVRF, mr, cg, vectorEncoding);
 
             // tmpVRF = tmpVRF * multiplierVRF
-            generateRegRegInstruction(TR::InstOpCode::PMULLDRegReg, node, tmpVRF, multiplier31PowNRegsVRF[i], cg,
-                vectorEncoding);
+            Inst_RegReg(TR::InstOpCode::PMULLDRegReg, node, tmpVRF, multiplier31PowNRegsVRF[i], cg, vectorEncoding);
             // hashRegsVRF = ( hashRegsVRF * {31^vl, ..., 31^vl} ) + tmpVRF
-            generateRegRegInstruction(TR::InstOpCode::PMULLDRegReg, node, hashRegsVRF[i], multiplierVRF, cg,
-                vectorEncoding);
-            generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, hashRegsVRF[i], tmpVRF, cg, vectorEncoding);
+            Inst_RegReg(TR::InstOpCode::PMULLDRegReg, node, hashRegsVRF[i], multiplierVRF, cg, vectorEncoding);
+            Inst_RegReg(TR::InstOpCode::PADDDRegReg, node, hashRegsVRF[i], tmpVRF, cg, vectorEncoding);
         }
     }
 
     // Increase loop index by the number of processed elements
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, index, numElements, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, index, numElements, cg);
     // Compare index with numElements and loop back if necessary
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, tmp, cg);
-    generateLabelInstruction(TR::InstOpCode::JL4, node, loopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, tmp, cg);
+    Inst_Label(TR::InstOpCode::JL4, node, loopLabel, cg);
 
     vectorizedHashCodeReductionHelper(node, hashRegsVRF, unrollCount, tmpVRF, result, vl, dt, cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
 
     cg->stopUsingRegister(tmp);
     cg->stopUsingRegister(tmpVRF);
@@ -10364,16 +10276,16 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
     if (nonZeroOffset) {
         TR::Register *offset = cg->evaluate(node->getChild(1));
         TR::MemoryReference *memRef = MRef_BISdisp32(address, offset, shift, 0, cg);
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, address, memRef, cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, address, memRef, cg);
     }
 
     if (!nodeHash) {
         // If nodeHash is not provided, assume initial hash value of 0.
-        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, initHash, initHash, cg);
+        Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, initHash, initHash, cg);
     }
 
     // Set index ptr to 0
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, index, index, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, index, index, cg);
 
     // Generate Main Loop; 4x Unrolled seems to yield the best performance for large arrays
     static char *unrollVar = feGetEnv("TR_setInlineVectorHashCodeUnrollCount");
@@ -10390,7 +10302,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
 
     // Generate a second vectorized loop if not disabled and Vl/unrollCount are not the same as the first loop
     if (!disableSecondLoop && (unrollCount != 1 || vl != TR::VectorLength128)) {
-        generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, initHash, result, cg);
+        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, initHash, result, cg);
         vectorizedHashCodeLoopHelper(node, dt, TR::VectorLength128, isSigned, result, initHash, index, length, address,
             1, cg);
     }
@@ -10405,13 +10317,13 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
         residueBeginLoopLabel->setStartInternalControlFlow();
         residueEndLoopLabel->setEndInternalControlFlow();
 
-        generateLabelInstruction(TR::InstOpCode::label, node, residueBeginLoopLabel, cg);
-        generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        generateLabelInstruction(TR::InstOpCode::JGE4, node, residueEndLoopLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, residueLoopLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, residueBeginLoopLabel, cg);
+        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
+        Inst_Label(TR::InstOpCode::JGE4, node, residueEndLoopLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, residueLoopLabel, cg);
 
         // hash = 31 * hash + arr[index] = tmp * hash + arr[index]
-        generateRegRegImmInstruction(TR::InstOpCode::IMUL4RegRegImm4, node, result, result, 31, cg);
+        Inst_RegRegImm(TR::InstOpCode::IMUL4RegRegImm4, node, result, result, 31, cg);
 
         static TR::InstOpCode::Mnemonic signedLoadOpcode[3]
             = { TR::InstOpCode::MOVSXReg4Mem1, TR::InstOpCode::MOVSXReg4Mem2, TR::InstOpCode::L4RegMem };
@@ -10420,17 +10332,17 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
         TR::InstOpCode::Mnemonic loadOpcode
             = isSigned ? signedLoadOpcode[dt - TR::Int8] : unsignedLoadOpcode[dt - TR::Int8];
 
-        generateRegMemInstruction(loadOpcode, node, tmp,
+        Inst_RegMem(loadOpcode, node, tmp,
             MRef_BISdisp32(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-        generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, result, tmp, cg);
+        Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, result, tmp, cg);
 
         // Increase loop index by the number of processed elements
-        generateRegInstruction(TR::InstOpCode::INCReg(), node, index, cg);
+        Inst_Reg(TR::InstOpCode::INCReg(), node, index, cg);
 
         // Compare index with numElements and loop back if necessary
-        generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
-        generateLabelInstruction(TR::InstOpCode::JL4, node, residueLoopLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, residueEndLoopLabel, deps, cg);
+        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
+        Inst_Label(TR::InstOpCode::JL4, node, residueLoopLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, residueEndLoopLabel, deps, cg);
     }
 
     if (nonZeroOffset) {
@@ -10586,53 +10498,53 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    generateRegRegInstruction(TR::InstOpCode::MOVDRegReg4, node, valueXMM, ch, cg);
-    generateRegMemInstruction(TR::InstOpCode::PSHUFBRegMem, node, valueXMM,
+    Inst_RegReg(TR::InstOpCode::MOVDRegReg4, node, valueXMM, ch, cg);
+    Inst_RegMem(TR::InstOpCode::PSHUFBRegMem, node, valueXMM,
         MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, result, offset, cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, result, offset, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, scratch,
+    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, scratch,
         MRef_BISdisp32(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, ECX, scratch, cg);
-    generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, scratch, ~(width - 1), cg);
-    generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, ECX, width - 1, cg);
-    generateLabelInstruction(TR::InstOpCode::JE1, node, loopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, ECX, scratch, cg);
+    Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, scratch, ~(width - 1), cg);
+    Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, ECX, width - 1, cg);
+    Inst_Label(TR::InstOpCode::JE1, node, loopLabel, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, scratchXMM, MRef_Bdisp32(scratch, 0, cg), cg);
-    generateRegRegInstruction(compareOp, node, scratchXMM, valueXMM, cg);
-    generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
-    generateRegInstruction(TR::InstOpCode::SHR4RegCL, node, scratch, cg);
-    generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, scratch, scratch, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE1, node, endLabel, cg);
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, scratchXMM, MRef_Bdisp32(scratch, 0, cg), cg);
+    Inst_RegReg(compareOp, node, scratchXMM, valueXMM, cg);
+    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
+    Inst_Reg(TR::InstOpCode::SHR4RegCL, node, scratch, cg);
+    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, scratch, scratch, cg);
+    Inst_Label(TR::InstOpCode::JNE1, node, endLabel, cg);
     if (shift) {
-        generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, ECX, shift, cg);
+        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, ECX, shift, cg);
     }
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, result, width >> shift, cg);
-    generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, result, ECX, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, result, length, cg);
-    generateLabelInstruction(TR::InstOpCode::JGE1, node, endLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, result, width >> shift, cg);
+    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, result, ECX, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, result, length, cg);
+    Inst_Label(TR::InstOpCode::JGE1, node, endLabel, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, scratchXMM,
+    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, scratchXMM,
         MRef_BISdisp32(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
-    generateRegRegInstruction(compareOp, node, scratchXMM, valueXMM, cg);
-    generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
-    generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, scratch, scratch, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE1, node, endLabel, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, result, width >> shift, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, result, length, cg);
-    generateLabelInstruction(TR::InstOpCode::JL1, node, loopLabel, cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, dependencies, cg);
+    Inst_RegReg(compareOp, node, scratchXMM, valueXMM, cg);
+    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
+    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, scratch, scratch, cg);
+    Inst_Label(TR::InstOpCode::JNE1, node, endLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, result, width >> shift, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, result, length, cg);
+    Inst_Label(TR::InstOpCode::JL1, node, loopLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, dependencies, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::BSF4RegReg, node, scratch, scratch, cg);
+    Inst_RegReg(TR::InstOpCode::BSF4RegReg, node, scratch, scratch, cg);
     if (shift) {
-        generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, scratch, shift, cg);
+        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, scratch, shift, cg);
     }
-    generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, result, scratch, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, result, length, cg);
-    generateRegMemInstruction(TR::InstOpCode::CMOVGERegMem(), node, result,
+    Inst_RegReg(TR::InstOpCode::ADDRegReg(), node, result, scratch, cg);
+    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, result, length, cg);
+    Inst_RegMem(TR::InstOpCode::CMOVGERegMem(), node, result,
         MRef_const(cg->comp()->target().is32Bit() ? cg->findOrCreate4ByteConstant(node, -1)
                                                   : cg->findOrCreate8ByteConstant(node, -1),
             cg),
@@ -10700,7 +10612,7 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
         maxReg = s1lenReg;
     } else {
         maxReg = cg->allocateRegister(TR_GPR);
-        generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, maxReg, s1lenReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, maxReg, s1lenReg, cg);
     }
 
     TR::Register *resultReg;
@@ -10708,7 +10620,7 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
         resultReg = offsetReg;
     } else {
         resultReg = cg->allocateRegister(TR_GPR);
-        generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, resultReg, offsetReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, resultReg, offsetReg, cg);
     }
 
     static uint8_t MASKOFSIZEONE[] = {
@@ -10811,120 +10723,116 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     int32_t hdrSize = static_cast<int32_t>(TR::Compiler->om.contiguousArrayHeaderSizeInBytes());
 
     // load first char of s2
-    generateRegMemInstruction(isLatin1 ? TR::InstOpCode::MOVZXReg4Mem1 : TR::InstOpCode::MOVZXReg4Mem2, node, tmpReg,
+    Inst_RegMem(isLatin1 ? TR::InstOpCode::MOVZXReg4Mem1 : TR::InstOpCode::MOVZXReg4Mem2, node, tmpReg,
         MRef_Bdisp32(s2Reg, hdrSize, cg), cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVDRegReg4, node, xmmReg2, tmpReg, cg);
-    generateRegMemInstruction(TR::InstOpCode::PSHUFBRegMem, node, xmmReg2,
+    Inst_RegReg(TR::InstOpCode::MOVDRegReg4, node, xmmReg2, tmpReg, cg);
+    Inst_RegMem(TR::InstOpCode::PSHUFBRegMem, node, xmmReg2,
         MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
 
     // calculate max
-    generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, maxReg, s2lenReg, cg); // s1len - s2len
+    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, maxReg, s2lenReg, cg); // s1len - s2len
 
     // outer loop
-    generateLabelInstruction(TR::InstOpCode::label, node, outerLoopLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, outerLoopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, notFoundLabel, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmpReg,
-        MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, ECX, tmpReg, cg);
-    generateRegImmInstruction(TR::InstOpCode::AND4RegImms, node, ECX, width - 1, cg);
-    generateLabelInstruction(TR::InstOpCode::JE1, node, firstCharLoopLabel, cg);
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmpReg, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, ECX, tmpReg, cg);
+    Inst_RegImm(TR::InstOpCode::AND4RegImms, node, ECX, width - 1, cg);
+    Inst_Label(TR::InstOpCode::JE1, node, firstCharLoopLabel, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, tmpReg, ~(width - 1), cg);
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_Bdisp32(tmpReg, 0, cg), cg);
-    generateRegRegInstruction(compareOp, node, xmmReg1, xmmReg2, cg);
-    generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
-    generateRegInstruction(TR::InstOpCode::SHR4RegCL, node, tmpReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ANDRegImms(), node, tmpReg, ~(width - 1), cg);
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_Bdisp32(tmpReg, 0, cg), cg);
+    Inst_RegReg(compareOp, node, xmmReg1, xmmReg2, cg);
+    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+    Inst_Reg(TR::InstOpCode::SHR4RegCL, node, tmpReg, cg);
+    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
+    Inst_Label(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
     if (!isLatin1) {
-        generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, ECX, 1, cg);
+        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, ECX, 1, cg);
     }
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, resultReg, width >> shift, cg);
-    generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, resultReg, ECX, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, resultReg, width >> shift, cg);
+    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, resultReg, ECX, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, notFoundLabel, cg);
 
     // loop for finding the first char
-    generateLabelInstruction(TR::InstOpCode::label, node, firstCharLoopLabel, cg);
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1,
-        MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
-    generateRegRegInstruction(compareOp, node, xmmReg1, xmmReg2, cg);
-    generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
-    generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, resultReg, width >> shift, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JLE1, node, firstCharLoopLabel, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, notFoundLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, firstCharLoopLabel, cg);
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
+    Inst_RegReg(compareOp, node, xmmReg1, xmmReg2, cg);
+    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
+    Inst_Label(TR::InstOpCode::JNE1, node, firstCharMatchedLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, resultReg, width >> shift, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(TR::InstOpCode::JLE1, node, firstCharLoopLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, notFoundLabel, cg);
 
     // first char matched
-    generateLabelInstruction(TR::InstOpCode::label, node, firstCharMatchedLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, firstCharMatchedLabel, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::BSF4RegReg, node, tmpReg, tmpReg, cg);
+    Inst_RegReg(TR::InstOpCode::BSF4RegReg, node, tmpReg, tmpReg, cg);
     if (!isLatin1) {
-        generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, tmpReg, 1, cg);
+        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, tmpReg, 1, cg);
     }
-    generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, resultReg, tmpReg, cg);
+    Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, resultReg, tmpReg, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, resultReg, maxReg, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, notFoundLabel, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, s1addrReg,
-        MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg); // s1addr = &(s1[resultReg << shift])
-    generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, s2idxReg, 1, cg); // s2idx = 1
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, s1addrReg, MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg),
+        cg); // s1addr = &(s1[resultReg << shift])
+    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, s2idxReg, 1, cg); // s2idx = 1
 
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, ECX, MRef_Bdisp32(s2lenReg, -1, cg),
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, ECX, MRef_Bdisp32(s2lenReg, -1, cg),
         cg); // ECX = s2len - 1: 1st char has already matched
-    generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, ECX, 4 - shift, cg); // div by 16 or 8
-    generateLabelInstruction(TR::InstOpCode::JE1, node, byteLoopLabel, cg);
+    Inst_RegImm(TR::InstOpCode::SHR4RegImm1, node, ECX, 4 - shift, cg); // div by 16 or 8
+    Inst_Label(TR::InstOpCode::JE1, node, byteLoopLabel, cg);
 
     // Compare by 16 bytes
-    generateLabelInstruction(TR::InstOpCode::label, node, qwordLoopLabel, cg);
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1,
-        MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), cg);
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg3,
-        MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
-    generateRegRegInstruction(TR::InstOpCode::PCMPEQBRegReg, node, xmmReg1, xmmReg3, cg);
-    generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, tmpReg, 0xffff, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, qwordLoopLabel, cg);
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), cg);
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmReg3, MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
+    Inst_RegReg(TR::InstOpCode::PCMPEQBRegReg, node, xmmReg1, xmmReg3, cg);
+    Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, tmpReg, 0xffff, cg);
+    Inst_Label(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, s2idxReg, width >> shift, cg);
-    generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, node, ECX, 1, cg);
-    generateLabelInstruction(TR::InstOpCode::JG1, node, qwordLoopLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, s2idxReg, width >> shift, cg);
+    Inst_RegImm(TR::InstOpCode::SUB4RegImms, node, ECX, 1, cg);
+    Inst_Label(TR::InstOpCode::JG1, node, qwordLoopLabel, cg);
 
     // Compare each byte
-    generateLabelInstruction(TR::InstOpCode::label, node, byteLoopLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, s2lenReg, s2idxReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JLE1, node, doneLabel, cg); // resultReg has the result
+    Inst_Label(TR::InstOpCode::label, node, byteLoopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, s2lenReg, s2idxReg, cg);
+    Inst_Label(TR::InstOpCode::JLE1, node, doneLabel, cg); // resultReg has the result
 
-    generateRegMemInstruction(isLatin1 ? TR::InstOpCode::L1RegMem : TR::InstOpCode::L2RegMem, node, tmpReg,
+    Inst_RegMem(isLatin1 ? TR::InstOpCode::L1RegMem : TR::InstOpCode::L2RegMem, node, tmpReg,
         MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
-    generateMemRegInstruction(isLatin1 ? TR::InstOpCode::CMP1MemReg : TR::InstOpCode::CMP2MemReg, node,
+    Inst_MemReg(isLatin1 ? TR::InstOpCode::CMP1MemReg : TR::InstOpCode::CMP2MemReg, node,
         MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), tmpReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
+    Inst_Label(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, s2idxReg, 1, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP1, node, byteLoopLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, s2idxReg, 1, cg);
+    Inst_Label(TR::InstOpCode::JMP1, node, byteLoopLabel, cg);
 
     // substring did not match
-    generateLabelInstruction(TR::InstOpCode::label, node, unmatchedLabel, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, resultReg, 1, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, outerLoopLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, unmatchedLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImms, node, resultReg, 1, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, outerLoopLabel, cg);
 
     // not found
-    generateLabelInstruction(TR::InstOpCode::label, node, notFoundLabel, cg);
-    generateRegImmInstruction(TR::InstOpCode::OR4RegImms, node, resultReg, -1, cg);
+    Inst_Label(TR::InstOpCode::label, node, notFoundLabel, cg);
+    Inst_RegImm(TR::InstOpCode::OR4RegImms, node, resultReg, -1, cg);
     // fall through to doneLabel
 
-    generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, dependencies, cg);
+    Inst_Label(TR::InstOpCode::label, node, doneLabel, dependencies, cg);
 
     cg->stopUsingRegister(ECX);
     cg->stopUsingRegister(tmpReg);
@@ -10995,14 +10903,13 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
         case gc_modron_readbar_none:
             break;
         case gc_modron_readbar_always:
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+            Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                 MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
-            generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
+            Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
             break;
         case gc_modron_readbar_range_check: {
-            generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, tmp,
-                MRef_BIS(object, offset, 0, cg), cg);
+            Inst_RegMem(TR::InstOpCode::LRegMem(use64BitClasses), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
 
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg);
             TR::LabelSymbol *endLabel = generateLabelSymbol(cg);
@@ -11014,29 +10921,29 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
             deps->addPreCondition(tmp, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(tmp, TR::RealRegister::NoReg, cg);
 
-            generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
+            Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
 
-            generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
+            Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
                 MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
                 cg);
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
 
             {
                 TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
-                generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
+                Inst_RegMem(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
                     MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
                     cg);
-                generateLabelInstruction(TR::InstOpCode::JA4, node, endLabel, cg);
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
-                generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+                Inst_Label(TR::InstOpCode::JA4, node, endLabel, cg);
+                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
+                Inst_MemReg(TR::InstOpCode::SMemReg(), node,
                     MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
-                generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
-                generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+                Inst_HelperCall(node, TR_softwareReadBarrier, NULL, cg);
+                Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
 
                 og.endOutlinedInstructionSequence();
             }
 
-            generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+            Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
         } break;
         default:
             TR_ASSERT(false, "Unsupported Read Barrier Type.");
@@ -11044,35 +10951,32 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
     }
 #endif
 
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, EAX, oldValue, cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tmp, newValue, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, EAX, oldValue, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tmp, newValue, cg);
     if (TR::Compiler->om.compressedReferenceShiftOffset() != 0) {
         if (!oldValueNode->isNull()) {
-            generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, EAX,
-                TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, EAX, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         }
         if (!newValueNode->isNull()) {
-            generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, tmp,
-                TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+            Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tmp, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         }
     }
 
     TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)1, 1, cg);
     deps->addPreCondition(EAX, TR::RealRegister::eax, cg);
     deps->addPostCondition(EAX, TR::RealRegister::eax, cg);
-    generateMemRegInstruction(use64BitClasses ? TR::InstOpCode::LCMPXCHG8MemReg : TR::InstOpCode::LCMPXCHG4MemReg, node,
+    Inst_MemReg(use64BitClasses ? TR::InstOpCode::LCMPXCHG8MemReg : TR::InstOpCode::LCMPXCHG4MemReg, node,
         MRef_BIS(object, offset, 0, cg), tmp, deps, cg);
 
     if (isExchange) {
         result = EAX;
         result->setContainsCollectedReference();
         if (TR::Compiler->om.compressedReferenceShiftOffset() != 0) {
-            generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(), node, EAX,
-                TR::Compiler->om.compressedReferenceShiftOffset(), cg);
+            Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, EAX, TR::Compiler->om.compressedReferenceShiftOffset(), cg);
         }
     } else {
-        generateRegInstruction(TR::InstOpCode::SETE1Reg, node, result, cg);
-        generateRegRegInstruction(TR::InstOpCode::MOVZXReg4Reg1, node, result, result, cg);
+        Inst_Reg(TR::InstOpCode::SETE1Reg, node, result, cg);
+        Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, result, result, cg);
     }
 
     // Non-realtime: Generate a write barrier for this kind of object.
@@ -11239,7 +11143,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         //   beforehand
         // For simplicity, just evaluate the store address into storeAddressRegForRealTime right now
         storeAddressRegForRealTime = scratchRegisterManagerForRealTime->findOrCreateScratchRegister();
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, storeAddressRegForRealTime, mr, cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, storeAddressRegForRealTime, mr, cg);
         if (node->getSymbolReference()->isUnresolved()) {
             TR::TreeEvaluator::padUnresolvedDataReferences(node, *node->getSymbolReference(), cg);
 
@@ -11284,7 +11188,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
 
         deps->stopAddingConditions();
 
-        generateMemInstruction(op, node, cmpxchgMR, deps, cg);
+        Inst_Mem(op, node, cmpxchgMR, deps, cg);
     } else {
         int numDeps = 1;
         if (storeAddressRegForRealTime != NULL) {
@@ -11304,7 +11208,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
 
         deps->stopAddingConditions();
 
-        generateMemRegInstruction(op, node, cmpxchgMR, newValueRegister, deps, cg);
+        Inst_MemReg(op, node, cmpxchgMR, newValueRegister, deps, cg);
     }
 
     if (isExchange) {
@@ -11313,7 +11217,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         if (isObject) {
             resultReg->setContainsCollectedReference();
             if (TR::Compiler->om.compressedReferenceShiftOffset() != 0) {
-                generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(), node, resultReg,
+                Inst_RegImm(TR::InstOpCode::SHLRegImm1(), node, resultReg,
                     TR::Compiler->om.compressedReferenceShiftOffset(), cg);
             }
         }
@@ -11327,8 +11231,8 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
 
     if (!isExchange) {
         resultReg = cg->allocateRegister();
-        generateRegInstruction(TR::InstOpCode::SETE1Reg, node, resultReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::MOVZXReg4Reg1, node, resultReg, resultReg, cg);
+        Inst_Reg(TR::InstOpCode::SETE1Reg, node, resultReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, resultReg, resultReg, cg);
     }
 
     // Non-realtime: Generate a write barrier for this kind of object.
@@ -11459,13 +11363,13 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, begLabel, cg);
 
     // If offheap is enabled, we will update bufReg to point to the actual start of the array data
     // and set offsetToDataElements to zero
 #ifdef J9VM_GC_SPARSE_HEAP_ALLOCATION
     if (TR::Compiler->om.isOffHeapAllocationEnabled()) {
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, bufReg,
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, bufReg,
             MRef_Bdisp32(bufReg, cg->comp()->fej9()->getOffsetOfContiguousDataAddrField(), cg), cg);
 
         // We'll be loading first data element address from array header so no need for offset
@@ -11474,67 +11378,65 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // index = offset
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, indexReg, offsetReg, cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, indexReg, offsetReg, cg);
 
     // limit = offset + length
-    generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, limitReg,
-        MRef_BISdisp32(offsetReg, lengthReg, 0, 0, cg), cg);
+    Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, limitReg, MRef_BISdisp32(offsetReg, lengthReg, 0, 0, cg), cg);
 
     // loopLimit = (length & -16) + offset
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, loopLimitReg, lengthReg, cg);
-    generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, loopLimitReg, -16, cg);
-    generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, loopLimitReg, offsetReg, cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, loopLimitReg, lengthReg, cg);
+    Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, loopLimitReg, -16, cg);
+    Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, loopLimitReg, offsetReg, cg);
 
     // If the 16 byte encoding of the pmovmskb instruction is not supported on this architecture,
     // Prepare an 8 byte sign bit mask so we can run an alternate version of the algorithm
     if (!useVectorInstructions) {
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, loopLabel, cg);
 
     // if index >= loopLimit, jump to handling the residual bytes
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, indexReg, loopLimitReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JGE4, node, residualLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, indexReg, loopLimitReg, cg);
+    Inst_Label(TR::InstOpCode::JGE4, node, residualLabel, cg);
 
     // If the 16 byte version of pmovmskb is supported on this architecture,
     // we can proceed to generate code for the loop
     if (useVectorInstructions) {
         // Load 16 bytes from address [buf + index]
-        generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmChunkReg,
+        Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmChunkReg,
             MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
 
         // Extract bitmask of sign bits
-        generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, maskReg, xmmChunkReg, cg, pmovmskbEncoding);
+        Inst_RegReg(TR::InstOpCode::PMOVMSKB4RegReg, node, maskReg, xmmChunkReg, cg, pmovmskbEncoding);
 
         // Check if any negative values exist
-        generateRegRegInstruction(TR::InstOpCode::TEST2RegReg, node, maskReg, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::TEST2RegReg, node, maskReg, maskReg, cg);
     }
     // If the 16 byte version of pmovmskb is not supported,
     // run an alternate version of the loop with an 8 byte chunk instead of a 16 byte chunk
     else {
         // Load 8 bytes from address [buf + index]
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, chunkReg,
+        Inst_RegMem(TR::InstOpCode::L8RegMem, node, chunkReg,
             MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
 
         // Check if any negative values exist
-        generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, chunkReg, maskReg, cg);
+        Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, chunkReg, maskReg, cg);
     }
 
     // If the result is nonzero, we found at least one negative byte
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, isHasNegatives ? returnBooleanLabel : returnHasNegativesLabel,
-        cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, isHasNegatives ? returnBooleanLabel : returnHasNegativesLabel, cg);
 
     // increment index by the appropriate amount and jump back to the top of the loop
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImm4, node, indexReg, useVectorInstructions ? 16 : 8, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, loopLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, indexReg, useVectorInstructions ? 16 : 8, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, loopLabel, cg);
 
     // Deal with the residual (last 15 or fewer) bytes
-    generateLabelInstruction(TR::InstOpCode::label, node, residualLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, residualLabel, cg);
 
     // Calculate bytes remaining: loopLimit = -(loopLimit - limit)
-    generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, loopLimitReg, limitReg, cg);
-    generateRegInstruction(TR::InstOpCode::NEG4Reg, node, loopLimitReg, cg);
+    Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, loopLimitReg, limitReg, cg);
+    Inst_Reg(TR::InstOpCode::NEG4Reg, node, loopLimitReg, cg);
 
     /*
      *    if loopLimit == 0
@@ -11568,103 +11470,102 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
      */
 
     // if loopLimit = 0, we did not find any negative bytes
-    generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, loopLimitReg, loopLimitReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, isHasNegatives ? returnBooleanLabel : returnNoNegativesLabel,
-        cg);
+    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, loopLimitReg, loopLimitReg, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, isHasNegatives ? returnBooleanLabel : returnNoNegativesLabel, cg);
 
     // Prepare an 8 byte sign bit mask
     // (if the 16 byte pmovmskb instruction above isn't supported, we already did this at the start)
     if (useVectorInstructions) {
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, maskReg, 0x8080808080808080, cg);
     }
 
     // if loopLimit > 8, jump to nineOrMoreBytesLabel
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 8, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, nineOrMoreBytesLabel, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 8, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, nineOrMoreBytesLabel, cg);
 
     // Zero out the chunk register
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, chunkReg, chunkReg, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, chunkReg, chunkReg, cg);
 
     // if loopLimit > 2, jump to threeOrMoreBytesLabel
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 2, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, threeOrMoreBytesLabel, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 2, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, threeOrMoreBytesLabel, cg);
 
     // Case in which there are one or two residual bytes
     // Load the byte at address [buf + index] into the chunk register
-    generateRegMemInstruction(TR::InstOpCode::L1RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+    Inst_RegMem(TR::InstOpCode::L1RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
+        cg);
     // OR the second byte (which is the same byte again in the 1 byte case)
-    generateRegMemInstruction(TR::InstOpCode::OR1RegMem, node, chunkReg,
+    Inst_RegMem(TR::InstOpCode::OR1RegMem, node, chunkReg,
         MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 1, cg), cg);
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
 
     // Case in which there are three or more residual bytes
-    generateLabelInstruction(TR::InstOpCode::label, node, threeOrMoreBytesLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, threeOrMoreBytesLabel, cg);
 
     // if loopLimit > 4, jump to fiveOrMoreBytesLabel
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 4, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, fiveOrMoreBytesLabel, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, loopLimitReg, 4, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, fiveOrMoreBytesLabel, cg);
 
     // Load the first two bytes at address [buf + index] into the chunk register
-    generateRegMemInstruction(TR::InstOpCode::L2RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+    Inst_RegMem(TR::InstOpCode::L2RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
+        cg);
     // OR the second two bytes at address [buf + (limit - 2)] into the chunk register
-    generateRegMemInstruction(TR::InstOpCode::OR2RegMem, node, chunkReg,
+    Inst_RegMem(TR::InstOpCode::OR2RegMem, node, chunkReg,
         MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 2, cg), cg);
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
 
     // Case in which there are five or more residual bytes
-    generateLabelInstruction(TR::InstOpCode::label, node, fiveOrMoreBytesLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, fiveOrMoreBytesLabel, cg);
 
     // Load the first four bytes at address [buf + index] into the chunk register
-    generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+    Inst_RegMem(TR::InstOpCode::L4RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
+        cg);
     // OR the second four bytes at address [buf + (limit - 4)] into the chunk register
-    generateRegMemInstruction(TR::InstOpCode::OR4RegMem, node, chunkReg,
+    Inst_RegMem(TR::InstOpCode::OR4RegMem, node, chunkReg,
         MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 4, cg), cg);
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
 
     // Case in which there are nine or more residual bytes
-    generateLabelInstruction(TR::InstOpCode::label, node, nineOrMoreBytesLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, nineOrMoreBytesLabel, cg);
 
     // Load the first eight bytes at address [buf + index] into the chunk register
-    generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, chunkReg,
-        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+    Inst_RegMem(TR::InstOpCode::L8RegMem, node, chunkReg, MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg),
+        cg);
     // OR the second eight bytes at address [buf + (limit - 8)] into the chunk register
-    generateRegMemInstruction(TR::InstOpCode::OR8RegMem, node, chunkReg,
+    Inst_RegMem(TR::InstOpCode::OR8RegMem, node, chunkReg,
         MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 8, cg), cg);
 
     // Examine the chunk register now that all of the residual bytes have been ORed into it
-    generateLabelInstruction(TR::InstOpCode::label, node, residualTestLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, residualTestLabel, cg);
     // AND the residual bytes with the new mask
-    generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, chunkReg, maskReg, cg);
+    Inst_RegReg(TR::InstOpCode::TEST8RegReg, node, chunkReg, maskReg, cg);
     if (!isHasNegatives) {
         // If the result is nonzero (i.e. at least one of the sign bits is set), jump to returnHasNegativesLabel
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, returnHasNegativesLabel, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, returnHasNegativesLabel, cg);
     }
 
     // Return result
     if (isHasNegatives) {
-        generateLabelInstruction(TR::InstOpCode::label, node, returnBooleanLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, returnBooleanLabel, cg);
         // If the result of the previous comparison is nonzero, a negative byte has been found somewhere, so return true
         // Otherwise, return false
-        generateRegInstruction(TR::InstOpCode::SETNE1Reg, node, indexReg, cg);
-        generateRegRegInstruction(TR::InstOpCode::MOVZXReg4Reg1, node, indexReg, indexReg, cg);
+        Inst_Reg(TR::InstOpCode::SETNE1Reg, node, indexReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVZXReg4Reg1, node, indexReg, indexReg, cg);
     } else {
         // no negatives found case, result = length
-        generateLabelInstruction(TR::InstOpCode::label, node, returnNoNegativesLabel, cg);
-        generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, indexReg, lengthReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, returnNoNegativesLabel, cg);
+        Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, indexReg, lengthReg, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
 
         // negative(s) found case, result = index - offset
-        generateLabelInstruction(TR::InstOpCode::label, node, returnHasNegativesLabel, cg);
-        generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, indexReg, offsetReg, cg);
+        Inst_Label(TR::InstOpCode::label, node, returnHasNegativesLabel, cg);
+        Inst_RegReg(TR::InstOpCode::SUB4RegReg, node, indexReg, offsetReg, cg);
     }
 
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, dependencies, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, dependencies, cg);
 
     cg->stopUsingRegister(bufReg);
     cg->stopUsingRegister(loopLimitReg);
@@ -11730,14 +11631,14 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
                         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
                         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
                         startLabel->setStartInternalControlFlow();
-                        generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+                        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
-                        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
+                        Inst_RegMem(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
                             MRef_Bdisp32(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg), cg);
-                        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
+                        Inst_RegMem(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
                             MRef_Bdisp32(nativeThreadReg, offsetof(J9Thread, handle), cg), cg);
                         doneLabel->setEndInternalControlFlow();
-                        generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+                        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
                     } else {
                         TR::MemoryReference *lowMR = MRef_Bdisp32(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg);
                         TR::MemoryReference *highMR = MRef_MRefOff(*lowMR, 4, cg);
@@ -11745,21 +11646,20 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
                         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
                         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
                         startLabel->setStartInternalControlFlow();
-                        generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+                        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
-                        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, nativeThreadReg, lowMR, cg);
-                        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highMR, cg);
+                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadReg, lowMR, cg);
+                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highMR, cg);
 
                         TR::MemoryReference *lowHandleMR
                             = MRef_Bdisp32(nativeThreadReg, offsetof(J9Thread, handle), cg);
                         TR::MemoryReference *highHandleMR = MRef_MRefOff(*lowMR, 4, cg);
 
-                        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, nativeThreadReg, lowHandleMR, cg);
-                        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highHandleMR,
-                            cg);
+                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadReg, lowHandleMR, cg);
+                        Inst_RegMem(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highHandleMR, cg);
 
                         doneLabel->setEndInternalControlFlow();
-                        generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+                        Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
                     }
 
                     if (comp->target().is32Bit()) {
@@ -11901,19 +11801,18 @@ static void generateWriteBarrierCall(TR::InstOpCode::Mnemonic branchOp, TR::Node
 
     TR::LabelSymbol *wrtBarLabel = generateLabelSymbol(cg);
 
-    generateLabelInstruction(branchOp, node, wrtBarLabel, cg);
+    Inst_Label(branchOp, node, wrtBarLabel, cg);
 
     TR_OutlinedInstructionsGenerator og(wrtBarLabel, node, cg);
 
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+    Inst_MemReg(TR::InstOpCode::SMemReg(), node,
         MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), owningObjectReg, cg);
     if (helperArgCount > 1) {
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceReg, cg);
     }
-    generateImmSymInstruction(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef,
-        cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
 
     og.endOutlinedInstructionSequence();
 }
@@ -12021,12 +11920,12 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
     if (doInternalControlFlow) {
         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
         startLabel->setStartInternalControlFlow();
-        generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
         doneLabel->setEndInternalControlFlow();
     }
 
     if (comp->getOption(TR_BreakOnWriteBarrier)) {
-        generateInstruction(TR::InstOpCode::INT3, node, cg);
+        Inst(TR::InstOpCode::INT3, node, cg);
     }
 
     TR::SymbolReference *wrtBarSymRef = NULL;
@@ -12067,7 +11966,7 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
         if (comp->getOption(TR_CountWriteBarriersRT)) {
             TR::MemoryReference *barrierCountMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, debugEventData6), cg);
-            generateMemInstruction(TR::InstOpCode::INCMem(comp->target().is64Bit()), node, barrierCountMR, cg);
+            Inst_Mem(TR::InstOpCode::INCMem(comp->target().is64Bit()), node, barrierCountMR, cg);
         }
 
         tempReg = srm->findOrCreateScratchRegister();
@@ -12075,28 +11974,27 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
         // if barrier not enabled, nothing to do
         TR::MemoryReference *fragmentParentMR = MRef_Bdisp32(cg->getVMThreadRegister(),
             fej9->thisThreadRememberedSetFragmentOffset() + fej9->getFragmentParentOffset(), cg);
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(comp->target().is64Bit()), node, tempReg, fragmentParentMR,
-            cg);
+        Inst_RegMem(TR::InstOpCode::LRegMem(comp->target().is64Bit()), node, tempReg, fragmentParentMR, cg);
         TR::MemoryReference *globalFragmentIDMR
             = MRef_Bdisp32(tempReg, fej9->getRememberedSetGlobalFragmentOffset(), cg);
-        generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node, globalFragmentIDMR, 0, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, doneLabel, cg);
+        Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, globalFragmentIDMR, 0, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
 
         // now check if double barrier is enabled and definitely execute the barrier if it is
         // if (vmThread->localFragmentIndex == 0) goto snippetLabel
         TR::MemoryReference *localFragmentIndexMR = MRef_Bdisp32(cg->getVMThreadRegister(),
             fej9->thisThreadRememberedSetFragmentOffset() + fej9->getLocalFragmentOffset(), cg);
-        generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node, localFragmentIndexMR, 0, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
+        Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, localFragmentIndexMR, 0, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
 
         // null test on the reference we're about to store over: if it is null goto doneLabel
         // if (destObject->field == null) goto doneLabel
         TR::MemoryReference *nullTestMR = MRef_Bdisp32(storeAddressRegForRealTime, 0, cg);
         if (comp->target().is64Bit() && comp->useCompressedPointers())
-            generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, node, nullTestMR, 0, cg);
+            Inst_MemImm(TR::InstOpCode::CMP4MemImms, node, nullTestMR, 0, cg);
         else
-            generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node, nullTestMR, 0, cg);
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
+            Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, nullTestMR, 0, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, snippetLabel, cg);
 
         // fall-through means write barrier not needed, just do the store
     }
@@ -12141,12 +12039,12 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
         srm->addScratchRegistersToDependencyList(conditions);
         conditions->stopAddingConditions();
 
-        generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, conditions, cg);
+        Inst_Label(TR::InstOpCode::label, node, doneLabel, conditions, cg);
 
         srm->stopUsingRegisters();
     } else {
         TR_ASSERT(node->getOpCodeValue() == TR::ArrayStoreCHK, "assertion failure");
-        generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, doneLabel, cg);
     }
 }
 
@@ -12326,12 +12224,12 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
     if (doInternalControlFlow) {
         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
         startLabel->setStartInternalControlFlow();
-        generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
         doneLabel->setEndInternalControlFlow();
     }
 
     if (comp->getOption(TR_BreakOnWriteBarrier)) {
-        generateInstruction(TR::InstOpCode::INT3, node, cg);
+        Inst(TR::InstOpCode::INT3, node, cg);
     }
 
     TR::MemoryReference *fragmentParentMR = MRef_Bdisp32(cg->getVMThreadRegister(),
@@ -12342,38 +12240,37 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
     if (doInlineCardMarkingWithoutOldSpaceCheck && doCheckConcurrentMarkActive) {
         TR::MemoryReference *vmThreadPrivateFlagsMR
             = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
-        generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR,
-            J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
+        Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR, J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE,
+            cg);
 
         // Branch to outlined instructions to inline card dirtying.
         //
         TR::LabelSymbol *inlineCardMarkLabel = generateLabelSymbol(cg);
 
-        generateLabelInstruction(TR::InstOpCode::JNE4, node, inlineCardMarkLabel, cg);
+        Inst_Label(TR::InstOpCode::JNE4, node, inlineCardMarkLabel, cg);
 
         // Dirty the card table.
         //
         TR_OutlinedInstructionsGenerator og(inlineCardMarkLabel, node, cg);
         TR::Register *tempReg = srm->findOrCreateScratchRegister();
 
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
 
         if (comp->getOptions()->isVariableHeapBaseForBarrierRange0()) {
             TR::MemoryReference *vhbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
-            generateRegMemInstruction(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
+            Inst_RegMem(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
         } else {
             uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
 
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg,
-                    TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
+                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
                 srm->reclaimScratchRegister(chbReg);
             } else {
-                generateRegImmInstruction(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
+                Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
                     TR_HEAP_BASE_FOR_BARRIER_RANGE);
             }
         }
@@ -12384,28 +12281,27 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->getOptions()->isVariableHeapSizeForBarrierRange0()) {
                 TR::MemoryReference *vhsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
+                Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
             } else {
                 uintptr_t chs = comp->getOptions()->getHeapSizeForBarrierRange0();
 
                 if (comp->target().is64Bit()
                     && (!IS_32BIT_SIGNED(chs) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                     TR::Register *chsReg = srm->findOrCreateScratchRegister();
-                    generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, chsReg, chs, cg,
-                        TR_HEAP_SIZE_FOR_BARRIER_RANGE);
-                    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, tempReg, chsReg, cg);
+                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chsReg, chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
+                    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, tempReg, chsReg, cg);
                     srm->reclaimScratchRegister(chsReg);
                 } else {
-                    generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)chs, cg,
+                    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)chs, cg,
                         TR_HEAP_SIZE_FOR_BARRIER_RANGE);
                 }
             }
 
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, cardMarkDoneLabel, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, cardMarkDoneLabel, cg);
         }
 
-        generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, tempReg,
-            comp->getOptions()->getHeapAddressToCardAddressShift(), cg);
+        Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tempReg, comp->getOptions()->getHeapAddressToCardAddressShift(),
+            cg);
 
         // Mark the card
         //
@@ -12416,7 +12312,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         if (comp->getOptions()->isVariableActiveCardTableBase()) {
             TR::MemoryReference *actbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
-            generateRegMemInstruction(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
+            Inst_RegMem(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
             cardTableMR = MRef_Bdisp32(tempReg, 0, cg);
         } else {
             uintptr_t actb = comp->getOptions()->getActiveCardTableBase();
@@ -12424,8 +12320,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(actb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *tempReg3 = srm->findOrCreateScratchRegister();
-                generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg,
-                    TR_ACTIVE_CARD_TABLE_BASE);
+                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg, TR_ACTIVE_CARD_TABLE_BASE);
                 cardTableMR = MRef_BIS(tempReg3, tempReg, 0, cg);
                 srm->reclaimScratchRegister(tempReg3);
             } else {
@@ -12434,9 +12329,9 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             }
         }
 
-        generateMemImmInstruction(TR::InstOpCode::S1MemImm1, node, cardTableMR, dirtyCard, cg);
+        Inst_MemImm(TR::InstOpCode::S1MemImm1, node, cardTableMR, dirtyCard, cg);
         srm->reclaimScratchRegister(tempReg);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
 
         og.endOutlinedInstructionSequence();
     } else if (doInlineCardMarkingWithoutOldSpaceCheck && !dirtyCardTableOutOfLine) {
@@ -12444,24 +12339,23 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         //
         TR::Register *tempReg = srm->findOrCreateScratchRegister();
 
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
 
         if (comp->getOptions()->isVariableHeapBaseForBarrierRange0()) {
             TR::MemoryReference *vhbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
-            generateRegMemInstruction(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
+            Inst_RegMem(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
         } else {
             uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
 
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg,
-                    TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
+                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
                 srm->reclaimScratchRegister(chbReg);
             } else {
-                generateRegImmInstruction(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
+                Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
                     TR_HEAP_BASE_FOR_BARRIER_RANGE);
             }
         }
@@ -12472,28 +12366,27 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->getOptions()->isVariableHeapSizeForBarrierRange0()) {
                 TR::MemoryReference *vhsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
+                Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
             } else {
                 uintptr_t chs = comp->getOptions()->getHeapSizeForBarrierRange0();
 
                 if (comp->target().is64Bit()
                     && (!IS_32BIT_SIGNED(chs) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                     TR::Register *chsReg = srm->findOrCreateScratchRegister();
-                    generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, chsReg, chs, cg,
-                        TR_HEAP_SIZE_FOR_BARRIER_RANGE);
-                    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, tempReg, chsReg, cg);
+                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chsReg, chs, cg, TR_HEAP_SIZE_FOR_BARRIER_RANGE);
+                    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, tempReg, chsReg, cg);
                     srm->reclaimScratchRegister(chsReg);
                 } else {
-                    generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)chs, cg,
+                    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)chs, cg,
                         TR_HEAP_SIZE_FOR_BARRIER_RANGE);
                 }
             }
 
-            generateLabelInstruction(TR::InstOpCode::JAE4, node, cardMarkDoneLabel, cg);
+            Inst_Label(TR::InstOpCode::JAE4, node, cardMarkDoneLabel, cg);
         }
 
-        generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, tempReg,
-            comp->getOptions()->getHeapAddressToCardAddressShift(), cg);
+        Inst_RegImm(TR::InstOpCode::SHRRegImm1(), node, tempReg, comp->getOptions()->getHeapAddressToCardAddressShift(),
+            cg);
 
         // Mark the card
         //
@@ -12504,7 +12397,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         if (comp->getOptions()->isVariableActiveCardTableBase()) {
             TR::MemoryReference *actbMR
                 = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
-            generateRegMemInstruction(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
+            Inst_RegMem(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
             cardTableMR = MRef_Bdisp32(tempReg, 0, cg);
         } else {
             uintptr_t actb = comp->getOptions()->getActiveCardTableBase();
@@ -12512,8 +12405,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (comp->target().is64Bit()
                 && (!IS_32BIT_SIGNED(actb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                 TR::Register *tempReg3 = srm->findOrCreateScratchRegister();
-                generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg,
-                    TR_ACTIVE_CARD_TABLE_BASE);
+                Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg, TR_ACTIVE_CARD_TABLE_BASE);
                 cardTableMR = MRef_BIS(tempReg3, tempReg, 0, cg);
                 srm->reclaimScratchRegister(tempReg3);
             } else {
@@ -12522,18 +12414,18 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             }
         }
 
-        generateMemImmInstruction(TR::InstOpCode::S1MemImm1, node, cardTableMR, dirtyCard, cg);
+        Inst_MemImm(TR::InstOpCode::S1MemImm1, node, cardTableMR, dirtyCard, cg);
 
         srm->reclaimScratchRegister(tempReg);
     }
 
     if (doIsDestAHeapObjectCheck && doIsDestInOldSpaceCheck) {
-        generateLabelInstruction(TR::InstOpCode::label, node, cardMarkDoneLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, cardMarkDoneLabel, cg);
     }
 
     if (doSrcIsNullCheck) {
-        generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, srcReg, srcReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, doneLabel, cg);
+        Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, srcReg, srcReg, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
     }
 
     if (doIsDestInOldSpaceCheck) {
@@ -12574,34 +12466,33 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                     uintptr_t che = comp->getOptions()->getHeapBaseForBarrierRange0()
                         + comp->getOptions()->getHeapSizeForBarrierRange0();
                     if (comp->target().is64Bit() && !IS_32BIT_SIGNED(che)) {
-                        generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, owningObjectReg,
+                        Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, owningObjectReg,
                             MRef_const(cg->findOrCreate8ByteConstant(node, che), cg), cg);
                     } else {
-                        generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, owningObjectReg, (int32_t)che,
-                            cg);
+                        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, owningObjectReg, (int32_t)che, cg);
                     }
                 } else {
                     uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
                     TR::Register *tempOwningObjReg = srm->findOrCreateScratchRegister();
-                    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempOwningObjReg, owningObjectReg, cg);
+                    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempOwningObjReg, owningObjectReg, cg);
                     if (comp->target().is64Bit()
                         && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                         TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg,
+                        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg,
                             TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                        generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, tempOwningObjReg, chbReg, cg);
+                        Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempOwningObjReg, chbReg, cg);
                         srm->reclaimScratchRegister(chbReg);
                     } else {
-                        generateRegImmInstruction(TR::InstOpCode::SUBRegImm4(), node, tempOwningObjReg, (int32_t)chb,
-                            cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                        Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempOwningObjReg, (int32_t)chb, cg,
+                            TR_HEAP_BASE_FOR_BARRIER_RANGE);
                     }
                     TR::MemoryReference *vhsMR1
                         = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                    generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempOwningObjReg, vhsMR1, cg);
+                    Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempOwningObjReg, vhsMR1, cg);
                     srm->reclaimScratchRegister(tempOwningObjReg);
                 }
 
-                generateLabelInstruction(TR::InstOpCode::JAE1, node, doneLabel, cg);
+                Inst_Label(TR::InstOpCode::JAE1, node, doneLabel, cg);
 
                 skipSnippetIfSrcNotOld = true;
             } else {
@@ -12614,12 +12505,12 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             if (byteOffset != -1) {
                 TR::MemoryReference *vmThreadPrivateFlagsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), byteOffset + offsetof(J9VMThread, privateFlags), cg);
-                generateMemImmInstruction(TR::InstOpCode::TEST1MemImm1, node, vmThreadPrivateFlagsMR,
+                Inst_MemImm(TR::InstOpCode::TEST1MemImm1, node, vmThreadPrivateFlagsMR,
                     J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >> (8 * byteOffset), cg);
             } else {
                 TR::MemoryReference *vmThreadPrivateFlagsMR
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
-                generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR,
+                Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR,
                     J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
             }
 
@@ -12659,31 +12550,29 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                 uintptr_t che = comp->getOptions()->getHeapBaseForBarrierRange0()
                     + comp->getOptions()->getHeapSizeForBarrierRange0();
                 if (comp->target().is64Bit() && !IS_32BIT_SIGNED(che)) {
-                    generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, checkDest ? owningObjectReg : srcReg,
+                    Inst_RegMem(TR::InstOpCode::CMP8RegMem, node, checkDest ? owningObjectReg : srcReg,
                         MRef_const(cg->findOrCreate8ByteConstant(node, che), cg), cg);
                 } else {
-                    generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, checkDest ? owningObjectReg : srcReg,
-                        (int32_t)che, cg);
+                    Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, checkDest ? owningObjectReg : srcReg, (int32_t)che,
+                        cg);
                 }
             } else {
                 uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
                 TR::Register *tempReg = srm->findOrCreateScratchRegister();
-                generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg,
-                    checkDest ? owningObjectReg : srcReg, cg);
+                Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, tempReg, checkDest ? owningObjectReg : srcReg, cg);
                 if (comp->target().is64Bit()
                     && (!IS_32BIT_SIGNED(chb) || TR::Compiler->om.nativeAddressesCanChangeSize())) {
                     TR::Register *chbReg = srm->findOrCreateScratchRegister();
-                    generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg,
-                        TR_HEAP_BASE_FOR_BARRIER_RANGE);
-                    generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
+                    Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, node, chbReg, chb, cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
+                    Inst_RegReg(TR::InstOpCode::SUBRegReg(), node, tempReg, chbReg, cg);
                     srm->reclaimScratchRegister(chbReg);
                 } else {
-                    generateRegImmInstruction(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
+                    Inst_RegImm(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
                         TR_HEAP_BASE_FOR_BARRIER_RANGE);
                 }
                 TR::MemoryReference *vhsMR1
                     = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
-                generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR1, cg);
+                Inst_RegMem(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR1, cg);
             }
 
             branchOp = skipSnippetIfOld ? TR::InstOpCode::JB4 : TR::InstOpCode::JAE4; // For branch to snippet
@@ -12693,18 +12582,17 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             // Now performing check for remembered
             if (skipSnippetIfDestRemembered) {
                 // Set up for branch *past* snippet call for previous comparison
-                generateLabelInstruction(reverseBranchOp, node, labelAfterBranchToSnippet, cg);
+                Inst_Label(reverseBranchOp, node, labelAfterBranchToSnippet, cg);
 
                 int32_t byteOffset = byteOffsetForMask(J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST, cg);
                 if (byteOffset != -1) {
                     TR::MemoryReference *MR
                         = MRef_Bdisp32(owningObjectReg, byteOffset + TR::Compiler->om.offsetOfHeaderFlags(), cg);
-                    generateMemImmInstruction(TR::InstOpCode::TEST1MemImm1, node, MR,
+                    Inst_MemImm(TR::InstOpCode::TEST1MemImm1, node, MR,
                         J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST >> (8 * byteOffset), cg);
                 } else {
                     TR::MemoryReference *MR = MRef_Bdisp32(owningObjectReg, TR::Compiler->om.offsetOfHeaderFlags(), cg);
-                    generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node, MR,
-                        J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST, cg);
+                    Inst_MemImm(TR::InstOpCode::TEST4MemImm4, node, MR, J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST, cg);
                 }
                 branchOp = TR::InstOpCode::JE4;
             }
@@ -12713,7 +12601,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         generateWriteBarrierCall(branchOp, node, gcModeForSnippet, owningObjectReg, srcReg, doneLabel, cg);
 
         if (labelAfterBranchToSnippet)
-            generateLabelInstruction(TR::InstOpCode::label, node, labelAfterBranchToSnippet, cg);
+            Inst_Label(TR::InstOpCode::label, node, labelAfterBranchToSnippet, cg);
     }
 
     int32_t numPostConditions = 2 + srm->numAvailableRegisters();
@@ -12735,7 +12623,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
     srm->addScratchRegistersToDependencyList(conditions);
     conditions->stopAddingConditions();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, conditions, cg);
+    Inst_Label(TR::InstOpCode::label, node, doneLabel, conditions, cg);
 
     srm->stopUsingRegisters();
 }
@@ -12745,7 +12633,7 @@ static TR::Instruction *doReferenceStore(TR::Node *node, TR::MemoryReference *st
 {
     TR::Compilation *comp = cg->comp();
     TR::InstOpCode::Mnemonic storeOp = usingCompressedPointers ? TR::InstOpCode::S4MemReg : TR::InstOpCode::SMemReg();
-    TR::Instruction *instr = generateMemRegInstruction(storeOp, node, storeMR, sourceReg, cg);
+    TR::Instruction *instr = Inst_MemReg(storeOp, node, storeMR, sourceReg, cg);
 
     // for real-time GC, the data reference has already been resolved into an earlier LEA instruction so this padding
     // isn't needed
@@ -12803,10 +12691,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
         else {
             translatedSourceReg = cg->evaluate(translatedStore->getSecondChild());
             if (!usingLowMemHeap) {
-                generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), translatedStore, sourceRegister, sourceRegister,
-                    cg);
-                generateRegRegInstruction(TR::InstOpCode::CMOVERegReg(), translatedStore, translatedSourceReg,
-                    sourceRegister, cg);
+                Inst_RegReg(TR::InstOpCode::TESTRegReg(), translatedStore, sourceRegister, sourceRegister, cg);
+                Inst_RegReg(TR::InstOpCode::CMOVERegReg(), translatedStore, translatedSourceReg, sourceRegister, cg);
             }
         }
     }
@@ -12823,7 +12709,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
         //   beforehand
         // For simplicity, just evaluate the store address into storeAddressRegForRealTime right now
         storeAddressRegForRealTime = scratchRegisterManager->findOrCreateScratchRegister();
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, storeAddressRegForRealTime, storeMR, cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, storeAddressRegForRealTime, storeMR, cg);
         if (node->getSymbolReference()->isUnresolved()) {
             TR::TreeEvaluator::padUnresolvedDataReferences(node, *node->getSymbolReference(), cg);
 
@@ -12850,9 +12736,9 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
             startLabel->setStartInternalControlFlow();
             doneWrtBarLabel->setEndInternalControlFlow();
 
-            generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
-            generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
-            generateLabelInstruction(TR::InstOpCode::JE4, node, doneWrtBarLabel, cg);
+            Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+            Inst_RegReg(TR::InstOpCode::TESTRegReg(), node, sourceRegister, sourceRegister, cg);
+            Inst_Label(TR::InstOpCode::JE4, node, doneWrtBarLabel, cg);
 
             deps = generateRegisterDependencyConditions(0, 3, cg);
             deps->addPostCondition(sourceRegister, TR::RealRegister::NoReg, cg);
@@ -12861,16 +12747,15 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
             deps->stopAddingConditions();
         }
 
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), owningObjectRegister, cg);
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
+        Inst_MemReg(TR::InstOpCode::SMemReg(), node,
             MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceRegister, cg);
 
         TR::SymbolReference *wrtBarSymRef = comp->getSymRefTab()->findOrCreateWriteBarrierStoreSymbolRef();
-        generateImmSymInstruction(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(),
-            wrtBarSymRef, cg);
+        Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef, cg);
 
-        generateLabelInstruction(TR::InstOpCode::label, node, doneWrtBarLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, node, doneWrtBarLabel, deps, cg);
     } else {
         if (isRealTimeGC) {
             TR::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(node, storeMR, storeAddressRegForRealTime,
@@ -12909,11 +12794,9 @@ void J9::X86::TreeEvaluator::generateVFTMaskInstruction(TR::Node *node, TR::Regi
     if (~mask == 0) {
         // no mask instruction required
     } else if (~mask <= 127) {
-        generateRegImmInstruction(TR::InstOpCode::ANDRegImms(is64Bit), node, reg,
-            TR::Compiler->om.maskOfObjectVftField(), cg);
+        Inst_RegImm(TR::InstOpCode::ANDRegImms(is64Bit), node, reg, TR::Compiler->om.maskOfObjectVftField(), cg);
     } else {
-        generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(is64Bit), node, reg,
-            TR::Compiler->om.maskOfObjectVftField(), cg);
+        Inst_RegImm(TR::InstOpCode::ANDRegImm4(is64Bit), node, reg, TR::Compiler->om.maskOfObjectVftField(), cg);
     }
 }
 
@@ -12933,10 +12816,9 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
         TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg);
         TR::LabelSymbol *restartLabel = generateLabelSymbol(cg);
 
-        generateMemInstruction(TR::InstOpCode::DEC4Mem, node,
-            MRef_sym(comp->getRecompilationInfo()->getCounterSymRef(), cg), cg);
-        generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
-        generateLabelInstruction(TR::InstOpCode::label, node, restartLabel, cg);
+        Inst_Mem(TR::InstOpCode::DEC4Mem, node, MRef_sym(comp->getRecompilationInfo()->getCounterSymRef(), cg), cg);
+        Inst_Label(TR::InstOpCode::JE4, node, snippetLabel, cg);
+        Inst_Label(TR::InstOpCode::label, node, restartLabel, cg);
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86ForceRecompilationSnippet(cg, node, restartLabel, snippetLabel));
         cg->comp()->getRecompilationInfo()->getJittedBodyInfo()->setHasEdoSnippet();
     }
@@ -13028,103 +12910,103 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     startLabelConditions->addPostCondition(dummyReg, TR::RealRegister::eax, cg);
     startLabelConditions->stopAddingConditions();
     cg->stopUsingRegister(dummyReg);
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, startLabelConditions, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, startLabelConditions, cg);
 
     // xbegin fall_back_path
-    generateLongLabelInstruction(TR::InstOpCode::XBEGIN4, node, fallBackPathLabel, cg);
+    Inst_LongLabel(TR::InstOpCode::XBEGIN4, node, fallBackPathLabel, cg);
     // mov monReg, obj+offset
     int32_t lwOffset = cg->fej9()->getByteOffsetToLockword((TR_OpaqueClassBlock *)cg->getMonClass(node));
     TR::MemoryReference *objLockRef = MRef_Bdisp32(objReg, lwOffset, cg);
     if (comp->target().is64Bit() && cg->fej9()->generateCompressedLockWord()) {
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, monReg, objLockRef, cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, monReg, objLockRef, cg);
     } else {
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, monReg, objLockRef, cg);
+        Inst_RegMem(TR::InstOpCode::LRegMem(), node, monReg, objLockRef, cg);
     }
 
     if (comp->target().is64Bit() && cg->fej9()->generateCompressedLockWord()) {
-        generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, monReg, 0, cg);
+        Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, monReg, 0, cg);
     } else {
-        generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, monReg, 0, cg);
+        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, monReg, 0, cg);
     }
 
     if (fallThroughConditions)
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThroughLabel, fallThroughConditions, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, fallThroughConditions, cg);
     else
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThroughLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, cg);
 
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
     if (comp->target().is64Bit() && cg->fej9()->generateCompressedLockWord()) {
-        generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, monReg, vmThreadReg, cg);
+        Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, monReg, vmThreadReg, cg);
     } else {
-        generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, monReg, vmThreadReg, cg);
+        Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, monReg, vmThreadReg, cg);
     }
 
     if (fallThroughConditions)
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThroughLabel, fallThroughConditions, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, fallThroughConditions, cg);
     else
-        generateLabelInstruction(TR::InstOpCode::JE4, node, fallThroughLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, fallThroughLabel, cg);
 
     // xabort
-    generateImmInstruction(TR::InstOpCode::XABORT, node, 0x01, cg);
+    Inst_Imm(TR::InstOpCode::XABORT, node, 0x01, cg);
 
     cg->stopUsingRegister(monReg);
     // fall_back_path:
-    generateLabelInstruction(TR::InstOpCode::label, node, fallBackPathLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, fallBackPathLabel, cg);
 
     endLabelConditions = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
     endLabelConditions->addPostCondition(accReg, TR::RealRegister::eax, cg);
     endLabelConditions->stopAddingConditions();
 
     // test eax, 0x2
-    generateRegImmInstruction(TR::InstOpCode::TEST1AccImm1, node, accReg, 0x2, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, gotoTransientFailure, cg);
+    Inst_RegImm(TR::InstOpCode::TEST1AccImm1, node, accReg, 0x2, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, gotoTransientFailure, cg);
 
     // abort because of nonzero lockword is also transient failure
-    generateRegImmInstruction(TR::InstOpCode::TEST4AccImm4, node, accReg, 0x00000001, cg);
+    Inst_RegImm(TR::InstOpCode::TEST4AccImm4, node, accReg, 0x00000001, cg);
     if (persistentConditions)
-        generateLabelInstruction(TR::InstOpCode::JE4, node, persistentFailureLabel, persistentConditions, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, persistentFailureLabel, persistentConditions, cg);
     else
-        generateLabelInstruction(TR::InstOpCode::JE4, node, persistentFailureLabel, cg);
+        Inst_Label(TR::InstOpCode::JE4, node, persistentFailureLabel, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::TEST4AccImm4, node, accReg, 0x01000000, cg);
+    Inst_RegImm(TR::InstOpCode::TEST4AccImm4, node, accReg, 0x01000000, cg);
     // je gotransientFailureNodeLabel
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, gotoTransientFailure, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, gotoTransientFailure, cg);
 
     if (persistentConditions)
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, persistentFailureLabel, persistentConditions, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, persistentFailureLabel, persistentConditions, cg);
     else
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, persistentFailureLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, persistentFailureLabel, cg);
     cg->stopUsingRegister(accReg);
 
     // gotoTransientFailureLabel:
     if (transientConditions)
-        generateLabelInstruction(TR::InstOpCode::label, node, gotoTransientFailure, transientConditions, cg);
+        Inst_Label(TR::InstOpCode::label, node, gotoTransientFailure, transientConditions, cg);
     else
-        generateLabelInstruction(TR::InstOpCode::label, node, gotoTransientFailure, cg);
+        Inst_Label(TR::InstOpCode::label, node, gotoTransientFailure, cg);
 
     // delay
     TR::Register *counterReg = cg->allocateRegister();
-    generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, counterReg, 100, cg);
+    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, counterReg, 100, cg);
     TR::LabelSymbol *spinLabel = TR::LabelSymbol::create(cg->trHeapMemory(), cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, spinLabel, cg);
-    generateInstruction(TR::InstOpCode::PAUSE, node, cg);
-    generateInstruction(TR::InstOpCode::PAUSE, node, cg);
-    generateInstruction(TR::InstOpCode::PAUSE, node, cg);
-    generateInstruction(TR::InstOpCode::PAUSE, node, cg);
-    generateInstruction(TR::InstOpCode::PAUSE, node, cg);
-    generateRegInstruction(TR::InstOpCode::DEC4Reg, node, counterReg, cg);
+    Inst_Label(TR::InstOpCode::label, node, spinLabel, cg);
+    Inst(TR::InstOpCode::PAUSE, node, cg);
+    Inst(TR::InstOpCode::PAUSE, node, cg);
+    Inst(TR::InstOpCode::PAUSE, node, cg);
+    Inst(TR::InstOpCode::PAUSE, node, cg);
+    Inst(TR::InstOpCode::PAUSE, node, cg);
+    Inst_Reg(TR::InstOpCode::DEC4Reg, node, counterReg, cg);
     TR::RegisterDependencyConditions *loopConditions = generateRegisterDependencyConditions((uint8_t)0, 1, cg);
     loopConditions->addPostCondition(counterReg, TR::RealRegister::NoReg, cg);
     loopConditions->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, spinLabel, loopConditions, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, spinLabel, loopConditions, cg);
     cg->stopUsingRegister(counterReg);
 
     if (transientConditions)
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, transientFailureLabel, transientConditions, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, transientFailureLabel, transientConditions, cg);
     else
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, transientFailureLabel, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, transientFailureLabel, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, endLabelConditions, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, endLabelConditions, cg);
     cg->decReferenceCount(objNode);
     cg->decReferenceCount(persistentFailureNode);
     cg->decReferenceCount(transientFailureNode);
@@ -13133,13 +13015,13 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
 
 TR::Register *J9::X86::TreeEvaluator::tfinishEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    generateInstruction(TR::InstOpCode::XEND, node, cg);
+    Inst(TR::InstOpCode::XEND, node, cg);
     return NULL;
 }
 
 TR::Register *J9::X86::TreeEvaluator::tabortEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    generateImmInstruction(TR::InstOpCode::XABORT, node, 0x04, cg);
+    Inst_Imm(TR::InstOpCode::XABORT, node, 0x04, cg);
     return NULL;
 }
 
@@ -13239,7 +13121,7 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
         case TR::java_lang_Thread_onSpinWait: {
             static char *disableOSW = feGetEnv("TR_noPauseOnSpinWait");
             if (!disableOSW) {
-                generateInstruction(TR::InstOpCode::PAUSE, node, cg);
+                Inst(TR::InstOpCode::PAUSE, node, cg);
 
                 static char *printIt = feGetEnv("TR_showPauseOnSpinWait");
                 if (printIt && comp->getOption(TR_TraceCG)) {
@@ -13400,23 +13282,23 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
 
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
     startLabel->setStartInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     TR::Node *destOffsetNode = node->getChild(3);
 
     if (!destOffsetNode->isConstZeroValue()) {
         // dest offset measured in characters, convert it to bytes
-        generateRegRegInstruction(TR::InstOpCode::ADD4RegReg, node, destOffsetReg, destOffsetReg, cg);
+        Inst_RegReg(TR::InstOpCode::ADD4RegReg, node, destOffsetReg, destOffsetReg, cg);
     }
 
-    generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, lengthReg, lengthReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, doneLabel, cg);
+    Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, lengthReg, lengthReg, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, doneLabel, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, lengthReg, 8, cg);
-    generateLabelInstruction(TR::InstOpCode::JL4, node, afterCopy8Label, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, lengthReg, 8, cg);
+    Inst_Label(TR::InstOpCode::JL4, node, afterCopy8Label, cg);
 
     // make sure the register is zero before interleaving
-    generateRegRegInstruction(TR::InstOpCode::PXORRegReg, node, zeroReg, zeroReg, cg);
+    Inst_RegReg(TR::InstOpCode::PXORRegReg, node, zeroReg, zeroReg, cg);
 
     TR::LabelSymbol *startLoop = generateLabelSymbol(cg);
     TR::LabelSymbol *endLoop = generateLabelSymbol(cg);
@@ -13424,52 +13306,52 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     // vectorized add in loop, 16 bytes per iteration
     // use srcOffsetReg for loop counter, add starting offset to lengthReg, subtract 16 (xmm register size)
     // to prevent reading/writing beyond the end of the array
-    generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, scratchReg,
+    Inst_RegMem(TR::InstOpCode::LEA4RegMem, node, scratchReg,
         MRef_BISdisp32(lengthReg, srcOffsetReg, 0, -vectorLengthConst, cg), cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLoop, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, srcOffsetReg, scratchReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JG4, node, endLoop, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLoop, cg);
+    Inst_RegReg(TR::InstOpCode::CMP4RegReg, node, srcOffsetReg, scratchReg, cg);
+    Inst_Label(TR::InstOpCode::JG4, node, endLoop, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmHighReg,
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmHighReg,
         MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOVDQURegReg, node, xmmLowReg, xmmHighReg, cg);
-    generateRegRegInstruction(TR::InstOpCode::PUNPCKHBWRegReg, node, xmmLowReg, zeroReg, cg);
-    generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
+    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmLowReg, xmmHighReg, cg);
+    Inst_RegReg(TR::InstOpCode::PUNPCKHBWRegReg, node, xmmLowReg, zeroReg, cg);
+    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
         MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst + vectorLengthConst, cg), xmmLowReg, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmHighReg, zeroReg, cg);
-    generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
+    Inst_RegReg(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmHighReg, zeroReg, cg);
+    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
         MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmHighReg, cg);
 
     // increase src offset by size of imm register
     // increase dest offset by double, to account for the byte->char inflation
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImm4, node, srcOffsetReg, vectorLengthConst, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImm4, node, destOffsetReg, 2 * vectorLengthConst, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, srcOffsetReg, vectorLengthConst, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, destOffsetReg, 2 * vectorLengthConst, cg);
 
     // LOOP BACK
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, startLoop, cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, endLoop, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, startLoop, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLoop, cg);
 
     // AND length with 15 to compute residual remainder
     // then copy and interleave 8 bytes from src buffer with 0s into dest buffer if possible
-    generateRegImmInstruction(TR::InstOpCode::AND4RegImm4, node, lengthReg, vectorLengthConst - 1, cg);
+    Inst_RegImm(TR::InstOpCode::AND4RegImm4, node, lengthReg, vectorLengthConst - 1, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, lengthReg, 8, cg);
-    generateLabelInstruction(TR::InstOpCode::JL1, node, afterCopy8Label, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, lengthReg, 8, cg);
+    Inst_Label(TR::InstOpCode::JL1, node, afterCopy8Label, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::MOVQRegMem, node, xmmLowReg,
+    Inst_RegMem(TR::InstOpCode::MOVQRegMem, node, xmmLowReg,
         MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
-    generateRegRegInstruction(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmLowReg, zeroReg, cg);
-    generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
+    Inst_RegReg(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmLowReg, zeroReg, cg);
+    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node,
         MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmLowReg, cg);
-    generateRegImmInstruction(TR::InstOpCode::SUB4RegImm4, node, lengthReg, 8, cg);
+    Inst_RegImm(TR::InstOpCode::SUB4RegImm4, node, lengthReg, 8, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImm4, node, srcOffsetReg, 8, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImm4, node, destOffsetReg, 16, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, srcOffsetReg, 8, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, destOffsetReg, 16, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, afterCopy8Label, cg);
+    Inst_Label(TR::InstOpCode::label, node, afterCopy8Label, cg);
 
     // handle residual (< 8 bytes left) & jump to copy instructions based on the number of bytes left
     // calculate how many bytes to skip based on length;
@@ -13480,9 +13362,8 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     // since copy_instruction_size could change depending on which registers are allocated to scratchReg, srcOffsetReg
     // and destOffsetReg we reserve them to be eax, ecx, edx, respectively
 
-    generateRegRegImmInstruction(TR::InstOpCode::IMUL4RegRegImm4, node, lengthReg, lengthReg, -copy_instruction_size,
-        cg);
-    generateRegImmInstruction(TR::InstOpCode::ADD4RegImm4, node, lengthReg, copy_instruction_size * 7, cg);
+    Inst_RegRegImm(TR::InstOpCode::IMUL4RegRegImm4, node, lengthReg, lengthReg, -copy_instruction_size, cg);
+    Inst_RegImm(TR::InstOpCode::ADD4RegImm4, node, lengthReg, copy_instruction_size * 7, cg);
 
     bool is64bit = cg->comp()->target().is64Bit();
     // calculate address to jump too
@@ -13493,27 +13374,27 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
         deps->addPostCondition(residueLabelMR->getAddressRegister(), TR::RealRegister::NoReg, cg);
     }
 
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(is64bit), node, scratchReg, residueLabelMR, cg);
-    generateRegRegInstruction(TR::InstOpCode::ADDRegReg(is64bit), node, lengthReg, scratchReg, cg);
+    Inst_RegMem(TR::InstOpCode::LEARegMem(is64bit), node, scratchReg, residueLabelMR, cg);
+    Inst_RegReg(TR::InstOpCode::ADDRegReg(is64bit), node, lengthReg, scratchReg, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(is64bit), node, srcOffsetReg,
+    Inst_RegMem(TR::InstOpCode::LEARegMem(is64bit), node, srcOffsetReg,
         MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, 0, cg), cg);
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(is64bit), node, destOffsetReg,
+    Inst_RegMem(TR::InstOpCode::LEARegMem(is64bit), node, destOffsetReg,
         MRef_BISdisp32(destBufferReg, destOffsetReg, 0, 0, cg), cg);
 
-    generateRegInstruction(TR::InstOpCode::JMPReg, node, lengthReg, cg);
+    Inst_Reg(TR::InstOpCode::JMPReg, node, lengthReg, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, copyResidueLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, copyResidueLabel, cg);
 
     for (int i = 0; i < 7; i++) {
-        generateRegMemInstruction(TR::InstOpCode::MOVZXReg2Mem1, node, scratchReg,
+        Inst_RegMem(TR::InstOpCode::MOVZXReg2Mem1, node, scratchReg,
             MRef_Bdisp32(srcOffsetReg, headerOffsetConst + 6 - i, cg), cg);
-        generateMemRegInstruction(TR::InstOpCode::S2MemReg, node,
-            MRef_Bdisp32(destOffsetReg, headerOffsetConst + 2 * (6 - i), cg), scratchReg, cg);
+        Inst_MemReg(TR::InstOpCode::S2MemReg, node, MRef_Bdisp32(destOffsetReg, headerOffsetConst + 2 * (6 - i), cg),
+            scratchReg, cg);
     }
 
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, doneLabel, deps, cg);
     doneLabel->setEndInternalControlFlow();
 
     cg->stopUsingRegister(srcOffsetReg);
@@ -13586,7 +13467,7 @@ TR::Register *J9::X86::TreeEvaluator::encodeUTF16Evaluator(TR::Node *node, TR::C
     else
         helper = bigEndian ? TR_IA32encodeUTF16Big : TR_IA32encodeUTF16Little;
 
-    generateHelperCallInstruction(node, helper, deps, cg);
+    Inst_HelperCall(node, helper, deps, cg);
 
     // Free up registers
     for (int i = 0; i < gprClobberCount; i++)
@@ -13853,41 +13734,41 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
     // Under decompressed string case for 32bits platforms, bail out if string is larger than INT_MAX32/2 since #
     // character to # byte conversion will cause overflow.
     if (!cg->comp()->target().is64Bit() && !manager.isCompressedString()) {
-        generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, length, (uint16_t)0x8000, cg);
-        generateLabelInstruction(TR::InstOpCode::JGE4, node, failLabel, cg);
+        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), node, length, (uint16_t)0x8000, cg);
+        Inst_Label(TR::InstOpCode::JGE4, node, failLabel, cg);
     }
 
     // 1. preparation (load value into registers, calculate length etc)
     auto lowerBndMinus1 = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getLowerBndMinus1()), cg);
-    cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegLowerBndMinus1, lowerBndMinus1, cg);
+    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegLowerBndMinus1, lowerBndMinus1, cg);
     iComment("lower bound ascii value minus one");
 
     auto upperBnd = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getUpperBnd()), cg);
-    cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegUpperBnd, upperBnd, cg);
+    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegUpperBnd, upperBnd, cg);
     iComment("upper bound ascii value");
 
     auto conversionDiff = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getConversionDiff()), cg);
-    cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegConversionDiff, conversionDiff, cg);
+    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegConversionDiff, conversionDiff, cg);
     iComment("case conversion diff value");
 
     auto minus1 = MRef_const(cg->findOrCreate16ByteConstant(node, MINUS1), cg);
-    cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegMinus1, minus1, cg);
+    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegMinus1, minus1, cg);
     iComment("-1");
 
     auto asciiUpperBnd = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getAsciiMax()), cg);
-    cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegAsciiUpperBnd, asciiUpperBnd, cg);
+    cursor = Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegAsciiUpperBnd, asciiUpperBnd, cg);
     iComment("maximum ascii value ");
 
-    generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, result, 1, cg);
+    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, node, result, 1, cg);
 
     // initialize the loop counter
-    cursor = generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, counter, counter, cg);
+    cursor = Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, counter, counter, cg);
     iComment("initialize loop counter");
 
     // calculate the residueStartLength. Later instructions compare the counter with this length and decide when to jump
     // to the residue handling sequence
-    generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, residueStartLength, length, cg);
-    generateRegImmInstruction(TR::InstOpCode::SUBRegImms(), node, residueStartLength, strideSize - 1, cg);
+    Inst_RegReg(TR::InstOpCode::MOVRegReg(), node, residueStartLength, length, cg);
+    Inst_RegImm(TR::InstOpCode::SUBRegImms(), node, residueStartLength, strideSize - 1, cg);
 
     // 2. vectorized case conversion loop
     TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
@@ -13897,105 +13778,95 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
 
     startLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     TR::LabelSymbol *caseConversionMainLoopLabel = generateLabelSymbol(cg);
-    generateLabelInstruction(TR::InstOpCode::label, node, caseConversionMainLoopLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, counter, residueStartLength, cg);
-    generateLabelInstruction(TR::InstOpCode::JGE4, node, residueStartLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, caseConversionMainLoopLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, counter, residueStartLength, cg);
+    Inst_Label(TR::InstOpCode::JGE4, node, residueStartLabel, cg);
 
     auto srcArrayMemRef = MRef_BISdisp32(srcArray, counter, 0, headerSize, cg);
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegArrayContentCopy0, srcArrayMemRef, cg);
+    Inst_RegMem(TR::InstOpCode::MOVDQURegMem, node, xmmRegArrayContentCopy0, srcArrayMemRef, cg);
 
     // detect invalid characters
-    generateRegRegInstruction(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
-    cursor = generateRegRegInstruction(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg
-                                                                    : TR::InstOpCode::PCMPGTWRegReg,
+    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
+    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
+    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
         node, xmmRegArrayContentCopy1, xmmRegMinus1, cg);
     iComment(" > -1");
-    cursor = generateRegRegInstruction(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg
-                                                                    : TR::InstOpCode::PCMPGTWRegReg,
+    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
         node, xmmRegArrayContentCopy2, xmmRegAsciiUpperBnd, cg);
     iComment(" > maximum ascii value");
-    cursor = generateRegRegInstruction(TR::InstOpCode::PANDNRegReg, node, xmmRegArrayContentCopy2,
-        xmmRegArrayContentCopy1, cg);
+    cursor = Inst_RegReg(TR::InstOpCode::PANDNRegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
     iComment(" >-1 && !(> maximum ascii value) valid when all bits are set");
-    cursor = generateRegRegInstruction(TR::InstOpCode::PXORRegReg, node, xmmRegArrayContentCopy2, xmmRegMinus1, cg);
+    cursor = Inst_RegReg(TR::InstOpCode::PXORRegReg, node, xmmRegArrayContentCopy2, xmmRegMinus1, cg);
     iComment("reverse all bits");
-    generateRegRegInstruction(TR::InstOpCode::PTESTRegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy2, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, failLabel, cg);
+    Inst_RegReg(TR::InstOpCode::PTESTRegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy2, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, failLabel, cg);
     iComment("jump out if invalid chars are detected");
 
     // calculate case conversion with vector registers
-    generateRegRegInstruction(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
-    generateRegRegInstruction(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
-    cursor = generateRegRegInstruction(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg
-                                                                    : TR::InstOpCode::PCMPGTWRegReg,
+    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
+    Inst_RegReg(TR::InstOpCode::MOVDQURegReg, node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy0, cg);
+    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
         node, xmmRegArrayContentCopy0, xmmRegLowerBndMinus1, cg);
     iComment(manager.toLowerCase() ? " > 'A-1'" : "> 'a-1'");
-    cursor = generateRegRegInstruction(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg
-                                                                    : TR::InstOpCode::PCMPGTWRegReg,
+    cursor = Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PCMPGTBRegReg : TR::InstOpCode::PCMPGTWRegReg,
         node, xmmRegArrayContentCopy1, xmmRegUpperBnd, cg);
     iComment(manager.toLowerCase() ? " > 'Z'" : " > 'z'");
-    cursor = generateRegRegInstruction(TR::InstOpCode::PANDNRegReg, node, xmmRegArrayContentCopy1,
-        xmmRegArrayContentCopy0, cg);
+    cursor = Inst_RegReg(TR::InstOpCode::PANDNRegReg, node, xmmRegArrayContentCopy1, xmmRegArrayContentCopy0, cg);
     iComment(const_cast<char *>(manager.toLowerCase() ? " >='A' && !( >'Z')" : " >='a' && !( >'z')"));
-    generateRegRegInstruction(TR::InstOpCode::PANDRegReg, node, xmmRegArrayContentCopy1, xmmRegConversionDiff, cg);
+    Inst_RegReg(TR::InstOpCode::PANDRegReg, node, xmmRegArrayContentCopy1, xmmRegConversionDiff, cg);
 
     if (manager.toLowerCase())
-        generateRegRegInstruction(manager.isCompressedString() ? TR::InstOpCode::PADDBRegReg
-                                                               : TR::InstOpCode::PADDWRegReg,
-            node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
+        Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PADDBRegReg : TR::InstOpCode::PADDWRegReg, node,
+            xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
     else
-        generateRegRegInstruction(manager.isCompressedString() ? TR::InstOpCode::PSUBBRegReg
-                                                               : TR::InstOpCode::PSUBWRegReg,
-            node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
+        Inst_RegReg(manager.isCompressedString() ? TR::InstOpCode::PSUBBRegReg : TR::InstOpCode::PSUBWRegReg, node,
+            xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
 
     auto dstArrayMemRef = MRef_BISdisp32(dstArray, counter, 0, headerSize, cg);
-    generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node, dstArrayMemRef, xmmRegArrayContentCopy2, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, counter, strideSize, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, caseConversionMainLoopLabel, cg);
+    Inst_MemReg(TR::InstOpCode::MOVDQUMemReg, node, dstArrayMemRef, xmmRegArrayContentCopy2, cg);
+    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, counter, strideSize, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, caseConversionMainLoopLabel, cg);
 
     // 3. handle residue with non vectorized case conversion loop
-    generateLabelInstruction(TR::InstOpCode::label, node, residueStartLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, counter, length, cg);
-    generateLabelInstruction(TR::InstOpCode::JGE4, node, endLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, residueStartLabel, cg);
+    Inst_RegReg(TR::InstOpCode::CMPRegReg(), node, counter, length, cg);
+    Inst_Label(TR::InstOpCode::JGE4, node, endLabel, cg);
     srcArrayMemRef = MRef_BISdisp32(srcArray, counter, 0, headerSize, cg);
-    generateRegMemInstruction(manager.isCompressedString() ? TR::InstOpCode::MOVZXReg4Mem1
-                                                           : TR::InstOpCode::MOVZXReg4Mem2,
-        node, singleChar, srcArrayMemRef, cg);
+    Inst_RegMem(manager.isCompressedString() ? TR::InstOpCode::MOVZXReg4Mem1 : TR::InstOpCode::MOVZXReg4Mem2, node,
+        singleChar, srcArrayMemRef, cg);
 
     // use unsigned compare to detect invalid range
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImms, node, singleChar, 0x7F, cg);
-    generateLabelInstruction(TR::InstOpCode::JA4, node, failLabel, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImms, node, singleChar, 0x7F, cg);
+    Inst_Label(TR::InstOpCode::JA4, node, failLabel, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'A' : 'a', cg);
-    generateLabelInstruction(TR::InstOpCode::JB4, node, storeToArrayLabel, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'A' : 'a', cg);
+    Inst_Label(TR::InstOpCode::JB4, node, storeToArrayLabel, cg);
 
-    generateRegImmInstruction(TR::InstOpCode::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'Z' : 'z', cg);
-    generateLabelInstruction(TR::InstOpCode::JA4, node, storeToArrayLabel, cg);
+    Inst_RegImm(TR::InstOpCode::CMP4RegImms, node, singleChar, manager.toLowerCase() ? 'Z' : 'z', cg);
+    Inst_Label(TR::InstOpCode::JA4, node, storeToArrayLabel, cg);
 
     if (manager.toLowerCase())
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, singleChar, MRef_Bdisp32(singleChar, 0x20, cg),
-            cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, singleChar, MRef_Bdisp32(singleChar, 0x20, cg), cg);
 
     else
-        generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, node, singleChar, 0x20, cg);
+        Inst_RegImm(TR::InstOpCode::SUB4RegImms, node, singleChar, 0x20, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, storeToArrayLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, storeToArrayLabel, cg);
 
     dstArrayMemRef = MRef_BISdisp32(dstArray, counter, 0, headerSize, cg);
-    generateMemRegInstruction(manager.isCompressedString() ? TR::InstOpCode::S1MemReg : TR::InstOpCode::S2MemReg, node,
+    Inst_MemReg(manager.isCompressedString() ? TR::InstOpCode::S1MemReg : TR::InstOpCode::S2MemReg, node,
         dstArrayMemRef, singleChar, cg);
-    generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, counter, manager.isCompressedString() ? 1 : 2, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, residueStartLabel, cg);
+    Inst_RegImm(TR::InstOpCode::ADDRegImms(), node, counter, manager.isCompressedString() ? 1 : 2, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, residueStartLabel, cg);
 
     // 4. handle invalid case
-    generateLabelInstruction(TR::InstOpCode::label, node, failLabel, cg);
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, result, result, cg);
+    Inst_Label(TR::InstOpCode::label, node, failLabel, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, result, result, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
     node->setRegister(result);
 
     cg->stopUsingRegister(length);
@@ -14071,12 +13942,10 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
     deps->addPreCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
     deps->addPostCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, dataBlockReg,
-        MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
-    generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), -1,
-        cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, node, unresolveLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, dataBlockReg, MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
+    Inst_MemImm(TR::InstOpCode::CMPMemImms(), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), -1, cg);
+    Inst_Label(TR::InstOpCode::JE4, node, unresolveLabel, cg);
 
     {
         TR_OutlinedInstructionsGenerator og(unresolveLabel, node, cg);
@@ -14085,12 +13954,12 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
             TR::Register *fieldClassReg;
             if (isWrite) {
                 fieldClassReg = cg->allocateRegister();
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, fieldClassReg,
+                Inst_RegMem(TR::InstOpCode::LRegMem(), node, fieldClassReg,
                     MRef_Bdisp32(sideEffectRegister, comp->fej9()->getOffsetOfClassFromJavaLangClassField(), cg), cg);
             } else {
                 fieldClassReg = sideEffectRegister;
             }
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(is64Bit), node,
+            Inst_MemReg(TR::InstOpCode::SMemReg(is64Bit), node,
                 MRef_Bdisp32(dataBlockReg, (intptr_t)(offsetof(J9JITWatchedStaticFieldData, fieldClass)), cg),
                 fieldClassReg, cg);
             deps->addPreCondition(fieldClassReg, TR::RealRegister::NoReg, cg);
@@ -14106,10 +13975,10 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
         if (is64Bit) {
             TR::Register *cpAddressReg = cg->allocateRegister();
             TR::Register *cpIndexReg = cg->allocateRegister();
-            generateRegImm64SymInstruction(TR::InstOpCode::MOV8RegImm64, node, cpAddressReg,
+            Inst_RegImm64Sym(TR::InstOpCode::MOV8RegImm64, node, cpAddressReg,
                 (uintptr_t)methodSymbol->getResolvedMethod()->constantPool(),
                 comp->getSymRefTab()->findOrCreateConstantPoolAddressSymbolRef(methodSymbol), cg);
-            generateRegImmInstruction(TR::InstOpCode::MOV8RegImm4, node, cpIndexReg, symRef->getCPIndex(), cg);
+            Inst_RegImm(TR::InstOpCode::MOV8RegImm4, node, cpIndexReg, symRef->getCPIndex(), cg);
             deps->addPreCondition(cpAddressReg, linkageProperties.getArgumentRegister(0, false /* isFloat */), cg);
             deps->addPostCondition(cpAddressReg, linkageProperties.getArgumentRegister(0, false /* isFloat */), cg);
             deps->addPreCondition(cpIndexReg, linkageProperties.getArgumentRegister(1, false /* isFloat */), cg);
@@ -14118,15 +13987,14 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
             resultReg
                 = cpAddressReg; // for 64bit private linkage both the first argument reg and the return reg are rax
         } else {
-            generateImmInstruction(TR::InstOpCode::PUSHImm4, node, symRef->getCPIndex(), cg);
-            generateImmSymInstruction(TR::InstOpCode::PUSHImm4, node,
-                (uintptr_t)methodSymbol->getResolvedMethod()->constantPool(),
+            Inst_Imm(TR::InstOpCode::PUSHImm4, node, symRef->getCPIndex(), cg);
+            Inst_ImmSym(TR::InstOpCode::PUSHImm4, node, (uintptr_t)methodSymbol->getResolvedMethod()->constantPool(),
                 comp->getSymRefTab()->findOrCreateConstantPoolAddressSymbolRef(methodSymbol), cg);
             resultReg = cg->allocateRegister();
             deps->addPreCondition(resultReg, linkageProperties.getIntegerReturnRegister(), cg);
             deps->addPostCondition(resultReg, linkageProperties.getIntegerReturnRegister(), cg);
         }
-        TR::Instruction *call = generateHelperCallInstruction(node, helperIndex, NULL, cg);
+        TR::Instruction *call = Inst_HelperCall(node, helperIndex, NULL, cg);
         call->setNeedsGCMap(0xFF00FFFF);
 
         /*
@@ -14134,20 +14002,20 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
         subtract the header size to get the offset needed by field watch helpers
         */
         if (!isStatic) {
-            generateRegImmInstruction(TR::InstOpCode::SubRegImm4(is64Bit, false /*isWithBorrow*/), node, resultReg,
+            Inst_RegImm(TR::InstOpCode::SubRegImm4(is64Bit, false /*isWithBorrow*/), node, resultReg,
                 TR::Compiler->om.objectHeaderSizeInBytes(), cg);
         }
 
         // store result into J9JITWatchedStaticFieldData.fieldAddress / J9JITWatchedInstanceFieldData.offset
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(is64Bit), node,
-            MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), resultReg, cg);
-        generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+        Inst_MemReg(TR::InstOpCode::SMemReg(is64Bit), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg),
+            resultReg, cg);
+        Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
 
         og.endOutlinedInstructionSequence();
     }
 
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
     cg->stopUsingRegister(dataBlockReg);
     cg->stopUsingRegister(resultReg);
 }
@@ -14202,20 +14070,18 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
         if (!valueReg->getRegisterPair()) {
             if (valueReg->getKind() == TR_GPR) {
                 TR::AutomaticSymbol *autoSymbol = valueMR->getSymbolReference().getSymbol()->getAutoSymbol();
-                generateMemRegInstruction(TR::InstOpCode::SMemReg(autoSymbol->getRoundedSize() == 8), node, valueMR,
-                    valueReg, cg);
+                Inst_MemReg(TR::InstOpCode::SMemReg(autoSymbol->getRoundedSize() == 8), node, valueMR, valueReg, cg);
             } else if (valueReg->isSinglePrecision())
-                generateMemRegInstruction(TR::InstOpCode::MOVSSMemReg, node, valueMR, valueReg, cg);
+                Inst_MemReg(TR::InstOpCode::MOVSSMemReg, node, valueMR, valueReg, cg);
             else
-                generateMemRegInstruction(TR::InstOpCode::MOVSDMemReg, node, valueMR, valueReg, cg);
+                Inst_MemReg(TR::InstOpCode::MOVSDMemReg, node, valueMR, valueReg, cg);
             // valueReg and valueReferenceReg are different. Add conditions for valueReg here
             deps->addPreCondition(valueReg, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(valueReg, TR::RealRegister::NoReg, cg);
             valueReferenceReg = cg->allocateRegister();
         } else { // 32bit long
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, valueMR, valueReg->getLowOrder(), cg);
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, MRef_MRefOff(*valueMR, 4, cg),
-                valueReg->getHighOrder(), cg);
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node, valueMR, valueReg->getLowOrder(), cg);
+            Inst_MemReg(TR::InstOpCode::SMemReg(), node, MRef_MRefOff(*valueMR, 4, cg), valueReg->getHighOrder(), cg);
 
             // Add the dependency for higher half register here
             deps->addPostCondition(valueReg->getHighOrder(), TR::RealRegister::NoReg, cg);
@@ -14229,11 +14095,10 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
         }
 
         // store the stack location into a register
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, valueReferenceReg, valueMR, cg);
+        Inst_RegMem(TR::InstOpCode::LEARegMem(), node, valueReferenceReg, valueMR, cg);
     }
 
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, dataBlockReg,
-        MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
+    Inst_RegMem(TR::InstOpCode::LEARegMem(), node, dataBlockReg, MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
     int numArgs = 0;
     if (is64Bit) {
         deps->addPreCondition(dataBlockReg, linkageProperties.getArgumentRegister(numArgs, false /* isFloat */), cg);
@@ -14256,29 +14121,29 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
         }
     } else {
         if (isWrite) {
-            generateRegInstruction(TR::InstOpCode::PUSHReg, node, valueReferenceReg, cg);
+            Inst_Reg(TR::InstOpCode::PUSHReg, node, valueReferenceReg, cg);
             deps->addPostCondition(valueReferenceReg, TR::RealRegister::NoReg, cg);
             deps->addPreCondition(valueReferenceReg, TR::RealRegister::NoReg, cg);
         }
 
         if (isInstanceField) {
-            generateRegInstruction(TR::InstOpCode::PUSHReg, node, sideEffectRegister, cg);
+            Inst_Reg(TR::InstOpCode::PUSHReg, node, sideEffectRegister, cg);
             deps->addPreCondition(sideEffectRegister, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(sideEffectRegister, TR::RealRegister::NoReg, cg);
         }
-        generateRegInstruction(TR::InstOpCode::PUSHReg, node, dataBlockReg, cg);
+        Inst_Reg(TR::InstOpCode::PUSHReg, node, dataBlockReg, cg);
         deps->addPreCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(dataBlockReg, TR::RealRegister::NoReg, cg);
     }
 
-    TR::Instruction *call = generateHelperCallInstruction(node, helperIndex, NULL, cg);
+    TR::Instruction *call = Inst_HelperCall(node, helperIndex, NULL, cg);
     call->setNeedsGCMap(0xFF00FFFF);
     // Restore the value of lower part register
     if (isWrite && valueReg->getRegisterPair() && valueReg->getKind() == TR_GPR)
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, valueReg->getLowOrder(), valueMR, cg);
+        Inst_RegMem(TR::InstOpCode::L4RegMem, node, valueReg->getLowOrder(), valueMR, cg);
     if (!reuseValueReg)
         cg->stopUsingRegister(valueReferenceReg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, endLabel, cg);
     cg->stopUsingRegister(dataBlockReg);
 }
 
@@ -14319,7 +14184,7 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
     startLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
     TR::Register *fieldClassReg = NULL;
     TR::MemoryReference *classFlagsMemRef = NULL;
@@ -14344,16 +14209,16 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
                 // because the fieldClass in an AOT body will be invalid if we load using the dataSnippet's helper query
                 // at compile time.
                 fieldClassReg = cg->allocateRegister();
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, fieldClassReg,
+                Inst_RegMem(TR::InstOpCode::LEARegMem(), node, fieldClassReg,
                     MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, fieldClassReg,
+                Inst_RegMem(TR::InstOpCode::LRegMem(), node, fieldClassReg,
                     MRef_Bdisp32(fieldClassReg, offsetof(J9JITWatchedStaticFieldData, fieldClass), cg), cg);
                 classFlagsMemRef = MRef_Bdisp32(fieldClassReg, fej9->getOffsetOfClassFlags(), cg);
             }
         } else {
             if (isWrite) {
                 fieldClassReg = cg->allocateRegister();
-                generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, fieldClassReg,
+                Inst_RegMem(TR::InstOpCode::LRegMem(), node, fieldClassReg,
                     MRef_Bdisp32(sideEffectRegister, fej9->getOffsetOfClassFromJavaLangClassField(), cg), cg);
             } else {
                 fieldClassReg = sideEffectRegister;
@@ -14362,8 +14227,8 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
         }
     }
 
-    generateMemImmInstruction(TR::InstOpCode::TEST2MemImm2, node, classFlagsMemRef, J9ClassHasWatchedFields, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, fieldReportLabel, cg);
+    Inst_MemImm(TR::InstOpCode::TEST2MemImm2, node, classFlagsMemRef, J9ClassHasWatchedFields, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, fieldReportLabel, cg);
 
     uint8_t numOfConditions = getNumOfConditionsForReportFieldAccess(node, !node->getSymbolReference()->isUnresolved(),
         isWrite, isInstanceField, cg);
@@ -14380,7 +14245,7 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
         og.endOutlinedInstructionSequence();
     }
     deps->stopAddingConditions();
-    generateLabelInstruction(TR::InstOpCode::label, node, endLabel, deps, cg);
+    Inst_Label(TR::InstOpCode::label, node, endLabel, deps, cg);
 
     if (isInstanceField || (!isResolved && isWrite) || fieldClassNeedsRelocation) {
         cg->stopUsingRegister(fieldClassReg);
@@ -14400,7 +14265,7 @@ TR::Register *J9::X86::TreeEvaluator::generateConcurrentScavengeSequence(TR::Nod
                                     ->fieldSignatureChars(node->getSymbolReference()->getCPIndex(), len);
 
         if (fieldName && strstr(fieldName, "Ljava/lang/String;")) {
-            generateMemInstruction(TR::InstOpCode::PREFETCHT0, node, MRef_Bdisp32(object, 0, cg), cg);
+            Inst_Mem(TR::InstOpCode::PREFETCHT0, node, MRef_Bdisp32(object, 0, cg), cg);
         }
     }
     return object;
@@ -14613,15 +14478,15 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, highRegister, secondHigh, cg);
-    generateRegRegInstruction(TR::InstOpCode::OR4RegReg, node, highRegister, firstHigh, cg);
-    // generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, highRegister, highRegister, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, callLabel, cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highRegister, secondHigh, cg);
+    Inst_RegReg(TR::InstOpCode::OR4RegReg, node, highRegister, firstHigh, cg);
+    // Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, highRegister, highRegister, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, callLabel, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
-    divInstr = generateRegRegInstruction(TR::InstOpCode::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(),
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
+    divInstr = Inst_RegReg(TR::InstOpCode::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(),
         idivDependencies, cg);
 
     cg->setImplicitExceptionPoint(divInstr);
@@ -14632,11 +14497,11 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     xorDependencies1->addPreCondition(highRegister, TR::RealRegister::edx, cg);
     xorDependencies1->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
     xorDependencies1->addPostCondition(highRegister, TR::RealRegister::edx, cg);
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, highRegister, highRegister, xorDependencies1, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, highRegister, highRegister, xorDependencies1, cg);
 
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, callLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, callLabel, cg);
 
     TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions((uint8_t)0, 2, cg);
     dependencies->addPostCondition(lowRegister, TR::RealRegister::eax, cg);
@@ -14644,7 +14509,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     J9::IA32PrivateLinkage *linkage = static_cast<J9::IA32PrivateLinkage *>(cg->getLinkage(TR_Private));
     TR::IA32LinkageUtils::pushLongArg(secondChild, cg);
     TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
-    TR::X86ImmSymInstruction *instr = generateHelperCallInstruction(node, TR_IA32longDivide, dependencies, cg);
+    TR::X86ImmSymInstruction *instr = Inst_HelperCall(node, TR_IA32longDivide, dependencies, cg);
     if (!linkage->getProperties().getCallerCleanup()) {
         instr->setAdjustsFramePointerBy(-16); // 2 long args
     }
@@ -14667,7 +14532,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairDivEvaluator(TR::Node *no
     labelDependencies->addPostCondition(firstRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
     labelDependencies->addPostCondition(secondRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, labelDependencies, cg);
+    Inst_Label(TR::InstOpCode::label, node, doneLabel, labelDependencies, cg);
 
     TR::Register *targetRegister = cg->allocateRegisterPair(lowRegister, highRegister);
     node->setRegister(targetRegister);
@@ -14712,27 +14577,27 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
     startLabel->setStartInternalControlFlow();
     doneLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, startLabel, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, highRegister, secondHigh, cg);
-    generateRegRegInstruction(TR::InstOpCode::OR4RegReg, node, highRegister, firstHigh, cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, highRegister, secondHigh, cg);
+    Inst_RegReg(TR::InstOpCode::OR4RegReg, node, highRegister, firstHigh, cg);
     // it doesn't need the test instruction, OR will set the flags properly
-    // generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, highRegister, highRegister, cg);
-    generateLabelInstruction(TR::InstOpCode::JNE4, node, callLabel, cg);
+    // Inst_RegReg(TR::InstOpCode::TEST4RegReg, node, highRegister, highRegister, cg);
+    Inst_Label(TR::InstOpCode::JNE4, node, callLabel, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
-    divInstr = generateRegRegInstruction(TR::InstOpCode::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(),
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, lowRegister, firstRegister->getLowOrder(), cg);
+    divInstr = Inst_RegReg(TR::InstOpCode::DIV4AccReg, node, lowRegister, secondRegister->getLowOrder(),
         idivDependencies, cg);
 
     cg->setImplicitExceptionPoint(divInstr);
     divInstr->setNeedsGCMap(0xFF00FFF6);
 
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, lowRegister, highRegister, cg);
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, node, lowRegister, highRegister, cg);
 
-    generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, highRegister, highRegister, cg);
-    generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
+    Inst_RegReg(TR::InstOpCode::XOR4RegReg, node, highRegister, highRegister, cg);
+    Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, callLabel, cg);
+    Inst_Label(TR::InstOpCode::label, node, callLabel, cg);
 
     TR::RegisterDependencyConditions *dependencies = generateRegisterDependencyConditions((uint8_t)4, 6, cg);
 
@@ -14750,7 +14615,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
     J9::IA32PrivateLinkage *linkage = static_cast<J9::IA32PrivateLinkage *>(cg->getLinkage(TR_Private));
     TR::IA32LinkageUtils::pushLongArg(secondChild, cg);
     TR::IA32LinkageUtils::pushLongArg(firstChild, cg);
-    TR::X86ImmSymInstruction *instr = generateHelperCallInstruction(node, TR_IA32longRemainder, dependencies, cg);
+    TR::X86ImmSymInstruction *instr = Inst_HelperCall(node, TR_IA32longRemainder, dependencies, cg);
     if (!linkage->getProperties().getCallerCleanup()) {
         instr->setAdjustsFramePointerBy(-16); // 2 long args
     }
@@ -14773,7 +14638,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::integerPairRemEvaluator(TR::Node *no
     movDependencies->addPostCondition(firstRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
     movDependencies->addPostCondition(secondRegister->getLowOrder(), TR::RealRegister::NoReg, cg);
 
-    generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, movDependencies, cg);
+    Inst_Label(TR::InstOpCode::label, node, doneLabel, movDependencies, cg);
 
     TR::Register *targetRegister = cg->allocateRegisterPair(lowRegister, highRegister);
     node->setRegister(targetRegister);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -153,7 +153,7 @@ inline void generateLoadJ9Class(TR::Node *node, TR::Register *j9class, TR::Regis
 
     auto use64BitClasses = cg->comp()->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
     auto instr = generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, j9class,
-        generateX86MemoryReference(object, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+        MRef_Bdisp32(object, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
     if (needsNULLCHK) {
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
@@ -221,8 +221,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         // Check if the base array has a spine.  If not, this is a real AIOB.
         // -------------------------------------------------------------------------
 
-        TR::MemoryReference *arraySizeMR
-            = generateX86MemoryReference(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
+        TR::MemoryReference *arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
 
         generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
 
@@ -237,7 +236,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         // The array has a spine.  Do a bound check on its true length.
         // -------------------------------------------------------------------------
 
-        arraySizeMR = generateX86MemoryReference(baseArrayReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg);
+        arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg);
 
         if (!indexReg) {
             TR::InstOpCode::Mnemonic op
@@ -306,13 +305,13 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
         int32_t spineShift = fej9->getArraySpineShift(elementSize);
         generateRegImmInstruction(TR::InstOpCode::SARRegImm1(), node, scratchReg, spineShift, cg);
 
-        spineMR = generateX86MemoryReference(baseArrayReg, scratchReg,
+        spineMR = MRef_BISdisp32(baseArrayReg, scratchReg,
             TR::MemoryReference::convertMultiplierToStride(spinePointerSize), arrayHeaderSize, cg);
     } else {
         int32_t spineIndex = fej9->getArrayletLeafIndex(indexValue, elementSize);
         int32_t spineDisp32 = (spineIndex * spinePointerSize) + arrayHeaderSize;
 
-        spineMR = generateX86MemoryReference(baseArrayReg, spineDisp32, cg);
+        spineMR = MRef_Bdisp32(baseArrayReg, spineDisp32, cg);
     }
 
     TR::InstOpCode::Mnemonic op = (spinePointerSize == 8) ? TR::InstOpCode::L8RegMem : TR::InstOpCode::L4RegMem;
@@ -337,13 +336,12 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
 
         generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, scratchReg2, indexReg, cg);
         generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, scratchReg2, arrayletMask, cg);
-        arrayletMR = generateX86MemoryReference(scratchReg, scratchReg2,
-            TR::MemoryReference::convertMultiplierToStride(elementSize), cg);
+        arrayletMR = MRef_BIS(scratchReg, scratchReg2, TR::MemoryReference::convertMultiplierToStride(elementSize), cg);
 
         cg->stopUsingRegister(scratchReg2);
     } else {
         int32_t arrayletIndex = ((TR_J9VMBase *)fej9)->getLeafElementIndex(indexValue, elementSize);
-        arrayletMR = generateX86MemoryReference(scratchReg, arrayletIndex * elementSize, cg);
+        arrayletMR = MRef_Bdisp32(scratchReg, arrayletIndex * elementSize, cg);
     }
 
     cg->stopUsingRegister(scratchReg);
@@ -379,7 +377,7 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
                         TR_ASSERT(loadOrStoreReg->getRegisterPair(), "expecting a register pair");
 
                         op = TR::InstOpCode::L4RegMem;
-                        highArrayletMR = generateX86MemoryReference(*arrayletMR, 4, cg);
+                        highArrayletMR = MRef_MRefOff(*arrayletMR, 4, cg);
                         highRegister = loadOrStoreReg->getHighOrder();
                         loadOrStoreReg = loadOrStoreReg->getLowOrder();
                     }
@@ -448,16 +446,16 @@ static TR_OutlinedInstructions *generateArrayletReference(TR::Node *node, TR::No
                             TR_ASSERT(valueReg->getRegisterPair(), "value must be a register pair");
                             generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, arrayletMR,
                                 valueReg->getLowOrder(), cg);
-                            generateMemRegInstruction(TR::InstOpCode::S4MemReg, node,
-                                generateX86MemoryReference(*arrayletMR, 4, cg), valueReg->getHighOrder(), cg);
+                            generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_MRefOff(*arrayletMR, 4, cg),
+                                valueReg->getHighOrder(), cg);
                         } else {
                             TR::Node *valueChild = actualLoadOrStoreOrArrayElementNode->getSecondChild();
                             TR_ASSERT(valueChild->getOpCode().isLoadConst(), "expecting a long constant child");
 
                             generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, arrayletMR,
                                 valueChild->getLongIntLow(), cg);
-                            generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-                                generateX86MemoryReference(*arrayletMR, 4, cg), valueChild->getLongIntHigh(), cg);
+                            generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node, MRef_MRefOff(*arrayletMR, 4, cg),
+                                valueChild->getLongIntHigh(), cg);
                         }
 
                         needStore = false;
@@ -585,7 +583,7 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
 
         TR::MemoryReference *tempMR = cg->machine()->getDummyLocalMR(TR::Float);
         generateMemRegInstruction(TR::InstOpCode::MOVSSMemReg, node, tempMR, floatReg, cg);
-        generateMemInstruction(TR::InstOpCode::FLDMem, node, generateX86MemoryReference(*tempMR, 0, cg), cg);
+        generateMemInstruction(TR::InstOpCode::FLDMem, node, MRef_MRefOff(*tempMR, 0, cg), cg);
 
         generateInstruction(TR::InstOpCode::FLDDUP, node, cg);
 
@@ -599,14 +597,14 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
             int16_t fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ? SINGLE_PRECISION_ROUND_TO_ZERO
                                                                                     : DOUBLE_PRECISION_ROUND_TO_ZERO;
             generateMemInstruction(TR::InstOpCode::LDCWMem, node,
-                generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
+                MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
             generateMemInstruction(TR::InstOpCode::FLSTPMem, node, convertedLongMR, cg);
 
             fpcw = comp->getJittedMethodSymbol()->usesSinglePrecisionMode() ? SINGLE_PRECISION_ROUND_TO_NEAREST
                                                                             : DOUBLE_PRECISION_ROUND_TO_NEAREST;
 
             generateMemInstruction(TR::InstOpCode::LDCWMem, node,
-                generateX86MemoryReference(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
+                MRef_const(cg->findOrCreate2ByteConstant(node, fpcw), cg), cg);
         }
 
         // WARNING:
@@ -615,10 +613,10 @@ TR::Register *J9::X86::TreeEvaluator::fpConvertToLong(TR::Node *node, TR::Symbol
         // If they or their format is changed, you may need to change the snippet also.
         //
         loadHighInstr = generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, highReg,
-            generateX86MemoryReference(*convertedLongMR, 4, cg), cg);
+            MRef_MRefOff(*convertedLongMR, 4, cg), cg);
 
         loadLowInstr = generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lowReg,
-            generateX86MemoryReference(*convertedLongMR, 0, cg), cg);
+            MRef_MRefOff(*convertedLongMR, 0, cg), cg);
 
         // Jump to the snippet if the converted value is an indefinite integer; otherwise continue.
         //
@@ -727,20 +725,20 @@ TR::Register *J9::X86::TreeEvaluator::f2iEvaluator(TR::Node *node, TR::CodeGener
         // compare source with ZERO
         generateRegMemInstruction(doubleSource ? TR::InstOpCode::UCOMISDRegMem : TR::InstOpCode::UCOMISSRegMem, node,
             sourceRegister,
-            generateX86MemoryReference(
-                doubleSource ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0), cg),
+            MRef_const(doubleSource ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0),
+                cg),
             cg);
         // load max int if source is positive, note that for long case, LLONG_MAX << 1 is loaded as it will be shifted
         // right
         generateRegMemInstruction(TR::InstOpCode::CMOVARegMem(longTarget), node, targetRegister,
-            generateX86MemoryReference(longTarget ? cg->findOrCreate8ByteConstant(node, LLONG_MAX << 1)
-                                                  : cg->findOrCreate4ByteConstant(node, INT_MAX),
+            MRef_const(longTarget ? cg->findOrCreate8ByteConstant(node, LLONG_MAX << 1)
+                                  : cg->findOrCreate4ByteConstant(node, INT_MAX),
                 cg),
             cg);
         // load zero if source is NaN
         generateRegMemInstruction(TR::InstOpCode::CMOVPRegMem(longTarget), node, targetRegister,
-            generateX86MemoryReference(
-                longTarget ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0), cg),
+            MRef_const(longTarget ? cg->findOrCreate8ByteConstant(node, 0) : cg->findOrCreate4ByteConstant(node, 0),
+                cg),
             cg);
 
         generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
@@ -864,7 +862,7 @@ static void generateCommonLockNurseryCodes(TR::Node *node, TR::CodeGenerator *cg
         int32_t offsetOfMonitorLookupCache = offsetof(J9VMThread, objectMonitorLookupCache);
 
         // generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, objectClassReg,
-        // generateX86MemoryReference(vmThreadReg, offsetOfMonitorLookupCache, cg), cg);
+        // MRef_Bdisp32(vmThreadReg, offsetOfMonitorLookupCache, cg), cg);
         generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, lookupOffsetReg, objectReg, cg);
 
         generateRegImmInstruction(TR::InstOpCode::SARRegImm1(comp->target().is64Bit()), node, lookupOffsetReg,
@@ -878,26 +876,25 @@ static void generateCommonLockNurseryCodes(TR::Node *node, TR::CodeGenerator *cg
         generateRegMemInstruction((comp->target().is64Bit() && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::L4RegMem
                 : TR::InstOpCode::LRegMem(),
-            node, objectClassReg,
-            generateX86MemoryReference(vmThreadReg, lookupOffsetReg, 0, offsetOfMonitorLookupCache, cg), cg);
+            node, objectClassReg, MRef_BISdisp32(vmThreadReg, lookupOffsetReg, 0, offsetOfMonitorLookupCache, cg), cg);
 
         generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, objectClassReg, objectClassReg, cg);
         generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
 
         int32_t offsetOfMonitor = offsetof(J9ObjectMonitor, monitor);
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
-            generateX86MemoryReference(objectClassReg, offsetOfMonitor, cg), cg);
+            MRef_Bdisp32(objectClassReg, offsetOfMonitor, cg), cg);
 
         int32_t offsetOfUserData = offsetof(J9ThreadAbstractMonitor, userData);
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
-            generateX86MemoryReference(lookupOffsetReg, offsetOfUserData, cg), cg);
+            MRef_Bdisp32(lookupOffsetReg, offsetOfUserData, cg), cg);
 
         generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, lookupOffsetReg, objectReg, cg);
         generateLabelInstruction(TR::InstOpCode::JNE4, node, snippetLabel, cg);
 
         int32_t offsetOfAlternateLockWord = offsetof(J9ObjectMonitor, alternateLockword);
         // generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, lookupOffsetReg,
-        // generateX86MemoryReference(objectClassReg, offsetOfAlternateLockWord, cg), cg);
+        // MRef_Bdisp32(objectClassReg, offsetOfAlternateLockWord, cg), cg);
         generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, objectClassReg, offsetOfAlternateLockWord, cg);
         // generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, objectClassReg, lookupOffsetReg, cg);
         generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, objectClassReg, objectReg, cg);
@@ -934,7 +931,7 @@ TR::Register *J9::X86::I386::TreeEvaluator::conditionalHelperEvaluator(TR::Node 
             opCode = TR::InstOpCode::CMP4MemImms;
         else
             opCode = TR::InstOpCode::CMP4MemImm4;
-        TR::MemoryReference *memRef = generateX86MemoryReference(firstChild, cg);
+        TR::MemoryReference *memRef = MRef_node(firstChild, cg);
         generateMemImmInstruction(opCode, node, memRef, value, cg);
         memRef->decNodeReferenceCounts(cg);
         cg->decReferenceCount(secondChild);
@@ -1042,7 +1039,7 @@ TR::Register *J9::X86::AMD64::TreeEvaluator::conditionalHelperEvaluator(TR::Node
         && (!testIs64Bit || IS_32BIT_SIGNED(secondChild->getLongInt()))) {
         // Try to compare memory directly with immediate
         //
-        TR::MemoryReference *memRef = generateX86MemoryReference(testNode->getFirstChild(), cg);
+        TR::MemoryReference *memRef = MRef_node(testNode->getFirstChild(), cg);
         TR::InstOpCode::Mnemonic op;
 
         if (testIs64Bit) {
@@ -1138,7 +1135,7 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
     TR::Compilation *comp = cg->comp();
     bool use64BitClasses = comp->target().is64Bit() && !comp->useCompressedPointers();
 
-    TR::MemoryReference *sourceMR = generateX86MemoryReference(node, cg);
+    TR::MemoryReference *sourceMR = MRef_node(node, cg);
     TR::Register *address
         = TR::TreeEvaluator::loadMemory(node, sourceMR, TR_RematerializableLoadEffectiveAddress, false, cg);
     address->setMemRef(sourceMR);
@@ -1146,7 +1143,7 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
 
     TR::Register *object = cg->allocateRegister();
     TR::Instruction *load = generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, object,
-        generateX86MemoryReference(address, 0, cg), cg);
+        MRef_Bdisp32(address, 0, cg), cg);
     cg->setImplicitExceptionPoint(load);
 
     switch (TR::Compiler->om.readBarrierType()) {
@@ -1155,11 +1152,10 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
             break;
         case gc_modron_readbar_always:
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address,
-                cg);
+                MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
             generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, object,
-                generateX86MemoryReference(address, 0, cg), cg);
+                MRef_Bdisp32(address, 0, cg), cg);
             break;
         case gc_modron_readbar_range_check: {
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg);
@@ -1176,23 +1172,20 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
 
             generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
             generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
-                generateX86MemoryReference(cg->getVMThreadRegister(),
-                    comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
+                MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
                 cg);
             generateLabelInstruction(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
             {
                 TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
                 generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, object,
-                    generateX86MemoryReference(cg->getVMThreadRegister(),
-                        comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
+                    MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
                     cg);
                 generateLabelInstruction(TR::InstOpCode::JA4, node, endLabel, cg);
                 generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                    generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg),
-                    address, cg);
+                    MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), address, cg);
                 generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, object,
-                    generateX86MemoryReference(address, 0, cg), cg);
+                    MRef_Bdisp32(address, 0, cg), cg);
                 generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
                 og.endOutlinedInstructionSequence();
             }
@@ -1211,7 +1204,7 @@ TR::Register *J9::X86::TreeEvaluator::performHeapLoadWithReadBarrier(TR::Node *n
 //
 TR::Register *J9::X86::TreeEvaluator::writeBarrierEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
-    TR::MemoryReference *storeMR = generateX86MemoryReference(node, cg);
+    TR::MemoryReference *storeMR = MRef_node(node, cg);
     TR::Node *destOwningObject;
     TR::Node *sourceObject;
     TR::Compilation *comp = cg->comp();
@@ -1287,7 +1280,7 @@ TR::Register *J9::X86::TreeEvaluator::asynccheckEvaluator(TR::Node *node, TR::Co
         TR_ASSERT_FATAL(secondChild->getOpCode().isLoadConst(),
             "unrecognized asynccheck test: special async check value is not a constant");
 
-        TR::MemoryReference *mr = generateX86MemoryReference(compareNode->getFirstChild(), cg);
+        TR::MemoryReference *mr = MRef_node(compareNode->getFirstChild(), cg);
         if ((secondChild->getRegister() != NULL)
             || (comp->target().is64Bit() && !IS_32BIT_SIGNED(secondChild->getLongInt()))) {
             TR::Register *valueReg = cg->evaluate(secondChild);
@@ -1550,8 +1543,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     generateRegImmInstruction(TR::InstOpCode::MOV8RegImm4, node, tempReg, zeroArraySizeAligned, cg);
 
     TR::Register *firstDimReg = cg->allocateRegister();
-    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimReg,
-        generateX86MemoryReference(dimsPtrReg, 4, cg), cg);
+    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
 
     // if first dim = 0 load the zero array size and skip over calculating the leaf block size
     generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, firstDimReg, firstDimReg, cg);
@@ -1567,7 +1559,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // spine size += first dim * reference size
     generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, spineSizeReg,
-        generateX86MemoryReference(spineSizeReg, firstDimReg, trailingZeroes((int32_t)referenceSize), 0, cg), cg);
+        MRef_BISdisp32(spineSizeReg, firstDimReg, trailingZeroes((int32_t)referenceSize), 0, cg), cg);
 
     // pad spine size so leaf arrays will be aligned
     if (needsAlignSpine) {
@@ -1582,8 +1574,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // if second dim = 0 load the zero array size and skip over calculating the leaf size
     TR::Register *secondDimReg = cg->allocateRegister();
-    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, secondDimReg,
-        generateX86MemoryReference(dimsPtrReg, 0, cg), cg);
+    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, secondDimReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
 
     generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, secondDimReg, secondDimReg, cg);
     generateRegRegInstruction(TR::InstOpCode::CMOVE8RegReg, node, leafSizeReg, tempReg, cg);
@@ -1595,7 +1586,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // leaf size = header size + second dim * leaf element size
     generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, leafSizeReg,
-        generateX86MemoryReference(leafSizeReg, secondDimReg, trailingZeroes(leafArrayElementSize), 0, cg), cg);
+        MRef_BISdisp32(leafSizeReg, secondDimReg, trailingZeroes(leafArrayElementSize), 0, cg), cg);
 
     // pad leafSize for alignment
     if (needsAlignLeaf) {
@@ -1616,25 +1607,25 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     // spinePtrReg = vmThread->heapAlloc
     TR::Register *vmThreadReg = cg->getVMThreadRegister();
     generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, spinePtrReg,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
     // allocEnd = spinePtr + spineSize + leafBlockSize
     TR::Register *leafPtrReg = cg->allocateRegister();
     generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, leafPtrReg,
-        generateX86MemoryReference(spinePtrReg, spineSizeReg, 0, 0, cg), cg);
+        MRef_BISdisp32(spinePtrReg, spineSizeReg, 0, 0, cg), cg);
 
     // if allocEnd > vmThread->heapTop go to helper
     generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, leafPtrReg,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
     generateLabelInstruction(TR::InstOpCode::JA4, node, helperLabel, cg);
 
     // bump vmThread->heapAlloc to allocate the memory needed
     generateMemRegInstruction(TR::InstOpCode::S8MemReg, node,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), leafPtrReg, cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), leafPtrReg, cg);
 
     // load class into spine header
     generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-        generateX86MemoryReference(spinePtrReg, classOffset, cg), classReg, cg);
+        MRef_Bdisp32(spinePtrReg, classOffset, cg), classReg, cg);
 
     // if first dim = 0 goto initialise zero length spine
     TR::LabelSymbol *initZeroLengthLabel = generateLabelSymbol(cg);
@@ -1646,15 +1637,15 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // init size and mustBeZero ('0') fields to 0
     generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-        generateX86MemoryReference(spinePtrReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
+        MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
     generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-        generateX86MemoryReference(spinePtrReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
+        MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Init 1st dim dataAddr slot to 0
         generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
-            generateX86MemoryReference(spinePtrReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
+            MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
@@ -1662,8 +1653,8 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
     zeroLengthOOL.endOutlinedInstructionSequence();
 
     // otherwise load first dim into spine header
-    generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(spinePtrReg, sizeOffset, cg),
-        firstDimReg, cg);
+    generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(spinePtrReg, sizeOffset, cg), firstDimReg,
+        cg);
 
     // zero out the leaf portion of the allocation if necessary
     bool clearAllocation = !fej9->tlhHasBeenCleared();
@@ -1697,7 +1688,7 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // load element class
     generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
-        generateX86MemoryReference(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
+        MRef_Bdisp32(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
@@ -1705,9 +1696,9 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
-            generateX86MemoryReference(spinePtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+            MRef_Bdisp32(spinePtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(spinePtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
+            MRef_Bdisp32(spinePtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
@@ -1730,13 +1721,13 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
         // initialise leaf array class
         generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-            generateX86MemoryReference(leafPtrReg, classOffset, cg), tempReg, cg);
+            MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg, cg);
         // length, mustBeZero, and dataAddr fields are already set to zero since the allocation is zeroed
 
         // insert leaf array reference into spine array
         // spinePtr[first dim * reference size + (header size - reference size)] = leafPtr
         // subtract reference size to account for the off by one value of first dim
-        TR::MemoryReference *spineSlotMemRef = generateX86MemoryReference(spinePtrReg, firstDimReg,
+        TR::MemoryReference *spineSlotMemRef = MRef_BISdisp32(spinePtrReg, firstDimReg,
             trailingZeroes((int32_t)referenceSize), contiguousArrayHeaderSize - referenceSize, cg);
         if (comp->useCompressedPointers()) {
             int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
@@ -1773,13 +1764,13 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
 
     // initialise leaf array
     if (arrayHeaderFitsInGPR) {
-        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node,
-            generateX86MemoryReference(leafPtrReg, classOffset, cg), secondDimReg, cg);
+        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(leafPtrReg, classOffset, cg),
+            secondDimReg, cg);
     } else {
         generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-            generateX86MemoryReference(leafPtrReg, classOffset, cg), tempReg, cg);
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node,
-            generateX86MemoryReference(leafPtrReg, sizeOffset, cg), secondDimReg, cg);
+            MRef_Bdisp32(leafPtrReg, classOffset, cg), tempReg, cg);
+        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(leafPtrReg, sizeOffset, cg),
+            secondDimReg, cg);
     }
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
@@ -1788,16 +1779,16 @@ static TR::Register *generate2DArrayWithInlineAllocators(TR::Node *node, TR::Cod
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, spineSizeReg,
-            generateX86MemoryReference(leafPtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+            MRef_Bdisp32(leafPtrReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(leafPtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
+            MRef_Bdisp32(leafPtrReg, fej9->getOffsetOfContiguousDataAddrField(), cg), spineSizeReg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
     // insert leaf array reference into spine array
     // spinePtr[first dim * reference size + (header size - reference size)] = leafPtr
     // subtract reference size to account for the off by one value of first dim
-    TR::MemoryReference *spineSlotMemRef = generateX86MemoryReference(spinePtrReg, firstDimReg,
+    TR::MemoryReference *spineSlotMemRef = MRef_BISdisp32(spinePtrReg, firstDimReg,
         trailingZeroes((int32_t)referenceSize), contiguousArrayHeaderSize - referenceSize, cg);
     if (comp->useCompressedPointers()) {
         int32_t shiftAmount = TR::Compiler->om.compressedReferenceShift();
@@ -1954,13 +1945,11 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
 
     // inlined code for allocating zero length arrays where the zero len is in either the first or second dimension
 
-    generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, secondDimLenReg,
-        generateX86MemoryReference(dimsPtrReg, 0, cg), cg);
+    generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, secondDimLenReg, MRef_Bdisp32(dimsPtrReg, 0, cg), cg);
     // Load the 32-bit length value as a 64-bit value so that the top half of the register
     // can be zeroed out. This will allow us to treat the value as 64-bit when performing
     // calculations later on.
-    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg,
-        generateX86MemoryReference(dimsPtrReg, 4, cg), cg);
+    generateRegMemInstruction(TR::InstOpCode::MOVSXReg8Mem4, node, firstDimLenReg, MRef_Bdisp32(dimsPtrReg, 4, cg), cg);
 
     generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, secondDimLenReg, 0, cg);
 
@@ -1972,36 +1961,36 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
 
     // First Dim zero, only allocate 1 zero-length object array
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, targetReg,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
     // Take into account alignment requirements for the size of the zero-length array header
     int32_t zeroArraySizeAligned = OMR::align(TR::Compiler->om.discontiguousArrayHeaderSizeInBytes(),
         TR::Compiler->om.getObjectAlignmentInBytes());
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, temp1Reg,
-        generateX86MemoryReference(targetReg, zeroArraySizeAligned, cg), cg);
+        MRef_Bdisp32(targetReg, zeroArraySizeAligned, cg), cg);
 
     generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, temp1Reg,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
     generateLabelInstruction(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
     generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp1Reg, cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp1Reg, cg);
 
     // Init class
     bool use64BitClasses = comp->target().is64Bit() && !TR::Compiler->om.generateCompressedObjectHeaders();
     generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-        generateX86MemoryReference(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
+        MRef_Bdisp32(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
 
     // Init size and mustBeZero ('0') fields to 0
     generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-        generateX86MemoryReference(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
+        MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
     generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-        generateX86MemoryReference(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
+        MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Init 1st dim dataAddr slot to 0
         generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
-            generateX86MemoryReference(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
+            MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
     generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg);
@@ -2010,7 +1999,7 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
     generateLabelInstruction(TR::InstOpCode::label, node, nonZeroFirstDimLabel, cg);
 
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, componentClassReg,
-        generateX86MemoryReference(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
+        MRef_Bdisp32(classReg, offsetof(J9ArrayClass, componentType), cg), cg);
 
     int32_t elementSize = TR::Compiler->om.sizeofReferenceField();
 
@@ -2046,31 +2035,31 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
     generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
 
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, targetReg,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
     // temp2Reg = temp2Reg + J9VMThread->heapAlloc
     generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, temp2Reg, targetReg, cg);
 
     generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, temp2Reg,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
     generateLabelInstruction(TR::InstOpCode::JA4, node, oolJumpPoint, cg);
     generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp2Reg, cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), temp2Reg, cg);
 
     // init 1st dim array class field
     generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-        generateX86MemoryReference(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
+        MRef_Bdisp32(targetReg, TR::Compiler->om.offsetOfObjectVftField(), cg), classReg, cg);
     // Init 1st dim array size field
     generateMemRegInstruction(TR::InstOpCode::S4MemReg, node,
-        generateX86MemoryReference(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), firstDimLenReg, cg);
+        MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousArraySizeField(), cg), firstDimLenReg, cg);
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         /* Populate dataAddr slot of 1st dimension array. Arrays of non-zero size
          * use contiguous header layout while zero size arrays use discontiguous header layout.
          */
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, temp3Reg,
-            generateX86MemoryReference(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+            MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg), temp3Reg, cg);
+            MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg), temp3Reg, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
@@ -2079,24 +2068,24 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
     generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, temp2Reg, temp1Reg, cg);
     // temp1 points to 1st dim array past header
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, temp1Reg,
-        generateX86MemoryReference(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+        MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
 
     // loop start
     generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
     // Init 2nd dim element's class
     generateMemRegInstruction(TR::InstOpCode::SMemReg(use64BitClasses), node,
-        generateX86MemoryReference(temp2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), componentClassReg, cg);
+        MRef_Bdisp32(temp2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), componentClassReg, cg);
     // Init 2nd dim element's size and mustBeZero ('0') fields to 0
     generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-        generateX86MemoryReference(temp2Reg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
+        MRef_Bdisp32(temp2Reg, fej9->getOffsetOfContiguousArraySizeField(), cg), 0, cg);
     generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-        generateX86MemoryReference(temp2Reg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
+        MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
 
 #if defined(J9VM_GC_SPARSE_HEAP_ALLOCATION)
     if (isOffHeapAllocationEnabled) {
         // Populate dataAddr slot for 2nd dimension zero size array.
         generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
-            generateX86MemoryReference(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
+            MRef_Bdisp32(temp2Reg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg), 0, cg);
     }
 #endif /* J9VM_GC_SPARSE_HEAP_ALLOCATION */
 
@@ -2107,11 +2096,9 @@ static TR::Register *generate2DZeroLengthArrayWithInlineAllocators(TR::Node *nod
         if (shiftAmount != 0) {
             generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, temp3Reg, shiftAmount, cg);
         }
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(temp1Reg, 0, cg), temp3Reg,
-            cg);
+        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(temp1Reg, 0, cg), temp3Reg, cg);
     } else {
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, generateX86MemoryReference(temp1Reg, 0, cg),
-            temp2Reg, cg);
+        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(temp1Reg, 0, cg), temp2Reg, cg);
     }
 
     // Advance cursors temp1 and temp2
@@ -2273,9 +2260,9 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
         deps->addPostCondition(sizeReg, TR::RealRegister::ecx, cg);
 
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg, cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg, cg);
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg, cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg, cg);
         generateHelperCallInstruction(node, TR_referenceArrayCopy, deps, cg)->setNeedsGCMap(0xFF00FFFF);
 
         auto snippetLabel = generateLabelSymbol(cg);
@@ -2363,18 +2350,15 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
             TR::LabelSymbol *rdbarLabel = generateLabelSymbol(cg);
             // EvacuateTopAddress == 0 means Concurrent Scavenge is inactive
             generateMemImmInstruction(TR::InstOpCode::CMPMemImms(use64BitClasses), node,
-                generateX86MemoryReference(cg->getVMThreadRegister(),
-                    comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
-                0, cg);
+                MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg), 0,
+                cg);
             generateLabelInstruction(TR::InstOpCode::JNE4, node, rdbarLabel, cg);
 
             TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg,
-                cg);
+                MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), srcObjReg, cg);
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg,
-                cg);
+                MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), dstObjReg, cg);
             generateHelperCallInstruction(node, TR_referenceArrayCopy, NULL, cg)->setNeedsGCMap(0xFF00FFFF);
             generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
             og.endOutlinedInstructionSequence();
@@ -2401,15 +2385,15 @@ TR::Register *J9::X86::TreeEvaluator::arraycopyEvaluator(TR::Node *node, TR::Cod
 
             generateRegRegInstruction(TR::InstOpCode::SUBRegReg(), node, RDI, RSI, cg); // dst = dst - src
             generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, RDI, RCX, cg); // cmp dst, size
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, RDI,
-                generateX86MemoryReference(RDI, RSI, 0, cg), cg); // dst = dst + src
+            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, RDI, MRef_BIS(RDI, RSI, 0, cg),
+                cg); // dst = dst + src
             generateLabelInstruction(TR::InstOpCode::JB4, node, backwardLabel, cg); // jb, skip backward copy setup
 
             TR_OutlinedInstructionsGenerator og(backwardLabel, node, cg);
             generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, RSI,
-                generateX86MemoryReference(RSI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
+                MRef_BISdisp32(RSI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, RDI,
-                generateX86MemoryReference(RDI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
+                MRef_BISdisp32(RDI, RCX, 0, -TR::Compiler->om.sizeofReferenceField(), cg), cg);
             generateRegImmInstruction(TR::InstOpCode::SHRRegImm1(), node, RCX, use64BitClasses ? 3 : 2, cg);
             generateInstruction(TR::InstOpCode::STD, node, cg);
             generateInstruction(use64BitClasses ? TR::InstOpCode::REPMOVSQ : TR::InstOpCode::REPMOVSD, node, cg);
@@ -2455,10 +2439,10 @@ TR::Register *J9::X86::TreeEvaluator::arraylengthEvaluator(TR::Node *node, TR::C
     TR::Register *lengthReg = cg->allocateRegister();
 
     TR::MemoryReference *contiguousArraySizeMR
-        = generateX86MemoryReference(objectReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
+        = MRef_Bdisp32(objectReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
 
     TR::MemoryReference *discontiguousArraySizeMR
-        = generateX86MemoryReference(objectReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg);
+        = MRef_Bdisp32(objectReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg);
 
     generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lengthReg, contiguousArraySizeMR, cg);
     generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, lengthReg, lengthReg, cg);
@@ -2644,10 +2628,9 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
                 if (TR::Compiler->om.compressedReferenceShift() > 0 && firstChild->getType() == TR::Address
                     && firstChild->getOpCode().hasSymbolReference()
                     && firstChild->getSymbol()->isCollectedReference()) {
-                    memRef = generateX86MemoryReference(NULL, refRegister, TR::Compiler->om.compressedReferenceShift(),
-                        0, cg);
+                    memRef = MRef_BISdisp32(NULL, refRegister, TR::Compiler->om.compressedReferenceShift(), 0, cg);
                 } else {
-                    memRef = generateX86MemoryReference(refRegister, 0, cg);
+                    memRef = MRef_Bdisp32(refRegister, 0, cg);
                 }
                 appendTo = generateMemImmInstruction(appendTo, TR::InstOpCode::TEST1MemImm1, memRef, 0, cg);
                 cg->setImplicitExceptionPoint(appendTo);
@@ -2671,7 +2654,7 @@ TR::Register *J9::X86::TreeEvaluator::evaluateNULLCHKWithPossibleResolve(TR::Nod
         //
         if (opCode.getOpCodeValue() == TR::PassThrough && reference->getOpCode().isLoadVar()
             && reference->getRegister() == NULL && reference->getReferenceCount() == 1) {
-            TR::MemoryReference *tempMR = generateX86MemoryReference(reference, cg);
+            TR::MemoryReference *tempMR = MRef_node(reference, cg);
 
             if (!appendTo)
                 appendTo = cg->getAppendInstruction();
@@ -3329,7 +3312,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
 
     if (generateWriteBarrier) {
         if (!deferDestinationEvaluation) {
-            tempMR = generateX86MemoryReference(firstChild, cg);
+            tempMR = MRef_node(firstChild, cg);
         } else {
             /* Evaluate destination subtrees
              * ArrayStoreCHK
@@ -3474,7 +3457,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
 
         if (deferDestinationEvaluation) {
             // Perform deferred destination evaluation
-            tempMR = generateX86MemoryReference(firstChild, cg);
+            tempMR = MRef_node(firstChild, cg);
         }
 
         TR::TreeEvaluator::VMwrtbarWithStoreEvaluator(node, tempMR, scratchRegisterManager, destinationChild,
@@ -3510,7 +3493,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             //
             TR_OutlinedInstructionsGenerator og(nullTargetLabel, node, cg);
 
-            tempMR2 = generateX86MemoryReference(*tempMR, 0, cg);
+            tempMR2 = MRef_MRefOff(*tempMR, 0, cg);
 
             if (usingCompressedPointers)
                 generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, tempMR2, compressedRegister, cg);
@@ -3529,7 +3512,7 @@ TR::Register *J9::X86::TreeEvaluator::ArrayStoreCHKEvaluator(TR::Node *node, TR:
             //
             dependencyAnchorInstruction = cg->getAppendInstruction();
 
-            tempMR = generateX86MemoryReference(firstChild, cg);
+            tempMR = MRef_node(firstChild, cg);
 
             TR::X86MemRegInstruction *storeInstr;
 
@@ -3734,8 +3717,7 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
             cg->evaluate(indexChild);
         }
 
-        TR::MemoryReference *arraySizeMR
-            = generateX86MemoryReference(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
+        TR::MemoryReference *arraySizeMR = MRef_Bdisp32(baseArrayReg, fej9->getOffsetOfContiguousArraySizeField(), cg);
 
         generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, node, arraySizeMR, 0, cg);
         generateLabelInstruction(TR::InstOpCode::JE4, node, boundCheckFailureLabel, cg);
@@ -3871,7 +3853,7 @@ TR::Register *J9::X86::TreeEvaluator::barrierFenceEvaluator(TR::Node *node, TR::
         generateInstruction(TR::InstOpCode::MFENCE, node, cg);
     } else {
         TR::RealRegister *stackReg = cg->machine()->getRealRegister(TR::RealRegister::esp);
-        TR::MemoryReference *mr = generateX86MemoryReference(stackReg, intptr_t(0), cg);
+        TR::MemoryReference *mr = MRef_Bdisp32(stackReg, intptr_t(0), cg);
 
         mr->setRequiresLockPrefix();
         generateMemImmInstruction(TR::InstOpCode::OR4MemImms, node, mr, 0, cg);
@@ -3915,8 +3897,7 @@ TR::Register *J9::X86::TreeEvaluator::readbarEvaluator(TR::Node *node, TR::CodeG
     }
 
     // handle is not NULL or we're an implicit nullcheck, so go through forwarding pointer to get object
-    TR::MemoryReference *handleMR
-        = generateX86MemoryReference(handleRegister, node->getSymbolReference()->getOffset(), cg);
+    TR::MemoryReference *handleMR = MRef_Bdisp32(handleRegister, node->getSymbolReference()->getOffset(), cg);
     TR::Instruction *forwardingInstr
         = generateRegMemInstruction(TR::InstOpCode::L4RegMem, handleNode, handleRegister, handleMR, cg);
     cg->setImplicitExceptionPoint(forwardingInstr);
@@ -4242,11 +4223,11 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
 
     // temp2Reg holds romClass of cast class, for testing array, interface class type
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp2Reg,
-        generateX86MemoryReference(castClassReg, offsetof(J9Class, romClass), cg), cg);
+        MRef_Bdisp32(castClassReg, offsetof(J9Class, romClass), cg), cg);
 
     // If cast class is array, call out of line helper
     generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        generateX86MemoryReference(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
+        MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
     generateLabelInstruction(TR::InstOpCode::JNE4, node, outlinedCallLabel, cg);
 
     // objClassReg holds object class
@@ -4259,22 +4240,22 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     // Object not array, inline checks
     // Check cast class is interface
     generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        generateX86MemoryReference(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccInterface, cg);
+        MRef_Bdisp32(temp2Reg, offsetof(J9ROMClass, modifiers), cg), J9AccInterface, cg);
     generateLabelInstruction(TR::InstOpCode::JE4, node, isClassLabel, cg);
 
     // Obtain I-Table
     // temp1Reg holds head of J9Class->iTable of obj class
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        generateX86MemoryReference(objClassReg, offsetof(J9Class, iTable), cg), cg);
+        MRef_Bdisp32(objClassReg, offsetof(J9Class, iTable), cg), cg);
     // Loop through I-Table
     // temp1Reg holds iTable list element through the loop
     generateLabelInstruction(TR::InstOpCode::label, node, iTableLoopLabel, cg);
     generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, temp1Reg, temp1Reg, cg);
     generateLabelInstruction(TR::InstOpCode::JE4, node, throwLabel, cg);
-    auto interfaceMR = generateX86MemoryReference(temp1Reg, offsetof(J9ITable, interfaceClass), cg);
+    auto interfaceMR = MRef_Bdisp32(temp1Reg, offsetof(J9ITable, interfaceClass), cg);
     generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), node, interfaceMR, castClassReg, cg);
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        generateX86MemoryReference(temp1Reg, offsetof(J9ITable, next), cg), cg);
+        MRef_Bdisp32(temp1Reg, offsetof(J9ITable, next), cg), cg);
     generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
 
     // Found from I-Table
@@ -4291,11 +4272,11 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     // class depth mask must be low 16 bits to safely load without the mask.
     static_assert(J9AccClassDepthMask == 0xffff, "J9_JAVA_CLASS_DEPTH_MASK must be 0xffff");
     generateRegMemInstruction(comp->target().is64Bit() ? TR::InstOpCode::MOVZXReg8Mem2 : TR::InstOpCode::MOVZXReg4Mem2,
-        node, temp2Reg, generateX86MemoryReference(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+        node, temp2Reg, MRef_Bdisp32(castClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
 
     // cast class depth >= obj class depth, throw
     generateRegMemInstruction(TR::InstOpCode::CMP2RegMem, node, temp2Reg,
-        generateX86MemoryReference(objClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+        MRef_Bdisp32(objClassReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
     generateLabelInstruction(TR::InstOpCode::JAE4, node, throwLabel, cg);
 
     // check obj class's super class array entry
@@ -4308,9 +4289,9 @@ inline void generateInlinedCheckCastForDynamicCastClass(TR::Node *node, TR::Code
     // On 32 bit, it could put more register pressure due to limited number of regs.
     // Since 64-bit is more prevalent, we opt to optimize for 64bit in this case
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, temp1Reg,
-        generateX86MemoryReference(objClassReg, offsetof(J9Class, superclasses), cg), cg);
+        MRef_Bdisp32(objClassReg, offsetof(J9Class, superclasses), cg), cg);
     generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, castClassReg,
-        generateX86MemoryReference(temp1Reg, temp2Reg, comp->target().is64Bit() ? 3 : 2, cg), cg);
+        MRef_BIS(temp1Reg, temp2Reg, comp->target().is64Bit() ? 3 : 2, cg), cg);
     generateLabelInstruction(TR::InstOpCode::JNE4, node, throwLabel, cg);
 
     // throw classCastException
@@ -4458,20 +4439,19 @@ static void inlineCheckCastOrInstanceOfObjectArrayCastClass(TR::Node *node, TR_O
     // Check if romClass is an array
     //
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, romClassReg,
-        generateX86MemoryReference(objectClassReg, offsetof(J9Class, romClass), cg), cg);
+        MRef_Bdisp32(objectClassReg, offsetof(J9Class, romClass), cg), cg);
     generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        generateX86MemoryReference(romClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
+        MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassArray, cg);
     generateLabelInstruction(TR::InstOpCode::JE4, node, notCastableLabel, cg);
 
     // Check if object class is a primitive array
     //
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, componentClassReg,
-        generateX86MemoryReference(objectClassReg, offsetof(J9ArrayClass, componentType), cg), cg);
+        MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, componentType), cg), cg);
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, romClassReg,
-        generateX86MemoryReference(componentClassReg, offsetof(J9Class, romClass), cg), cg);
+        MRef_Bdisp32(componentClassReg, offsetof(J9Class, romClass), cg), cg);
     generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node,
-        generateX86MemoryReference(romClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassInternalPrimitiveType,
-        cg);
+        MRef_Bdisp32(romClassReg, offsetof(J9ROMClass, modifiers), cg), J9AccClassInternalPrimitiveType, cg);
     generateLabelInstruction(TR::InstOpCode::JNE4, node, notCastableLabel, cg);
 
     if (!isCheckCast) {
@@ -4735,8 +4715,7 @@ static void generateCastClassCacheUpdate(TR::Register *objectClassReg, uintptr_t
     if (dontUpdateCastClassCache)
         return;
 
-    TR::MemoryReference *castClassMR
-        = generateX86MemoryReference(objectClassReg, offsetof(J9Class, castClassCache), cg);
+    TR::MemoryReference *castClassMR = MRef_Bdisp32(objectClassReg, offsetof(J9Class, castClassCache), cg);
 
     bool use32Bit = (!cg->comp()->compileRelocatableCode())
         && (!use64BitClasses || (use64BitClasses && IS_32BIT_SIGNED(clazzAddress)));
@@ -4938,7 +4917,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         scratchReg = cg->allocateRegister();
 
     generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
-        generateX86MemoryReference(objectClassReg, offsetof(J9Class, castClassCache), cg), cg);
+        MRef_Bdisp32(objectClassReg, offsetof(J9Class, castClassCache), cg), cg);
 
     if (use64BitClasses) {
         if (IS_32BIT_SIGNED(clazzAddress) && !comp->compileRelocatableCode()) {
@@ -4983,8 +4962,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
 
         generateMemImmInstruction(IS_8BIT_SIGNED(J9AccClassRAMArray) ? TR::InstOpCode::TEST1MemImm1
                                                                      : TR::InstOpCode::TEST4MemImm4,
-            node, generateX86MemoryReference(objectClassReg, offsetof(J9Class, classDepthAndFlags), cg),
-            J9AccClassRAMArray, cg);
+            node, MRef_Bdisp32(objectClassReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
         generateLabelInstruction(TR::InstOpCode::JE4, node, notCastableUpdateCacheLabel, cg);
 
         // ----------------------------------------------------------------------
@@ -4993,7 +4971,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // ----------------------------------------------------------------------
 
         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
-            generateX86MemoryReference(objectClassReg, offsetof(J9ArrayClass, arity), cg), cg);
+            MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, arity), cg), cg);
 
         UDATA arity = static_cast<TR_J9VM *>(fej9)->getArityFromArrayClass((TR_OpaqueClassBlock *)clazz);
         generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, scratchReg, arity, cg);
@@ -5010,8 +4988,8 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
 
             generateMemImmInstruction(IS_8BIT_SIGNED(J9ClassArrayIsNullRestricted) ? TR::InstOpCode::TEST1MemImm1
                                                                                    : TR::InstOpCode::TEST4MemImm4,
-                node, generateX86MemoryReference(objectClassReg, offsetof(J9Class, classFlags), cg),
-                J9ClassArrayIsNullRestricted, cg);
+                node, MRef_Bdisp32(objectClassReg, offsetof(J9Class, classFlags), cg), J9ClassArrayIsNullRestricted,
+                cg);
 
             // Fail, since a nullable array class cannot be cast to a null-restricted class
             //
@@ -5027,7 +5005,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             objectClassLeafReg = cg->allocateRegister();
 
         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, objectClassLeafReg,
-            generateX86MemoryReference(objectClassReg, offsetof(J9ArrayClass, leafComponentType), cg), cg);
+            MRef_Bdisp32(objectClassReg, offsetof(J9ArrayClass, leafComponentType), cg), cg);
 
         // ----------------------------------------------------------------------
         // If objectClassLeaf is not a mixed object (reference) then
@@ -5035,7 +5013,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
         // ----------------------------------------------------------------------
 
         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
-            generateX86MemoryReference(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+            MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
         generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, scratchReg,
             (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
         generateRegImmInstruction(TR::InstOpCode::CMP8RegImm4, node, scratchReg,
@@ -5076,7 +5054,7 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
 
             static_assert(J9AccClassDepthMask == 0xffff, "J9AccClassDepthMask must be 0xffff");
             TR::MemoryReference *objectClassLeafDepthMR
-                = generateX86MemoryReference(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg);
+                = MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, classDepthAndFlags), cg);
             generateMemImmInstruction(TR::InstOpCode::CMP2MemImm2, node, objectClassLeafDepthMR, castClassLeafDepth,
                 cg);
 
@@ -5094,11 +5072,11 @@ static void inlineCheckCastOrInstanceOfKnownArrayCastClass(TR::Node *node, TR_Op
             }
 
             generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, scratchReg,
-                generateX86MemoryReference(objectClassLeafReg, offsetof(J9Class, superclasses), cg), cg);
+                MRef_Bdisp32(objectClassLeafReg, offsetof(J9Class, superclasses), cg), cg);
             auto offset = castClassLeafDepth * sizeof(J9Class *);
             TR_ASSERT_FATAL(IS_32BIT_SIGNED(offset), "superclass array offset is unreasonably large");
 
-            TR::MemoryReference *superclassMR2 = generateX86MemoryReference(scratchReg, offset, cg);
+            TR::MemoryReference *superclassMR2 = MRef_Bdisp32(scratchReg, offset, cg);
             if (use64BitClasses) {
                 if (IS_32BIT_SIGNED(componentClazzAddress) && !comp->compileRelocatableCode()) {
                     generateMemImmInstruction(TR::InstOpCode::CMP8MemImm4, node, superclassMR2,
@@ -5303,7 +5281,7 @@ static void generateInlinedCheckCastOrInstanceOfForArrayClass(TR::Node *node, TR
         // the exception after the checkcast. If the checkcast was combined with nullpointer
         // there's nobody after the checkcast to throw the exception.
         auto instr = generateMemImmInstruction(TR::InstOpCode::TEST1MemImm1, node,
-            generateX86MemoryReference(object, TR::Compiler->om.offsetOfObjectVftField(), cg), 0, cg);
+            MRef_Bdisp32(object, TR::Compiler->om.offsetOfObjectVftField(), cg), 0, cg);
         cg->setImplicitExceptionPoint(instr);
         instr->setNeedsGCMap(0xFF00FFFF);
         instr->setNode(comp->findNullChkInfo(node));
@@ -5339,7 +5317,7 @@ static void inlineInterfaceLookup(TR::Node *node, TR::CodeGenerator *cg, TR::Lab
     generateLabelInstruction(TR::InstOpCode::label, node, iTableLoopLabel, cg);
     generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), node, itableReg, itableReg, cg);
     generateLabelInstruction(TR::InstOpCode::JE4, node, iTableLookUpFailLabel, cg);
-    auto interfaceMR = generateX86MemoryReference(itableReg, offsetof(J9ITable, interfaceClass), cg);
+    auto interfaceMR = MRef_Bdisp32(itableReg, offsetof(J9ITable, interfaceClass), cg);
     if (castClassReg) {
         generateMemRegInstruction(TR::InstOpCode::CMP8MemReg, node, interfaceMR, castClassReg, cg);
     } else {
@@ -5347,7 +5325,7 @@ static void inlineInterfaceLookup(TR::Node *node, TR::CodeGenerator *cg, TR::Lab
             reinterpret_cast<uintptr_t>(castClass), node->getChild(1)->getSymbolReference(), cg);
     }
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, itableReg,
-        generateX86MemoryReference(itableReg, offsetof(J9ITable, next), cg), cg);
+        MRef_Bdisp32(itableReg, offsetof(J9ITable, next), cg), cg);
     generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLoopLabel, cg);
 
     // If the loop does not iterate then a match was found
@@ -5453,7 +5431,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
                                             : cg->create8ByteData(node, (uint64_t)guessClass);
         cache->setClassAddress(true);
         generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, instanceClassReg,
-            generateX86MemoryReference(cache, cg), cg);
+            MRef_const(cache, cg), cg);
         generateLabelInstruction(TR::InstOpCode::JNE4, node, iTableLookUpPathLabel, cg);
 
         // I-Table lookup out-of-line
@@ -5469,7 +5447,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
             // Obtain I-Table
             // Re-use the instanceClassReg register to perform itable lookup
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, instanceClassReg,
-                generateX86MemoryReference(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
+                MRef_Bdisp32(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
 
             inlineInterfaceLookup(node, cg, iTableLookUpFailLabel, castClass, castClassReg, instanceClassReg);
 
@@ -5485,7 +5463,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
              */
             static bool updateCacheSlot = feGetEnv("TR_updateInterfaceCheckCastCacheSlot") != NULL;
             if (updateCacheSlot) {
-                generateMemInstruction(TR::InstOpCode::POPMem, node, generateX86MemoryReference(cache, cg),
+                generateMemInstruction(TR::InstOpCode::POPMem, node, MRef_const(cache, cg),
                     cg); // j9class
             } else {
                 generateRegInstruction(TR::InstOpCode::POPReg, node, instanceClassReg, cg); // j9class
@@ -5537,7 +5515,7 @@ inline void generateInlinedCheckCastOrInstanceOfForInterface(TR::Node *node, TR_
 
         // Obtain I-Table
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, itableReg,
-            generateX86MemoryReference(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
+            MRef_Bdisp32(instanceClassReg, offsetof(J9Class, iTable), cg), cg);
 
         inlineInterfaceLookup(node, cg, isCheckCast ? iTableLookUpFailLabel : endLabel, castClass, castClassReg,
             itableReg);
@@ -5641,8 +5619,7 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
         // However, LHS for TR_checkAssignable may be abstract or interface as it may be an arbitrary class, and
         // hence equality test is always needed.
         if (use64BitClasses) {
-            generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, j9class,
-                generateX86MemoryReference(clazzData, cg), cg);
+            generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, j9class, MRef_const(clazzData, cg), cg);
         } else {
             generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, j9class, (uintptr_t)clazz, cg);
         }
@@ -5657,7 +5634,7 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
         auto depth = TR::Compiler->cls.classDepthOf(clazz);
         if (depth >= comp->getOptions()->_minimumSuperclassArraySize) {
             static_assert(J9AccClassDepthMask == 0xffff, "J9AccClassDepthMask must be 0xffff");
-            auto depthMR = generateX86MemoryReference(j9class, offsetof(J9Class, classDepthAndFlags), cg);
+            auto depthMR = MRef_Bdisp32(j9class, offsetof(J9Class, classDepthAndFlags), cg);
             generateMemImmInstruction(TR::InstOpCode::CMP2MemImm2, node, depthMR, depth, cg);
             if (!isCheckCast) {
                 // Need ensure CF is cleared before reaching to fail label
@@ -5674,14 +5651,13 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
         }
 
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tmp,
-            generateX86MemoryReference(j9class, offsetof(J9Class, superclasses), cg), cg);
+            MRef_Bdisp32(j9class, offsetof(J9Class, superclasses), cg), cg);
         auto offset = depth * sizeof(J9Class *);
         TR_ASSERT(IS_32BIT_SIGNED(offset), "The offset to superclass is unreasonably large.");
-        auto superclass = generateX86MemoryReference(tmp, offset, cg);
+        auto superclass = MRef_Bdisp32(tmp, offset, cg);
         if (use64BitClasses) {
             generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, tmp, superclass, cg);
-            generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, tmp, generateX86MemoryReference(clazzData, cg),
-                cg);
+            generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, tmp, MRef_const(clazzData, cg), cg);
         } else {
             generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, node, superclass, (int32_t)(uintptr_t)clazz, cg);
         }
@@ -5706,7 +5682,7 @@ inline void generateInlinedCheckCastOrInstanceOfForClass(TR::Node *node, TR_Opaq
 
         generateRegInstruction(TR::InstOpCode::PUSHReg, node, j9class, cg);
         if (use64BitClasses) {
-            generateMemInstruction(TR::InstOpCode::PUSHMem, node, generateX86MemoryReference(clazzData, cg), cg);
+            generateMemInstruction(TR::InstOpCode::PUSHMem, node, MRef_const(clazzData, cg), cg);
         } else {
             generateImmInstruction(TR::InstOpCode::PUSHImm4, node, (int32_t)(uintptr_t)clazz, cg);
         }
@@ -5772,15 +5748,15 @@ static TR::MemoryReference *getMemoryReference(TR::Register *objectClassReg, TR:
     TR::CodeGenerator *cg)
 {
     if (objectClassReg)
-        return generateX86MemoryReference(objectReg, objectClassReg, 0, cg);
+        return MRef_BIS(objectReg, objectClassReg, 0, cg);
     else
-        return generateX86MemoryReference(objectReg, lwOffset, cg);
+        return MRef_Bdisp32(objectReg, lwOffset, cg);
 }
 
 void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGenerator *cg,
     TR::LabelSymbol *snippetLabel)
 {
-    TR::MemoryReference *SOMmr = generateX86MemoryReference(node->getFirstChild()->getFirstChild(), cg);
+    TR::MemoryReference *SOMmr = MRef_node(node->getFirstChild()->getFirstChild(), cg);
     TR::Compilation *comp = cg->comp();
 
     if (cg->comp()->target().is64Bit()) {
@@ -5826,12 +5802,11 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
             generateInstruction(TR::InstOpCode::INT3, node, cg);
 
         generateMemImmInstruction(TR::InstOpCode::S8MemImm4, node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
         generateRegImmInstruction(TR::InstOpCode::MOV8RegImm4, node, tempReg,
             1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(), cg);
         generateMemRegInstruction(TR::InstOpCode::LOR8MemReg, node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg), tempReg,
-            cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg), tempReg, cg);
 
         // Populate the code we are going to patch in
         //
@@ -5846,8 +5821,8 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         // Load the original value
         //
 
-        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, patchValReg,
-            generateX86MemoryReference(patchableAddrReg, -5, cg), cg);
+        generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, patchValReg, MRef_Bdisp32(patchableAddrReg, -5, cg),
+            cg);
         generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
         generateRegRegInstruction(TR::InstOpCode::OR8RegReg, node, patchValReg, tempReg, cg);
         generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg, (uint64_t)0x0, cg);
@@ -5860,8 +5835,8 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
         deps->stopAddingConditions();
 
-        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, generateX86MemoryReference(patchableAddrReg, -5, cg),
-            patchValReg, deps, cg);
+        generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(patchableAddrReg, -5, cg), patchValReg,
+            deps, cg);
         generateLabelInstruction(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
         generateLabelInstruction(TR::InstOpCode::JMP4, node, snippetLabel, cg);
 
@@ -5916,12 +5891,11 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         // Signal the async event
         //
         generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, stackOverflowMark), cg), -1, cg);
         generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, lowPatchValReg,
             1 << comp->getPersistentInfo()->getGCMapCheckEventHandle(), cg);
         generateMemRegInstruction(TR::InstOpCode::LOR4MemReg, node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg),
-            lowPatchValReg, cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, asyncEventFlags), cg), lowPatchValReg, cg);
 
         // Populate the registers we are going to use in the lock cmp xchg
         //
@@ -5933,9 +5907,9 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         // Populate the existing inline code
         //
         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lowExistingValReg,
-            generateX86MemoryReference(patchableAddrReg, -5, cg), cg);
+            MRef_Bdisp32(patchableAddrReg, -5, cg), cg);
         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, highExistingValReg,
-            generateX86MemoryReference(patchableAddrReg, -1, cg), cg);
+            MRef_Bdisp32(patchableAddrReg, -1, cg), cg);
 
         // Populate the code we are going to patch in
         // 837d28ff        cmp     dword ptr [ebp+28h],0FFFFFFFFh <--- patching in
@@ -5956,8 +5930,7 @@ void J9::X86::TreeEvaluator::asyncGCMapCheckPatching(TR::Node *node, TR::CodeGen
         deps->addPostCondition(highExistingValReg, TR::RealRegister::edx, cg);
         deps->addPostCondition(cg->getVMThreadRegister(), TR::RealRegister::ebp, cg);
         deps->stopAddingConditions();
-        generateMemInstruction(TR::InstOpCode::LCMPXCHG8BMem, node,
-            generateX86MemoryReference(patchableAddrReg, -5, cg), deps, cg);
+        generateMemInstruction(TR::InstOpCode::LCMPXCHG8BMem, node, MRef_Bdisp32(patchableAddrReg, -5, cg), deps, cg);
         generateLabelInstruction(TR::InstOpCode::label, node, asyncWithoutPatch, cg);
         generateVFPRestoreInstruction(generateLabelInstruction(TR::InstOpCode::JMP4, node, snippetLabel, cg),
             vfpSaveInst, cg);
@@ -6016,7 +5989,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
         || node->getSymbolReference() == cg->comp()->getSymRefTab()->findOrCreateMonitorEntrySymbolRef(NULL);
 
     generateRegMemInstruction(TR::InstOpCode::LRegMem(use64bitOp), node, lockWordReg,
-        generateX86MemoryReference(objectReg, lwOffset, cg), cg);
+        MRef_Bdisp32(objectReg, lwOffset, cg), cg);
     generateRegImmInstruction(TR::InstOpCode::ADDRegImm4(use64bitOp), node, lockWordReg,
         isMonitorEnter ? INC_DEC_VALUE : -INC_DEC_VALUE, cg);
     generateRegImmInstruction(TR::InstOpCode::MOVRegImm4(use64bitOp), node, lockWordMaskedReg,
@@ -6025,8 +5998,8 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     generateRegRegInstruction(TR::InstOpCode::CMPRegReg(use64bitOp), node, lockWordMaskedReg, vmThreadReg, cg);
 
     generateLabelInstruction(TR::InstOpCode::JNE4, node, jitMonitorEnterOrExitSnippetLabel, cg);
-    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64bitOp), node,
-        generateX86MemoryReference(objectReg, lwOffset, cg), lockWordReg, cg);
+    generateMemRegInstruction(TR::InstOpCode::SMemReg(use64bitOp), node, MRef_Bdisp32(objectReg, lwOffset, cg),
+        lockWordReg, cg);
 
 #if defined(TR_TARGET_64BIT) && (JAVA_SPEC_VERSION >= 19)
     // Adjust J9VMThread ownedMonitorCount for execution paths that do not
@@ -6035,7 +6008,7 @@ void J9::X86::TreeEvaluator::inlineRecursiveMonitor(TR::Node *node, TR::CodeGene
     // underflow.
     //
     generateMemInstruction(isMonitorEnter ? TR::InstOpCode::INC8Mem : TR::InstOpCode::DEC8Mem, node,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
     TR::RegisterDependencyConditions *restartDeps = generateRegisterDependencyConditions((uint8_t)0, 4, cg);
@@ -6066,8 +6039,7 @@ void J9::X86::TreeEvaluator::generateCheckForValueMonitorEnterOrExit(TR::Node *n
     TR::Register *j9classReg = cg->allocateRegister();
     generateLoadJ9Class(node, j9classReg, objectReg, cg);
     auto fej9 = (TR_J9VMBase *)(cg->fe());
-    TR::MemoryReference *classFlagsMR
-        = generateX86MemoryReference(j9classReg, (uintptr_t)(fej9->getOffsetOfClassFlags()), cg);
+    TR::MemoryReference *classFlagsMR = MRef_Bdisp32(j9classReg, (uintptr_t)(fej9->getOffsetOfClassFlags()), cg);
 
     TR::InstOpCode::Mnemonic testOpCode;
     if ((uint32_t)classFlag <= USHRT_MAX)
@@ -6266,7 +6238,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
     TR::Register *lookupOffsetReg = NULL;
 
     if (lwOffset <= 0) {
-        TR::MemoryReference *objectClassMR = generateX86MemoryReference(objectReg, TMP_OFFSETOF_J9OBJECT_CLAZZ, cg);
+        TR::MemoryReference *objectClassMR = MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_CLAZZ, cg);
         objectClassReg = cg->allocateRegister();
         numDeps++;
 
@@ -6283,7 +6255,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
         TR::TreeEvaluator::generateVFTMaskInstruction(node, objectClassReg, cg);
         int32_t offsetOfLockOffset = offsetof(J9Class, lockOffset);
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, objectClassReg,
-            generateX86MemoryReference(objectClassReg, offsetOfLockOffset, cg), cg);
+            MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
         generateRegImmInstruction(TR::InstOpCode::CMPRegImms(), node, objectClassReg, 0, cg);
 
         generateCommonLockNurseryCodes(node, cg,
@@ -6296,8 +6268,8 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
         TR::LabelSymbol *mismatchLabel
             = TR::Options::_aggressiveLockReservation ? snippetLabel : generateLabelSymbol(cg);
 
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, eaxReal,
-            generateX86MemoryReference(vmThreadReg, RES_BIT, cg), cg);
+        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, eaxReal, MRef_Bdisp32(vmThreadReg, RES_BIT, cg),
+            cg);
 
         TR::InstOpCode::Mnemonic cmpMemRegOp = (is64Bit && fej9->generateCompressedLockWord())
             ? TR::InstOpCode::CMP4MemReg
@@ -6439,7 +6411,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonentEvaluator(TR::Node *node, TR::Code
     // this unconditionally.  There is no need to check for overflow..
     //
     generateMemInstruction(TR::InstOpCode::INC8Mem, node,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
     // Create dependencies for the registers used.
@@ -6569,7 +6541,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     TR::LabelSymbol *fallThruFromMonitorLookupCacheLabel = generateLabelSymbol(cg);
 
     if (lwOffset <= 0) {
-        TR::MemoryReference *objectClassMR = generateX86MemoryReference(objectReg, TMP_OFFSETOF_J9OBJECT_CLAZZ, cg);
+        TR::MemoryReference *objectClassMR = MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_CLAZZ, cg);
         TR::InstOpCode::Mnemonic op
             = TR::Compiler->om.compressObjectReferences() ? TR::InstOpCode::L4RegMem : TR::InstOpCode::LRegMem();
         objectClassReg = cg->allocateRegister();
@@ -6584,7 +6556,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
         TR::TreeEvaluator::generateVFTMaskInstruction(node, objectClassReg, cg);
         int32_t offsetOfLockOffset = offsetof(J9Class, lockOffset);
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, objectClassReg,
-            generateX86MemoryReference(objectClassReg, offsetOfLockOffset, cg), cg);
+            MRef_Bdisp32(objectClassReg, offsetOfLockOffset, cg), cg);
 
         numDeps++;
 
@@ -6675,7 +6647,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
             } else {
                 reservingDecrementNeeded = true;
                 generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
-                    generateX86MemoryReference(vmThreadReg, (REC_BIT | RES_BIT), cg), cg);
+                    MRef_Bdisp32(vmThreadReg, (REC_BIT | RES_BIT), cg), cg);
                 cg->setImplicitExceptionPoint(generateMemRegInstruction(TR::InstOpCode::CMPMemReg(gen64BitInstr), node,
                     getMemoryReference(objectClassReg, objectReg, lwOffset, cg), tempReg, cg));
             }
@@ -6722,7 +6694,7 @@ TR::Register *J9::X86::TreeEvaluator::VMmonexitEvaluator(TR::Node *node, TR::Cod
     // this unconditionally.  There is no need to check for underflow.
     //
     generateMemInstruction(TR::InstOpCode::DEC8Mem, node,
-        generateX86MemoryReference(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
+        MRef_Bdisp32(vmThreadReg, fej9->thisThreadGetOwnedMonitorCountOffset(), cg), cg);
 #endif
 
     // Create dependencies for the registers used.
@@ -6832,8 +6804,7 @@ static void insertAllocationPrefetch(TR::Node *node, int32_t numPrefetches, TR::
     TR::CodeGenerator *cg)
 {
     for (int32_t i = 0; i < numPrefetches; i++) {
-        generateMemInstruction(TR::InstOpCode::PREFETCHNTA, node, generateX86MemoryReference(allocationReg, offset, cg),
-            cg);
+        generateMemInstruction(TR::InstOpCode::PREFETCHNTA, node, MRef_Bdisp32(allocationReg, offset, cg), cg);
         offset += 64;
     }
 }
@@ -6897,9 +6868,8 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
             // now compute size of object in bytes
             generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
-                generateX86MemoryReference(eaxReal, sizeReg,
-                    TR::MemoryReference::convertMultiplierToStride(elementSize), allocationSizeOrDataOffset + round,
-                    cg),
+                MRef_BISdisp32(eaxReal, sizeReg, TR::MemoryReference::convertMultiplierToStride(elementSize),
+                    allocationSizeOrDataOffset + round, cg),
                 cg);
 
             if (elementSize < sizeof(UDATA))
@@ -6915,11 +6885,11 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
             // get size class
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
+                MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(tempReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
+                MRef_Bdisp32(tempReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(tempReg, segmentReg, TR::MemoryReference::convertMultiplierToStride(1),
+                MRef_BISdisp32(tempReg, segmentReg, TR::MemoryReference::convertMultiplierToStride(1),
                     fej9->getSizeClassesIndexOffset(), cg),
                 cg);
 
@@ -6937,27 +6907,26 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 //   To avoid two shifts, only do one for stride sizeof(UDATA) and use a multiplier in memory ref for 16
                 //   64-bit, so shift 3 times for sizeof(UDATA) and use multiplier stride 2 in memory references
                 generateRegImmInstruction(TR::InstOpCode::SHLRegImm1(), node, tempReg, 3, cg);
-                currentMemRef = generateX86MemoryReference(vmThreadReg, tempReg,
-                    TR::MemoryReference::convertMultiplierToStride(2), fej9->thisThreadAllocationCacheCurrentOffset(0),
-                    cg);
-                topMemRef = generateX86MemoryReference(vmThreadReg, tempReg,
-                    TR::MemoryReference::convertMultiplierToStride(2), fej9->thisThreadAllocationCacheTopOffset(0), cg);
-                currentMemRefBump = generateX86MemoryReference(vmThreadReg, tempReg,
-                    TR::MemoryReference::convertMultiplierToStride(2), fej9->thisThreadAllocationCacheCurrentOffset(0),
-                    cg);
+                currentMemRef = MRef_BISdisp32(vmThreadReg, tempReg, TR::MemoryReference::convertMultiplierToStride(2),
+                    fej9->thisThreadAllocationCacheCurrentOffset(0), cg);
+                topMemRef = MRef_BISdisp32(vmThreadReg, tempReg, TR::MemoryReference::convertMultiplierToStride(2),
+                    fej9->thisThreadAllocationCacheTopOffset(0), cg);
+                currentMemRefBump
+                    = MRef_BISdisp32(vmThreadReg, tempReg, TR::MemoryReference::convertMultiplierToStride(2),
+                        fej9->thisThreadAllocationCacheCurrentOffset(0), cg);
             } else {
                 // size needs to be 8 or less or it there's no multiplier stride available (would need to use other
                 // branch of else)
                 TR_ASSERT(sizeof(J9VMGCSegregatedAllocationCacheEntry) <= 8,
                     "unexpected J9VMGCSegregatedAllocationCacheEntry size");
 
-                currentMemRef = generateX86MemoryReference(vmThreadReg, tempReg,
+                currentMemRef = MRef_BISdisp32(vmThreadReg, tempReg,
                     TR::MemoryReference::convertMultiplierToStride(sizeof(J9VMGCSegregatedAllocationCacheEntry)),
                     fej9->thisThreadAllocationCacheCurrentOffset(0), cg);
-                topMemRef = generateX86MemoryReference(vmThreadReg, tempReg,
+                topMemRef = MRef_BISdisp32(vmThreadReg, tempReg,
                     TR::MemoryReference::convertMultiplierToStride(sizeof(J9VMGCSegregatedAllocationCacheEntry)),
                     fej9->thisThreadAllocationCacheTopOffset(0), cg);
-                currentMemRefBump = generateX86MemoryReference(vmThreadReg, tempReg,
+                currentMemRefBump = MRef_BISdisp32(vmThreadReg, tempReg,
                     TR::MemoryReference::convertMultiplierToStride(sizeof(J9VMGCSegregatedAllocationCacheEntry)),
                     fej9->thisThreadAllocationCacheCurrentOffset(0), cg);
             }
@@ -6973,21 +6942,20 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
             // have a valid cell, need to update current cell pointer
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
-                generateX86MemoryReference(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
+                MRef_Bdisp32(vmThreadReg, fej9->thisThreadJavaVMOffset(), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
-                generateX86MemoryReference(segmentReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
+                MRef_Bdisp32(segmentReg, fej9->getRealtimeSizeClassesOffset(), cg), cg);
             if (cg->comp()->target().is64Bit()) {
                 // tempReg already has already been shifted for sizeof(UDATA)
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
-                    generateX86MemoryReference(segmentReg, tempReg, TR::MemoryReference::convertMultiplierToStride(1),
+                    MRef_BISdisp32(segmentReg, tempReg, TR::MemoryReference::convertMultiplierToStride(1),
                         fej9->getSmallCellSizesOffset(), cg),
                     cg);
             } else {
                 // tempReg needs to be shifted for sizeof(UDATA)
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, segmentReg,
-                    generateX86MemoryReference(segmentReg, tempReg,
-                        TR::MemoryReference::convertMultiplierToStride(sizeof(UDATA)), fej9->getSmallCellSizesOffset(),
-                        cg),
+                    MRef_BISdisp32(segmentReg, tempReg, TR::MemoryReference::convertMultiplierToStride(sizeof(UDATA)),
+                        fej9->getSmallCellSizesOffset(), cg),
                     cg);
             }
             // segmentReg now holds cell size
@@ -6996,11 +6964,10 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             generateMemRegInstruction(TR::InstOpCode::ADDMemReg(), node, currentMemRefBump, segmentReg, cg);
         } else {
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
-                generateX86MemoryReference(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg),
-                cg);
+                MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg), cg);
 
             generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, eaxReal,
-                generateX86MemoryReference(vmThreadReg, fej9->thisThreadAllocationCacheTopOffset(sizeClass), cg), cg);
+                MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheTopOffset(sizeClass), cg), cg);
 
             generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
 
@@ -7016,8 +6983,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 opcode = TR::InstOpCode::ADDMemImm4();
 
             generateMemImmInstruction(opcode, node,
-                generateX86MemoryReference(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg),
-                cellSize, cg);
+                MRef_Bdisp32(vmThreadReg, fej9->thisThreadAllocationCacheCurrentOffset(sizeClass), cg), cellSize, cg);
         }
 
         // we're done
@@ -7042,7 +7008,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         // dominates all control paths through this internal control flow region.
         //
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
-            generateX86MemoryReference(vmThreadReg, heapAlloc_offset, cg), cg);
+            MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), cg);
 
         bool canSkipOverflowCheck = false;
 
@@ -7155,8 +7121,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                     J9_GC_MINIMUM_OBJECT_SIZE);
 
                 generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
-                    generateX86MemoryReference(eaxReal, sizeReg,
-                        TR::MemoryReference::convertMultiplierToStride(elementSize),
+                    MRef_BISdisp32(eaxReal, sizeReg, TR::MemoryReference::convertMultiplierToStride(elementSize),
                         allocationSizeOrDataOffset + disp32, cg),
                     cg);
 
@@ -7171,7 +7136,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 #endif
 
                 generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
-                    generateX86MemoryReference(
+                    MRef_BISdisp32(
 #ifdef J9VM_INTERP_FLAGS_IN_CLASS_SLOT
                         tempReg,
 #else
@@ -7214,12 +7179,12 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                 generateLabelInstruction(TR::InstOpCode::JB4, node, failLabel, cg);
             } else {
                 generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
-                    generateX86MemoryReference(eaxReal, allocationSizeOrDataOffset, cg), cg);
+                    MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg), cg);
             }
         }
 
         generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg,
-            generateX86MemoryReference(vmThreadReg, heapTop_offset, cg), cg);
+            MRef_Bdisp32(vmThreadReg, heapTop_offset, cg), cg);
 
         generateLabelInstruction(TR::InstOpCode::JA4, node, failLabel, cg);
 
@@ -7229,7 +7194,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
         //
         if (generateArraylets && (node->getOpCodeValue() == TR::anewarray || node->getOpCodeValue() == TR::newarray)) {
             generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
-                generateX86MemoryReference(tempReg, TR::Compiler->om.getObjectAlignmentInBytes() - 1, cg), cg);
+                MRef_Bdisp32(tempReg, TR::Compiler->om.getObjectAlignmentInBytes() - 1, cg), cg);
             if (cg->comp()->target().is64Bit())
                 generateRegImmInstruction(TR::InstOpCode::AND8RegImm4, node, tempReg,
                     -TR::Compiler->om.getObjectAlignmentInBytes(), cg);
@@ -7238,8 +7203,8 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
                     -TR::Compiler->om.getObjectAlignmentInBytes(), cg);
         }
 
-        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
+        generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg),
+            tempReg, cg);
 
         if (!isSmallAllocation && cg->enableTLHPrefetching()) {
             TR::LabelSymbol *prefetchSnippetLabel = generateLabelSymbol(cg);
@@ -7266,7 +7231,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
             generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, tempReg, eaxReal, cg);
 
             generateMemRegInstruction(TR::InstOpCode::SUB4MemReg, node,
-                generateX86MemoryReference(vmThreadReg, tlhPrefetchFTA_offset, cg), tempReg, cg);
+                MRef_Bdisp32(vmThreadReg, tlhPrefetchFTA_offset, cg), tempReg, cg);
             if (!useDirectPrefetchCall)
                 generateLabelInstruction(TR::InstOpCode::JLE4, node, prefetchSnippetLabel, cg);
             else {
@@ -7292,7 +7257,7 @@ static void genHeapAllocForDiscontiguousArraysOrRealtime(TR::Node *node, TR_Opaq
 
 #else // J9VM_GC_THREAD_LOCAL_HEAP
         generateMemRegInstruction(TR::InstOpCode::CMPXCHGMemReg(), node,
-            generateX86MemoryReference(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
+            MRef_Bdisp32(vmThreadReg, heapAlloc_offset, cg), tempReg, cg);
         generateLabelInstruction(TR::InstOpCode::JNE4, node, loopLabel, cg);
 #endif // !J9VM_GC_THREAD_LOCAL_HEAP
     }
@@ -7347,7 +7312,7 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
         generateLabelInstruction(TR::InstOpCode::JAE4, node, failLabel, cg);
 
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
-            generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+            MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
         generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, nextTLHAllocReg, sizeReg, cg);
 
@@ -7395,7 +7360,7 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
         // ----------
 
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, eaxReal,
-            generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
+            MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), cg);
 
         if (comp->getOptLevel() < hot)
             isTooSmallToPrefetch = allocationSizeOrDataOffset <= 0x40 ? true : false;
@@ -7418,7 +7383,7 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
             generateLabelInstruction(TR::InstOpCode::JB4, node, failLabel, cg);
         } else {
             generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, nextTLHAllocReg,
-                generateX86MemoryReference(eaxReal, allocationSizeOrDataOffset, cg), cg);
+                MRef_Bdisp32(eaxReal, allocationSizeOrDataOffset, cg), cg);
         }
     }
 
@@ -7427,7 +7392,7 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
     // -----------
 
     generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, nextTLHAllocReg,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapTop), cg), cg);
 
     generateLabelInstruction(TR::InstOpCode::JA4, node, failLabel, cg);
 
@@ -7436,7 +7401,7 @@ static void genHeapAllocForObjectOrHybridArraylet(TR::Node *node, TR_OpaqueClass
     }
 
     generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-        generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), nextTLHAllocReg, cg);
+        MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, heapAlloc), cg), nextTLHAllocReg, cg);
 
     if (!isTooSmallToPrefetch && node->getOpCodeValue() != TR::New && cg->enableTLHPrefetching()) {
         insertAllocationPrefetch(node, 3, nextTLHAllocReg, 0x100, cg);
@@ -7476,22 +7441,22 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
         TR_ASSERT(classReg, "must have a classReg for dynamic allocation");
         clzReg = tempReg;
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, clzReg,
-            generateX86MemoryReference(classReg, offsetof(J9Class, arrayClass), cg), cg);
+            MRef_Bdisp32(classReg, offsetof(J9Class, arrayClass), cg), cg);
     }
     // TODO: should be able to use a TR_ClassPointer relocation without this stuff (along with class validation)
     else if (cg->needClassAndMethodPointerRelocations() && !comp->getOption(TR_UseSymbolValidationManager)) {
         TR::Register *vmThreadReg = cg->getVMThreadRegister();
         if (node->getOpCodeValue() == TR::newarray) {
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+                MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(tempReg,
+                MRef_Bdisp32(tempReg,
                     offsetof(J9JavaVM, booleanArrayClass) + (node->getSecondChild()->getInt() - 4) * sizeof(J9Class *),
                     cg),
                 cg);
             // tempReg should contain a 32 bit pointer.
             generateMemRegInstruction(opSMemReg, node,
-                generateX86MemoryReference(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), tempReg, cg);
+                MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), tempReg, cg);
             clzReg = tempReg;
         } else {
             TR_ASSERT_FATAL((node->getOpCodeValue() == TR::New) && classReg,
@@ -7514,10 +7479,10 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
                 instr = generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg,
                     ((intptr_t)clazz | orFlagsClass), cg);
             generateMemRegInstruction(TR::InstOpCode::S8MemReg, node,
-                generateX86MemoryReference(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), tempReg, cg);
+                MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), tempReg, cg);
         } else {
             instr = generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-                generateX86MemoryReference(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg),
+                MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg),
                 (int32_t)((uintptr_t)clazz | orFlagsClass), cg);
         }
     } else {
@@ -7525,7 +7490,7 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
             generateRegImmInstruction(use64BitClasses ? TR::InstOpCode::OR8RegImm4 : TR::InstOpCode::OR4RegImm4, node,
                 clzReg, orFlagsClass, cg);
         generateMemRegInstruction(opSMemReg, node,
-            generateX86MemoryReference(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), clzReg, cg);
+            MRef_Bdisp32(objectReg, TR::Compiler->om.offsetOfObjectVftField(), cg), clzReg, cg);
     }
 
     // --------------------------------------------------------------------------------
@@ -7548,7 +7513,7 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
 #if defined(J9VM_OPT_NEW_OBJECT_HASH)
         // put orFlags or 0 into header if needed
         generateMemImmInstruction(TR::InstOpCode::S4MemImm4, node,
-            generateX86MemoryReference(objectReg, TMP_OFFSETOF_J9OBJECT_FLAGS, cg), orFlags, cg);
+            MRef_Bdisp32(objectReg, TMP_OFFSETOF_J9OBJECT_FLAGS, cg), orFlags, cg);
 
 #endif /* !J9VM_OPT_NEW_OBJECT_HASH */
     }
@@ -7566,12 +7531,12 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
     if (isDynamicAllocation) {
         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-            generateX86MemoryReference(clzReg, offsetof(J9ArrayClass, lockOffset), cg), cg);
+            MRef_Bdisp32(clzReg, offsetof(J9ArrayClass, lockOffset), cg), cg);
         generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg, (int32_t)-1, cg);
         generateLabelInstruction(TR::InstOpCode::JE4, node, doneLabel, cg);
         generateMemImmInstruction(
             TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
-            generateX86MemoryReference(objectReg, tempReg, 0, cg), 0, cg);
+            MRef_BIS(objectReg, tempReg, 0, cg), 0, cg);
         generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, cg);
     } else {
         bool initReservable = TR::Compiler->cls.classFlagReservableWordInitValue(clazz);
@@ -7588,7 +7553,7 @@ static void genInitObjectHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::
 
                 generateMemImmInstruction(
                     TR::InstOpCode::SMemImm4(comp->target().is64Bit() && !fej9->generateCompressedLockWord()), node,
-                    generateX86MemoryReference(objectReg, lwOffset, cg), initialLwValue, cg);
+                    MRef_Bdisp32(objectReg, lwOffset, cg), initialLwValue, cg);
             }
         }
     }
@@ -7609,7 +7574,7 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
 
     int32_t arraySizeOffset = fej9->getOffsetOfContiguousArraySizeField();
 
-    TR::MemoryReference *arraySizeMR = generateX86MemoryReference(objectReg, arraySizeOffset, cg);
+    TR::MemoryReference *arraySizeMR = MRef_Bdisp32(objectReg, arraySizeOffset, cg);
     // Special handling of zero sized arrays.
     // Zero length arrays are discontiguous (i.e. they also need the discontiguous length field to be 0) because
     // they are indistinguishable from non-zero length discontiguous arrays. But instead of explicitly checking
@@ -7629,8 +7594,7 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
     //
     // Refer to J9IndexableObject(Dis)contiguousCompressed structs runtime/oti/j9nonbuilder.h for more detail
     int32_t arrayDiscontiguousSizeOffset = fej9->getOffsetOfDiscontiguousArraySizeField();
-    TR::MemoryReference *arrayDiscontiguousSizeMR
-        = generateX86MemoryReference(objectReg, arrayDiscontiguousSizeOffset, cg);
+    TR::MemoryReference *arrayDiscontiguousSizeMR = MRef_Bdisp32(objectReg, arrayDiscontiguousSizeOffset, cg);
 
     TR::Compilation *comp = cg->comp();
 
@@ -7684,7 +7648,7 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
         TR::InstOpCode::Mnemonic storeOp;
 
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg,
-            generateX86MemoryReference(objectReg, arrayletDataOffset, cg), cg);
+            MRef_Bdisp32(objectReg, arrayletDataOffset, cg), cg);
 
         if (comp->useCompressedPointers()) {
             storeOp = TR::InstOpCode::S4MemReg;
@@ -7699,8 +7663,8 @@ static void genInitArrayHeader(TR::Node *node, TR_OpaqueClassBlock *clazz, TR::R
         }
 
         TR_J9VMBase *fej9 = (TR_J9VMBase *)(cg->fe());
-        generateMemRegInstruction(storeOp, node,
-            generateX86MemoryReference(objectReg, fej9->getFirstArrayletPointerOffset(comp), cg), tempReg, cg);
+        generateMemRegInstruction(storeOp, node, MRef_Bdisp32(objectReg, fej9->getFirstArrayletPointerOffset(comp), cg),
+            tempReg, cg);
     }
 }
 
@@ -7822,7 +7786,7 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
             // if necessary
             //
             generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
-                generateX86MemoryReference(newObjectAddressReg, headerSizeInBytes + startingAddressAdjustment, cg), cg);
+                MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + startingAddressAdjustment, cg), cg);
 
             generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, zeroInitScratchReg, zeroInitScratchReg, cg);
 
@@ -7830,7 +7794,7 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
             //
             TR::LabelSymbol *zeroInitLoopLabelSym = generateLabelSymbol(cg);
             generateLabelInstruction(TR::InstOpCode::label, node, zeroInitLoopLabelSym, cg);
-            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, generateX86MemoryReference(segmentReg, 0, cg),
+            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(segmentReg, 0, cg),
                 zeroInitScratchReg, cg);
             generateRegImmInstruction(TR::InstOpCode::ADD8RegImms, node, segmentReg, 8, cg);
             generateRegImmInstruction(TR::InstOpCode::SUB8RegImms, node, numBytesToZeroInitReg, 8, cg);
@@ -7848,7 +7812,7 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
                 // Begin zero initialization after the header
                 //
                 generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
-                    generateX86MemoryReference(newObjectAddressReg, headerSizeInBytes, cg), cg);
+                    MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg), cg);
 
                 generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg,
                     cg);
@@ -7871,7 +7835,7 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
             // Begin zero initialization after the header
             //
             generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
-                generateX86MemoryReference(newObjectAddressReg, headerSizeInBytes, cg), cg);
+                MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes, cg), cg);
 
             if (comp->target().is64Bit()) {
                 generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, zeroInitScratchReg, newObjectAddressReg,
@@ -7905,7 +7869,7 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
         int32_t offset = 0;
         while (objectSizeInBytes >= 16) {
             generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
-                generateX86MemoryReference(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
+                MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
             objectSizeInBytes -= 16;
             offset += 16;
         }
@@ -7913,11 +7877,11 @@ static bool genZeroInitForEntireObjectOrHybridArraylet(TR::Node *node, int32_t o
         switch (objectSizeInBytes) {
             case 8:
                 generateMemRegInstruction(TR::InstOpCode::MOVQMemReg, node,
-                    generateX86MemoryReference(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
+                    MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
                 break;
             case 4:
                 generateMemRegInstruction(TR::InstOpCode::MOVDMemReg, node,
-                    generateX86MemoryReference(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
+                    MRef_Bdisp32(newObjectAddressReg, headerSizeInBytes + offset, cg), scratchReg, cg);
                 break;
             case 0:
                 break;
@@ -8036,7 +8000,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         // startOffset will be monitorSlot only for arrays
 
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, segmentReg,
-            generateX86MemoryReference(targetReg, startOfZeroInits, cg), cg);
+            MRef_Bdisp32(targetReg, startOfZeroInits, cg), cg);
 
         if (sizeReg) {
             int32_t additionalSlots = 0;
@@ -8054,42 +8018,42 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
                 case 1:
                     if (comp->target().is64Bit()) {
                         generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            generateX86MemoryReference(sizeReg, (additionalSlots * 8) + 7, cg), cg);
+                            MRef_Bdisp32(sizeReg, (additionalSlots * 8) + 7, cg), cg);
                         generateRegImmInstruction(TR::InstOpCode::SHR8RegImm1, node, tempReg, 3, cg);
                     } else {
                         generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
-                            generateX86MemoryReference(sizeReg, (additionalSlots * 4) + 3, cg), cg);
+                            MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg), cg);
                         generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, tempReg, 2, cg);
                     }
                     break;
                 case 2:
                     if (comp->target().is64Bit()) {
                         generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            generateX86MemoryReference(sizeReg, (additionalSlots * 4) + 3, cg), cg);
+                            MRef_Bdisp32(sizeReg, (additionalSlots * 4) + 3, cg), cg);
                         generateRegImmInstruction(TR::InstOpCode::SHR8RegImm1, node, tempReg, 2, cg);
                     } else {
                         generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
-                            generateX86MemoryReference(sizeReg, (additionalSlots * 2) + 1, cg), cg);
+                            MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg), cg);
                         generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, tempReg, 1, cg);
                     }
                     break;
                 case 4:
                     if (comp->target().is64Bit()) {
                         generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            generateX86MemoryReference(sizeReg, (additionalSlots * 2) + 1, cg), cg);
+                            MRef_Bdisp32(sizeReg, (additionalSlots * 2) + 1, cg), cg);
                         generateRegImmInstruction(TR::InstOpCode::SHR8RegImm1, node, tempReg, 1, cg);
                     } else {
                         generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
-                            generateX86MemoryReference(sizeReg, additionalSlots, cg), cg);
+                            MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
                     }
                     break;
                 case 8:
                     if (comp->target().is64Bit()) {
                         generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, tempReg,
-                            generateX86MemoryReference(sizeReg, additionalSlots, cg), cg);
+                            MRef_Bdisp32(sizeReg, additionalSlots, cg), cg);
                     } else {
                         generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, tempReg,
-                            generateX86MemoryReference(NULL, sizeReg, TR::MemoryReference::convertMultiplierToStride(2),
+                            MRef_BISdisp32(NULL, sizeReg, TR::MemoryReference::convertMultiplierToStride(2),
                                 additionalSlots, cg),
                             cg);
                     }
@@ -8128,8 +8092,8 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::S4MemReg
                 : TR::InstOpCode::SMemReg();
-            generateMemRegInstruction(op, node, generateX86MemoryReference(segmentReg, lwOffset - startOfZeroInits, cg),
-                targetReg, cg);
+            generateMemRegInstruction(op, node, MRef_Bdisp32(segmentReg, lwOffset - startOfZeroInits, cg), targetReg,
+                cg);
         }
 
         TR::InstOpCode::Mnemonic op = comp->target().is64Bit() ? TR::InstOpCode::REPSTOSQ : TR::InstOpCode::REPSTOSD;
@@ -8156,7 +8120,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::S4MemReg
                 : TR::InstOpCode::SMemReg();
-            generateMemRegInstruction(op, node, generateX86MemoryReference(targetReg, lwOffset, cg), tempReg, cg);
+            generateMemRegInstruction(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), tempReg, cg);
         }
     } else {
         bool initLw = (node->getOpCodeValue() != TR::New);
@@ -8167,7 +8131,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             TR::InstOpCode::Mnemonic op = (comp->target().is64Bit() && fej9->generateCompressedLockWord())
                 ? TR::InstOpCode::S4MemImm4
                 : TR::InstOpCode::SMemImm4();
-            generateMemImmInstruction(op, node, generateX86MemoryReference(targetReg, lwOffset, cg), 0, cg);
+            generateMemImmInstruction(op, node, MRef_Bdisp32(targetReg, lwOffset, cg), 0, cg);
         }
         return false;
     }
@@ -8191,7 +8155,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
         for (i = maxZeroInitWordsPerIteration; i > 0; i--) {
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                generateX86MemoryReference(targetReg, segmentReg,
+                MRef_BISdisp32(targetReg, segmentReg,
                     TR::MemoryReference::convertMultiplierToStride((int32_t)TR::Compiler->om.sizeofReferenceAddress()),
                     endOffset - TR::Compiler->om.sizeofReferenceAddress() * i, cg),
                 tempReg, cg);
@@ -8203,8 +8167,7 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
         //
         for (i = 0; i < numSlots % maxZeroInitWordsPerIteration; i++) {
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                generateX86MemoryReference(targetReg, endOffset + TR::Compiler->om.sizeofReferenceAddress() * i, cg),
-                tempReg, cg);
+                MRef_Bdisp32(targetReg, endOffset + TR::Compiler->om.sizeofReferenceAddress() * i, cg), tempReg, cg);
         }
     } else {
         // Generate the initializations inline
@@ -8213,9 +8176,8 @@ static bool genZeroInitEntireObject(TR::Node *node, int32_t objectSize, int32_t 
             // Don't bother initializing the array-size slot
             //
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                generateX86MemoryReference(targetReg, i * TR::Compiler->om.sizeofReferenceAddress() + startOfZeroInits,
-                    cg),
-                tempReg, cg);
+                MRef_Bdisp32(targetReg, i * TR::Compiler->om.sizeofReferenceAddress() + startOfZeroInits, cg), tempReg,
+                cg);
         }
     }
 
@@ -8271,9 +8233,9 @@ static void handleOffHeapDataForArrays(TR::Node *node, TR::Register *sizeReg, TR
         generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, sizeReg, 1, cg);
         generateRegImmInstruction(TR::InstOpCode::ADCRegImm4(), node, discontiguousDataAddrOffsetReg, 0, cg);
 
-        dataAddrMR = generateX86MemoryReference(targetReg, discontiguousDataAddrOffsetReg, 3,
+        dataAddrMR = MRef_BISdisp32(targetReg, discontiguousDataAddrOffsetReg, 3,
             TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
-        dataAddrSlotMR = generateX86MemoryReference(targetReg, discontiguousDataAddrOffsetReg, 3,
+        dataAddrSlotMR = MRef_BISdisp32(targetReg, discontiguousDataAddrOffsetReg, 3,
             fej9->getOffsetOfContiguousDataAddrField(), cg);
         // Load first data element address
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
@@ -8293,7 +8255,7 @@ static void handleOffHeapDataForArrays(TR::Node *node, TR::Register *sizeReg, TR
         && node->getFirstChild()->getInt() == 0) {
         logprintf(trace, log, "Node (%p): Dealing with full/compressed refs fixed length zero size array.\n", node);
 
-        dataAddrSlotMR = generateX86MemoryReference(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg);
+        dataAddrSlotMR = MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousDataAddrField(), cg);
         generateMemImmInstruction(TR::InstOpCode::SMemImm4(), node, dataAddrSlotMR, 0, cg);
     } else {
         logprintf(trace, log,
@@ -8310,8 +8272,8 @@ static void handleOffHeapDataForArrays(TR::Node *node, TR::Register *sizeReg, TR
                 fej9->getOffsetOfDiscontiguousDataAddrField(), fej9->getOffsetOfContiguousDataAddrField());
         }
 
-        dataAddrMR = generateX86MemoryReference(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
-        dataAddrSlotMR = generateX86MemoryReference(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg);
+        dataAddrMR = MRef_Bdisp32(targetReg, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
+        dataAddrSlotMR = MRef_Bdisp32(targetReg, fej9->getOffsetOfContiguousDataAddrField(), cg);
         // Load first data element address
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tempReg, dataAddrMR, cg);
 
@@ -8636,7 +8598,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, node, tempReg, tempReg, cg);
                 while (bvi.hasMoreElements()) {
                     generateMemRegInstruction(TR::InstOpCode::S4MemReg, node,
-                        generateX86MemoryReference(targetReg, bvi.getNextElement() * 4 + dataOffset, cg), tempReg, cg);
+                        MRef_Bdisp32(targetReg, bvi.getNextElement() * 4 + dataOffset, cg), tempReg, cg);
                 }
             } else {
                 int32_t lastElementIndex = -1;
@@ -8656,8 +8618,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                         continue;
                     } else if (span == 3) {
                         generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
-                            generateX86MemoryReference(targetReg, lastElementIndex * 4 + dataOffset, cg), scratchReg,
-                            cg);
+                            MRef_Bdisp32(targetReg, lastElementIndex * 4 + dataOffset, cg), scratchReg, cg);
                         lastSpan = -1;
                         lastElementIndex = -1;
                     } else if (span > 3) {
@@ -8671,8 +8632,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                         }
 
                         generateMemRegInstruction(storeOpCode, node,
-                            generateX86MemoryReference(targetReg, lastElementIndex * 4 + dataOffset, cg), scratchReg,
-                            cg);
+                            MRef_Bdisp32(targetReg, lastElementIndex * 4 + dataOffset, cg), scratchReg, cg);
 
                         lastElementIndex = nextE;
                         lastSpan = 0;
@@ -8700,8 +8660,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
 
                 if (storeOpCode != TR::InstOpCode::bad) {
                     generateMemRegInstruction(storeOpCode, node,
-                        generateX86MemoryReference(targetReg, lastElementIndex * 4 + adjustedDataOffset, cg),
-                        scratchReg, cg);
+                        MRef_Bdisp32(targetReg, lastElementIndex * 4 + adjustedDataOffset, cg), scratchReg, cg);
                 }
 
                 srm->reclaimScratchRegister(scratchReg);
@@ -8737,8 +8696,7 @@ TR::Register *J9::X86::TreeEvaluator::VMnewEvaluator(TR::Node *node, TR::CodeGen
                 //
                 if (node->getOpCodeValue() != TR::New && (comp->target().is32Bit() || comp->useCompressedPointers())) {
                     generateMemImmInstruction(TR::InstOpCode::SMemImm4(), node,
-                        generateX86MemoryReference(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0,
-                        cg);
+                        MRef_Bdisp32(targetReg, fej9->getOffsetOfDiscontiguousArraySizeField(), cg), 0, cg);
                     shouldInitZeroSizedArrayHeader = false;
                 }
             }
@@ -8903,8 +8861,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             // FIXME: Add check for hint when doing the arraystore check as below when class pointer compression
             // is enabled.
 
-            TR::MemoryReference *destTypeMR
-                = generateX86MemoryReference(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
+            TR::MemoryReference *destTypeMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
 
             generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, destComponentClassReg, destTypeMR,
                 cg); // class pointer is 32 bits
@@ -8930,7 +8887,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             // ..
 
             TR::MemoryReference *destCompTypeMR
-                = generateX86MemoryReference(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
+                = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
 
             // here we may have to convert the J9Class pointer from destComponentClassReg into
@@ -8938,7 +8895,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             // ..
 
             TR::MemoryReference *sourceRegClassMR
-                = generateX86MemoryReference(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
+                = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
             generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, sourceClassReg, sourceRegClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
 
@@ -8952,21 +8909,18 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             // -------------------------------------------------------------------------
 
             generateMemRegInstruction(TR::InstOpCode::CMP4MemReg, node,
-                generateX86MemoryReference(sourceClassReg, offsetof(J9Class, castClassCache), cg),
-                destComponentClassReg, cg);
+                MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg), destComponentClassReg, cg);
         } else // no class pointer compression
         {
-            TR::MemoryReference *sourceClassMR
-                = generateX86MemoryReference(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
+            TR::MemoryReference *sourceClassMR = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
 
-            TR::MemoryReference *destClassMR
-                = generateX86MemoryReference(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
+            TR::MemoryReference *destClassMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
             TR::MemoryReference *destCompTypeMR
-                = generateX86MemoryReference(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
+                = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destCompTypeMR, cg);
 
             generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, destComponentClassReg, sourceClassReg, cg);
@@ -8979,8 +8933,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             // -------------------------------------------------------------------------
 
             generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), node,
-                generateX86MemoryReference(sourceClassReg, offsetof(J9Class, castClassCache), cg),
-                destComponentClassReg, cg);
+                MRef_Bdisp32(sourceClassReg, offsetof(J9Class, castClassCache), cg), destComponentClassReg, cg);
         }
         generateLabelInstruction(TR::InstOpCode::JE4, node, wrtbarLabel, cg);
 
@@ -9090,7 +9043,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
         //
         bool eliminateDepthMask = (J9AccClassDepthMask == 0xffff);
         TR::MemoryReference *destComponentClassDepthMR
-            = generateX86MemoryReference(destComponentClassReg, offsetof(J9Class, classDepthAndFlags), cg);
+            = MRef_Bdisp32(destComponentClassReg, offsetof(J9Class, classDepthAndFlags), cg);
 
         // DMDM  32-bit only???
         if (comp->target().is32Bit()) {
@@ -9130,7 +9083,7 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
         // Get the depth of type of object being stored into the array in testerReg2
         //
 
-        TR::MemoryReference *mr = generateX86MemoryReference(sourceClassReg, offsetof(J9Class, classDepthAndFlags), cg);
+        TR::MemoryReference *mr = MRef_Bdisp32(sourceClassReg, offsetof(J9Class, classDepthAndFlags), cg);
 
         // There aren't enough registers available on 32-bit across this internal
         // control flow region.  Give one back and manually and force the source
@@ -9194,13 +9147,12 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
             // Rematerialize the source class.
             //
             sourceClassReg = scratchRegisterManager->findOrCreateScratchRegister();
-            TR::MemoryReference *sourceClassMR
-                = generateX86MemoryReference(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
+            TR::MemoryReference *sourceClassMR = MRef_Bdisp32(sourceReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceClassReg, sourceClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, sourceClassReg, cg);
         }
 
-        TR::MemoryReference *tempMR = generateX86MemoryReference(sourceClassReg, offsetof(J9Class, superclasses), cg);
+        TR::MemoryReference *tempMR = MRef_Bdisp32(sourceClassReg, offsetof(J9Class, superclasses), cg);
 
         if (comp->target().is32Bit()) {
             scratchRegisterManager->reclaimScratchRegister(sourceClassReg);
@@ -9210,8 +9162,8 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, sourceSuperClassReg, tempMR, cg);
 
-        TR::MemoryReference *leaMR = generateX86MemoryReference(sourceSuperClassReg, destComponentClassDepthReg,
-            logBase2(sizeof(uintptr_t)), 0, cg);
+        TR::MemoryReference *leaMR
+            = MRef_BISdisp32(sourceSuperClassReg, destComponentClassDepthReg, logBase2(sizeof(uintptr_t)), 0, cg);
 
         // For compressed references:
         // leaMR is a memory reference to a J9Class
@@ -9223,13 +9175,12 @@ void J9::X86::TreeEvaluator::VMarrayStoreCHKEvaluator(TR::Node *node, TR::Node *
 
             // Rematerialize destination component class
             //
-            TR::MemoryReference *destClassMR
-                = generateX86MemoryReference(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
+            TR::MemoryReference *destClassMR = MRef_Bdisp32(destReg, TR::Compiler->om.offsetOfObjectVftField(), cg);
 
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, destComponentClassReg, destClassMR, cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, destComponentClassReg, cg);
             TR::MemoryReference *destCompTypeMR
-                = generateX86MemoryReference(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
+                = MRef_Bdisp32(destComponentClassReg, offsetof(J9ArrayClass, componentType), cg);
 
             generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), node, destCompTypeMR, sourceSuperClassReg, cg);
         } else {
@@ -9304,14 +9255,14 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
 
         if (TR::Compiler->om.compressObjectReferences())
             generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, tempReg,
-                generateX86MemoryReference(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+                MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
         else
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+                MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
 
         TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
-        generateMemImmInstruction(testOpCode, node,
-            generateX86MemoryReference(tempReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
+        generateMemImmInstruction(testOpCode, node, MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg),
+            J9AccClassRAMArray, cg);
         if (!snippetLabel) {
             snippetLabel = generateLabelSymbol(cg);
             instr = generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
@@ -9325,9 +9276,9 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
     // Test equality of the object classes.
     //
     generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, tempReg,
-        generateX86MemoryReference(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+        MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
     generateRegMemInstruction(TR::InstOpCode::XORRegMem(use64BitClasses), node, tempReg,
-        generateX86MemoryReference(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+        MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
     TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
 
     // If either object is known to be a primitive array, we are done. Either
@@ -9358,14 +9309,14 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
         if (!node->isArrayChkReferenceArray1()) {
             if (TR::Compiler->om.compressObjectReferences())
                 generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, tempReg,
-                    generateX86MemoryReference(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+                    MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             else
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                    generateX86MemoryReference(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+                    MRef_Bdisp32(object1Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
 
             TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+                MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
             // X = (ramclass->ClassDepthAndFlags)>>J9AccClassRAMShapeShift
 
             // X & OBJECT_HEADER_SHAPE_MASK
@@ -9396,13 +9347,13 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
             //
             if (TR::Compiler->om.compressObjectReferences())
                 generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, tempReg,
-                    generateX86MemoryReference(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+                    MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             else
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                    generateX86MemoryReference(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
+                    MRef_Bdisp32(object2Reg, TR::Compiler->om.offsetOfObjectVftField(), cg), cg);
             TR::TreeEvaluator::generateVFTMaskInstruction(node, tempReg, cg);
             generateMemImmInstruction(testOpCode, node,
-                generateX86MemoryReference(tempReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
+                MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), J9AccClassRAMArray, cg);
             if (!snippetLabel) {
                 snippetLabel = generateLabelSymbol(cg);
                 instr = generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
@@ -9413,7 +9364,7 @@ TR::Register *J9::X86::TreeEvaluator::VMarrayCheckEvaluator(TR::Node *node, TR::
                 generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
 
             generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, tempReg,
-                generateX86MemoryReference(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
+                MRef_Bdisp32(tempReg, offsetof(J9Class, classDepthAndFlags), cg), cg);
             generateRegImmInstruction(TR::InstOpCode::ANDRegImm4(), node, tempReg,
                 (OBJECT_HEADER_SHAPE_MASK << J9AccClassRAMShapeShift), cg);
             generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, tempReg,
@@ -9497,29 +9448,28 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // result = tv_sec * 1,000,000,000 (converts seconds to nanoseconds)
 
-        tv_sec = generateX86MemoryReference(timevalNode, cg, false);
+        tv_sec = MRef_node(timevalNode, cg, false);
         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, result, tv_sec, cg);
         generateRegRegImmInstruction(TR::InstOpCode::IMUL8RegRegImm4, node, result, result,
             J9TIME_NANOSECONDS_PER_SECOND, cg);
 
         // reg = tv_usec
         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg,
-            generateX86MemoryReference(*tv_sec, offsetof(struct timespec, tv_nsec), cg), cg);
+            MRef_MRefOff(*tv_sec, offsetof(struct timespec, tv_nsec), cg), cg);
 
         // result = reg + result
-        generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, result,
-            generateX86MemoryReference(reg, result, 0, cg), cg);
+        generateRegMemInstruction(TR::InstOpCode::LEA8RegMem, node, result, MRef_BIS(reg, result, 0, cg), cg);
 
 #if defined(J9VM_OPT_CRIU_SUPPORT)
         if (fej9->isSnapshotModeEnabled()) {
             // result = result - nanoTimeMonotonicClockDelta
             TR::Register *vmThreadReg = cg->getVMThreadRegister();
             generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg,
-                generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+                MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, reg,
-                generateX86MemoryReference(reg, offsetof(J9JavaVM, portLibrary), cg), cg);
+                MRef_Bdisp32(reg, offsetof(J9JavaVM, portLibrary), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::SUB8RegMem, node, result,
-                generateX86MemoryReference(reg, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
+                MRef_Bdisp32(reg, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
         }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
@@ -9527,8 +9477,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // Store the result to memory if necessary
         if (resultAddress) {
-            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, generateX86MemoryReference(resultAddress, 0, cg),
-                result, cg);
+            generateMemRegInstruction(TR::InstOpCode::S8MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), result, cg);
 
             cg->decReferenceCount(node->getFirstChild());
             if (node->getReferenceCount() == 1
@@ -9611,8 +9560,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // load usec to a register
         TR::Register *reglow = cg->allocateRegister();
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, reglow,
-            generateX86MemoryReference(resultAddress, 4, cg), cg);
+        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, reglow, MRef_Bdisp32(resultAddress, 4, cg), cg);
 
         TR::RegisterDependencyConditions *dep1 = generateRegisterDependencyConditions((uint8_t)2, 2, cg);
         dep1->addPreCondition(eaxReal, TR::RealRegister::eax, cg);
@@ -9622,8 +9570,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
 
         // load second to eax then multiply by 1,000,000,000
 
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, edxReal,
-            generateX86MemoryReference(resultAddress, 0, cg), cg);
+        generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, edxReal, MRef_Bdisp32(resultAddress, 0, cg), cg);
         generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, eaxReal, J9TIME_NANOSECONDS_PER_SECOND, cg);
         generateRegRegInstruction(TR::InstOpCode::IMUL4AccReg, node, eaxReal, edxReal, dep1, cg);
 
@@ -9636,21 +9583,19 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
             // subtract nanoTimeMonotonicClockDelta from the result
             TR::Register *vmThreadReg = cg->getVMThreadRegister();
             generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, regLow,
-                generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+                MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, regLow,
-                generateX86MemoryReference(regLow, offsetof(J9JavaVM, portLibrary), cg), cg);
+                MRef_Bdisp32(regLow, offsetof(J9JavaVM, portLibrary), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::SUB4RegMem, node, eaxReal,
-                generateX86MemoryReference(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
+                MRef_Bdisp32(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta), cg), cg);
             generateRegMemInstruction(TR::InstOpCode::SBB4RegMem, node, edxReal,
-                generateX86MemoryReference(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta) + 4, cg), cg);
+                MRef_Bdisp32(regLow, offsetof(J9PortLibrary, nanoTimeMonotonicClockDelta) + 4, cg), cg);
         }
 #endif /* defined(J9VM_OPT_CRIU_SUPPORT) */
 
         // store it back
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(resultAddress, 0, cg),
-            eaxReal, cg);
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, generateX86MemoryReference(resultAddress, 4, cg),
-            edxReal, cg);
+        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 0, cg), eaxReal, cg);
+        generateMemRegInstruction(TR::InstOpCode::S4MemReg, node, MRef_Bdisp32(resultAddress, 4, cg), edxReal, cg);
 
         cg->stopUsingRegister(eaxReal);
         cg->stopUsingRegister(edxReal);
@@ -9662,10 +9607,10 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         if (node->getNumChildren() == 1) {
             if (node->getReferenceCount() > 1
                 || cg->getCurrentEvaluationTreeTop()->getNode()->getOpCodeValue() != TR::treetop) {
-                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lowReg,
-                    generateX86MemoryReference(resultAddress, 0, cg), cg);
-                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, highReg,
-                    generateX86MemoryReference(resultAddress, 4, cg), cg);
+                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, lowReg, MRef_Bdisp32(resultAddress, 0, cg),
+                    cg);
+                generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, highReg, MRef_Bdisp32(resultAddress, 4, cg),
+                    cg);
 
                 TR::RegisterPair *result = cg->allocateRegisterPair(lowReg, highReg);
                 node->setRegister(result);
@@ -9691,9 +9636,9 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         //
         temp2 = cg->allocateRegister();
         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, temp2,
-            generateX86MemoryReference(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
+            MRef_Bdisp32(vmThreadReg, offsetof(J9VMThread, javaVM), cg), cg);
         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, temp2,
-            generateX86MemoryReference(temp2, offsetof(J9JavaVM, portLibrary), cg), cg);
+            MRef_Bdisp32(temp2, offsetof(J9JavaVM, portLibrary), cg), cg);
         generateRegInstruction(TR::InstOpCode::PUSHReg, node, espReal, cg);
         generateRegInstruction(TR::InstOpCode::PUSHReg, node, temp2, cg);
 
@@ -9721,7 +9666,7 @@ static bool inlineNanoTime(TR::Node *node, TR::CodeGenerator *cg)
         deps->stopAddingConditions();
 
         generateCallMemInstruction(TR::InstOpCode::CALLMem, node,
-            generateX86MemoryReference(temp2, offsetof(OMRPortLibrary, time_hires_clock), cg), deps, cg);
+            MRef_Bdisp32(temp2, offsetof(OMRPortLibrary, time_hires_clock), cg), deps, cg);
         cg->stopUsingRegister(temp2);
 
         generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, espReal, 8, cg);
@@ -9767,11 +9712,11 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
     if (memLoadLhs) {
         TR::InstOpCode::Mnemonic opcode
             = is64Bit ? TR::InstOpCode::VFMADD231SDRegRegMem : TR::InstOpCode::VFMADD231SSRegRegMem;
-        TR::MemoryReference *lhsMR = generateX86MemoryReference(firstChild, cg);
+        TR::MemoryReference *lhsMR = MRef_node(firstChild, cg);
 
         if (memLoadRhs) {
             // a (2) * b (3) + c (1)
-            TR::MemoryReference *rhsMR = generateX86MemoryReference(thirdChild, cg);
+            TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
             generateRegMemInstruction(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, rhsMR, cg);
 
             midReg = cg->evaluate(secondChild);
@@ -9781,7 +9726,7 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
             // fma = a (1) * b (3) + c (2)
             opcode = is64Bit ? TR::InstOpCode::VFMADD132SDRegRegMem : TR::InstOpCode::VFMADD132SSRegRegMem;
 
-            TR::MemoryReference *midMR = generateX86MemoryReference(secondChild, cg);
+            TR::MemoryReference *midMR = MRef_node(secondChild, cg);
             rhsReg = cg->evaluate(thirdChild);
 
             generateRegMemInstruction(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, lhsMR, cg);
@@ -9794,14 +9739,14 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
             generateRegRegMemInstruction(opcode, node, result, midReg, lhsMR, cg);
         }
     } else if (memLoadMiddle) {
-        TR::MemoryReference *midMR = generateX86MemoryReference(secondChild, cg);
+        TR::MemoryReference *midMR = MRef_node(secondChild, cg);
         lhsReg = cg->evaluate(firstChild);
 
         if (memLoadRhs) {
             // fma = a (2) * b (1) + c (3)
             TR::InstOpCode::Mnemonic opcode
                 = is64Bit ? TR::InstOpCode::VFMADD213SDRegRegMem : TR::InstOpCode::VFMADD213SSRegRegMem;
-            TR::MemoryReference *rhsMR = generateX86MemoryReference(thirdChild, cg);
+            TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
 
             generateRegMemInstruction(TR::InstOpCode::MOVSRegMem(is64Bit), node, result, midMR, cg);
             generateRegRegMemInstruction(opcode, node, result, lhsReg, rhsMR, cg);
@@ -9819,7 +9764,7 @@ TR::Register *J9::X86::TreeEvaluator::inlineMathFma(TR::Node *node, TR::CodeGene
         TR::InstOpCode::Mnemonic opcode
             = is64Bit ? TR::InstOpCode::VFMADD213SDRegRegMem : TR::InstOpCode::VFMADD213SSRegRegMem;
 
-        TR::MemoryReference *rhsMR = generateX86MemoryReference(thirdChild, cg);
+        TR::MemoryReference *rhsMR = MRef_node(thirdChild, cg);
         lhsReg = cg->evaluate(firstChild);
         midReg = cg->evaluate(secondChild);
 
@@ -9992,7 +9937,7 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
     generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, index, length, cg);
     generateRegImmInstruction(TR::InstOpCode::AND4RegImms, node, index, size - 1, cg); // mod size
     generateRegMemInstruction(TR::InstOpCode::CMOVE4RegMem, node, index,
-        generateX86MemoryReference(cg->findOrCreate4ByteConstant(node, size), cg), cg);
+        MRef_const(cg->findOrCreate4ByteConstant(node, size), cg), cg);
 
     // Prepend zeros
     {
@@ -10001,15 +9946,13 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
         static uint64_t MASKDECOMPRESSED[] = { 0x0000000000000000ULL, 0xffffffffffffffffULL };
         static uint64_t MASKCOMPRESSED[] = { 0xffffffff00000000ULL, 0x0000000000000000ULL };
         generateRegMemInstruction(isCompressed ? TR::InstOpCode::MOVDRegMem : TR::InstOpCode::MOVQRegMem, node, hashXMM,
-            generateX86MemoryReference(address, index, shift,
+            MRef_BISdisp32(address, index, shift,
                 -(size << shift) + TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg),
             cg);
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp,
-            generateX86MemoryReference(
-                cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg),
-            cg);
+            MRef_const(cg->findOrCreate16ByteConstant(node, isCompressed ? MASKCOMPRESSED : MASKDECOMPRESSED), cg), cg);
 
-        auto mr = generateX86MemoryReference(tmp, index, shift, 0, cg);
+        auto mr = MRef_BISdisp32(tmp, index, shift, 0, cg);
         if (comp->target().cpu.supportsAVX()) {
             generateRegMemInstruction(TR::InstOpCode::PANDRegMem, node, hashXMM, mr, cg);
         } else {
@@ -10027,13 +9970,11 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
         generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
         generateLabelInstruction(TR::InstOpCode::JGE4, node, endLabel, cg);
         generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, multiplierXMM,
-            generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
+            MRef_const(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
         generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
         generateRegRegInstruction(TR::InstOpCode::PMULLDRegReg, node, hashXMM, multiplierXMM, cg);
         generateRegMemInstruction(isCompressed ? TR::InstOpCode::PMOVZXBDRegMem : TR::InstOpCode::PMOVZXWDRegMem, node,
-            tmpXMM,
-            generateX86MemoryReference(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg),
-            cg);
+            tmpXMM, MRef_BISdisp32(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
         generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, index, 4, cg);
         generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
         generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, index, length, cg);
@@ -10045,7 +9986,7 @@ static TR::Register *inlineStringHashCode(TR::Node *node, bool isCompressed, TR:
     {
         static uint32_t multiplier[] = { 31 * 31 * 31, 31 * 31, 31, 1 };
         generateRegMemInstruction(TR::InstOpCode::PMULLDRegMem, node, hashXMM,
-            generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
+            MRef_const(cg->findOrCreate16ByteConstant(node, multiplier), cg), cg);
         generateRegRegImmInstruction(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x0e, cg);
         generateRegRegInstruction(TR::InstOpCode::PADDDRegReg, node, hashXMM, tmpXMM, cg);
         generateRegRegImmInstruction(TR::InstOpCode::PSHUFDRegRegImm1, node, tmpXMM, hashXMM, 0x01, cg);
@@ -10248,7 +10189,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
         // Fill multiplier array with 31^numElements
         std::fill_n(multiplier31PowNData, 16, powersOf31[64 - numElements]);
         generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, multiplierVRF,
-            generateX86MemoryReference(
+            MRef_const(
                 cg->findOrCreateConstantDataSnippet(node, multiplier31PowNData, vectorSizeElements * sizeof(int32_t)),
                 cg),
             cg, vectorEncoding);
@@ -10272,8 +10213,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
             int32_t offset = sizeof(powersOf31) / sizeof(int32_t) - (vectorSizeElements * (unrollCount - i));
 
             int32_t *multiplier = const_cast<int32_t *>(powersOf31 + offset);
-            TR::MemoryReference *mr
-                = generateX86MemoryReference(cg->findOrCreateConstantDataSnippet(node, multiplier, vectorSize), cg);
+            TR::MemoryReference *mr = MRef_const(cg->findOrCreateConstantDataSnippet(node, multiplier, vectorSize), cg);
 
             generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, multiplier31PowN_i, mr, cg, vectorEncoding);
         }
@@ -10309,7 +10249,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeLoopHelper(TR::Node *nod
 
             int32_t displacement
                 = TR::Compiler->om.contiguousArrayHeaderSizeInBytes() + i * (vectorSizeElements * elementSize);
-            TR::MemoryReference *mr = generateX86MemoryReference(arrayAddress, index, shift, displacement, cg);
+            TR::MemoryReference *mr = MRef_BISdisp32(arrayAddress, index, shift, displacement, cg);
             // load next batch of data
             generateRegMemInstruction(loadOpcode, node, tmpVRF, mr, cg, vectorEncoding);
 
@@ -10423,7 +10363,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
 
     if (nonZeroOffset) {
         TR::Register *offset = cg->evaluate(node->getChild(1));
-        TR::MemoryReference *memRef = generateX86MemoryReference(address, offset, shift, 0, cg);
+        TR::MemoryReference *memRef = MRef_BISdisp32(address, offset, shift, 0, cg);
         generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, address, memRef, cg);
     }
 
@@ -10481,8 +10421,7 @@ TR::Register *J9::X86::TreeEvaluator::vectorizedHashCodeHelper(TR::Node *node, T
             = isSigned ? signedLoadOpcode[dt - TR::Int8] : unsignedLoadOpcode[dt - TR::Int8];
 
         generateRegMemInstruction(loadOpcode, node, tmp,
-            generateX86MemoryReference(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg),
-            cg);
+            MRef_BISdisp32(address, index, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
         generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, result, tmp, cg);
 
         // Increase loop index by the number of processed elements
@@ -10649,20 +10588,19 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
 
     generateRegRegInstruction(TR::InstOpCode::MOVDRegReg4, node, valueXMM, ch, cg);
     generateRegMemInstruction(TR::InstOpCode::PSHUFBRegMem, node, valueXMM,
-        generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
+        MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
 
     generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, result, offset, cg);
 
     generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, scratch,
-        generateX86MemoryReference(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+        MRef_BISdisp32(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
     generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, ECX, scratch, cg);
     generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, scratch, ~(width - 1), cg);
     generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, ECX, width - 1, cg);
     generateLabelInstruction(TR::InstOpCode::JE1, node, loopLabel, cg);
 
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, scratchXMM,
-        generateX86MemoryReference(scratch, 0, cg), cg);
+    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, scratchXMM, MRef_Bdisp32(scratch, 0, cg), cg);
     generateRegRegInstruction(compareOp, node, scratchXMM, valueXMM, cg);
     generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
     generateRegInstruction(TR::InstOpCode::SHR4RegCL, node, scratch, cg);
@@ -10678,7 +10616,7 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
 
     generateLabelInstruction(TR::InstOpCode::label, node, loopLabel, cg);
     generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, scratchXMM,
-        generateX86MemoryReference(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
+        MRef_BISdisp32(array, result, shift, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg), cg);
     generateRegRegInstruction(compareOp, node, scratchXMM, valueXMM, cg);
     generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, scratch, scratchXMM, cg);
     generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, scratch, scratch, cg);
@@ -10695,8 +10633,8 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
     generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), node, result, scratch, cg);
     generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, result, length, cg);
     generateRegMemInstruction(TR::InstOpCode::CMOVGERegMem(), node, result,
-        generateX86MemoryReference(cg->comp()->target().is32Bit() ? cg->findOrCreate4ByteConstant(node, -1)
-                                                                  : cg->findOrCreate8ByteConstant(node, -1),
+        MRef_const(cg->comp()->target().is32Bit() ? cg->findOrCreate4ByteConstant(node, -1)
+                                                  : cg->findOrCreate8ByteConstant(node, -1),
             cg),
         cg);
 
@@ -10879,10 +10817,10 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
 
     // load first char of s2
     generateRegMemInstruction(isLatin1 ? TR::InstOpCode::MOVZXReg4Mem1 : TR::InstOpCode::MOVZXReg4Mem2, node, tmpReg,
-        generateX86MemoryReference(s2Reg, hdrSize, cg), cg);
+        MRef_Bdisp32(s2Reg, hdrSize, cg), cg);
     generateRegRegInstruction(TR::InstOpCode::MOVDRegReg4, node, xmmReg2, tmpReg, cg);
     generateRegMemInstruction(TR::InstOpCode::PSHUFBRegMem, node, xmmReg2,
-        generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
+        MRef_const(cg->findOrCreate16ByteConstant(node, shuffleMask), cg), cg);
 
     // calculate max
     generateRegRegInstruction(TR::InstOpCode::SUB4RegReg, node, maxReg, s2lenReg, cg); // s1len - s2len
@@ -10893,14 +10831,13 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
 
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmpReg,
-        generateX86MemoryReference(s1Reg, resultReg, shift, hdrSize, cg), cg);
+        MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
     generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, ECX, tmpReg, cg);
     generateRegImmInstruction(TR::InstOpCode::AND4RegImms, node, ECX, width - 1, cg);
     generateLabelInstruction(TR::InstOpCode::JE1, node, firstCharLoopLabel, cg);
 
     generateRegImmInstruction(TR::InstOpCode::ANDRegImms(), node, tmpReg, ~(width - 1), cg);
-    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, generateX86MemoryReference(tmpReg, 0, cg),
-        cg);
+    generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1, MRef_Bdisp32(tmpReg, 0, cg), cg);
     generateRegRegInstruction(compareOp, node, xmmReg1, xmmReg2, cg);
     generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
     generateRegInstruction(TR::InstOpCode::SHR4RegCL, node, tmpReg, cg);
@@ -10917,7 +10854,7 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     // loop for finding the first char
     generateLabelInstruction(TR::InstOpCode::label, node, firstCharLoopLabel, cg);
     generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1,
-        generateX86MemoryReference(s1Reg, resultReg, shift, hdrSize, cg), cg);
+        MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg);
     generateRegRegInstruction(compareOp, node, xmmReg1, xmmReg2, cg);
     generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
     generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, node, tmpReg, tmpReg, cg);
@@ -10940,10 +10877,10 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     generateLabelInstruction(TR::InstOpCode::JG4, node, notFoundLabel, cg);
 
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, s1addrReg,
-        generateX86MemoryReference(s1Reg, resultReg, shift, hdrSize, cg), cg); // s1addr = &(s1[resultReg << shift])
+        MRef_BISdisp32(s1Reg, resultReg, shift, hdrSize, cg), cg); // s1addr = &(s1[resultReg << shift])
     generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, node, s2idxReg, 1, cg); // s2idx = 1
 
-    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, ECX, generateX86MemoryReference(s2lenReg, -1, cg),
+    generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, ECX, MRef_Bdisp32(s2lenReg, -1, cg),
         cg); // ECX = s2len - 1: 1st char has already matched
     generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, node, ECX, 4 - shift, cg); // div by 16 or 8
     generateLabelInstruction(TR::InstOpCode::JE1, node, byteLoopLabel, cg);
@@ -10951,9 +10888,9 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     // Compare by 16 bytes
     generateLabelInstruction(TR::InstOpCode::label, node, qwordLoopLabel, cg);
     generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg1,
-        generateX86MemoryReference(s1addrReg, s2idxReg, shift, 0, cg), cg);
+        MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), cg);
     generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmReg3,
-        generateX86MemoryReference(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
+        MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
     generateRegRegInstruction(TR::InstOpCode::PCMPEQBRegReg, node, xmmReg1, xmmReg3, cg);
     generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, tmpReg, xmmReg1, cg);
     generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, tmpReg, 0xffff, cg);
@@ -10969,9 +10906,9 @@ static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::Code
     generateLabelInstruction(TR::InstOpCode::JLE1, node, doneLabel, cg); // resultReg has the result
 
     generateRegMemInstruction(isLatin1 ? TR::InstOpCode::L1RegMem : TR::InstOpCode::L2RegMem, node, tmpReg,
-        generateX86MemoryReference(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
+        MRef_BISdisp32(s2Reg, s2idxReg, shift, hdrSize, cg), cg);
     generateMemRegInstruction(isLatin1 ? TR::InstOpCode::CMP1MemReg : TR::InstOpCode::CMP2MemReg, node,
-        generateX86MemoryReference(s1addrReg, s2idxReg, shift, 0, cg), tmpReg, cg);
+        MRef_BISdisp32(s1addrReg, s2idxReg, shift, 0, cg), tmpReg, cg);
     generateLabelInstruction(TR::InstOpCode::JNE1, node, unmatchedLabel, cg);
 
     generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, node, s2idxReg, 1, cg);
@@ -11058,15 +10995,14 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
         case gc_modron_readbar_none:
             break;
         case gc_modron_readbar_always:
-            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp,
-                generateX86MemoryReference(object, offset, 0, cg), cg);
+            generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
+                MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
             generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
             break;
         case gc_modron_readbar_range_check: {
             generateRegMemInstruction(TR::InstOpCode::LRegMem(use64BitClasses), node, tmp,
-                generateX86MemoryReference(object, offset, 0, cg), cg);
+                MRef_BIS(object, offset, 0, cg), cg);
 
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg);
             TR::LabelSymbol *endLabel = generateLabelSymbol(cg);
@@ -11081,23 +11017,19 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
             generateLabelInstruction(TR::InstOpCode::label, node, begLabel, cg);
 
             generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
-                generateX86MemoryReference(cg->getVMThreadRegister(),
-                    comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
+                MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateBaseAddressOffset(), cg),
                 cg);
             generateLabelInstruction(TR::InstOpCode::JAE4, node, rdbarLabel, cg);
 
             {
                 TR_OutlinedInstructionsGenerator og(rdbarLabel, node, cg);
                 generateRegMemInstruction(TR::InstOpCode::CMPRegMem(use64BitClasses), node, tmp,
-                    generateX86MemoryReference(cg->getVMThreadRegister(),
-                        comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
+                    MRef_Bdisp32(cg->getVMThreadRegister(), comp->fej9()->thisThreadGetEvacuateTopAddressOffset(), cg),
                     cg);
                 generateLabelInstruction(TR::InstOpCode::JA4, node, endLabel, cg);
-                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp,
-                    generateX86MemoryReference(object, offset, 0, cg), cg);
+                generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, tmp, MRef_BIS(object, offset, 0, cg), cg);
                 generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-                    generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp,
-                    cg);
+                    MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), tmp, cg);
                 generateHelperCallInstruction(node, TR_softwareReadBarrier, NULL, cg);
                 generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
 
@@ -11129,7 +11061,7 @@ static TR::Register *inlineCompareAndSwapObjectNative(TR::Node *node, TR::CodeGe
     deps->addPreCondition(EAX, TR::RealRegister::eax, cg);
     deps->addPostCondition(EAX, TR::RealRegister::eax, cg);
     generateMemRegInstruction(use64BitClasses ? TR::InstOpCode::LCMPXCHG8MemReg : TR::InstOpCode::LCMPXCHG4MemReg, node,
-        generateX86MemoryReference(object, offset, 0, cg), tmp, deps, cg);
+        MRef_BIS(object, offset, 0, cg), tmp, deps, cg);
 
     if (isExchange) {
         result = EAX;
@@ -11248,9 +11180,9 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
     TR::MemoryReference *mr;
 
     if (offsetReg)
-        mr = generateX86MemoryReference(objectReg, offsetReg, 0, cg);
+        mr = MRef_BIS(objectReg, offsetReg, 0, cg);
     else
-        mr = generateX86MemoryReference(objectReg, offset, cg);
+        mr = MRef_Bdisp32(objectReg, offset, cg);
 
     bool bumpedRefCount = false;
     TR::Node *translatedNode = newValueChild;
@@ -11331,7 +11263,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         int numDeps = 4;
         if (storeAddressRegForRealTime != NULL) {
             numDeps++;
-            cmpxchgMR = generateX86MemoryReference(storeAddressRegForRealTime, 0, cg);
+            cmpxchgMR = MRef_Bdisp32(storeAddressRegForRealTime, 0, cg);
         }
 
         if (scratchRegisterManagerForRealTime)
@@ -11357,7 +11289,7 @@ static bool inlineCompareAndSwapNative(TR::Node *node, int8_t size, bool isObjec
         int numDeps = 1;
         if (storeAddressRegForRealTime != NULL) {
             numDeps++;
-            cmpxchgMR = generateX86MemoryReference(storeAddressRegForRealTime, 0, cg);
+            cmpxchgMR = MRef_Bdisp32(storeAddressRegForRealTime, 0, cg);
         }
 
         if (scratchRegisterManagerForRealTime)
@@ -11534,7 +11466,7 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
 #ifdef J9VM_GC_SPARSE_HEAP_ALLOCATION
     if (TR::Compiler->om.isOffHeapAllocationEnabled()) {
         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, bufReg,
-            generateX86MemoryReference(bufReg, cg->comp()->fej9()->getOffsetOfContiguousDataAddrField(), cg), cg);
+            MRef_Bdisp32(bufReg, cg->comp()->fej9()->getOffsetOfContiguousDataAddrField(), cg), cg);
 
         // We'll be loading first data element address from array header so no need for offset
         offsetToDataElements = 0;
@@ -11546,7 +11478,7 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
 
     // limit = offset + length
     generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, limitReg,
-        generateX86MemoryReference(offsetReg, lengthReg, 0, 0, cg), cg);
+        MRef_BISdisp32(offsetReg, lengthReg, 0, 0, cg), cg);
 
     // loopLimit = (length & -16) + offset
     generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, node, loopLimitReg, lengthReg, cg);
@@ -11570,7 +11502,7 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     if (useVectorInstructions) {
         // Load 16 bytes from address [buf + index]
         generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmChunkReg,
-            generateX86MemoryReference(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+            MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
 
         // Extract bitmask of sign bits
         generateRegRegInstruction(TR::InstOpCode::PMOVMSKB4RegReg, node, maskReg, xmmChunkReg, cg, pmovmskbEncoding);
@@ -11583,7 +11515,7 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     else {
         // Load 8 bytes from address [buf + index]
         generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, chunkReg,
-            generateX86MemoryReference(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+            MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
 
         // Check if any negative values exist
         generateRegRegInstruction(TR::InstOpCode::TEST8RegReg, node, chunkReg, maskReg, cg);
@@ -11660,10 +11592,10 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     // Case in which there are one or two residual bytes
     // Load the byte at address [buf + index] into the chunk register
     generateRegMemInstruction(TR::InstOpCode::L1RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second byte (which is the same byte again in the 1 byte case)
     generateRegMemInstruction(TR::InstOpCode::OR1RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, limitReg, 0, offsetToDataElements - 1, cg), cg);
+        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 1, cg), cg);
 
     generateLabelInstruction(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
 
@@ -11676,10 +11608,10 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
 
     // Load the first two bytes at address [buf + index] into the chunk register
     generateRegMemInstruction(TR::InstOpCode::L2RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second two bytes at address [buf + (limit - 2)] into the chunk register
     generateRegMemInstruction(TR::InstOpCode::OR2RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, limitReg, 0, offsetToDataElements - 2, cg), cg);
+        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 2, cg), cg);
 
     generateLabelInstruction(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
 
@@ -11688,10 +11620,10 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
 
     // Load the first four bytes at address [buf + index] into the chunk register
     generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second four bytes at address [buf + (limit - 4)] into the chunk register
     generateRegMemInstruction(TR::InstOpCode::OR4RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, limitReg, 0, offsetToDataElements - 4, cg), cg);
+        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 4, cg), cg);
 
     generateLabelInstruction(TR::InstOpCode::JMP4, node, residualTestLabel, cg);
 
@@ -11700,10 +11632,10 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
 
     // Load the first eight bytes at address [buf + index] into the chunk register
     generateRegMemInstruction(TR::InstOpCode::L8RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
+        MRef_BISdisp32(bufReg, indexReg, 0, offsetToDataElements, cg), cg);
     // OR the second eight bytes at address [buf + (limit - 8)] into the chunk register
     generateRegMemInstruction(TR::InstOpCode::OR8RegMem, node, chunkReg,
-        generateX86MemoryReference(bufReg, limitReg, 0, offsetToDataElements - 8, cg), cg);
+        MRef_BISdisp32(bufReg, limitReg, 0, offsetToDataElements - 8, cg), cg);
 
     // Examine the chunk register now that all of the residual bytes have been ORed into it
     generateLabelInstruction(TR::InstOpCode::label, node, residualTestLabel, cg);
@@ -11801,15 +11733,14 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
                         generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
 
                         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
-                            generateX86MemoryReference(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg), cg);
+                            MRef_Bdisp32(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg), cg);
                         generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, nativeThreadReg,
-                            generateX86MemoryReference(nativeThreadReg, offsetof(J9Thread, handle), cg), cg);
+                            MRef_Bdisp32(nativeThreadReg, offsetof(J9Thread, handle), cg), cg);
                         doneLabel->setEndInternalControlFlow();
                         generateLabelInstruction(TR::InstOpCode::label, node, doneLabel, deps, cg);
                     } else {
-                        TR::MemoryReference *lowMR
-                            = generateX86MemoryReference(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg);
-                        TR::MemoryReference *highMR = generateX86MemoryReference(*lowMR, 4, cg);
+                        TR::MemoryReference *lowMR = MRef_Bdisp32(vmThreadReg, fej9->thisThreadOSThreadOffset(), cg);
+                        TR::MemoryReference *highMR = MRef_MRefOff(*lowMR, 4, cg);
 
                         TR::LabelSymbol *startLabel = generateLabelSymbol(cg);
                         TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
@@ -11820,8 +11751,8 @@ bool J9::X86::TreeEvaluator::VMinlineCallEvaluator(TR::Node *node, bool isIndire
                         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highMR, cg);
 
                         TR::MemoryReference *lowHandleMR
-                            = generateX86MemoryReference(nativeThreadReg, offsetof(J9Thread, handle), cg);
-                        TR::MemoryReference *highHandleMR = generateX86MemoryReference(*lowMR, 4, cg);
+                            = MRef_Bdisp32(nativeThreadReg, offsetof(J9Thread, handle), cg);
+                        TR::MemoryReference *highHandleMR = MRef_MRefOff(*lowMR, 4, cg);
 
                         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, nativeThreadReg, lowHandleMR, cg);
                         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, nativeThreadRegHigh, highHandleMR,
@@ -11975,11 +11906,10 @@ static void generateWriteBarrierCall(TR::InstOpCode::Mnemonic branchOp, TR::Node
     TR_OutlinedInstructionsGenerator og(wrtBarLabel, node, cg);
 
     generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-        generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), owningObjectReg,
-        cg);
+        MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), owningObjectReg, cg);
     if (helperArgCount > 1) {
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceReg, cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceReg, cg);
     }
     generateImmSymInstruction(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(), wrtBarSymRef,
         cg);
@@ -12136,32 +12066,32 @@ void J9::X86::TreeEvaluator::VMwrtbarRealTimeWithoutStoreEvaluator(TR::Node *nod
 
         if (comp->getOption(TR_CountWriteBarriersRT)) {
             TR::MemoryReference *barrierCountMR
-                = generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, debugEventData6), cg);
+                = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, debugEventData6), cg);
             generateMemInstruction(TR::InstOpCode::INCMem(comp->target().is64Bit()), node, barrierCountMR, cg);
         }
 
         tempReg = srm->findOrCreateScratchRegister();
 
         // if barrier not enabled, nothing to do
-        TR::MemoryReference *fragmentParentMR = generateX86MemoryReference(cg->getVMThreadRegister(),
+        TR::MemoryReference *fragmentParentMR = MRef_Bdisp32(cg->getVMThreadRegister(),
             fej9->thisThreadRememberedSetFragmentOffset() + fej9->getFragmentParentOffset(), cg);
         generateRegMemInstruction(TR::InstOpCode::LRegMem(comp->target().is64Bit()), node, tempReg, fragmentParentMR,
             cg);
         TR::MemoryReference *globalFragmentIDMR
-            = generateX86MemoryReference(tempReg, fej9->getRememberedSetGlobalFragmentOffset(), cg);
+            = MRef_Bdisp32(tempReg, fej9->getRememberedSetGlobalFragmentOffset(), cg);
         generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node, globalFragmentIDMR, 0, cg);
         generateLabelInstruction(TR::InstOpCode::JE4, node, doneLabel, cg);
 
         // now check if double barrier is enabled and definitely execute the barrier if it is
         // if (vmThread->localFragmentIndex == 0) goto snippetLabel
-        TR::MemoryReference *localFragmentIndexMR = generateX86MemoryReference(cg->getVMThreadRegister(),
+        TR::MemoryReference *localFragmentIndexMR = MRef_Bdisp32(cg->getVMThreadRegister(),
             fej9->thisThreadRememberedSetFragmentOffset() + fej9->getLocalFragmentOffset(), cg);
         generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node, localFragmentIndexMR, 0, cg);
         generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
 
         // null test on the reference we're about to store over: if it is null goto doneLabel
         // if (destObject->field == null) goto doneLabel
-        TR::MemoryReference *nullTestMR = generateX86MemoryReference(storeAddressRegForRealTime, 0, cg);
+        TR::MemoryReference *nullTestMR = MRef_Bdisp32(storeAddressRegForRealTime, 0, cg);
         if (comp->target().is64Bit() && comp->useCompressedPointers())
             generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, node, nullTestMR, 0, cg);
         else
@@ -12404,14 +12334,14 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         generateInstruction(TR::InstOpCode::INT3, node, cg);
     }
 
-    TR::MemoryReference *fragmentParentMR = generateX86MemoryReference(cg->getVMThreadRegister(),
+    TR::MemoryReference *fragmentParentMR = MRef_Bdisp32(cg->getVMThreadRegister(),
         fej9->thisThreadRememberedSetFragmentOffset() + fej9->getFragmentParentOffset(), cg);
-    TR::MemoryReference *localFragmentIndexMR = generateX86MemoryReference(cg->getVMThreadRegister(),
+    TR::MemoryReference *localFragmentIndexMR = MRef_Bdisp32(cg->getVMThreadRegister(),
         fej9->thisThreadRememberedSetFragmentOffset() + fej9->getLocalFragmentOffset(), cg);
     TR_OutlinedInstructions *inlineCardMarkPath = NULL;
     if (doInlineCardMarkingWithoutOldSpaceCheck && doCheckConcurrentMarkActive) {
         TR::MemoryReference *vmThreadPrivateFlagsMR
-            = generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
+            = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
         generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR,
             J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
 
@@ -12429,8 +12359,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
 
         if (comp->getOptions()->isVariableHeapBaseForBarrierRange0()) {
-            TR::MemoryReference *vhbMR = generateX86MemoryReference(cg->getVMThreadRegister(),
-                offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
+            TR::MemoryReference *vhbMR
+                = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
             generateRegMemInstruction(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
         } else {
             uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
@@ -12452,8 +12382,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             cardMarkDoneLabel = doIsDestInOldSpaceCheck ? generateLabelSymbol(cg) : doneLabel;
 
             if (comp->getOptions()->isVariableHeapSizeForBarrierRange0()) {
-                TR::MemoryReference *vhsMR = generateX86MemoryReference(cg->getVMThreadRegister(),
-                    offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
+                TR::MemoryReference *vhsMR
+                    = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
                 generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
             } else {
                 uintptr_t chs = comp->getOptions()->getHeapSizeForBarrierRange0();
@@ -12485,9 +12415,9 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
 
         if (comp->getOptions()->isVariableActiveCardTableBase()) {
             TR::MemoryReference *actbMR
-                = generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
+                = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
             generateRegMemInstruction(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
-            cardTableMR = generateX86MemoryReference(tempReg, 0, cg);
+            cardTableMR = MRef_Bdisp32(tempReg, 0, cg);
         } else {
             uintptr_t actb = comp->getOptions()->getActiveCardTableBase();
 
@@ -12496,10 +12426,10 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                 TR::Register *tempReg3 = srm->findOrCreateScratchRegister();
                 generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg,
                     TR_ACTIVE_CARD_TABLE_BASE);
-                cardTableMR = generateX86MemoryReference(tempReg3, tempReg, 0, cg);
+                cardTableMR = MRef_BIS(tempReg3, tempReg, 0, cg);
                 srm->reclaimScratchRegister(tempReg3);
             } else {
-                cardTableMR = generateX86MemoryReference(NULL, tempReg, 0, (int32_t)actb, cg);
+                cardTableMR = MRef_BISdisp32(NULL, tempReg, 0, (int32_t)actb, cg);
                 cardTableMR->setReloKind(TR_ACTIVE_CARD_TABLE_BASE);
             }
         }
@@ -12517,8 +12447,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
         generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), node, tempReg, owningObjectReg, cg);
 
         if (comp->getOptions()->isVariableHeapBaseForBarrierRange0()) {
-            TR::MemoryReference *vhbMR = generateX86MemoryReference(cg->getVMThreadRegister(),
-                offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
+            TR::MemoryReference *vhbMR
+                = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapBaseForBarrierRange0), cg);
             generateRegMemInstruction(TR::InstOpCode::SUBRegMem(), node, tempReg, vhbMR, cg);
         } else {
             uintptr_t chb = comp->getOptions()->getHeapBaseForBarrierRange0();
@@ -12540,8 +12470,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             cardMarkDoneLabel = doIsDestInOldSpaceCheck ? generateLabelSymbol(cg) : doneLabel;
 
             if (comp->getOptions()->isVariableHeapSizeForBarrierRange0()) {
-                TR::MemoryReference *vhsMR = generateX86MemoryReference(cg->getVMThreadRegister(),
-                    offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
+                TR::MemoryReference *vhsMR
+                    = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
                 generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR, cg);
             } else {
                 uintptr_t chs = comp->getOptions()->getHeapSizeForBarrierRange0();
@@ -12573,9 +12503,9 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
 
         if (comp->getOptions()->isVariableActiveCardTableBase()) {
             TR::MemoryReference *actbMR
-                = generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
+                = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, activeCardTableBase), cg);
             generateRegMemInstruction(TR::InstOpCode::ADDRegMem(), node, tempReg, actbMR, cg);
-            cardTableMR = generateX86MemoryReference(tempReg, 0, cg);
+            cardTableMR = MRef_Bdisp32(tempReg, 0, cg);
         } else {
             uintptr_t actb = comp->getOptions()->getActiveCardTableBase();
 
@@ -12584,10 +12514,10 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                 TR::Register *tempReg3 = srm->findOrCreateScratchRegister();
                 generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, node, tempReg3, actb, cg,
                     TR_ACTIVE_CARD_TABLE_BASE);
-                cardTableMR = generateX86MemoryReference(tempReg3, tempReg, 0, cg);
+                cardTableMR = MRef_BIS(tempReg3, tempReg, 0, cg);
                 srm->reclaimScratchRegister(tempReg3);
             } else {
-                cardTableMR = generateX86MemoryReference(NULL, tempReg, 0, (int32_t)actb, cg);
+                cardTableMR = MRef_BISdisp32(NULL, tempReg, 0, (int32_t)actb, cg);
                 cardTableMR->setReloKind(TR_ACTIVE_CARD_TABLE_BASE);
             }
         }
@@ -12645,7 +12575,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                         + comp->getOptions()->getHeapSizeForBarrierRange0();
                     if (comp->target().is64Bit() && !IS_32BIT_SIGNED(che)) {
                         generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, owningObjectReg,
-                            generateX86MemoryReference(cg->findOrCreate8ByteConstant(node, che), cg), cg);
+                            MRef_const(cg->findOrCreate8ByteConstant(node, che), cg), cg);
                     } else {
                         generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, owningObjectReg, (int32_t)che,
                             cg);
@@ -12665,8 +12595,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                         generateRegImmInstruction(TR::InstOpCode::SUBRegImm4(), node, tempOwningObjReg, (int32_t)chb,
                             cg, TR_HEAP_BASE_FOR_BARRIER_RANGE);
                     }
-                    TR::MemoryReference *vhsMR1 = generateX86MemoryReference(cg->getVMThreadRegister(),
-                        offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
+                    TR::MemoryReference *vhsMR1
+                        = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
                     generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempOwningObjReg, vhsMR1, cg);
                     srm->reclaimScratchRegister(tempOwningObjReg);
                 }
@@ -12682,13 +12612,13 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
             //
             int32_t byteOffset = byteOffsetForMask(J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
             if (byteOffset != -1) {
-                TR::MemoryReference *vmThreadPrivateFlagsMR = generateX86MemoryReference(cg->getVMThreadRegister(),
-                    byteOffset + offsetof(J9VMThread, privateFlags), cg);
+                TR::MemoryReference *vmThreadPrivateFlagsMR
+                    = MRef_Bdisp32(cg->getVMThreadRegister(), byteOffset + offsetof(J9VMThread, privateFlags), cg);
                 generateMemImmInstruction(TR::InstOpCode::TEST1MemImm1, node, vmThreadPrivateFlagsMR,
                     J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE >> (8 * byteOffset), cg);
             } else {
                 TR::MemoryReference *vmThreadPrivateFlagsMR
-                    = generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
+                    = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, privateFlags), cg);
                 generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node, vmThreadPrivateFlagsMR,
                     J9_PRIVATE_FLAGS_CONCURRENT_MARK_ACTIVE, cg);
             }
@@ -12730,7 +12660,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                     + comp->getOptions()->getHeapSizeForBarrierRange0();
                 if (comp->target().is64Bit() && !IS_32BIT_SIGNED(che)) {
                     generateRegMemInstruction(TR::InstOpCode::CMP8RegMem, node, checkDest ? owningObjectReg : srcReg,
-                        generateX86MemoryReference(cg->findOrCreate8ByteConstant(node, che), cg), cg);
+                        MRef_const(cg->findOrCreate8ByteConstant(node, che), cg), cg);
                 } else {
                     generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), node, checkDest ? owningObjectReg : srcReg,
                         (int32_t)che, cg);
@@ -12751,8 +12681,8 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
                     generateRegImmInstruction(TR::InstOpCode::SUBRegImm4(), node, tempReg, (int32_t)chb, cg,
                         TR_HEAP_BASE_FOR_BARRIER_RANGE);
                 }
-                TR::MemoryReference *vhsMR1 = generateX86MemoryReference(cg->getVMThreadRegister(),
-                    offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
+                TR::MemoryReference *vhsMR1
+                    = MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, heapSizeForBarrierRange0), cg);
                 generateRegMemInstruction(TR::InstOpCode::CMPRegMem(), node, tempReg, vhsMR1, cg);
             }
 
@@ -12767,13 +12697,12 @@ void J9::X86::TreeEvaluator::VMwrtbarWithoutStoreEvaluator(TR::Node *node,
 
                 int32_t byteOffset = byteOffsetForMask(J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST, cg);
                 if (byteOffset != -1) {
-                    TR::MemoryReference *MR = generateX86MemoryReference(owningObjectReg,
-                        byteOffset + TR::Compiler->om.offsetOfHeaderFlags(), cg);
+                    TR::MemoryReference *MR
+                        = MRef_Bdisp32(owningObjectReg, byteOffset + TR::Compiler->om.offsetOfHeaderFlags(), cg);
                     generateMemImmInstruction(TR::InstOpCode::TEST1MemImm1, node, MR,
                         J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST >> (8 * byteOffset), cg);
                 } else {
-                    TR::MemoryReference *MR
-                        = generateX86MemoryReference(owningObjectReg, TR::Compiler->om.offsetOfHeaderFlags(), cg);
+                    TR::MemoryReference *MR = MRef_Bdisp32(owningObjectReg, TR::Compiler->om.offsetOfHeaderFlags(), cg);
                     generateMemImmInstruction(TR::InstOpCode::TEST4MemImm4, node, MR,
                         J9_OBJECT_HEADER_REMEMBERED_MASK_FOR_TEST, cg);
                 }
@@ -12933,11 +12862,9 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
         }
 
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg),
-            owningObjectRegister, cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp1), cg), owningObjectRegister, cg);
         generateMemRegInstruction(TR::InstOpCode::SMemReg(), node,
-            generateX86MemoryReference(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceRegister,
-            cg);
+            MRef_Bdisp32(cg->getVMThreadRegister(), offsetof(J9VMThread, floatTemp2), cg), sourceRegister, cg);
 
         TR::SymbolReference *wrtBarSymRef = comp->getSymRefTab()->findOrCreateWriteBarrierStoreSymbolRef();
         generateImmSymInstruction(TR::InstOpCode::CALLImm4, node, (uintptr_t)wrtBarSymRef->getMethodAddress(),
@@ -12958,7 +12885,7 @@ void J9::X86::TreeEvaluator::VMwrtbarWithStoreEvaluator(TR::Node *node, TR::Memo
     //
     if (isRealTimeGC) {
         TR_ASSERT(storeAddressRegForRealTime, "assertion failure");
-        TR::MemoryReference *myStoreMR = generateX86MemoryReference(storeAddressRegForRealTime, 0, cg);
+        TR::MemoryReference *myStoreMR = MRef_Bdisp32(storeAddressRegForRealTime, 0, cg);
         storeInstr = doReferenceStore(node, myStoreMR, translatedSourceReg, usingCompressedPointers, cg);
         scratchRegisterManager->reclaimScratchRegister(storeAddressRegForRealTime);
     }
@@ -13007,7 +12934,7 @@ void VMgenerateCatchBlockBBStartPrologue(TR::Node *node, TR::Instruction *fenceI
         TR::LabelSymbol *restartLabel = generateLabelSymbol(cg);
 
         generateMemInstruction(TR::InstOpCode::DEC4Mem, node,
-            generateX86MemoryReference(comp->getRecompilationInfo()->getCounterSymRef(), cg), cg);
+            MRef_sym(comp->getRecompilationInfo()->getCounterSymRef(), cg), cg);
         generateLabelInstruction(TR::InstOpCode::JE4, node, snippetLabel, cg);
         generateLabelInstruction(TR::InstOpCode::label, node, restartLabel, cg);
         cg->addSnippet(new (cg->trHeapMemory()) TR::X86ForceRecompilationSnippet(cg, node, restartLabel, snippetLabel));
@@ -13107,7 +13034,7 @@ TR::Register *J9::X86::TreeEvaluator::tstartEvaluator(TR::Node *node, TR::CodeGe
     generateLongLabelInstruction(TR::InstOpCode::XBEGIN4, node, fallBackPathLabel, cg);
     // mov monReg, obj+offset
     int32_t lwOffset = cg->fej9()->getByteOffsetToLockword((TR_OpaqueClassBlock *)cg->getMonClass(node));
-    TR::MemoryReference *objLockRef = generateX86MemoryReference(objReg, lwOffset, cg);
+    TR::MemoryReference *objLockRef = MRef_Bdisp32(objReg, lwOffset, cg);
     if (comp->target().is64Bit() && cg->fej9()->generateCompressedLockWord()) {
         generateRegMemInstruction(TR::InstOpCode::L4RegMem, node, monReg, objLockRef, cg);
     } else {
@@ -13498,24 +13425,23 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     // use srcOffsetReg for loop counter, add starting offset to lengthReg, subtract 16 (xmm register size)
     // to prevent reading/writing beyond the end of the array
     generateRegMemInstruction(TR::InstOpCode::LEA4RegMem, node, scratchReg,
-        generateX86MemoryReference(lengthReg, srcOffsetReg, 0, -vectorLengthConst, cg), cg);
+        MRef_BISdisp32(lengthReg, srcOffsetReg, 0, -vectorLengthConst, cg), cg);
 
     generateLabelInstruction(TR::InstOpCode::label, node, startLoop, cg);
     generateRegRegInstruction(TR::InstOpCode::CMP4RegReg, node, srcOffsetReg, scratchReg, cg);
     generateLabelInstruction(TR::InstOpCode::JG4, node, endLoop, cg);
 
     generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmHighReg,
-        generateX86MemoryReference(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
+        MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
 
     generateRegRegInstruction(TR::InstOpCode::MOVDQURegReg, node, xmmLowReg, xmmHighReg, cg);
     generateRegRegInstruction(TR::InstOpCode::PUNPCKHBWRegReg, node, xmmLowReg, zeroReg, cg);
     generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
-        generateX86MemoryReference(destBufferReg, destOffsetReg, 0, headerOffsetConst + vectorLengthConst, cg),
-        xmmLowReg, cg);
+        MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst + vectorLengthConst, cg), xmmLowReg, cg);
 
     generateRegRegInstruction(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmHighReg, zeroReg, cg);
     generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
-        generateX86MemoryReference(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmHighReg, cg);
+        MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmHighReg, cg);
 
     // increase src offset by size of imm register
     // increase dest offset by double, to account for the byte->char inflation
@@ -13534,10 +13460,10 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     generateLabelInstruction(TR::InstOpCode::JL1, node, afterCopy8Label, cg);
 
     generateRegMemInstruction(TR::InstOpCode::MOVQRegMem, node, xmmLowReg,
-        generateX86MemoryReference(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
+        MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, headerOffsetConst, cg), cg);
     generateRegRegInstruction(TR::InstOpCode::PUNPCKLBWRegReg, node, xmmLowReg, zeroReg, cg);
     generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node,
-        generateX86MemoryReference(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmLowReg, cg);
+        MRef_BISdisp32(destBufferReg, destOffsetReg, 0, headerOffsetConst, cg), xmmLowReg, cg);
     generateRegImmInstruction(TR::InstOpCode::SUB4RegImm4, node, lengthReg, 8, cg);
 
     generateRegImmInstruction(TR::InstOpCode::ADD4RegImm4, node, srcOffsetReg, 8, cg);
@@ -13561,7 +13487,7 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     bool is64bit = cg->comp()->target().is64Bit();
     // calculate address to jump too
 
-    TR::MemoryReference *residueLabelMR = generateX86MemoryReference(copyResidueLabel, cg);
+    TR::MemoryReference *residueLabelMR = MRef_label(copyResidueLabel, cg);
 
     if (cg->comp()->target().is64Bit() && residueLabelMR->getAddressRegister()) {
         deps->addPostCondition(residueLabelMR->getAddressRegister(), TR::RealRegister::NoReg, cg);
@@ -13571,9 +13497,9 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
     generateRegRegInstruction(TR::InstOpCode::ADDRegReg(is64bit), node, lengthReg, scratchReg, cg);
 
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(is64bit), node, srcOffsetReg,
-        generateX86MemoryReference(srcBufferReg, srcOffsetReg, 0, 0, cg), cg);
+        MRef_BISdisp32(srcBufferReg, srcOffsetReg, 0, 0, cg), cg);
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(is64bit), node, destOffsetReg,
-        generateX86MemoryReference(destBufferReg, destOffsetReg, 0, 0, cg), cg);
+        MRef_BISdisp32(destBufferReg, destOffsetReg, 0, 0, cg), cg);
 
     generateRegInstruction(TR::InstOpCode::JMPReg, node, lengthReg, cg);
 
@@ -13581,9 +13507,9 @@ TR::Register *J9::X86::TreeEvaluator::inlineStringLatin1Inflate(TR::Node *node, 
 
     for (int i = 0; i < 7; i++) {
         generateRegMemInstruction(TR::InstOpCode::MOVZXReg2Mem1, node, scratchReg,
-            generateX86MemoryReference(srcOffsetReg, headerOffsetConst + 6 - i, cg), cg);
+            MRef_Bdisp32(srcOffsetReg, headerOffsetConst + 6 - i, cg), cg);
         generateMemRegInstruction(TR::InstOpCode::S2MemReg, node,
-            generateX86MemoryReference(destOffsetReg, headerOffsetConst + 2 * (6 - i), cg), scratchReg, cg);
+            MRef_Bdisp32(destOffsetReg, headerOffsetConst + 2 * (6 - i), cg), scratchReg, cg);
     }
 
     deps->stopAddingConditions();
@@ -13932,25 +13858,23 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
     }
 
     // 1. preparation (load value into registers, calculate length etc)
-    auto lowerBndMinus1
-        = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, manager.getLowerBndMinus1()), cg);
+    auto lowerBndMinus1 = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getLowerBndMinus1()), cg);
     cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegLowerBndMinus1, lowerBndMinus1, cg);
     iComment("lower bound ascii value minus one");
 
-    auto upperBnd = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, manager.getUpperBnd()), cg);
+    auto upperBnd = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getUpperBnd()), cg);
     cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegUpperBnd, upperBnd, cg);
     iComment("upper bound ascii value");
 
-    auto conversionDiff
-        = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, manager.getConversionDiff()), cg);
+    auto conversionDiff = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getConversionDiff()), cg);
     cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegConversionDiff, conversionDiff, cg);
     iComment("case conversion diff value");
 
-    auto minus1 = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, MINUS1), cg);
+    auto minus1 = MRef_const(cg->findOrCreate16ByteConstant(node, MINUS1), cg);
     cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegMinus1, minus1, cg);
     iComment("-1");
 
-    auto asciiUpperBnd = generateX86MemoryReference(cg->findOrCreate16ByteConstant(node, manager.getAsciiMax()), cg);
+    auto asciiUpperBnd = MRef_const(cg->findOrCreate16ByteConstant(node, manager.getAsciiMax()), cg);
     cursor = generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegAsciiUpperBnd, asciiUpperBnd, cg);
     iComment("maximum ascii value ");
 
@@ -13980,7 +13904,7 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
     generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, counter, residueStartLength, cg);
     generateLabelInstruction(TR::InstOpCode::JGE4, node, residueStartLabel, cg);
 
-    auto srcArrayMemRef = generateX86MemoryReference(srcArray, counter, 0, headerSize, cg);
+    auto srcArrayMemRef = MRef_BISdisp32(srcArray, counter, 0, headerSize, cg);
     generateRegMemInstruction(TR::InstOpCode::MOVDQURegMem, node, xmmRegArrayContentCopy0, srcArrayMemRef, cg);
 
     // detect invalid characters
@@ -14028,7 +13952,7 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
                                                                : TR::InstOpCode::PSUBWRegReg,
             node, xmmRegArrayContentCopy2, xmmRegArrayContentCopy1, cg);
 
-    auto dstArrayMemRef = generateX86MemoryReference(dstArray, counter, 0, headerSize, cg);
+    auto dstArrayMemRef = MRef_BISdisp32(dstArray, counter, 0, headerSize, cg);
     generateMemRegInstruction(TR::InstOpCode::MOVDQUMemReg, node, dstArrayMemRef, xmmRegArrayContentCopy2, cg);
     generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, counter, strideSize, cg);
     generateLabelInstruction(TR::InstOpCode::JMP4, node, caseConversionMainLoopLabel, cg);
@@ -14037,7 +13961,7 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
     generateLabelInstruction(TR::InstOpCode::label, node, residueStartLabel, cg);
     generateRegRegInstruction(TR::InstOpCode::CMPRegReg(), node, counter, length, cg);
     generateLabelInstruction(TR::InstOpCode::JGE4, node, endLabel, cg);
-    srcArrayMemRef = generateX86MemoryReference(srcArray, counter, 0, headerSize, cg);
+    srcArrayMemRef = MRef_BISdisp32(srcArray, counter, 0, headerSize, cg);
     generateRegMemInstruction(manager.isCompressedString() ? TR::InstOpCode::MOVZXReg4Mem1
                                                            : TR::InstOpCode::MOVZXReg4Mem2,
         node, singleChar, srcArrayMemRef, cg);
@@ -14053,15 +13977,15 @@ TR::Register *J9::X86::TreeEvaluator::stringCaseConversionHelper(TR::Node *node,
     generateLabelInstruction(TR::InstOpCode::JA4, node, storeToArrayLabel, cg);
 
     if (manager.toLowerCase())
-        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, singleChar,
-            generateX86MemoryReference(singleChar, 0x20, cg), cg);
+        generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, singleChar, MRef_Bdisp32(singleChar, 0x20, cg),
+            cg);
 
     else
         generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, node, singleChar, 0x20, cg);
 
     generateLabelInstruction(TR::InstOpCode::label, node, storeToArrayLabel, cg);
 
-    dstArrayMemRef = generateX86MemoryReference(dstArray, counter, 0, headerSize, cg);
+    dstArrayMemRef = MRef_BISdisp32(dstArray, counter, 0, headerSize, cg);
     generateMemRegInstruction(manager.isCompressedString() ? TR::InstOpCode::S1MemReg : TR::InstOpCode::S2MemReg, node,
         dstArrayMemRef, singleChar, cg);
     generateRegImmInstruction(TR::InstOpCode::ADDRegImms(), node, counter, manager.isCompressedString() ? 1 : 2, cg);
@@ -14149,9 +14073,9 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
 
     generateLabelInstruction(TR::InstOpCode::label, node, startLabel, cg);
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, dataBlockReg,
-        generateX86MemoryReference(dataSnippet->getSnippetLabel(), cg), cg);
-    generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node,
-        generateX86MemoryReference(dataBlockReg, offsetInDataBlock, cg), -1, cg);
+        MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
+    generateMemImmInstruction(TR::InstOpCode::CMPMemImms(), node, MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), -1,
+        cg);
     generateLabelInstruction(TR::InstOpCode::JE4, node, unresolveLabel, cg);
 
     {
@@ -14162,15 +14086,12 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
             if (isWrite) {
                 fieldClassReg = cg->allocateRegister();
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, fieldClassReg,
-                    generateX86MemoryReference(sideEffectRegister,
-                        comp->fej9()->getOffsetOfClassFromJavaLangClassField(), cg),
-                    cg);
+                    MRef_Bdisp32(sideEffectRegister, comp->fej9()->getOffsetOfClassFromJavaLangClassField(), cg), cg);
             } else {
                 fieldClassReg = sideEffectRegister;
             }
             generateMemRegInstruction(TR::InstOpCode::SMemReg(is64Bit), node,
-                generateX86MemoryReference(dataBlockReg, (intptr_t)(offsetof(J9JITWatchedStaticFieldData, fieldClass)),
-                    cg),
+                MRef_Bdisp32(dataBlockReg, (intptr_t)(offsetof(J9JITWatchedStaticFieldData, fieldClass)), cg),
                 fieldClassReg, cg);
             deps->addPreCondition(fieldClassReg, TR::RealRegister::NoReg, cg);
             deps->addPostCondition(fieldClassReg, TR::RealRegister::NoReg, cg);
@@ -14219,7 +14140,7 @@ void J9::X86::TreeEvaluator::generateFillInDataBlockSequenceForUnresolvedField(T
 
         // store result into J9JITWatchedStaticFieldData.fieldAddress / J9JITWatchedInstanceFieldData.offset
         generateMemRegInstruction(TR::InstOpCode::SMemReg(is64Bit), node,
-            generateX86MemoryReference(dataBlockReg, offsetInDataBlock, cg), resultReg, cg);
+            MRef_Bdisp32(dataBlockReg, offsetInDataBlock, cg), resultReg, cg);
         generateLabelInstruction(TR::InstOpCode::JMP4, node, endLabel, cg);
 
         og.endOutlinedInstructionSequence();
@@ -14293,7 +14214,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
             valueReferenceReg = cg->allocateRegister();
         } else { // 32bit long
             generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, valueMR, valueReg->getLowOrder(), cg);
-            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, generateX86MemoryReference(*valueMR, 4, cg),
+            generateMemRegInstruction(TR::InstOpCode::SMemReg(), node, MRef_MRefOff(*valueMR, 4, cg),
                 valueReg->getHighOrder(), cg);
 
             // Add the dependency for higher half register here
@@ -14312,7 +14233,7 @@ void generateReportFieldAccessOutlinedInstructions(TR::Node *node, TR::LabelSymb
     }
 
     generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, dataBlockReg,
-        generateX86MemoryReference(dataSnippet->getSnippetLabel(), cg), cg);
+        MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
     int numArgs = 0;
     if (is64Bit) {
         deps->addPreCondition(dataBlockReg, linkageProperties.getArgumentRegister(numArgs, false /* isFloat */), cg);
@@ -14410,37 +14331,34 @@ void J9::X86::TreeEvaluator::generateTestAndReportFieldWatchInstructions(TR::Cod
         TR::Register *objReg = sideEffectRegister;
         fieldClassReg = cg->allocateRegister();
         generateLoadJ9Class(node, fieldClassReg, objReg, cg);
-        classFlagsMemRef = generateX86MemoryReference(fieldClassReg, (uintptr_t)(fej9->getOffsetOfClassFlags()), cg);
+        classFlagsMemRef = MRef_Bdisp32(fieldClassReg, (uintptr_t)(fej9->getOffsetOfClassFlags()), cg);
     } else {
         if (isResolved) {
             if (!fieldClassNeedsRelocation) {
                 // For non-AOT (JIT and JITServer) compiles we don't need to use sideEffectRegister here as the class
                 // information is available to us at compile time.
                 J9Class *fieldClass = static_cast<TR::J9WatchedStaticFieldSnippet *>(dataSnippet)->getFieldClass();
-                classFlagsMemRef
-                    = generateX86MemoryReference((uintptr_t)fieldClass + fej9->getOffsetOfClassFlags(), cg);
+                classFlagsMemRef = MRef_abs((uintptr_t)fieldClass + fej9->getOffsetOfClassFlags(), cg);
             } else {
                 // If this is an AOT compile, we generate instructions to load the fieldClass directly from the snippet
                 // because the fieldClass in an AOT body will be invalid if we load using the dataSnippet's helper query
                 // at compile time.
                 fieldClassReg = cg->allocateRegister();
                 generateRegMemInstruction(TR::InstOpCode::LEARegMem(), node, fieldClassReg,
-                    generateX86MemoryReference(dataSnippet->getSnippetLabel(), cg), cg);
+                    MRef_label(dataSnippet->getSnippetLabel(), cg), cg);
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, fieldClassReg,
-                    generateX86MemoryReference(fieldClassReg, offsetof(J9JITWatchedStaticFieldData, fieldClass), cg),
-                    cg);
-                classFlagsMemRef = generateX86MemoryReference(fieldClassReg, fej9->getOffsetOfClassFlags(), cg);
+                    MRef_Bdisp32(fieldClassReg, offsetof(J9JITWatchedStaticFieldData, fieldClass), cg), cg);
+                classFlagsMemRef = MRef_Bdisp32(fieldClassReg, fej9->getOffsetOfClassFlags(), cg);
             }
         } else {
             if (isWrite) {
                 fieldClassReg = cg->allocateRegister();
                 generateRegMemInstruction(TR::InstOpCode::LRegMem(), node, fieldClassReg,
-                    generateX86MemoryReference(sideEffectRegister, fej9->getOffsetOfClassFromJavaLangClassField(), cg),
-                    cg);
+                    MRef_Bdisp32(sideEffectRegister, fej9->getOffsetOfClassFromJavaLangClassField(), cg), cg);
             } else {
                 fieldClassReg = sideEffectRegister;
             }
-            classFlagsMemRef = generateX86MemoryReference(fieldClassReg, fej9->getOffsetOfClassFlags(), cg);
+            classFlagsMemRef = MRef_Bdisp32(fieldClassReg, fej9->getOffsetOfClassFlags(), cg);
         }
     }
 
@@ -14482,7 +14400,7 @@ TR::Register *J9::X86::TreeEvaluator::generateConcurrentScavengeSequence(TR::Nod
                                     ->fieldSignatureChars(node->getSymbolReference()->getCPIndex(), len);
 
         if (fieldName && strstr(fieldName, "Ljava/lang/String;")) {
-            generateMemInstruction(TR::InstOpCode::PREFETCHT0, node, generateX86MemoryReference(object, 0, cg), cg);
+            generateMemInstruction(TR::InstOpCode::PREFETCHT0, node, MRef_Bdisp32(object, 0, cg), cg);
         }
     }
     return object;

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -98,7 +98,7 @@ uint8_t *J9::X86::UnresolvedDataSnippet::emitSnippetBody()
     TR::Instruction *stackMapInstr = getDataReferenceInstruction();
 
     if (!stackMapInstr) {
-        return TR::InstOpCode(TR::InstOpCode::bad).binary(cursor, OMR::X86::Default);
+        return TR::InstOpCode(OP::bad).binary(cursor, OMR::X86::Default);
     }
 
     _glueSymRef = cg()->symRefTab()->findOrCreateRuntimeHelper(getHelper());
@@ -145,7 +145,7 @@ uint8_t *J9::X86::UnresolvedDataSnippet::emitResolveHelperCall(uint8_t *cursor)
         TR_ASSERT(IS_32BIT_RIP(glueAddress, rip), "Local helper trampoline should be reachable directly.\n");
     }
 
-    *cursor++ = 0xe8; // TR::InstOpCode::CALLImm4
+    *cursor++ = 0xe8; // OP::CALLImm4
 
     int32_t offset = (int32_t)((intptr_t)glueAddress - rip);
     *(int32_t *)cursor = offset;
@@ -174,16 +174,16 @@ uint32_t J9::X86::UnresolvedDataSnippet::getUnresolvedStaticStoreDeltaWithMemBar
     uint8_t delta = instIter->getBinaryEncoding() - dataRefInstOffset;
 
     if (cg()->comp()->getOption(TR_X86UseMFENCE)) {
-        while (instIter->getOpCode().getOpCodeValue() != TR::InstOpCode::MFENCE && delta <= 20) {
+        while (instIter->getOpCode().getOpCodeValue() != OP::MFENCE && delta <= 20) {
             instIter = instIter->getNext();
             delta = instIter->getBinaryEncoding() - dataRefInstOffset;
         }
 
         // Return the appropriate offset flag.
         //
-        if (delta == 20 && instIter->getOpCode().getOpCodeValue() == TR::InstOpCode::MFENCE) {
+        if (delta == 20 && instIter->getOpCode().getOpCodeValue() == OP::MFENCE) {
             return cpIndex_extremeStaticMemBarPos;
-        } else if (delta == 16 && instIter->getOpCode().getOpCodeValue() == TR::InstOpCode::MFENCE) {
+        } else if (delta == 16 && instIter->getOpCode().getOpCodeValue() == OP::MFENCE) {
             return cpIndex_genStaticMemBarPos;
         } else {
             TR_ASSERT(0,
@@ -193,16 +193,16 @@ uint32_t J9::X86::UnresolvedDataSnippet::getUnresolvedStaticStoreDeltaWithMemBar
             return 0;
         }
     } else {
-        while (instIter->getOpCode().getOpCodeValue() != TR::InstOpCode::LOR4MemImms && delta <= 24) {
+        while (instIter->getOpCode().getOpCodeValue() != OP::LOR4MemImms && delta <= 24) {
             instIter = instIter->getNext();
             delta = instIter->getBinaryEncoding() - dataRefInstOffset;
         }
 
         // Return the appropriate offset flag.
         //
-        if (delta == 24 && instIter->getOpCode().getOpCodeValue() == TR::InstOpCode::LOR4MemImms) {
+        if (delta == 24 && instIter->getOpCode().getOpCodeValue() == OP::LOR4MemImms) {
             return cpIndex_extremeStaticMemBarPos;
-        } else if (delta == 16 && instIter->getOpCode().getOpCodeValue() == TR::InstOpCode::LOR4MemImms) {
+        } else if (delta == 16 && instIter->getOpCode().getOpCodeValue() == OP::LOR4MemImms) {
             return cpIndex_genStaticMemBarPos;
         } else {
             TR_ASSERT(0,
@@ -341,13 +341,13 @@ uint8_t *J9::X86::UnresolvedDataSnippet::emitConstantPoolIndex(uint8_t *cursor)
 
     if (!comp->getOption(TR_DisableNewX86VolatileSupport) && getDataReferenceInstruction() != NULL) {
         TR::Instruction *dataRefInst = getDataReferenceInstruction();
-        TR::InstOpCode::Mnemonic opCode = dataRefInst->getOpCode().getOpCodeValue();
+        OP::Mnemonic opCode = dataRefInst->getOpCode().getOpCodeValue();
 
         // If this is a store operation on an unresolved field, set the volatility check flag.
         //
         if (comp->target().isSMP()) {
             if (!getDataSymbol()->isClassObject() && !getDataSymbol()->isConstObjectRef() && isUnresolvedStore()
-                && opCode != TR::InstOpCode::CMPXCHG8BMem && getDataSymbol()->isVolatile()) {
+                && opCode != OP::CMPXCHG8BMem && getDataSymbol()->isVolatile()) {
                 cpIndex |= cpIndex_checkVolatility;
 
                 if (comp->target().is64Bit() && ((TR::X86MemInstruction *)dataRefInst)->getMemoryReference()) {
@@ -417,16 +417,16 @@ uint8_t *J9::X86::UnresolvedDataSnippet::fixupDataReferenceInstruction(uint8_t *
         bytesToCopy = std::max<uint8_t>(8, length);
         memcpy(cursor, instructionStart, bytesToCopy);
 
-        // If the TR::InstOpCode::RET will overwrite one of the eight bytes that will eventually be patched
+        // If the OP::RET will overwrite one of the eight bytes that will eventually be patched
         // then the byte it overwrites needs to be preserved.
         //
         if (length < 8) {
             uint8_t b = *(cursor + length);
-            *(cursor + length) = 0xc3; // TR::InstOpCode::RET
+            *(cursor + length) = 0xc3; // OP::RET
             cursor += bytesToCopy;
             *cursor++ = b;
         } else {
-            *(cursor + length) = 0xc3; // TR::InstOpCode::RET
+            *(cursor + length) = 0xc3; // OP::RET
             cursor += (bytesToCopy + 1);
         }
     } else {
@@ -481,7 +481,7 @@ uint32_t J9::X86::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart
 {
     uint32_t length;
 
-    length = 5; // TR::InstOpCode::CALLImm4 to resolve helper
+    length = 5; // OP::CALLImm4 to resolve helper
 
     // cpAddr
     //
@@ -496,8 +496,8 @@ uint32_t J9::X86::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart
     // 32-bit adjustments
     //
     if (cg()->comp()->target().is32Bit()) {
-        length += (1 // TR::InstOpCode::PUSHImm4 for cpAddr
-            + 1 // TR::InstOpCode::PUSHImm4 for cpIndex
+        length += (1 // OP::PUSHImm4 for cpAddr
+            + 1 // OP::PUSHImm4 for cpIndex
             + 1 // descriptor byte
         );
     }
@@ -507,8 +507,8 @@ uint32_t J9::X86::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart
         //
         uint32_t instructionLength = getDataReferenceInstruction()->getBinaryLength();
 
-        // +1 is for either a TR::InstOpCode::RET instruction if instructionLength > 7 or for a copy of
-        // the byte that the TR::InstOpCode::RET instruction overwrites if instructionLength < 8.
+        // +1 is for either a OP::RET instruction if instructionLength > 7 or for a copy of
+        // the byte that the OP::RET instruction overwrites if instructionLength < 8.
         //
         length += std::max<uint32_t>(8, instructionLength) + 1;
     } else {
@@ -604,16 +604,16 @@ void TR_Debug::print(OMR::Logger *log, TR::UnresolvedDataSnippet *snippet)
         if (length < 8) {
             printPrefix(log, NULL, bufferPos, bytesToCopy);
             bufferPos += bytesToCopy;
-            log->printf("%s\t(%d)\t\t\t%s patch instruction bytes + TR::InstOpCode::RET + residue", dbString(),
-                bytesToCopy, commentString());
+            log->printf("%s\t(%d)\t\t\t%s patch instruction bytes + OP::RET + residue", dbString(), bytesToCopy,
+                commentString());
             printPrefix(log, NULL, bufferPos, 1);
-            log->printf("%s\t\t\t\t\t\t%s byte that TR::InstOpCode::RET overwrote", dbString(), commentString());
+            log->printf("%s\t\t\t\t\t\t%s byte that OP::RET overwrote", dbString(), commentString());
             bufferPos++;
         } else {
             printPrefix(log, NULL, bufferPos, bytesToCopy + 1);
             bufferPos += (bytesToCopy + 1);
-            log->printf("%s\t(%d)\t\t\t\t%s patch instruction bytes + TR::InstOpCode::RET", dbString(),
-                (bytesToCopy + 1), commentString());
+            log->printf("%s\t(%d)\t\t\t\t%s patch instruction bytes + OP::RET", dbString(), (bytesToCopy + 1),
+                commentString());
         }
     } else {
         int32_t bytesToCopy;
@@ -628,8 +628,7 @@ void TR_Debug::print(OMR::Logger *log, TR::UnresolvedDataSnippet *snippet)
                 bytesToCopy = 2;
                 printPrefix(log, NULL, bufferPos, bytesToCopy);
                 bufferPos += bytesToCopy;
-                log->printf("%s\t\t\t\t\t\t\t\t%s REX + op of TR::InstOpCode::MOV8RegImm64", dwString(),
-                    commentString());
+                log->printf("%s\t\t\t\t\t\t\t\t%s REX + op of OP::MOV8RegImm64", dwString(), commentString());
             }
         } else {
             if (snippet->getDataSymbol()->isConstString()) {

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -131,20 +131,20 @@ uint8_t *TR::X86StackOverflowCheckInstruction::generateBinaryEncoding()
     return cursor;
 };
 
-TR::X86StackOverflowCheckInstruction *generateStackOverflowCheckInstruction(TR::Instruction *precedingInstruction,
+TR::X86StackOverflowCheckInstruction *Inst_StackOverflowCheck(TR::Instruction *precedingInstruction,
     TR::InstOpCode::Mnemonic op, TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86StackOverflowCheckInstruction(precedingInstruction, op, cmpRegister, mr, cg);
 }
 
-TR::X86CheckAsyncMessagesMemImmInstruction *generateCheckAsyncMessagesInstruction(TR::Node *node,
-    TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg)
+TR::X86CheckAsyncMessagesMemImmInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+    TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86CheckAsyncMessagesMemImmInstruction(node, op, mr, value, cg);
 }
 
-TR::X86CheckAsyncMessagesMemRegInstruction *generateCheckAsyncMessagesInstruction(TR::Node *node,
-    TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, TR::Register *reg, TR::CodeGenerator *cg)
+TR::X86CheckAsyncMessagesMemRegInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+    TR::MemoryReference *mr, TR::Register *reg, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86CheckAsyncMessagesMemRegInstruction(node, op, mr, reg, cg);
 }
@@ -161,7 +161,7 @@ uint8_t *TR::X86CheckAsyncMessagesMemRegInstruction::generateBinaryEncoding()
     return cursor;
 };
 
-TR::X86MemImmSnippetInstruction *generateMemImmSnippetInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
+TR::X86MemImmSnippetInstruction *Inst_MemImmSnippet(TR::InstOpCode::Mnemonic op, TR::Node *node,
     TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *snippet, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86MemImmSnippetInstruction(op, node, mr, imm, snippet, cg);

--- a/runtime/compiler/x/codegen/J9X86Instruction.cpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.cpp
@@ -38,15 +38,14 @@
 // TR::X86MemImmSnippetInstruction:: member functions
 ////////////////////////////////////////////////////////////////////////////////
 
-TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *us, TR::CodeGenerator *cg)
+TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    int32_t imm, TR::UnresolvedDataSnippet *us, TR::CodeGenerator *cg)
     : TR::X86MemImmInstruction(imm, mr, node, op, cg)
     , _unresolvedSnippet(us)
 {}
 
-TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(TR::Instruction *precedingInstruction,
-    TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *us,
-    TR::CodeGenerator *cg)
+TR::X86MemImmSnippetInstruction::X86MemImmSnippetInstruction(TR::Instruction *precedingInstruction, OP::Mnemonic op,
+    TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *us, TR::CodeGenerator *cg)
     : TR::X86MemImmInstruction(imm, mr, op, precedingInstruction, cg)
     , _unresolvedSnippet(us)
 {}
@@ -110,18 +109,18 @@ uint8_t *TR::X86MemImmSnippetInstruction::generateBinaryEncoding()
     }
 }
 
-TR::X86CheckAsyncMessagesMemImmInstruction::X86CheckAsyncMessagesMemImmInstruction(TR::Node *node,
-    TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg)
+TR::X86CheckAsyncMessagesMemImmInstruction::X86CheckAsyncMessagesMemImmInstruction(TR::Node *node, OP::Mnemonic op,
+    TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg)
     : TR::X86MemImmInstruction(value, mr, node, op, cg)
 {}
 
-TR::X86CheckAsyncMessagesMemRegInstruction::X86CheckAsyncMessagesMemRegInstruction(TR::Node *node,
-    TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, TR::Register *valueReg, TR::CodeGenerator *cg)
+TR::X86CheckAsyncMessagesMemRegInstruction::X86CheckAsyncMessagesMemRegInstruction(TR::Node *node, OP::Mnemonic op,
+    TR::MemoryReference *mr, TR::Register *valueReg, TR::CodeGenerator *cg)
     : TR::X86MemRegInstruction(valueReg, mr, node, op, cg)
 {}
 
 TR::X86StackOverflowCheckInstruction::X86StackOverflowCheckInstruction(TR::Instruction *precedingInstruction,
-    TR::InstOpCode::Mnemonic op, TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg)
+    OP::Mnemonic op, TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg)
     : TR::X86RegMemInstruction(mr, cmpRegister, op, precedingInstruction, cg)
 {}
 
@@ -131,19 +130,19 @@ uint8_t *TR::X86StackOverflowCheckInstruction::generateBinaryEncoding()
     return cursor;
 };
 
-TR::X86StackOverflowCheckInstruction *Inst_StackOverflowCheck(TR::Instruction *precedingInstruction,
-    TR::InstOpCode::Mnemonic op, TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg)
+TR::X86StackOverflowCheckInstruction *Inst_StackOverflowCheck(TR::Instruction *precedingInstruction, OP::Mnemonic op,
+    TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86StackOverflowCheckInstruction(precedingInstruction, op, cmpRegister, mr, cg);
 }
 
-TR::X86CheckAsyncMessagesMemImmInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+TR::X86CheckAsyncMessagesMemImmInstruction *Inst_CheckAsyncMessages(TR::Node *node, OP::Mnemonic op,
     TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86CheckAsyncMessagesMemImmInstruction(node, op, mr, value, cg);
 }
 
-TR::X86CheckAsyncMessagesMemRegInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+TR::X86CheckAsyncMessagesMemRegInstruction *Inst_CheckAsyncMessages(TR::Node *node, OP::Mnemonic op,
     TR::MemoryReference *mr, TR::Register *reg, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86CheckAsyncMessagesMemRegInstruction(node, op, mr, reg, cg);
@@ -161,8 +160,8 @@ uint8_t *TR::X86CheckAsyncMessagesMemRegInstruction::generateBinaryEncoding()
     return cursor;
 };
 
-TR::X86MemImmSnippetInstruction *Inst_MemImmSnippet(TR::InstOpCode::Mnemonic op, TR::Node *node,
-    TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *snippet, TR::CodeGenerator *cg)
+TR::X86MemImmSnippetInstruction *Inst_MemImmSnippet(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr,
+    int32_t imm, TR::UnresolvedDataSnippet *snippet, TR::CodeGenerator *cg)
 {
     return new (cg->trHeapMemory()) TR::X86MemImmSnippetInstruction(op, node, mr, imm, snippet, cg);
 }

--- a/runtime/compiler/x/codegen/J9X86Instruction.hpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.hpp
@@ -93,16 +93,16 @@ public:
 
 } // namespace TR
 
-TR::X86MemImmSnippetInstruction *generateMemImmSnippetInstruction(TR::InstOpCode::Mnemonic op, TR::Node *,
-    TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *, TR::CodeGenerator *cg);
+TR::X86MemImmSnippetInstruction *Inst_MemImmSnippet(TR::InstOpCode::Mnemonic op, TR::Node *, TR::MemoryReference *mr,
+    int32_t imm, TR::UnresolvedDataSnippet *, TR::CodeGenerator *cg);
 
-TR::X86CheckAsyncMessagesMemImmInstruction *generateCheckAsyncMessagesInstruction(TR::Node *node,
-    TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg);
+TR::X86CheckAsyncMessagesMemImmInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+    TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg);
 
-TR::X86CheckAsyncMessagesMemRegInstruction *generateCheckAsyncMessagesInstruction(TR::Node *node,
-    TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr, TR::Register *reg, TR::CodeGenerator *cg);
+TR::X86CheckAsyncMessagesMemRegInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+    TR::MemoryReference *mr, TR::Register *reg, TR::CodeGenerator *cg);
 
-TR::X86StackOverflowCheckInstruction *generateStackOverflowCheckInstruction(TR::Instruction *precedingInstruction,
+TR::X86StackOverflowCheckInstruction *Inst_StackOverflowCheck(TR::Instruction *precedingInstruction,
     TR::InstOpCode::Mnemonic op, TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg);
 
 #endif

--- a/runtime/compiler/x/codegen/J9X86Instruction.hpp
+++ b/runtime/compiler/x/codegen/J9X86Instruction.hpp
@@ -42,11 +42,11 @@ class X86MemImmSnippetInstruction : public TR::X86MemImmInstruction {
     TR::UnresolvedDataSnippet *_unresolvedSnippet;
 
 public:
-    X86MemImmSnippetInstruction(TR::InstOpCode::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, int32_t imm,
+    X86MemImmSnippetInstruction(OP::Mnemonic op, TR::Node *node, TR::MemoryReference *mr, int32_t imm,
         TR::UnresolvedDataSnippet *us, TR::CodeGenerator *cg);
 
-    X86MemImmSnippetInstruction(TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op,
-        TR::MemoryReference *mr, int32_t imm, TR::UnresolvedDataSnippet *us, TR::CodeGenerator *cg);
+    X86MemImmSnippetInstruction(TR::Instruction *precedingInstruction, OP::Mnemonic op, TR::MemoryReference *mr,
+        int32_t imm, TR::UnresolvedDataSnippet *us, TR::CodeGenerator *cg);
 
     virtual const char *description() { return "X86MemImmSnippet"; }
 
@@ -63,7 +63,7 @@ public:
 
 class X86CheckAsyncMessagesMemRegInstruction : public TR::X86MemRegInstruction {
 public:
-    X86CheckAsyncMessagesMemRegInstruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr,
+    X86CheckAsyncMessagesMemRegInstruction(TR::Node *node, OP::Mnemonic op, TR::MemoryReference *mr,
         TR::Register *valueReg, TR::CodeGenerator *cg);
 
     virtual const char *description() { return "X86CheckAsyncMessagesMemReg"; }
@@ -73,8 +73,8 @@ public:
 
 class X86CheckAsyncMessagesMemImmInstruction : public TR::X86MemImmInstruction {
 public:
-    X86CheckAsyncMessagesMemImmInstruction(TR::Node *node, TR::InstOpCode::Mnemonic op, TR::MemoryReference *mr,
-        int32_t value, TR::CodeGenerator *cg);
+    X86CheckAsyncMessagesMemImmInstruction(TR::Node *node, OP::Mnemonic op, TR::MemoryReference *mr, int32_t value,
+        TR::CodeGenerator *cg);
 
     virtual const char *description() { return "X86CheckAsyncMessagesMemImm"; }
 
@@ -83,8 +83,8 @@ public:
 
 class X86StackOverflowCheckInstruction : public TR::X86RegMemInstruction {
 public:
-    X86StackOverflowCheckInstruction(TR::Instruction *precedingInstruction, TR::InstOpCode::Mnemonic op,
-        TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg);
+    X86StackOverflowCheckInstruction(TR::Instruction *precedingInstruction, OP::Mnemonic op, TR::Register *cmpRegister,
+        TR::MemoryReference *mr, TR::CodeGenerator *cg);
 
     virtual const char *description() { return "X86StackOverflowCheck"; }
 
@@ -93,16 +93,16 @@ public:
 
 } // namespace TR
 
-TR::X86MemImmSnippetInstruction *Inst_MemImmSnippet(TR::InstOpCode::Mnemonic op, TR::Node *, TR::MemoryReference *mr,
-    int32_t imm, TR::UnresolvedDataSnippet *, TR::CodeGenerator *cg);
+TR::X86MemImmSnippetInstruction *Inst_MemImmSnippet(OP::Mnemonic op, TR::Node *, TR::MemoryReference *mr, int32_t imm,
+    TR::UnresolvedDataSnippet *, TR::CodeGenerator *cg);
 
-TR::X86CheckAsyncMessagesMemImmInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+TR::X86CheckAsyncMessagesMemImmInstruction *Inst_CheckAsyncMessages(TR::Node *node, OP::Mnemonic op,
     TR::MemoryReference *mr, int32_t value, TR::CodeGenerator *cg);
 
-TR::X86CheckAsyncMessagesMemRegInstruction *Inst_CheckAsyncMessages(TR::Node *node, TR::InstOpCode::Mnemonic op,
+TR::X86CheckAsyncMessagesMemRegInstruction *Inst_CheckAsyncMessages(TR::Node *node, OP::Mnemonic op,
     TR::MemoryReference *mr, TR::Register *reg, TR::CodeGenerator *cg);
 
-TR::X86StackOverflowCheckInstruction *Inst_StackOverflowCheck(TR::Instruction *precedingInstruction,
-    TR::InstOpCode::Mnemonic op, TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg);
+TR::X86StackOverflowCheckInstruction *Inst_StackOverflowCheck(TR::Instruction *precedingInstruction, OP::Mnemonic op,
+    TR::Register *cmpRegister, TR::MemoryReference *mr, TR::CodeGenerator *cg);
 
 #endif

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -234,22 +234,21 @@ TR::Register *J9::X86::HelperCallSite::BuildCall()
     for (size_t i = 0; i < _Params.size(); i++) {
         size_t index = _Params.size() - i - 1;
         if (index < NumberOfIntParamRegisters) {
-            Inst_RegReg(TR::InstOpCode::MOVRegReg(), _Node, RealRegisters.Use(IntParamRegisters[index]), _Params[i],
-                cg());
+            Inst_RegReg(OP::MOVRegReg(), _Node, RealRegisters.Use(IntParamRegisters[index]), _Params[i], cg());
         } else {
             NumberOfParamOnStack++;
             if (CalleeCleanup) {
-                Inst_Reg(TR::InstOpCode::PUSHReg, _Node, _Params[i], cg());
+                Inst_Reg(OP::PUSHReg, _Node, _Params[i], cg());
             } else {
                 size_t offset = StackSlotSize * (index - StackIndexAdjustment);
-                Inst_MemReg(TR::InstOpCode::SMemReg(), _Node, MRef_Bdisp32(ESP, offset, cg()), _Params[i], cg());
+                Inst_MemReg(OP::SMemReg(), _Node, MRef_Bdisp32(ESP, offset, cg()), _Params[i], cg());
             }
         }
     }
 
     // Call helper
-    TR::X86ImmInstruction *instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, _Node, (uintptr_t)_SymRef->getMethodAddress(),
-        _SymRef, RealRegisters.BuildRegisterDependencyConditions(), cg());
+    TR::X86ImmInstruction *instr = Inst_ImmSym(OP::CALLImm4, _Node, (uintptr_t)_SymRef->getMethodAddress(), _SymRef,
+        RealRegisters.BuildRegisterDependencyConditions(), cg());
     instr->setNeedsGCMap(PreservedRegisterMapForGC);
 
     // Stack adjustment
@@ -286,7 +285,7 @@ TR::Register *J9::X86::HelperCallSite::BuildCall()
             break;
     }
     if (ret) {
-        Inst_RegReg(TR::InstOpCode::MOVRegReg(), _Node, ret, EAX, cg());
+        Inst_RegReg(OP::MOVRegReg(), _Node, ret, EAX, cg());
     }
 
     return ret;

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -235,23 +235,22 @@ TR::Register *J9::X86::HelperCallSite::BuildCall()
     for (size_t i = 0; i < _Params.size(); i++) {
         size_t index = _Params.size() - i - 1;
         if (index < NumberOfIntParamRegisters) {
-            generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), _Node, RealRegisters.Use(IntParamRegisters[index]),
-                _Params[i], cg());
+            Inst_RegReg(TR::InstOpCode::MOVRegReg(), _Node, RealRegisters.Use(IntParamRegisters[index]), _Params[i],
+                cg());
         } else {
             NumberOfParamOnStack++;
             if (CalleeCleanup) {
-                generateRegInstruction(TR::InstOpCode::PUSHReg, _Node, _Params[i], cg());
+                Inst_Reg(TR::InstOpCode::PUSHReg, _Node, _Params[i], cg());
             } else {
                 size_t offset = StackSlotSize * (index - StackIndexAdjustment);
-                generateMemRegInstruction(TR::InstOpCode::SMemReg(), _Node, MRef_Bdisp32(ESP, offset, cg()), _Params[i],
-                    cg());
+                Inst_MemReg(TR::InstOpCode::SMemReg(), _Node, MRef_Bdisp32(ESP, offset, cg()), _Params[i], cg());
             }
         }
     }
 
     // Call helper
-    TR::X86ImmInstruction *instr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, _Node,
-        (uintptr_t)_SymRef->getMethodAddress(), _SymRef, RealRegisters.BuildRegisterDependencyConditions(), cg());
+    TR::X86ImmInstruction *instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, _Node, (uintptr_t)_SymRef->getMethodAddress(),
+        _SymRef, RealRegisters.BuildRegisterDependencyConditions(), cg());
     instr->setNeedsGCMap(PreservedRegisterMapForGC);
 
     // Stack adjustment
@@ -288,7 +287,7 @@ TR::Register *J9::X86::HelperCallSite::BuildCall()
             break;
     }
     if (ret) {
-        generateRegRegInstruction(TR::InstOpCode::MOVRegReg(), _Node, ret, EAX, cg());
+        Inst_RegReg(TR::InstOpCode::MOVRegReg(), _Node, ret, EAX, cg());
     }
 
     return ret;

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -243,8 +243,8 @@ TR::Register *J9::X86::HelperCallSite::BuildCall()
                 generateRegInstruction(TR::InstOpCode::PUSHReg, _Node, _Params[i], cg());
             } else {
                 size_t offset = StackSlotSize * (index - StackIndexAdjustment);
-                generateMemRegInstruction(TR::InstOpCode::SMemReg(), _Node,
-                    generateX86MemoryReference(ESP, offset, cg()), _Params[i], cg());
+                generateMemRegInstruction(TR::InstOpCode::SMemReg(), _Node, MRef_Bdisp32(ESP, offset, cg()), _Params[i],
+                    cg());
             }
         }
     }

--- a/runtime/compiler/x/codegen/X86HelperLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86HelperLinkage.cpp
@@ -72,10 +72,9 @@ public:
     // Build the dependencies for each virtual-real register pair
     TR::RegisterDependencyConditions *BuildRegisterDependencyConditions()
     {
-        TR::RegisterDependencyConditions *deps
-            = generateRegisterDependencyConditions(NumberOfRegistersInUse() + 1, // For VMThread
-                NumberOfRegistersInUse() + 1, // For VMThread
-                _cg);
+        TR::RegisterDependencyConditions *deps = RegDeps(NumberOfRegistersInUse() + 1, // For VMThread
+            NumberOfRegistersInUse() + 1, // For VMThread
+            _cg);
         for (uint8_t i = (uint8_t)TR::RealRegister::NoReg; i < (uint8_t)TR::RealRegister::NumRegisters; i++) {
             if (_Registers[i] != NULL) {
                 deps->addPreCondition(_Registers[i], (TR::RealRegister::RegNum)i, _cg);

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -1065,10 +1065,9 @@ TR::X86CallSite::X86CallSite(TR::Node *callNode, TR::Linkage *calleeLinkage)
     uint32_t numPostconditions = calleeLinkage->getProperties().getNumberOfVolatileGPRegisters()
         + calleeLinkage->getProperties().getNumberOfVolatileXMMRegisters() + 3; // return reg + VM Thread + scratch
 
-    _preConditionsUnderConstruction = generateRegisterDependencyConditions(numPreconditions, 0, cg());
-    _postConditionsUnderConstruction
-        = generateRegisterDependencyConditions((COPY_PRECONDITIONS_TO_POSTCONDITIONS ? numPreconditions : 0),
-            numPostconditions + (COPY_PRECONDITIONS_TO_POSTCONDITIONS ? numPreconditions : 0), cg());
+    _preConditionsUnderConstruction = RegDeps(numPreconditions, 0, cg());
+    _postConditionsUnderConstruction = RegDeps((COPY_PRECONDITIONS_TO_POSTCONDITIONS ? numPreconditions : 0),
+        numPostconditions + (COPY_PRECONDITIONS_TO_POSTCONDITIONS ? numPreconditions : 0), cg());
 
     _preservedRegisterMask = getLinkage()->getProperties().getPreservedRegisterMapForGC();
     if (getMethodSymbol()->preservesAllRegisters()) {
@@ -2369,7 +2368,7 @@ static void generateITableEntryLoop(uint32_t iterations, TR::Node *callNode, TR:
                 gotoLastITableDispatchLabel, cg);
         }
     } else {
-        TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions(0, 4, cg);
+        TR::RegisterDependencyConditions *deps = RegDeps(0, 4, cg);
         TR::LabelSymbol *startLoopLabel = generateLabelSymbol(cg);
         TR::LabelSymbol *endLoopLabel = generateLabelSymbol(cg);
         TR::Register *indexReg = cg->allocateRegister();
@@ -2581,7 +2580,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     TR::Register *vftReg = site.evaluateVFT();
     TR::Register *scratchReg = cg()->allocateRegister();
     TR::Register *vtableIndexReg = cg()->allocateRegister();
-    TR::RegisterDependencyConditions *vtableIndexRegDeps = generateRegisterDependencyConditions(1, 0, cg());
+    TR::RegisterDependencyConditions *vtableIndexRegDeps = RegDeps(1, 0, cg());
     vtableIndexRegDeps->addPreCondition(vtableIndexReg, getProperties().getVTableIndexArgumentRegister(), cg());
     // Now things get weird.
     //

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -185,12 +185,10 @@ TR::Instruction *J9::X86::PrivateLinkage::movLinkageRegisters(TR::Instruction *c
 
             if (isStore) {
                 // stack := lri
-                cursor = generateMemRegInstruction(cursor, TR::Linkage::movOpcodes(MemReg, movDataType), memRef, reg,
-                    cg());
+                cursor = Inst_MemReg(cursor, TR::Linkage::movOpcodes(MemReg, movDataType), memRef, reg, cg());
             } else {
                 // lri := stack
-                cursor = generateRegMemInstruction(cursor, TR::Linkage::movOpcodes(RegMem, movDataType), reg, memRef,
-                    cg());
+                cursor = Inst_RegMem(cursor, TR::Linkage::movOpcodes(RegMem, movDataType), reg, memRef, cg());
             }
         }
     }
@@ -256,7 +254,7 @@ TR::Instruction *J9::X86::PrivateLinkage::copyParametersToHomeLocation(TR::Instr
                 if (debug("traceCopyParametersToHomeLocation"))
                     diagnostic("copyParametersToHomeLocation: Loading %d\n", ai);
                 // ai := stack
-                loadCursor = generateRegMemInstruction(loadCursor, TR::Linkage::movOpcodes(RegMem, movDataType),
+                loadCursor = Inst_RegMem(loadCursor, TR::Linkage::movOpcodes(RegMem, movDataType),
                     machine->getRealRegister(ai), MRef_Bdisp32(framePointer, offset, cg()), cg());
             }
         } else // It's in a linkage register
@@ -275,7 +273,7 @@ TR::Instruction *J9::X86::PrivateLinkage::copyParametersToHomeLocation(TR::Instr
                     if (debug("traceCopyParametersToHomeLocation"))
                         diagnostic("copyParametersToHomeLocation: Storing %d\n", sourceIndex);
                     // stack := lri
-                    cursor = generateMemRegInstruction(cursor, TR::Linkage::movOpcodes(MemReg, movDataType),
+                    cursor = Inst_MemReg(cursor, TR::Linkage::movOpcodes(MemReg, movDataType),
                         MRef_Bdisp32(framePointer, offset, cg()), machine->getRealRegister(sourceIndex), cg());
                 }
             }
@@ -353,8 +351,7 @@ TR::Instruction *J9::X86::PrivateLinkage::copyParametersToHomeLocation(TR::Instr
                 if (debug("traceCopyParametersToHomeLocation"))
                     diagnostic("copyParametersToHomeLocation: Moving %d to %d\n", source, regCursor);
                 // regCursor := regCursor.sourceReg
-                cursor = generateRegRegInstruction(cursor,
-                    TR::Linkage::movOpcodes(RegReg, movStatus[source].outgoingDataType),
+                cursor = Inst_RegReg(cursor, TR::Linkage::movOpcodes(RegReg, movStatus[source].outgoingDataType),
                     machine->getRealRegister(regCursor), machine->getRealRegister(source), cg());
                 // Update movStatus as we go so we don't generate redundant movs
                 movStatus[regCursor].sourceReg = noReg;
@@ -634,8 +631,8 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
 
         TR::Instruction *jitOverflowCheck = NULL;
         if (doOverflowCheck) {
-            TR::X86VFPSaveInstruction *vfp = generateVFPSaveInstruction(cursor, cg());
-            cursor = generateStackOverflowCheckInstruction(vfp, TR::InstOpCode::CMPRegMem(), espReal,
+            TR::X86VFPSaveInstruction *vfp = Inst_VFPSave(cursor, cg());
+            cursor = Inst_StackOverflowCheck(vfp, TR::InstOpCode::CMPRegMem(), espReal,
                 MRef_Bdisp32(metaDataReg, cg()->getStackLimitOffset(), cg()), cg());
 
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg());
@@ -645,9 +642,9 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
             endLabel->setEndInternalControlFlow();
             checkLabel->setStartOfColdInstructionStream();
 
-            cursor = generateLabelInstruction(cursor, TR::InstOpCode::label, begLabel, cg());
-            cursor = generateLabelInstruction(cursor, TR::InstOpCode::JBE4, checkLabel, cg());
-            cursor = generateLabelInstruction(cursor, TR::InstOpCode::label, endLabel, cg());
+            cursor = Inst_Label(cursor, TR::InstOpCode::label, begLabel, cg());
+            cursor = Inst_Label(cursor, TR::InstOpCode::JBE4, checkLabel, cg());
+            cursor = Inst_Label(cursor, TR::InstOpCode::label, endLabel, cg());
 
             // Code Cache disclaim is more efficient if this code is in the warm area
             bool moveToWarm = TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming)
@@ -666,23 +663,23 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                 followInstruction = cg()->getAppendInstruction()->getNext();
             } else {
                 // At this point, cg()->getAppendInstruction() is already in the cold code section.
-                generateVFPRestoreInstruction(vfp, cursor->getNode(), cg());
+                Inst_VFPRestore(vfp, cursor->getNode(), cg());
             }
 
-            generateLabelInstruction(TR::InstOpCode::label, cursor->getNode(), checkLabel, cg());
-            generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, cursor->getNode(),
+            Inst_Label(TR::InstOpCode::label, cursor->getNode(), checkLabel, cg());
+            Inst_RegImm(TR::InstOpCode::MOV4RegImm4, cursor->getNode(),
                 machine()->getRealRegister(TR::RealRegister::edi), allocSize, cg());
             if (doAllocateFrameSpeculatively) {
-                generateRegImmInstruction(TR::InstOpCode::ADDRegImm4(), cursor->getNode(), espReal, allocSize, cg());
+                Inst_RegImm(TR::InstOpCode::ADDRegImm4(), cursor->getNode(), espReal, allocSize, cg());
             }
             TR::SymbolReference *helper = comp()->getSymRefTab()->findOrCreateStackOverflowSymbolRef(NULL);
-            jitOverflowCheck = generateImmSymInstruction(TR::InstOpCode::CALLImm4, cursor->getNode(),
+            jitOverflowCheck = Inst_ImmSym(TR::InstOpCode::CALLImm4, cursor->getNode(),
                 (uintptr_t)helper->getMethodAddress(), helper, cg());
             jitOverflowCheck->setNeedsGCMap(0xFF00FFFF);
             if (doAllocateFrameSpeculatively) {
-                generateRegImmInstruction(TR::InstOpCode::SUBRegImm4(), cursor->getNode(), espReal, allocSize, cg());
+                Inst_RegImm(TR::InstOpCode::SUBRegImm4(), cursor->getNode(), espReal, allocSize, cg());
             }
-            generateLabelInstruction(TR::InstOpCode::JMP4, cursor->getNode(), endLabel, cg());
+            Inst_Label(TR::InstOpCode::JMP4, cursor->getNode(), endLabel, cg());
 
             if (moveToWarm) {
                 TR::Instruction *appendInstruction = cg()->getAppendInstruction();
@@ -927,16 +924,16 @@ void J9::X86::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
     if (_properties.getAlwaysDedicateFramePointerRegister()) {
         // Restore stack pointer from frame pointer
         //
-        cursor = generateRegRegInstruction(cursor, TR::InstOpCode::MOVRegReg(), espReal,
+        cursor = Inst_RegReg(cursor, TR::InstOpCode::MOVRegReg(), espReal,
             machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
-        cursor = generateRegInstruction(cursor, TR::InstOpCode::POPReg,
+        cursor = Inst_Reg(cursor, TR::InstOpCode::POPReg,
             machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
     } else {
         auto frameSize = cg()->getFrameSizeInBytes();
         if (frameSize != 0) {
-            cursor = generateRegImmInstruction(cursor,
-                (frameSize <= 127) ? TR::InstOpCode::ADDRegImms() : TR::InstOpCode::ADDRegImm4(), espReal, frameSize,
-                cg());
+            cursor
+                = Inst_RegImm(cursor, (frameSize <= 127) ? TR::InstOpCode::ADDRegImms() : TR::InstOpCode::ADDRegImm4(),
+                    espReal, frameSize, cg());
         }
     }
 
@@ -985,7 +982,7 @@ TR::Register *J9::X86::PrivateLinkage::buildDirectDispatch(TR::Node *callNode, b
         char *name = method->getClassNameFromConstantPool(cpIndex, len);
         if (name) {
             if (TR::SimpleRegex::matchIgnoringLocale(r, name)) {
-                generateInstruction(TR::InstOpCode::INT3, callNode, cg());
+                Inst(TR::InstOpCode::INT3, callNode, cg());
             }
         }
     }
@@ -1012,17 +1009,15 @@ TR::Register *J9::X86::PrivateLinkage::buildDirectDispatch(TR::Node *callNode, b
 
     // Create the internal control flow region and VFP adjustment
     //
-    generateLabelInstruction(startBookmark, TR::InstOpCode::label, startLabel, site.getPreConditionsUnderConstruction(),
-        cg());
+    Inst_Label(startBookmark, TR::InstOpCode::label, startLabel, site.getPreConditionsUnderConstruction(), cg());
     if (getProperties().getCallerCleanup()) {
         // TODO: Caller must clean up
     } else if (callNode->getSymbol()->castToMethodSymbol()->isHelper() && getProperties().getUsesRegsForHelperArgs()) {
         // No cleanup needed for helpers if args are passed in registers
     } else {
-        generateVFPCallCleanupInstruction(-site.getArgSize(), callNode, cg());
+        Inst_VFPCallCleanup(-site.getArgSize(), callNode, cg());
     }
-    generateLabelInstruction(TR::InstOpCode::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(),
-        cg());
+    Inst_Label(TR::InstOpCode::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(), cg());
 
     // Stop using the killed registers that are not going to persist
     //
@@ -1628,7 +1623,7 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
 
                 picSlot = i.getNext();
                 if (picSlot)
-                    generateLabelInstruction(TR::InstOpCode::label, site.getCallNode(), picMismatchLabel, cg());
+                    Inst_Label(TR::InstOpCode::label, site.getCallNode(), picMismatchLabel, cg());
             }
 
             site.setFirstPICSlotInstruction(NULL);
@@ -1666,12 +1661,10 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
 
     // Create the internal control flow region and VFP adjustment
     //
-    generateLabelInstruction(startBookmark, TR::InstOpCode::label, startLabel, site.getPreConditionsUnderConstruction(),
-        cg());
+    Inst_Label(startBookmark, TR::InstOpCode::label, startLabel, site.getPreConditionsUnderConstruction(), cg());
     if (!getProperties().getCallerCleanup())
-        generateVFPCallCleanupInstruction(-site.getArgSize(), callNode, cg());
-    generateLabelInstruction(TR::InstOpCode::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(),
-        cg());
+        Inst_VFPCallCleanup(-site.getArgSize(), callNode, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(), cg());
 
     // Stop using the killed registers that are not going to persist
     //
@@ -1721,14 +1714,14 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
 
         // Load the RAM method into rdi and call the helper
         if (comp()->target().is64Bit()) {
-            generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, ramMethodReg,
+            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, ramMethodReg,
                 (uint64_t)(uintptr_t)methodSymbol->getMethodAddress(), cg());
         } else {
-            generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, callNode, ramMethodReg,
+            Inst_RegImm(TR::InstOpCode::MOV4RegImm4, callNode, ramMethodReg,
                 (uint32_t)(uintptr_t)methodSymbol->getMethodAddress(), cg());
         }
 
-        callInstr = generateHelperCallInstruction(callNode, TR_j2iTransition, NULL, cg());
+        callInstr = Inst_HelperCall(callNode, TR_j2iTransition, NULL, cg());
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
         auto rm = methodSymbol->getMandatoryRecognizedMethod();
@@ -1746,9 +1739,9 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         TR::Register *nativeMethodReg = cg()->allocateRegister();
         site.addPostCondition(nativeMethodReg, TR::RealRegister::edi);
 
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, nativeMethodReg,
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, nativeMethodReg,
             (uint64_t)(uintptr_t)methodSymbol->getMethodAddress(), cg());
-        callInstr = generateRegInstruction(TR::InstOpCode::CALLReg, callNode, nativeMethodReg, cg());
+        callInstr = Inst_Reg(TR::InstOpCode::CALLReg, callNode, nativeMethodReg, cg());
         cg()->stopUsingRegister(nativeMethodReg);
     } else if (methodSymRef->isUnresolved() || methodSymbol->isInterpreted()
         || (comp()->compileRelocatableCode() && !methodSymbol->isHelper())) {
@@ -1758,14 +1751,13 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         cg()->addSnippet(snippet);
         snippet->gcMap().setGCRegisterMask(site.getPreservedRegisterMask());
 
-        callInstr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, 0,
+        callInstr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, 0,
             new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), label), cg());
-        generateBoundaryAvoidanceInstruction(TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8,
-            callInstr, cg());
+        Inst_BoundaryAvoidance(TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8, callInstr, cg());
 
         // Nop is necessary due to confusion when resolving shared slots at a transition
         if (methodSymRef->isOSRInductionHelper())
-            generatePaddingInstruction(1, callNode, cg());
+            Inst_Padding(1, callNode, cg());
     } else if (isJitDispatchJ9Method) {
         // This should occur only on 64-bit because it's generated only for
         // OpenJDK MethodHandles, which are not yet in use in Java 8, with Java 8
@@ -1784,8 +1776,7 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         TR::Register *j9mReg = callNode->getChild(0)->getRegister();
 
         int32_t extraOffset = (int32_t)offsetof(J9Method, extra);
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
-            MRef_Bdisp32(j9mReg, extraOffset, cg()), cg());
+        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg, MRef_Bdisp32(j9mReg, extraOffset, cg()), cg());
 
         // The test/jnz sequence assumes that J9_STARTPC_NOT_TRANSLATED is a
         // single bit in the low byte.
@@ -1794,24 +1785,24 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         static_assert((J9_STARTPC_NOT_TRANSLATED & (J9_STARTPC_NOT_TRANSLATED - 1)) == 0,
             "non-power-of-two J9_STARTPC_NOT_TRANSLATED");
 
-        generateRegImmInstruction(TR::InstOpCode::TEST1RegImm1, callNode, scratchReg, J9_STARTPC_NOT_TRANSLATED, cg());
+        Inst_RegImm(TR::InstOpCode::TEST1RegImm1, callNode, scratchReg, J9_STARTPC_NOT_TRANSLATED, cg());
 
         TR::InstOpCode::Mnemonic oolBranchOp = TR::InstOpCode::JNE4;
         if (cg()->stressJitDispatchJ9MethodJ2I())
             oolBranchOp = TR::InstOpCode::JMP4; // go to J2I path unconditionally
 
-        generateLabelInstruction(oolBranchOp, callNode, interpreterCallLabel, cg());
+        Inst_Label(oolBranchOp, callNode, interpreterCallLabel, cg());
 
         // The method is compiled - call through register to JIT entry point
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode,
+        Inst_RegMem(TR::InstOpCode::L4RegMem, callNode,
             j9mReg, // can reuse because the actual J9Method isn't needed anymore
             MRef_Bdisp32(scratchReg, -4, cg()), cg());
 
-        generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, callNode, j9mReg, 16, cg());
+        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, callNode, j9mReg, 16, cg());
 
-        generateRegRegInstruction(TR::InstOpCode::ADDRegReg(), callNode, scratchReg, j9mReg, cg());
+        Inst_RegReg(TR::InstOpCode::ADDRegReg(), callNode, scratchReg, j9mReg, cg());
 
-        callInstr = generateRegInstruction(TR::InstOpCode::CALLReg, callNode, scratchReg, cg());
+        callInstr = Inst_Reg(TR::InstOpCode::CALLReg, callNode, scratchReg, cg());
 
         // But if the method is interpreted, call through a call snippet instead.
         // The snippet will store arguments to the stack and do a J2I transition.
@@ -1820,10 +1811,9 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
             = new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), snippetLabel);
 
         TR_OutlinedInstructionsGenerator og(interpreterCallLabel, callNode, cg());
-        TR::Instruction *interpreterCallInstr
-            = generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, 0, labelSymRef, cg());
+        TR::Instruction *interpreterCallInstr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, 0, labelSymRef, cg());
         interpreterCallInstr->setNeedsGCMap(site.getPreservedRegisterMask());
-        generateLabelInstruction(TR::InstOpCode::JMP4, callNode, doneLabel, cg());
+        Inst_Label(TR::InstOpCode::JMP4, callNode, doneLabel, cg());
         og.endOutlinedInstructionSequence();
 
         TR::Snippet *snippet = new (trHeapMemory()) TR::X86CallSnippet(cg(), callNode, snippetLabel, false);
@@ -1831,12 +1821,12 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         cg()->addSnippet(snippet);
         cg()->stopUsingRegister(scratchReg);
     } else {
-        callInstr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode,
-            (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, cg());
+        callInstr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(),
+            methodSymRef, cg());
 
         if (comp()->target().isSMP() && !methodSymbol->isHelper()) {
             // Make sure it's patchable in case it gets (re)compiled
-            generatePatchableCodeAlignmentInstruction(callSiteAtomicRegions, callInstr, cg());
+            Inst_PatchableCodeAlignment(callSiteAtomicRegions, callInstr, cg());
         }
     }
 
@@ -1906,18 +1896,18 @@ bool J9::X86::PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::Label
             = TR_VirtualGuard::createGuardedDevirtualizationGuard(site.getVirtualGuardKind(), comp(), callNode);
 
         TR::Instruction *patchable
-            = generateVirtualGuardNOPInstruction(callNode, virtualGuard->addNOPSite(), NULL, revirtualizeLabel, cg());
+            = Inst_VirtualGuardNOP(callNode, virtualGuard->addNOPSite(), NULL, revirtualizeLabel, cg());
 
         if (comp()->target().isSMP())
-            generatePatchableCodeAlignmentInstruction(vgnopAtomicRegions, patchable, cg());
+            Inst_PatchableCodeAlignment(vgnopAtomicRegions, patchable, cg());
         // HCR in J9::X86::PrivateLinkage::buildRevirtualizedCall
         if (comp()->getOption(TR_EnableHCR)) {
             TR_VirtualGuard *HCRGuard
                 = TR_VirtualGuard::createGuardedDevirtualizationGuard(TR_HCRGuard, comp(), callNode);
             TR::Instruction *HCRpatchable
-                = generateVirtualGuardNOPInstruction(callNode, HCRGuard->addNOPSite(), NULL, revirtualizeLabel, cg());
+                = Inst_VirtualGuardNOP(callNode, HCRGuard->addNOPSite(), NULL, revirtualizeLabel, cg());
             if (comp()->target().isSMP())
-                generatePatchableCodeAlignmentInstruction(vgnopAtomicRegions, HCRpatchable, cg());
+                Inst_PatchableCodeAlignment(vgnopAtomicRegions, HCRpatchable, cg());
         }
         return true;
     } else if (site.getVirtualGuardKind() == TR_NonoverriddenGuard
@@ -1935,11 +1925,11 @@ bool J9::X86::PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::Label
         else
             opCode = TR::InstOpCode::TEST4MemImm4;
 
-        generateMemImmInstruction(opCode, callNode,
+        Inst_MemImm(opCode, callNode,
             MRef_abs((intptr_t)site.getResolvedMethod()->addressContainingIsOverriddenBit(), cg()), overRiddenBit,
             cg());
 
-        generateLabelInstruction(TR::InstOpCode::JNE4, callNode, revirtualizeLabel, cg());
+        Inst_Label(TR::InstOpCode::JNE4, callNode, revirtualizeLabel, cg());
 
         return true;
     } else {
@@ -1955,7 +1945,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
     TR::Node *callNode = site.getCallNode();
     if (cg()->enableSinglePrecisionMethods() && comp()->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = cg()->findOrCreate2ByteConstant(callNode, DOUBLE_PRECISION_ROUND_TO_NEAREST);
-        generateMemInstruction(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
+        Inst_Mem(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
     }
 
     TR::Instruction *callInstr;
@@ -1964,7 +1954,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
         // Fix the displacement at 4 bytes so j2iVirtual can decode it if necessary
         if (targetAddressMemref)
             targetAddressMemref->setForceWideDisplacement();
-        callInstr = generateCallMemInstruction(dispatchOp.getOpCodeValue(), callNode, targetAddressMemref, cg());
+        callInstr = Inst_CallMem(dispatchOp.getOpCodeValue(), callNode, targetAddressMemref, cg());
     } else {
         TR_ASSERT(targetAddressReg, "Call via register requires register");
         TR::Node *callNode = site.getCallNode();
@@ -1992,7 +1982,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
             // Mainline call
             //
             TR::LabelSymbol *jmpLabel = TR::LabelSymbol::create(cg()->trHeapMemory(), cg());
-            callInstr = generateLabelInstruction(TR::InstOpCode::CALLImm4, callNode, jmpLabel, cg());
+            callInstr = Inst_Label(TR::InstOpCode::CALLImm4, callNode, jmpLabel, cg());
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
             // JITHelpers.dispatchVirtual() can target MethodHandle.invokeBasic().
@@ -2006,7 +1996,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
             //
             {
                 TR_OutlinedInstructionsGenerator og(jmpLabel, callNode, cg());
-                generateRegInstruction(TR::InstOpCode::JMPReg, callNode, targetAddressReg, cg());
+                Inst_Reg(TR::InstOpCode::JMPReg, callNode, targetAddressReg, cg());
                 og.endOutlinedInstructionSequence();
             }
 
@@ -2023,7 +2013,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
             } else
                 dependencies->unionPreCondition(targetAddressReg, TR::RealRegister::NoReg, cg());
         } else {
-            callInstr = generateRegInstruction(dispatchOp.getOpCodeValue(), callNode, targetAddressReg, cg());
+            callInstr = Inst_Reg(dispatchOp.getOpCodeValue(), callNode, targetAddressReg, cg());
         }
     }
 
@@ -2034,7 +2024,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
 
     if (cg()->enableSinglePrecisionMethods() && comp()->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = cg()->findOrCreate2ByteConstant(callNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
-        generateMemInstruction(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
+        Inst_Mem(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
     }
 
     return callInstr;
@@ -2224,7 +2214,7 @@ void J9::X86::PrivateLinkage::buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *
     TR_ASSERT(doneLabel, "a doneLabel is required for VPIC dispatches");
 
     if (entryLabel)
-        generateLabelInstruction(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
 
     int32_t numVPicSlots = VPicParameters.defaultNumberOfSlots;
 
@@ -2291,29 +2281,29 @@ static void generateITableEntryCompareLogic(TR::Node *callNode, TR::Register *sc
     TR::Compilation *comp = cg->comp();
 
     // Test if iTable == NULL?
-    generateRegRegInstruction(TR::InstOpCode::TESTRegReg(), callNode, scratchReg, scratchReg, cg);
-    generateLabelInstruction(TR::InstOpCode::JE4, callNode, lookupDispatchSnippetLabel, cg);
+    Inst_RegReg(TR::InstOpCode::TESTRegReg(), callNode, scratchReg, scratchReg, cg);
+    Inst_Label(TR::InstOpCode::JE4, callNode, lookupDispatchSnippetLabel, cg);
 
     if (use32BitInterfaceClassPointers) {
         // The field is 8 bytes, but only 4 matter
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg),
             (int32_t)(intptr_t)declaringClass, cg, TR_ClassPointer);
     } else {
         TR_ASSERT_FATAL(comp->target().is64Bit(), "Only 64-bit path should reach here.");
 
-        generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, interfaceClassReg, (intptr_t)declaringClass,
-            cg, TR_ClassPointer);
-        generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), callNode,
+        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, interfaceClassReg, (intptr_t)declaringClass, cg,
+            TR_ClassPointer);
+        Inst_MemReg(TR::InstOpCode::CMPMemReg(), callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg), interfaceClassReg, cg);
     }
 
-    generateLongLabelInstruction(TR::InstOpCode::JE4, callNode, gotoLastITableDispatchLabel, cg);
+    Inst_LongLabel(TR::InstOpCode::JE4, callNode, gotoLastITableDispatchLabel, cg);
 
     if (!isLastIteration) {
         // This step should be skipped on the last unrolled iteration
         // scratchReg = iTable->next
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg,
             MRef_Bdisp32(scratchReg, offsetof(J9ITable, next), cg), cg);
     }
 }
@@ -2367,8 +2357,8 @@ static void generateITableEntryLoop(uint32_t iterations, TR::Node *callNode, TR:
     const uint32_t maxUnrolledIterations = 4;
 
     // scratchReg = j9class->iTable
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
-        MRef_Bdisp32(vftReg, offsetof(J9Class, iTable), cg), cg);
+    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg, MRef_Bdisp32(vftReg, offsetof(J9Class, iTable), cg),
+        cg);
 
     if (iterations <= maxUnrolledIterations) {
         // If number of iterations is less than maxUnrolledIterations, we generate an unrolled sequence.
@@ -2389,24 +2379,24 @@ static void generateITableEntryLoop(uint32_t iterations, TR::Node *callNode, TR:
         deps->addPostCondition(scratchReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(interfaceClassReg, TR::RealRegister::NoReg, cg);
 
-        generateRegRegInstruction(TR::InstOpCode::XORRegReg(), callNode, indexReg, indexReg, cg);
-        generateLabelInstruction(TR::InstOpCode::label, callNode, startLoopLabel, deps, cg);
+        Inst_RegReg(TR::InstOpCode::XORRegReg(), callNode, indexReg, indexReg, cg);
+        Inst_Label(TR::InstOpCode::label, callNode, startLoopLabel, deps, cg);
 
         // index = 0
         // do { ... } while (index < iterations);
         generateITableEntryCompareLogic(callNode, scratchReg, interfaceClassReg, declaringClass,
             use32BitInterfaceClassPointers, false, lookupDispatchSnippetLabel, gotoLastITableDispatchLabel, cg);
 
-        generateRegInstruction(TR::InstOpCode::INCReg(), callNode, indexReg, cg);
-        generateRegImmInstruction(TR::InstOpCode::CMPRegImm4(), callNode, indexReg, iterations, cg);
-        generateLabelInstruction(TR::InstOpCode::JL1, callNode, startLoopLabel, cg);
+        Inst_Reg(TR::InstOpCode::INCReg(), callNode, indexReg, cg);
+        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), callNode, indexReg, iterations, cg);
+        Inst_Label(TR::InstOpCode::JL1, callNode, startLoopLabel, cg);
 
         cg->stopUsingRegister(indexReg);
-        generateLabelInstruction(TR::InstOpCode::label, callNode, endLoopLabel, deps, cg);
+        Inst_Label(TR::InstOpCode::label, callNode, endLoopLabel, deps, cg);
     }
 
     // If there is no match found.
-    generateLabelInstruction(TR::InstOpCode::JMP4, callNode, lookupDispatchSnippetLabel, cg);
+    Inst_Label(TR::InstOpCode::JMP4, callNode, lookupDispatchSnippetLabel, cg);
 }
 
 /**
@@ -2441,15 +2431,15 @@ static void generateLastITableDispatch(TR::Node *callNode, TR::LabelSymbol *look
 {
     // X86PicBuilder routines (for example, resolveIPicClass) expect the last JNE before the
     // done label to jump to the lookup snippet.
-    generateLongLabelInstruction(TR::InstOpCode::JNE4, callNode, lookupDispatchSnippetLabel,
+    Inst_LongLabel(TR::InstOpCode::JNE4, callNode, lookupDispatchSnippetLabel,
         cg); // PICBuilder needs this to have a 4-byte offset
 
     if (gotoLastITableDispatchLabel)
-        generateLabelInstruction(TR::InstOpCode::label, callNode, gotoLastITableDispatchLabel, cg);
+        Inst_Label(TR::InstOpCode::label, callNode, gotoLastITableDispatchLabel, cg);
 
     if (cg->comp()->target().is32Bit())
-        generatePaddingInstruction(3, callNode, cg);
-    generateLabelInstruction(TR::InstOpCode::CALLImm4, callNode, lastITableDispatchLabel, vtableIndexRegDeps, cg);
+        Inst_Padding(3, callNode, cg);
+    Inst_Label(TR::InstOpCode::CALLImm4, callNode, lastITableDispatchLabel, vtableIndexRegDeps, cg);
 }
 
 static uint32_t determineNumOfITableIterations(TR::X86CallSite &site, TR_OpaqueClassBlock *declaringClass,
@@ -2585,7 +2575,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
         // TODO: This is lame.  Without IPIC slots, generating this sequence
         // upside-down is sub-optimal.
         //
-        generateLabelInstruction(TR::InstOpCode::JMP4, callNode, lastITableTestLabel, cg());
+        Inst_Label(TR::InstOpCode::JMP4, callNode, lastITableTestLabel, cg());
     }
 
     TR::Register *vftReg = site.evaluateVFT();
@@ -2656,10 +2646,9 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     //
 
     TR::Instruction *lastITableDispatchStart
-        = generateLabelInstruction(TR::InstOpCode::label, callNode, lastITableDispatchLabel, cg());
-    generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, callNode, vtableIndexReg,
-        fej9->getITableEntryJitVTableOffset(), cg());
-    generateRegMemInstruction(TR::InstOpCode::SUBRegMem(), callNode, vtableIndexReg,
+        = Inst_Label(TR::InstOpCode::label, callNode, lastITableDispatchLabel, cg());
+    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, callNode, vtableIndexReg, fej9->getITableEntryJitVTableOffset(), cg());
+    Inst_RegMem(TR::InstOpCode::SUBRegMem(), callNode, vtableIndexReg,
         MRef_Bdisp32(scratchReg, fej9->convertITableIndexToOffset(itableIndex), cg()), cg());
     buildVFTCall(site, TR::InstOpCode::JMPMem, NULL, MRef_BIS(vftReg, vtableIndexReg, 0, cg()));
 
@@ -2672,10 +2661,10 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
 
     // The test sequence
     //
-    generateLabelInstruction(TR::InstOpCode::label, callNode, lastITableTestLabel, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, lastITableTestLabel, cg());
     if (breakBeforeInterfaceDispatchUsingLastITable)
-        generateInstruction(TR::InstOpCode::INT3, callNode, cg());
-    generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
+        Inst(TR::InstOpCode::INT3, callNode, cg());
+    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg,
         MRef_Bdisp32(vftReg, (int32_t)fej9->getOffsetOfLastITableFromClassField(), cg()), cg());
     bool use32BitInterfaceClassPointers = comp()->target().is32Bit();
     if (comp()->useCompressedPointers() /* actually compressed object headers */) {
@@ -2684,7 +2673,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     }
     if (use32BitInterfaceClassPointers) {
         // The field is 8 bytes, but only 4 matter
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()),
             (int32_t)(intptr_t)declaringClass, cg());
     } else {
@@ -2692,8 +2681,8 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
         TR::Register *interfaceClassReg = vtableIndexReg;
         auto cds = cg()->findOrCreate8ByteConstant(site.getCallNode(), (intptr_t)declaringClass);
         TR::MemoryReference *interfaceClassAddr = MRef_const(cds, cg());
-        generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, interfaceClassReg, interfaceClassAddr, cg());
-        generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), callNode,
+        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, interfaceClassReg, interfaceClassAddr, cg());
+        Inst_MemReg(TR::InstOpCode::CMPMemReg(), callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()), interfaceClassReg, cg());
     }
 
@@ -2731,7 +2720,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
             TR::LabelSymbol *iterateITableLabel = generateLabelSymbol(cg());
             TR::LabelSymbol *gotoLastITableDispatchLabel = generateLabelSymbol(cg());
 
-            generateLongLabelInstruction(TR::InstOpCode::JNE4, callNode, iterateITableLabel, cg());
+            Inst_LongLabel(TR::InstOpCode::JNE4, callNode, iterateITableLabel, cg());
 
             // The following sequence of instructions that iterate through the iTable cannot be inserted
             // after the test of the lastITableCache in the mainline code.  The routines in X86PicBuilder,

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -153,8 +153,7 @@ void J9::X86::PrivateLinkage::copyGlRegDepsToParameterSymbols(TR::Node *bbStart,
 
 TR::Instruction *J9::X86::PrivateLinkage::copyStackParametersToLinkageRegisters(TR::Instruction *procEntryInstruction)
 {
-    TR_ASSERT(procEntryInstruction && procEntryInstruction->getOpCodeValue() == TR::InstOpCode::proc,
-        "assertion failure");
+    TR_ASSERT(procEntryInstruction && procEntryInstruction->getOpCodeValue() == OP::proc, "assertion failure");
     TR::Instruction *intrpPrev = procEntryInstruction->getPrev(); // The instruction before the interpreter entry point
     movLinkageRegisters(intrpPrev, false);
     return intrpPrev->getNext();
@@ -378,8 +377,8 @@ static TR::Instruction *initializeLocals(TR::Instruction *cursor, int32_t lowOff
         // For a small number, just generate a sequence of stores.
         //
         for (int32_t i = 0; i < count; i++, offset += pointerSize) {
-            cursor = new (cg->trHeapMemory()) TR::X86MemRegInstruction(cursor, TR::InstOpCode::SMemReg(),
-                MRef_Bdisp32(framePointer, offset, cg), sourceReg, cg);
+            cursor = new (cg->trHeapMemory())
+                TR::X86MemRegInstruction(cursor, OP::SMemReg(), MRef_Bdisp32(framePointer, offset, cg), sourceReg, cg);
         }
     } else {
         // For a large number, generate a loop.
@@ -389,19 +388,19 @@ static TR::Instruction *initializeLocals(TR::Instruction *cursor, int32_t lowOff
         //
         TR_ASSERT(count > 0, "positive count required for dword RegImm instruction");
 
-        cursor = new (cg->trHeapMemory()) TR::X86RegMemInstruction(cursor, TR::InstOpCode::LEARegMem(), loopReg,
-            MRef_Bdisp32(sourceReg, count - 1, cg), cg);
+        cursor = new (cg->trHeapMemory())
+            TR::X86RegMemInstruction(cursor, OP::LEARegMem(), loopReg, MRef_Bdisp32(sourceReg, count - 1, cg), cg);
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
-        cursor = new (cg->trHeapMemory()) TR::X86LabelInstruction(cursor, TR::InstOpCode::label, loopLabel, cg);
+        cursor = new (cg->trHeapMemory()) TR::X86LabelInstruction(cursor, OP::label, loopLabel, cg);
 
-        cursor = new (cg->trHeapMemory()) TR::X86MemRegInstruction(cursor, TR::InstOpCode::SMemReg(),
+        cursor = new (cg->trHeapMemory()) TR::X86MemRegInstruction(cursor, OP::SMemReg(),
             MRef_BISdisp32(framePointer, loopReg, TR::MemoryReference::convertMultiplierToStride(pointerSize), offset,
                 cg),
             sourceReg, cg);
 
-        cursor = new (cg->trHeapMemory()) TR::X86RegImmInstruction(cursor, TR::InstOpCode::SUB4RegImms, loopReg, 1, cg);
-        cursor = new (cg->trHeapMemory()) TR::X86LabelInstruction(cursor, TR::InstOpCode::JAE4, loopLabel, cg);
+        cursor = new (cg->trHeapMemory()) TR::X86RegImmInstruction(cursor, OP::SUB4RegImms, loopReg, 1, cg);
+        cursor = new (cg->trHeapMemory()) TR::X86LabelInstruction(cursor, OP::JAE4, loopLabel, cg);
     }
 
     return cursor;
@@ -505,7 +504,7 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
             cursor = new (trHeapMemory())
                 TR::X86PaddingInstruction(cursor, minInstructionSize, TR_AtomicNoOpPadding, cg());
         }
-        cursor = new (trHeapMemory()) TR::Instruction(TR::InstOpCode::INT3, cursor, cg());
+        cursor = new (trHeapMemory()) TR::Instruction(OP::INT3, cursor, cg());
     }
 
     // Compute the nature of the preserved regs
@@ -589,7 +588,7 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
         TR_DebugFrameSegmentInfo(comp(), 0, getProperties().getPointerSize(), "Return address", debugFrameSlotInfo);
 #endif
 
-    // Set the VFP state for the TR::InstOpCode::proc instruction
+    // Set the VFP state for the OP::proc instruction
     //
     if (_properties.getAlwaysDedicateFramePointerRegister()) {
         cg()->initializeVFPState(getProperties().getFramePointerRegister(), 0);
@@ -621,9 +620,8 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                 minInstructionSize);
             TR_ASSERT(allocSize >= 1, "When allocSize >= 1, the frame should be small or large, but never medium");
 
-            const TR::InstOpCode::Mnemonic subOp = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3)
-                ? TR::InstOpCode::SUBRegImms()
-                : TR::InstOpCode::SUBRegImm4();
+            const OP::Mnemonic subOp
+                = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3) ? OP::SUBRegImms() : OP::SUBRegImm4();
             cursor = new (trHeapMemory()) TR::X86RegImmInstruction(cursor, subOp, espReal, allocSize, cg());
 
             minInstructionSize = 0; // The SUB satisfies the constraint
@@ -632,7 +630,7 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
         TR::Instruction *jitOverflowCheck = NULL;
         if (doOverflowCheck) {
             TR::X86VFPSaveInstruction *vfp = Inst_VFPSave(cursor, cg());
-            cursor = Inst_StackOverflowCheck(vfp, TR::InstOpCode::CMPRegMem(), espReal,
+            cursor = Inst_StackOverflowCheck(vfp, OP::CMPRegMem(), espReal,
                 MRef_Bdisp32(metaDataReg, cg()->getStackLimitOffset(), cg()), cg());
 
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg());
@@ -642,9 +640,9 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
             endLabel->setEndInternalControlFlow();
             checkLabel->setStartOfColdInstructionStream();
 
-            cursor = Inst_Label(cursor, TR::InstOpCode::label, begLabel, cg());
-            cursor = Inst_Label(cursor, TR::InstOpCode::JBE4, checkLabel, cg());
-            cursor = Inst_Label(cursor, TR::InstOpCode::label, endLabel, cg());
+            cursor = Inst_Label(cursor, OP::label, begLabel, cg());
+            cursor = Inst_Label(cursor, OP::JBE4, checkLabel, cg());
+            cursor = Inst_Label(cursor, OP::label, endLabel, cg());
 
             // Code Cache disclaim is more efficient if this code is in the warm area
             bool moveToWarm = TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming)
@@ -666,20 +664,20 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
                 Inst_VFPRestore(vfp, cursor->getNode(), cg());
             }
 
-            Inst_Label(TR::InstOpCode::label, cursor->getNode(), checkLabel, cg());
-            Inst_RegImm(TR::InstOpCode::MOV4RegImm4, cursor->getNode(),
-                machine()->getRealRegister(TR::RealRegister::edi), allocSize, cg());
+            Inst_Label(OP::label, cursor->getNode(), checkLabel, cg());
+            Inst_RegImm(OP::MOV4RegImm4, cursor->getNode(), machine()->getRealRegister(TR::RealRegister::edi),
+                allocSize, cg());
             if (doAllocateFrameSpeculatively) {
-                Inst_RegImm(TR::InstOpCode::ADDRegImm4(), cursor->getNode(), espReal, allocSize, cg());
+                Inst_RegImm(OP::ADDRegImm4(), cursor->getNode(), espReal, allocSize, cg());
             }
             TR::SymbolReference *helper = comp()->getSymRefTab()->findOrCreateStackOverflowSymbolRef(NULL);
-            jitOverflowCheck = Inst_ImmSym(TR::InstOpCode::CALLImm4, cursor->getNode(),
-                (uintptr_t)helper->getMethodAddress(), helper, cg());
+            jitOverflowCheck
+                = Inst_ImmSym(OP::CALLImm4, cursor->getNode(), (uintptr_t)helper->getMethodAddress(), helper, cg());
             jitOverflowCheck->setNeedsGCMap(0xFF00FFFF);
             if (doAllocateFrameSpeculatively) {
-                Inst_RegImm(TR::InstOpCode::SUBRegImm4(), cursor->getNode(), espReal, allocSize, cg());
+                Inst_RegImm(OP::SUBRegImm4(), cursor->getNode(), espReal, allocSize, cg());
             }
-            Inst_Label(TR::InstOpCode::JMP4, cursor->getNode(), endLabel, cg());
+            Inst_Label(OP::JMP4, cursor->getNode(), endLabel, cg());
 
             if (moveToWarm) {
                 TR::Instruction *appendInstruction = cg()->getAppendInstruction();
@@ -744,9 +742,8 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
     } else if (!doAllocateFrameSpeculatively) {
         TR_ASSERT(minInstructionSize <= 5, "Can't guarantee SUB instruction will be at least %d bytes",
             minInstructionSize);
-        const TR::InstOpCode::Mnemonic subOp = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3)
-            ? TR::InstOpCode::SUBRegImms()
-            : TR::InstOpCode::SUBRegImm4();
+        const OP::Mnemonic subOp
+            = (allocSize <= 127 && getMinimumFirstInstructionSize() <= 3) ? OP::SUBRegImms() : OP::SUBRegImm4();
         cursor = new (trHeapMemory()) TR::X86RegImmInstruction(cursor, subOp, espReal, allocSize, cg());
     }
 
@@ -786,26 +783,26 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
         // Load the 64 bit paint value into a paint reg.
 #ifdef TR_TARGET_64BIT
         paintReg = machine()->getRealRegister(TR::RealRegister::r8);
-        cursor = new (trHeapMemory())
-            TR::AMD64RegImm64Instruction(cursor, TR::InstOpCode::MOV8RegImm64, paintReg, paintValue64, cg());
+        cursor
+            = new (trHeapMemory()) TR::AMD64RegImm64Instruction(cursor, OP::MOV8RegImm64, paintReg, paintValue64, cg());
 #endif
 
         // Perform the paint.
         //
         cursor = new (trHeapMemory())
-            TR::X86RegImmInstruction(cursor, TR::InstOpCode::MOVRegImm4(), frameSlotIndexReg, paintSize, cg());
-        cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, TR::InstOpCode::label, startLabel, cg());
+            TR::X86RegImmInstruction(cursor, OP::MOVRegImm4(), frameSlotIndexReg, paintSize, cg());
+        cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, OP::label, startLabel, cg());
         if (comp()->target().is64Bit())
-            cursor = new (trHeapMemory()) TR::X86MemRegInstruction(cursor, TR::InstOpCode::S8MemReg,
+            cursor = new (trHeapMemory()) TR::X86MemRegInstruction(cursor, OP::S8MemReg,
                 MRef_BISdisp32(espReal, frameSlotIndexReg, 0, (uint8_t)paintSlotsOffset, cg()), paintReg, cg());
         else
-            cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, TR::InstOpCode::SMemImm4(),
+            cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, OP::SMemImm4(),
                 MRef_BISdisp32(espReal, frameSlotIndexReg, 0, (uint8_t)paintSlotsOffset, cg()), paintValue32, cg());
         cursor = new (trHeapMemory())
-            TR::X86RegImmInstruction(cursor, TR::InstOpCode::SUBRegImms(), frameSlotIndexReg, sizeof(intptr_t), cg());
+            TR::X86RegImmInstruction(cursor, OP::SUBRegImms(), frameSlotIndexReg, sizeof(intptr_t), cg());
         cursor = new (trHeapMemory())
-            TR::X86RegImmInstruction(cursor, TR::InstOpCode::CMPRegImm4(), frameSlotIndexReg, paintBound, cg());
-        cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, TR::InstOpCode::JGE4, startLabel, cg());
+            TR::X86RegImmInstruction(cursor, OP::CMPRegImm4(), frameSlotIndexReg, paintBound, cg());
+        cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, OP::JGE4, startLabel, cg());
     }
 
     // Save preserved regs
@@ -835,8 +832,8 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
         }
 
         if (numReferenceLocalSlotsToInitialize > 0 || numInternalPointerSlotsToInitialize > 0) {
-            cursor = new (trHeapMemory())
-                TR::X86RegRegInstruction(cursor, TR::InstOpCode::XOR4RegReg, scratchReg, scratchReg, cg());
+            cursor
+                = new (trHeapMemory()) TR::X86RegRegInstruction(cursor, OP::XOR4RegReg, scratchReg, scratchReg, cg());
 
             // Initialize locals that are live on entry
             //
@@ -924,20 +921,18 @@ void J9::X86::PrivateLinkage::createEpilogue(TR::Instruction *cursor)
     if (_properties.getAlwaysDedicateFramePointerRegister()) {
         // Restore stack pointer from frame pointer
         //
-        cursor = Inst_RegReg(cursor, TR::InstOpCode::MOVRegReg(), espReal,
+        cursor = Inst_RegReg(cursor, OP::MOVRegReg(), espReal,
             machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
-        cursor = Inst_Reg(cursor, TR::InstOpCode::POPReg,
-            machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
+        cursor = Inst_Reg(cursor, OP::POPReg, machine()->getRealRegister(_properties.getFramePointerRegister()), cg());
     } else {
         auto frameSize = cg()->getFrameSizeInBytes();
         if (frameSize != 0) {
-            cursor
-                = Inst_RegImm(cursor, (frameSize <= 127) ? TR::InstOpCode::ADDRegImms() : TR::InstOpCode::ADDRegImm4(),
-                    espReal, frameSize, cg());
+            cursor = Inst_RegImm(cursor, (frameSize <= 127) ? OP::ADDRegImms() : OP::ADDRegImm4(), espReal, frameSize,
+                cg());
         }
     }
 
-    if (cursor->getNext()->getOpCodeValue() == TR::InstOpCode::RETImm2) {
+    if (cursor->getNext()->getOpCodeValue() == OP::RETImm2) {
         toIA32ImmInstruction(cursor->getNext())
             ->setSourceImmediate(
                 comp()->getJittedMethodSymbol()->getNumParameterSlots() << getProperties().getParmSlotShift());
@@ -982,7 +977,7 @@ TR::Register *J9::X86::PrivateLinkage::buildDirectDispatch(TR::Node *callNode, b
         char *name = method->getClassNameFromConstantPool(cpIndex, len);
         if (name) {
             if (TR::SimpleRegex::matchIgnoringLocale(r, name)) {
-                Inst(TR::InstOpCode::INT3, callNode, cg());
+                Inst(OP::INT3, callNode, cg());
             }
         }
     }
@@ -1009,7 +1004,7 @@ TR::Register *J9::X86::PrivateLinkage::buildDirectDispatch(TR::Node *callNode, b
 
     // Create the internal control flow region and VFP adjustment
     //
-    Inst_Label(startBookmark, TR::InstOpCode::label, startLabel, site.getPreConditionsUnderConstruction(), cg());
+    Inst_Label(startBookmark, OP::label, startLabel, site.getPreConditionsUnderConstruction(), cg());
     if (getProperties().getCallerCleanup()) {
         // TODO: Caller must clean up
     } else if (callNode->getSymbol()->castToMethodSymbol()->isHelper() && getProperties().getUsesRegsForHelperArgs()) {
@@ -1017,7 +1012,7 @@ TR::Register *J9::X86::PrivateLinkage::buildDirectDispatch(TR::Node *callNode, b
     } else {
         Inst_VFPCallCleanup(-site.getArgSize(), callNode, cg());
     }
-    Inst_Label(TR::InstOpCode::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(), cg());
+    Inst_Label(OP::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(), cg());
 
     // Stop using the killed registers that are not going to persist
     //
@@ -1622,7 +1617,7 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
 
                 picSlot = i.getNext();
                 if (picSlot)
-                    Inst_Label(TR::InstOpCode::label, site.getCallNode(), picMismatchLabel, cg());
+                    Inst_Label(OP::label, site.getCallNode(), picMismatchLabel, cg());
             }
 
             site.setFirstPICSlotInstruction(NULL);
@@ -1660,10 +1655,10 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
 
     // Create the internal control flow region and VFP adjustment
     //
-    Inst_Label(startBookmark, TR::InstOpCode::label, startLabel, site.getPreConditionsUnderConstruction(), cg());
+    Inst_Label(startBookmark, OP::label, startLabel, site.getPreConditionsUnderConstruction(), cg());
     if (!getProperties().getCallerCleanup())
         Inst_VFPCallCleanup(-site.getArgSize(), callNode, cg());
-    Inst_Label(TR::InstOpCode::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(), cg());
+    Inst_Label(OP::label, callNode, doneLabel, site.getPostConditionsUnderConstruction(), cg());
 
     // Stop using the killed registers that are not going to persist
     //
@@ -1713,11 +1708,11 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
 
         // Load the RAM method into rdi and call the helper
         if (comp()->target().is64Bit()) {
-            Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, ramMethodReg,
+            Inst_RegImm64(OP::MOV8RegImm64, callNode, ramMethodReg,
                 (uint64_t)(uintptr_t)methodSymbol->getMethodAddress(), cg());
         } else {
-            Inst_RegImm(TR::InstOpCode::MOV4RegImm4, callNode, ramMethodReg,
-                (uint32_t)(uintptr_t)methodSymbol->getMethodAddress(), cg());
+            Inst_RegImm(OP::MOV4RegImm4, callNode, ramMethodReg, (uint32_t)(uintptr_t)methodSymbol->getMethodAddress(),
+                cg());
         }
 
         callInstr = Inst_HelperCall(callNode, TR_j2iTransition, NULL, cg());
@@ -1738,9 +1733,9 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         TR::Register *nativeMethodReg = cg()->allocateRegister();
         site.addPostCondition(nativeMethodReg, TR::RealRegister::edi);
 
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, nativeMethodReg,
+        Inst_RegImm64(OP::MOV8RegImm64, callNode, nativeMethodReg,
             (uint64_t)(uintptr_t)methodSymbol->getMethodAddress(), cg());
-        callInstr = Inst_Reg(TR::InstOpCode::CALLReg, callNode, nativeMethodReg, cg());
+        callInstr = Inst_Reg(OP::CALLReg, callNode, nativeMethodReg, cg());
         cg()->stopUsingRegister(nativeMethodReg);
     } else if (methodSymRef->isUnresolved() || methodSymbol->isInterpreted()
         || (comp()->compileRelocatableCode() && !methodSymbol->isHelper())) {
@@ -1750,7 +1745,7 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         cg()->addSnippet(snippet);
         snippet->gcMap().setGCRegisterMask(site.getPreservedRegisterMask());
 
-        callInstr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, 0,
+        callInstr = Inst_ImmSym(OP::CALLImm4, callNode, 0,
             new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), label), cg());
         Inst_BoundaryAvoidance(TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8, callInstr, cg());
 
@@ -1775,7 +1770,7 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         TR::Register *j9mReg = callNode->getChild(0)->getRegister();
 
         int32_t extraOffset = (int32_t)offsetof(J9Method, extra);
-        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg, MRef_Bdisp32(j9mReg, extraOffset, cg()), cg());
+        Inst_RegMem(OP::LRegMem(), callNode, scratchReg, MRef_Bdisp32(j9mReg, extraOffset, cg()), cg());
 
         // The test/jnz sequence assumes that J9_STARTPC_NOT_TRANSLATED is a
         // single bit in the low byte.
@@ -1784,24 +1779,24 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         static_assert((J9_STARTPC_NOT_TRANSLATED & (J9_STARTPC_NOT_TRANSLATED - 1)) == 0,
             "non-power-of-two J9_STARTPC_NOT_TRANSLATED");
 
-        Inst_RegImm(TR::InstOpCode::TEST1RegImm1, callNode, scratchReg, J9_STARTPC_NOT_TRANSLATED, cg());
+        Inst_RegImm(OP::TEST1RegImm1, callNode, scratchReg, J9_STARTPC_NOT_TRANSLATED, cg());
 
-        TR::InstOpCode::Mnemonic oolBranchOp = TR::InstOpCode::JNE4;
+        OP::Mnemonic oolBranchOp = OP::JNE4;
         if (cg()->stressJitDispatchJ9MethodJ2I())
-            oolBranchOp = TR::InstOpCode::JMP4; // go to J2I path unconditionally
+            oolBranchOp = OP::JMP4; // go to J2I path unconditionally
 
         Inst_Label(oolBranchOp, callNode, interpreterCallLabel, cg());
 
         // The method is compiled - call through register to JIT entry point
-        Inst_RegMem(TR::InstOpCode::L4RegMem, callNode,
+        Inst_RegMem(OP::L4RegMem, callNode,
             j9mReg, // can reuse because the actual J9Method isn't needed anymore
             MRef_Bdisp32(scratchReg, -4, cg()), cg());
 
-        Inst_RegImm(TR::InstOpCode::SHR4RegImm1, callNode, j9mReg, 16, cg());
+        Inst_RegImm(OP::SHR4RegImm1, callNode, j9mReg, 16, cg());
 
-        Inst_RegReg(TR::InstOpCode::ADDRegReg(), callNode, scratchReg, j9mReg, cg());
+        Inst_RegReg(OP::ADDRegReg(), callNode, scratchReg, j9mReg, cg());
 
-        callInstr = Inst_Reg(TR::InstOpCode::CALLReg, callNode, scratchReg, cg());
+        callInstr = Inst_Reg(OP::CALLReg, callNode, scratchReg, cg());
 
         // But if the method is interpreted, call through a call snippet instead.
         // The snippet will store arguments to the stack and do a J2I transition.
@@ -1810,9 +1805,9 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
             = new (trHeapMemory()) TR::SymbolReference(comp()->getSymRefTab(), snippetLabel);
 
         TR_OutlinedInstructionsGenerator og(interpreterCallLabel, callNode, cg());
-        TR::Instruction *interpreterCallInstr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, 0, labelSymRef, cg());
+        TR::Instruction *interpreterCallInstr = Inst_ImmSym(OP::CALLImm4, callNode, 0, labelSymRef, cg());
         interpreterCallInstr->setNeedsGCMap(site.getPreservedRegisterMask());
-        Inst_Label(TR::InstOpCode::JMP4, callNode, doneLabel, cg());
+        Inst_Label(OP::JMP4, callNode, doneLabel, cg());
         og.endOutlinedInstructionSequence();
 
         TR::Snippet *snippet = new (trHeapMemory()) TR::X86CallSnippet(cg(), callNode, snippetLabel, false);
@@ -1820,8 +1815,8 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         cg()->addSnippet(snippet);
         cg()->stopUsingRegister(scratchReg);
     } else {
-        callInstr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(),
-            methodSymRef, cg());
+        callInstr
+            = Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, cg());
 
         if (comp()->target().isSMP() && !methodSymbol->isHelper()) {
             // Make sure it's patchable in case it gets (re)compiled
@@ -1917,18 +1912,18 @@ bool J9::X86::PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::Label
         // We can do an explicit guard
         //
         uint32_t overRiddenBit = fej9->offsetOfIsOverriddenBit();
-        TR::InstOpCode::Mnemonic opCode;
+        OP::Mnemonic opCode;
 
         if (overRiddenBit <= 0xff)
-            opCode = TR::InstOpCode::TEST1MemImm1;
+            opCode = OP::TEST1MemImm1;
         else
-            opCode = TR::InstOpCode::TEST4MemImm4;
+            opCode = OP::TEST4MemImm4;
 
         Inst_MemImm(opCode, callNode,
             MRef_abs((intptr_t)site.getResolvedMethod()->addressContainingIsOverriddenBit(), cg()), overRiddenBit,
             cg());
 
-        Inst_Label(TR::InstOpCode::JNE4, callNode, revirtualizeLabel, cg());
+        Inst_Label(OP::JNE4, callNode, revirtualizeLabel, cg());
 
         return true;
     } else {
@@ -1944,7 +1939,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
     TR::Node *callNode = site.getCallNode();
     if (cg()->enableSinglePrecisionMethods() && comp()->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = cg()->findOrCreate2ByteConstant(callNode, DOUBLE_PRECISION_ROUND_TO_NEAREST);
-        Inst_Mem(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
+        Inst_Mem(OP::LDCWMem, callNode, MRef_const(cds, cg()), cg());
     }
 
     TR::Instruction *callInstr;
@@ -1968,20 +1963,20 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
             // Bad news.
             //
             // icallVMprJavaSendPatchupVirtual requires that a virtual call site
-            // either (1) uses a TR::InstOpCode::CALLMem with a fixed VFT offset, or (2) puts the
-            // VFT index into r8 and uses a TR::InstOpCode::CALLImm4 with a fixed call target.
+            // either (1) uses a OP::CALLMem with a fixed VFT offset, or (2) puts the
+            // VFT index into r8 and uses a OP::CALLImm4 with a fixed call target.
             // We have neither a fixed VFT offset nor a fixed call target!
-            // Adding support for TR::InstOpCode::CALLReg is difficult because the instruction is
+            // Adding support for OP::CALLReg is difficult because the instruction is
             // a different length, making it hard to back up and disassemble it.
             //
             // Therefore, we cannot have the return address pointing after a
-            // TR::InstOpCode::CALLReg instruction.  Instead, we use a TR::InstOpCode::CALLImm4 with a fixed
-            // displacement to get to out-of-line instructions that do a TR::InstOpCode::JMPReg.
+            // OP::CALLReg instruction.  Instead, we use a OP::CALLImm4 with a fixed
+            // displacement to get to out-of-line instructions that do a OP::JMPReg.
 
             // Mainline call
             //
             TR::LabelSymbol *jmpLabel = TR::LabelSymbol::create(cg()->trHeapMemory(), cg());
-            callInstr = Inst_Label(TR::InstOpCode::CALLImm4, callNode, jmpLabel, cg());
+            callInstr = Inst_Label(OP::CALLImm4, callNode, jmpLabel, cg());
 
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
             // JITHelpers.dispatchVirtual() can target MethodHandle.invokeBasic().
@@ -1995,7 +1990,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
             //
             {
                 TR_OutlinedInstructionsGenerator og(jmpLabel, callNode, cg());
-                Inst_Reg(TR::InstOpCode::JMPReg, callNode, targetAddressReg, cg());
+                Inst_Reg(OP::JMPReg, callNode, targetAddressReg, cg());
                 og.endOutlinedInstructionSequence();
             }
 
@@ -2023,7 +2018,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
 
     if (cg()->enableSinglePrecisionMethods() && comp()->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = cg()->findOrCreate2ByteConstant(callNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
-        Inst_Mem(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
+        Inst_Mem(OP::LDCWMem, callNode, MRef_const(cds, cg()), cg());
     }
 
     return callInstr;
@@ -2213,7 +2208,7 @@ void J9::X86::PrivateLinkage::buildVPIC(TR::X86CallSite &site, TR::LabelSymbol *
     TR_ASSERT(doneLabel, "a doneLabel is required for VPIC dispatches");
 
     if (entryLabel)
-        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(OP::label, site.getCallNode(), entryLabel, cg());
 
     int32_t numVPicSlots = VPicParameters.defaultNumberOfSlots;
 
@@ -2280,30 +2275,28 @@ static void generateITableEntryCompareLogic(TR::Node *callNode, TR::Register *sc
     TR::Compilation *comp = cg->comp();
 
     // Test if iTable == NULL?
-    Inst_RegReg(TR::InstOpCode::TESTRegReg(), callNode, scratchReg, scratchReg, cg);
-    Inst_Label(TR::InstOpCode::JE4, callNode, lookupDispatchSnippetLabel, cg);
+    Inst_RegReg(OP::TESTRegReg(), callNode, scratchReg, scratchReg, cg);
+    Inst_Label(OP::JE4, callNode, lookupDispatchSnippetLabel, cg);
 
     if (use32BitInterfaceClassPointers) {
         // The field is 8 bytes, but only 4 matter
-        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
+        Inst_MemImm(OP::CMP4MemImm4, callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg),
             (int32_t)(intptr_t)declaringClass, cg, TR_ClassPointer);
     } else {
         TR_ASSERT_FATAL(comp->target().is64Bit(), "Only 64-bit path should reach here.");
 
-        Inst_RegImm64(TR::InstOpCode::MOV8RegImm64, callNode, interfaceClassReg, (intptr_t)declaringClass, cg,
-            TR_ClassPointer);
-        Inst_MemReg(TR::InstOpCode::CMPMemReg(), callNode,
+        Inst_RegImm64(OP::MOV8RegImm64, callNode, interfaceClassReg, (intptr_t)declaringClass, cg, TR_ClassPointer);
+        Inst_MemReg(OP::CMPMemReg(), callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg), interfaceClassReg, cg);
     }
 
-    Inst_LongLabel(TR::InstOpCode::JE4, callNode, gotoLastITableDispatchLabel, cg);
+    Inst_LongLabel(OP::JE4, callNode, gotoLastITableDispatchLabel, cg);
 
     if (!isLastIteration) {
         // This step should be skipped on the last unrolled iteration
         // scratchReg = iTable->next
-        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg,
-            MRef_Bdisp32(scratchReg, offsetof(J9ITable, next), cg), cg);
+        Inst_RegMem(OP::LRegMem(), callNode, scratchReg, MRef_Bdisp32(scratchReg, offsetof(J9ITable, next), cg), cg);
     }
 }
 
@@ -2356,8 +2349,7 @@ static void generateITableEntryLoop(uint32_t iterations, TR::Node *callNode, TR:
     const uint32_t maxUnrolledIterations = 4;
 
     // scratchReg = j9class->iTable
-    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg, MRef_Bdisp32(vftReg, offsetof(J9Class, iTable), cg),
-        cg);
+    Inst_RegMem(OP::LRegMem(), callNode, scratchReg, MRef_Bdisp32(vftReg, offsetof(J9Class, iTable), cg), cg);
 
     if (iterations <= maxUnrolledIterations) {
         // If number of iterations is less than maxUnrolledIterations, we generate an unrolled sequence.
@@ -2378,24 +2370,24 @@ static void generateITableEntryLoop(uint32_t iterations, TR::Node *callNode, TR:
         deps->addPostCondition(scratchReg, TR::RealRegister::NoReg, cg);
         deps->addPostCondition(interfaceClassReg, TR::RealRegister::NoReg, cg);
 
-        Inst_RegReg(TR::InstOpCode::XORRegReg(), callNode, indexReg, indexReg, cg);
-        Inst_Label(TR::InstOpCode::label, callNode, startLoopLabel, deps, cg);
+        Inst_RegReg(OP::XORRegReg(), callNode, indexReg, indexReg, cg);
+        Inst_Label(OP::label, callNode, startLoopLabel, deps, cg);
 
         // index = 0
         // do { ... } while (index < iterations);
         generateITableEntryCompareLogic(callNode, scratchReg, interfaceClassReg, declaringClass,
             use32BitInterfaceClassPointers, false, lookupDispatchSnippetLabel, gotoLastITableDispatchLabel, cg);
 
-        Inst_Reg(TR::InstOpCode::INCReg(), callNode, indexReg, cg);
-        Inst_RegImm(TR::InstOpCode::CMPRegImm4(), callNode, indexReg, iterations, cg);
-        Inst_Label(TR::InstOpCode::JL1, callNode, startLoopLabel, cg);
+        Inst_Reg(OP::INCReg(), callNode, indexReg, cg);
+        Inst_RegImm(OP::CMPRegImm4(), callNode, indexReg, iterations, cg);
+        Inst_Label(OP::JL1, callNode, startLoopLabel, cg);
 
         cg->stopUsingRegister(indexReg);
-        Inst_Label(TR::InstOpCode::label, callNode, endLoopLabel, deps, cg);
+        Inst_Label(OP::label, callNode, endLoopLabel, deps, cg);
     }
 
     // If there is no match found.
-    Inst_Label(TR::InstOpCode::JMP4, callNode, lookupDispatchSnippetLabel, cg);
+    Inst_Label(OP::JMP4, callNode, lookupDispatchSnippetLabel, cg);
 }
 
 /**
@@ -2430,15 +2422,15 @@ static void generateLastITableDispatch(TR::Node *callNode, TR::LabelSymbol *look
 {
     // X86PicBuilder routines (for example, resolveIPicClass) expect the last JNE before the
     // done label to jump to the lookup snippet.
-    Inst_LongLabel(TR::InstOpCode::JNE4, callNode, lookupDispatchSnippetLabel,
+    Inst_LongLabel(OP::JNE4, callNode, lookupDispatchSnippetLabel,
         cg); // PICBuilder needs this to have a 4-byte offset
 
     if (gotoLastITableDispatchLabel)
-        Inst_Label(TR::InstOpCode::label, callNode, gotoLastITableDispatchLabel, cg);
+        Inst_Label(OP::label, callNode, gotoLastITableDispatchLabel, cg);
 
     if (cg->comp()->target().is32Bit())
         Inst_Padding(3, callNode, cg);
-    Inst_Label(TR::InstOpCode::CALLImm4, callNode, lastITableDispatchLabel, vtableIndexRegDeps, cg);
+    Inst_Label(OP::CALLImm4, callNode, lastITableDispatchLabel, vtableIndexRegDeps, cg);
 }
 
 static uint32_t determineNumOfITableIterations(TR::X86CallSite &site, TR_OpaqueClassBlock *declaringClass,
@@ -2574,7 +2566,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
         // TODO: This is lame.  Without IPIC slots, generating this sequence
         // upside-down is sub-optimal.
         //
-        Inst_Label(TR::InstOpCode::JMP4, callNode, lastITableTestLabel, cg());
+        Inst_Label(OP::JMP4, callNode, lastITableTestLabel, cg());
     }
 
     TR::Register *vftReg = site.evaluateVFT();
@@ -2591,7 +2583,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     // Why?
     //
     // 1) You can't call a j2i thunk with your return address pointing at a
-    //    TR::InstOpCode::CALLMem unless that TR::InstOpCode::CALLMem has a displacement which equals the jit
+    //    OP::CALLMem unless that OP::CALLMem has a displacement which equals the jit
     //    vtable offset.  We don't know the vtable offset statically, so we
     //    must pass it in r8 and leave the return address pointing at a CALLImm.
     //
@@ -2644,12 +2636,11 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     // The dispatch sequence
     //
 
-    TR::Instruction *lastITableDispatchStart
-        = Inst_Label(TR::InstOpCode::label, callNode, lastITableDispatchLabel, cg());
-    Inst_RegImm(TR::InstOpCode::MOV4RegImm4, callNode, vtableIndexReg, fej9->getITableEntryJitVTableOffset(), cg());
-    Inst_RegMem(TR::InstOpCode::SUBRegMem(), callNode, vtableIndexReg,
+    TR::Instruction *lastITableDispatchStart = Inst_Label(OP::label, callNode, lastITableDispatchLabel, cg());
+    Inst_RegImm(OP::MOV4RegImm4, callNode, vtableIndexReg, fej9->getITableEntryJitVTableOffset(), cg());
+    Inst_RegMem(OP::SUBRegMem(), callNode, vtableIndexReg,
         MRef_Bdisp32(scratchReg, fej9->convertITableIndexToOffset(itableIndex), cg()), cg());
-    buildVFTCall(site, TR::InstOpCode::JMPMem, NULL, MRef_BIS(vftReg, vtableIndexReg, 0, cg()));
+    buildVFTCall(site, OP::JMPMem, NULL, MRef_BIS(vftReg, vtableIndexReg, 0, cg()));
 
     // Without PIC slots, lastITableDispatchStart takes the place of various "first instruction" pointers
     //
@@ -2660,10 +2651,10 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
 
     // The test sequence
     //
-    Inst_Label(TR::InstOpCode::label, callNode, lastITableTestLabel, cg());
+    Inst_Label(OP::label, callNode, lastITableTestLabel, cg());
     if (breakBeforeInterfaceDispatchUsingLastITable)
-        Inst(TR::InstOpCode::INT3, callNode, cg());
-    Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, scratchReg,
+        Inst(OP::INT3, callNode, cg());
+    Inst_RegMem(OP::LRegMem(), callNode, scratchReg,
         MRef_Bdisp32(vftReg, (int32_t)fej9->getOffsetOfLastITableFromClassField(), cg()), cg());
     bool use32BitInterfaceClassPointers = comp()->target().is32Bit();
     if (comp()->useCompressedPointers() /* actually compressed object headers */) {
@@ -2672,7 +2663,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     }
     if (use32BitInterfaceClassPointers) {
         // The field is 8 bytes, but only 4 matter
-        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
+        Inst_MemImm(OP::CMP4MemImm4, callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()),
             (int32_t)(intptr_t)declaringClass, cg());
     } else {
@@ -2680,8 +2671,8 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
         TR::Register *interfaceClassReg = vtableIndexReg;
         auto cds = cg()->findOrCreate8ByteConstant(site.getCallNode(), (intptr_t)declaringClass);
         TR::MemoryReference *interfaceClassAddr = MRef_const(cds, cg());
-        Inst_RegMem(TR::InstOpCode::LRegMem(), callNode, interfaceClassReg, interfaceClassAddr, cg());
-        Inst_MemReg(TR::InstOpCode::CMPMemReg(), callNode,
+        Inst_RegMem(OP::LRegMem(), callNode, interfaceClassReg, interfaceClassAddr, cg());
+        Inst_MemReg(OP::CMPMemReg(), callNode,
             MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()), interfaceClassReg, cg());
     }
 
@@ -2719,7 +2710,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
             TR::LabelSymbol *iterateITableLabel = generateLabelSymbol(cg());
             TR::LabelSymbol *gotoLastITableDispatchLabel = generateLabelSymbol(cg());
 
-            Inst_LongLabel(TR::InstOpCode::JNE4, callNode, iterateITableLabel, cg());
+            Inst_LongLabel(OP::JNE4, callNode, iterateITableLabel, cg());
 
             // The following sequence of instructions that iterate through the iTable cannot be inserted
             // after the test of the lastITableCache in the mainline code.  The routines in X86PicBuilder,

--- a/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
+++ b/runtime/compiler/x/codegen/X86PrivateLinkage.cpp
@@ -181,7 +181,7 @@ TR::Instruction *J9::X86::PrivateLinkage::movLinkageRegisters(TR::Instruction *c
             TR_MovDataTypes movDataType = paramMovType(paramCursor);
             TR::RealRegister *reg
                 = machine->getRealRegister(getProperties().getArgumentRegister(lri, isFloat(movDataType)));
-            TR::MemoryReference *memRef = generateX86MemoryReference(rspReal, paramCursor->getParameterOffset(), cg());
+            TR::MemoryReference *memRef = MRef_Bdisp32(rspReal, paramCursor->getParameterOffset(), cg());
 
             if (isStore) {
                 // stack := lri
@@ -257,7 +257,7 @@ TR::Instruction *J9::X86::PrivateLinkage::copyParametersToHomeLocation(TR::Instr
                     diagnostic("copyParametersToHomeLocation: Loading %d\n", ai);
                 // ai := stack
                 loadCursor = generateRegMemInstruction(loadCursor, TR::Linkage::movOpcodes(RegMem, movDataType),
-                    machine->getRealRegister(ai), generateX86MemoryReference(framePointer, offset, cg()), cg());
+                    machine->getRealRegister(ai), MRef_Bdisp32(framePointer, offset, cg()), cg());
             }
         } else // It's in a linkage register
         {
@@ -276,8 +276,7 @@ TR::Instruction *J9::X86::PrivateLinkage::copyParametersToHomeLocation(TR::Instr
                         diagnostic("copyParametersToHomeLocation: Storing %d\n", sourceIndex);
                     // stack := lri
                     cursor = generateMemRegInstruction(cursor, TR::Linkage::movOpcodes(MemReg, movDataType),
-                        generateX86MemoryReference(framePointer, offset, cg()), machine->getRealRegister(sourceIndex),
-                        cg());
+                        MRef_Bdisp32(framePointer, offset, cg()), machine->getRealRegister(sourceIndex), cg());
                 }
             }
 
@@ -383,7 +382,7 @@ static TR::Instruction *initializeLocals(TR::Instruction *cursor, int32_t lowOff
         //
         for (int32_t i = 0; i < count; i++, offset += pointerSize) {
             cursor = new (cg->trHeapMemory()) TR::X86MemRegInstruction(cursor, TR::InstOpCode::SMemReg(),
-                generateX86MemoryReference(framePointer, offset, cg), sourceReg, cg);
+                MRef_Bdisp32(framePointer, offset, cg), sourceReg, cg);
         }
     } else {
         // For a large number, generate a loop.
@@ -394,14 +393,14 @@ static TR::Instruction *initializeLocals(TR::Instruction *cursor, int32_t lowOff
         TR_ASSERT(count > 0, "positive count required for dword RegImm instruction");
 
         cursor = new (cg->trHeapMemory()) TR::X86RegMemInstruction(cursor, TR::InstOpCode::LEARegMem(), loopReg,
-            generateX86MemoryReference(sourceReg, count - 1, cg), cg);
+            MRef_Bdisp32(sourceReg, count - 1, cg), cg);
 
         TR::LabelSymbol *loopLabel = generateLabelSymbol(cg);
         cursor = new (cg->trHeapMemory()) TR::X86LabelInstruction(cursor, TR::InstOpCode::label, loopLabel, cg);
 
         cursor = new (cg->trHeapMemory()) TR::X86MemRegInstruction(cursor, TR::InstOpCode::SMemReg(),
-            generateX86MemoryReference(framePointer, loopReg,
-                TR::MemoryReference::convertMultiplierToStride(pointerSize), offset, cg),
+            MRef_BISdisp32(framePointer, loopReg, TR::MemoryReference::convertMultiplierToStride(pointerSize), offset,
+                cg),
             sourceReg, cg);
 
         cursor = new (cg->trHeapMemory()) TR::X86RegImmInstruction(cursor, TR::InstOpCode::SUB4RegImms, loopReg, 1, cg);
@@ -637,7 +636,7 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
         if (doOverflowCheck) {
             TR::X86VFPSaveInstruction *vfp = generateVFPSaveInstruction(cursor, cg());
             cursor = generateStackOverflowCheckInstruction(vfp, TR::InstOpCode::CMPRegMem(), espReal,
-                generateX86MemoryReference(metaDataReg, cg()->getStackLimitOffset(), cg()), cg());
+                MRef_Bdisp32(metaDataReg, cg()->getStackLimitOffset(), cg()), cg());
 
             TR::LabelSymbol *begLabel = generateLabelSymbol(cg());
             TR::LabelSymbol *endLabel = generateLabelSymbol(cg());
@@ -801,12 +800,10 @@ void J9::X86::PrivateLinkage::createPrologue(TR::Instruction *cursor)
         cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, TR::InstOpCode::label, startLabel, cg());
         if (comp()->target().is64Bit())
             cursor = new (trHeapMemory()) TR::X86MemRegInstruction(cursor, TR::InstOpCode::S8MemReg,
-                generateX86MemoryReference(espReal, frameSlotIndexReg, 0, (uint8_t)paintSlotsOffset, cg()), paintReg,
-                cg());
+                MRef_BISdisp32(espReal, frameSlotIndexReg, 0, (uint8_t)paintSlotsOffset, cg()), paintReg, cg());
         else
             cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, TR::InstOpCode::SMemImm4(),
-                generateX86MemoryReference(espReal, frameSlotIndexReg, 0, (uint8_t)paintSlotsOffset, cg()),
-                paintValue32, cg());
+                MRef_BISdisp32(espReal, frameSlotIndexReg, 0, (uint8_t)paintSlotsOffset, cg()), paintValue32, cg());
         cursor = new (trHeapMemory())
             TR::X86RegImmInstruction(cursor, TR::InstOpCode::SUBRegImms(), frameSlotIndexReg, sizeof(intptr_t), cg());
         cursor = new (trHeapMemory())
@@ -1503,7 +1500,7 @@ TR::Register *J9::X86::PrivateLinkage::buildIndirectDispatch(TR::Node *callNode)
                                        callNode->getByteCodeInfo().getCallerIndex(),
                                        callNode->getByteCodeInfo().getByteCodeIndex()));
             */
-            TR::MemoryReference *sourceMR = generateX86MemoryReference(vftChild, cg());
+            TR::MemoryReference *sourceMR = MRef_node(vftChild, cg());
             TR::Register *reg = cg()->allocateRegister();
             // as vftChild->getOpCode().isLoadIndirect is true here, need set exception point
             TR::Instruction *instr
@@ -1788,7 +1785,7 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
 
         int32_t extraOffset = (int32_t)offsetof(J9Method, extra);
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
-            generateX86MemoryReference(j9mReg, extraOffset, cg()), cg());
+            MRef_Bdisp32(j9mReg, extraOffset, cg()), cg());
 
         // The test/jnz sequence assumes that J9_STARTPC_NOT_TRANSLATED is a
         // single bit in the low byte.
@@ -1808,7 +1805,7 @@ void J9::X86::PrivateLinkage::buildDirectCall(TR::SymbolReference *methodSymRef,
         // The method is compiled - call through register to JIT entry point
         generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode,
             j9mReg, // can reuse because the actual J9Method isn't needed anymore
-            generateX86MemoryReference(scratchReg, -4, cg()), cg());
+            MRef_Bdisp32(scratchReg, -4, cg()), cg());
 
         generateRegImmInstruction(TR::InstOpCode::SHR4RegImm1, callNode, j9mReg, 16, cg());
 
@@ -1939,8 +1936,8 @@ bool J9::X86::PrivateLinkage::buildVirtualGuard(TR::X86CallSite &site, TR::Label
             opCode = TR::InstOpCode::TEST4MemImm4;
 
         generateMemImmInstruction(opCode, callNode,
-            generateX86MemoryReference((intptr_t)site.getResolvedMethod()->addressContainingIsOverriddenBit(), cg()),
-            overRiddenBit, cg());
+            MRef_abs((intptr_t)site.getResolvedMethod()->addressContainingIsOverriddenBit(), cg()), overRiddenBit,
+            cg());
 
         generateLabelInstruction(TR::InstOpCode::JNE4, callNode, revirtualizeLabel, cg());
 
@@ -1958,7 +1955,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
     TR::Node *callNode = site.getCallNode();
     if (cg()->enableSinglePrecisionMethods() && comp()->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = cg()->findOrCreate2ByteConstant(callNode, DOUBLE_PRECISION_ROUND_TO_NEAREST);
-        generateMemInstruction(TR::InstOpCode::LDCWMem, callNode, generateX86MemoryReference(cds, cg()), cg());
+        generateMemInstruction(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
     }
 
     TR::Instruction *callInstr;
@@ -2037,7 +2034,7 @@ TR::Instruction *J9::X86::PrivateLinkage::buildVFTCall(TR::X86CallSite &site, TR
 
     if (cg()->enableSinglePrecisionMethods() && comp()->getJittedMethodSymbol()->usesSinglePrecisionMode()) {
         auto cds = cg()->findOrCreate2ByteConstant(callNode, SINGLE_PRECISION_ROUND_TO_NEAREST);
-        generateMemInstruction(TR::InstOpCode::LDCWMem, callNode, generateX86MemoryReference(cds, cg()), cg());
+        generateMemInstruction(TR::InstOpCode::LDCWMem, callNode, MRef_const(cds, cg()), cg());
     }
 
     return callInstr;
@@ -2300,7 +2297,7 @@ static void generateITableEntryCompareLogic(TR::Node *callNode, TR::Register *sc
     if (use32BitInterfaceClassPointers) {
         // The field is 8 bytes, but only 4 matter
         generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
-            generateX86MemoryReference(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg),
+            MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg),
             (int32_t)(intptr_t)declaringClass, cg, TR_ClassPointer);
     } else {
         TR_ASSERT_FATAL(comp->target().is64Bit(), "Only 64-bit path should reach here.");
@@ -2308,8 +2305,7 @@ static void generateITableEntryCompareLogic(TR::Node *callNode, TR::Register *sc
         generateRegImm64Instruction(TR::InstOpCode::MOV8RegImm64, callNode, interfaceClassReg, (intptr_t)declaringClass,
             cg, TR_ClassPointer);
         generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), callNode,
-            generateX86MemoryReference(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg),
-            interfaceClassReg, cg);
+            MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg), interfaceClassReg, cg);
     }
 
     generateLongLabelInstruction(TR::InstOpCode::JE4, callNode, gotoLastITableDispatchLabel, cg);
@@ -2318,7 +2314,7 @@ static void generateITableEntryCompareLogic(TR::Node *callNode, TR::Register *sc
         // This step should be skipped on the last unrolled iteration
         // scratchReg = iTable->next
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
-            generateX86MemoryReference(scratchReg, offsetof(J9ITable, next), cg), cg);
+            MRef_Bdisp32(scratchReg, offsetof(J9ITable, next), cg), cg);
     }
 }
 
@@ -2372,7 +2368,7 @@ static void generateITableEntryLoop(uint32_t iterations, TR::Node *callNode, TR:
 
     // scratchReg = j9class->iTable
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
-        generateX86MemoryReference(vftReg, offsetof(J9Class, iTable), cg), cg);
+        MRef_Bdisp32(vftReg, offsetof(J9Class, iTable), cg), cg);
 
     if (iterations <= maxUnrolledIterations) {
         // If number of iterations is less than maxUnrolledIterations, we generate an unrolled sequence.
@@ -2664,8 +2660,8 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     generateRegImmInstruction(TR::InstOpCode::MOV4RegImm4, callNode, vtableIndexReg,
         fej9->getITableEntryJitVTableOffset(), cg());
     generateRegMemInstruction(TR::InstOpCode::SUBRegMem(), callNode, vtableIndexReg,
-        generateX86MemoryReference(scratchReg, fej9->convertITableIndexToOffset(itableIndex), cg()), cg());
-    buildVFTCall(site, TR::InstOpCode::JMPMem, NULL, generateX86MemoryReference(vftReg, vtableIndexReg, 0, cg()));
+        MRef_Bdisp32(scratchReg, fej9->convertITableIndexToOffset(itableIndex), cg()), cg());
+    buildVFTCall(site, TR::InstOpCode::JMPMem, NULL, MRef_BIS(vftReg, vtableIndexReg, 0, cg()));
 
     // Without PIC slots, lastITableDispatchStart takes the place of various "first instruction" pointers
     //
@@ -2680,7 +2676,7 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     if (breakBeforeInterfaceDispatchUsingLastITable)
         generateInstruction(TR::InstOpCode::INT3, callNode, cg());
     generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, scratchReg,
-        generateX86MemoryReference(vftReg, (int32_t)fej9->getOffsetOfLastITableFromClassField(), cg()), cg());
+        MRef_Bdisp32(vftReg, (int32_t)fej9->getOffsetOfLastITableFromClassField(), cg()), cg());
     bool use32BitInterfaceClassPointers = comp()->target().is32Bit();
     if (comp()->useCompressedPointers() /* actually compressed object headers */) {
         // The field is 8 bytes, but only 4 matter
@@ -2689,17 +2685,16 @@ void J9::X86::PrivateLinkage::buildInterfaceDispatchUsingLastITable(TR::X86CallS
     if (use32BitInterfaceClassPointers) {
         // The field is 8 bytes, but only 4 matter
         generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
-            generateX86MemoryReference(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()),
+            MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()),
             (int32_t)(intptr_t)declaringClass, cg());
     } else {
         TR_ASSERT(comp()->target().is64Bit(), "Only 64-bit path should reach here.");
         TR::Register *interfaceClassReg = vtableIndexReg;
         auto cds = cg()->findOrCreate8ByteConstant(site.getCallNode(), (intptr_t)declaringClass);
-        TR::MemoryReference *interfaceClassAddr = generateX86MemoryReference(cds, cg());
+        TR::MemoryReference *interfaceClassAddr = MRef_const(cds, cg());
         generateRegMemInstruction(TR::InstOpCode::LRegMem(), callNode, interfaceClassReg, interfaceClassAddr, cg());
         generateMemRegInstruction(TR::InstOpCode::CMPMemReg(), callNode,
-            generateX86MemoryReference(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()),
-            interfaceClassReg, cg());
+            MRef_Bdisp32(scratchReg, fej9->getOffsetOfInterfaceClassFromITableField(), cg()), interfaceClassReg, cg());
     }
 
     if (comp()->getOption(TR_DisableITableIterationsAfterLastITableCacheCheck)

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -111,7 +111,7 @@ TR::Instruction *TR_X86Recompilation::generatePrePrologue()
     if (cg()->comp()->target().is64Bit()) {
         // A copy of the first two bytes of the method, in case we need to un-patch them
         //
-        prev = new (trHeapMemory()) TR::X86ImmInstruction(prev, TR::InstOpCode::DWImm2, 0xcccc, cg());
+        prev = new (trHeapMemory()) TR::X86ImmInstruction(prev, OP::DWImm2, 0xcccc, cg());
     }
 
     if (useSampling()) {
@@ -132,12 +132,11 @@ TR::Instruction *TR_X86Recompilation::generatePrePrologue()
         // binary-encoding-time support.  If you change this, be sure to adjust
         // the alignmentMargin above.
         //
-        prev = new (trHeapMemory())
-            TR::AMD64Imm64Instruction(prev, TR::InstOpCode::DQImm64, (uintptr_t)getJittedBodyInfo(), cg());
+        prev = new (trHeapMemory()) TR::AMD64Imm64Instruction(prev, OP::DQImm64, (uintptr_t)getJittedBodyInfo(), cg());
         prev->setNeedsAOTRelocation();
     } else {
         prev = new (trHeapMemory())
-            TR::X86ImmInstruction(prev, TR::InstOpCode::DDImm4, (uint32_t)(uintptr_t)getJittedBodyInfo(), cg());
+            TR::X86ImmInstruction(prev, OP::DDImm4, (uint32_t)(uintptr_t)getJittedBodyInfo(), cg());
         prev->setNeedsAOTRelocation();
     }
 
@@ -145,7 +144,7 @@ TR::Instruction *TR_X86Recompilation::generatePrePrologue()
     // even if the linkage is not private, so that all the offsets are
     // predictable.
     //
-    return Inst_Imm(TR::InstOpCode::DDImm4, startNode, 0, cg());
+    return Inst_Imm(OP::DDImm4, startNode, 0, cg());
 }
 
 TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)
@@ -162,8 +161,8 @@ TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)
                 TR_ASSERT(linkage->getMinimumFirstInstructionSize() <= 10,
                     "Can't satisfy first instruction size constraint");
                 TR::RealRegister *scratchReg = machine->getRealRegister(TR::RealRegister::edi);
-                cursor = new (trHeapMemory()) TR::AMD64RegImm64Instruction(cursor, TR::InstOpCode::MOV8RegImm64,
-                    scratchReg, (uintptr_t)getCounterAddress(), cg());
+                cursor = new (trHeapMemory()) TR::AMD64RegImm64Instruction(cursor, OP::MOV8RegImm64, scratchReg,
+                    (uintptr_t)getCounterAddress(), cg());
                 mRef = MRef_Bdisp32(scratchReg, 0, cg());
             } else {
                 TR_ASSERT(linkage->getMinimumFirstInstructionSize() <= 5,
@@ -172,20 +171,18 @@ TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)
             }
 
             if (!isProfilingCompilation())
-                cursor
-                    = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, TR::InstOpCode::SUB4MemImms, mRef, 1, cg());
+                cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, OP::SUB4MemImms, mRef, 1, cg());
             else {
                 // This only applies to JitProfiling, as JProfiling uses sampling
                 TR_ASSERT(_compilation->getProfilingMode() == JitProfiling,
                     "JProfiling should not use counting mechanism to trigger recompilation");
-                cursor
-                    = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, TR::InstOpCode::CMP4MemImms, mRef, 0, cg());
+                cursor = new (trHeapMemory()) TR::X86MemImmInstruction(cursor, OP::CMP4MemImms, mRef, 0, cg());
             }
 
             TR::Instruction *counterInstruction = cursor;
             TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
 
-            cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, TR::InstOpCode::JL4, snippetLabel, cg());
+            cursor = new (trHeapMemory()) TR::X86LabelInstruction(cursor, OP::JL4, snippetLabel, cg());
             ((TR::X86LabelInstruction *)cursor)->prohibitShortening();
             TR::Snippet *snippet
                 = new (trHeapMemory()) TR::X86RecompilationSnippet(snippetLabel, counterInstruction->getNode(), cg());

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -164,11 +164,11 @@ TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)
                 TR::RealRegister *scratchReg = machine->getRealRegister(TR::RealRegister::edi);
                 cursor = new (trHeapMemory()) TR::AMD64RegImm64Instruction(cursor, TR::InstOpCode::MOV8RegImm64,
                     scratchReg, (uintptr_t)getCounterAddress(), cg());
-                mRef = generateX86MemoryReference(scratchReg, 0, cg());
+                mRef = MRef_Bdisp32(scratchReg, 0, cg());
             } else {
                 TR_ASSERT(linkage->getMinimumFirstInstructionSize() <= 5,
                     "Can't satisfy first instruction size constraint");
-                mRef = generateX86MemoryReference((intptr_t)getCounterAddress(), cg());
+                mRef = MRef_abs((intptr_t)getCounterAddress(), cg());
             }
 
             if (!isProfilingCompilation())

--- a/runtime/compiler/x/codegen/X86Recompilation.cpp
+++ b/runtime/compiler/x/codegen/X86Recompilation.cpp
@@ -105,7 +105,7 @@ TR::Instruction *TR_X86Recompilation::generatePrePrologue()
         //
         prev = cg()->generateSwitchToInterpreterPrePrologue(prev, alignmentBoundary, alignmentMargin);
     } else {
-        prev = generateAlignmentInstruction(prev, alignmentBoundary, alignmentMargin, cg());
+        prev = Inst_Alignment(prev, alignmentBoundary, alignmentMargin, cg());
     }
 
     if (cg()->comp()->target().is64Bit()) {
@@ -120,7 +120,7 @@ TR::Instruction *TR_X86Recompilation::generatePrePrologue()
         // 4-byte boundary, which is more than enough to ensure it can be patched
         // atomically.
         //
-        prev = generateHelperCallInstruction(prev, SAMPLING_RECOMPILE_METHOD, cg());
+        prev = Inst_HelperCall(prev, SAMPLING_RECOMPILE_METHOD, cg());
     }
 
     // The address of the persistent method info is inserted in the pre-prologue
@@ -145,7 +145,7 @@ TR::Instruction *TR_X86Recompilation::generatePrePrologue()
     // even if the linkage is not private, so that all the offsets are
     // predictable.
     //
-    return generateImmInstruction(TR::InstOpCode::DDImm4, startNode, 0, cg());
+    return Inst_Imm(TR::InstOpCode::DDImm4, startNode, 0, cg());
 }
 
 TR::Instruction *TR_X86Recompilation::generatePrologue(TR::Instruction *cursor)

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -84,10 +84,10 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, callNode, begLabel, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, begLabel, cg());
 
     // Save VFP
-    TR::X86VFPSaveInstruction *vfpSave = generateVFPSaveInstruction(callNode, cg());
+    TR::X86VFPSaveInstruction *vfpSave = Inst_VFPSave(callNode, cg());
 
     TR::J9LinkageUtils::switchToMachineCStack(callNode, cg());
 
@@ -103,11 +103,9 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
     TR::RegisterDependencyConditions *dummy = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)0, cg());
 
     // Call-out
-    generateRegImmInstruction(argSize >= -128 && argSize <= 127 ? TR::InstOpCode::SUB4RegImms
-                                                                : TR::InstOpCode::SUB4RegImm4,
-        callNode, espReal, argSize, cg());
-    generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(),
-        methodSymRef, cg());
+    Inst_RegImm(argSize >= -128 && argSize <= 127 ? TR::InstOpCode::SUB4RegImms : TR::InstOpCode::SUB4RegImm4, callNode,
+        espReal, argSize, cg());
+    Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, cg());
 
     if (returnReg && !(methodSymbol->isHelper()))
         TR::J9LinkageUtils::cleanupReturnValue(callNode, returnReg, returnReg, cg());
@@ -115,8 +113,8 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
     TR::J9LinkageUtils::switchToJavaStack(callNode, cg());
 
     // Restore VFP
-    generateVFPRestoreInstruction(vfpSave, callNode, cg());
-    generateLabelInstruction(TR::InstOpCode::label, callNode, endLabel, deps, cg());
+    Inst_VFPRestore(vfpSave, callNode, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, endLabel, deps, cg());
 
     // Stop using the killed registers that are not going to persist
     //
@@ -148,12 +146,12 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
     }
     // Load C Stack Pointer
     auto cSP = cg()->allocateRegister();
-    generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, cSP,
+    Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, cSP,
         MRef_Bdisp32(cg()->getVMThreadRegister(), fej9->thisThreadGetMachineSPOffset(), cg()), cg());
     // Pass in the env to the jni method as the lexically first arg.
     if (passVMThread) {
         auto slot = MRef_Bdisp32(cSP, 0, cg());
-        generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, cg()->getVMThreadRegister(), cg());
+        Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, cg()->getVMThreadRegister(), cg());
         paramsSlotsOnStack.push(slot);
     }
     // Evaluate params
@@ -166,43 +164,41 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
             case TR::Int8:
             case TR::Int16:
             case TR::Int32:
-                generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
+                Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
                 break;
             case TR::Address:
                 if (wrapAddress && child->getOpCodeValue() == TR::loadaddr) {
                     TR::StaticSymbol *sym = child->getSymbolReference()->getSymbol()->getStaticSymbol();
                     if (sym && sym->isAddressOfClassObject()) {
-                        generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
+                        Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
                     } else // must be loadaddr of parm or local
                     {
                         TR::Register *tmp = cg()->allocateRegister();
-                        generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, child, tmp, tmp, cg());
-                        generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, child,
-                            MRef_Bdisp32(child->getRegister(), 0, cg()), 0, cg());
-                        generateRegRegInstruction(TR::InstOpCode::CMOVNE4RegReg, child, tmp, child->getRegister(),
+                        Inst_RegReg(TR::InstOpCode::XOR4RegReg, child, tmp, tmp, cg());
+                        Inst_MemImm(TR::InstOpCode::CMP4MemImms, child, MRef_Bdisp32(child->getRegister(), 0, cg()), 0,
                             cg());
-                        generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, tmp, cg());
+                        Inst_RegReg(TR::InstOpCode::CMOVNE4RegReg, child, tmp, child->getRegister(), cg());
+                        Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, tmp, cg());
                         cg()->stopUsingRegister(tmp);
                     }
                 } else {
-                    generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
+                    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
                 }
                 break;
             case TR::Int64:
-                generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, param->getLowOrder(), cg());
+                Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param->getLowOrder(), cg());
                 {
                     auto highslot = MRef_Bdisp32(cSP, 0, cg());
                     paramsSlotsOnStack.push(highslot);
-                    generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, highslot, param->getHighOrder(),
-                        cg());
+                    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, highslot, param->getHighOrder(), cg());
                 }
                 break;
             case TR::Float:
-                generateMemRegInstruction(TR::InstOpCode::MOVSSMemReg, callNode, slot, param, cg());
+                Inst_MemReg(TR::InstOpCode::MOVSSMemReg, callNode, slot, param, cg());
                 break;
             case TR::Double:
                 paramsSlotsOnStack.push(NULL);
-                generateMemRegInstruction(TR::InstOpCode::MOVSDMemReg, callNode, slot, param, cg());
+                Inst_MemReg(TR::InstOpCode::MOVSDMemReg, callNode, slot, param, cg());
                 break;
         }
         cg()->decReferenceCount(child);

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -84,7 +84,7 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, callNode, begLabel, cg());
+    Inst_Label(OP::label, callNode, begLabel, cg());
 
     // Save VFP
     TR::X86VFPSaveInstruction *vfpSave = Inst_VFPSave(callNode, cg());
@@ -103,9 +103,9 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
     TR::RegisterDependencyConditions *dummy = RegDeps((uint8_t)0, (uint8_t)0, cg());
 
     // Call-out
-    Inst_RegImm(argSize >= -128 && argSize <= 127 ? TR::InstOpCode::SUB4RegImms : TR::InstOpCode::SUB4RegImm4, callNode,
-        espReal, argSize, cg());
-    Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, cg());
+    Inst_RegImm(argSize >= -128 && argSize <= 127 ? OP::SUB4RegImms : OP::SUB4RegImm4, callNode, espReal, argSize,
+        cg());
+    Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)methodSymbol->getMethodAddress(), methodSymRef, cg());
 
     if (returnReg && !(methodSymbol->isHelper()))
         TR::J9LinkageUtils::cleanupReturnValue(callNode, returnReg, returnReg, cg());
@@ -114,7 +114,7 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
 
     // Restore VFP
     Inst_VFPRestore(vfpSave, callNode, cg());
-    Inst_Label(TR::InstOpCode::label, callNode, endLabel, deps, cg());
+    Inst_Label(OP::label, callNode, endLabel, deps, cg());
 
     // Stop using the killed registers that are not going to persist
     //
@@ -146,12 +146,12 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
     }
     // Load C Stack Pointer
     auto cSP = cg()->allocateRegister();
-    Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, cSP,
+    Inst_RegMem(OP::L4RegMem, callNode, cSP,
         MRef_Bdisp32(cg()->getVMThreadRegister(), fej9->thisThreadGetMachineSPOffset(), cg()), cg());
     // Pass in the env to the jni method as the lexically first arg.
     if (passVMThread) {
         auto slot = MRef_Bdisp32(cSP, 0, cg());
-        Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, cg()->getVMThreadRegister(), cg());
+        Inst_MemReg(OP::S4MemReg, callNode, slot, cg()->getVMThreadRegister(), cg());
         paramsSlotsOnStack.push(slot);
     }
     // Evaluate params
@@ -164,41 +164,40 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
             case TR::Int8:
             case TR::Int16:
             case TR::Int32:
-                Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
+                Inst_MemReg(OP::S4MemReg, callNode, slot, param, cg());
                 break;
             case TR::Address:
                 if (wrapAddress && child->getOpCodeValue() == TR::loadaddr) {
                     TR::StaticSymbol *sym = child->getSymbolReference()->getSymbol()->getStaticSymbol();
                     if (sym && sym->isAddressOfClassObject()) {
-                        Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
+                        Inst_MemReg(OP::S4MemReg, callNode, slot, param, cg());
                     } else // must be loadaddr of parm or local
                     {
                         TR::Register *tmp = cg()->allocateRegister();
-                        Inst_RegReg(TR::InstOpCode::XOR4RegReg, child, tmp, tmp, cg());
-                        Inst_MemImm(TR::InstOpCode::CMP4MemImms, child, MRef_Bdisp32(child->getRegister(), 0, cg()), 0,
-                            cg());
-                        Inst_RegReg(TR::InstOpCode::CMOVNE4RegReg, child, tmp, child->getRegister(), cg());
-                        Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, tmp, cg());
+                        Inst_RegReg(OP::XOR4RegReg, child, tmp, tmp, cg());
+                        Inst_MemImm(OP::CMP4MemImms, child, MRef_Bdisp32(child->getRegister(), 0, cg()), 0, cg());
+                        Inst_RegReg(OP::CMOVNE4RegReg, child, tmp, child->getRegister(), cg());
+                        Inst_MemReg(OP::S4MemReg, callNode, slot, tmp, cg());
                         cg()->stopUsingRegister(tmp);
                     }
                 } else {
-                    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param, cg());
+                    Inst_MemReg(OP::S4MemReg, callNode, slot, param, cg());
                 }
                 break;
             case TR::Int64:
-                Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, slot, param->getLowOrder(), cg());
+                Inst_MemReg(OP::S4MemReg, callNode, slot, param->getLowOrder(), cg());
                 {
                     auto highslot = MRef_Bdisp32(cSP, 0, cg());
                     paramsSlotsOnStack.push(highslot);
-                    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, highslot, param->getHighOrder(), cg());
+                    Inst_MemReg(OP::S4MemReg, callNode, highslot, param->getHighOrder(), cg());
                 }
                 break;
             case TR::Float:
-                Inst_MemReg(TR::InstOpCode::MOVSSMemReg, callNode, slot, param, cg());
+                Inst_MemReg(OP::MOVSSMemReg, callNode, slot, param, cg());
                 break;
             case TR::Double:
                 paramsSlotsOnStack.push(NULL);
-                Inst_MemReg(TR::InstOpCode::MOVSDMemReg, callNode, slot, param, cg());
+                Inst_MemReg(OP::MOVSDMemReg, callNode, slot, param, cg());
                 break;
         }
         cg()->decReferenceCount(child);

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -97,10 +97,10 @@ TR::Register *TR::IA32J9SystemLinkage::buildDirectDispatch(TR::Node *callNode, b
         numXmmRegs = (uint8_t)(machine()->getLastXMMR() - machine()->getFirstXMMR() + 1);
 
     TR::RegisterDependencyConditions *deps;
-    deps = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)6 + numXmmRegs, cg());
+    deps = RegDeps((uint8_t)0, (uint8_t)6 + numXmmRegs, cg());
     TR::Register *returnReg = buildVolatileAndReturnDependencies(callNode, deps);
 
-    TR::RegisterDependencyConditions *dummy = generateRegisterDependencyConditions((uint8_t)0, (uint8_t)0, cg());
+    TR::RegisterDependencyConditions *dummy = RegDeps((uint8_t)0, (uint8_t)0, cg());
 
     // Call-out
     Inst_RegImm(argSize >= -128 && argSize <= 127 ? TR::InstOpCode::SUB4RegImms : TR::InstOpCode::SUB4RegImm4, callNode,

--- a/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32J9SystemLinkage.cpp
@@ -149,10 +149,10 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
     // Load C Stack Pointer
     auto cSP = cg()->allocateRegister();
     generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, cSP,
-        generateX86MemoryReference(cg()->getVMThreadRegister(), fej9->thisThreadGetMachineSPOffset(), cg()), cg());
+        MRef_Bdisp32(cg()->getVMThreadRegister(), fej9->thisThreadGetMachineSPOffset(), cg()), cg());
     // Pass in the env to the jni method as the lexically first arg.
     if (passVMThread) {
-        auto slot = generateX86MemoryReference(cSP, 0, cg());
+        auto slot = MRef_Bdisp32(cSP, 0, cg());
         generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, cg()->getVMThreadRegister(), cg());
         paramsSlotsOnStack.push(slot);
     }
@@ -160,7 +160,7 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
     for (size_t i = firstParamIndex; i < callNode->getNumChildren(); i++) {
         auto child = callNode->getChild(i);
         auto param = cg()->evaluate(child);
-        auto slot = generateX86MemoryReference(cSP, 0, cg());
+        auto slot = MRef_Bdisp32(cSP, 0, cg());
         paramsSlotsOnStack.push(slot);
         switch (child->getDataType()) {
             case TR::Int8:
@@ -178,7 +178,7 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
                         TR::Register *tmp = cg()->allocateRegister();
                         generateRegRegInstruction(TR::InstOpCode::XOR4RegReg, child, tmp, tmp, cg());
                         generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, child,
-                            generateX86MemoryReference(child->getRegister(), 0, cg()), 0, cg());
+                            MRef_Bdisp32(child->getRegister(), 0, cg()), 0, cg());
                         generateRegRegInstruction(TR::InstOpCode::CMOVNE4RegReg, child, tmp, child->getRegister(),
                             cg());
                         generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, tmp, cg());
@@ -191,7 +191,7 @@ int32_t TR::IA32J9SystemLinkage::buildParametersOnCStack(TR::Node *callNode, int
             case TR::Int64:
                 generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, slot, param->getLowOrder(), cg());
                 {
-                    auto highslot = generateX86MemoryReference(cSP, 0, cg());
+                    auto highslot = MRef_Bdisp32(cSP, 0, cg());
                     paramsSlotsOnStack.push(highslot);
                     generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode, highslot, param->getHighOrder(),
                         cg());

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -102,7 +102,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    Inst_Label(TR::InstOpCode::label, callNode, begLabel, cg());
+    Inst_Label(OP::label, callNode, begLabel, cg());
 
     // Save VFP
     TR::X86VFPSaveInstruction *vfpSave = Inst_VFPSave(callNode, cg());
@@ -115,8 +115,8 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
         // Begin: mask out the magic bit that indicates JIT frames below
         //
-        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
-            MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
+        Inst_MemImm(OP::S4MemImm4, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0,
+            cg());
         // End: mask out the magic bit that indicates JIT frames below
 
         ebxReal->setHasBeenAssignedInMethod(true);
@@ -134,21 +134,20 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
         // Push tag bits (savedA0 slot).
         //
-        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, tagBits, cg());
+        Inst_Imm(OP::PUSHImm4, callNode, tagBits, cg());
 
         // Allocate space to get to frame size for special frames (skip savedPC slot).
         //
-        Inst_RegImm(TR::InstOpCode::SUB4RegImms, callNode, espReal, 4, cg());
+        Inst_RegImm(OP::SUB4RegImms, callNode, espReal, 4, cg());
 
         // Push return address in this frame (savedCP slot).
         //
-        TR::X86LabelInstruction *returnAddrLabelInstruction
-            = Inst_Label(TR::InstOpCode::PUSHImm4, callNode, returnAddrLabel, cg());
+        TR::X86LabelInstruction *returnAddrLabelInstruction = Inst_Label(OP::PUSHImm4, callNode, returnAddrLabel, cg());
         returnAddrLabelInstruction->setReloType(TR_AbsoluteMethodAddress);
 
         // Push frame flags.
         //
-        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, fej9->constJNICallOutFrameFlags(), cg());
+        Inst_Imm(OP::PUSHImm4, callNode, fej9->constJNICallOutFrameFlags(), cg());
 
         // Push the RAM method for the native.
         //
@@ -156,34 +155,32 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
             TR_NoRelocation /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst };
         int rType = resolvedMethodSymbol->getMethodKind() - 1; // method kinds are 1-based
         TR_ASSERT(reloTypes[rType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
-        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, (uintptr_t)resolvedMethod->resolvedMethodAddress(), cg(),
-            reloTypes[rType]);
+        Inst_Imm(OP::PUSHImm4, callNode, (uintptr_t)resolvedMethod->resolvedMethodAddress(), cg(), reloTypes[rType]);
 
         // Store out pc and literals values indicating the callout frame.
         //
-        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaPCOffset(), cg()),
+        Inst_MemImm(OP::S4MemImm4, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaPCOffset(), cg()),
             fej9->constJNICallOutFrameType(), cg());
-        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
-            MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
+        Inst_MemImm(OP::S4MemImm4, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0,
+            cg());
     }
 
     // Store out jsp.
     //
-    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()),
-        espReal, cg());
+    Inst_MemReg(OP::S4MemReg, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), espReal, cg());
 
     // Switch stacks.
     // Load up machine SP.
     //
-    Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, espReal,
+    Inst_RegMem(OP::L4RegMem, callNode, espReal,
         MRef_Bdisp32(ebpReal, ((TR_J9VMBase *)fej9)->thisThreadGetMachineSPOffset(), cg()), cg());
 
     // Save ESP to EDI, a callee preserved register
     // It is necessary because the JNI method may be either caller-cleanup or callee-cleanup
     TR::Register *ediReal = cg()->allocateRegister();
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, callNode, ediReal, espReal, cg());
-    Inst_RegImm(argSize >= -128 && argSize <= 127 ? TR::InstOpCode::SUB4RegImms : TR::InstOpCode::SUB4RegImm4, callNode,
-        espReal, argSize, cg());
+    Inst_RegReg(OP::MOV4RegReg, callNode, ediReal, espReal, cg());
+    Inst_RegImm(argSize >= -128 && argSize <= 127 ? OP::SUB4RegImms : OP::SUB4RegImm4, callNode, espReal, argSize,
+        cg());
 
     // We have to be careful to allocate the return register after the
     // dependency conditions for the other killed registers have been set up,
@@ -236,34 +233,34 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     }
 
     if (dropVMAccess) {
-        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
-            MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
+        Inst_MemImm(OP::S4MemImm4, callNode, MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 1,
+            cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
         TR::MemoryReference *mr = MRef_Bdisp32(espReal, intptr_t(0), cg());
         mr->setRequiresLockPrefix();
-        Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+        Inst_MemImm(OP::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
         TR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
         TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
 
         static_assert(J9_PUBLIC_FLAGS_VM_ACCESS <= 0x7fffffff, "VM access bit must be immediate");
-        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
-            MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-        Inst_Label(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
-        Inst_Label(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
+        Inst_MemImm(OP::CMP4MemImm4, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()),
+            J9_PUBLIC_FLAGS_VM_ACCESS, cg());
+        Inst_Label(OP::JNE4, callNode, longReleaseSnippetLabel, cg());
+        Inst_Label(OP::label, callNode, longReleaseRestartLabel, cg());
 
         TR_OutlinedInstructionsGenerator og(longReleaseSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getMethodSymbol());
-        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-        Inst_Label(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
+        Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(OP::JMP4, callNode, longReleaseRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
 
     // Dispatch jni method directly.
     //
-    TR::Instruction *instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode,
+    TR::Instruction *instr = Inst_ImmSym(OP::CALLImm4, callNode,
         (uintptr_t)resolvedMethodSymbol->getResolvedMethod()->startAddressForJNIMethod(comp()),
         callNode->getSymbolReference(), cg());
 
@@ -278,10 +275,10 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
     // Lay down a label for the frame push to reference.
     //
-    Inst_Label(TR::InstOpCode::label, callNode, returnAddrLabel, cg());
+    Inst_Label(OP::label, callNode, returnAddrLabel, cg());
 
     // Restore stack pointer
-    Inst_RegReg(TR::InstOpCode::MOV4RegReg, callNode, espReal, ediReal, cg());
+    Inst_RegReg(OP::MOV4RegReg, callNode, espReal, ediReal, cg());
     cg()->stopUsingRegister(ediReal);
 
     // Need to squirrel away the return value for some data types to avoid register
@@ -298,48 +295,47 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
             if (isBoolean) {
                 // For bool return type, must check whether value returned by
                 // JNI is zero (false) or non-zero (true) to yield Java result
-                Inst_RegReg(TR::InstOpCode::TEST1RegReg, callNode, eaxReal, eaxReal, cg());
-                Inst_Reg(TR::InstOpCode::SETNE1Reg, callNode, eaxReal, cg());
+                Inst_RegReg(OP::TEST1RegReg, callNode, eaxReal, eaxReal, cg());
+                Inst_Reg(OP::SETNE1Reg, callNode, eaxReal, cg());
             }
-            Inst_RegReg((isUnsigned || isBoolean) ? TR::InstOpCode::MOVZXReg4Reg1 : TR::InstOpCode::MOVSXReg4Reg1,
-                callNode, ecxReal, eaxReal, cg());
+            Inst_RegReg((isUnsigned || isBoolean) ? OP::MOVZXReg4Reg1 : OP::MOVSXReg4Reg1, callNode, ecxReal, eaxReal,
+                cg());
             break;
         case TR::Int16:
-            Inst_RegReg(isUnsigned ? TR::InstOpCode::MOVZXReg4Reg2 : TR::InstOpCode::MOVSXReg4Reg2, callNode, ecxReal,
-                eaxReal, cg());
+            Inst_RegReg(isUnsigned ? OP::MOVZXReg4Reg2 : OP::MOVSXReg4Reg2, callNode, ecxReal, eaxReal, cg());
             break;
         case TR::Address:
         case TR::Int64:
         case TR::Int32:
-            Inst_RegReg(TR::InstOpCode::MOV4RegReg, callNode, ecxReal, eaxReal, cg());
+            Inst_RegReg(OP::MOV4RegReg, callNode, ecxReal, eaxReal, cg());
             break;
     }
 
     if (dropVMAccess) {
         // Re-acquire vm access.
         //
-        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
-            MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
+        Inst_MemImm(OP::S4MemImm4, callNode, MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 0,
+            cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
         TR::MemoryReference *mr = MRef_Bdisp32(espReal, intptr_t(0), cg());
         mr->setRequiresLockPrefix();
-        Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+        Inst_MemImm(OP::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
         TR::LabelSymbol *longAcquireSnippetLabel = generateLabelSymbol(cg());
         TR::LabelSymbol *longAcquireRestartLabel = generateLabelSymbol(cg());
 
         static_assert(J9_PUBLIC_FLAGS_VM_ACCESS <= 0x7fffffff, "VM access bit must be immediate");
-        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
-            MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-        Inst_Label(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
-        Inst_Label(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
+        Inst_MemImm(OP::CMP4MemImm4, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()),
+            J9_PUBLIC_FLAGS_VM_ACCESS, cg());
+        Inst_Label(OP::JNE4, callNode, longAcquireSnippetLabel, cg());
+        Inst_Label(OP::label, callNode, longAcquireRestartLabel, cg());
 
         TR_OutlinedInstructionsGenerator og(longAcquireSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getMethodSymbol());
-        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
-        Inst_Label(TR::InstOpCode::JMP4, callNode, longAcquireRestartLabel, cg());
+        Inst_ImmSym(OP::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(OP::JMP4, callNode, longAcquireRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
 
@@ -347,26 +343,25 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
         // Unless NULL, need to indirect once to get the real java reference
         //
         TR::LabelSymbol *tempLab = generateLabelSymbol(cg());
-        Inst_RegReg(TR::InstOpCode::TEST4RegReg, callNode, ecxReal, ecxReal, cg());
-        Inst_Label(TR::InstOpCode::JE4, callNode, tempLab, cg());
-        Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, ecxReal, MRef_Bdisp32(ecxReal, 0, cg()), cg());
-        Inst_Label(TR::InstOpCode::label, callNode, tempLab, cg());
+        Inst_RegReg(OP::TEST4RegReg, callNode, ecxReal, ecxReal, cg());
+        Inst_Label(OP::JE4, callNode, tempLab, cg());
+        Inst_RegMem(OP::L4RegMem, callNode, ecxReal, MRef_Bdisp32(ecxReal, 0, cg()), cg());
+        Inst_Label(OP::label, callNode, tempLab, cg());
     }
 
     // Switch stacks back.
     // First store out the machine sp into the vm thread.  It has to be done as sometimes
     // it gets tromped on by call backs.
     //
-    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetMachineSPOffset(), cg()),
-        espReal, cg());
+    Inst_MemReg(OP::S4MemReg, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetMachineSPOffset(), cg()), espReal,
+        cg());
 
     // Next load up the java sp so we have the callout frame on top of the java stack.
     //
-    Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, espReal,
-        MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), cg());
+    Inst_RegMem(OP::L4RegMem, callNode, espReal, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), cg());
 
     if (createJNIFrame) {
-        Inst_RegMem(TR::InstOpCode::ADD4RegMem, callNode, espReal,
+        Inst_RegMem(OP::ADD4RegMem, callNode, espReal,
             MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
 
         if (tearDownJNIFrame) {
@@ -374,24 +369,23 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
             // leave a bunch of pinned garbage behind that screws up the gc quality forever.
             //
             uint32_t flagValue = fej9->constJNIReferenceFrameAllocatedFlags();
-            TR::InstOpCode::Mnemonic op
-                = flagValue <= 255 ? TR::InstOpCode::TEST1MemImm1 : TR::InstOpCode::TEST4MemImm4;
+            OP::Mnemonic op = flagValue <= 255 ? OP::TEST1MemImm1 : OP::TEST4MemImm4;
             TR::LabelSymbol *refPoolSnippetLabel = generateLabelSymbol(cg());
             TR::LabelSymbol *refPoolRestartLabel = generateLabelSymbol(cg());
             Inst_MemImm(op, callNode, MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()), flagValue,
                 cg());
-            Inst_Label(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
-            Inst_Label(TR::InstOpCode::label, callNode, refPoolRestartLabel, cg());
+            Inst_Label(OP::JNE4, callNode, refPoolSnippetLabel, cg());
+            Inst_Label(OP::label, callNode, refPoolRestartLabel, cg());
 
             TR_OutlinedInstructionsGenerator og(refPoolSnippetLabel, callNode, cg());
             Inst_HelperCall(callNode, TR_IA32jitCollapseJNIReferenceFrame, NULL, cg());
-            Inst_Label(TR::InstOpCode::JMP4, callNode, refPoolRestartLabel, cg());
+            Inst_Label(OP::JMP4, callNode, refPoolRestartLabel, cg());
             og.endOutlinedInstructionSequence();
         }
 
         // Now set esp back to its previous value.
         //
-        Inst_RegImm(TR::InstOpCode::ADD4RegImms, callNode, espReal, 20, cg());
+        Inst_RegImm(OP::ADD4RegImms, callNode, espReal, 20, cg());
     }
 
     // Get return registers set up before preserved regs are restored.
@@ -423,10 +417,10 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     if (checkExceptions) {
         // Check exceptions.
         //
-        Inst_MemImm(TR::InstOpCode::CMP4MemImms, callNode,
-            MRef_Bdisp32(ebpReal, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
+        Inst_MemImm(OP::CMP4MemImms, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetCurrentExceptionOffset(), cg()),
+            0, cg());
         TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
-        instr = Inst_Label(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
+        instr = Inst_Label(OP::JNE4, callNode, snippetLabel, cg());
         instr->setNeedsGCMap((argSize << 14) | 0xFF00FFFF);
 
         TR::Snippet *snippet = new (trHeapMemory())
@@ -437,7 +431,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
     // Restore VFP
     Inst_VFPRestore(vfpSave, callNode, cg());
-    Inst_Label(TR::InstOpCode::label, callNode, endLabel, deps, cg());
+    Inst_Label(OP::label, callNode, endLabel, deps, cg());
 
     // Stop using the killed registers that are not going to persist.
     //

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -102,10 +102,10 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     begLabel->setStartInternalControlFlow();
     endLabel->setEndInternalControlFlow();
 
-    generateLabelInstruction(TR::InstOpCode::label, callNode, begLabel, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, begLabel, cg());
 
     // Save VFP
-    TR::X86VFPSaveInstruction *vfpSave = generateVFPSaveInstruction(callNode, cg());
+    TR::X86VFPSaveInstruction *vfpSave = Inst_VFPSave(callNode, cg());
 
     returnAddrLabel = generateLabelSymbol(cg());
     if (createJNIFrame) {
@@ -115,7 +115,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
         // Begin: mask out the magic bit that indicates JIT frames below
         //
-        generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
             MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
         // End: mask out the magic bit that indicates JIT frames below
 
@@ -134,21 +134,21 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
         // Push tag bits (savedA0 slot).
         //
-        generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, tagBits, cg());
+        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, tagBits, cg());
 
         // Allocate space to get to frame size for special frames (skip savedPC slot).
         //
-        generateRegImmInstruction(TR::InstOpCode::SUB4RegImms, callNode, espReal, 4, cg());
+        Inst_RegImm(TR::InstOpCode::SUB4RegImms, callNode, espReal, 4, cg());
 
         // Push return address in this frame (savedCP slot).
         //
         TR::X86LabelInstruction *returnAddrLabelInstruction
-            = generateLabelInstruction(TR::InstOpCode::PUSHImm4, callNode, returnAddrLabel, cg());
+            = Inst_Label(TR::InstOpCode::PUSHImm4, callNode, returnAddrLabel, cg());
         returnAddrLabelInstruction->setReloType(TR_AbsoluteMethodAddress);
 
         // Push frame flags.
         //
-        generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, fej9->constJNICallOutFrameFlags(), cg());
+        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, fej9->constJNICallOutFrameFlags(), cg());
 
         // Push the RAM method for the native.
         //
@@ -156,35 +156,34 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
             TR_NoRelocation /*Interfaces*/, TR_StaticRamMethodConst, TR_SpecialRamMethodConst };
         int rType = resolvedMethodSymbol->getMethodKind() - 1; // method kinds are 1-based
         TR_ASSERT(reloTypes[rType] != TR_NoRelocation, "There shouldn't be direct JNI interface calls!");
-        generateImmInstruction(TR::InstOpCode::PUSHImm4, callNode, (uintptr_t)resolvedMethod->resolvedMethodAddress(),
-            cg(), reloTypes[rType]);
+        Inst_Imm(TR::InstOpCode::PUSHImm4, callNode, (uintptr_t)resolvedMethod->resolvedMethodAddress(), cg(),
+            reloTypes[rType]);
 
         // Store out pc and literals values indicating the callout frame.
         //
-        generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
-            MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaPCOffset(), cg()), fej9->constJNICallOutFrameType(), cg());
-        generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaPCOffset(), cg()),
+            fej9->constJNICallOutFrameType(), cg());
+        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
             MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
     }
 
     // Store out jsp.
     //
-    generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode,
-        MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), espReal, cg());
+    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()),
+        espReal, cg());
 
     // Switch stacks.
     // Load up machine SP.
     //
-    generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, espReal,
+    Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, espReal,
         MRef_Bdisp32(ebpReal, ((TR_J9VMBase *)fej9)->thisThreadGetMachineSPOffset(), cg()), cg());
 
     // Save ESP to EDI, a callee preserved register
     // It is necessary because the JNI method may be either caller-cleanup or callee-cleanup
     TR::Register *ediReal = cg()->allocateRegister();
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, callNode, ediReal, espReal, cg());
-    generateRegImmInstruction(argSize >= -128 && argSize <= 127 ? TR::InstOpCode::SUB4RegImms
-                                                                : TR::InstOpCode::SUB4RegImm4,
-        callNode, espReal, argSize, cg());
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, callNode, ediReal, espReal, cg());
+    Inst_RegImm(argSize >= -128 && argSize <= 127 ? TR::InstOpCode::SUB4RegImms : TR::InstOpCode::SUB4RegImm4, callNode,
+        espReal, argSize, cg());
 
     // We have to be careful to allocate the return register after the
     // dependency conditions for the other killed registers have been set up,
@@ -237,35 +236,34 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     }
 
     if (dropVMAccess) {
-        generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
             MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
         TR::MemoryReference *mr = MRef_Bdisp32(espReal, intptr_t(0), cg());
         mr->setRequiresLockPrefix();
-        generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+        Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
         TR::LabelSymbol *longReleaseSnippetLabel = generateLabelSymbol(cg());
         TR::LabelSymbol *longReleaseRestartLabel = generateLabelSymbol(cg());
 
         static_assert(J9_PUBLIC_FLAGS_VM_ACCESS <= 0x7fffffff, "VM access bit must be immediate");
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
             MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-        generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
-        generateLabelInstruction(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
+        Inst_Label(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
+        Inst_Label(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
 
         TR_OutlinedInstructionsGenerator og(longReleaseSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateReleaseVMAccessSymbolRef(comp()->getMethodSymbol());
-        generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper,
-            cg());
-        generateLabelInstruction(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
+        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(TR::InstOpCode::JMP4, callNode, longReleaseRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
 
     // Dispatch jni method directly.
     //
-    TR::Instruction *instr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode,
+    TR::Instruction *instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode,
         (uintptr_t)resolvedMethodSymbol->getResolvedMethod()->startAddressForJNIMethod(comp()),
         callNode->getSymbolReference(), cg());
 
@@ -280,10 +278,10 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
     // Lay down a label for the frame push to reference.
     //
-    generateLabelInstruction(TR::InstOpCode::label, callNode, returnAddrLabel, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, returnAddrLabel, cg());
 
     // Restore stack pointer
-    generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, callNode, espReal, ediReal, cg());
+    Inst_RegReg(TR::InstOpCode::MOV4RegReg, callNode, espReal, ediReal, cg());
     cg()->stopUsingRegister(ediReal);
 
     // Need to squirrel away the return value for some data types to avoid register
@@ -300,50 +298,48 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
             if (isBoolean) {
                 // For bool return type, must check whether value returned by
                 // JNI is zero (false) or non-zero (true) to yield Java result
-                generateRegRegInstruction(TR::InstOpCode::TEST1RegReg, callNode, eaxReal, eaxReal, cg());
-                generateRegInstruction(TR::InstOpCode::SETNE1Reg, callNode, eaxReal, cg());
+                Inst_RegReg(TR::InstOpCode::TEST1RegReg, callNode, eaxReal, eaxReal, cg());
+                Inst_Reg(TR::InstOpCode::SETNE1Reg, callNode, eaxReal, cg());
             }
-            generateRegRegInstruction((isUnsigned || isBoolean) ? TR::InstOpCode::MOVZXReg4Reg1
-                                                                : TR::InstOpCode::MOVSXReg4Reg1,
+            Inst_RegReg((isUnsigned || isBoolean) ? TR::InstOpCode::MOVZXReg4Reg1 : TR::InstOpCode::MOVSXReg4Reg1,
                 callNode, ecxReal, eaxReal, cg());
             break;
         case TR::Int16:
-            generateRegRegInstruction(isUnsigned ? TR::InstOpCode::MOVZXReg4Reg2 : TR::InstOpCode::MOVSXReg4Reg2,
-                callNode, ecxReal, eaxReal, cg());
+            Inst_RegReg(isUnsigned ? TR::InstOpCode::MOVZXReg4Reg2 : TR::InstOpCode::MOVSXReg4Reg2, callNode, ecxReal,
+                eaxReal, cg());
             break;
         case TR::Address:
         case TR::Int64:
         case TR::Int32:
-            generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, callNode, ecxReal, eaxReal, cg());
+            Inst_RegReg(TR::InstOpCode::MOV4RegReg, callNode, ecxReal, eaxReal, cg());
             break;
     }
 
     if (dropVMAccess) {
         // Re-acquire vm access.
         //
-        generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::S4MemImm4, callNode,
             MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
         TR::MemoryReference *mr = MRef_Bdisp32(espReal, intptr_t(0), cg());
         mr->setRequiresLockPrefix();
-        generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
+        Inst_MemImm(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
 
         TR::LabelSymbol *longAcquireSnippetLabel = generateLabelSymbol(cg());
         TR::LabelSymbol *longAcquireRestartLabel = generateLabelSymbol(cg());
 
         static_assert(J9_PUBLIC_FLAGS_VM_ACCESS <= 0x7fffffff, "VM access bit must be immediate");
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
+        Inst_MemImm(TR::InstOpCode::CMP4MemImm4, callNode,
             MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
-        generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
-        generateLabelInstruction(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
+        Inst_Label(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
+        Inst_Label(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
 
         TR_OutlinedInstructionsGenerator og(longAcquireSnippetLabel, callNode, cg());
         auto helper = comp()->getSymRefTab()->findOrCreateAcquireVMAccessSymbolRef(comp()->getMethodSymbol());
-        generateImmSymInstruction(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper,
-            cg());
-        generateLabelInstruction(TR::InstOpCode::JMP4, callNode, longAcquireRestartLabel, cg());
+        Inst_ImmSym(TR::InstOpCode::CALLImm4, callNode, (uintptr_t)helper->getMethodAddress(), helper, cg());
+        Inst_Label(TR::InstOpCode::JMP4, callNode, longAcquireRestartLabel, cg());
         og.endOutlinedInstructionSequence();
     }
 
@@ -351,26 +347,26 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
         // Unless NULL, need to indirect once to get the real java reference
         //
         TR::LabelSymbol *tempLab = generateLabelSymbol(cg());
-        generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, callNode, ecxReal, ecxReal, cg());
-        generateLabelInstruction(TR::InstOpCode::JE4, callNode, tempLab, cg());
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, ecxReal, MRef_Bdisp32(ecxReal, 0, cg()), cg());
-        generateLabelInstruction(TR::InstOpCode::label, callNode, tempLab, cg());
+        Inst_RegReg(TR::InstOpCode::TEST4RegReg, callNode, ecxReal, ecxReal, cg());
+        Inst_Label(TR::InstOpCode::JE4, callNode, tempLab, cg());
+        Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, ecxReal, MRef_Bdisp32(ecxReal, 0, cg()), cg());
+        Inst_Label(TR::InstOpCode::label, callNode, tempLab, cg());
     }
 
     // Switch stacks back.
     // First store out the machine sp into the vm thread.  It has to be done as sometimes
     // it gets tromped on by call backs.
     //
-    generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode,
-        MRef_Bdisp32(ebpReal, fej9->thisThreadGetMachineSPOffset(), cg()), espReal, cg());
+    Inst_MemReg(TR::InstOpCode::S4MemReg, callNode, MRef_Bdisp32(ebpReal, fej9->thisThreadGetMachineSPOffset(), cg()),
+        espReal, cg());
 
     // Next load up the java sp so we have the callout frame on top of the java stack.
     //
-    generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, espReal,
+    Inst_RegMem(TR::InstOpCode::L4RegMem, callNode, espReal,
         MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), cg());
 
     if (createJNIFrame) {
-        generateRegMemInstruction(TR::InstOpCode::ADD4RegMem, callNode, espReal,
+        Inst_RegMem(TR::InstOpCode::ADD4RegMem, callNode, espReal,
             MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
 
         if (tearDownJNIFrame) {
@@ -382,20 +378,20 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
                 = flagValue <= 255 ? TR::InstOpCode::TEST1MemImm1 : TR::InstOpCode::TEST4MemImm4;
             TR::LabelSymbol *refPoolSnippetLabel = generateLabelSymbol(cg());
             TR::LabelSymbol *refPoolRestartLabel = generateLabelSymbol(cg());
-            generateMemImmInstruction(op, callNode,
-                MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()), flagValue, cg());
-            generateLabelInstruction(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
-            generateLabelInstruction(TR::InstOpCode::label, callNode, refPoolRestartLabel, cg());
+            Inst_MemImm(op, callNode, MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()), flagValue,
+                cg());
+            Inst_Label(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
+            Inst_Label(TR::InstOpCode::label, callNode, refPoolRestartLabel, cg());
 
             TR_OutlinedInstructionsGenerator og(refPoolSnippetLabel, callNode, cg());
-            generateHelperCallInstruction(callNode, TR_IA32jitCollapseJNIReferenceFrame, NULL, cg());
-            generateLabelInstruction(TR::InstOpCode::JMP4, callNode, refPoolRestartLabel, cg());
+            Inst_HelperCall(callNode, TR_IA32jitCollapseJNIReferenceFrame, NULL, cg());
+            Inst_Label(TR::InstOpCode::JMP4, callNode, refPoolRestartLabel, cg());
             og.endOutlinedInstructionSequence();
         }
 
         // Now set esp back to its previous value.
         //
-        generateRegImmInstruction(TR::InstOpCode::ADD4RegImms, callNode, espReal, 20, cg());
+        Inst_RegImm(TR::InstOpCode::ADD4RegImms, callNode, espReal, 20, cg());
     }
 
     // Get return registers set up before preserved regs are restored.
@@ -427,10 +423,10 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     if (checkExceptions) {
         // Check exceptions.
         //
-        generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, callNode,
+        Inst_MemImm(TR::InstOpCode::CMP4MemImms, callNode,
             MRef_Bdisp32(ebpReal, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
         TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
-        instr = generateLabelInstruction(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
+        instr = Inst_Label(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
         instr->setNeedsGCMap((argSize << 14) | 0xFF00FFFF);
 
         TR::Snippet *snippet = new (trHeapMemory())
@@ -440,8 +436,8 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     }
 
     // Restore VFP
-    generateVFPRestoreInstruction(vfpSave, callNode, cg());
-    generateLabelInstruction(TR::InstOpCode::label, callNode, endLabel, deps, cg());
+    Inst_VFPRestore(vfpSave, callNode, cg());
+    Inst_Label(TR::InstOpCode::label, callNode, endLabel, deps, cg());
 
     // Stop using the killed registers that are not going to persist.
     //

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -116,7 +116,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
         // Begin: mask out the magic bit that indicates JIT frames below
         //
         generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
-            generateX86MemoryReference(ebpReal, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
+            MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaFrameFlagsOffset(), cg()), 0, cg());
         // End: mask out the magic bit that indicates JIT frames below
 
         ebxReal->setHasBeenAssignedInMethod(true);
@@ -162,22 +162,21 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
         // Store out pc and literals values indicating the callout frame.
         //
         generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
-            generateX86MemoryReference(ebpReal, fej9->thisThreadGetJavaPCOffset(), cg()),
-            fej9->constJNICallOutFrameType(), cg());
+            MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaPCOffset(), cg()), fej9->constJNICallOutFrameType(), cg());
         generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
-            generateX86MemoryReference(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
+            MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), 0, cg());
     }
 
     // Store out jsp.
     //
     generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode,
-        generateX86MemoryReference(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), espReal, cg());
+        MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), espReal, cg());
 
     // Switch stacks.
     // Load up machine SP.
     //
     generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, espReal,
-        generateX86MemoryReference(ebpReal, ((TR_J9VMBase *)fej9)->thisThreadGetMachineSPOffset(), cg()), cg());
+        MRef_Bdisp32(ebpReal, ((TR_J9VMBase *)fej9)->thisThreadGetMachineSPOffset(), cg()), cg());
 
     // Save ESP to EDI, a callee preserved register
     // It is necessary because the JNI method may be either caller-cleanup or callee-cleanup
@@ -239,10 +238,10 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
     if (dropVMAccess) {
         generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
-            generateX86MemoryReference(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
+            MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 1, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-        TR::MemoryReference *mr = generateX86MemoryReference(espReal, intptr_t(0), cg());
+        TR::MemoryReference *mr = MRef_Bdisp32(espReal, intptr_t(0), cg());
         mr->setRequiresLockPrefix();
         generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
@@ -252,8 +251,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
         static_assert(J9_PUBLIC_FLAGS_VM_ACCESS <= 0x7fffffff, "VM access bit must be immediate");
         generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
-            generateX86MemoryReference(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()),
-            J9_PUBLIC_FLAGS_VM_ACCESS, cg());
+            MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
         generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longReleaseSnippetLabel, cg());
         generateLabelInstruction(TR::InstOpCode::label, callNode, longReleaseRestartLabel, cg());
 
@@ -324,10 +322,10 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
         // Re-acquire vm access.
         //
         generateMemImmInstruction(TR::InstOpCode::S4MemImm4, callNode,
-            generateX86MemoryReference(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
+            MRef_Bdisp32(ebpReal, offsetof(struct J9VMThread, inNative), cg()), 0, cg());
 
 #if !defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH)
-        TR::MemoryReference *mr = generateX86MemoryReference(espReal, intptr_t(0), cg());
+        TR::MemoryReference *mr = MRef_Bdisp32(espReal, intptr_t(0), cg());
         mr->setRequiresLockPrefix();
         generateMemImmInstruction(TR::InstOpCode::OR4MemImms, callNode, mr, 0, cg());
 #endif /* !J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH */
@@ -337,8 +335,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 
         static_assert(J9_PUBLIC_FLAGS_VM_ACCESS <= 0x7fffffff, "VM access bit must be immediate");
         generateMemImmInstruction(TR::InstOpCode::CMP4MemImm4, callNode,
-            generateX86MemoryReference(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()),
-            J9_PUBLIC_FLAGS_VM_ACCESS, cg());
+            MRef_Bdisp32(ebpReal, fej9->thisThreadGetPublicFlagsOffset(), cg()), J9_PUBLIC_FLAGS_VM_ACCESS, cg());
         generateLabelInstruction(TR::InstOpCode::JNE4, callNode, longAcquireSnippetLabel, cg());
         generateLabelInstruction(TR::InstOpCode::label, callNode, longAcquireRestartLabel, cg());
 
@@ -356,8 +353,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
         TR::LabelSymbol *tempLab = generateLabelSymbol(cg());
         generateRegRegInstruction(TR::InstOpCode::TEST4RegReg, callNode, ecxReal, ecxReal, cg());
         generateLabelInstruction(TR::InstOpCode::JE4, callNode, tempLab, cg());
-        generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, ecxReal,
-            generateX86MemoryReference(ecxReal, 0, cg()), cg());
+        generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, ecxReal, MRef_Bdisp32(ecxReal, 0, cg()), cg());
         generateLabelInstruction(TR::InstOpCode::label, callNode, tempLab, cg());
     }
 
@@ -366,16 +362,16 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
     // it gets tromped on by call backs.
     //
     generateMemRegInstruction(TR::InstOpCode::S4MemReg, callNode,
-        generateX86MemoryReference(ebpReal, fej9->thisThreadGetMachineSPOffset(), cg()), espReal, cg());
+        MRef_Bdisp32(ebpReal, fej9->thisThreadGetMachineSPOffset(), cg()), espReal, cg());
 
     // Next load up the java sp so we have the callout frame on top of the java stack.
     //
     generateRegMemInstruction(TR::InstOpCode::L4RegMem, callNode, espReal,
-        generateX86MemoryReference(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), cg());
+        MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaSPOffset(), cg()), cg());
 
     if (createJNIFrame) {
         generateRegMemInstruction(TR::InstOpCode::ADD4RegMem, callNode, espReal,
-            generateX86MemoryReference(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
+            MRef_Bdisp32(ebpReal, fej9->thisThreadGetJavaLiteralsOffset(), cg()), cg());
 
         if (tearDownJNIFrame) {
             // Must check to see if the ref pool was used and clean them up if so--or we
@@ -387,7 +383,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
             TR::LabelSymbol *refPoolSnippetLabel = generateLabelSymbol(cg());
             TR::LabelSymbol *refPoolRestartLabel = generateLabelSymbol(cg());
             generateMemImmInstruction(op, callNode,
-                generateX86MemoryReference(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()), flagValue, cg());
+                MRef_Bdisp32(espReal, fej9->constJNICallOutFrameFlagsOffset(), cg()), flagValue, cg());
             generateLabelInstruction(TR::InstOpCode::JNE4, callNode, refPoolSnippetLabel, cg());
             generateLabelInstruction(TR::InstOpCode::label, callNode, refPoolRestartLabel, cg());
 
@@ -432,7 +428,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
         // Check exceptions.
         //
         generateMemImmInstruction(TR::InstOpCode::CMP4MemImms, callNode,
-            generateX86MemoryReference(ebpReal, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
+            MRef_Bdisp32(ebpReal, fej9->thisThreadGetCurrentExceptionOffset(), cg()), 0, cg());
         TR::LabelSymbol *snippetLabel = generateLabelSymbol(cg());
         instr = generateLabelInstruction(TR::InstOpCode::JNE4, callNode, snippetLabel, cg());
         instr->setNeedsGCMap((argSize << 14) | 0xFF00FFFF);

--- a/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32JNILinkage.cpp
@@ -59,7 +59,7 @@ TR::Register *J9::X86::I386::JNILinkage::buildDirectDispatch(TR::Node *callNode,
 
 TR::Register *J9::X86::I386::JNILinkage::buildJNIDispatch(TR::Node *callNode)
 {
-    TR::RegisterDependencyConditions *deps = generateRegisterDependencyConditions((uint8_t)0, 20, cg());
+    TR::RegisterDependencyConditions *deps = RegDeps((uint8_t)0, 20, cg());
 
     TR::SymbolReference *callSymRef = callNode->getSymbolReference();
     TR::MethodSymbol *callSymbol = callSymRef->getSymbol()->castToMethodSymbol();

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -156,7 +156,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::savePreservedRegisters(TR::Instr
         TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked) {
-            cursor = Inst_MemReg(cursor, TR::InstOpCode::S4MemReg,
+            cursor = Inst_MemReg(cursor, OP::S4MemReg,
                 MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), reg, cg());
             offsetCursor -= pointerSize;
         }
@@ -176,7 +176,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::restorePreservedRegisters(TR::In
         TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod()) {
-            cursor = Inst_RegMem(cursor, TR::InstOpCode::L4RegMem, reg,
+            cursor = Inst_RegMem(cursor, OP::L4RegMem, reg,
                 MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), cg());
             offsetCursor -= pointerSize;
         }
@@ -265,7 +265,7 @@ int32_t J9::X86::I386::PrivateLinkage::buildArgs(TR::Node *callNode, TR::Registe
 
         if (thisChild->getReferenceCount() > 1) {
             eaxRegister = cg()->allocateCollectedReferenceRegister();
-            Inst_RegReg(TR::InstOpCode::MOV4RegReg, thisChild, eaxRegister, rcvrReg, cg());
+            Inst_RegReg(OP::MOV4RegReg, thisChild, eaxRegister, rcvrReg, cg());
         } else {
             eaxRegister = rcvrReg;
         }
@@ -288,8 +288,7 @@ TR::UnresolvedDataSnippet *J9::X86::I386::PrivateLinkage::generateX86UnresolvedD
         = TR::UnresolvedDataSnippet::create(cg(), child, symRef, false, (debug("gcOnResolve") != NULL));
     cg()->addSnippet(snippet);
 
-    TR::Instruction *dataReferenceInstruction
-        = Inst_ImmSnippet(TR::InstOpCode::PUSHImm4, child, cpIndex, snippet, cg());
+    TR::Instruction *dataReferenceInstruction = Inst_ImmSnippet(OP::PUSHImm4, child, cpIndex, snippet, cg());
     snippet->setDataReferenceInstruction(dataReferenceInstruction);
     Inst_BoundaryAvoidance(TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8, dataReferenceInstruction,
         cg());
@@ -303,11 +302,11 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushIntegerWordArg(TR::Node *child)
     if (child->getRegister() == NULL) {
         if (child->getOpCode().isLoadConst()) {
             int32_t value = child->getInt();
-            TR::InstOpCode::Mnemonic pushOp;
+            OP::Mnemonic pushOp;
             if (value >= -128 && value <= 127) {
-                pushOp = TR::InstOpCode::PUSHImms;
+                pushOp = OP::PUSHImms;
             } else {
-                pushOp = TR::InstOpCode::PUSHImm4;
+                pushOp = OP::PUSHImm4;
             }
 
             if (child->getOpCodeValue() == TR::aconst && child->isMethodPointerConstant()
@@ -330,7 +329,7 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushIntegerWordArg(TR::Node *child)
                 } else {
                     // Must pass symbol reference so that aot can put out a relocation for it
                     //
-                    Inst_ImmSym(TR::InstOpCode::PUSHImm4, child, (uintptr_t)sym->getStaticAddress(), symRef, cg());
+                    Inst_ImmSym(OP::PUSHImm4, child, (uintptr_t)sym->getStaticAddress(), symRef, cg());
                 }
 
                 cg()->decReferenceCount(child);
@@ -348,7 +347,7 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushThis(TR::Node *child)
     // had a chance to set up its dependency conditions
     //
     TR::Register *tempRegister = cg()->evaluate(child);
-    Inst_Reg(TR::InstOpCode::PUSHReg, child, tempRegister, cg());
+    Inst_Reg(OP::PUSHReg, child, tempRegister, cg());
     return tempRegister;
 }
 
@@ -371,10 +370,10 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(TR::X86PICSlot picS
     TR::Instruction *firstInstruction;
     if (picSlot.getMethodAddress()) {
         addrToBeCompared = (uintptr_t)picSlot.getMethodAddress();
-        firstInstruction = Inst_MemImm(TR::InstOpCode::CMPMemImm4(false), node,
-            MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()), (uint32_t)addrToBeCompared, cg());
+        firstInstruction = Inst_MemImm(OP::CMPMemImm4(false), node, MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()),
+            (uint32_t)addrToBeCompared, cg());
     } else
-        firstInstruction = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, vftReg, addrToBeCompared, cg());
+        firstInstruction = Inst_RegImm(OP::CMP4RegImm4, node, vftReg, addrToBeCompared, cg());
 
     firstInstruction->setNeedsGCMap(site.getPreservedRegisterMask());
 
@@ -387,35 +386,33 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(TR::X86PICSlot picS
 
     if (picSlot.needsJumpOnNotEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            Inst_LongLabel(TR::InstOpCode::JNE4, node, mismatchLabel, cg());
+            Inst_LongLabel(OP::JNE4, node, mismatchLabel, cg());
         } else {
-            TR::InstOpCode::Mnemonic op
-                = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JNE1 : TR::InstOpCode::JNE4;
+            OP::Mnemonic op = picSlot.needsShortConditionalBranch() ? OP::JNE1 : OP::JNE4;
             Inst_Label(op, node, mismatchLabel, cg());
         }
     } else if (picSlot.needsJumpOnEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            Inst_LongLabel(TR::InstOpCode::JE4, node, mismatchLabel, cg());
+            Inst_LongLabel(OP::JE4, node, mismatchLabel, cg());
         } else {
-            TR::InstOpCode::Mnemonic op
-                = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JE1 : TR::InstOpCode::JE4;
+            OP::Mnemonic op = picSlot.needsShortConditionalBranch() ? OP::JE1 : OP::JE4;
             Inst_Label(op, node, mismatchLabel, cg());
         }
     } else if (picSlot.needsNopAndJump()) {
         Inst_Padding(1, node, cg())->setNeedsGCMap((site.getArgSize() << 14) | site.getPreservedRegisterMask());
-        Inst_LongLabel(TR::InstOpCode::JMP4, node, mismatchLabel, cg());
+        Inst_LongLabel(OP::JMP4, node, mismatchLabel, cg());
     }
 
     TR::Instruction *instr;
     if (picSlot.getMethod()) {
-        instr = Inst_Imm(TR::InstOpCode::CALLImm4, node,
-            (uint32_t)(uintptr_t)picSlot.getMethod()->startAddressForJittedMethod(), cg());
+        instr = Inst_Imm(OP::CALLImm4, node, (uint32_t)(uintptr_t)picSlot.getMethod()->startAddressForJittedMethod(),
+            cg());
     } else if (picSlot.getHelperMethodSymbolRef()) {
         TR::MethodSymbol *helperMethod = picSlot.getHelperMethodSymbolRef()->getSymbol()->castToMethodSymbol();
-        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uint32_t)(uintptr_t)helperMethod->getMethodAddress(),
+        instr = Inst_ImmSym(OP::CALLImm4, node, (uint32_t)(uintptr_t)helperMethod->getMethodAddress(),
             picSlot.getHelperMethodSymbolRef(), cg());
     } else {
-        instr = Inst_Imm(TR::InstOpCode::CALLImm4, node, 0, cg());
+        instr = Inst_Imm(OP::CALLImm4, node, 0, cg());
     }
 
     instr->setNeedsGCMap(site.getPreservedRegisterMask());
@@ -430,12 +427,12 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(TR::X86PICSlot picS
     // TODO: Can we get rid of some of these?  Maybe they don't cost anything.
     //
     if (picSlot.needsJumpToDone()) {
-        instr = Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg());
+        instr = Inst_Label(OP::JMP4, node, doneLabel, cg());
         instr->setNeedsGCMap(site.getPreservedRegisterMask());
     }
 
     if (picSlot.generateNextSlotLabelInstruction()) {
-        Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg());
+        Inst_Label(OP::label, node, mismatchLabel, cg());
     }
 
     return firstInstruction;
@@ -480,7 +477,7 @@ void J9::X86::I386::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSy
     TR_ASSERT(doneLabel, "a doneLabel is required for IPIC dispatches");
 
     if (entryLabel)
-        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(OP::label, site.getCallNode(), entryLabel, cg());
 
     TR::Instruction *startOfPicInstruction = cg()->getAppendInstruction();
 
@@ -501,7 +498,7 @@ void J9::X86::I386::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSy
 
     if (useLastITableCache) {
         if (breakBeforeIPICUsingLastITable)
-            Inst(TR::InstOpCode::INT3, site.getCallNode(), cg());
+            Inst(OP::INT3, site.getCallNode(), cg());
         if (numIPicSlotsBeforeLastITable)
             numIPicSlots = atoi(numIPicSlotsBeforeLastITable);
     }
@@ -558,7 +555,7 @@ void J9::X86::I386::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSy
     // of the PIC.
     //
     startOfPicInstruction = startOfPicInstruction->getNext();
-    while (startOfPicInstruction->getOpCodeValue() == TR::InstOpCode::bad) {
+    while (startOfPicInstruction->getOpCodeValue() == OP::bad) {
         startOfPicInstruction = startOfPicInstruction->getNext();
     }
 
@@ -581,18 +578,18 @@ void J9::X86::I386::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &
         TR::Register *targetAddress = site.evaluateVFT();
         if (targetAddress->getRegisterPair())
             targetAddress = targetAddress->getRegisterPair()->getLowOrder();
-        buildVFTCall(site, TR::InstOpCode::CALLReg, targetAddress, NULL);
+        buildVFTCall(site, OP::CALLReg, targetAddress, NULL);
     } else if (resolvedSite && site.resolvedVirtualShouldUseVFTCall()) {
         // There are no J2I thunks on x86-32, so no J2I thunk validation is needed
 
         if (entryLabel)
-            Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+            Inst_Label(OP::label, site.getCallNode(), entryLabel, cg());
 
         intptr_t offset = site.getSymbolReference()->getOffset();
         if (!resolvedSite)
             offset = 0;
 
-        buildVFTCall(site, TR::InstOpCode::CALLMem, NULL, MRef_Bdisp32(site.evaluateVFT(), offset, cg()));
+        buildVFTCall(site, OP::CALLMem, NULL, MRef_Bdisp32(site.evaluateVFT(), offset, cg()));
     } else {
         J9::X86::PrivateLinkage::buildVPIC(site, entryLabel, doneLabel);
     }

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -156,7 +156,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::savePreservedRegisters(TR::Instr
         TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked) {
-            cursor = generateMemRegInstruction(cursor, TR::InstOpCode::S4MemReg,
+            cursor = Inst_MemReg(cursor, TR::InstOpCode::S4MemReg,
                 MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), reg, cg());
             offsetCursor -= pointerSize;
         }
@@ -176,7 +176,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::restorePreservedRegisters(TR::In
         TR::RealRegister::RegNum idx = _properties.getPreservedRegister((uint32_t)pindex);
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod()) {
-            cursor = generateRegMemInstruction(cursor, TR::InstOpCode::L4RegMem, reg,
+            cursor = Inst_RegMem(cursor, TR::InstOpCode::L4RegMem, reg,
                 MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), cg());
             offsetCursor -= pointerSize;
         }
@@ -265,7 +265,7 @@ int32_t J9::X86::I386::PrivateLinkage::buildArgs(TR::Node *callNode, TR::Registe
 
         if (thisChild->getReferenceCount() > 1) {
             eaxRegister = cg()->allocateCollectedReferenceRegister();
-            generateRegRegInstruction(TR::InstOpCode::MOV4RegReg, thisChild, eaxRegister, rcvrReg, cg());
+            Inst_RegReg(TR::InstOpCode::MOV4RegReg, thisChild, eaxRegister, rcvrReg, cg());
         } else {
             eaxRegister = rcvrReg;
         }
@@ -289,10 +289,10 @@ TR::UnresolvedDataSnippet *J9::X86::I386::PrivateLinkage::generateX86UnresolvedD
     cg()->addSnippet(snippet);
 
     TR::Instruction *dataReferenceInstruction
-        = generateImmSnippetInstruction(TR::InstOpCode::PUSHImm4, child, cpIndex, snippet, cg());
+        = Inst_ImmSnippet(TR::InstOpCode::PUSHImm4, child, cpIndex, snippet, cg());
     snippet->setDataReferenceInstruction(dataReferenceInstruction);
-    generateBoundaryAvoidanceInstruction(TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8,
-        dataReferenceInstruction, cg());
+    Inst_BoundaryAvoidance(TR::X86BoundaryAvoidanceInstruction::unresolvedAtomicRegions, 8, 8, dataReferenceInstruction,
+        cg());
 
     return snippet;
 }
@@ -312,9 +312,9 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushIntegerWordArg(TR::Node *child)
 
             if (child->getOpCodeValue() == TR::aconst && child->isMethodPointerConstant()
                 && cg()->needClassAndMethodPointerRelocations()) {
-                generateImmInstruction(pushOp, child, value, cg(), TR_MethodPointer);
+                Inst_Imm(pushOp, child, value, cg(), TR_MethodPointer);
             } else {
-                generateImmInstruction(pushOp, child, value, cg());
+                Inst_Imm(pushOp, child, value, cg());
             }
             cg()->decReferenceCount(child);
             return NULL;
@@ -330,8 +330,7 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushIntegerWordArg(TR::Node *child)
                 } else {
                     // Must pass symbol reference so that aot can put out a relocation for it
                     //
-                    generateImmSymInstruction(TR::InstOpCode::PUSHImm4, child, (uintptr_t)sym->getStaticAddress(),
-                        symRef, cg());
+                    Inst_ImmSym(TR::InstOpCode::PUSHImm4, child, (uintptr_t)sym->getStaticAddress(), symRef, cg());
                 }
 
                 cg()->decReferenceCount(child);
@@ -349,7 +348,7 @@ TR::Register *J9::X86::I386::PrivateLinkage::pushThis(TR::Node *child)
     // had a chance to set up its dependency conditions
     //
     TR::Register *tempRegister = cg()->evaluate(child);
-    generateRegInstruction(TR::InstOpCode::PUSHReg, child, tempRegister, cg());
+    Inst_Reg(TR::InstOpCode::PUSHReg, child, tempRegister, cg());
     return tempRegister;
 }
 
@@ -372,10 +371,10 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(TR::X86PICSlot picS
     TR::Instruction *firstInstruction;
     if (picSlot.getMethodAddress()) {
         addrToBeCompared = (uintptr_t)picSlot.getMethodAddress();
-        firstInstruction = generateMemImmInstruction(TR::InstOpCode::CMPMemImm4(false), node,
+        firstInstruction = Inst_MemImm(TR::InstOpCode::CMPMemImm4(false), node,
             MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()), (uint32_t)addrToBeCompared, cg());
     } else
-        firstInstruction = generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, vftReg, addrToBeCompared, cg());
+        firstInstruction = Inst_RegImm(TR::InstOpCode::CMP4RegImm4, node, vftReg, addrToBeCompared, cg());
 
     firstInstruction->setNeedsGCMap(site.getPreservedRegisterMask());
 
@@ -383,47 +382,46 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(TR::X86PICSlot picS
         site.setFirstPICSlotInstruction(firstInstruction);
 
     if (picSlot.needsPicSlotAlignment()) {
-        generateBoundaryAvoidanceInstruction(X86PicSlotAtomicRegion, 8, 8, firstInstruction, cg());
+        Inst_BoundaryAvoidance(X86PicSlotAtomicRegion, 8, 8, firstInstruction, cg());
     }
 
     if (picSlot.needsJumpOnNotEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            generateLongLabelInstruction(TR::InstOpCode::JNE4, node, mismatchLabel, cg());
+            Inst_LongLabel(TR::InstOpCode::JNE4, node, mismatchLabel, cg());
         } else {
             TR::InstOpCode::Mnemonic op
                 = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JNE1 : TR::InstOpCode::JNE4;
-            generateLabelInstruction(op, node, mismatchLabel, cg());
+            Inst_Label(op, node, mismatchLabel, cg());
         }
     } else if (picSlot.needsJumpOnEqual()) {
         if (picSlot.needsLongConditionalBranch()) {
-            generateLongLabelInstruction(TR::InstOpCode::JE4, node, mismatchLabel, cg());
+            Inst_LongLabel(TR::InstOpCode::JE4, node, mismatchLabel, cg());
         } else {
             TR::InstOpCode::Mnemonic op
                 = picSlot.needsShortConditionalBranch() ? TR::InstOpCode::JE1 : TR::InstOpCode::JE4;
-            generateLabelInstruction(op, node, mismatchLabel, cg());
+            Inst_Label(op, node, mismatchLabel, cg());
         }
     } else if (picSlot.needsNopAndJump()) {
-        generatePaddingInstruction(1, node, cg())
-            ->setNeedsGCMap((site.getArgSize() << 14) | site.getPreservedRegisterMask());
-        generateLongLabelInstruction(TR::InstOpCode::JMP4, node, mismatchLabel, cg());
+        Inst_Padding(1, node, cg())->setNeedsGCMap((site.getArgSize() << 14) | site.getPreservedRegisterMask());
+        Inst_LongLabel(TR::InstOpCode::JMP4, node, mismatchLabel, cg());
     }
 
     TR::Instruction *instr;
     if (picSlot.getMethod()) {
-        instr = generateImmInstruction(TR::InstOpCode::CALLImm4, node,
+        instr = Inst_Imm(TR::InstOpCode::CALLImm4, node,
             (uint32_t)(uintptr_t)picSlot.getMethod()->startAddressForJittedMethod(), cg());
     } else if (picSlot.getHelperMethodSymbolRef()) {
         TR::MethodSymbol *helperMethod = picSlot.getHelperMethodSymbolRef()->getSymbol()->castToMethodSymbol();
-        instr = generateImmSymInstruction(TR::InstOpCode::CALLImm4, node,
-            (uint32_t)(uintptr_t)helperMethod->getMethodAddress(), picSlot.getHelperMethodSymbolRef(), cg());
+        instr = Inst_ImmSym(TR::InstOpCode::CALLImm4, node, (uint32_t)(uintptr_t)helperMethod->getMethodAddress(),
+            picSlot.getHelperMethodSymbolRef(), cg());
     } else {
-        instr = generateImmInstruction(TR::InstOpCode::CALLImm4, node, 0, cg());
+        instr = Inst_Imm(TR::InstOpCode::CALLImm4, node, 0, cg());
     }
 
     instr->setNeedsGCMap(site.getPreservedRegisterMask());
 
     if (picSlot.needsPicCallAlignment()) {
-        generateBoundaryAvoidanceInstruction(X86PicCallAtomicRegion, 8, 8, instr, cg());
+        Inst_BoundaryAvoidance(X86PicCallAtomicRegion, 8, 8, instr, cg());
     }
 
     // Put a GC map on this label, since the instruction after it may provide
@@ -432,12 +430,12 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(TR::X86PICSlot picS
     // TODO: Can we get rid of some of these?  Maybe they don't cost anything.
     //
     if (picSlot.needsJumpToDone()) {
-        instr = generateLabelInstruction(TR::InstOpCode::JMP4, node, doneLabel, cg());
+        instr = Inst_Label(TR::InstOpCode::JMP4, node, doneLabel, cg());
         instr->setNeedsGCMap(site.getPreservedRegisterMask());
     }
 
     if (picSlot.generateNextSlotLabelInstruction()) {
-        generateLabelInstruction(TR::InstOpCode::label, node, mismatchLabel, cg());
+        Inst_Label(TR::InstOpCode::label, node, mismatchLabel, cg());
     }
 
     return firstInstruction;
@@ -482,7 +480,7 @@ void J9::X86::I386::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSy
     TR_ASSERT(doneLabel, "a doneLabel is required for IPIC dispatches");
 
     if (entryLabel)
-        generateLabelInstruction(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+        Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
 
     TR::Instruction *startOfPicInstruction = cg()->getAppendInstruction();
 
@@ -503,7 +501,7 @@ void J9::X86::I386::PrivateLinkage::buildIPIC(TR::X86CallSite &site, TR::LabelSy
 
     if (useLastITableCache) {
         if (breakBeforeIPICUsingLastITable)
-            generateInstruction(TR::InstOpCode::INT3, site.getCallNode(), cg());
+            Inst(TR::InstOpCode::INT3, site.getCallNode(), cg());
         if (numIPicSlotsBeforeLastITable)
             numIPicSlots = atoi(numIPicSlotsBeforeLastITable);
     }
@@ -588,7 +586,7 @@ void J9::X86::I386::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &
         // There are no J2I thunks on x86-32, so no J2I thunk validation is needed
 
         if (entryLabel)
-            generateLabelInstruction(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
+            Inst_Label(TR::InstOpCode::label, site.getCallNode(), entryLabel, cg());
 
         intptr_t offset = site.getSymbolReference()->getOffset();
         if (!resolvedSite)

--- a/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
+++ b/runtime/compiler/x/i386/codegen/IA32PrivateLinkage.cpp
@@ -157,8 +157,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::savePreservedRegisters(TR::Instr
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod() && reg->getState() != TR::RealRegister::Locked) {
             cursor = generateMemRegInstruction(cursor, TR::InstOpCode::S4MemReg,
-                generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), reg,
-                cg());
+                MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), reg, cg());
             offsetCursor -= pointerSize;
         }
     }
@@ -178,8 +177,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::restorePreservedRegisters(TR::In
         TR::RealRegister *reg = machine()->getRealRegister(idx);
         if (reg->getHasBeenAssignedInMethod()) {
             cursor = generateRegMemInstruction(cursor, TR::InstOpCode::L4RegMem, reg,
-                generateX86MemoryReference(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()),
-                cg());
+                MRef_Bdisp32(machine()->getRealRegister(TR::RealRegister::vfp), offsetCursor, cg()), cg());
             offsetCursor -= pointerSize;
         }
     }
@@ -375,7 +373,7 @@ TR::Instruction *J9::X86::I386::PrivateLinkage::buildPICSlot(TR::X86PICSlot picS
     if (picSlot.getMethodAddress()) {
         addrToBeCompared = (uintptr_t)picSlot.getMethodAddress();
         firstInstruction = generateMemImmInstruction(TR::InstOpCode::CMPMemImm4(false), node,
-            generateX86MemoryReference(vftReg, picSlot.getSlot(), cg()), (uint32_t)addrToBeCompared, cg());
+            MRef_Bdisp32(vftReg, picSlot.getSlot(), cg()), (uint32_t)addrToBeCompared, cg());
     } else
         firstInstruction = generateRegImmInstruction(TR::InstOpCode::CMP4RegImm4, node, vftReg, addrToBeCompared, cg());
 
@@ -596,7 +594,7 @@ void J9::X86::I386::PrivateLinkage::buildVirtualOrComputedCall(TR::X86CallSite &
         if (!resolvedSite)
             offset = 0;
 
-        buildVFTCall(site, TR::InstOpCode::CALLMem, NULL, generateX86MemoryReference(site.evaluateVFT(), offset, cg()));
+        buildVFTCall(site, TR::InstOpCode::CALLMem, NULL, MRef_Bdisp32(site.evaluateVFT(), offset, cg()));
     } else {
         J9::X86::PrivateLinkage::buildVPIC(site, entryLabel, doneLabel);
     }


### PR DESCRIPTION
* Use `Inst_XXX` family of functions instead of `generateXXXInstruction`
* Use `RegDeps` in place of `generateRegisterDependencyConditions`
* Use `MRef_` family of functions in place of `generateX86MemoryReference`
* Use `OP::` typedef instead of `TR::InstOpCode::`