### PR TITLE
Exclude AIX from JFR NetworkUtilization test platforms

### DIFF
--- a/test/functional/cmdLineTests/jfr/jfrevents.xml
+++ b/test/functional/cmdLineTests/jfr/jfrevents.xml
@@ -168,7 +168,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="success" caseSensitive="yes" regex="no">heapSpace</output>
 		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
 	</test>
-	<test id="test jfr NetworkUtilization - approx 30 seconds">
+	<test id="test jfr NetworkUtilization - approx 30 seconds" platforms="linux.*,osx.*,win.*">
 		<command>$JFR_EXE$ print --xml --events "NetworkUtilization" defaultJ9recording.jfr</command>
 		<output type="required" caseSensitive="yes" regex="no">http://www.w3.org/2001/XMLSchema-instance</output>
 		<output type="required" caseSensitive="yes" regex="no">jdk.NetworkUtilization</output>


### PR DESCRIPTION
omrnetwork_get_network_interfaces is not supported on AIX currently so AIX needs to be excluded from testing platforms.

Closes: https://github.com/eclipse-openj9/openj9/issues/24000