### PR TITLE
(0.60) Ensure shared classes cleanup on silent exit for printStats

### DIFF
--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -454,18 +454,12 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 				if (nonfatal) {
 					return J9VMDLLMAIN_OK;
 				} else {
-#if defined(J9ZOS390)
-					if ((J9VMDLLMAIN_SILENT_EXIT_VM == rc)
-						&& J9_ARE_ALL_BITS_SET(vm->sharedCacheAPI->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_PERSISTENT_CACHE)
-						&& J9_ARE_NO_BITS_SET(vm->sharedCacheAPI->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_READONLY)
-					) {
-						/**
-						 * Call j9shr_guaranteed_exit() to ensure any modification to the cache is flushed to the file on disk.
-						 * For utility option printStats and its variants, J9SHR_RUNTIMEFLAG_ENABLE_READONLY is always set.
-						 */
-						j9shr_guaranteed_exit(vm, FALSE);
+					if (J9VMDLLMAIN_SILENT_EXIT_VM == rc) {
+						if (J9_ARE_NO_BITS_SET(vm->sharedCacheAPI->runtimeFlags, J9SHR_RUNTIMEFLAG_ENABLE_READONLY)) {
+							j9shr_guaranteed_exit(vm, FALSE);
+						}
+						j9shr_shutdown(vm);
 					}
-#endif /* defined(J9ZOS390) */
 					return rc;
 				}
 			}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
@@ -1548,11 +1548,4 @@ public class TestUtils {
 		fail("Error: should never hit this code, directory " + dir + " is not correct.");
 		return "";
 	}
