### PR TITLE
Set JFR system properties when JFR V2 support is enabled

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/System.java
+++ b/jcl/src/java.base/share/classes/java/lang/System.java
@@ -732,8 +732,16 @@ private static void ensureProperties(boolean isInitialization) {
 	/*[IF JFR_SUPPORT]*/
 	/* Enables openj9 JFR tests. */
 	initializedProperties.put("org.eclipse.openj9.jfr.isJFREnabled", "true"); //$NON-NLS-1$ //$NON-NLS-2$
-	/* TODO disable JFR JCL APIs until JFR natives are implemented. */
-	initializedProperties.put("jfr.unsupported.vm", "true"); //$NON-NLS-1$ //$NON-NLS-2$
+	/*[IF JAVA_SPEC_VERSION == 17]*/
+	if (com.ibm.oti.vm.VM.isJFRV2SupportEnabled()) {
+		initializedProperties.put("jfr.unsupported.vm", "false"); //$NON-NLS-1$ //$NON-NLS-2$
+		initializedProperties.put("vm.hasJFR", "true"); //$NON-NLS-1$ //$NON-NLS-2$
+	} else
+	/*[ENDIF] JAVA_SPEC_VERSION == 17 */
+	{
+		/* TODO disable JFR JCL APIs until JFR natives are implemented. */
+		initializedProperties.put("jfr.unsupported.vm", "true"); //$NON-NLS-1$ //$NON-NLS-2$
+	}
 	/*[ENDIF] JFR_SUPPORT */
 
 	/*[IF JAVA_SPEC_VERSION >= 17]*/

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -26,20 +26,20 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 <suite id="JFR v2 Tests" timeout="3000">
 	<test id="Test JFRv2 cmdline option - no options">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OpenJDK Runtime Environment</output>
 	</test>
 	<!-- See https://github.com/eclipse-openj9/openj9/issues/23980
 	<test id="Test JFRv2 cmdline option - memcheck">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>
 	</test>
 	-->
 	<test id="Test JFRv2 with file">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Djfr.unsupported.vm=false -cp $RESJAR$ org.openj9.test.WorkLoad</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -cp $RESJAR$ org.openj9.test.WorkLoad</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="required" caseSensitive="yes" regex="no">0 / 100 complete</output>
 	</test>
@@ -60,13 +60,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="required" caseSensitive="yes" regex="no">JVMInformation</output>
 	</test>
 	<test id="Test JFRv2 with JMX">
-		<command>$EXE$ -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 	</test>
 	<!-- See https://github.com/eclipse-openj9/openj9/issues/23980
 	<test id="Test JFRv2 with JMX and memcheck">
-		<command>$EXE$ -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Djfr.unsupported.vm=false  -version</command>
+		<command>$EXE$ -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -version</command>
 		<output type="success" caseSensitive="yes" regex="no">Eclipse OpenJ9 VM</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>


### PR DESCRIPTION
[Set JFR system properties when JFR V2 support is enabled](https://github.com/eclipse-openj9/openj9/commit/b300e26e3e0d446ff7e8f6745773594902cea804) 

Set the system properties `jfr.unsupported.vm=false` and `vm.hasJFR=true` if `VM.isJFRV2SupportEnabled()` returns `true`.

closes https://github.com/eclipse-openj9/openj9/issues/23972

Signed-off-by: Jason Feng <fengj@ca.ibm.com>