### PR TITLE
Remove no longer needed files from UMA build

### DIFF
--- a/runtime/compiler/build/files/host/p.mk
+++ b/runtime/compiler/build/files/host/p.mk
@@ -22,7 +22,6 @@ JIT_PRODUCT_BACKEND_SOURCES+= \
     omr/compiler/p/runtime/VirtualGuardRuntime.spp
 
 JIT_PRODUCT_SOURCE_FILES+=\
-    compiler/p/runtime/CodeSync.cpp \
     compiler/p/runtime/ebb.spp \
     compiler/p/runtime/Emulation.c \
     compiler/p/runtime/J9PPCArrayCopy.spp \
@@ -36,6 +35,7 @@ JIT_PRODUCT_SOURCE_FILES+=\
     compiler/p/runtime/PicBuilder.spp \
     compiler/p/runtime/Recomp.cpp \
     compiler/p/runtime/Recompilation.spp \
+    omr/compiler/p/runtime/CodeSync.cpp \
     omr/compiler/p/runtime/OMRCodeCacheConfig.cpp
 
 ifeq ($(OS),aix)

--- a/runtime/compiler/build/files/target/z.mk
+++ b/runtime/compiler/build/files/target/z.mk
@@ -48,7 +48,6 @@ JIT_PRODUCT_BACKEND_SOURCES+=\
     omr/compiler/z/codegen/S390HelperCallSnippet.cpp \
     omr/compiler/z/codegen/S390Instruction.cpp \
     omr/compiler/z/codegen/S390OutOfLineCodeSection.cpp \
-    omr/compiler/z/codegen/S390Snippets.cpp \
     omr/compiler/z/codegen/SystemLinkage.cpp \
     omr/compiler/z/codegen/SystemLinkageLinux.cpp \
     omr/compiler/z/codegen/SystemLinkagezOS.cpp \


### PR DESCRIPTION
p/runtime/CodeSync.cpp and omr/compiler/z/codegen/z/J9S390Snippets.cpp either no longer exist or should no longer be compiled for OpenJ9.

UMA changes so won't be useful to do CI testing here, but I have an internal build running on the AIX, Linux on P, and Linux on Z platforms and will report back here when it's done.