### PR TITLE
x86: Implement Integer and Long compareUnsigned intrinsic

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -632,6 +632,26 @@ public:
      */
     void setSupportsInlineUnsafeCompareAndExchange() { _j9Flags.set(SupportsInlineUnsafeCompareAndExchange); }
 
+    /** \brief
+     *    Determines whether the code generator supports inlining of java/lang/Integer.compareUnsigned()
+     */
+    bool getSupportsInlineIntegerCompareUnsigned() { return _j9Flags.testAny(SupportsInlineIntegerCompareUnsigned); }
+
+    /** \brief
+     *    Determines whether the code generator supports inlining of java/lang/Long.compareUnsigned()
+     */
+    bool getSupportsInlineLongCompareUnsigned() { return _j9Flags.testAny(SupportsInlineLongCompareUnsigned); }
+
+    /** \brief
+     *    The code generator supports inlining of java/lang/Integer.compareUnsigned()
+     */
+    void setSupportsInlineIntegerCompareUnsigned() { _j9Flags.set(SupportsInlineIntegerCompareUnsigned); }
+
+    /** \brief
+     *    The code generator supports inlining of java/lang/Long.compareUnsigned()
+     */
+    void setSupportsInlineLongCompareUnsigned() { _j9Flags.set(SupportsInlineLongCompareUnsigned); }
+
     /**
      * \brief
      *    The number of nodes between a monext and the next monent before
@@ -848,6 +868,8 @@ private:
         SupportsInlineUnsafeCompareAndExchange = 0x00040000,
         SupportsInlineStringIndexOfString = 0x00080000, /*! codegen inlining of Java string index of string */
         SupportsInlineDecodeToLatin1Impl = 0x00100000,
+        SupportsInlineIntegerCompareUnsigned = 0x00200000,
+        SupportsInlineLongCompareUnsigned = 0x00400000,
     };
 
     flags32_t _j9Flags;

--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -287,11 +287,13 @@ FirstJ9Method = LastOMRMethod + 1,
     java_lang_Integer_rotateLeft, java_lang_Integer_rotateRight, java_lang_Integer_compress, java_lang_Integer_expand,
     java_lang_Integer_valueOf, java_lang_Integer_toUnsignedLong, java_lang_Integer_stringSize,
     java_lang_Integer_getChars, java_lang_Integer_getChars_charBuffer, java_lang_Integer_toString,
+    java_lang_Integer_compareUnsigned,
 
     java_lang_Long_getChars, java_lang_Long_getChars_charBuffer, java_lang_Long_bitCount, java_lang_Long_lowestOneBit,
     java_lang_Long_highestOneBit, java_lang_Long_numberOfLeadingZeros, java_lang_Long_numberOfTrailingZeros,
     java_lang_Long_reverseBytes, java_lang_Long_rotateLeft, java_lang_Long_rotateRight, java_lang_Long_compress,
     java_lang_Long_expand, java_lang_Short_reverseBytes, java_lang_Long_stringSize, java_lang_Long_toString,
+    java_lang_Long_compareUnsigned,
 
     java_math_BigDecimal_add, java_math_BigDecimal_clone, java_math_BigDecimal_subtract, java_math_BigDecimal_multiply,
     java_math_BigDecimal_valueOf, java_math_BigDecimal_valueOf_J, java_math_BigDecimal_setScale,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -3208,6 +3208,7 @@ void TR_ResolvedJ9Method::construct()
         { x(TR::java_lang_Integer_toString, "toString", "(I)Ljava/lang/String;") },
         { x(TR::java_lang_Integer_getChars, "getChars", "(II[B)I") },
         { x(TR::java_lang_Integer_getChars_charBuffer, "getChars", "(II[C)V") },
+        { x(TR::java_lang_Integer_compareUnsigned, "compareUnsigned", "(II)I") },
         { TR::unknownMethod }
     };
 
