### PR TITLE
Enable inhibitRecompilation option for specific methods

### DIFF
--- a/runtime/compiler/control/J9CompilationStrategy.cpp
+++ b/runtime/compiler/control/J9CompilationStrategy.cpp
@@ -671,6 +671,8 @@ bool J9::CompilationStrategy::ProcessJittedSample::shouldProcessSample()
             != -1) // prevent recompilation when opt level is specified
     {
         shouldProcess = false;
+    } else if (_methodInfo->inhibitRecompilation()) {
+        shouldProcess = false;
     } else {
         _isAlreadyBeingCompiled
             = TR::Recompilation::isAlreadyBeingCompiled(_methodInfo->getMethodInfo(), _startPC, _fe);
@@ -931,7 +933,6 @@ void J9::CompilationStrategy::ProcessJittedSample::determineWhetherToRecompileBa
             hotStartCountDelta = 0xffff;
         _bodyInfo->setHotStartCountDelta(hotStartCountDelta);
     }
-
     if (_recompile) {
         // One more test
         if (!_isAlreadyBeingCompiled) {
@@ -1205,7 +1206,7 @@ TR_OptimizationPlan *J9::CompilationStrategy::processHWPSample(TR_MethodEvent *e
 
     methodInfo = bodyInfo->getMethodInfo();
     hotnessLevel = bodyInfo->getHotness();
-    if (bodyInfo->getIsProfilingBody() && !bodyInfo->getUsesJProfiling()) {
+    if ((bodyInfo->getIsProfilingBody() && !bodyInfo->getUsesJProfiling()) || (methodInfo->inhibitRecompilation())) {
         // We rely on a count-based recompilation for profiled methods.
         return NULL;
     }

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -101,6 +101,10 @@ void J9::Recompilation::setupMethodInfo()
         _methodInfo->setNextCompileLevel(optimizationPlan->getOptLevel(),
             (optimizationPlan->insertInstrumentation() != 0));
         _methodInfo->setWasNeverInterpreted(!comp()->fej9()->methodMayHaveBeenInterpreted(comp()));
+
+        if (_compilation->getOption(TR_InhibitRecompilation)) {
+            _methodInfo->setIsInhibitRecompilation(true);
+        }
     } else // this is a recompilation
     {
         // There already is a persistent method info for this method which already

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -246,6 +246,10 @@ public:
         }
     }
 
+    bool inhibitRecompilation() { return _flags.testAny(IsInhibitRecompilation); }
+
+    void setIsInhibitRecompilation(bool b) { _flags.set(IsInhibitRecompilation, b); }
+
     enum InfoBits {
         // Normally set by the previous compilation to indicate that the next
         // compilation should use profiling.  Sometimes we can start out without
@@ -316,6 +320,8 @@ public:
                                           // Attention: this is not always accurate
         WasScannedForInlining = 0x00400000, // New scanning for warm method inlining
         IsInDataCache = 0x00800000, // This TR_PersistentMethodInfo is stored in the datacache for AOT
+
+        IsInhibitRecompilation = 0x01000000,
 
         lastFlag = 0x80000000
     };


### PR DESCRIPTION
Currently, the option inhibitRecompilation is applied globally. This update enables the user to use the option for a specific method.
OMR PR (https://github.com/eclipse-omr/omr/pull/8282) is required for the method to work as intended.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23902

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)