### PR TITLE
Gate JFR DataLoss event test to JDK17 and above

### DIFF
--- a/test/functional/cmdLineTests/jfr/build.xml
+++ b/test/functional/cmdLineTests/jfr/build.xml
@@ -33,6 +33,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<!-- Set properties for this build. -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jfr" />
 	<property name="src" location="src" />
+	<property name="TestUtilities" location="../../TestUtilities/src" />
 	<property name="build" location="bin" />
 
 	<!-- Define jfrEnabled early. -->
@@ -83,6 +84,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<compilerarg line="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED" />
 			<src path="${src}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar" />
+			</classpath>
 		</javac>
 	</target>
 

--- a/test/functional/cmdLineTests/jfr/jfrevents.xml
+++ b/test/functional/cmdLineTests/jfr/jfrevents.xml
@@ -182,5 +182,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="required" caseSensitive="yes" regex="no">amount</output>
 		<output type="success" caseSensitive="yes" regex="no">total</output>
 		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
+		<versions>
+			<version>17+</version>
+		</versions>
 	</test>
 </suite>

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
@@ -32,6 +32,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
+import org.openj9.test.util.VersionCheck;
 
 public class WorkLoad {
 
@@ -148,7 +149,9 @@ public class WorkLoad {
 			contendOnLock();
 			burnCPU();
 			generateClassLoader();
-			emitDataLoss();
+			if (VersionCheck.major() >= 17) {
+				emitDataLoss();
+			}
 			if (vthreads) {
 				runWorkWithVirtualThreads(8);
 			}
@@ -243,10 +246,9 @@ public class WorkLoad {
 	private void emitDataLoss() {
 		try {
 			Class<?> jvmClass = Class.forName("jdk.jfr.internal.JVM");
-			Method emitDataLossMethod = jvmClass.getMethod("emitDataLoss", long.class);
-			emitDataLossMethod.invoke(null, 1024L);
+			jvmClass.getMethod("emitDataLoss", long.class).invoke(null, 1024L);
 		} catch (Exception e) {
-			e.printStackTrace();
+			throw new RuntimeException(e);
 		}
 	}
 


### PR DESCRIPTION
The `jdk.DataLoss` event is only available on `JDK17` and above. Move
the test into a new suite `jfrevents_jdk17andUp.xml` gated to JDK17+.
In WorkLoad, check if `emitDataLoss()` exists at class load and skip
the call if absent, ensuring safe execution on older JDKs.

Fixes: https://github.com/eclipse-openj9/openj9/issues/24085