### PR TITLE
Add JFRv2 support for jcmd

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -222,4 +222,48 @@ public interface VMLangAccess {
 	 */
 	public ConstantPool getConstantPoolCache(Class<?> clazz);
 
+	/*[IF JAVA_SPEC_VERSION == 17]*/
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdStart.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdStart.execute()
+	 */
+	public String[] doJFRDCmdStartExecute(String execArgs);
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdStop.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdStop.execute()
+	 */
+	public String[] doJFRDCmdStopExecute(String execArgs);
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdConfigure.execute().
+	 *
+	 * @param verbose print verbose output
+	 * @param repositoryPath the repository path
+	 * @param dumpPath the dump path when fatal error
+	 * @param stackDepth the stack trace depth
+	 * @param globalBufferCount the number of global buffers
+	 * @param globalBufferSize the size of global buffers
+	 * @param threadBufferSize the size of thread buffer
+	 * @param memorySize the memory size
+	 * @param maxChunkSize the chunk size threshold that a new one is to be created
+	 * @param sampleThreads if thread sampling is to be enabled
+	 * @return A string array returned from DCmdConfigure.execute()
+	 */
+	public String[] doJFRDCmdConfigureExecute(
+			boolean verbose, String repositoryPath, String dumpPath, Integer stackDepth, Long globalBufferCount,
+			Long globalBufferSize, Long threadBufferSize, Long memorySize, Long maxChunkSize, Boolean sampleThreads);
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdDump.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdDump.execute()
+	 */
+	public String[] doJFRDCmdDumpExecute(String execArgs);
+	/*[ENDIF] JAVA_SPEC_VERSION == 17 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
+++ b/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
@@ -34,6 +34,7 @@ import java.util.regex.Pattern;
 import com.ibm.oti.vm.VM;
 import jdk.internal.misc.Unsafe;
 
+@SuppressWarnings("nls")
 final class JFRHelpers {
 	private static Class<?> jfrjvmClass;
 	private static Class<?> logTagClass;
@@ -56,6 +57,27 @@ final class JFRHelpers {
 			initJFRClasses();
 		}
 	}
+
+	private static final class DCmdInvocation {
+		private Object dcmdInstance;
+		private Method dcmdExecute;
+
+		DCmdInvocation(Object dcmdInstance, Method dcmdExecute) {
+			this.dcmdInstance = dcmdInstance;
+			this.dcmdExecute = dcmdExecute;
+		}
+
+		Object getDCmdInstance() {
+			return this.dcmdInstance;
+		}
+		Method getDcmdExecute() {
+			return this.dcmdExecute;
+		}
+	}
+	private static DCmdInvocation dcmdStart;
+	private static DCmdInvocation dcmdStop;
+	private static DCmdInvocation dcmdConfigure;
+	private static DCmdInvocation dcmdDump;
 
 	private static Long convertToBytes(String text) {
 		Pattern pattern = Pattern.compile("(\\d+)([gkm]b?)?", Pattern.CASE_INSENSITIVE);
@@ -130,12 +152,9 @@ final class JFRHelpers {
 	}
 
 	private static void initJFRCmdlineOptions() {
+		/*[IF (JAVA_SPEC_VERSION == 11) | (JAVA_SPEC_VERSION == 17)]*/
 		try {
-			Class<?> dcmdStartClass = Class.forName("jdk.jfr.internal.dcmd.DCmdStart");
-			Constructor<?> constructor = dcmdStartClass.getDeclaredConstructor();
-			constructor.setAccessible(true);
-			Object dcmdStartInstance = constructor.newInstance();
-
+			dcmdStart = initDCmdInvocation(dcmdStart, "jdk.jfr.internal.dcmd.DCmdStart");
 			/*[IF JAVA_SPEC_VERSION == 11]*/
 			String fileName = null;
 			String settings = null;
@@ -184,24 +203,8 @@ final class JFRHelpers {
 			}
 			/* Convert the string to a String array */
 			String[] settingsArray = new String[] { settings };
-
-			Method executeMethod = dcmdStartClass.getDeclaredMethod(
-				"execute",
-				String.class, //name
-				String[].class, //settings
-				Long.class, //delay
-				Long.class, //duration
-				Boolean.class, //disk
-				String.class, //path
-				Long.class, //maxAge
-				Long.class, //maxSize
-				Boolean.class, //dumpOnExit
-				Boolean.class //pathToGcRoots
-			);
-
-			executeMethod.setAccessible(true);
-			String results = (String) executeMethod.invoke(
-				dcmdStartInstance,
+			String results = (String) dcmdStart.getDcmdExecute().invoke(
+				dcmdStart.getDCmdInstance(),
 				null,
 				settingsArray,
 				delay,
@@ -216,24 +219,23 @@ final class JFRHelpers {
 			if (null != results) {
 				logJFR(results, 0, 2);
 			}
-			/*[ELSEIF JAVA_SPEC_VERSION >= 17]*/
-			Method executeMethod = dcmdStartClass.getSuperclass().getDeclaredMethod("execute", String.class, String.class, char.class);
-			executeMethod.setAccessible(true);
-
-			String[] results = (String []) executeMethod.invoke(dcmdStartInstance, "internal", jfrCMDLineOption, ',');
+			/*[ELSE] JAVA_SPEC_VERSION == 11 */
+			String[] results = (String []) dcmdStart.getDcmdExecute().invoke(
+					dcmdStart.getDCmdInstance(), "internal", jfrCMDLineOption, ',');
 			if (null != results) {
 				for (String result : results) {
 					logJFR(result, 0, 2);
 				}
 			}
-			/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
+			/*[ENDIF] JAVA_SPEC_VERSION == 11 */
 		} catch (InvocationTargetException e) {
-			Throwable cause = e.getCause();
-			e.printStackTrace();
-			throw new InternalError(cause);
+			throw new InternalError(e.getCause());
 		} catch (Exception e) {
 			throw new InternalError(e);
 		}
+		/*[ELSE] (JAVA_SPEC_VERSION == 11) | (JAVA_SPEC_VERSION == 17) */
+		throw new InternalError("JFR support is not enabled");
+		/*[ENDIF] (JAVA_SPEC_VERSION == 11) | (JAVA_SPEC_VERSION == 17) */
 	}
 
 	/**
@@ -249,9 +251,11 @@ final class JFRHelpers {
 				loggerClass = Class.forName("jdk.jfr.internal.Logger");
 				jfrUpCallClass = Class.forName("jdk.jfr.internal.JVMUpcalls");
 
+				Module javabase = System.class.getModule();
 				Module jdkJFR = jfrjvmClass.getModule();
 				Module systemUnnamedModule = VM.getUnnamedModuleForSystemLoader();
-				jdkJFR.implAddExports("jdk.jfr.internal", System.class.getModule());
+				jdkJFR.implAddExports("jdk.jfr.internal", javabase);
+				jdkJFR.implAddExports("jdk.jfr.internal.dcmd", javabase);
 				jdkJFR.implAddExports("jdk.jfr.internal.handlers", systemUnnamedModule);
 				jdkJFR.implAddExportsToAllUnnamed("jdk.jfr.internal.handlers");
 				VM.getUnnamedModuleForSystemLoader().implAddReads(jdkJFR);
@@ -429,4 +433,156 @@ final class JFRHelpers {
 		stopThread.setDaemon(true);
 		stopThread.start();
 	}
+
+	/*[IF (JAVA_SPEC_VERSION == 11) | (JAVA_SPEC_VERSION == 17) ]*/
+	private static DCmdInvocation initDCmdInvocation(DCmdInvocation dcmdInvocation, String className) {
+		// No synchronization overhead, it is okay to initialize dcmdInvocation more than once.
+		if (dcmdInvocation == null) {
+			try {
+				Class<?> dcmdClass = Class.forName(className);
+				Constructor<?> constructor = dcmdClass.getDeclaredConstructor();
+				constructor.setAccessible(true);
+				Method dcmdExecute;
+				if (className.equals("jdk.jfr.internal.dcmd.DCmdConfigure")) {
+					// DCmdConfigure doesn't implement execute(ArgumentParser parser)
+					dcmdExecute = dcmdClass.getDeclaredMethod(
+							"execute",
+							boolean.class, // verbose
+							String.class, // repositoryPath
+							String.class, // dumpPath
+							Integer.class, // stackDepth
+							Long.class, // globalBufferCount
+							Long.class, // globalBufferSize
+							Long.class, // threadBufferSize
+							Long.class, // memorySize
+							Long.class, // maxChunkSize
+							Boolean.class // sampleThreads
+							);
+				} else
+				/*[IF JAVA_SPEC_VERSION == 11]*/
+				if (className.equals("jdk.jfr.internal.dcmd.DCmdStart")) {
+					dcmdExecute = dcmdClass.getDeclaredMethod(
+							"execute",
+							String.class, // name
+							String[].class, // settings
+							Long.class, // delay
+							Long.class, // duration
+							Boolean.class, // disk
+							String.class, // path
+							Long.class, // maxAge
+							Long.class, // maxSize
+							Boolean.class, // dumpOnExit
+							Boolean.class // pathToGcRoots
+							);
+				} else
+				/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
+				{
+					dcmdExecute = dcmdClass.getSuperclass().getDeclaredMethod(
+							"execute",
+							String.class, // source
+							String.class, // arg
+							char.class // delimiter
+							);
+				}
+				dcmdExecute.setAccessible(true);
+				dcmdInvocation = new DCmdInvocation(constructor.newInstance(), dcmdExecute);
+			} catch (InvocationTargetException e) {
+				throw new InternalError(e.getCause());
+			} catch (Exception e) {
+				throw new InternalError(e);
+			}
+		}
+		return dcmdInvocation;
+	}
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdStart.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdStart.execute()
+	 */
+	public static String[] doJFRDCmdStartExecute(String execArgs) {
+		dcmdStart = initDCmdInvocation(dcmdStart, "jdk.jfr.internal.dcmd.DCmdStart");
+		try {
+			return (String[]) dcmdStart.getDcmdExecute().invoke(dcmdStart.getDCmdInstance(), "internal", execArgs, ',');
+		} catch (InvocationTargetException e) {
+			throw new InternalError(e.getCause());
+		} catch (Exception e) {
+			throw new InternalError(e);
+		}
+	}
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdStop.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdStop.execute()
+	 */
+	public static String[] doJFRDCmdStopExecute(String execArgs) {
+		dcmdStop = initDCmdInvocation(dcmdStop, "jdk.jfr.internal.dcmd.DCmdStop");
+		try {
+			return (String[]) dcmdStop.getDcmdExecute().invoke(dcmdStop.getDCmdInstance(), "internal", execArgs, ',');
+		} catch (InvocationTargetException e) {
+			throw new InternalError(e.getCause());
+		} catch (Exception e) {
+			throw new InternalError(e);
+		}
+	}
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdConfigure.execute().
+	 *
+	 * @param verbose print verbose output
+	 * @param repositoryPath the repository path
+	 * @param dumpPath the dump path when fatal error
+	 * @param stackDepth the stack trace depth
+	 * @param globalBufferCount the number of global buffers
+	 * @param globalBufferSize the size of global buffers
+	 * @param threadBufferSize the size of thread buffer
+	 * @param memorySize the memory size
+	 * @param maxChunkSize the chunk size threshold that a new one is to be created
+	 * @param sampleThreads if thread sampling is to be enabled
+	 * @return A string array returned from DCmdConfigure.execute()
+	 */
+	public static String[] doJFRDCmdConfigureExecute(
+			boolean verbose, String repositoryPath, String dumpPath, Integer stackDepth, Long globalBufferCount,
+			Long globalBufferSize, Long threadBufferSize, Long memorySize, Long maxChunkSize, Boolean sampleThreads) {
+		dcmdConfigure = initDCmdInvocation(dcmdConfigure, "jdk.jfr.internal.dcmd.DCmdConfigure");
+		try {
+			return (String[]) dcmdConfigure.getDcmdExecute().invoke(
+					dcmdConfigure.getDCmdInstance(),
+					verbose,
+					repositoryPath,
+					dumpPath,
+					stackDepth,
+					globalBufferCount,
+					globalBufferSize,
+					threadBufferSize,
+					memorySize,
+					maxChunkSize,
+					sampleThreads);
+		} catch (InvocationTargetException e) {
+			throw new InternalError(e.getCause());
+		} catch (Exception e) {
+			throw new InternalError(e);
+		}
+	}
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdDump.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdDump.execute()
+	 */
+	public static String[] doJFRDCmdDumpExecute(String execArgs) {
+		dcmdDump = initDCmdInvocation(dcmdDump, "jdk.jfr.internal.dcmd.DCmdDump");
+		try {
+			return (String[]) dcmdDump.getDcmdExecute().invoke(dcmdDump.getDCmdInstance(), "internal", execArgs, ',');
+		} catch (InvocationTargetException e) {
+			throw new InternalError(e.getCause());
+		} catch (Exception e) {
+			throw new InternalError(e);
+		}
+	}
+	/*[ENDIF] (JAVA_SPEC_VERSION == 11) | (JAVA_SPEC_VERSION == 17) */
 }

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -1,4 +1,4 @@
-/*[INCLUDE-IF Sidecar16]*/
+/*[INCLUDE-IF JAVA_SPEC_VERSION >= 8]*/
 /*
  * Copyright IBM Corp. and others 2012
  *
@@ -289,4 +289,71 @@ final class VMAccess implements VMLangAccess {
 	public ConstantPool getConstantPoolCache(Class<?> clazz) {
 		return clazz.constantPoolObject;
 	}
+
+	/*[IF JAVA_SPEC_VERSION == 17]*/
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdStart.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdStart.execute()
+	 */
+	@Override
+	public String[] doJFRDCmdStartExecute(String execArgs) {
+		return JFRHelpers.doJFRDCmdStartExecute(execArgs);
+	}
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdStop.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdStop.execute()
+	 */
+	@Override
+	public String[] doJFRDCmdStopExecute(String execArgs) {
+		return JFRHelpers.doJFRDCmdStopExecute(execArgs);
+	}
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdConfigure.execute().
+	 *
+	 * @param verbose print verbose output
+	 * @param repositoryPath the repository path
+	 * @param dumpPath the dump path when fatal error
+	 * @param stackDepth the stack trace depth
+	 * @param globalBufferCount the number of global buffers
+	 * @param globalBufferSize the size of global buffers
+	 * @param threadBufferSize the size of thread buffer
+	 * @param memorySize the memory size
+	 * @param maxChunkSize the chunk size threshold that a new one is to be created
+	 * @param sampleThreads if thread sampling is to be enabled
+	 * @return A string array returned from DCmdConfigure.execute()
+	 */
+	@Override
+	public String[] doJFRDCmdConfigureExecute(
+			boolean verbose, String repositoryPath, String dumpPath, Integer stackDepth, Long globalBufferCount,
+			Long globalBufferSize, Long threadBufferSize, Long memorySize, Long maxChunkSize, Boolean sampleThreads) {
+		return JFRHelpers.doJFRDCmdConfigureExecute(
+				verbose,
+				repositoryPath,
+				dumpPath,
+				stackDepth,
+				globalBufferCount,
+				globalBufferSize,
+				threadBufferSize,
+				memorySize,
+				maxChunkSize,
+				sampleThreads);
+	}
+
+	/**
+	 * Invoke jdk.jfr.internal.dcmd.DCmdDump.execute().
+	 *
+	 * @param execArgs The string arguments separated by a delimiter
+	 * @return A string array returned from DCmdDump.execute()
+	 */
+	@Override
+	public String[] doJFRDCmdDumpExecute(String execArgs) {
+		return JFRHelpers.doJFRDCmdDumpExecute(execArgs);
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION == 17 */
 }

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/AttachHandler.java
@@ -296,6 +296,9 @@ public class AttachHandler extends Thread {
 				IPC.logStream = new PrintStream(logFile);
 				IPC.setDefaultVmId(pidProperty);
 				IPC.printMessageWithHeader("AttachHandler initialized", IPC.logStream); //$NON-NLS-1$
+				/*[IF JAVA_SPEC_VERSION >= 11]*/
+				IPC.printMessageWithHeader(ProcessHandle.current().info().commandLine().orElse("default"), IPC.logStream);
+				/*[ENDIF] JAVA_SPEC_VERSION >= 11 */
 				loggingStatus = LOGGING_ENABLED;
 			} else {
 				loggingStatus = LOGGING_DISABLED;

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -32,9 +32,6 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
 import com.ibm.oti.vm.VM;
@@ -58,8 +55,8 @@ import openj9.management.internal.ThreadInfoBase;
 @SuppressWarnings("nls")
 public class DiagnosticUtils {
 
-	private static final String FORMAT_PREFIX = " Format: ";
-	private static final String SYNTAX_PREFIX = "Syntax : ";
+	static final String FORMAT_PREFIX = " Format: ";
+	static final String SYNTAX_PREFIX = "Syntax : ";
 
 	private static final String HEAP_DUMP_OPTION_HELP = " [request=<options>] [opts=<options>] [<file path>]%n"
 			+ " Set optional request= and opts= -Xdump options. The order of the parameters does not matter.%n";
@@ -75,35 +72,6 @@ public class DiagnosticUtils {
 			" <file path> is optional, otherwise a default path/name is used.%n"
 			+ " Relative paths are resolved to the target's working directory.%n"
 			+ " The dump agent may choose a different file path if the requested file exists.%n";
-
-/*[IF JFR_SUPPORT]*/
-	private static String jfrRecordingFileName = "defaultJ9recording.jfr";
-	private static final String JFR_START_OPTION_HELP =
-			" [options]%n"
-			+ "%n"
-			+ "Options:%n"
-			+ "%n"
-			+ "duration     (Optional) Length of time to record. Note that 0s means forever.%n"
-			+ "             (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for hours)%n"
-			+ "%n"
-			+ "filename     (Optional) Name of the file to which the flight recording data is%n"
-			+ "              written when the recording is stopped.%n";
-
-	private static final String JFR_STOP_OPTION_HELP =
-			" [options]%n"
-			+ "%n"
-			+ "Options:%n"
-			+ "%n"
-			+ "filename     (Optional) Name of the file to which the recording is written%n"
-			+ "              when the recording is stopped.%n";
-
-	private static final String JFR_DUMP_OPTION_HELP =
-			" [options]%n"
-			+ "%n"
-			+ "Options:%n"
-			+ "%n"
-			+ "filename        (Optional) Name of the file to which the flight recording data is written.%n";
-/*[ENDIF] JFR_SUPPORT */
 
 	/**
 	 * Command strings for executeDiagnosticCommand()
@@ -158,18 +126,6 @@ public class DiagnosticUtils {
 	private static final String DIAGNOSTICS_DUMP_JAVA = "Dump.java";
 	private static final String DIAGNOSTICS_DUMP_SNAP = "Dump.snap";
 	private static final String DIAGNOSTICS_DUMP_SYSTEM = "Dump.system";
-
-/*[IF JFR_SUPPORT]*/
-	/**
-	 * Commands for JFR start, stop and dump
-	 */
-	private static final String DIAGNOSTICS_JFR_START = "JFR.start";
-	private static final String DIAGNOSTICS_JFR_DUMP = "JFR.dump";
-	private static final String DIAGNOSTICS_JFR_STOP = "JFR.stop";
-
-	private static final int ERROR_NO_TIME_UNIT = -1;
-	private static final int ERROR_NO_TIME_DURATION = -2;
-/*[ENDIF] JFR_SUPPORT */
 
 	/**
 	 * Get JVM statistics
@@ -239,7 +195,7 @@ public class DiagnosticUtils {
 /*[IF JFR_SUPPORT]*/
 		if (optionsLength >= 2) {
 			// there is a jcmd command
-			if (DIAGNOSTICS_JFR_START.equalsIgnoreCase(options[1])) {
+			if (JFR.DIAGNOSTICS_JFR_START.equalsIgnoreCase(options[1])) {
 				// search JFR.start options
 				for (int i = 2; i < optionsLength; i++) {
 					String option = options[i];
@@ -449,156 +405,6 @@ public class DiagnosticUtils {
 		return result;
 	}
 
-/*[IF JFR_SUPPORT]*/
-	private static long convertToMilliseconds(String timeValue) {
-		long timeInMilli = 0L;
-
-		// extract the numeric part and the time unit
-		String numericPart = timeValue.replaceAll("[^0-9]", "");
-
-		// convert the unit to lowercase for consistency
-		String timeUnit = timeValue.replaceAll("[0-9]", "").toLowerCase();
-
-		// parse the numeric part
-		long time = Long.parseLong(numericPart);
-
-		// convert to milliseconds based on the unit
-		switch (timeUnit) {
-		case "s":
-			timeInMilli = TimeUnit.SECONDS.toMillis(time);
-			break;
-		case "m":
-			timeInMilli = TimeUnit.MINUTES.toMillis(time);
-			break;
-		case "h":
-			timeInMilli = TimeUnit.HOURS.toMillis(time);
-			break;
-		case "d":
-			timeInMilli = TimeUnit.DAYS.toMillis(time);
-			break;
-		default:
-			// no unit or unrecognized unit, return ERROR_NO_TIME_UNIT
-			timeInMilli = ERROR_NO_TIME_UNIT;
-			break;
-		}
-		return timeInMilli;
-	}
-
-	/**
-	 * Parse a time parameter, and return the duration in milliseconds.
-	 * If the time unit is missing, ERROR_NO_TIME_UNIT is returned.
-	 * If the paramName is not in parameters, ERROR_NO_TIME_DURATION is returned.
-	 *
-	 * @param paramName the parameter name
-	 * @param parameters the parameter array
-	 *
-	 * @return the duration in milliseconds,
-	 *         ERROR_NO_TIME_UNIT if no time unit,
-	 *         ERROR_NO_TIME_DURATION if paramName wasn't found.
-	 */
-	private static long parseTimeParameter(String paramName, String[] parameters) {
-		for (String param : parameters) {
-			if (param.startsWith(paramName + "=")) {
-				int valueStart = param.indexOf("=");
-				if (valueStart != -1) {
-					return convertToMilliseconds(param.substring(valueStart + 1));
-				}
-			}
-		}
-		return ERROR_NO_TIME_DURATION;
-	}
-
-	private static String parseStringParameter(String paramName, String[] parameters, String defaultValue) {
-		for (String param : parameters) {
-			if (param.startsWith(paramName + "=")) {
-				int valueStart = param.indexOf("=");
-				if (valueStart != -1) {
-					return param.substring(valueStart + 1);
-				}
-			}
-		}
-		return defaultValue;
-	}
-
-	private static DiagnosticProperties doJFR(String diagnosticCommand) {
-		if (VM.isStartFlightRecordingSpecified()) {
-			return DiagnosticProperties.makeStringResult("Cannot use jcmd JFR options at the same time as -XX:startFlightRecording.");
-		}
-
-		DiagnosticProperties result = null;
-		// split the command and arguments
-		String[] parts = diagnosticCommand.split(DIAGNOSTICS_OPTION_SEPARATOR);
-		IPC.logMessage("doJFR: ", diagnosticCommand);
-		// ensure there's at least one part for the command
-		if (parts.length == 0) {
-			return DiagnosticProperties.makeErrorProperties("Error: No JFR command specified");
-		}
-		String command = parts[0].trim();
-		String[] parameters = Arrays.copyOfRange(parts, 1, parts.length);
-		String fileName = parseStringParameter("filename", parameters, null);
-		IPC.logMessage("doJFR: filename = ", fileName);
-
-		try {
-			if (command.equalsIgnoreCase(DIAGNOSTICS_JFR_START)) {
-				if (VM.isJFRRecordingStarted()) {
-					result = DiagnosticProperties.makeErrorProperties("One JFR recording is in progress [" + jfrRecordingFileName + "], only one recording is allowed at a time.");
-				} else {
-					// only JFR.start command is allowed to change the recording filename
-					boolean setFileName = (fileName != null) && !fileName.isEmpty();
-					if (setFileName) {
-						// the recording filename should be set before VM.startJFR() which invokes JFRWriter:openJFRFile()
-						if (!VM.setJFRRecordingFileName(fileName)) {
-							return DiagnosticProperties.makeErrorProperties("setJFRRecordingFileName() failed");
-						} else {
-							jfrRecordingFileName = fileName;
-						}
-					}
-					long duration = parseTimeParameter("duration", parameters);
-					IPC.logMessage("doJFR: duration = " + duration);
-					if (duration == ERROR_NO_TIME_UNIT) {
-						return DiagnosticProperties.makeErrorProperties("The duration doesn't have a time unit.");
-					}
-					VM.startJFR();
-					if (duration > 0) {
-						Timer timer = new Timer();
-						TimerTask jfrDumpTask = new TimerTask() {
-							public void run() {
-								if (VM.isJFRRecordingStarted()) {
-									VM.stopJFR();
-								}
-							}
-						};
-						timer.schedule(jfrDumpTask, duration);
-					} else {
-						// the recording is on until JFR.stop
-					}
-					result = DiagnosticProperties.makeStringResult("Start JFR recording to " + jfrRecordingFileName);
-				}
-			} else if (command.equalsIgnoreCase(DIAGNOSTICS_JFR_STOP)) {
-				if (VM.isJFRRecordingStarted()) {
-					VM.stopJFR();
-					result = DiagnosticProperties.makeStringResult("Stop JFR recording, and dump all Java threads to " + jfrRecordingFileName);
-				} else {
-					result = DiagnosticProperties.makeErrorProperties("Could not stop recording [" + jfrRecordingFileName + "], run JFR.start first.");
-				}
-			} else if (command.equalsIgnoreCase(DIAGNOSTICS_JFR_DUMP)) {
-				if (VM.isJFRRecordingStarted()) {
-					VM.jfrDump();
-					result = DiagnosticProperties.makeStringResult("Dump all Java threads to " + jfrRecordingFileName);
-				} else {
-					result = DiagnosticProperties.makeErrorProperties("Could not create a JFR recording [" + jfrRecordingFileName + "], run JFR.start first.");
-				}
-			} else {
-				result = DiagnosticProperties.makeErrorProperties("Command not recognized: " + command);
-			}
-		} catch (Exception e) {
-			result = DiagnosticProperties.makeErrorProperties("Error in JFR: " + e.getMessage());
-		}
-
-		return result;
-	}
-/*[ENDIF] JFR_SUPPORT */
-
 	private static native ThreadInfoBase[] dumpAllThreadsImpl(boolean lockedMonitors,
 			boolean lockedSynchronizers, int maxDepth);
 
@@ -799,17 +605,6 @@ public class DiagnosticUtils {
 			+ "NOTE: this utility might significantly affect the performance of the target VM.%n";
 /*[ENDIF] CRIU_SUPPORT */
 
-/*[IF JFR_SUPPORT]*/
-	private static final String DIAGNOSTICS_JFR_START_HELP = "Start a new Recording%n%n"
-			+ SYNTAX_PREFIX + DIAGNOSTICS_JFR_START + JFR_START_OPTION_HELP;
-
-	private static final String DIAGNOSTICS_JFR_DUMP_HELP = "Dump a JFR recording to file%n%n"
-			+ SYNTAX_PREFIX + DIAGNOSTICS_JFR_DUMP + JFR_DUMP_OPTION_HELP;
-
-	private static final String DIAGNOSTICS_JFR_STOP_HELP = "Stop a JFR recording%n%n"
-			+ SYNTAX_PREFIX + FORMAT_PREFIX + DIAGNOSTICS_JFR_STOP + JFR_STOP_OPTION_HELP;
-/*[ENDIF] JFR_SUPPORT */
-
 	/* Initialize the command and help text tables */
 	static {
 		IDCacheInitializer.init();
@@ -865,16 +660,32 @@ public class DiagnosticUtils {
 
 /*[IF JFR_SUPPORT]*/
 		if (VM.isJFREnabled()) {
-			commandTable.put(DIAGNOSTICS_JFR_START, DiagnosticUtils::doJFR);
-			helpTable.put(DIAGNOSTICS_JFR_START, DIAGNOSTICS_JFR_START_HELP);
+/*[IF JAVA_SPEC_VERSION == 17]*/
+			if (VM.isJFRV2SupportEnabled()) {
+				commandTable.put(JFR.DIAGNOSTICS_JFR_START, JFR::doJFRv2);
+				helpTable.put(JFR.DIAGNOSTICS_JFR_START, JFR.DIAGNOSTICS_JFR_START_HELP);
 
-			commandTable.put(DIAGNOSTICS_JFR_DUMP, DiagnosticUtils::doJFR);
-			helpTable.put(DIAGNOSTICS_JFR_DUMP, DIAGNOSTICS_JFR_DUMP_HELP);
+				commandTable.put(JFR.DIAGNOSTICS_JFR_DUMP, JFR::doJFRv2);
+				helpTable.put(JFR.DIAGNOSTICS_JFR_DUMP, JFR.DIAGNOSTICS_JFR_DUMP_HELP);
 
-			commandTable.put(DIAGNOSTICS_JFR_STOP, DiagnosticUtils::doJFR);
-			helpTable.put(DIAGNOSTICS_JFR_STOP, DIAGNOSTICS_JFR_STOP_HELP);
+				commandTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR::doJFRv2);
+				helpTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR.DIAGNOSTICS_JFR_STOP_HELP);
+
+				commandTable.put(JFR.DIAGNOSTICS_JFR_CONFIGURE, JFR::doJFRv2);
+				helpTable.put(JFR.DIAGNOSTICS_JFR_CONFIGURE, JFR.DIAGNOSTICS_JFR_CONFIGURE_HELP);
+			} else
+/*[ENDIF] JAVA_SPEC_VERSION == 17 */
+			{
+				commandTable.put(JFR.DIAGNOSTICS_JFR_START, JFR::doJFR);
+				helpTable.put(JFR.DIAGNOSTICS_JFR_START, JFR.DIAGNOSTICS_JFR_START_HELP);
+
+				commandTable.put(JFR.DIAGNOSTICS_JFR_DUMP, JFR::doJFR);
+				helpTable.put(JFR.DIAGNOSTICS_JFR_DUMP, JFR.DIAGNOSTICS_JFR_DUMP_HELP);
+
+				commandTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR::doJFR);
+				helpTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR.DIAGNOSTICS_JFR_STOP_HELP);
+			}
 		}
-
 /*[ENDIF] JFR_SUPPORT */
 	}
 }

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/JFR.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/JFR.java
@@ -1,0 +1,390 @@
+/*[INCLUDE-IF JFR_SUPPORT]*/
+/*
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package openj9.internal.tools.attach.target;
+
+import static openj9.internal.tools.attach.target.IPC.LOGGING_ENABLED;
+import static openj9.internal.tools.attach.target.IPC.loggingStatus;
+
+import com.ibm.oti.vm.VM;
+import com.ibm.oti.vm.VMLangAccess;
+
+import java.util.Arrays;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Common methods for the JFR diagnostics tools.
+ *
+ */
+@SuppressWarnings("nls")
+public class JFR {
+	/**
+	 * Commands for JFR start, stop, dump and configure.
+	 */
+	static final String DIAGNOSTICS_JFR_START = "JFR.start";
+	static final String DIAGNOSTICS_JFR_DUMP = "JFR.dump";
+	static final String DIAGNOSTICS_JFR_STOP = "JFR.stop";
+	static final String DIAGNOSTICS_JFR_CONFIGURE = "JFR.configure";
+
+	private static final int ERROR_NO_TIME_UNIT = -1;
+	private static final int ERROR_NO_TIME_DURATION = -2;
+
+	private static String jfrRecordingFileName = "defaultJ9recording.jfr";
+	private static final String JFR_START_OPTION_HELP =
+			" [options]%n"
+			+ "%n"
+			+ "Options:%n"
+			+ "%n"
+			+ "duration     (Optional) Length of time to record. Note that 0s means forever.%n"
+			+ "             (INTEGER followed by 's' for seconds 'm' for minutes or 'h' for hours)%n"
+			+ "%n"
+			+ "filename     (Optional) Name of the file to which the flight recording data is%n"
+			+ "              written when the recording is stopped.%n";
+
+	private static final String JFR_STOP_OPTION_HELP =
+			" [options]%n"
+			+ "%n"
+			+ "Options:%n"
+			+ "%n"
+			+ "filename     (Optional) Name of the file to which the recording is written%n"
+			+ "              when the recording is stopped.%n";
+
+	private static final String JFR_DUMP_OPTION_HELP =
+			" [options]%n"
+			+ "%n"
+			+ "Options:%n"
+			+ "%n"
+			+ "filename        (Optional) Name of the file to which the flight recording data is written.%n";
+
+	private static final String JFR_CONFIGURE_OPTION_HELP =
+			" [options]%n"
+			+ "%n"
+			+ "Options:%n"
+			+ "%n"
+			+ "samplethreads      (Optional) Flag for activating thread sampling. (BOOLEAN, true)%n";
+
+	static final String DIAGNOSTICS_JFR_START_HELP = "Start a new Recording%n%n"
+			+ DiagnosticUtils.SYNTAX_PREFIX + DIAGNOSTICS_JFR_START + JFR_START_OPTION_HELP;
+
+	static final String DIAGNOSTICS_JFR_DUMP_HELP = "Dump a JFR recording to file%n%n"
+			+ DiagnosticUtils.SYNTAX_PREFIX + DIAGNOSTICS_JFR_DUMP + JFR_DUMP_OPTION_HELP;
+
+	static final String DIAGNOSTICS_JFR_CONFIGURE_HELP = "Modify JFR configuration files%n%n"
+			+ DiagnosticUtils.SYNTAX_PREFIX + DIAGNOSTICS_JFR_CONFIGURE + JFR_CONFIGURE_OPTION_HELP;
+
+	static final String DIAGNOSTICS_JFR_STOP_HELP = "Stop a JFR recording%n%n"
+			+ DiagnosticUtils.SYNTAX_PREFIX + DiagnosticUtils.FORMAT_PREFIX + DIAGNOSTICS_JFR_STOP + JFR_STOP_OPTION_HELP;
+
+	private static long convertToMilliseconds(String timeValue) {
+		long timeInMilli = 0L;
+
+		// Extract the numeric part and the time unit.
+		String numericPart = timeValue.replaceAll("[^0-9]", "");
+
+		// Convert the unit to lower case for consistency.
+		String timeUnit = timeValue.replaceAll("[0-9]", "").toLowerCase();
+
+		// Parse the numeric part.
+		long time = Long.parseLong(numericPart);
+
+		// Convert to milliseconds based on the unit.
+		switch (timeUnit) {
+		case "s":
+			timeInMilli = TimeUnit.SECONDS.toMillis(time);
+			break;
+		case "m":
+			timeInMilli = TimeUnit.MINUTES.toMillis(time);
+			break;
+		case "h":
+			timeInMilli = TimeUnit.HOURS.toMillis(time);
+			break;
+		case "d":
+			timeInMilli = TimeUnit.DAYS.toMillis(time);
+			break;
+		default:
+			// No unit or unrecognized unit, return ERROR_NO_TIME_UNIT.
+			timeInMilli = ERROR_NO_TIME_UNIT;
+			break;
+		}
+		return timeInMilli;
+	}
+
+	/**
+	 * Parse a time parameter, and return the duration in milliseconds.
+	 * If the time unit is missing, ERROR_NO_TIME_UNIT is returned.
+	 * If the paramName is not in parameters, ERROR_NO_TIME_DURATION is returned.
+	 *
+	 * @param paramName the parameter name
+	 * @param parameters the parameter array
+	 *
+	 * @return the duration in milliseconds,
+	 *         ERROR_NO_TIME_UNIT if no time unit,
+	 *         ERROR_NO_TIME_DURATION if paramName wasn't found.
+	 */
+	private static long parseTimeParameter(String paramName, String[] parameters) {
+		for (String param : parameters) {
+			if (param.startsWith(paramName + "=")) {
+				int valueStart = param.indexOf("=");
+				if (valueStart != -1) {
+					return convertToMilliseconds(param.substring(valueStart + 1));
+				}
+			}
+		}
+		return ERROR_NO_TIME_DURATION;
+	}
+
+	private static String parseStringParameter(String paramName, String[] parameters, String defaultValue) {
+		for (String param : parameters) {
+			if (param.startsWith(paramName + "=")) {
+				int valueStart = param.indexOf("=");
+				if (valueStart != -1) {
+					return param.substring(valueStart + 1);
+				}
+			}
+		}
+		return defaultValue;
+	}
+
+	private static Object parseTypeParameter(String typeName, String[] types, Object defaultValue) {
+		for (String type : types) {
+			if (type.startsWith(typeName + "=")) {
+				int valueStart = type.indexOf("=");
+				if (valueStart != -1) {
+					Object result;
+					String typeValue = type.substring(valueStart + 1);
+					IPC.logMessage("JFR:parseTypeParameter() typeName = " + typeName + ", found typeValue = " + typeValue);
+					switch (typeName) {
+					case "repositorypath":
+					case "dumppath":
+						result = typeValue;
+						break;
+					case "stackdepth":
+						result = new Integer(typeValue);
+						break;
+					case "globalbuffercount":
+					case "globalbuffersize":
+					case "thread_buffer_size":
+					case "memorysize":
+					case "maxchunksize":
+						result = new Long(typeValue);
+						break;
+					case "samplethreads":
+						result = new Boolean(typeValue);
+						break;
+					default:
+						IPC.logMessage("JFR:parseTypeParameter() unexpected typeName = " + typeName);
+						result = null;
+						break;
+					}
+					return result;
+				}
+			}
+		}
+		return defaultValue;
+	}
+
+	static DiagnosticProperties doJFR(String diagnosticCommand) {
+		if (VM.isStartFlightRecordingSpecified()) {
+			return DiagnosticProperties.makeStringResult("Cannot use jcmd JFR options at the same time as -XX:startFlightRecording.");
+		}
+
+		DiagnosticProperties result = null;
+		// Split the command and arguments.
+		String[] parts = diagnosticCommand.split(DiagnosticUtils.DIAGNOSTICS_OPTION_SEPARATOR);
+		IPC.logMessage("doJFR() diagnosticCommand = " + diagnosticCommand);
+		// Ensure there's at least one part for the command.
+		if (parts.length == 0) {
+			return DiagnosticProperties.makeErrorProperties("Error: No JFR command specified");
+		}
+		String command = parts[0].trim();
+		String[] parameters = Arrays.copyOfRange(parts, 1, parts.length);
+		String fileName = parseStringParameter("filename", parameters, null);
+		IPC.logMessage("doJFR(): filename = ", fileName);
+
+		IPC.logMessage("doJFR(): JFR support is enabled with V1 implementation");
+		try {
+			switch (command) {
+			case DIAGNOSTICS_JFR_START:
+				if (VM.isJFRRecordingStarted()) {
+					result = DiagnosticProperties.makeErrorProperties("One JFR recording is in progress ["
+							+ jfrRecordingFileName + "], only one recording is allowed at a time.");
+				} else {
+					// Only JFR.start command is allowed to change the recording filename.
+					boolean setFileName = (fileName != null) && !fileName.isEmpty();
+					if (setFileName) {
+						// The recording filename should be set before VM.startJFR() which invokes JFRWriter:openJFRFile().
+						if (!VM.setJFRRecordingFileName(fileName)) {
+							return DiagnosticProperties.makeErrorProperties("setJFRRecordingFileName() failed");
+						} else {
+							jfrRecordingFileName = fileName;
+						}
+					}
+					long duration = parseTimeParameter("duration", parameters);
+					IPC.logMessage("doJFR(): duration = " + duration);
+					if (duration == ERROR_NO_TIME_UNIT) {
+						return DiagnosticProperties.makeErrorProperties("The duration doesn't have a time unit.");
+					}
+					VM.startJFR();
+					if (duration > 0) {
+						Timer timer = new Timer();
+						TimerTask jfrDumpTask = new TimerTask() {
+							public void run() {
+								if (VM.isJFRRecordingStarted()) {
+									VM.stopJFR();
+								}
+							}
+						};
+						timer.schedule(jfrDumpTask, duration);
+					} else {
+						// The recording is on until JFR.stop.
+					}
+					result = DiagnosticProperties.makeStringResult("Start JFR recording to " + jfrRecordingFileName);
+				}
+				break;
+			case DIAGNOSTICS_JFR_STOP:
+				if (!VM.isJFRRecordingStarted()) {
+					result = DiagnosticProperties.makeErrorProperties("Could not stop recording ["
+							+ jfrRecordingFileName + "], run JFR.start first.");
+				} else {
+					VM.stopJFR();
+					result = DiagnosticProperties.makeStringResult("Stop JFR recording, and dump all Java threads to "
+							+ jfrRecordingFileName);
+				}
+				break;
+			case DIAGNOSTICS_JFR_DUMP:
+				if (!VM.isJFRRecordingStarted()) {
+					result = DiagnosticProperties.makeErrorProperties("Could not create a JFR recording ["
+							+ jfrRecordingFileName + "], run JFR.start first.");
+				} else {
+					VM.jfrDump();
+					result = DiagnosticProperties.makeStringResult("Dump all Java threads to " + jfrRecordingFileName);
+				}
+				break;
+			default:
+				result = DiagnosticProperties.makeErrorProperties("Command not recognized: " + command);
+				break;
+			}
+		} catch (Exception e) {
+			result = DiagnosticProperties.makeErrorProperties("Error in JFR: " + e.getMessage());
+		}
+
+		return result;
+	}
+
+/*[IF JAVA_SPEC_VERSION == 17]*/
+	static DiagnosticProperties doJFRv2(String diagnosticCommand) {
+		// Split the command and arguments.
+		String[] parts = diagnosticCommand.split(DiagnosticUtils.DIAGNOSTICS_OPTION_SEPARATOR);
+		IPC.logMessage("doJFRv2() diagnosticCommand = " + diagnosticCommand);
+		String command = parts[0];
+		String execArgs = "";
+		if (parts.length > 1) {
+			execArgs = diagnosticCommand.substring(command.length() + 1);
+		}
+		command = command.trim();
+
+		DiagnosticProperties result;
+		VMLangAccess access = VM.getVMLangAccess();
+		String[] jfrDcmdResult;
+		try {
+			switch (command) {
+			case DIAGNOSTICS_JFR_START:
+				jfrDcmdResult = access.doJFRDCmdStartExecute(execArgs);
+				if (LOGGING_ENABLED == loggingStatus) {
+					for (String str : jfrDcmdResult) {
+						IPC.logMessage("JFR.start Result string: " + str);
+					}
+				}
+				result = DiagnosticProperties.makeStringResult(Stream.of(jfrDcmdResult).collect(Collectors.joining("\n")));
+				break;
+			case DIAGNOSTICS_JFR_STOP:
+				jfrDcmdResult = access.doJFRDCmdStopExecute(execArgs);
+				if (LOGGING_ENABLED == loggingStatus) {
+					for (String str : jfrDcmdResult) {
+						IPC.logMessage("JFR.stop Result string = " + str);
+					}
+				}
+				result = DiagnosticProperties.makeStringResult(Stream.of(jfrDcmdResult).collect(Collectors.joining("\n")));
+				break;
+			case DIAGNOSTICS_JFR_DUMP:
+				jfrDcmdResult = access.doJFRDCmdDumpExecute(execArgs);
+				if (LOGGING_ENABLED == loggingStatus) {
+					for (String str : jfrDcmdResult) {
+						IPC.logMessage("JFR.dump Result string = " + str);
+					}
+				}
+				result = DiagnosticProperties.makeStringResult(Stream.of(jfrDcmdResult).collect(Collectors.joining("\n")));
+				break;
+			case DIAGNOSTICS_JFR_CONFIGURE:
+				String repositoryPath = (String) parseTypeParameter("repositorypath", parts, null);
+				String dumpPath = (String) parseTypeParameter("dumppath", parts, null);
+				Integer stackDepth = (Integer) parseTypeParameter("stackdepth", parts, null);
+				Long globalBufferCount = (Long) parseTypeParameter("globalbuffercount", parts, null);
+				Long globalBufferSize = (Long) parseTypeParameter("globalbuffersize", parts, null);
+				Long threadBufferSize = (Long) parseTypeParameter("thread_buffer_size", parts, null);
+				Long memorySize = (Long) parseTypeParameter("memorysize", parts, null);
+				Long maxChunkSize = (Long) parseTypeParameter("maxchunksize", parts, null);
+				Boolean sampleThreads = (Boolean) parseTypeParameter("samplethreads", parts, null);
+				IPC.logMessage("JFRHelpers:doJFRDCmdConfigureExecute() verbose = true"
+						+ ", repositoryPath = " + repositoryPath
+						+ ", dumpPath = " + dumpPath
+						+ ", stackDepth = " + stackDepth
+						+ ", globalBufferCount = " + globalBufferCount
+						+ ", globalBufferSize = " + globalBufferSize
+						+ ", threadBufferSize = " + threadBufferSize
+						+ ", memorySize = " + memorySize
+						+ ", maxChunkSize = " + maxChunkSize
+						+ ", sampleThreads = " + sampleThreads);
+				jfrDcmdResult = access.doJFRDCmdConfigureExecute(
+						true, // verbose on
+						repositoryPath,
+						dumpPath,
+						stackDepth,
+						globalBufferCount,
+						globalBufferSize,
+						threadBufferSize,
+						memorySize,
+						maxChunkSize,
+						sampleThreads);
+				if (LOGGING_ENABLED == loggingStatus) {
+					for (String str : jfrDcmdResult) {
+						IPC.logMessage("JFR.configure Result string = " + str);
+					}
+				}
+				result = DiagnosticProperties.makeStringResult(Stream.of(jfrDcmdResult).collect(Collectors.joining("\n")));
+				break;
+			default:
+				result = DiagnosticProperties.makeErrorProperties("JFR command not recognized: " + command);
+				break;
+			}
+		} catch (Exception e) {
+			result = DiagnosticProperties.makeErrorProperties("Error in JFR: " + e.getMessage());
+		}
+
+		return result;
+	}
+/*[ENDIF] JAVA_SPEC_VERSION == 17 */
+}

--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -40,6 +40,7 @@ import java.util.Optional;
 
 import org.openj9.test.util.PlatformInfo;
 import org.openj9.test.util.StringUtilities;
+import org.openj9.test.util.VersionCheck;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
@@ -71,6 +72,16 @@ public class TestJcmd extends AttachApiTest {
 		DUMP_SYSTEM, GC_CLASS_HISTOGRAM, GC_HEAP_DUMP, GC_RUN, HELP_COMMAND, THREAD_PRINT};
 	private static String[] JCMD_COMMANDS_REQUIRE_OPTION = {GC_CLASS_HISTOGRAM, GC_RUN, HELP_COMMAND, THREAD_PRINT};
 	private static String[] JCMD_COMMANDS_DUMP = {DUMP_HEAP, DUMP_JAVA, DUMP_SNAP, DUMP_SYSTEM, GC_HEAP_DUMP};
+
+	// Same as DiagnosticUtils.DIAGNOSTICS_OPTION_SEPARATOR.
+	private static final String DIAGNOSTICS_OPTION_SEPARATOR = ",";
+
+	private static final ArrayList<String> TEST_JFR_VM_ARGS = new ArrayList<>(List.of(
+			"-XX:+EnableOpenJ9ExperimentalFlightRecording",
+			"-Dibm.java9.forceCommonCleanerShutdown=true",
+			"-Xint",
+			"-Xshare:off",
+			"-Xshareclasses:none"));
 
 	/*
 	 * Contains strings expected to be contained in the outputs of various commands
@@ -400,6 +411,156 @@ public class TestJcmd extends AttachApiTest {
 		testDisplayNameHelper("0");
 	}
 
+	@Test
+	public void testJFRStart() throws IOException {
+		if (VersionCheck.major() != 17) {
+			log("Skip JFR V2 test for non JDK17");
+			return;
+		}
+		TargetManager tgt = new TargetManager(TestConstants.TARGET_VM_CLASS, null,
+				TEST_JFR_VM_ARGS, Collections.emptyList());
+		tgt.syncWithTarget();
+		String targetId = tgt.targetId;
+		assertNotNull(targetId, ERROR_TARGET_NOT_LAUNCH);
+		try {
+			List<String> args = new ArrayList<>();
+			args.add(targetId);
+			String command = "JFR.start";
+			log("testJFRStart() command = " + command);
+			args.add(command);
+			List<String> jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRStart() jcmdOutput = " + jcmdOutput);
+			log("testJFRStart() getOutOutput() : " + tgt.getOutOutput());
+			log("testJFRStart() getErrOutput() : " + tgt.getErrOutput());
+			Optional<String> searchResult = StringUtilities.searchSubstring("Started recording", jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+		} finally {
+			tgt.terminateTarget();
+		}
+	}
+
+	@Test
+	public void testJFRDump() throws IOException {
+		if (VersionCheck.major() != 17) {
+			log("Skip JFR V2 test for non JDK17");
+			return;
+		}
+		TargetManager tgt = new TargetManager(TestConstants.TARGET_VM_CLASS, null,
+				TEST_JFR_VM_ARGS, Collections.emptyList());
+		tgt.syncWithTarget();
+		String targetId = tgt.targetId;
+		assertNotNull(targetId, ERROR_TARGET_NOT_LAUNCH);
+		try {
+			List<String> args = new ArrayList<>();
+			args.add(targetId);
+			String command = "JFR.start";
+			log("testJFRDump() command = " + command);
+			args.add(command);
+			List<String> jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRDump() jcmdOutput (JFR.start) = " + jcmdOutput);
+			Optional<String> searchResult = StringUtilities.searchSubstring("Started recording", jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+
+			args.clear();
+			args.add(targetId);
+			command = "JFR.dump";
+			log("testJFRDump() command = " + command);
+			args.add(command);
+			jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRDump() jcmdOutput (JFR.dump) = " + jcmdOutput);
+			searchResult = StringUtilities.searchSubstring("Dumped recording", jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+		} finally {
+			tgt.terminateTarget();
+		}
+	}
+
+	@Test
+	public void testJFRStop() throws IOException {
+		if (VersionCheck.major() != 17) {
+			log("Skip JFR V2 test for non JDK17");
+			return;
+		}
+		TargetManager tgt = new TargetManager(TestConstants.TARGET_VM_CLASS, null,
+				TEST_JFR_VM_ARGS, Collections.emptyList());
+		tgt.syncWithTarget();
+		String targetId = tgt.targetId;
+		assertNotNull(targetId, ERROR_TARGET_NOT_LAUNCH);
+		try {
+			List<String> args = new ArrayList<>();
+			args.add(targetId);
+			String command = "JFR.start";
+			log("testJFRStop() command = " + command);
+			args.add(command);
+			List<String> jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRStop() jcmdOutput (JFR.start) = " + jcmdOutput);
+			Optional<String> searchResult = StringUtilities.searchSubstring("Started recording", jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+
+			args.clear();
+			args.add(targetId);
+			command = "JFR.stop" + DIAGNOSTICS_OPTION_SEPARATOR + "name=1";
+			log("testJFRStop() command = " + command);
+			args.add(command);
+			jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRStop() jcmdOutput (JFR.stop) = " + jcmdOutput);
+			searchResult = StringUtilities.searchSubstring("Stopped recording", jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+		} finally {
+			tgt.terminateTarget();
+		}
+	}
+
+	@Test
+	public void testJFRConfigure() throws IOException {
+		if (VersionCheck.major() != 17) {
+			log("Skip JFR V2 test for non JDK17");
+			return;
+		}
+		TargetManager tgt = new TargetManager(TestConstants.TARGET_VM_CLASS, null,
+				TEST_JFR_VM_ARGS, Collections.emptyList());
+		tgt.syncWithTarget();
+		String targetId = tgt.targetId;
+		assertNotNull(targetId, ERROR_TARGET_NOT_LAUNCH);
+		try {
+			List<String> args = new ArrayList<>();
+			args.add(targetId);
+			String command = "JFR.configure";
+			log("testJFRConfigure() command = " + command);
+			args.add(command);
+			List<String> jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRConfigure() jcmdOutput = " + jcmdOutput);
+
+			String[] expectedStrings = new String[] {
+					"Current configuration:",
+					"Repository path:",
+					"Stack depth:",
+					"Global buffer count:",
+					"Global buffer size:",
+					"Memory size:",
+					"Sample threads:"};
+			Optional<String> searchResult;
+			for (String expectedString : expectedStrings) {
+				searchResult = StringUtilities.searchSubstring(expectedString, jcmdOutput);
+				assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+			}
+
+			args.add("stackdepth=256");
+			jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRConfigure() jcmdOutput with stackdepth=256 = " + jcmdOutput);
+			searchResult = StringUtilities.searchSubstring("Stack depth: 256", jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+
+			args.add("samplethreads=false");
+			jcmdOutput = runCommandAndLogOutput(args);
+			log("testJFRConfigure() jcmdOutput with samplethreads=false = " + jcmdOutput);
+			searchResult = StringUtilities.searchSubstring("Sample threads: false", jcmdOutput);
+			assertTrue(searchResult.isPresent(), "Unpexpected jcmd output: " + jcmdOutput);
+		} finally {
+			tgt.terminateTarget();
+		}
+	}
+
 	@BeforeMethod
 	protected void setUp(Method testMethod) {
 		testName = testMethod.getName();
@@ -423,5 +584,4 @@ public class TestJcmd extends AttachApiTest {
 		commandExpectedOutputs.put(DUMP_SNAP, WRONG_NUMBER_OF_ARGUMENTS);
 		commandExpectedOutputs.put(DUMP_SYSTEM, WRONG_NUMBER_OF_ARGUMENTS);
 	}
-
 }


### PR DESCRIPTION
[Add JFRv2 support for jcmd](https://github.com/eclipse-openj9/openj9/commit/40b6b4d4ddd227b37e98ed55629fb904ae5d17ae) 

When JFRv2 is enable, invoke `jdk.jfr.internal.dcmd.DCmdStart.execute()` for `JFR.start`, `jdk.jfr.internal.dcmd.DCmdStop.execute()` for `JFR.stop`, `jdk.jfr.internal.dcmd.DCmdConfigure.execute()` for `JFR.configure`, `jdk.jfr.internal.dcmd.DCmdDump.execute()` for `JFR.dump`;
`Jcmd` calls `DiagnosticUtils`->`VMAccess`->`JFRHelpers` with added `VMLangAccess` APIs;
Added tests for `JFR.start`, `JFR.stop`, `JFR.configure` and `JFR.dump`.

Signed-off-by: Jason Feng <fengj@ca.ibm.com>