-
-	public static void delayBeforeDestroyNonPersistent() {
-		try {
-			Thread.sleep(500);
-		} catch (InterruptedException e) {
-		}
-	}
 }

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats02.java
@@ -54,7 +54,6 @@ public class TestPrintStats02 extends TestUtils {
 	checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
 	checkOutputContains("1:.*CLASSPATH","Expected to find a line in the printAllStats output relating to CLASSPATH");
 	
-	delayBeforeDestroyNonPersistent();
 	runDestroyAllCaches();
   }
 }

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats06.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestPrintStats06.java
@@ -52,7 +52,6 @@ public class TestPrintStats06 extends TestUtils {
 		checkOutputContains("Current statistics for cache", "Did not find expected line of output 'Current statistics for cache'");
 		
 		/* using nonpersistent cache now should result in cache corruption due to semaphore mismatch */
-		delayBeforeDestroyNonPersistent();
 		runSimpleJavaProgramWithNonPersistentCache("Foo", "disablecorruptcachedumps");
 		checkOutputContains("JVMSHRC508E", "Did not find expected message about mismatch semaphore");
 		checkOutputContains("JVMSHRC442E", "Did not find expected message about corrupt cache");
@@ -65,7 +64,6 @@ public class TestPrintStats06 extends TestUtils {
 		/* JVMSHRC023E Cache does not exist */
 		checkOutputContains("JVMSHRC023E", "Did not find expected line of output 'Cache does not exist'");
 		/* destroy control files */
-		delayBeforeDestroyNonPersistent();
 		destroyNonPersistentCache("Foo");
 		runDestroyAllCaches();
 	}

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset02.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset02.java
@@ -37,7 +37,6 @@ public class TestReset02 extends TestUtils {
 	runPrintAllStats("Foo",false);
 	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
 
-	delayBeforeDestroyNonPersistent();
 	runResetNonPersistentCache("Foo");
 	
 	checkOutputContains("JVMSHRC159I","Expected message about the cache being opened: JVMSHRC159I");
@@ -48,7 +47,6 @@ public class TestReset02 extends TestUtils {
 	runPrintAllStats("Foo",false);
 	checkOutputDoesNotContain("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
 
-	delayBeforeDestroyNonPersistent();
 	runDestroyAllCaches();
   }
 }

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset05.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestReset05.java
@@ -37,7 +37,6 @@ public class TestReset05 extends TestUtils {
 	runPrintAllStats("Foo",false);
 	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
 
-	delayBeforeDestroyNonPersistent();
 	runSimpleJavaProgramWithNonPersistentCacheAndReset("Foo");
 	checkOutputContains("JVMSHRC159I","Expected message about the cache being opened: JVMSHRC159I");
 	checkOutputContains("is destroyed","Expected message about the cache being destroyed: is destroyed");
@@ -46,7 +45,6 @@ public class TestReset05 extends TestUtils {
 	runPrintAllStats("Foo",false);
 	checkOutputContains("ROMCLASS:.*SimpleApp", "Did not find expected entry for SimpleApp in the printAllStats output");
 
-	delayBeforeDestroyNonPersistent();
 	runDestroyAllCaches();
   }
 }

--- a/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheEnableBCI.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/options/TestSharedCacheEnableBCI.java
@@ -213,7 +213,6 @@ public class TestSharedCacheEnableBCI extends TestUtils {
 			fail("# ROMClasses statement not found in printStats output");
 		}
 
-		delayBeforeDestroyNonPersistent();
 		destroyNonPersistentCache(cacheName);
 		checkFileDoesNotExistForNonPersistentCache(cacheName);
 
@@ -244,7 +243,6 @@ public class TestSharedCacheEnableBCI extends TestUtils {
 			fail("# ROMClasses statement not found in printStats output");
 		}
 
-		delayBeforeDestroyNonPersistent();
 		destroyNonPersistentCache(cacheName);
 		checkFileDoesNotExistForNonPersistentCache(cacheName);
 
@@ -288,7 +286,6 @@ public class TestSharedCacheEnableBCI extends TestUtils {
 			fail("# ROMClasses statement not found in printStats output");
 		}
 
-		delayBeforeDestroyNonPersistent();
 		destroyNonPersistentCache(cacheName);
 		checkFileDoesNotExistForNonPersistentCache(cacheName);
 
@@ -442,7 +439,6 @@ public class TestSharedCacheEnableBCI extends TestUtils {
 			}
 		}
 
-		delayBeforeDestroyNonPersistent();
 		destroyNonPersistentCache(cacheName);
 		checkFileDoesNotExistForNonPersistentCache(cacheName);
 
@@ -536,7 +532,6 @@ public class TestSharedCacheEnableBCI extends TestUtils {
 		checkOutputContains("^.*ROMCLASS: " + classToModify + " at.*$",
 				classToModify + " not found in the cache");
 
-		delayBeforeDestroyNonPersistent();
 		destroyNonPersistentCache(cacheName);
 		checkFileDoesNotExistForNonPersistentCache(cacheName);
 	}

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/ShareClassesCMLTests-1.xml
@@ -510,8 +510,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 
-	<exec command="sleep 0.5" platforms="linux.*" />
-
 	<test id="Test 30: CMVC 168131 : Cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">has been destroyed</output>
@@ -558,8 +556,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-
-	<exec command="sleep 0.5" platforms="linux.*" />
 
 	<test id="Test 35: CMVC 168131 : Cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>

--- a/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
+++ b/test/functional/cmdLineTests/shareClassTests/SCCMLTests/testSCCMLSnapshot.xml
@@ -152,8 +152,6 @@
 		<output type="failure" caseSensitive="no" regex="no">corrupt</output>
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
-
-	<exec command="sleep 0.5" platforms="linux.*" />
 	
 	<test id="Test 6: Clean up, destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
@@ -190,8 +188,6 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<exec command="sleep 0.5" platforms="linux.*" />
-
 	<test id="Test 9s: Set up for test 9. Destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
@@ -257,8 +253,6 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<exec command="sleep 0.5" platforms="linux.*" />
-
 	<test id="Test 11 - b: Setup for test 11. Destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
@@ -308,8 +302,6 @@
 		<output type="failure" caseSensitive="yes" regex="no">Processing dump event</output>
 	</test>
 	
-	<exec command="sleep 0.5" platforms="linux.*" />
-
 	<test id="Test 14: Clean up, destroy the non-persistent cache if it exists" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>
@@ -410,8 +402,6 @@
 		<output type="failure" caseSensitive="yes" regex="no">JVM requested Snap dump</output>
 	</test>
 	
-	<exec command="sleep 0.5" platforms="linux.*" />
-
 	<test id="At end destroy non-persistent cache for cleanup" timeout="600" runPath=".">
 		<command>$JAVA_EXE$ $currentMode$,nonpersistent,destroy</command>
 		<output type="success" caseSensitive="yes" regex="no">Cache does not exist</output>


### PR DESCRIPTION
Fix by explicitly calling j9shr_guaranteed_exit(vm, FALSE) and j9shr_shutdown(vm) in the silent exit path to flush the cache and properly detach shared memory.

Also reverts all the changes here https://github.com/eclipse-openj9/openj9/issues/23896#issuecomment-4443238806

Closes https://github.com/eclipse-openj9/openj9/issues/23896

Port of https://github.com/eclipse-openj9/openj9/pull/24055