### PR TITLE
Fix Java 8 compilation error

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -31,6 +31,7 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
 import java.util.HashMap;
@@ -76,12 +77,8 @@ public class TestJcmd extends AttachApiTest {
 	// Same as DiagnosticUtils.DIAGNOSTICS_OPTION_SEPARATOR.
 	private static final String DIAGNOSTICS_OPTION_SEPARATOR = ",";
 
-	private static final ArrayList<String> TEST_JFR_VM_ARGS = new ArrayList<>(List.of(
-			"-XX:+EnableOpenJ9ExperimentalFlightRecording",
-			"-Dibm.java9.forceCommonCleanerShutdown=true",
-			"-Xint",
-			"-Xshare:off",
-			"-Xshareclasses:none"));
+	private static final ArrayList<String> TEST_JFR_VM_ARGS = new ArrayList<>(Arrays.asList(
+			"-XX:+EnableOpenJ9ExperimentalFlightRecording"));
 
 	/*
 	 * Contains strings expected to be contained in the outputs of various commands


### PR DESCRIPTION
[Fix Java 8 compilation error](https://github.com/eclipse-openj9/openj9/commit/67ee19defae08c69378bd82eaf4a00450db1b71a) 

```
    [javac] Compiling 384 source files to /tmp/bld_119059/workspace/test/functional/Java8andUp/bin
    [javac] /tmp/bld_119059/workspace/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java:79: error: cannot find symbol
    [javac] 	private static final ArrayList<String> TEST_JFR_VM_ARGS = new ArrayList<>(List.of(
    [javac] 	                                                                              ^
    [javac]   symbol:   method of(String,String,String,String,String)
    [javac]   location: interface List
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>