@@ -3228,6 +3229,7 @@ void TR_ResolvedJ9Method::construct()
         { x(TR::java_lang_Long_toString, "toString", "(J)Ljava/lang/String;") },
         { x(TR::java_lang_Long_getChars, "getChars", "(JI[B)I") },
         { x(TR::java_lang_Long_getChars_charBuffer, "getChars", "(JI[C)V") },
+        { x(TR::java_lang_Long_compareUnsigned, "compareUnsigned", "(JJ)I") },
         { TR::unknownMethod }
     };
 

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5500,6 +5500,14 @@ bool TR_J9InlinerPolicy::suppressInliningRecognizedInitialCallee(TR_CallSite *ca
                 return true;
             }
             break;
+        case TR::java_lang_Integer_compareUnsigned:
+            if (cg->getSupportsInlineIntegerCompareUnsigned()) {
+                return true;
+            }
+        case TR::java_lang_Long_compareUnsigned:
+            if (cg->getSupportsInlineLongCompareUnsigned()) {
+                return true;
+            }
         default:
             break;
     }

--- a/runtime/compiler/x/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/x/codegen/J9CodeGenerator.cpp
@@ -147,6 +147,14 @@ void J9::X86::CodeGenerator::initialize()
         cg->setSupportsInlineUnsafeCompareAndExchange();
     }
 
+    static const bool disableCompareUnsignedInlining = feGetEnv("TR_DisableCompareUnsignedInlining") != NULL;
+    if (!disableCompareUnsignedInlining) {
+        cg->setSupportsInlineIntegerCompareUnsigned();
+        if (comp->target().is64Bit()) {
+            cg->setSupportsInlineLongCompareUnsigned();
+        }
+    }
+
     // Disable fast gencon barriers for AOT compiles because relocations on
     // the inlined heap addresses are not available (yet).
     //

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -11459,6 +11459,28 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, TR::Reco
     return indexReg;
 }
 
+static TR::Register *inlineIntegerLongCompareUnsigned(TR::Node *node, bool isInt, TR::CodeGenerator *cg)
+{
+    TR::Register *aReg = cg->evaluate(node->getChild(0));
+    TR::Register *bReg = cg->evaluate(node->getChild(1));
+    TR::Register *resultReg = cg->allocateRegister();
+
+    Inst_RegReg(OP::XOR4RegReg, node, resultReg, resultReg, cg);
+
+    Inst_RegReg((isInt ? OP::CMP4RegReg : OP::CMP8RegReg), node, aReg, bReg, cg);
+
+    // Set return register to 1 if x > y unsigned, otherwise remain 0
+    Inst_Reg(OP::SETA1Reg, node, resultReg, cg);
+    // Subtract CF from return register if x < y, otherwise remain 0
+    Inst_RegImm(OP::SBB4RegImm4, node, resultReg, 0, cg);
+
+    node->setRegister(resultReg);
+    cg->decReferenceCount(node->getChild(0));
+    cg->decReferenceCount(node->getChild(1));
+
+    return resultReg;
+}
+
 // Generate inline code if possible for a call to an inline method. The call
 // may be direct or indirect; if it is indirect a guard will be generated around
 // the inline code and a fall-back to the indirect call.
@@ -13077,7 +13099,16 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
 
             callInlined = true;
             break;
-
+        case TR::java_lang_Integer_compareUnsigned:
+            if (cg->getSupportsInlineIntegerCompareUnsigned()) {
+                return inlineIntegerLongCompareUnsigned(node, true /* isInt */, cg);
+            }
+            break;
+        case TR::java_lang_Long_compareUnsigned:
+            if (cg->getSupportsInlineLongCompareUnsigned()) {
+                return inlineIntegerLongCompareUnsigned(node, false /* isInt */, cg);
+            }
+            break;
         default:
             break;
     }


### PR DESCRIPTION
This PR implements Integer.compareUnsigned() and Long.compareUnsigned() as intrinsics on x86. The function compareUnsigned is implemented with a nested ternary operator: `(x < y) ? -1 :  ((x == y) ? 0 : 1)`, this intrinsic uses comparisons as a shortcut: `(x > y) - (x < y)`. On x86, this can be performed with just one comparison.

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>