### PR TITLE
Update tests to add a sleep before destroying nonpersistent cache

### DIFF
--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -510,6 +510,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 
+	<exec command="sleep 0.5" platforms="linux.*" />
+
 	<test id="Test 30: CMVC 168131 : Cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>


### PR DESCRIPTION
Related to https://github.com/eclipse-openj9/openj9/pull/23881

Fix for the failure at http://vmfarm.rtp.raleigh.ibm.com/job_output.php?id=127219201