### PR TITLE
Remove Xverify:none from Valhalla tests

### DIFF
--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/DDRValueTypeTest.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/DDRValueTypeTest.java
@@ -60,7 +60,7 @@ public class DDRValueTypeTest {
 		};
 		Object assortedValueWithSingleAlignment = ValueTypeTests.createAssorted(makeAssortedValueWithSingleAlignment, ValueTypeTests.typeWithSingleAlignmentFields);
 		Object assortedValueWithSingleAlignmentAlt = ValueTypeTests.createAssorted(makeAssortedValueWithSingleAlignment, ValueTypeTests.typeWithSingleAlignmentFields, altFields);
-		Object valueTypeWithVolatileFields = ValueTypeTests.createValueTypeWithVolatileFields();
+		Object referenceTypeWithVolatileValueTypeFields = ValueTypeTests.createIdentityClassWithVolatileValueTypeFields();
 
 		Object[] valArray = ValueClass.newNullRestrictedAtomicArray(assortedValueWithSingleAlignmentClass, 2, assortedValueWithSingleAlignment);
 		valArray[1] = assortedValueWithSingleAlignmentAlt;
@@ -68,7 +68,7 @@ public class DDRValueTypeTest {
 		ValueTypeTests.checkObject(assortedValueWithSingleAlignment, 
 				assortedValueWithSingleAlignmentAlt, 
 				valArray, 
-				valueTypeWithVolatileFields
+				referenceTypeWithVolatileValueTypeFields
 				);
 	}
 }

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeGenerator.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeGenerator.java
@@ -208,9 +208,9 @@ public class ValueTypeGenerator extends ClassLoader {
 		String classFileName = className + ".class";
 
 		if (isRef) {
-			cw.visit(ValhallaUtils.VALUE_TYPE_CLASS_FILE_VERSION, ACC_PUBLIC + ACC_FINAL + ValhallaUtils.ACC_IDENTITY + extraClassFlags, className, null, superName, null);
+			cw.visit(ValhallaUtils.VALUE_TYPE_CLASS_FILE_VERSION, ACC_PUBLIC | ACC_FINAL | ValhallaUtils.ACC_IDENTITY | extraClassFlags, className, null, superName, null);
 		} else {
-			cw.visit(ValhallaUtils.VALUE_TYPE_CLASS_FILE_VERSION, ACC_PUBLIC + ACC_FINAL + extraClassFlags, className, null, superName, null);
+			cw.visit(ValhallaUtils.VALUE_TYPE_CLASS_FILE_VERSION, ACC_PUBLIC | ACC_FINAL | extraClassFlags, className, null, superName, null);
 		}
 
 		cw.visitSource(className + ".java", null);
@@ -232,14 +232,16 @@ public class ValueTypeGenerator extends ClassLoader {
 			String[] nameAndSigValue = s.split(":");
 			final int fieldModifiers;
 			if (isRef) {
-				fieldModifiers = ACC_PUBLIC + ACC_STRICT_INIT;
+				if ((nameAndSigValue.length > 3) && nameAndSigValue[3].equals("volatile")) {
+					fieldModifiers = ACC_PUBLIC | ACC_VOLATILE | ACC_STRICT_INIT;
+				} else {
+					fieldModifiers = ACC_PUBLIC | ACC_STRICT_INIT;
+				}
 			} else {
 				if ((nameAndSigValue.length > 2) && nameAndSigValue[2].equals("static")) {
-					fieldModifiers = ACC_PUBLIC + ACC_STATIC;
-				} else if ((nameAndSigValue.length > 3) && nameAndSigValue[3].equals("volatile")) {
-					fieldModifiers = ACC_PUBLIC + ACC_FINAL + ACC_VOLATILE + ACC_STRICT_INIT;
+					fieldModifiers = ACC_PUBLIC | ACC_STATIC;
 				} else {
-					fieldModifiers = ACC_PUBLIC + ACC_FINAL + ACC_STRICT_INIT;
+					fieldModifiers = ACC_PUBLIC | ACC_FINAL | ACC_STRICT_INIT;
 				}
 			}
 			fv = cw.visitField(fieldModifiers, nameAndSigValue[0], nameAndSigValue[1], null, null);
@@ -299,7 +301,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void addStaticSynchronizedMethods(ClassWriter cw) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC + ACC_SYNCHRONIZED, "staticSynchronizedMethodReturnInt", "()I", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC | ACC_SYNCHRONIZED, "staticSynchronizedMethodReturnInt", "()I", null, null);
 		mv.visitCode();
 		mv.visitInsn(ICONST_1);
 		mv.visitInsn(IRETURN);
@@ -308,7 +310,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 	
 	private static void addSynchronizedMethods(ClassWriter cw) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_SYNCHRONIZED, "synchronizedMethodReturnInt", "()I", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_SYNCHRONIZED, "synchronizedMethodReturnInt", "()I", null, null);
 		mv.visitCode();
 		mv.visitInsn(ICONST_1);
 		mv.visitInsn(IRETURN);
