### PR TITLE
(0.60) Preserve OJDK MH LambdaForm CP patches during Extended HCR

### DIFF
--- a/runtime/util/hshelp.c
+++ b/runtime/util/hshelp.c
@@ -2158,46 +2158,45 @@ fixConstantPoolsForFastHCR(J9VMThread *currentThread, J9HashTable *classPairs, J
 
 
 void
-unresolveAllClasses(J9VMThread * currentThread, J9HashTable * classPairs, J9HashTable * methodPairs, UDATA extensionsUsed)
+unresolveAllClasses(J9VMThread *currentThread, J9HashTable *classPairs, J9HashTable *methodPairs, UDATA extensionsUsed)
 {
-	J9JavaVM * vm = currentThread->javaVM;
+	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 	J9ClassWalkState state;
-	J9Class * clazz;
+	J9Class *clazz = vmFuncs->allClassesStartDo(&state, vm, NULL);
 
-
-
-	clazz = vmFuncs->allClassesStartDo(&state, vm, NULL);
-
-	while (clazz != NULL) {
+	while (NULL != clazz) {
 		U_16 i = 0;
+		J9ROMClass *romClass = clazz->romClass;
+		if (0 != romClass->ramConstantPoolCount) {
+			BOOLEAN isLambdaFormClass = FALSE;
+#if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
+			J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
+			isLambdaFormClass = isLambdaFormClassName((const char *)J9UTF8_DATA(className), J9UTF8_LENGTH(className), NULL);
+#endif /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 
-		if (extensionsUsed) {
-
-			/* Zero the constant pool and then run the pre-init instructions.
-			 * Do not zero the first entry as it contains VM information, not a CP item. */
-			if (clazz->romClass->ramConstantPoolCount != 0) {
-				memset(((J9RAMConstantPoolItem *) J9_CP_FROM_CLASS(clazz)) + 1, 0,
-					   (clazz->romClass->ramConstantPoolCount - 1) * sizeof(J9RAMConstantPoolItem));
+			if ((0 != extensionsUsed) && !isLambdaFormClass) {
+				/* Zero the constant pool and then run the pre-init instructions.
+				 * Do not zero the first entry as it contains VM information, not a CP item.
+				 */
+				memset(
+					((J9RAMConstantPoolItem *)J9_CP_FROM_CLASS(clazz)) + 1, 0,
+					(romClass->ramConstantPoolCount - 1) * sizeof(J9RAMConstantPoolItem));
 				vmFuncs->internalRunPreInitInstructions(clazz, currentThread);
-			}
-
-		} else {
-
-			if (clazz->romClass->ramConstantPoolCount != 0) {
+			} else {
 				reresolveHotSwappedConstantPool(J9_CP_FROM_CLASS(clazz), currentThread, classPairs, methodPairs);
 			}
 		}
 
-		/* unresolve split table entries */
+		/* Unresolve split table entries. */
 		if (NULL != clazz->staticSplitMethodTable) {
-			for (i = 0; i < clazz->romClass->staticSplitMethodRefCount; ++i) {
-				clazz->staticSplitMethodTable[i] = (J9Method*)vm->initialMethods.initialStaticMethod;
+			for (i = 0; i < romClass->staticSplitMethodRefCount; ++i) {
+				clazz->staticSplitMethodTable[i] = (J9Method *)vm->initialMethods.initialStaticMethod;
 			}
 		}
 		if (NULL != clazz->specialSplitMethodTable) {
-			for (i = 0; i < clazz->romClass->specialSplitMethodRefCount; ++i) {
-				clazz->specialSplitMethodTable[i] = (J9Method*)vm->initialMethods.initialSpecialMethod;
+			for (i = 0; i < romClass->specialSplitMethodRefCount; ++i) {
+				clazz->specialSplitMethodTable[i] = (J9Method *)vm->initialMethods.initialSpecialMethod;
 			}
 		}
 
@@ -2206,10 +2205,8 @@ unresolveAllClasses(J9VMThread * currentThread, J9HashTable * classPairs, J9Hash
 
 	vmFuncs->allClassesEndDo(&state);
 
-	/* Fix the JCL Constant Pool entries containing known classes amongst other things */
-
+	/* Fix the JCL Constant Pool entries containing known classes amongst other things. */
 	reresolveHotSwappedConstantPool((J9ConstantPool *) vm->jclConstantPool, currentThread, classPairs, methodPairs);
-
 }
 
 


### PR DESCRIPTION
OpenJDK `MethodHandle` generated `LambdaForm` classes may contain ROM
string placeholder CP entries, such as `CONSTANT_PLACEHOLDER_*`, whose
RAM CP slots are patched to runtime objects by `defineAnonymousClass()`.
For example, a `LambdaForm$DMH` class can have bytecode like:
```
ldc CONSTANT_PLACEHOLDER_1
checkcast java/lang/invoke/MethodHandle
```
At define time, the RAM CP entry is patched to the corresponding
`DirectMethodHandle`. The patch map is temporary and is discarded after
`defineAnonymousClass()` returns.

During Extended HCR, `unresolveAllClasses()` clears the RAM CP for all
loaded classes when extensions are used. This also clears the patched
`LambdaForm` RAM CP entries. The next `ldc` then treats the null slot as an
unresolved string constant and resolves the ROM placeholder as a
`java/lang/String`. The following `checkcast` to `MethodHandle` then fails
with `ClassCastException`.

Avoid clearing RAM CP entries for OJDK `LambdaForm` generated classes in
the Extended HCR path. Route these classes through the normal hot-swap
constant-pool reresolve path instead, preserving the patched RAM CP
entries while still allowing affected refs to be updated.

The risk of this change is that `LambdaForm` classes will no longer take
the full RAM CP reset path during Extended HCR. This is intentionally
limited to OJDK `LambdaForm` generated classes because their RAM CP can
contain patched runtime objects that cannot be reconstructed after the
patch map is discarded. The reresolve path is expected to be safer for
these classes because it preserves string CP entries and only updates
refs that need hot-swap repair.

Related: #24076

Fixes: #23909