### PR TITLE
Implement JVM_isAvailable native method

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -365,8 +365,9 @@ Java_jdk_jfr_internal_JVM_destroyJFR(JNIEnv *env, jobject obj)
 jboolean JNICALL
 Java_jdk_jfr_internal_JVM_isAvailable(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return JNI_FALSE;
+	return Java_com_ibm_oti_vm_VM_isJFRV2SupportEnabled(env, NULL) && Java_com_ibm_oti_vm_VM_isJFREnabled(env, NULL)
+				? JNI_TRUE
+				: JNI_FALSE;
 }
 
 jdouble JNICALL


### PR DESCRIPTION
The JVM_isAvailable returns true if JFRv2 is supported on the platform. This requires first check if JFR is enabled at all (-XX:+FlightRecorder) and then checking is JFRv2 or v1 is enabled.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23779