### PR TITLE
Fix AccessFlag.IDENTITY assignment for identity types

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -44,6 +44,7 @@ import java.security.ProtectionDomain;
 import java.util.Collection;
 /*[IF INLINE-TYPES]*/
 import java.util.Collections;
+import jdk.internal.misc.PreviewFeatures;
 /*[ENDIF] INLINE-TYPES */
 import java.util.HashMap;
 /*[IF (JAVA_SPEC_VERSION >= 16) | INLINE-TYPES]*/
@@ -174,10 +175,6 @@ public final class Class<T> implements java.io.Serializable, GenericDeclaration,
 	private static final int ANNOTATION = 0x2000;
 	private static final int ENUM = 0x4000;
 	private static final int MEMBER_INVALID_TYPE = -1;
-/*[IF INLINE-TYPES]*/
-	private static final int CLASSFILE_MAJOR_VALHALLA = 44 + 27;
-	private static final int CLASSFILE_MINOR_PREVIEW = 65535;
-/*[ENDIF] INLINE-TYPES */
 
 /*[IF]*/
 	/**
@@ -6173,21 +6170,6 @@ public Class<?>[] getNestMembers()
 
 /*[IF JAVA_SPEC_VERSION >= 20]*/
 
-/*[IF INLINE-TYPES]*/
-	private static int getClassFileMajorVersion(int classFileVersion) {
-		return classFileVersion & 0xFFFF;
-	}
-
-	private static int getClassFileMinorVersion(int classFileVersion) {
-		return classFileVersion >>> 16;
-	}
-
-	private static boolean isValhallaPreviewClassFile(int classFileVersion) {
-		return (getClassFileMajorVersion(classFileVersion) >= CLASSFILE_MAJOR_VALHALLA)
-			&& (getClassFileMinorVersion(classFileVersion) == CLASSFILE_MINOR_PREVIEW);
-	}
-/*[ENDIF] INLINE-TYPES */
-
 	/**
 	 * For an array class, the PUBLIC, PRIVATE and PROTECTED access flags should be the
 	 * same as those of its component type, and the FINAL access flag should always be
@@ -6224,8 +6206,8 @@ public Class<?>[] getNestMembers()
 
 		Set<AccessFlag> flags = AccessFlag.maskToAccessFlags(maskedModifiers, location);
 /*[IF INLINE-TYPES]*/
-		if (isValhallaPreviewClassFile(getClassFileVersion())) {
-			if (isArrayClass && (rawModifiers & AccessFlag.IDENTITY.mask()) != 0) {
+		if (PreviewFeatures.isEnabled()) {
+			if (isArrayClass || (rawModifiers & AccessFlag.IDENTITY.mask()) != 0) {
 				flags = new HashSet<>(flags);
 				flags.add(AccessFlag.IDENTITY);
 				flags = Collections.unmodifiableSet(flags);

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -3214,15 +3214,18 @@ done:
 		if (isArray) {
 			/* OR in the required Sun bits */
 			modifiers |= (J9AccAbstract | J9AccFinal);
-
+		}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-			if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass)
-				&& J9_ARE_ANY_BITS_SET(_vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW)
+		if (J9_ARE_ANY_BITS_SET(_vm->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW)) {
+			if ((!J9_IS_J9CLASS_VALUETYPE(receiverClazz)
+					&& !J9ROMCLASS_IS_INTERFACE(romClass)
+					&& !J9ROMCLASS_IS_PRIMITIVE_TYPE(romClass))
+					|| isArray
 			) {
 				modifiers |= J9AccClassHasIdentity;
 			}
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		returnSingleFromINL(REGISTER_ARGS, modifiers, 1);
 		return EXECUTE_BYTECODE;
 	}

--- a/runtime/vm/FastJNI_java_lang_Class.cpp
+++ b/runtime/vm/FastJNI_java_lang_Class.cpp
@@ -181,14 +181,18 @@ Fast_java_lang_Class_getModifiersImpl(J9VMThread *currentThread, j9object_t rece
 	if (isArray) {
 		/* OR in the required Sun bits */
 		modifiers |= (J9AccAbstract | J9AccFinal);
+	}
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-		if (J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(romClass)
-			&& J9_ARE_ANY_BITS_SET(currentThread->javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW)
+	if (J9_ARE_ANY_BITS_SET(currentThread->javaVM->extendedRuntimeFlags2, J9_EXTENDED_RUNTIME2_ENABLE_PREVIEW)) {
+		if ((!J9_IS_J9CLASS_VALUETYPE(receiverClazz)
+				&& !J9ROMCLASS_IS_INTERFACE(romClass)
+				&& !J9ROMCLASS_IS_PRIMITIVE_TYPE(romClass))
+				|| isArray
 		) {
 			modifiers |= J9AccClassHasIdentity;
 		}
-#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 	return (jint)modifiers;
 }
 

--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2449,8 +2449,9 @@ nativeOOM:
 			}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
-		} else if (!J9ROMCLASS_IS_VALUE(romClass) && !J9ROMCLASS_IS_INTERFACE(romClass)) {
-			/* All classes which are not value classes and are not interfaces are identity. */
+		} else if (!J9ROMCLASS_IS_VALUE(romClass) && !J9ROMCLASS_IS_INTERFACE(romClass)
+				&& !J9ROMCLASS_IS_PRIMITIVE_TYPE(romClass)) {
+			/* All classes which are not value classes,interfaces or classes of primitive types are identity types. */
 			classFlags |= J9ClassHasIdentity;
 		}
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)


### PR DESCRIPTION
- Ensure J9ClassHasIdentity is not set for classes of primitive types.
- Set AccessFlag.IDENTITY for arrays and identity types.
- Set J9AccClassHasIdentity for identity types when preview features are enabled.

These changes are required for:
valhalla/valuetypes/IdentityReflectionTest.java
valhalla/valuetypes/ValueObjectMethodsTest.java
