### PR TITLE
Reduce `getResolvedMethods`

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -381,6 +381,38 @@ static bool handleResponse(JITServer::MessageType response, JITServer::ClientStr
             }
             client->write(response, methods, methodsInfo);
         } break;
+        case MessageType::VM_getResolvedMethodsForNameAndMirror: {
+            auto recv = client->getRecvData<TR_OpaqueClassBlock *, std::string>();
+            TR_OpaqueClassBlock *clazz = std::get<0>(recv);
+            auto &methodNameString = std::get<1>(recv);
+
+            auto nameLength = methodNameString.size();
+            J9Method *j9methods = (J9Method *)fe->getMethods(clazz);
+            uint32_t numMethods = fe->getNumMethods(clazz);
+
+            // Create mirrors and put methodInfo for each method in a vector to be sent to the server
+            J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(TR::Compiler->cls.romClassOf(clazz));
+            std::vector<J9Method *> methods;
+            std::vector<TR_ResolvedJ9JITServerMethodInfo> methodsInfo;
+            for (uint32_t i = 0; i < numMethods; i++) {
+                J9Method *method = j9methods + i;
+
+                J9UTF8 *mName = J9ROMMETHOD_NAME(romMethod);
+                if ((J9UTF8_LENGTH(mName) == nameLength)
+                    && (memcmp(utf8Data(mName), methodNameString.c_str(), nameLength) == 0)) {
+                    TR_ResolvedJ9JITServerMethodInfo methodInfo;
+                    TR_ResolvedJ9JITServerMethod::createResolvedMethodMirror(methodInfo, (TR_OpaqueMethodBlock *)method,
+                        0, 0, fe, trMemory);
+
+                    methods.push_back(method);
+                    methodsInfo.push_back(methodInfo);
+                }
+
+                romMethod = nextROMMethod(romMethod);
+            }
+
+            client->write(response, methods, methodsInfo);
+        } break;
         case MessageType::VM_getVMInfo: {
             ClientSessionData::VMInfo vmInfo = {};
             J9JavaVM *javaVM = vmThread->javaVM;

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2114,15 +2114,7 @@ TR_Debug *TR_J9VMBase::createDebug(TR::Compilation *comp)
 
 TR_ResolvedMethod *TR_J9VMBase::getDefaultConstructor(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer)
 {
-    TR::VMAccessCriticalSection getDefaultConstructor(this);
-    List<TR_ResolvedMethod> list(trMemory);
-    getResolvedMethods(trMemory, classPointer, &list);
-    ListIterator<TR_ResolvedMethod> methods(&list);
-    TR_ResolvedMethod *m = methods.getFirst();
-    for (; m; m = methods.getNext())
-        if (m->isConstructor() && m->signatureLength() == 3 && !strncmp(m->signatureChars(), "()V", 3))
-            break;
-    return m;
+    return getResolvedMethodForConstructorWithSig(trMemory, classPointer, "()V");
 }
 
 extern "C" J9NameAndSignature newInstancePrototypeNameAndSig;
@@ -6077,22 +6069,76 @@ bool TR_J9VMBase::isContinuationClass(TR_OpaqueClassBlock *clazz)
 const char *TR_J9VMBase::getByteCodeName(uint8_t opcode) { return JavaBCNames[opcode]; }
 
 void TR_J9VMBase::getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
-    List<TR_ResolvedMethod> *resolvedMethodsInClass)
+    List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName)
 {
+    size_t nameLength = methodName ? strlen(methodName) : 0;
+
     TR::VMAccessCriticalSection getResolvedMethods(this); // Prevent HCR
-    J9Method *resolvedMethods = (J9Method *)getMethods(classPointer);
-    uint32_t i;
+
+    J9ROMClass *romClass = TR::Compiler->cls.romClassOf(classPointer);
+    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
+
+    J9Method *j9methods = (J9Method *)getMethods(classPointer);
     uint32_t numMethods = getNumMethods(classPointer);
-    for (i = 0; i < numMethods; i++) {
-        resolvedMethodsInClass->add(createResolvedMethod(trMemory, (TR_OpaqueMethodBlock *)&(resolvedMethods[i]), 0));
+    for (uint32_t i = 0; i < numMethods; i++) {
+        TR_OpaqueMethodBlock *method = (TR_OpaqueMethodBlock *)(j9methods + i);
+        bool addTolist = true;
+
+        if (methodName) {
+            const bool ignoreSig = true;
+            addTolist = matchedMethod(method, romMethod, classPointer, i, methodName, nameLength, NULL, 0, ignoreSig);
+            romMethod = nextROMMethod(romMethod);
+        }
+
+        if (addTolist) {
+            resolvedMethodsInClass->add(createResolvedMethod(trMemory, method, 0));
+        }
     }
 }
 
 /*
- * Should be called with VMAccess
+ * Should be called with VMAccess.
+ *
+ * Helper to determine if the given RAM method has a name/signature matching
+ * the provided methodName/signature parameters. If ignoreSig is true, only
+ * the name is compared. If a match is found and the Symbol Validation Manager
+ * is active, a validation record is added for the method.
+ */
+bool TR_J9VMBase::matchedMethod(TR_OpaqueMethodBlock *method, J9ROMMethod *romMethod, TR_OpaqueClassBlock *classPointer,
+    uint32_t methodIndex, const char *methodName, size_t nameLength, const char *signature, size_t sigLength,
+    bool ignoreSig)
+{
+    bool matched = false;
+
+    J9UTF8 *mName = J9ROMMETHOD_NAME(romMethod);
+    if ((J9UTF8_LENGTH(mName) == nameLength) && (memcmp(utf8Data(mName), methodName, nameLength) == 0)) {
+        if (!ignoreSig) {
+            J9UTF8 *mSig = J9ROMMETHOD_SIGNATURE(romMethod);
+            matched = (J9UTF8_LENGTH(mSig) == sigLength) && (memcmp(utf8Data(mSig), signature, sigLength) == 0);
+        } else {
+            matched = true;
+        }
+
+        if (matched) {
+            TR::Compilation *comp = _compInfoPT ? _compInfoPT->getCompilation() : NULL;
+            if (comp && comp->getOption(TR_UseSymbolValidationManager)) {
+                comp->getSymbolValidationManager()->addMethodFromClassRecord(method, classPointer, methodIndex);
+            }
+        }
+    }
+
+    return matched;
+}
+
+/*
+ * Should be called with VMAccess.
+ *
+ * Iterates over all ROM methods in the given class and returns the
+ * TR_OpaqueMethodBlock for the first method matching methodName and
+ * signature, or NULL if not found.
  */
 TR_OpaqueMethodBlock *TR_J9VMBase::getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock *classPointer,
-    const char *methodName, const char *signature, bool validate)
+    const char *methodName, const char *signature)
 {
     size_t nameLength = strlen(methodName);
     size_t sigLength = strlen(signature);
@@ -6107,20 +6153,13 @@ TR_OpaqueMethodBlock *TR_J9VMBase::getMatchingMethodFromNameAndSignature(TR_Opaq
 
     // Iterate over all romMethods until the desired one is found
     for (uint32_t i = 0; i < numMethods; i++) {
-        J9UTF8 *mName = J9ROMMETHOD_NAME(romMethod);
-        J9UTF8 *mSig = J9ROMMETHOD_SIGNATURE(romMethod);
-        if (J9UTF8_LENGTH(mName) == nameLength && J9UTF8_LENGTH(mSig) == sigLength
-            && memcmp(utf8Data(mName), methodName, nameLength) == 0
-            && memcmp(utf8Data(mSig), signature, sigLength) == 0) {
-            method = (TR_OpaqueMethodBlock *)(j9Methods + i);
-            if (validate) {
-                TR::Compilation *comp = TR::comp();
-                if (comp && comp->getOption(TR_UseSymbolValidationManager)) {
-                    comp->getSymbolValidationManager()->addMethodFromClassRecord(method, classPointer, i);
-                }
-            }
+        TR_OpaqueMethodBlock *methodToCheck = (TR_OpaqueMethodBlock *)(j9Methods + i);
+
+        if (matchedMethod(methodToCheck, romMethod, classPointer, i, methodName, nameLength, signature, sigLength)) {
+            method = methodToCheck;
             break;
         }
+
         romMethod = nextROMMethod(romMethod);
     }
 
@@ -6138,6 +6177,12 @@ TR_ResolvedMethod *TR_J9VMBase::getResolvedMethodForNameAndSignature(TR_Memory *
         rm = createResolvedMethod(trMemory, method, 0);
 
     return rm;
+}
+
+TR_ResolvedMethod *TR_J9VMBase::getResolvedMethodForConstructorWithSig(TR_Memory *trMemory,
+    TR_OpaqueClassBlock *classPointer, const char *signature)
+{
+    return getResolvedMethodForNameAndSignature(trMemory, classPointer, "<init>", signature);
 }
 
 void *TR_J9VMBase::getMethods(TR_OpaqueClassBlock *classPointer)
@@ -7396,20 +7441,13 @@ TR::Node *TR_J9VM::inlineNativeCall(TR::Compilation *comp, TR::TreeTop *callNode
         }
         case TR::java_lang_J9VMInternals_defaultClone: {
             TR_OpaqueClassBlock *bdClass = getClassFromSignature("java/lang/Object", 16, comp->getCurrentMethod());
-            TR_ScratchList<TR_ResolvedMethod> bdMethods(comp->trMemory());
-            getResolvedMethods(comp->trMemory(), bdClass, &bdMethods);
-            ListIterator<TR_ResolvedMethod> bdit(&bdMethods);
-
-            TR_ResolvedMethod *method = NULL;
-            for (method = bdit.getCurrent(); method; method = bdit.getNext()) {
-                const char *sig = method->signature(comp->trMemory());
-                int32_t len = strlen(sig);
-                if (!strncmp(sig, "java/lang/Object.clone()Ljava/lang/Object;", len)) {
-                    callNode->setSymbolReference(comp->getSymRefTab()->findOrCreateMethodSymbol(
-                        callNode->getSymbolReference()->getOwningMethodIndex(), -1, method, TR::MethodSymbol::Special));
-                    break;
-                }
+            TR_ResolvedMethod *method
+                = getResolvedMethodForNameAndSignature(comp->trMemory(), bdClass, "clone", "()Ljava/lang/Object;");
+            if (method) {
+                callNode->setSymbolReference(comp->getSymRefTab()->findOrCreateMethodSymbol(
+                    callNode->getSymbolReference()->getOwningMethodIndex(), -1, method, TR::MethodSymbol::Special));
             }
+
             return callNode;
         }
         case TR::java_lang_J9VMInternals_isClassModifierPublic: {
@@ -7542,17 +7580,31 @@ TR::Node *TR_J9VM::inlineNativeCall(TR::Compilation *comp, TR::TreeTop *callNode
             if (jitHelpersClass && isClassInitialized(jitHelpersClass)) {
                 // fish for the getSuperclass method in JITHelpers
                 //
-                const char *callerSig = comp->signature();
                 const char *getHelpersSig = "jitHelpers";
-                int32_t getHelpersSigLength = 10;
+                int32_t getHelpersSigLength = strlen(getHelpersSig);
+                const char *getSuperclassSig = "getSuperclass";
+                int32_t getSuperclassSigLength = strlen(getSuperclassSig);
+
                 TR::SymbolReference *getSuperclassSymRef = NULL;
                 TR::SymbolReference *getHelpersSymRef = NULL;
+
                 TR_ScratchList<TR_ResolvedMethod> helperMethods(comp->trMemory());
-                getResolvedMethods(comp->trMemory(), jitHelpersClass, &helperMethods);
+                getResolvedMethods(comp->trMemory(), jitHelpersClass, &helperMethods, getHelpersSig);
+
+                // Because the helperMethods scratch list is reused here, in an
+                // AOT compilation, the compiler will try and redundantly add
+                // validations for the methods acquired from the previous
+                // query; however, this isn't really an issue since the relo
+                // infrastructure does not add duplicate validation records.
+                // Doing this this way makes the code much more readable. This
+                // comes at the expense of making AOT compiles slightly
+                // inefficient.
+                getResolvedMethods(comp->trMemory(), jitHelpersClass, &helperMethods, getSuperclassSig);
+
                 ListIterator<TR_ResolvedMethod> it(&helperMethods);
                 for (TR_ResolvedMethod *m = it.getCurrent(); m; m = it.getNext()) {
                     char *sig = m->nameChars();
-                    if (!strncmp(sig, "getSuperclass", 13)) {
+                    if (!strncmp(sig, getSuperclassSig, getSuperclassSigLength)) {
                         getSuperclassSymRef = comp->getSymRefTab()->findOrCreateMethodSymbol(
                             callNode->getSymbolReference()->getOwningMethodIndex(), -1, m, TR::MethodSymbol::Virtual);
                         getSuperclassSymRef->setOffset(getVTableSlot(m->getPersistentIdentifier(), jitHelpersClass));
@@ -8120,7 +8172,7 @@ TR_OpaqueClassBlock *TR_J9SharedCacheVM::getSuperClass(TR_OpaqueClassBlock *clas
 }
 
 void TR_J9SharedCacheVM::getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
-    List<TR_ResolvedMethod> *resolvedMethodsInClass)
+    List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName)
 {
     TR::Compilation *comp = _compInfoPT->getCompilation();
     TR_ASSERT(comp, "Should be called only within a compilation");
@@ -8139,10 +8191,16 @@ void TR_J9SharedCacheVM::getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassB
         TR::VMAccessCriticalSection getResolvedMethods(this); // Prevent HCR
 
         if (comp->getOption(TR_UseSymbolValidationManager)) {
-            comp->getSymbolValidationManager()->addMethodsFromClassRecord(classPointer);
+            // TR_J9VM::getResolvedMethods, more specifically
+            // TR_J9VM::matchedMethod, will add a validation record for each
+            // method that matches the methodName. However, if methodName is
+            // NULL, then ensure that the MethodsFromClass record is added.
+            if (methodName == NULL) {
+                comp->getSymbolValidationManager()->addMethodsFromClassRecord(classPointer);
+            }
         }
 
-        TR_J9VM::getResolvedMethods(trMemory, classPointer, resolvedMethodsInClass);
+        TR_J9VM::getResolvedMethods(trMemory, classPointer, resolvedMethodsInClass, methodName);
     }
 }
 

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -445,14 +445,64 @@ protected:
     bool isAotResolvedDirectDispatchGuaranteed(TR::Compilation *comp);
     bool isAotResolvedVirtualDispatchGuaranteed(TR::Compilation *comp);
 
+    /**
+     * @brief Helper to test if a ram method has a specific name/signature
+     *
+     * A helper method to determine if the method passed in has the same name
+     * and signature as the methodName/signature parameters passed in.
+     *
+     * Should be called with VMAccess.
+     *
+     * @param method The method to compare
+     * @param romMethod The J9ROMMethod of the method
+     * @param classPointer The J9Class of the method
+     * @param methodIndex The method's index into the classPointer's array of
+     *                    J9Methods
+     * @param methodName The method name to compare
+     * @param nameLength The length of methodName
+     * @param signature The signature to compare
+     * @param sigLength The length of signature
+     * @param ignoreSig Flag to control whether the signature should be ignored
+     *                  when comparing against the method
+     *
+     * @return true if method's name/signature matches methodName/signature;
+     *         false otherwise.
+     */
+    bool matchedMethod(TR_OpaqueMethodBlock *method, J9ROMMethod *romMethod, TR_OpaqueClassBlock *classPointer,
+        uint32_t methodIndex, const char *methodName, size_t nameLength, const char *signature, size_t sigLength,
+        bool ignoreSig = false);
+
+    /**
+     * @brief Finds a method in a class with a specific name/signature
+     *
+     * Should be called with VMAccess.
+     *
+     * @param classPointer The class used to find the method
+     * @param methodName The name of the method
+     * @param signature The signature of the method
+     */
+    TR_OpaqueMethodBlock *getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock *classPointer,
+        const char *methodName, const char *signature);
+
 public:
     virtual TR_OpaqueMethodBlock *getMethodFromClass(TR_OpaqueClassBlock *, const char *, const char *,
         TR_OpaqueClassBlock * = NULL);
 
-    TR_OpaqueMethodBlock *getMatchingMethodFromNameAndSignature(TR_OpaqueClassBlock *classPointer,
-        const char *methodName, const char *signature, bool validate = true);
-
-    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
+    /**
+     * @brief Gets resolved methods in a class
+     *
+     * If methodName is NULL, then this returns all resolved methods in the
+     * class. Otherwise, this returns only the methods that match methodName
+     * (regardless of signature).
+     *
+     * @param trMemory The TR_Memory instance to allocate memory from
+     * @param classPointer The class whose methods should be found
+     * @param resolvedMethodsInClass A List<TR_ResolvedMethod> containing the
+     *                               list of TR_ResolvedMethods
+     * @param methodName Optional, the method name that the methods must match
+     */
+    virtual void getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
+        List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName = NULL);
     /**
      * @brief Create a TR_ResolvedMethod given a class, method name and signature
      *
@@ -467,6 +517,19 @@ public:
      */
     virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory *trMemory,
         TR_OpaqueClassBlock *classPointer, const char *methodName, const char *signature);
+
+    /**
+     * @brief A specialized version of getResolvedMethodForNameAndSignature for constructors
+     *
+     * @param trMemory     Pointer to TR_Memory object used for memory allocation
+     * @param classPointer The j9class that is searched for method name/signature
+     * @param signature    Null terminated string denoting the signature of the method we want
+     *
+     * @return             A pointer to a TR_ResolvedMethod for the indicated j9method, or null if not found
+     */
+    virtual TR_ResolvedMethod *getResolvedMethodForConstructorWithSig(TR_Memory *trMemory,
+        TR_OpaqueClassBlock *classPointer, const char *signature);
+
     virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock *classObject, int32_t cpIndex,
         bool ignoreReResolve = true);
     virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod,
@@ -1909,7 +1972,8 @@ public:
     virtual bool canMethodExitEventBeHooked();
     virtual bool methodsCanBeInlinedEvenIfEventHooksEnabled(TR::Compilation *comp);
     virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method);
-    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *);
+    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *,
+        const char *methodName = NULL);
     virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory *trMemory,
         TR_OpaqueClassBlock *classPointer, const char *methodName, const char *signature);
     virtual uint32_t getInstanceFieldOffset(TR_OpaqueClassBlock *classPointer, const char *fieldName, uint32_t fieldLen,

--- a/runtime/compiler/env/VMJ9Server.cpp
+++ b/runtime/compiler/env/VMJ9Server.cpp
@@ -62,6 +62,32 @@ void TR_J9ServerVM::getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueC
     }
 }
 
