### PR TITLE
Correct spelling of recalculate

### DIFF
--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.hpp
@@ -421,9 +421,9 @@ public:
 		return _schedulingDelegate.getCurrentEdenSizeInBytes(env);
 	}
 
-	MMINLINE void reCalculateEdenSize(MM_EnvironmentVLHGC *env)
+	MMINLINE void recalculateEdenSize(MM_EnvironmentVLHGC *env)
 	{
-		_schedulingDelegate.reCalculateEdenSize(env);
+		_schedulingDelegate.recalculateEdenSize(env);
 	}
 
 	MM_IncrementalGenerationalGC(MM_EnvironmentVLHGC *env, MM_HeapRegionManager *manager);

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -944,13 +944,13 @@ MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescri
 	} else {
 		/**
 		 * In case there is no heap resize, check if there is the case that free size is smaller than eden size
-		 * due to the conflict between eden resize and heap resize, reCalculateEdenSize if it happens.
+		 * due to the conflict between eden resize and heap resize, recalculateEdenSize if it happens.
 		 */
 		uintptr_t freeBytes = _globalAllocationManagerTarok->getFreeRegionCount()*_heapRegionManager->getRegionSize();
 		MM_IncrementalGenerationalGC *collector = (MM_IncrementalGenerationalGC*)_extensions->getGlobalCollector();
 		uintptr_t edenSizeInBytes = collector->getCurrentEdenSizeInBytes((MM_EnvironmentVLHGC *)env);
 		if (edenSizeInBytes > freeBytes) {
-			collector->reCalculateEdenSize((MM_EnvironmentVLHGC *)env);
+			collector->recalculateEdenSize((MM_EnvironmentVLHGC *)env);
 			edenSizeInBytes = collector->getCurrentEdenSizeInBytes((MM_EnvironmentVLHGC *)env);
 		}
 		Assert_MM_true(freeBytes >= edenSizeInBytes);

--- a/runtime/gc_vlhgc/SchedulingDelegate.hpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.hpp
@@ -663,7 +663,7 @@ public:
 	/**
 	 * call calculateEdenSize() without allowTotalHeapResize option
 	 */
-	void reCalculateEdenSize(MM_EnvironmentVLHGC *env)
+	void recalculateEdenSize(MM_EnvironmentVLHGC *env)
 	{
 		calculateEdenSize(env);
 	}


### PR DESCRIPTION
The name "reCalculate" (introduced in #22579) suggests "re" and "calculate" are separate words: they are not.