@@ -396,7 +398,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	 * TestMonitorExitWithRefType test
 	 */
 	private static void testMonitorExitOnObject(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testMonitorExitOnObject", "(Ljava/lang/Object;)V", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testMonitorExitOnObject", "(Ljava/lang/Object;)V", null, null);
 		mv.visitCode();
 		mv.visitVarInsn(ALOAD, 0);
 		mv.visitInsn(MONITOREXIT);
@@ -410,7 +412,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	 * TestMonitorEnterAndExitWithRefType test
 	 */
 	private static void testMonitorEnterAndExitWithRefType(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testMonitorEnterAndExitWithRefType", "(Ljava/lang/Object;)V", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testMonitorEnterAndExitWithRefType", "(Ljava/lang/Object;)V", null, null);
 		mv.visitCode();
 		mv.visitVarInsn(ALOAD, 0);
 		mv.visitInsn(DUP);
@@ -470,7 +472,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 	
 	private static void makeValueTypeDefaultValue(ClassWriter cw, String valueName, String makeValueSig, String[] fields, int makeMaxLocal) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "makeValueTypeDefaultValue", "()Ljava/lang/Object;", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "makeValueTypeDefaultValue", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitTypeInsn(NEW, valueName);
 		mv.visitInsn(DUP);
@@ -481,7 +483,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void testCheckCastNullRestrictedTypeOnNonNullType(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "testCheckCastNullRestrictedTypeOnNonNullType", "()Ljava/lang/Object;", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testCheckCastNullRestrictedTypeOnNonNullType", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitTypeInsn(NEW, className);
 		mv.visitInsn(DUP);
@@ -493,7 +495,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void testCheckCastNullRestrictedTypeOnNull(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastNullRestrictedTypeOnNull", "()Ljava/lang/Object;", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testCheckCastNullRestrictedTypeOnNull", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitInsn(ACONST_NULL);
 		mv.visitTypeInsn(CHECKCAST, className);
@@ -503,7 +505,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void testCheckCastNullableTypeOnNull(ClassWriter cw, String className, String[] fields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testCheckCastNullableTypeOnNull", "()Ljava/lang/Object;", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testCheckCastNullableTypeOnNull", "()Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitInsn(ACONST_NULL);
 		mv.visitTypeInsn(CHECKCAST, className);
@@ -513,7 +515,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void testUnresolvedValueTypeDefaultValue(ClassWriter cw, String className, String valueUsedInCode) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testUnresolvedValueTypeDefaultValue", "(I)Ljava/lang/Object;", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testUnresolvedValueTypeDefaultValue", "(I)Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitVarInsn(ILOAD, 0);
 		Label falseLabel = new Label();
@@ -537,7 +539,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void testUnresolvedValueTypeGetField(ClassWriter cw, String className, String containerClassName, String[] containerFields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testUnresolvedValueTypeGetField", "(IL"+containerClassName+";)Ljava/lang/Object;", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testUnresolvedValueTypeGetField", "(IL"+containerClassName+";)Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitVarInsn(ILOAD, 0);
 		int fieldCount = containerFields.length;
@@ -567,7 +569,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void testUnresolvedValueTypePutField(ClassWriter cw, String className, String containerClassName, String[] containerFields) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "testUnresolvedValueTypePutField", "(IL"+containerClassName+";Ljava/lang/Object;)V", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "testUnresolvedValueTypePutField", "(IL"+containerClassName+";Ljava/lang/Object;)V", null, null);
 		mv.visitCode();
 		mv.visitVarInsn(ILOAD, 0);
 		int fieldCount = containerFields.length;
@@ -598,7 +600,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	private static void makeGeneric(ClassWriter cw, String className, String methodName, String specificMethodName, String makeValueSig, String makeValueGenericSig, String[] fields, int makeMaxLocal) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, methodName, "(" + makeValueGenericSig + ")Ljava/lang/Object;", null, new String[] {"java/lang/Exception"});
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, methodName, "(" + makeValueGenericSig + ")Ljava/lang/Object;", null, new String[] {"java/lang/Exception"});
 		mv.visitCode();
 		for (int i = 0; i <  fields.length; i++) {
 			String[] nameAndSigValue = fields[i].split(":");
@@ -658,7 +660,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	private static void makeObject(ClassWriter cw, String className, String makeValueSig, String[]fields, int makeMaxLocal) {
 		boolean doubleDetected = false;
 		int count = 0;
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC  + ACC_STATIC, "makeObject", "(" + makeValueSig + ")" + "L" + className + ";", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "makeObject", "(" + makeValueSig + ")" + "L" + className + ";", null, null);
 		mv.visitCode();
 		mv.visitTypeInsn(NEW, className);
 		mv.visitInsn(DUP);
@@ -1126,7 +1128,7 @@ public class ValueTypeGenerator extends ClassLoader {
 	}
 
 	public static void test2DMultiANewArray(ClassWriter cw, String className) {
-		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC + ACC_STATIC, "generate2DMultiANewArray", "(II)Ljava/lang/Object;", null, null);
+		MethodVisitor mv = cw.visitMethod(ACC_PUBLIC | ACC_STATIC, "generate2DMultiANewArray", "(II)Ljava/lang/Object;", null, null);
 		mv.visitCode();
 		mv.visitVarInsn(ILOAD, 0);
 		mv.visitVarInsn(ILOAD, 1);
@@ -1150,7 +1152,7 @@ public class ValueTypeGenerator extends ClassLoader {
 
 		ClassWriter classWriter = new ClassWriter(0);
 		classWriter.visit(ValhallaUtils.VALUE_TYPE_CLASS_FILE_VERSION,
-			ACC_PUBLIC + ACC_FINAL + (isRef ? ValhallaUtils.ACC_IDENTITY : 0),
+			ACC_PUBLIC | ACC_FINAL | (isRef ? ValhallaUtils.ACC_IDENTITY : 0),
 			className, null, "java/lang/Object", null);
 		classWriter.visitField(fieldFlags, fieldName, fieldDesc, null, null);
 

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -1207,28 +1207,28 @@ public class ValueTypeTests {
 	}
 	
 	/*	
-	 * Create a valueType with four valueType members including 2 volatile.
+	 * Create a class with four valueType members including 2 volatile.
 	 *
-	 * value valueWithVolatile {
+	 * class refWithVolatile {
 	 *  flattened ValueInt i;
 	 *  flattened ValueInt i2;
 	 *  flattened Point2D point;   <--- 8 bytes, will be flattened.
 	 *  volatile Point2D vpoint;   <--- volatile 8 bytes, will be flattened.
-	 *  flattened Line2D 1ine;     <--- 16 bytes, will be flattened.
+	 *  flattened Line2D line;     <--- 16 bytes, will be flattened.
 	 *  volatile Line2D vline;     <--- volatile 16 bytes, will not be flattened.
 	 * }
 	 */
 	@Test(priority=3)
-	static public Object createValueTypeWithVolatileFields() throws Throwable {
+	static public Object createIdentityClassWithVolatileValueTypeFields() throws Throwable {
 		String[] fields = {"i:LValueInt;:NR", "i2:LValueInt;:NR", "point:LPoint2D;:NR", "vpoint:LPoint2D;:NR:volatile",
 				"line:LFlattenedLine2D;:NR", "vline:LFlattenedLine2D;:NR:volatile"};
-		Class<?> ValueTypeWithVolatileFieldsClass = ValueTypeGenerator.generateValueClass("ValueTypeWithVolatileFields", fields);
-		MethodHandle valueWithVolatile = lookup.findStatic(ValueTypeWithVolatileFieldsClass, "makeObjectGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class,
+		Class<?> IdentityClassWithVolatileValueTypeFieldsClass = ValueTypeGenerator.generateRefClass("IdentityClassWithVolatileValueTypeFields", fields);
+		MethodHandle refWithVolatile = lookup.findStatic(IdentityClassWithVolatileValueTypeFieldsClass, "makeObjectGeneric", MethodType.methodType(Object.class, Object.class, Object.class, Object.class,
 				Object.class, Object.class, Object.class));
-		MethodHandle[][] getterList = generateGenericGetterList(ValueTypeWithVolatileFieldsClass, fields);
-		Object valueWithVolatileObj = createAssorted(valueWithVolatile, fields);
-		checkFieldAccessMHOfAssortedType(getterList, valueWithVolatileObj, fields, true);
-		return valueWithVolatileObj;
+		MethodHandle[][] getterList = generateGenericGetterList(IdentityClassWithVolatileValueTypeFieldsClass, fields);
+		Object refWithVolatileObj = createAssorted(refWithVolatile, fields);
+		checkFieldAccessMHOfAssortedType(getterList, refWithVolatileObj, fields, true);
+		return refWithVolatileObj;
 	}
 
 	/*

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattened32bitRefBackfillTest.xml
@@ -23,7 +23,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
-	<variable name="ARGS" value="--enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
+	<variable name="ARGS" value="--enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRBackfillLayoutTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -25,8 +25,8 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
-	<variable name="ARGS" value="-Xint --enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
-	<variable name="ARGS_NOCR" value="-Xint --enable-preview -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
+	<variable name="ARGS" value="-Xint --enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
+	<variable name="ARGS_NOCR" value="-Xint --enable-preview -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />
@@ -157,26 +157,26 @@
 			<input>!j9object $valueAddr1$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
-		<output regex="no" type="required" showMatch="yes"> i (offset = 12) (ValueInt)</output>
-		<output regex="no" type="required" showMatch="yes"> i2 (offset = 16) (ValueInt)</output>
-		<output regex="no" type="required" showMatch="yes"> point (offset = 20) (Point2D)</output>
+		<output regex="no" type="success" showMatch="yes"> IdentityClassWithVolatileValueTypeFields</output>
+		<output regex="no" type="required" showMatch="yes"> i (offset = 16) (ValueInt)</output>
+		<output regex="no" type="required" showMatch="yes"> i2 (offset = 20) (ValueInt)</output>
+		<output regex="no" type="required" showMatch="yes"> point (offset = 24) (Point2D)</output>
 		<output regex="no" type="required" showMatch="yes"> vpoint (offset = 4) (Point2D)</output>
-		<output regex="no" type="required" showMatch="yes"> line (offset = 28) (FlattenedLine2D)</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x[\w]+ \(offset = 0\)</output>
+		<output regex="no" type="required" showMatch="yes"> line (offset = 32) (FlattenedLine2D)</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes"> vline = !fj9object 0x[\w]+ \(offset = 12\)</output>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !flatobject $valueAddr1$ to show the all fields of ValueTypeWithVolatileFields. Make sure all the flattened fields have the correct values">
+	<test id="Run !flatobject $valueAddr1$ to show the all fields of IdentityClassWithVolatileValueTypeFields. Make sure all the flattened fields have the correct values">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $valueAddr1$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i (.)* \(offset = 12\)[\n\r](.)*I i = 0x12123434</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i2 (.)* \(offset = 16\)[\n\r](.)*I i = 0x12123434</output>
-		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 20\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
+		<output regex="no" type="success" showMatch="yes"> IdentityClassWithVolatileValueTypeFields</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i (.)* \(offset = 16\)[\n\r](.)*I i = 0x12123434</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">ValueInt i2 (.)* \(offset = 20\)[\n\r](.)*I i = 0x12123434</output>
+		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D point (.)* \(offset = 24\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D vpoint (.)* \(offset = 4\)[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D st (.)*[\n\r](.)*I x = 0xFFEEFFEE[\n\r](.)*I y = 0xAABBAABB</output>
 		<output regex="yes" javaUtilPattern="yes" type="required" showMatch="yes">Point2D en (.)*[\n\r](.)*I x = 0xCCDDCCDD[\n\r](.)*I y = 0x33443344</output>
@@ -184,7 +184,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 	
-	<test id="Run !flatobject $vlineAddr$ to show the field vline of ValueTypeWithVolatileFields. Make sure it has the correct values">
+	<test id="Run !flatobject $vlineAddr$ to show the field vline of IdentityClassWithVolatileValueTypeFields. Make sure it has the correct values">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $vlineAddr$</input>
@@ -244,13 +244,13 @@
 			<input>!j9object $valueAddr1$</input>
 			<input>quit</input>
 		</command>
-		<output regex="no" type="success" showMatch="yes"> ValueTypeWithVolatileFields</output>
-		<output regex="no" type="required" showMatch="yes">(offset = 0)</output>
+		<output regex="no" type="success" showMatch="yes"> IdentityClassWithVolatileValueTypeFields</output>
 		<output regex="no" type="required" showMatch="yes">(offset = 8)</output>
 		<output regex="no" type="required" showMatch="yes">(offset = 16)</output>
 		<output regex="no" type="required" showMatch="yes">(offset = 24)</output>
 		<output regex="no" type="required" showMatch="yes">(offset = 32)</output>
-		<output regex="no" type="required" showMatch="yes">(offset = 48)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 40)</output>
+		<output regex="no" type="required" showMatch="yes">(offset = 56)</output>
 
 		<output regex="no" type="failure">(offset = 4)</output>
 		<output regex="no" type="failure">(offset = 12)</output>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests_lw5.xml
@@ -25,8 +25,8 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Value Type ddr test with flattening enabled" timeout="600">
-	<variable name="ARGS" value="-Xint --enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
-	<variable name="ARGS_NOCR" value="-Xint --enable-preview -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<variable name="ARGS" value="-Xint --enable-preview -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
+	<variable name="ARGS_NOCR" value="-Xint --enable-preview -Xnocompressedrefs -XX:ValueTypeFlatteningThreshold=999999 -XX:+EnableArrayFlattening --add-opens java.base/jdk.internal.misc=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -29,7 +29,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xverify:none \
+			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
 			--enable-preview \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
@@ -68,7 +68,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xverify:none \
+			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
 			--enable-preview \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
@@ -107,7 +107,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xverify:none \
+			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
 			--enable-preview \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \
@@ -147,7 +147,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		</variations>
 		<command>
 			perl $(JVM_TEST_ROOT)$(D)TestConfig$(D)scripts$(D)tools$(D)sysvcleanup.pl all ; \
-			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) -Xverify:none \
+			$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
 			--enable-preview \
 			--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
 			-DRESJAR=$(CMDLINETESTER_RESJAR) \

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -25,7 +25,7 @@
 <!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
 
 <suite id="J9 Value Type ddr test with flattening disabled" timeout="600">
-	<variable name="ARGS" value="--enable-preview -Xint -Xverify:none --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
+	<variable name="ARGS" value="--enable-preview -Xint --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-exports java.base/jdk.internal.value=ALL-UNNAMED" />
 	<variable name="JARS" value="-cp $ASMJAR$$CPDL$$JCOMMANDERJAR$$CPDL$$TESTNGJAR$$CPDL$$VALUETYPEJAR$" />
 	<variable name="PROGRAM" value="org.openj9.test.lworld.DDRValueTypeTest" />
 	<variable name="DUMPFILE" value="j9core.dmp" />


### PR DESCRIPTION
The Xverify:none option has been removed in JDK 27. This change removes its use from the Valhalla tests.

I modified createIdentityClassWithVolatileValueTypeFields to create an identity class instead of a value type to test that volatile fields are not flattened. It is not legal in Java to create a volatile field in a value class since value class instance fields are implicitly final. Offsets of this class are updated as well to account for the new lockword space created now that the class is not a value type.

https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdkValhalla_j9_extended.functional_x86-64_linux_valhalla_Nightly/1811/