### PR TITLE
Skip null/bndchk, array zero init in MutableBigInt

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -498,6 +498,8 @@ FirstJ9Method = LastOMRMethod + 1,
     java_math_BigInteger_init_long, java_math_BigInteger_toByteArray, java_math_BigInteger_stripLeadingZeroBytes1,
     java_math_BigInteger_stripLeadingZeroBytes2, java_math_BigInteger_bitCount, java_math_BigInteger_bitLength,
 
+    java_math_MutableBigInteger_divideMagnitude, java_math_MutableBigInteger_divideOneWord,
+
     java_text_NumberFormat_format,
 
     /* recognize the native subset of StrictMath */

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2407,6 +2407,13 @@ void TR_ResolvedJ9Method::construct()
               { x(TR::java_math_BigInteger_bitCount, "bitCount", "()I") },
               { x(TR::java_math_BigInteger_bitLength, "bitLength", "()I") }, { TR::unknownMethod } };
 
+    static X MutableBigIntegerMethods[] = {
+        { x(TR::java_math_MutableBigInteger_divideMagnitude, "divideMagnitude",
+            "(Ljava/math/MutableBigInteger;Ljava/math/MutableBigInteger;Z)Ljava/math/MutableBigInteger;") },
+        { x(TR::java_math_MutableBigInteger_divideOneWord, "divideOneWord", "(ILjava/math/MutableBigInteger;)I") },
+        { TR::unknownMethod }
+    };
+
     static X OSMemoryMethods[]
         = { { x(TR::org_apache_harmony_luni_platform_OSMemory_putByte_JB_V, "putByte", "(JB)V") },
               { x(TR::org_apache_harmony_luni_platform_OSMemory_putShort_JS_V, "putShort", "(JS)V") },
@@ -4017,6 +4024,7 @@ void TR_ResolvedJ9Method::construct()
         { "sun/nio/cs/ext/SBCS_Decoder", EncodeMethods },
         { "java/lang/invoke/FoldHandle", FoldHandleMethods },
         { "java/lang/ref/SoftReference", JavaLangRefSoftReferenceMethods },
+        { "java/math/MutableBigInteger", MutableBigIntegerMethods },
         { 0 }
     };
 

--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -176,7 +176,8 @@ static TR::RecognizedMethod canSkipNullChecks[] = {
     // TR::java_util_Vector_addElement,
     TR::java_math_BigDecimal_longString1C, TR::java_math_BigDecimal_longString2, TR::java_math_BigInteger_init_long,
 #ifdef OPENJ9_BUILD
-    TR::java_math_BigInteger_toByteArray,
+    TR::java_math_BigInteger_toByteArray, TR::java_math_MutableBigInteger_divideMagnitude,
+    TR::java_math_MutableBigInteger_divideOneWord,
 #endif // OPENJ9_BUILD
     TR::java_math_BigInteger_stripLeadingZeroBytes1, TR::java_math_BigInteger_stripLeadingZeroBytes2,
     TR::java_util_EnumMap__nec_, TR::java_nio_Bits_getCharB, TR::java_nio_Bits_getCharL, TR::java_nio_Bits_getShortB,
@@ -259,6 +260,7 @@ static TR::RecognizedMethod canSkipBoundChecks[] = {
     TR::java_math_BigInteger_stripLeadingZeroBytes1, TR::java_math_BigInteger_stripLeadingZeroBytes2,
 #ifdef OPENJ9_BUILD
     TR::java_math_BigInteger_bitCount, TR::java_math_BigInteger_bitLength,
+    TR::java_math_MutableBigInteger_divideMagnitude, TR::java_math_MutableBigInteger_divideOneWord,
 #endif // OPENJ9_BUILD
     TR::java_util_HashMap_get, TR::java_util_HashMap_findNonNullKeyEntry, TR::java_util_HashMap_putImpl,
     TR::java_lang_String_init_int_String_int_String_String, TR::java_lang_String_init_int_int_char_boolean,
@@ -579,7 +581,7 @@ static TR::RecognizedMethod canSkipZeroInitializationOnNewarrays[] = { TR::java_
     // TR::java_lang_String_toUpperCaseCore,
     TR::java_lang_String_split_str_int, TR::java_math_BigDecimal_toString, TR::java_math_BigInteger_init_long,
 #ifdef OPENJ9_BUILD
-    TR::java_math_BigInteger_toByteArray,
+    TR::java_math_BigInteger_toByteArray, TR::java_math_MutableBigInteger_divideOneWord,
 #endif // OPENJ9_BUILD
     TR::java_math_BigInteger_stripLeadingZeroBytes1, TR::java_math_BigInteger_stripLeadingZeroBytes2,
     TR::java_lang_Integer_toString, TR::java_lang_Long_toString, TR::java_lang_StringCoding_encode,


### PR DESCRIPTION
Allow the JIT to skip generating NULLCHK, BNDCHK, and array zero-initialization in the following methods:
- java_math_MutableBigInteger_divideMagnitude
- java_math_MutableBigInteger_divideOneWord