### PR TITLE
Simplify computation of bytecodeSize()

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -1037,8 +1037,7 @@ void DLTLogic(J9VMThread *vmThread, TR::CompilationInfo *compInfo)
                 if (enableDLTidx != -1) {
                     J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(walkState.method);
                     bcIndex = enableDLTidx;
-                    if (enableDLTidx >= (J9_BYTECODE_END_FROM_ROM_METHOD(romMethod))
-                            - (J9_BYTECODE_START_FROM_ROM_METHOD(romMethod)))
+                    if (enableDLTidx >= J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod))
                         return;
                     dltBlock->bcIndex[idx] = enableDLTidx;
                 }
@@ -3078,8 +3077,7 @@ static void updateOverriddenFlag(J9VMThread *vm, J9Class *cl)
                 if (traceIt) {
                     printf("For submethod %p, j9methods don't match.  Setting overridden bit. endbc - startbc = "
                            "%" OMR_PRIdPTR "\n",
-                        subMethod,
-                        (J9_BYTECODE_END_FROM_ROM_METHOD(subROM) - J9_BYTECODE_START_FROM_ROM_METHOD(subROM)));
+                        subMethod, J9_BYTECODE_SIZE_FROM_ROM_METHOD(subROM));
                     fflush(stdout);
                 }
 

--- a/runtime/compiler/env/J9VMMethodEnv.cpp
+++ b/runtime/compiler/env/J9VMMethodEnv.cpp
@@ -98,7 +98,7 @@ uint32_t J9::VMMethodEnv::bytecodeSize(TR_OpaqueMethodBlock *method)
     {
         romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
     }
-    return (uint32_t)(J9_BYTECODE_END_FROM_ROM_METHOD(romMethod) - J9_BYTECODE_START_FROM_ROM_METHOD(romMethod));
+    return (uint32_t)J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod);
 }
 
 bool J9::VMMethodEnv::isFrameIteratorSkipMethod(J9Method *method)

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -5481,7 +5481,7 @@ uint32_t TR_J9VMBase::getMethodSize(TR_OpaqueMethodBlock *method)
 {
     J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD((J9Method *)method);
 
-    return (uint32_t)(J9_BYTECODE_END_FROM_ROM_METHOD(romMethod) - J9_BYTECODE_START_FROM_ROM_METHOD(romMethod));
+    return (uint32_t)J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod);
 }
 
 int32_t TR_J9VMBase::getLineNumberForMethodAndByteCodeIndex(TR_OpaqueMethodBlock *method, int32_t bcIndex)

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -5087,10 +5087,7 @@ U_16 TR_ResolvedJ9Method::numberOfPendingPushes()
 
 U_8 *TR_ResolvedJ9Method::bytecodeStart() { return J9_BYTECODE_START_FROM_ROM_METHOD(romMethod()); }
 
-U_32 TR_ResolvedJ9Method::maxBytecodeIndex()
-{
-    return (U_32)(J9_BYTECODE_END_FROM_ROM_METHOD(romMethod()) - bytecodeStart());
-}
+U_32 TR_ResolvedJ9Method::maxBytecodeIndex() { return (U_32)J9_BYTECODE_SIZE_FROM_ROM_METHOD(romMethod()); }
 
 void *TR_ResolvedJ9Method::ramConstantPool() { return literals(); }
 

--- a/runtime/compiler/runtime/IProfiler.cpp
+++ b/runtime/compiler/runtime/IProfiler.cpp
@@ -3154,8 +3154,7 @@ void TR_IProfiler::checkMethodHashTable()
                     J9UTF8_LENGTH(nameUTF8), J9UTF8_DATA(nameUTF8), J9UTF8_LENGTH(signatureUTF8),
                     J9UTF8_DATA(signatureUTF8));
                 fprintf(fout, "\t is %" OMR_PRIdPTR " bytecode long",
-                    J9_BYTECODE_END_FROM_ROM_METHOD(getOriginalROMMethod(method))
-                        - J9_BYTECODE_START_FROM_ROM_METHOD(getOriginalROMMethod(method)));
+                    J9_BYTECODE_SIZE_FROM_ROM_METHOD(getOriginalROMMethod(method)));
             }
             fprintf(fout, "\n");
             fflush(fout);


### PR DESCRIPTION
Just use `size` instead of computing `((start + size) - start)`.