### PR TITLE
JVMTI: Clone value types in GetLocalInstance to preserve immutability

### DIFF
--- a/runtime/jvmti/jvmtiLocalVariable.cpp
+++ b/runtime/jvmti/jvmtiLocalVariable.cpp
@@ -473,6 +473,15 @@ release:
 
 			if (objectFetched) {
 				j9object_t obj = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				/* For value types, create defensive copy to preserve immutability during inspection */
+				if ((NULL != obj) && J9_IS_J9CLASS_VALUETYPE(J9OBJECT_CLAZZ(currentThread, obj))) {
+					obj = vm->internalVMFunctions->cloneValueType(currentThread,
+							J9OBJECT_CLAZZ(currentThread, obj),
+							obj,
+							FALSE);
+				}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 				*((jobject *)value_ptr) = vm->internalVMFunctions->j9jni_createLocalRef((JNIEnv *)currentThread, obj);
 			}
 			releaseVMThread(currentThread, targetThread, thread);


### PR DESCRIPTION
Fix for Issue #24012 

Clone value types via cloneValueType() to ensure JVMTI 
inspection returns independent immutable snapshots.


Fixes test: serviceability/jvmti/valhalla/GetCtorLocal/ValueGetCtorLocal.java
Passing test:https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/60363/

