### PR TITLE
Prevent value types from being used as monitors

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Object.java
+++ b/jcl/src/java.base/share/classes/java/lang/Object.java
@@ -295,6 +295,11 @@ public final void wait(long time, int frac) throws InterruptedException {
 		}
 	}
 /*[ELSE] JAVA_SPEC_VERSION < 24 */
+/*[IF INLINE-TYPES]*/
+	if (this.getClass().isValue()) {
+		throw new IllegalMonitorStateException();
+	}
+/*[ENDIF] INLINE-TYPES */
 	if ((time < 0) || (frac < 0)) {
 		throw new IllegalArgumentException("timeout value is negative");
 	}

--- a/runtime/oti/ObjectMonitor.hpp
+++ b/runtime/oti/ObjectMonitor.hpp
@@ -174,7 +174,14 @@ done:
 		bool notify = false;
 		omrthread_monitor_t monitor = (omrthread_monitor_t)(UDATA)1; // invalid but non-NULL value
 		j9objectmonitor_t lock = 0;
-		j9objectmonitor_t *lockEA = inlineGetLockAddress(currentThread, object);
+		j9objectmonitor_t *lockEA = NULL;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		J9Class *clazz = J9OBJECT_CLAZZ(currentThread, object);
+		if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
+			goto done;
+		}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+		lockEA = inlineGetLockAddress(currentThread, object);
 		if (NULL == lockEA) {
 			goto done;
 		}

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1052,3 +1052,5 @@ TraceEvent=Trc_VM_freeJavaStack_mprotectError NoEnv Overhead=1 Level=1 Template=
 
 TraceEvent=Trc_VM_internalCreateRAMClassDone_hotswapping_set_state Overhead=1 Level=2 Template="className (%.*s), state(%p)->classObject is set to (%p)"
 TraceEvent=Trc_VM_internalCreateRAMClassDone_bootstrap_state Overhead=1 Level=2 Template="className (%.*s), state(%p)->classObject is NULL"
+
+TraceExit-Exception=Trc_VM_objectMonitorExit_Exit_ValueType Overhead=1 Level=4 Template="IllegalMonitorState in objectMonitorExit. obj=%p is a value type."

--- a/runtime/vm/monhelpers.c
+++ b/runtime/vm/monhelpers.c
@@ -36,11 +36,23 @@ objectMonitorExit(J9VMThread* vmStruct, j9object_t object)
 	IDATA rc = J9THREAD_ILLEGAL_MONITOR_STATE;
 	j9objectmonitor_t *lockEA = NULL;
 	j9objectmonitor_t lock = 0;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	J9Class *clazz = NULL;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 	Assert_VM_true(vmStruct != NULL);
 	Assert_VM_true(J9_ARE_NO_BITS_SET((UDATA)vmStruct, OBJECT_HEADER_LOCK_BITS_MASK));
 
 	Trc_VM_objectMonitorExit_Entry(vmStruct, object);
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	/* There is a test that calls monitorExit without monitorEnter. */
+	clazz = J9OBJECT_CLAZZ(vmStruct, object);
+	if (J9_IS_J9CLASS_VALUETYPE(clazz)) {
+		Trc_VM_objectMonitorExit_Exit_ValueType(vmStruct, object);
+		goto done;
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 	if (!LN_HAS_LOCKWORD(vmStruct, object)) {
 		J9ObjectMonitor *objectMonitor = NULL;


### PR DESCRIPTION
Throw IllegalMonitorStateException if value types
are used as monitors

These changes are required for:
- runtime/valhalla/inlinetypes/ObjectMethods.java#compressed-class-pointers
- runtime/valhalla/inlinetypes/ObjectMethods.java#no-verify
- runtime/valhalla/inlinetypes/ObjectMethods.java#no-compressed-class-pointers