### PR TITLE
JDK11 JFR test skips emitDataLoss()

### DIFF
--- a/test/functional/cmdLineTests/jfr/build.xml
+++ b/test/functional/cmdLineTests/jfr/build.xml
@@ -33,6 +33,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	<!-- Set properties for this build. -->
 	<property name="DEST" value="${BUILD_ROOT}/functional/cmdLineTests/jfr" />
 	<property name="src" location="src" />
+	<property name="TestUtilities" location="../../TestUtilities/src"/>
 	<property name="build" location="bin" />
 
 	<!-- Define jfrEnabled early. -->
@@ -83,6 +84,10 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<javac srcdir="${src}" destdir="${build}" debug="true" fork="true" executable="${compiler.javac}" includeAntRuntime="false" encoding="ISO-8859-1">
 			<compilerarg line="--add-exports java.base/com.ibm.oti.vm=ALL-UNNAMED" />
 			<src path="${src}" />
+			<src path="${TestUtilities}" />
+			<classpath>
+				<pathelement location="${LIB_DIR}/testng.jar"/>
+			</classpath>
 		</javac>
 	</target>
 

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
@@ -33,6 +33,8 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.LockSupport;
 
+import org.openj9.test.util.VersionCheck;
+
 public class WorkLoad {
 
 	private static interface GlobalLoack { }
@@ -148,7 +150,10 @@ public class WorkLoad {
 			contendOnLock();
 			burnCPU();
 			generateClassLoader();
-			emitDataLoss();
+			if (VersionCheck.major() >= 17) {
+				// JDK11 jdk.jfr.internal.JVM doesn't have emitDataLoss().
+				emitDataLoss();
+			}
 			if (vthreads) {
 				runWorkWithVirtualThreads(8);
 			}


### PR DESCRIPTION
[JDK11 JFR test skips emitDataLoss()](https://github.com/eclipse-openj9/openj9/commit/9e79f4fe9246568fa03bc874fc3787dbf350d1b2) 

JDK11 `jdk.jfr.internal.JVM` doesn't have `emitDataLoss()`.

This fixes the test failure - https://openj9-jenkins.osuosl.org/job/Test_openjdk11_j9_sanity.functional_aarch64_linux_OpenJDK11_testList_2/5/console
```
02:23:29           [ERR] java.lang.NoSuchMethodException: jdk.jfr.internal.JVM.emitDataLoss(long)
02:23:29           [ERR] 	at java.base/java.lang.Class.newNoSuchMethodException(Class.java:654)
02:23:29           [ERR] 	at java.base/java.lang.Class.throwExceptionOrReturnNull(Class.java:1482)
02:23:29           [ERR] 	at java.base/java.lang.Class.getMethodHelper(Class.java:1579)
02:23:29           [ERR] 	at java.base/java.lang.Class.getMethod(Class.java:1474)
02:23:29           [ERR] 	at org.openj9.test.WorkLoad.emitDataLoss(WorkLoad.java:246)
02:23:29           [ERR] 	at org.openj9.test.WorkLoad.workload(WorkLoad.java:151)
02:23:29           [ERR] 	at org.openj9.test.WorkLoad.lambda$runWork$0(WorkLoad.java:94)
02:23:29           [ERR] 	at java.base/java.lang.Thread.run(Thread.java:836)
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>