+void TR_J9ServerVM::getResolvedMethodsAndMethodsForName(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
+    List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName, bool relocatable)
+{
+    TR_MethodToBeCompiled *entry = _compInfoPT->getMethodBeingCompiled();
+    JITServer::ServerStream *stream = entry->_stream;
+    std::string methodNameString(methodName);
+    stream->write(JITServer::MessageType::VM_getResolvedMethodsForNameAndMirror, classPointer, methodNameString);
+    auto recv = stream->read<std::vector<J9Method *>, std::vector<TR_ResolvedJ9JITServerMethodInfo> >();
+    auto &methodsInClass = std::get<0>(recv);
+    auto &methodsInfo = std::get<1>(recv);
+
+    TR_ASSERT_FATAL(methodsInClass.size() == methodsInfo.size(),
+        "methodsInClass and methodsInfo do not have the same size\n");
+
+    for (int i = 0; i < methodsInfo.size(); ++i) {
+        // create resolved methods, using information from mirrors
+        auto resolvedMethod = relocatable
+            ? new (trMemory->trHeapMemory()) TR_ResolvedRelocatableJ9JITServerMethod(
+                  (TR_OpaqueMethodBlock *)methodsInClass[i], this, trMemory, methodsInfo[i], 0)
+            : new (trMemory->trHeapMemory()) TR_ResolvedJ9JITServerMethod((TR_OpaqueMethodBlock *)methodsInClass[i],
+                  this, trMemory, methodsInfo[i], 0);
+
+        resolvedMethodsInClass->add(resolvedMethod);
+    }
+}
+
 bool TR_J9ServerVM::isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT)
 {
     return isClassLibraryClass(getClassFromMethodBlock(method));
@@ -823,9 +849,13 @@ void *TR_J9ServerVM::getMethods(TR_OpaqueClassBlock *clazz)
 }
 
 void TR_J9ServerVM::getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
