### PR TITLE
Remove unused function JVM_IsValhallaEnabled()

### DIFF
--- a/runtime/j9vm/exports.cmake
+++ b/runtime/j9vm/exports.cmake
@@ -538,7 +538,6 @@ if(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		JVM_IsAtomicArray
 		JVM_IsFlatArray
 		JVM_IsNullRestrictedArray
-		JVM_IsValhallaEnabled
 		JVM_NewNullableAtomicArray
 		JVM_NewNullRestrictedAtomicArray
 		JVM_NewNullRestrictedNonAtomicArray

--- a/runtime/j9vm/valhallavmi.cpp
+++ b/runtime/j9vm/valhallavmi.cpp
@@ -131,12 +131,6 @@ JVM_IsNullRestrictedArray(JNIEnv *env, jarray obj)
 	return result;
 }
 
-JNIEXPORT jboolean JNICALL
-JVM_IsValhallaEnabled()
-{
-	return JNI_TRUE;
-}
-
 static jarray
 newArrayHelper(JNIEnv *env, jclass componentType, jint length, bool isNullRestricted, jobject initialValueJni)
 {

--- a/runtime/redirector/forwarders.m4
+++ b/runtime/redirector/forwarders.m4
@@ -472,8 +472,6 @@ _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_IsNullRestrictedArray, JNICALL, false, jboolean, JNIEnv *env, jarray obj)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
-	[_X(JVM_IsValhallaEnabled, JNICALL, false, jboolean, void)])
-_IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_NewNullableAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length)])
 _IF([defined(J9VM_OPT_VALHALLA_VALUE_TYPES)],
 	[_X(JVM_NewNullRestrictedAtomicArray, JNICALL, false, jarray, JNIEnv *env, jclass cls, jint length, jobject initialValue)])


### PR DESCRIPTION
The declaration was removed upstream in
* [8385474: [lworld] Leftover JVM_IsValhallaEnabled and JVM_IsIdentityClass](https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/commit/fe6a032192b9893fc66c36dbe4dbb21303ab5663).

`JVM_IsIdentityClass()` was also removed, but it appears that function was never implemented in OpenJ9.