### PR TITLE
Stop recognizing `-Xverify:none` for Java 27+

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -3227,9 +3227,9 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 			return result;
 		}
 	} else {
-		/* Special checking to look for jsr's if -noverify - the verifyFunction normally scans and tags
-		 * for inlining methods and classes that contain jsr's unless the class file version is 51 or
-		 * greater as jsr / ret are always illegal in that case
+		/* Special checking to look for JSRs if -Xverify:none - the verifyFunction normally scans and tags
+		 * for inlining methods and classes that contain JSRs unless the class file version is 51 or
+		 * greater as JSR / RET are always illegal in that case.
 		 */
 		if (classfile->majorVersion < 51) {
 			hasRET = checkForJsrs(classfile);

--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -86,8 +86,8 @@ static void bcvHookClassesUnload (J9HookInterface** hook, UDATA eventNum, void* 
 static void printMethod (J9BytecodeVerificationData * verifyData);
 static IDATA simulateStack (J9BytecodeVerificationData * verifyData);
 
-static IDATA parseOptions (J9JavaVM *vm, char *optionValues, const char **errorString);
-static IDATA setVerifyState ( J9JavaVM *vm, char *option, const char **errorString );
+static IDATA parseOptions(J9JavaVM *vm, const char *optionValues, const char **errorString);
+static IDATA setVerifyState(J9JavaVM *vm, const char *option, const char **errorString );
 
 #if defined(J9VM_OPT_VALHALLA_STRICT_FIELDS)
 static UDATA strictFieldHashFn(void *key, void *userData);
@@ -2788,10 +2788,10 @@ _done:
 IDATA
 j9bcv_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved)
 {
-	J9BytecodeVerificationData* verifyData = NULL;
-	char optionValuesBuffer[128];					/* Needs to be big enough to hold -Xverify option values */
-	char* optionValuesBufferPtr = optionValuesBuffer;
-	J9VMDllLoadInfo* loadInfo = NULL;
+	J9BytecodeVerificationData *verifyData = NULL;
+	char optionValuesBuffer[128]; /* Needs to be big enough to hold -Xverify option values. */
+	char *optionValuesBufferPtr = optionValuesBuffer;
+	J9VMDllLoadInfo *loadInfo = NULL;
 	IDATA xVerifyIndex = -1;
 	IDATA xVerifyColonIndex = -1;
 	IDATA verboseVerificationIndex = -1;
@@ -2802,12 +2802,12 @@ j9bcv_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved)
 	IDATA noClassRelationshipVerifierIndex = -1;
 	IDATA returnVal = J9VMDLLMAIN_OK;
 #if defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING)
-	J9HookInterface ** vmHooks = vm->internalVMFunctions->getVMHookInterface(vm);
+	J9HookInterface **vmHooks = vm->internalVMFunctions->getVMHookInterface(vm);
 #endif /* J9VM_GC_DYNAMIC_CLASS_UNLOADING */
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	switch(stage) {
+	switch (stage) {
 
 		case ALL_VM_ARGS_CONSUMED :
 			FIND_AND_CONSUME_VMARG( OPTIONAL_LIST_MATCH, OPT_XVERIFY, NULL);
@@ -2843,15 +2843,15 @@ j9bcv_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved)
 			 *
 			 * This parsing is a duplicate of the parsing in the function VMInitStages of jvminit.c
 			 */
-			xVerifyIndex = FIND_ARG_IN_VMARGS( EXACT_MATCH, OPT_XVERIFY, NULL);
-			xVerifyColonIndex = FIND_ARG_IN_VMARGS_FORWARD( STARTSWITH_MATCH, OPT_XVERIFY_COLON, NULL);
+			xVerifyIndex = FIND_ARG_IN_VMARGS(EXACT_MATCH, OPT_XVERIFY, NULL);
+			xVerifyColonIndex = FIND_ARG_IN_VMARGS_FORWARD(STARTSWITH_MATCH, OPT_XVERIFY_COLON, NULL);
 			while (xVerifyColonIndex >= 0) {
-				/* Ignore -Xverify:<opt>'s prior to the last -Xverify */
+				/* Ignore -Xverify:<opt>'s prior to the last -Xverify. */
 				if (xVerifyColonIndex > xVerifyIndex) {
-					/* Deal with possible -Xverify:<opt>,<opt> case */
-					GET_OPTION_VALUES( xVerifyColonIndex, ':', ',', &optionValuesBufferPtr, 128 );
+					/* Deal with possible -Xverify:<opt>,<opt> case. */
+					GET_OPTION_VALUES(xVerifyColonIndex, ':', ',', &optionValuesBufferPtr, sizeof(optionValuesBuffer));
 
-					if ('\0' != *optionValuesBuffer) {
+					if ('\0' != optionValuesBuffer[0]) {
 						const char *errorString = NULL;
 						if (!parseOptions(vm, optionValuesBuffer, &errorString)) {
 							vm->internalVMFunctions->setErrorJ9dll(PORTLIB, loadInfo, errorString, FALSE);
@@ -2906,7 +2906,7 @@ j9bcv_J9VMDllMain (J9JavaVM* vm, IDATA stage, void* reserved)
 
 
 static IDATA
-setVerifyState(J9JavaVM *vm, char *option, const char **errorString)
+setVerifyState(J9JavaVM *vm, const char *option, const char **errorString)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
@@ -2925,25 +2925,25 @@ setVerifyState(J9JavaVM *vm, char *option, const char **errorString)
 		vm->bytecodeVerificationData->verificationFlags |= J9_VERIFY_IGNORE_STACK_MAPS;
 	} else if (0 == strncmp(option, OPT_EXCLUDEATTRIBUTE_EQUAL, sizeof(OPT_EXCLUDEATTRIBUTE_EQUAL) - 1)) {
 		if (0 != option[sizeof(OPT_EXCLUDEATTRIBUTE_EQUAL)]) {
-			UDATA length;
+			UDATA length = 0;
 			vm->bytecodeVerificationData->verificationFlags |= J9_VERIFY_EXCLUDE_ATTRIBUTE;
 			/* Save the parameter string, NULL terminated and the length excluding the NULL */
 			length = strlen(option) - sizeof(OPT_EXCLUDEATTRIBUTE_EQUAL) + 1;
 			vm->bytecodeVerificationData->excludeAttribute = j9mem_allocate_memory(length + 1, J9MEM_CATEGORY_CLASSES);
 			if (NULL == vm->bytecodeVerificationData->excludeAttribute) {
-				if (errorString) {
+				if (NULL != errorString) {
 					*errorString = "Out of memory processing -Xverify:<opt>";
 				}
 				return FALSE;
 			}
-			memcpy(vm->bytecodeVerificationData->excludeAttribute, &(option[sizeof(OPT_EXCLUDEATTRIBUTE_EQUAL) - 1]), length + 1);
+			memcpy(vm->bytecodeVerificationData->excludeAttribute, &option[sizeof(OPT_EXCLUDEATTRIBUTE_EQUAL) - 1], length + 1);
 		}
 	} else if (0 == strcmp(option, OPT_BOOTCLASSPATH_STATIC)) {
 		vm->bytecodeVerificationData->verificationFlags |= J9_VERIFY_BOOTCLASSPATH_STATIC;
 	} else if (0 == strcmp(option, OPT_DO_PROTECTED_ACCESS_CHECK)) {
 		vm->bytecodeVerificationData->verificationFlags |= J9_VERIFY_DO_PROTECTED_ACCESS_CHECK;
 	} else {
-		if (errorString) {
+		if (NULL != errorString) {
 			*errorString = "Unrecognised option(s) for -Xverify:<opt>";
 		}
 		return FALSE;
@@ -2954,16 +2954,16 @@ setVerifyState(J9JavaVM *vm, char *option, const char **errorString)
 
 
 static IDATA
-parseOptions(J9JavaVM *vm, char *optionValues, const char **errorString)
+parseOptions(J9JavaVM *vm, const char *optionValues, const char **errorString)
 {
-	char *optionValue = optionValues;			/* Values are separated by single NULL characters. */
+	const char *optionValue = optionValues; /* Values are separated by single NULL characters. */
 
 	/* call setVerifyState on each individual option */
-	while (*optionValue) {
-		if( !setVerifyState( vm, optionValue, errorString ) ) {
+	while ('\0' != optionValue[0]) {
+		if (!setVerifyState(vm, optionValue, errorString)) {
 			return FALSE;
 		}
-		optionValue = optionValue + strlen(optionValue) + 1;			/* Step past null separator to next element */
+		optionValue += strlen(optionValue) + 1; /* Step past NULL separator to next element. */
 	}
 	return TRUE;
 }
@@ -3015,5 +3015,3 @@ static UDATA earlyLarvalFrameEqualFn(void *leftKey, void *rightKey, void *userDa
 	return (leftEntry->baseFramePC == rightEntry->baseFramePC);
 }
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */
-
-

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -3515,13 +3515,20 @@ consumeVMArgs(J9JavaVM* vm, J9VMInitArgs* j9vm_args)
 	BOOLEAN assertOptionFound = FALSE;
 
 	findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XINT, NULL, TRUE);
-	/* If -Xverify:none, other -Xverify args previous to that should be ignored. As of Java 13 -Xverify:none and -noverify are deprecated. */
-	if (findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XVERIFY_COLON, OPT_NONE, TRUE) >= 0) {
+
+	/* If -Xverify:none, other -Xverify args previous to that should be ignored.
+	 * As of Java 13 -Xverify:none and -noverify are deprecated.
+	 * As of Java 27 -Xverify:none and -noverify are no longer recognized.
+	 */
+	if ((JAVA_SPEC_VERSION < 27)
+		&& (findArgInVMArgs(PORTLIB, j9vm_args, STARTSWITH_MATCH, VMOPT_XVERIFY_COLON, OPT_NONE, TRUE) >= 0)
+	) {
 		if (JAVA_SPEC_VERSION >= 13) {
 			j9nls_printf(PORTLIB, J9NLS_WARNING, J9NLS_VM_XVERIFYNONE_DEPRECATED);
 		}
-		findArgInVMArgs( PORTLIB, j9vm_args, OPTIONAL_LIST_MATCH, VMOPT_XVERIFY, NULL, TRUE);
+		findArgInVMArgs(PORTLIB, j9vm_args, OPTIONAL_LIST_MATCH, VMOPT_XVERIFY, NULL, TRUE);
 	}
+
 #if defined(J9VM_INTERP_VERBOSE)
 	/* If -verbose:none, other -verbose args previous to that should be ignored */
 	if (findArgInVMArgs( PORTLIB, j9vm_args, STARTSWITH_MATCH, OPT_VERBOSE_COLON, OPT_NONE, TRUE) >= 0) {
@@ -3588,7 +3595,6 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 	BOOLEAN xint = FALSE;
 	BOOLEAN xjit = FALSE;
 	BOOLEAN xnojit = FALSE;
-	BOOLEAN xverify = FALSE;
 	BOOLEAN xxverboseverification = FALSE;
 	BOOLEAN verbose = FALSE;
 	BOOLEAN xnolinenumbers = FALSE;
@@ -3612,7 +3618,7 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 #define ADD_FLAG_AT_INDEX(flag, index) j9vm_args->j9Options[index].flags |= flag
 #define SET_FLAG_AT_INDEX(flag, index) j9vm_args->j9Options[index].flags = flag | (j9vm_args->j9Options[index].flags & ARG_MEMORY_ALLOCATION)
 
-	xverify = ((xverifyIndex = findArgInVMArgs( PORTLIB, j9vm_args, OPTIONAL_LIST_MATCH, VMOPT_XVERIFY, NULL, FALSE))>=0);
+	xverifyIndex = findArgInVMArgs(PORTLIB, j9vm_args, OPTIONAL_LIST_MATCH, VMOPT_XVERIFY, NULL, FALSE);
 
 	xxverboseverificationIndex = findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XXVERBOSEVERIFICATION, NULL, FALSE);
 	xxnoverboseverificationIndex = findArgInVMArgs( PORTLIB, j9vm_args, EXACT_MATCH, VMOPT_XXNOVERBOSEVERIFICATION, NULL, FALSE);
@@ -3855,21 +3861,26 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 		FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_XXJITDIRECTORY_EQUALS, NULL);
 	}
 
-	if (xverify) {
-		ADD_FLAG_AT_INDEX( ARG_REQUIRES_LIBRARY, xverifyIndex );
-		optionValueOperations(PORTLIB, j9vm_args, xverifyIndex, GET_OPTION, &optionValue, 0, ':', 0, NULL); /* get option value for xverify: */
+	if (xverifyIndex >= 0) {
+		/* get option value for -Xverify: */
+		optionValueOperations(PORTLIB, j9vm_args, xverifyIndex, GET_OPTION, &optionValue, 0, ':', 0, NULL);
 	} else {
 		optionValue = NULL;
 	}
 
-	if ((optionValue != NULL) && (strcmp(optionValue, OPT_NONE) == 0)) {
+	if ((NULL != optionValue) && (0 == strcmp(optionValue, OPT_NONE))) {
+		/* Clear the DllMain function pointer so the library is never called. */
 		entry = findDllLoadInfo(loadTable, J9_VERIFY_DLL_NAME);
-		/* Unsetting the DllMain function pointer so library is never called */
-		entry->j9vmdllmain = 0;
-	} else if (xxverboseverification || xxverifyerrordetails) {
-		entry = getVerboseDllLoadInfo(vm);
-		entry->loadFlags |= LOAD_BY_DEFAULT;
-		JVMINIT_VERBOSE_INIT_VM_TRACE(vm, "verbose support required... whacking table\n");
+		entry->j9vmdllmain = NULL;
+	} else {
+		if (xverifyIndex >= 0) {
+			ADD_FLAG_AT_INDEX(ARG_REQUIRES_LIBRARY, xverifyIndex);
+		}
+		if (xxverboseverification || xxverifyerrordetails) {
+			entry = getVerboseDllLoadInfo(vm);
+			entry->loadFlags |= LOAD_BY_DEFAULT;
+			JVMINIT_VERBOSE_INIT_VM_TRACE(vm, "verbose support required... whacking table\n");
+		}
 	}
 
 #if defined( J9VM_OPT_SIDECAR )
@@ -3907,7 +3918,7 @@ modifyDllLoadTable(J9JavaVM * vm, J9Pool* loadTable, J9VMInitArgs* j9vm_args)
 #ifndef J9VM_OPT_DYNAMIC_LOAD_SUPPORT
 		entry = findDllLoadInfo(loadTable, J9_DYNLOAD_DLL_NAME);
 		/* Unsetting the DllMain function pointer so library is never called */
-		entry->j9vmdllmain = 0;
+		entry->j9vmdllmain = NULL;
 		JVMINIT_VERBOSE_INIT_VM_TRACE(vm, "No dynamic load support... whacking table\n");
 #endif
 
@@ -4857,7 +4868,7 @@ runJ9VMDllMain(void* dllLoadInfo, void* userDataTemp)
 	if (userData->filterFlags==0 || ((userData->filterFlags & entry->loadFlags) == userData->filterFlags)) {
 
 		/* Loaded libraries are guaranteed to have a descriptor. NOT_A_LIBRARY entries will already have a j9vmdllmain entry */
-		if (!entry->j9vmdllmain && entry->descriptor) {
+		if ((NULL == entry->j9vmdllmain) && (0 != entry->descriptor)) {
 			if (j9sl_lookup_name (entry->descriptor , "J9VMDllMain", (void *) &J9VMDllMainFunc, "PLpL")) {
 				setErrorJ9dll(PORTLIB, entry, j9nls_lookup_message(J9NLS_DO_NOT_APPEND_NEWLINE | J9NLS_ERROR, J9NLS_VM_J9VMDLLMAIN_NOT_FOUND, NULL), FALSE);
 				return;
@@ -4865,7 +4876,7 @@ runJ9VMDllMain(void* dllLoadInfo, void* userDataTemp)
 				entry->j9vmdllmain = J9VMDllMainFunc;
 			}
 		}
-		if (entry->j9vmdllmain) {
+		if (NULL != entry->j9vmdllmain) {
 			I_64 start = 0;
 			I_64 end = 0;
 			char* dllName = (entry->loadFlags & ALTERNATE_LIBRARY_USED) ? entry->alternateDllName : entry->dllName;
@@ -5025,10 +5036,10 @@ unloadDLL(void* dllLoadInfo, void* userDataTemp)
 	J9VMDllLoadInfo* entry = (J9VMDllLoadInfo*) dllLoadInfo;
 	LoadInitData* userData = (LoadInitData*) userDataTemp;
 
-	if (entry->descriptor && (entry->loadFlags & userData->flags)) {
+	if ((0 != entry->descriptor) && (0 != (entry->loadFlags & userData->flags))) {
 		if (shutdownDLL(userData->vm, entry->descriptor, FALSE) == 0) {
 			entry->descriptor = 0;
-			entry->j9vmdllmain = 0;
+			entry->j9vmdllmain = NULL;
 			entry->loadFlags &= ~LOADED;
 			JVMINIT_VERBOSE_INIT_VM_TRACE1(userData->vm, "\tfor %s\n", entry->dllName);
 		} else {
@@ -5416,7 +5427,7 @@ runJVMOnLoad(J9JavaVM* vm, J9VMDllLoadInfo* loadInfo, char* options)
 
 	PORT_ACCESS_FROM_JAVAVM(vm);
 
-	if (loadInfo->descriptor) {
+	if (0 != loadInfo->descriptor) {
 		if (j9sl_lookup_name ( loadInfo->descriptor , "JVM_OnLoad", (void *) &jvmOnLoadFunc, "iLLL")) {
 			setErrorJ9dll(PORTLIB, loadInfo, "JVM_OnLoad not found", FALSE);
 		} else {
@@ -5442,7 +5453,7 @@ closeAllDLLs(J9JavaVM* vm)
 
 		entry = (J9VMDllLoadInfo*) pool_startDo(vm->dllLoadTable, &aState);
 		while(entry) {
-			if (entry->descriptor && !(entry->loadFlags & NEVER_CLOSE_DLL)) {
+			if ((0 != entry->descriptor) && (0 == (entry->loadFlags & NEVER_CLOSE_DLL))) {
 				char* dllName = (entry->loadFlags & ALTERNATE_LIBRARY_USED) ? entry->alternateDllName : entry->dllName;
 
 				j9sl_close_shared_library(entry->descriptor);
@@ -5493,8 +5504,8 @@ runUnOnloads(J9JavaVM* vm, UDATA shutdownDueToExit)
 
 		entry = (J9VMDllLoadInfo*) pool_startDo(vm->dllLoadTable, &aState);
 		while(entry) {
-			if (entry->descriptor && ((entry->loadFlags & (NO_J9VMDLLMAIN | AGENT_XRUN)) == NO_J9VMDLLMAIN)) {
-				if(0 == j9sl_lookup_name ( entry->descriptor , "JVM_OnUnload", (void *) &j9OnUnLoadFunc, "iLL")) {
+			if ((0 != entry->descriptor) && (NO_J9VMDLLMAIN == (entry->loadFlags & (NO_J9VMDLLMAIN | AGENT_XRUN)))) {
+				if (0 == j9sl_lookup_name(entry->descriptor, "JVM_OnUnload", (void *) &j9OnUnLoadFunc, "iLL")) {
 					JVMINIT_VERBOSE_INIT_VM_TRACE1(vm, "Running JVM_OnUnload for %s\n", entry->dllName);
 					(*j9OnUnLoadFunc) (vm, (void *) shutdownDueToExit);
 				}

--- a/test/functional/Java11andUp/build.xml
+++ b/test/functional/Java11andUp/build.xml
@@ -31,7 +31,7 @@
 
 	<!-- set global properties for this build -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/Java11andUp" />
-		
+
 	<!--Properties for this particular build-->
 	<property name="src" location="./src"/>
 	<property name="build" location="./bin"/>
@@ -63,11 +63,10 @@
 		</javac>
 	</target>
 
-	<target name="generate_condy" depends="compile_generator" description="Run Condugenerator to generate bytecode" >
+	<target name="generate_condy" depends="compile_generator" description="Run Condygenerator to generate bytecode" >
 		<property name="javaexecutable.java" value="${TEST_JDK_HOME}/bin/java" />
 		<echo>Running CondyGenerator</echo>
 		<java classname="org.openj9.test.condy.CondyGenerator" fork="true" failonerror="true" logError="true" jvm="${javaexecutable.java}">
-			<jvmarg value="-Xverify:none" />
 			<classpath>
 				<pathelement location="${LIB_DIR}/asm.jar" />
 				<pathelement location="${build}" />
@@ -80,7 +79,7 @@
 			</fileset>
 		</delete>
 	</target>
-	
+
 	<target name="compile" depends="generate_condy" description="Using java ${JDK_VERSION} to compile the source" >
 		<echo>Ant version is ${ant.version}</echo>
 		<echo>============COMPILER SETTINGS============</echo>
@@ -113,7 +112,7 @@
 			<fileset dir="${src}/../" includes="*.mk" />
 		</copy>
 	</target>
-	
+
 	<target name="build" >
 		<condition property="is_JDK_IMPL_ibm">
 			<or>

--- a/test/functional/VM_Test/src/j9vm/regression/ClassLoadDuringException.java
+++ b/test/functional/VM_Test/src/j9vm/regression/ClassLoadDuringException.java
@@ -21,10 +21,10 @@
  */
 package j9vm.regression;
 
-//j9 -noverify -Xjit:count=0,noopt,limit={*.jitted*} ClassLoadDuringException
+//j9 -Xverify:none -Xjit:count=0,noopt,limit={*.jitted*} ClassLoadDuringException
 
 public class ClassLoadDuringException {
-	public static void main(String args[]) throws Throwable {
+	public static void main(String[] args) throws Throwable {
 		a();
 	}
 
@@ -35,7 +35,7 @@ public class ClassLoadDuringException {
 	public static void jittedB() {
 		try {
 			c();
-		} catch(NullPointerException e) {
+		} catch (NullPointerException e) {
 			System.out.println("caught npe");
 		}
 	}
@@ -43,11 +43,11 @@ public class ClassLoadDuringException {
 	public static void c() {
 		jittedD();
 	}
-	
+
 	public static void jittedD() {
 		try {
 			e();
-		} catch(NotLoadedYet e) {
+		} catch (NotLoadedYet e) {
 		}
 	}
 

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java_common.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java_common.xml
@@ -64,6 +64,9 @@
  <test id="noverify">
   <command>$EXE$ -noverify $CLASS$</command>
   <output>$FIBOUT$</output>
+  <versions>
+    <version>[8,26]</version>
+  </versions>
  </test>
 
  <test id="Xint">

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -183,7 +183,7 @@
 		<saveoutput regex="no" type="required" saveName="vlineAddr" splitIndex="1" splitBy="vline = !fj9object " showMatch="yes">vline = !fj9object 0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
-	
+
 	<test id="Run !flatobject $vlineAddr$ to show the field vline of IdentityClassWithVolatileValueTypeFields. Make sure it has the correct values">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
@@ -202,7 +202,7 @@
 		<saveoutput regex="no" type="required" saveName="DUMPFILE" splitIndex="1" splitBy="System dump written to ">System dump written to </saveoutput>
 		<output regex="no" type="failure">Exception caught!</output>
 	</test>
-	
+
 	<test id="Run !threads on nocompressedrefs core">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
@@ -224,7 +224,7 @@
 		<saveoutput regex="no" type="required" saveName="objectAddr" splitIndex="1" splitBy="= " showMatch="yes">I-Slot: a0[0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
-	
+
 	<test id="Run !j9object $objectAddr$ to display container array contents on nocompressedrefs core">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
@@ -237,7 +237,7 @@
 		<saveoutput regex="no" type="required" saveName="valueAddr1" splitIndex="1" splitBy="= !j9object " showMatch="yes">[3] = !fj9object 0x</saveoutput>
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
-	
+
 	<test id="Run !j9object $valueAddr1$ to show the fields are all at 8 bytes aligned offsets on nocompressedrefs core">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>


### PR DESCRIPTION
The mapping of `-noverify` to `-Xverify:none` was already removed:
* [8373481: Remove the deprecated -noclassgc, -noverify, -Xverify:none and -verifyremote options from the java launcher](https://github.com/ibmruntimes/openj9-openjdk-jdk/commit/43df81bd30107b49dadb0039c1a0d4b3fac66841)

This also:
* removes support for `-Xverify:none` in jdk27+
* updates code comments
* limits tests to versions where those options are supported
* removes unnecessary uses of those options in tests