### PR TITLE
Wrap arraytranslate node in treetop in J9RecognizedCallTransformer

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -355,6 +355,8 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     arrayTranslateNode->setAndIncChild(4, length);
     arrayTranslateNode->setAndIncChild(5, stoppingNode);
 
+    TR::Node *arraytranslateAnchorNode = TR::Node::create(TR::treetop, 1, arrayTranslateNode);
+
     TR::CFG *cfg = comp()->getFlowGraph();
 
     // if (length < 0) { call the original method }
@@ -382,8 +384,7 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     TR::Node *ifCmpNode5 = TR::Node::createif(TR::ificmplt, ishrNode, iaddNode2);
     TR::TreeTop *ifCmpTreeTop5 = TR::TreeTop::create(comp(), ifCmpTreeTop4, ifCmpNode5);
 
-    TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arrayTranslateNode);
-
+    TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arraytranslateAnchorNode);
     TR::Block *ifCmpBlock1 = ifCmpTreeTop1->getEnclosingBlock();
     TR::Block *ifCmpBlock2
         = ifCmpBlock1->split(ifCmpTreeTop2, cfg, true /* fixUpCommoning */, true /* copyExceptionSuccessors */);


### PR DESCRIPTION
Fixed issue where arrayTranslate nodes appeared as parents in IL tree dumps but lacked the required treetop node wrapper. This ensures proper IL tree structure representation.

@matthewhall2 

The link to the issue: #23955 