### PR TITLE
Update OpenSSL to 3.5.7

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -143,7 +143,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-branch=openssl-3.5.6'
+  extra_getsource_options: '-openssl-branch=openssl-3.5.7'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
OpenSSL 3.5.7 includes fixes for:
* CVE-2026-7383
* CVE-2026-9076
* CVE-2026-34180
* CVE-2026-34181
* CVE-2026-34182
* CVE-2026-34183
* CVE-2026-42764
* CVE-2026-42766
* CVE-2026-42767
* CVE-2026-42768
* CVE-2026-42769
* CVE-2026-42770
* CVE-2026-45445
* CVE-2026-45446
* CVE-2026-45447