### PR TITLE
Suppress warning about use of flexible array

### DIFF
--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -183,11 +183,20 @@ struct ThreadGroupEntry {
 	ThreadGroupEntry *next;
 };
 
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable: 4200) /* Suppress warning about use of flexible array. */
+#endif /* defined(_MSC_VER) */
+
 struct NetworkInterfaceNameEntry {
 	NetworkInterfaceNameEntry *next;
 	U_32 index;
 	char networkInterfaceName[0];
 };
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif /* defined(_MSC_VER) */
 
 struct StackFrame {
 	U_32 methodIndex;


### PR DESCRIPTION
Builds are failing on Windows ([example](https://openj9-jenkins.osuosl.org/job/Build_JDK11_x86-64_windows_OpenJDK11/149)):
```
[2026-05-27T15:22:41.826Z] f:\users\jenkins\workspace\build_jdk11_x86-64_windows_openjdk11\openj9\runtime\vm\JFRConstantPoolTypes.hpp(189): error C2220: the following warning is treated as an error
[2026-05-27T15:22:41.826Z] f:\users\jenkins\workspace\build_jdk11_x86-64_windows_openjdk11\openj9\runtime\vm\JFRConstantPoolTypes.hpp(189): warning C4200: nonstandard extension used: zero-sized array in struct/union
[2026-05-27T15:22:41.826Z] f:\users\jenkins\workspace\build_jdk11_x86-64_windows_openjdk11\openj9\runtime\vm\JFRConstantPoolTypes.hpp(189): note: This member will be ignored by a defaulted constructor or copy/move assignment operator
[2026-05-27T15:22:41.826Z] make[6]: *** [runtime/vm/CMakeFiles/j9vm.dir/build.make:1635: runtime/vm/CMakeFiles/j9vm.dir/jfr.cpp.obj] Error 2
```