### PR TITLE
Valhalla JDK28 bringup

### DIFF
--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -1008,7 +1008,7 @@ extern "C" {
 
 /* Class version minimum for value type support. */
 
-#define VALUE_TYPES_MAJOR_VERSION (44 + 27)
+#define VALUE_TYPES_MAJOR_VERSION (44 + 28)
 #define STRICT_FIELDS_MAJOR_VERSION VALUE_TYPES_MAJOR_VERSION
 #define PREVIEW_MINOR_VERSION 65535
 #define J9_IS_CLASSFILE_OR_ROMCLASS_VALUETYPE_VERSION(classfileOrRomClass) (((classfileOrRomClass)->majorVersion >= VALUE_TYPES_MAJOR_VERSION) && (PREVIEW_MINOR_VERSION == (classfileOrRomClass)->minorVersion))

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -65,7 +65,7 @@
 			<compilerarg line='--add-exports java.base/jdk.internal.misc=ALL-UNNAMED' />
 			<compilerarg line='--add-exports java.base/jdk.internal.value=ALL-UNNAMED' />
 			<compilerarg line='--add-exports java.base/jdk.internal.vm.annotation=ALL-UNNAMED' />
-			<compilerarg line='--enable-preview -source 27'/>
+			<compilerarg line='--enable-preview -source 28'/>
 			<!-- uncomment when running with lw5 -->
 			<!--<compilerarg line='-XDenableNullRestrictedTypes' />-->
 			<classpath>

--- a/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
+++ b/test/functional/Valhalla/src/org/openj9/test/lworld/ValhallaUtils.java
@@ -27,13 +27,12 @@ import static org.objectweb.asm.Opcodes.*;
 
 public class ValhallaUtils {
 	/**
-	 * Currently value types are built on JDK27, so use java file major version (44 + 27) for now.
+	 * Currently value types are built on JDK28, so use java file major version (44 + 28) for now.
 	 * If moved this needs to be incremented to the next class file version.
 	 * VALUE_TYPES_MAJOR_VERSION in oti/j9consts.h needs to be updated as well.
-	 * Also update CLASSFILE_MAJOR_VALHALLA/CLASSFILE_MINOR_PREVIEW in Class.java when the version changes.
 	 * Minor version is in 16 most significant bits for asm.
 	 */
-	static final int VALUE_TYPE_CLASS_FILE_VERSION = (65535 << 16) | (44 + 27);
+	static final int VALUE_TYPE_CLASS_FILE_VERSION = (65535 << 16) | (44 + 28);
 
 	/* workaround till the new ASM is released */
 	static final int ACC_IDENTITY = 0x20;


### PR DESCRIPTION
[Valhalla JDK28 bringup](https://github.com/eclipse-openj9/openj9/commit/415305314fa1108a8ab1dedb244573ae4b9affd4) 

Required by 
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/43

[Personal build](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/2779/console) and [Test re-run](https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdkvalhalla_j9_sanity.functional_x86-64_linux_valhalla_Personal/263/console) 

Signed-off-by: Jason Feng <fengj@ca.ibm.com>