### PR TITLE
Add JFRv2 support for SCC

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -160,10 +160,23 @@ internalDefineClass(
 		} else if (NULL != superClass) {
 			J9Class *internalEventClass = J9VMJAVALANGCLASS_VMREF(vmThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrInternalEventClassRef));
 			if (isSameOrSuperClassOf(internalEventClass, superClass)) {
-				U_8* jfrModifiedBytes = NULL;
+				U_8 *jfrModifiedBytes = NULL;
 				UDATA jfrModifiedBytesLength = 0;
+				U_8 *upcallClassBytes = classData;
+				U_32 upcallClassBytesLength = classDataLength;
+
+				if (J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_SHRC_ROMCLASS_EXISTS)) {
+					PORT_ACCESS_FROM_JAVAVM(vm);
+					UDATA rc = BCT_ERR_NO_ERROR;
+					rc = j9bcutil_transformROMClass(vm, PORTLIB, (J9ROMClass *)classData, &upcallClassBytes, &upcallClassBytesLength);
+					if (BCT_ERR_NO_ERROR != result) {
+						Trc_BCU_internalLoadROMClass_ErrorInRecreatingClassfile(vmThread, classData, rc);
+						vmFuncs->setCurrentExceptionUTF(vmThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+						return NULL;
+					}
+				}
 				omrthread_monitor_exit(vm->classTableMutex);
-				vmFuncs->jvmUpcallsEagerByteInstrumentation(vmThread, superClass, className, (U_16)classNameLength, classLoader, classData, classDataLength, &jfrModifiedBytes, &jfrModifiedBytesLength);
+				vmFuncs->jvmUpcallsEagerByteInstrumentation(vmThread, superClass, className, (U_16)classNameLength, classLoader, upcallClassBytes, upcallClassBytesLength, &jfrModifiedBytes, &jfrModifiedBytesLength);
 				omrthread_monitor_enter(vm->classTableMutex);
 				if ((NULL == jfrModifiedBytes) || (0 == jfrModifiedBytesLength)) {
 					omrthread_monitor_exit(vm->classTableMutex);

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -26,20 +26,20 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 <suite id="JFR v2 Tests" timeout="3000">
 	<test id="Test JFRv2 cmdline option - no options">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording -Xshare:off -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording -Djfr.unsupported.vm=false  -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
 	</test>
 	<!-- See https://github.com/eclipse-openj9/openj9/issues/23980
 	<test id="Test JFRv2 cmdline option - memcheck">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -Xshare:off -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -Djfr.unsupported.vm=false  -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>
 	</test>
 	-->
 	<test id="Test JFRv2 with file">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Xshare:off -Djfr.unsupported.vm=false -cp $RESJAR$ org.openj9.test.WorkLoad</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Djfr.unsupported.vm=false -cp $RESJAR$ org.openj9.test.WorkLoad</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="required" caseSensitive="yes" regex="no">0 / 100 complete</output>
 	</test>
@@ -60,13 +60,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="required" caseSensitive="yes" regex="no">JVMInformation</output>
 	</test>
 	<test id="Test JFRv2 with JMX">
-		<command>$EXE$ -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Xshare:off -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Djfr.unsupported.vm=false  -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 	</test>
 	<!-- See https://github.com/eclipse-openj9/openj9/issues/23980
 	<test id="Test JFRv2 with JMX and memcheck">
-		<command>$EXE$ -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Xshare:off -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Djfr.unsupported.vm=false  -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>


### PR DESCRIPTION
Currently, the JFRv2 implemnetation only works with SCC disabled. This is because there is no support to add JFR instrumentation for classes loaded from the SCC. This PR adds support to instrument classes loaded by the SCC by first converting the ROM class into the java class file so that the class can be instrumented by the JCL.

Fixes https://github.com/eclipse-openj9/openj9/issues/23691