### PR TITLE
Fix vtable slot bounds checking for refined receiver types

### DIFF
--- a/runtime/compiler/env/PersistentCHTable.cpp
+++ b/runtime/compiler/env/PersistentCHTable.cpp
@@ -498,6 +498,22 @@ TR_ResolvedMethod *TR_PersistentCHTable::findSingleAbstractImplementer(TR_Opaque
     if (TR::Compiler->cls.isInterfaceClass(comp, thisClass))
         return 0;
 
+    // vftSlot is a vtable offset computed against the class the call was resolved against, whereas
+    // thisClass is the receiver's (possibly refined) type. For an interface accessor, any
+    // receiver type that was refined may fall outside thisClass's vtable.
+    // Skipping this for JITServer mode, as thisClass is a client-side class pointer
+    // that must not be dereferenced here. The per-class read happens on the client, where it is
+    // guarded by the equivalent check in TR_J9VMBase::getResolvedVirtualMethod.
+    if (!comp->isOutOfProcessCompilation()) {
+        J9Class *j9thisClass = (J9Class *)TR::Compiler->cls.convertClassOffsetToClassPtr(thisClass);
+        UDATA vTableSlot = (UDATA)comp->fej9()->virtualCallOffsetToVTableSlot(vftSlot);
+        UDATA vTableNumMethods = J9VTABLE_HEADER_FROM_RAM_CLASS(j9thisClass)->size;
+        UDATA firstSlot = sizeof(J9Class) + sizeof(J9VTableHeader);
+        UDATA lastSlot = firstSlot + (0 == vTableNumMethods ? 0 : (vTableNumMethods - 1)) * sizeof(UDATA);
+        if ((0 == vTableNumMethods) || (vTableSlot < firstSlot) || (vTableSlot > lastSlot))
+            return 0;
+    }
+
     TR_ResolvedMethod *implArray[2]; // collect maximum 2 implementers if you can
     comp->enterHeuristicRegion();
     int32_t implCount

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7402,13 +7402,36 @@ TR_OpaqueMethodBlock *TR_J9VMBase::getResolvedVirtualMethod(TR_OpaqueClassBlock 
     if (isInterfaceClass(classObject))
         return 0;
 
-    J9Method *ramMethod = *(J9Method **)((char *)TR::Compiler->cls.convertClassOffsetToClassPtr(classObject)
-        + virtualCallOffsetToVTableSlot(virtualCallOffset));
+    J9Class *j9class = (J9Class *)TR::Compiler->cls.convertClassOffsetToClassPtr(classObject);
+    UDATA vTableSlot = (UDATA)virtualCallOffsetToVTableSlot(virtualCallOffset);
+
+    TR::Compilation *comp = _compInfoPT->getCompilation();
+
+    // virtualCallOffset is a vtable slot computed against the class the call was resolved
+    // against, while classObject is the receiver's (possibly refined) type.  When those
+    // differ, such as when an interface accessor whose vtable slot was taken from one
+    // implementor which was then refined to a narrower implementor of the same interface,
+    // the slot can be out of range of the classObject's vtable, holding an arbitrary
+    // non-J9Method value (e.g. a heap object reference).
+    J9VTableHeader *vftHeader = J9VTABLE_HEADER_FROM_RAM_CLASS(j9class);
+    UDATA vTableNumMethods = vftHeader->size;
+    UDATA firstSlot = sizeof(J9Class) + sizeof(J9VTableHeader);
+    UDATA lastSlot = firstSlot + (0 == vTableNumMethods ? 0 : (vTableNumMethods - 1)) * sizeof(UDATA);
+    if ((0 == vTableNumMethods) || (vTableSlot < firstSlot) || (vTableSlot > lastSlot)) {
+        OMR::Logger *log = comp->log();
+        logprintf(comp->getOption(TR_TraceOptDetails), log,
+            "getResolvedVirtualMethod: vtable slot %d out of bounds for class %p (vtable holds %d methods, "
+            "valid byte range [%d..%d], virtualCallOffset=%d); failing query\n",
+            (int32_t)vTableSlot, (void *)j9class, (int32_t)vTableNumMethods, (int32_t)firstSlot, (int32_t)lastSlot,
+            virtualCallOffset);
+        return 0;
+    }
+
+    J9Method *ramMethod = *(J9Method **)((char *)j9class + vTableSlot);
 
     TR_ASSERT(ramMethod, "getResolvedVirtualMethod should always find a ramMethod in the vtable slot");
 
     // ramMethod might have been inherited from a superclass
-    TR::Compilation *comp = _compInfoPT->getCompilation();
     comp->constProvenanceGraph()->addEdge(classObject, ramMethod);
 
     if (ramMethod && (!(_jitConfig->runtimeFlags & J9JIT_RUNTIME_RESOLVE) || ignoreRtResolve)

--- a/runtime/compiler/optimizer/J9Inliner.cpp
+++ b/runtime/compiler/optimizer/J9Inliner.cpp
@@ -441,6 +441,21 @@ bool TR_J9VirtualCallSite::findCallSiteForAbstractClass(TR_InlinerBase *inliner)
         && !comp()->getOption(TR_DisableAbstractInlining)
         && (implementer
             = chTable->findSingleAbstractImplementer(_receiverClass, _vftSlot, _callerResolvedMethod, comp()))) {
+        // The (_receiverClass, _vftSlot) pair can be inconsistent when the receiver type
+        // was refined. Only devirtualize when the implementer actually matches _initialCalleeMethod.
+        if (_initialCalleeMethod
+            && (implementer->nameLength() != _initialCalleeMethod->nameLength()
+                || implementer->signatureLength() != _initialCalleeMethod->signatureLength()
+                || 0 != strncmp(implementer->nameChars(), _initialCalleeMethod->nameChars(), implementer->nameLength())
+                || 0
+                    != strncmp(implementer->signatureChars(), _initialCalleeMethod->signatureChars(),
+                        implementer->signatureLength()))) {
+            heuristicTrace(inliner->tracer(),
+                "Abstract implementer %p does not match intended callee %p (name/signature mismatch); not "
+                "devirtualizing",
+                implementer, _initialCalleeMethod);
+            return false;
+        }
         heuristicTrace(inliner->tracer(), "Found a single Abstract Implementer %p, signature = %s", implementer,
             inliner->tracer()->traceSignature(implementer));
         TR_VirtualGuardSelection *guard
@@ -1358,4 +1373,3 @@ bool TR_ProfileableCallSite::findProfiledCallTargets(TR_CallStack *callStack, TR
 
     return numTargets();
 }
-


### PR DESCRIPTION
When receiver types are refined during compilation (e.g., from an interface to a concrete implementor), the vtable slot offset computed against the original resolved class may fall outside the bounds of the refined class's vtable. This can lead to reading arbitrary memory values as J9Method pointers, causing crashes or incorrect devirtualization.

This commit adds vtable slot validation in three critical locations:

1. TR_PersistentCHTable::findSingleAbstractImplementer
   - Added bounds check
2. TR_J9VMBase::getResolvedVirtualMethod
   - Added bounds check
3. TR_J9VirtualCallSite::findCallSiteForAbstractClass
   - Added name/signature verification

This fixes the root cause of a class of failures observed with invalid vtable slot indices being used post-refinement, and we run into such issues in the scenario described below:
- A virtual call is resolved against one class (e.g., interface implementor A)
- The receiver type is refined to a different class (e.g., implementor B)
- The vtable slot from class A is used to index into class B's vtable
- Class B's vtable may be smaller or have different layout, causing OOB access

Issue: #24018, #24009