### PR TITLE
Implement JFR thread exclusion and inclusion support

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
@@ -54,13 +54,31 @@ Java_jdk_jfr_internal_JVM_setThrottle(JNIEnv *env, jobject obj, jlong eventTypeI
 void JNICALL
 Java_jdk_jfr_internal_JVM_exclude(JNIEnv *env, jobject obj, jobject thread)
 {
-	// TODO: implementation
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
+	J9VMThread *targetThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, threadObject);
+	if (NULL != targetThread) {
+		targetThread->threadJfrState.isJfrExcluded = TRUE;
+	}
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 void JNICALL
 Java_jdk_jfr_internal_JVM_include(JNIEnv *env, jobject obj, jobject thread)
 {
-	// TODO: implementation
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
+	J9VMThread *targetThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, threadObject);
+	if (NULL != targetThread) {
+		targetThread->threadJfrState.isJfrExcluded = FALSE;
+	}
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 jboolean JNICALL
@@ -70,8 +88,19 @@ Java_jdk_jfr_internal_JVM_isExcluded(JNIEnv *env, jobject obj, jobject thread)
 Java_jdk_jfr_internal_JVM_isExcluded__Ljava_lang_Thread_2(JNIEnv *env, jobject obj, jobject thread)
 #endif /* JAVA_SPEC_VERSION == 17 */
 {
-	// TODO: implementation
-	return JNI_FALSE;
+	jboolean result = JNI_FALSE;
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	j9object_t threadObject = J9_JNI_UNWRAP_REFERENCE(thread);
+	J9VMThread *targetThread = J9VMJAVALANGTHREAD_THREADREF(currentThread, threadObject);
+	if (NULL != targetThread) {
+		result = targetThread->threadJfrState.isJfrExcluded ? JNI_TRUE : JNI_FALSE;
+	}
+	vmFuncs->internalExitVMToJNI(currentThread);
+
+	return result;
 }
 
 jlong JNICALL

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -374,6 +374,7 @@ struct J9VMContinuation;
 typedef struct J9ThreadJFRState {
 	omrthread_thread_time_t prevThreadCPUTimes;
 	int64_t prevTimestamp;
+	BOOLEAN isJfrExcluded;
 } J9ThreadJFRState;
 
 typedef struct J9JFRBufferWalkState {

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -345,7 +345,7 @@ reserveBuffer(J9VMThread *currentThread, UDATA size)
 	Assert_VM_true(((currentThread)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS)
 	|| ((J9_XACCESS_EXCLUSIVE == vm->exclusiveAccessState) || (J9_XACCESS_EXCLUSIVE == vm->safePointState)));
 
-	if (!areJFRBuffersReadyForWrite(currentThread)) {
+	if (!areJFRBuffersReadyForWrite(currentThread) || currentThread->threadJfrState.isJfrExcluded) {
 		goto done;
 	}
 
@@ -431,6 +431,7 @@ jfrThreadCreated(J9HookInterface **hook, UDATA eventNum, void *eventData, void *
 		currentThread->jfrBuffer.bufferCurrent = buffer;
 		currentThread->jfrBuffer.bufferSize = J9JFR_THREAD_BUFFER_SIZE;
 		currentThread->jfrBuffer.bufferRemaining = J9JFR_THREAD_BUFFER_SIZE;
+		currentThread->threadJfrState.isJfrExcluded = FALSE;
 #if defined(DEBUG)
 		memset(currentThread->jfrBuffer.bufferStart, 0, J9JFR_THREAD_BUFFER_SIZE);
 #endif /* defined(DEBUG) */
@@ -999,6 +1000,7 @@ initializeJFR(J9JavaVM *vm, BOOLEAN lateInit)
 					walkThread->jfrBuffer.bufferCurrent = buffer;
 					walkThread->jfrBuffer.bufferSize = J9JFR_THREAD_BUFFER_SIZE;
 					walkThread->jfrBuffer.bufferRemaining = J9JFR_THREAD_BUFFER_SIZE;
+					walkThread->threadJfrState.isJfrExcluded = FALSE;
 				}
 			}
 


### PR DESCRIPTION
Add native implementations for JVM.exclude(), JVM.include(), and
JVM.isExcluded() to allow per-thread JFR event filtering.

Add isExcluded() check in reserveBuffer() that skips writing events
for excluded threads, covering all JFR hooks since every hook goes
through reserveBuffer().

Initialize isJfrExcluded to FALSE in jfrThreadCreated() for threads
created after JFR starts, and in the initializeJFR() late-init loop
for threads that already existed before JFR was initialized.

Issue: https://github.com/issues/assigned?issue=eclipse-openj9%7Copenj9%7C23765