-    List<TR_ResolvedMethod> *resolvedMethodsInClass)
+    List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName)
 {
-    getResolvedMethodsAndMethods(trMemory, classPointer, resolvedMethodsInClass);
+    if (methodName) {
+        getResolvedMethodsAndMethodsForName(trMemory, classPointer, resolvedMethodsInClass, methodName);
+    } else {
+        getResolvedMethodsAndMethods(trMemory, classPointer, resolvedMethodsInClass);
+    }
 }
 
 bool TR_J9ServerVM::isPrimitiveArray(TR_OpaqueClassBlock *clazz)
@@ -2945,7 +2975,7 @@ TR_OpaqueClassBlock *TR_J9SharedCacheServerVM::getSuperClass(TR_OpaqueClassBlock
 }
 
 void TR_J9SharedCacheServerVM::getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
-    List<TR_ResolvedMethod> *resolvedMethodsInClass)
+    List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName)
 {
     TR::Compilation *comp = _compInfoPT->getCompilation();
     TR_ASSERT(comp, "Should be called only within a compilation");
@@ -2961,25 +2991,47 @@ void TR_J9SharedCacheServerVM::getResolvedMethods(TR_Memory *trMemory, TR_Opaque
     }
 
     if (validated) {
-        J9Method *resolvedMethods;
-        uint32_t numMethods;
+        if (methodName) {
+            // getResolvedMethodsAndMethodsForName will create resolved
+            // methods; for AOT compilations, the constructor will check if the
+            // method and its defining class has already be validated; however,
+            // the validations are added below, after returning. Thus, wrap
+            // this query in a heuristic region to prevent the potential SVM
+            // assert.
+            comp->enterHeuristicRegion();
+            TR_J9ServerVM::getResolvedMethodsAndMethodsForName(trMemory, classPointer, resolvedMethodsInClass,
+                methodName, true /* relocatable */);
+            comp->exitHeuristicRegion();
 
-        // getResolvedMethodsAndMethods will create resolved methods; for AOT
-        // compilations, the constructor will check if the method and its
-        // defining class has already be validated; however, the validations
-        // are added below, after returning. Thus, wrap this query in a
-        // heuristic region to prevent the potential SVM assert.
-        comp->enterHeuristicRegion();
-        TR_J9ServerVM::getResolvedMethodsAndMethods(trMemory, classPointer, resolvedMethodsInClass, &resolvedMethods,
-            &numMethods, true /* relocatable */);
-        comp->exitHeuristicRegion();
+            // Add the necessary validation records
+            if (comp->getOption(TR_UseSymbolValidationManager)) {
+                ListIterator<TR_ResolvedMethod> it(resolvedMethodsInClass);
+                for (TR_ResolvedMethod *m = it.getCurrent(); m; m = it.getNext()) {
+                    comp->getSymbolValidationManager()->addMethodFromClassRecord(m->getNonPersistentIdentifier(),
+                        classPointer, -1);
+                }
+            }
+        } else {
+            J9Method *resolvedMethods;
+            uint32_t numMethods;
 
-        // Add the necessary validation records
-        if (comp->getOption(TR_UseSymbolValidationManager)) {
-            uint32_t indexIntoArray;
-            for (indexIntoArray = 0; indexIntoArray < numMethods; indexIntoArray++) {
-                comp->getSymbolValidationManager()->addMethodFromClassRecord(
-                    (TR_OpaqueMethodBlock *)&(resolvedMethods[indexIntoArray]), classPointer, indexIntoArray);
+            // getResolvedMethodsAndMethods will create resolved methods; for
+            // AOT compilations, the constructor will check if the method and
+            // its defining class has already be validated; however, the
+            // validations are added below, after returning. Thus, wrap this
+            // query in a heuristic region to prevent the potential SVM assert.
+            comp->enterHeuristicRegion();
+            TR_J9ServerVM::getResolvedMethodsAndMethods(trMemory, classPointer, resolvedMethodsInClass,
+                &resolvedMethods, &numMethods, true /* relocatable */);
+            comp->exitHeuristicRegion();
+
+            // Add the necessary validation records
+            if (comp->getOption(TR_UseSymbolValidationManager)) {
+                uint32_t indexIntoArray;
+                for (indexIntoArray = 0; indexIntoArray < numMethods; indexIntoArray++) {
+                    comp->getSymbolValidationManager()->addMethodFromClassRecord(
+                        (TR_OpaqueMethodBlock *)&(resolvedMethods[indexIntoArray]), classPointer, indexIntoArray);
+                }
             }
         }
     }

--- a/runtime/compiler/env/VMJ9Server.hpp
+++ b/runtime/compiler/env/VMJ9Server.hpp
@@ -133,7 +133,7 @@ public:
     virtual bool isJavaLangObject(TR_OpaqueClassBlock *clazz) override;
     virtual void *getMethods(TR_OpaqueClassBlock *clazz) override;
     virtual void getResolvedMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
-        List<TR_ResolvedMethod> *resolvedMethodsInClass) override;
+        List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName = NULL) override;
     virtual bool isPrimitiveArray(TR_OpaqueClassBlock *clazz) override;
     virtual uint32_t getAllocationSize(TR::StaticSymbol *classSym, TR_OpaqueClassBlock *clazz) override;
     virtual TR_OpaqueClassBlock *getObjectClass(uintptr_t objectPointer) override;
@@ -343,6 +343,9 @@ protected:
     void getResolvedMethodsAndMethods(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
         List<TR_ResolvedMethod> *resolvedMethodsInClass, J9Method **methods = NULL, uint32_t *numMethods = NULL,
         bool relocatable = false);
+    void getResolvedMethodsAndMethodsForName(TR_Memory *trMemory, TR_OpaqueClassBlock *classPointer,
+        List<TR_ResolvedMethod> *resolvedMethodsInClass, const char *methodName, bool relocatable = false);
+
     bool jitFieldsOrStaticsAreIdentical(TR_ResolvedMethod *method1, I_32 cpIndex1, TR_ResolvedMethod *method2,
         I_32 cpIndex2, int32_t isStatic);
 }; // class TR_J9ServerVM
