### PR TITLE
Fix AOT unstored bytes count regression. For issue #24038.

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -7438,7 +7438,9 @@ void *TR::CompilationInfoPerThreadBase::postCompilationTasks(J9VMThread *vmThrea
     if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableUpdateAOTBytesSize) && metaData
         && // Compilation succeeded
         !canDoRelocatableCompile && // Non-AOT Compilation
-        ineligibleForRelocatableCompile == RELOCATABLE_COMPILE_OK && // Was eligible for AOT Compilation
+        (ineligibleForRelocatableCompile == RELOCATABLE_COMPILE_OK
+            || ineligibleForRelocatableCompile == AOT_INELIGIBLE_NO_STORE_AOT)
+        && // Was eligible for AOT Compilation
         TR::Options::getAOTCmdLineOptions()->getOption(TR_NoStoreAOT) && // AOT Disabled
         TR_J9SharedCache::isSharedCacheDisabledBecauseFull(&_compInfo)
             == TR_yes) // AOT Compilation Disabled because SCC is full


### PR DESCRIPTION
Fixes #24038.

The condition in `postCompilationTasks `that tracks unstored AOT bytes was checking `ineligibleForRelocatableCompile == RELOCATABLE_COMPILE_OK`, but this value gets overwritten to `AOT_INELIGIBLE_NO_STORE_AOT` when `TR_NoStoreAOT` is set, causing the unstored AOT bytes count to always be 0.

Fix by also checking for `AOT_INELIGIBLE_NO_STORE_AOT` in the condition.

Introduced by #23890.