### PR TITLE
Advise using conforming attributes in commit messages

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -223,7 +223,7 @@ attribute that at the end of the commit message (before any human authorship
 signatures).
 
 ```
-Co-authored by <YOUR AI ASSISTANT>
+Co-authored-by: <YOUR AI ASSISTANT>
 ```
 
 ### Tagging


### PR DESCRIPTION
Attribute names should not have embedded spaces and should be followed by a colon.