@@ -437,7 +440,8 @@ public:
         const char *sig, uint32_t sigLen, UDATA options) override;
     virtual TR_OpaqueClassBlock *getClassOfMethod(TR_OpaqueMethodBlock *method) override;
     virtual TR_OpaqueClassBlock *getSuperClass(TR_OpaqueClassBlock *classPointer) override;
-    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *) override;
+    virtual void getResolvedMethods(TR_Memory *, TR_OpaqueClassBlock *, List<TR_ResolvedMethod> *,
+        const char *methodName = NULL) override;
     virtual TR_ResolvedMethod *getResolvedMethodForNameAndSignature(TR_Memory *trMemory,
         TR_OpaqueClassBlock *classPointer, const char *methodName, const char *signature) override;
     virtual bool isClassLibraryMethod(TR_OpaqueMethodBlock *method, bool vettedForAOT = false) override;

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -4676,20 +4676,8 @@ TR::Node *TR_J9ByteCodeIlGenerator::genInvokeInner(TR::SymbolReference *symRef, 
                 }
 
                 if (orbClass && !fej9()->isClassLoadedBySystemClassLoader(cl)) {
-                    TR_ScratchList<TR_ResolvedMethod> methods(trMemory());
-                    fej9()->getResolvedMethods(trMemory(), orbClass, &methods);
-                    ListIterator<TR_ResolvedMethod> it(&methods);
-                    TR_ResolvedMethod *replacementMethod;
-                    for (replacementMethod = it.getCurrent(); replacementMethod; replacementMethod = it.getNext()) {
-                        if (replacementMethod->nameLength() == ORB_REPLACE_METHOD_NAME_LEN
-                            && !strncmp(replacementMethod->nameChars(), ORB_REPLACE_METHOD_NAME,
-                                ORB_REPLACE_METHOD_NAME_LEN)) {
-                            if ((replacementMethod->signatureLength() == ORB_REPLACE_METHOD_SIG_LEN)
-                                && !strncmp(replacementMethod->signatureChars(), ORB_REPLACE_METHOD_SIG,
-                                    ORB_REPLACE_METHOD_SIG_LEN))
-                                break; // found it
-                        }
-                    }
+                    TR_ResolvedMethod *replacementMethod = fej9()->getResolvedMethodForNameAndSignature(trMemory(),
+                        orbClass, ORB_REPLACE_METHOD_NAME, ORB_REPLACE_METHOD_SIG);
 
                     if (replacementMethod) {
                         if (performTransformation(comp(),
@@ -4753,21 +4741,10 @@ TR::Node *TR_J9ByteCodeIlGenerator::genInvokeInner(TR::SymbolReference *symRef, 
                         logprintf(traceILGen, log, "serialClass = %p, serialClassLoader %s systemClassLoader\n",
                             serialClass, (!fej9()->isClassLoadedBySystemClassLoader(cl)) ? "!=" : "==");
                         if (serialClass && !fej9()->isClassLoadedBySystemClassLoader(cl)) {
-                            TR_ScratchList<TR_ResolvedMethod> methods(trMemory());
-                            fej9()->getResolvedMethods(trMemory(), serialClass, &methods);
-                            ListIterator<TR_ResolvedMethod> it(&methods);
-                            TR_ResolvedMethod *replacementMethod;
-                            for (replacementMethod = it.getCurrent(); replacementMethod;
-                                 replacementMethod = it.getNext()) {
-                                if (replacementMethod->nameLength() == JAVA_SERIAL_REPLACE_METHOD_NAME_LEN
-                                    && !strncmp(replacementMethod->nameChars(), JAVA_SERIAL_REPLACE_METHOD_NAME,
-                                        JAVA_SERIAL_REPLACE_METHOD_NAME_LEN)) {
-                                    if ((replacementMethod->signatureLength() == JAVA_SERIAL_REPLACE_METHOD_SIG_LEN)
-                                        && !strncmp(replacementMethod->signatureChars(), JAVA_SERIAL_REPLACE_METHOD_SIG,
-                                            JAVA_SERIAL_REPLACE_METHOD_SIG_LEN))
-                                        break; // found it
-                                }
-                            }
+                            TR_ResolvedMethod *replacementMethod
+                                = fej9()->getResolvedMethodForNameAndSignature(trMemory(), serialClass,
+                                    JAVA_SERIAL_REPLACE_METHOD_NAME, JAVA_SERIAL_REPLACE_METHOD_SIG);
+
                             if (replacementMethod) {
                                 if (performTransformation(comp(),
                                         "O^O JAVA SERIALIZATION OPTIMIZATION : changing ObjectInputStream.readObject "

--- a/runtime/compiler/net/MessageTypes.cpp
+++ b/runtime/compiler/net/MessageTypes.cpp
@@ -159,6 +159,7 @@ const char *messageNames[] = {
     "VM_createMethodHandleArchetypeSpecimen",
     "VM_instanceOfOrCheckCast",
     "VM_getResolvedMethodsAndMirror",
+    "VM_getResolvedMethodsForNameAndMirror",
     "VM_getVMInfo",
     "VM_dereferenceStaticAddress",
     "VM_getClassFromCP",

--- a/runtime/compiler/net/MessageTypes.hpp
+++ b/runtime/compiler/net/MessageTypes.hpp
@@ -171,6 +171,7 @@ enum MessageType : uint16_t {
     VM_createMethodHandleArchetypeSpecimen,
     VM_instanceOfOrCheckCast,
     VM_getResolvedMethodsAndMirror,
+    VM_getResolvedMethodsForNameAndMirror,
     VM_getVMInfo,
     VM_dereferenceStaticAddress,
     VM_getClassFromCP,

--- a/runtime/compiler/optimizer/J9ValuePropagation.cpp
+++ b/runtime/compiler/optimizer/J9ValuePropagation.cpp
@@ -3571,8 +3571,7 @@ bool J9::ValuePropagation::canClassBeTrustedAsFixedClass(TR::SymbolReference *sy
 }
 
 static void getHelperSymRefs(OMR::ValuePropagation *vp, TR::Node *curCallNode, TR::SymbolReference *&getHelpersSymRef,
-    TR::SymbolReference *&helperSymRef, const char *helperSig, int32_t helperSigLen,
-    TR::MethodSymbol::Kinds helperCallKind)
+    TR::SymbolReference *&helperSymRef, const char *helperSig, TR::MethodSymbol::Kinds helperCallKind)
 {
     // Function to retrieve the JITHelpers.getHelpers and JITHelpers.<helperSig> method symbol references.
     //
@@ -3583,12 +3582,24 @@ static void getHelperSymRefs(OMR::ValuePropagation *vp, TR::Node *curCallNode, T
     if (!jitHelpersClass || !TR::Compiler->cls.isClassInitialized(vp->comp(), jitHelpersClass))
         return;
 
+    const char *getHelpersSig = "jitHelpers";
+    int32_t getHelpersSiglen = strlen(getHelpersSig);
+    int32_t helperSigLen = strlen(helperSig);
+
     TR_ScratchList<TR_ResolvedMethod> helperMethods(vp->trMemory());
-    vp->comp()->fej9()->getResolvedMethods(vp->trMemory(), jitHelpersClass, &helperMethods);
-    ListIterator<TR_ResolvedMethod> it(&helperMethods);
+    vp->comp()->fej9()->getResolvedMethods(vp->trMemory(), jitHelpersClass, &helperMethods, helperSig);
+
+    // Because the helperMethods scratch list is reused here, in an AOT
+    // compilation, the compiler will try and redundantly add validations for
+    // the methods acquired from the previous query; however, this isn't really
+    // an issue since the relo infrastructure does not add duplicate validation
+    // records. Doing this this way makes the code much more readable. This
+    // comes at the expense of making AOT compiles slightly inefficient.
+    vp->comp()->fej9()->getResolvedMethods(vp->trMemory(), jitHelpersClass, &helperMethods, getHelpersSig);
 
     // Find the symRefs
     //
+    ListIterator<TR_ResolvedMethod> it(&helperMethods);
     for (TR_ResolvedMethod *m = it.getCurrent(); m; m = it.getNext()) {
         char *sig = m->nameChars();
         if (!strncmp(sig, helperSig, helperSigLen)) {
@@ -3603,7 +3614,7 @@ static void getHelperSymRefs(OMR::ValuePropagation *vp, TR::Node *curCallNode, T
                 helperSymRef = vp->comp()->getSymRefTab()->findOrCreateMethodSymbol(
                     curCallNode->getSymbolReference()->getOwningMethodIndex(), -1, m, helperCallKind);
             }
-        } else if (!strncmp(sig, "jitHelpers", 10)) {
+        } else if (!strncmp(sig, getHelpersSig, getHelpersSiglen)) {
             getHelpersSymRef = vp->comp()->getSymRefTab()->findOrCreateMethodSymbol(JITTED_METHOD_INDEX, -1, m,
                 TR::MethodSymbol::Static);
         }
@@ -3615,7 +3626,7 @@ static void transformToOptimizedCloneCall(OMR::ValuePropagation *vp, TR::Node *n
     TR::SymbolReference *getHelpersSymRef = NULL;
     TR::SymbolReference *optimizedCloneSymRef = NULL;
 
-    getHelperSymRefs(vp, node, getHelpersSymRef, optimizedCloneSymRef, "optimizedClone", 14, TR::MethodSymbol::Special);
+    getHelperSymRefs(vp, node, getHelpersSymRef, optimizedCloneSymRef, "optimizedClone", TR::MethodSymbol::Special);
 
     if (optimizedCloneSymRef && getHelpersSymRef
         && performTransformation(vp->comp(), "%sChanging call to new optimizedClone at node [%p]\n", OPT_DETAILS,


### PR DESCRIPTION
Picking up from #23624 

This addresses the remaining open review comment regarding expanding 
the doc comments on `matchedMethod` and `getMatchingMethodFromNameAndSignature`.

Issue #23591 