### PR TITLE
Fix location of AI attribution statement

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -18,9 +18,8 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: IBM Bob
  *******************************************************************************/
-
-// Assisted-by: IBM Bob
 
 #include <limits.h>
 #include <math.h>


### PR DESCRIPTION
Fix location of AI attribution statement to match current guidelines:
https://github.com/eclipse-openj9/openj9/blob/master/CONTRIBUTING.md#generative-artificial-intelligence-usage-guidelines