### PR TITLE
Improve TestConfigParser

### DIFF
--- a/test/functional/cmdline_options_tester/src/Output.java
+++ b/test/functional/cmdline_options_tester/src/Output.java
@@ -19,22 +19,22 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-import java.util.regex.PatternSyntaxException;
-
-import com.ibm.oti.util.regex.*;
+import com.ibm.oti.util.regex.Regex;
 
 class Output extends TestCondition {
-	private String _type;
-	private String _matchRegex;
-	private String _matchJavaUtilPattern;	
-	private String _matchCase;
-	private String _output;		// the output string taken from the file
-	private String _showRegexMatch;
-	
-	public Output( String matchRegex, String matchJavaUtilPattern, String showRegexMatch, String matchCase, String type ) {
+
+	private static boolean evalBoolean(String expr) {
+		return !"no".equalsIgnoreCase(TestSuite.evaluateVariables(expr));
+	}
+
+	private final String _type;
+	private final String _matchRegex;
+	private final String _matchJavaUtilPattern;
+	private final String _matchCase;
+	private String _output; // the output string taken from the file
+	private final String _showRegexMatch;
+
+	public Output(String matchRegex, String matchJavaUtilPattern, String showRegexMatch, String matchCase, String type) {
 		_matchRegex = matchRegex;
 		_matchJavaUtilPattern = matchJavaUtilPattern;
 		_showRegexMatch = showRegexMatch;
@@ -43,32 +43,32 @@ class Output extends TestCondition {
 		_output = "";
 	}
 
-	void setOutput( String s ) {
+	void setOutput(String s) {
 		_output = s;
 	}
-	
+
 	int getType() {
-		return parseType( TestSuite.evaluateVariables( _type ) );
+		return parseType(TestSuite.evaluateVariables(_type));
 	}
-	
+
 	public boolean isJavaUtilPattern() {
-		return !("no".equalsIgnoreCase( TestSuite.evaluateVariables( _matchJavaUtilPattern ) ));
+		return evalBoolean(_matchJavaUtilPattern);
 	}
-		
-	boolean match( Object o ) {
+
+	boolean match(Object o) {
 		String candidate = (String) o;
-		boolean matchRegex = !("no".equalsIgnoreCase(TestSuite.evaluateVariables(_matchRegex)));
-		boolean matchCase = !("no".equalsIgnoreCase(TestSuite.evaluateVariables(_matchCase)));
-		boolean matchJavaUtilPattern = !("no".equalsIgnoreCase(TestSuite.evaluateVariables(_matchJavaUtilPattern)));
-		boolean showRegexMatch = !("no".equalsIgnoreCase(TestSuite.evaluateVariables(_showRegexMatch)));
+		boolean matchRegex = evalBoolean(_matchRegex);
+		boolean matchCase = evalBoolean(_matchCase);
+		boolean matchJavaUtilPattern = evalBoolean(_matchJavaUtilPattern);
+		boolean showRegexMatch = evalBoolean(_showRegexMatch);
 		String string = TestSuite.evaluateVariables(_output);
 
-		if ((matchRegex) && (!matchJavaUtilPattern)) {
+		if (matchRegex && !matchJavaUtilPattern) {
 			try {
 				Regex regex = new Regex(string, matchCase);
 				boolean retval = regex.matches(candidate);
-				if(	retval && showRegexMatch) {
-					System.out.println("\tMatch ("+_type+"): "+candidate);
+				if (retval && showRegexMatch) {
+					System.out.println("\tMatch (" + _type + "): " + candidate);
 				}
 				return retval;
 			} catch (Exception e) {
@@ -77,25 +77,27 @@ class Output extends TestCondition {
 				e.printStackTrace();
 				return false;
 			}
-		} else if ((matchRegex) && (matchJavaUtilPattern)) {
+		} else if (matchRegex && matchJavaUtilPattern) {
 			/* CMVC 163891: Use of java.util.regex.Pattern/Matcher must be in a separate class, to avoid
 			 * problems with the verifier when using the embedded class library.
 			 */
-			return OutputRegexHelper.ContainsMatches(candidate,string,matchCase,showRegexMatch,_type);
+			return OutputRegexHelper.ContainsMatches(candidate, string, matchCase, showRegexMatch, _type);
 		} else {
 			if (!matchCase) {
 				string = string.toLowerCase();
 				candidate = candidate.toLowerCase();
 			}
-			boolean retval = (candidate.indexOf(string) >= 0);
-			if(	retval && showRegexMatch) {
-				System.out.println("\tMatch ("+_type+"): "+candidate);
+			boolean retval = candidate.contains(string);
+			if (retval && showRegexMatch) {
+				System.out.println("\tMatch (" + _type + "): " + candidate);
 			}
 			return retval;
 		}
 	}
-	
+
+	@Override
 	public String toString() {
-		return "Output match: " + TestSuite.evaluateVariables( _output );
+		return "Output match: " + TestSuite.evaluateVariables(_output);
 	}
+
 }

--- a/test/functional/cmdline_options_tester/src/Test.java
+++ b/test/functional/cmdline_options_tester/src/Test.java
@@ -34,9 +34,26 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @SuppressWarnings("nls")
 class Test {
+
+	static final class Range {
+		final int min;
+		final int max;
+
+		Range(int min, int max) {
+			this.min = min;
+			this.max = max;
+		}
+
+		boolean includes(int value) {
+			return (min <= value) && (value <= max);
+		}
+	}
+
 	private final String _id;
 	private String _command;
 	private final String _timeoutString;
@@ -54,6 +71,12 @@ class Test {
 	private String _commandExecutable;
 	private List<String> _commandArgs;
 	private List<String> _commandInputLines;
+	private final List<Range> _versionRanges;
+
+	private static final Pattern PLUS_PATTERN = Pattern.compile("\\s*(\\d+)\\s*\\+\\s*");
+	private static final Pattern RANGE_PATTERN = Pattern.compile("\\s*\\[\\s*(\\d+)\\s*,\\s*(\\d+)\\s*\\]\\s*");
+	private static final Pattern SINGLE_PATTERN = Pattern.compile("\\s*(\\d+)\\s*");
+
 	private static final long _JAVACORE_TIMEOUT_MILLIS = 5 * 60 * 1000; // 5 minute timeout
 	private static final long SHORT_TIMEOUT_MILLIS = 30 * 1000; // 30 second timeout
 
@@ -64,7 +87,7 @@ class Test {
 	 */
 	static final String CORE_COUNT_PROPERTY = "cmdline.corecount";
 	static final int CORE_COUNT = Integer.getInteger(CORE_COUNT_PROPERTY, 2).intValue();
-	
+
 	/**
 	 * The time in milliseconds between capturing core files (if CORE_COUNT > 1)
 	 * may be specified via
@@ -72,10 +95,20 @@ class Test {
 	 * The default is one minute.
 	 */
 	static final long CORE_SPACING_MILLIS = Long.getLong("cmdline.coreintervalms", 60 * 1000).longValue();
-	
-	static String archName = System.getProperty("os.arch");
-	static boolean isRiscv = archName.toLowerCase().contains("riscv");
-	static boolean isJava8 = System.getProperty("java.specification.version").equals("1.8");
+
+	static final String archName = System.getProperty("os.arch");
+	static final boolean isRiscv = archName.toLowerCase().contains("riscv");
+	static final int javaVersion;
+
+	static {
+		String versionString = System.getProperty("java.specification.version");
+
+		if (versionString.startsWith("1.")) {
+			versionString = versionString.substring(2);
+		}
+
+		javaVersion = Integer.parseInt(versionString);
+	}
 
 	/**
 	 * Create a new test case with the given id.
@@ -92,6 +125,7 @@ class Test {
 		_standardOutput = new StringBuilder();
 		_errorOutput = new StringBuilder();
 		_timedOut = false;
+		_versionRanges = new ArrayList<>();
 	}
 
 	void setOutputLimit(int outputLimit) {
@@ -125,6 +159,51 @@ class Test {
 		_testConditions.add(tc);
 	}
 
+	void constrainVersion(String constraint) {
+		Matcher matcher;
+
+		matcher = PLUS_PATTERN.matcher(constraint);
+		if (matcher.matches()) {
+			int min = Integer.parseInt(matcher.group(1).trim());
+
+			_versionRanges.add(new Range(min, Integer.MAX_VALUE));
+			return;
+		}
+
+		matcher = RANGE_PATTERN.matcher(constraint);
+		if (matcher.matches()) {
+			int min = Integer.parseInt(matcher.group(1).trim());
+			int max = Integer.parseInt(matcher.group(2).trim());
+
+			_versionRanges.add(new Range(min, max));
+			return;
+		}
+
+		matcher = SINGLE_PATTERN.matcher(constraint);
+		if (matcher.matches()) {
+			int version = Integer.parseInt(matcher.group(1).trim());
+
+			_versionRanges.add(new Range(version, version));
+			return;
+		}
+
+		throw new IllegalArgumentException(constraint);
+	}
+
+	private boolean shouldRun() {
+		if (_versionRanges.isEmpty()) {
+			return true;
+		}
+
+		for (Range range : _versionRanges) {
+			if (range.includes(javaVersion)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
 	/**
 	 * Does the required variable substitutions and runs the test case.
 	 *
@@ -137,6 +216,11 @@ class Test {
 	public boolean run(long defaultTimeout) {
 		// clear any previously captured output
 		destroy();
+
+		if (!shouldRun()) {
+			System.out.format("Skipping test which does not apply to Java %d%n.", javaVersion);
+			return true;
+		}
 
 		_matched = new boolean[_testConditions.size()];
 		long timer;
@@ -430,14 +514,14 @@ class Test {
 	public static boolean isLinux() {
 		String osName = System.getProperty("os.name", "<unknown>");
 
-		return osName.toLowerCase().indexOf("linux") >= 0;
+		return osName.toLowerCase().contains("linux");
 	}
 
 	public static int getPID(Process process) throws Exception {
 		if (isRiscv) {
 			return 0;
 		}
-		if (isJava8) {
+		if (javaVersion == 8) {
 			Class<?> cl = process.getClass();
 			if (!cl.getName().equals("java.lang.UNIXProcess")) {
 				return 0;

--- a/test/functional/cmdline_options_tester/src/TestConfigParser.java
+++ b/test/functional/cmdline_options_tester/src/TestConfigParser.java
@@ -19,11 +19,15 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.List;
+import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
-import com.oti.j9.exclude.*;
+import com.oti.j9.exclude.ExcludeList;
+import com.oti.j9.exclude.IXMLDocumentHandler;
+import com.oti.j9.exclude.XMLParser;
 
 class TestConfigParser {
 	private ExcludeList _excludes;
@@ -119,9 +123,9 @@ class TestConfigParser {
 		// this flag allows us to continue to use this parser implementation for the more complicated use of the command element without having to re-write it as a sort of delegating PDA
 		private boolean _isInNewCommandStanza;
 		// used to collect the contents of the in-order "arg" tags under the new-style command stanza (which are then passed as arguments to the underlying process)
-		private Vector<String> _commandArgs;
+		private List<String> _commandArgs;
 		// used to collect the contents of the in-order "input" tags under the new-style command stanza (which are then fed into the stdin of the underlying process as new-line terminated strings)
-		private Vector<String> _commandInputLines;
+		private List<String> _commandInputLines;
 
 		/**
 		 * Empty implementation
@@ -260,8 +264,8 @@ class TestConfigParser {
 					_commandExecutable = commandExecutable;
 					//also set the flag to know that we are in a command context and create the arrays for the arguments and inputs which may appear in that stanza
 					_isInNewCommandStanza = true;
-					_commandArgs = new Vector<>();
-					_commandInputLines = new Vector<>();
+					_commandArgs = new ArrayList<>();
+					_commandInputLines = new ArrayList<>();
 				}
 			} else if (elementName.equalsIgnoreCase("if")) {
 				_iterator.addCommand(new IfTest(attributes.get("testVariable"), attributes.get("testValue"),
@@ -325,6 +329,10 @@ class TestConfigParser {
 			} else if (elementName.equalsIgnoreCase("input")) {
 				if (_isInNewCommandStanza) {
 					_commandInputLines.add(readData);
+				}
+			} else if (elementName.equalsIgnoreCase("version")) {
+				if (_currentTest != null) {
+					_currentTest.constrainVersion(readData);
 				}
 			}
 			_data.setLength(0); // any data in here has outlived it's usefulness

--- a/test/functional/cmdline_options_tester/src/TestIterator.java
+++ b/test/functional/cmdline_options_tester/src/TestIterator.java
@@ -19,23 +19,24 @@
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  */
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 
 public class TestIterator {
-	private TestSuite _suite;
 
-	private String _loopIndex;
-	private String _loopFrom;
-	private String _loopUntil;
-	private String _loopInc;
-	
-	private boolean _singleIterationOnly;
+	private final TestSuite _suite;
+
+	private final String _loopIndex;
+	private final String _loopFrom;
+	private final String _loopUntil;
+	private final String _loopInc;
+
+	private final boolean _singleIterationOnly;
 	private boolean _loopIndexIncremented;
-	
+
 	private boolean _isInnerLoopOpen;
-	private ArrayList _subItems;
-	
+	private final List<Object> _subItems;
+
 	/**
 	 * This constructor creates a standard TestIterator object, which runs a given set of tests/variable assignments/etc.
 	 * a number of times. The number of times that the stuff is run depends on the <code>from</code>, <code>until</code>,
@@ -48,62 +49,67 @@ public class TestIterator {
 	 * The <code>from</code>, <code>until</code>, and <code>inc</code> strings may have variables in them, but after
 	 * variable substitution, must evaluate to integers.
 	 */
-	TestIterator( TestSuite suite, String index, String from, String until, String inc ) {
+	TestIterator(TestSuite suite, String index, String from, String until, String inc) {
 		_suite = suite;
 
 		_loopIndex = index;
 		_loopFrom = from;
 		_loopUntil = until;
 		_loopInc = inc;
-		
+
+		_singleIterationOnly = false;
 		_isInnerLoopOpen = false;
-		_subItems = new ArrayList();
-		
-		TestSuite.putVariable( _loopIndex, TestSuite.evaluateVariables( _loopFrom ) );
+		_subItems = new ArrayList<>();
+
+		TestSuite.putVariable(_loopIndex, TestSuite.evaluateVariables(_loopFrom));
 	}
-	
+
 	/**
 	 * This constructor creates a single-iteration version of this iterator. It will run everything passed
 	 * to it (by the addXXX methods) exactly once.
 	 */
-	TestIterator( TestSuite suite ) {
+	TestIterator(TestSuite suite) {
 		_suite = suite;
-		
+
+		_loopIndex = null;
+		_loopFrom = null;
+		_loopUntil = null;
+		_loopInc = null;
+
 		_singleIterationOnly = true;
-		
 		_isInnerLoopOpen = false;
-		_subItems = new ArrayList();
+		_subItems = new ArrayList<>();
 	}
-	
-	void addTest( Test t ) {
+
+	void addTest(Test t) {
 		if (_isInnerLoopOpen) {
-			getLastSubIterator().addTest( t );
+			getLastSubIterator().addTest(t);
 		} else {
-			_subItems.add( t );
+			_subItems.add(t);
 			if (canRunTest()) {
-				_suite.runTest( t );
+				_suite.runTest(t);
 			}
 		}
 	}
 
-	void addSubIterator( TestIterator it ) {
+	void addSubIterator(TestIterator it) {
 		if (_isInnerLoopOpen) {
-			getLastSubIterator().addSubIterator( it );
+			getLastSubIterator().addSubIterator(it);
 		} else {
-			_subItems.add( it );
+			_subItems.add(it);
 			_isInnerLoopOpen = true;
 		}
 	}
-	
-	void addCommand( Command c ) {
+
+	void addCommand(Command c) {
 		if (_isInnerLoopOpen) {
-			getLastSubIterator().addCommand( c );
+			getLastSubIterator().addCommand(c);
 		} else {
-			_subItems.add( c );
+			_subItems.add(c);
 			c.executeSelf();
 		}
 	}
-	
+
 	boolean closeInnerLoop() {
 		if (_isInnerLoopOpen) {
 			if (getLastSubIterator().closeInnerLoop()) {
@@ -112,77 +118,79 @@ public class TestIterator {
 			_isInnerLoopOpen = false;
 			return true;
 		}
-		// end of this TestIterator's corresponding <loop> element, so now we actually run the remaining
-		// iterations of the loop
+		// End of this TestIterator's corresponding <loop> element,
+		// so now we actually run the remaining iterations of the loop.
 		incrementLoopIndex();
 		while (canRunTest()) {
 			runIteration();
 		}
 		return false;
 	}
-	
+
 	private void incrementLoopIndex() {
 		if (_singleIterationOnly) {
 			_loopIndexIncremented = true;
 			return;
 		}
-		
+
 		try {
-			int increment = (_loopInc == null ? 1 : Integer.parseInt( TestSuite.evaluateVariables( _loopInc ).trim() ));
-			String value = TestSuite.getVariable( _loopIndex );
-			value = Integer.toString( Integer.parseInt( value.trim() ) + increment );
-			TestSuite.putVariable( _loopIndex, value );
+			int increment = (_loopInc == null) ? 1 : Integer.parseInt(TestSuite.evaluateVariables(_loopInc).trim());
+			String value = TestSuite.getVariable(_loopIndex);
+			value = Integer.toString(Integer.parseInt(value.trim()) + increment);
+			TestSuite.putVariable(_loopIndex, value);
 		} catch (Exception e) {
 			notifyInfiniteLoop(e);
 			System.exit(1);
 		}
 	}
-	
+
 	private void runEntireLoop() {
-		TestSuite.putVariable( _loopIndex, TestSuite.evaluateVariables( _loopFrom ) );
+		TestSuite.putVariable(_loopIndex, TestSuite.evaluateVariables(_loopFrom));
 		while (canRunTest()) {
 			runIteration();
 		}
 	}
-	
+
 	private void runIteration() {
-		for (int i = 0; i < _subItems.size(); i++) {
-			Object o = _subItems.get(i);
+		for (Object o : _subItems) {
 			if (o instanceof Test && canRunTest()) {
-				_suite.runTest( (Test)o );
+				_suite.runTest((Test) o);
 			} else if (o instanceof TestIterator) {
-				( (TestIterator)o ).runEntireLoop();
+				((TestIterator) o).runEntireLoop();
 			} else if (o instanceof Command) {
-				( (Command)o ).executeSelf();
+				((Command) o).executeSelf();
 			}
 		}
 		incrementLoopIndex();
 	}
-	
+
 	private boolean canRunTest() {
 		if (_singleIterationOnly) {
 			return !_loopIndexIncremented;
 		}
 		try {
-			return ! (Integer.parseInt(TestSuite.getVariable(_loopIndex)) == Integer.parseInt(TestSuite.evaluateVariables(_loopUntil)));			
+			int index = Integer.parseInt(TestSuite.getVariable(_loopIndex));
+			int until = Integer.parseInt(TestSuite.evaluateVariables(_loopUntil));
+			return index != until;
 		} catch (Exception e) {
 			notifyInfiniteLoop(e);
 			System.exit(1);
+			return false; // dead code, to satisfy compiler only
 		}
-		return false;	// dead code, to satisfy compiler only
 	}
-	
+
 	private TestIterator getLastSubIterator() {
-		return (TestIterator)_subItems.get( _subItems.size() - 1 );
+		return (TestIterator) _subItems.get(_subItems.size() - 1);
 	}
-	
-	private void notifyInfiniteLoop( Exception e ) {
+
+	private void notifyInfiniteLoop(Exception e) {
 		// if there is an exception here, it's an accidental infinite loop. tell user to fix!
-		System.err.println( "The test file passed to the cmdLineTester application contained an invalid loop" );
-		System.err.println( "of " + _loopIndex + " from " + _loopFrom + " until " + _loopUntil + ", with increment " + _loopInc + ". This loop" );
-		System.err.println( "contains an error that will get it stuck in an infinite cycle. Please fix it.. or" );
-		System.err.println( "modify the cmdLineTester application to deal with it, if it really is what you" );
-		System.err.println( "want to do. The cmdLineTester application will now terminate." );
+		System.err.println("The test file passed to the cmdLineTester application contained an invalid loop");
+		System.err.format("of %s from %s until %s, with increment %s. This loop%n",
+				_loopIndex, _loopFrom, _loopUntil, _loopInc);
+		System.err.println("contains an error that will get it stuck in an infinite cycle. Please fix it, or");
+		System.err.println("modify the cmdLineTester application to deal with it, if it really is what you");
+		System.err.println("want to do. The cmdLineTester application will now terminate.");
 		e.printStackTrace();
 	}
 }


### PR DESCRIPTION
Allow tests to specify applicable Java versions, using the same patterns as `TestInfoParser` in TKG.

Of note, without this change, the change to `j9tests_Java_common.xml` in https://github.com/eclipse-openj9/openj9/pull/24015 is ineffective.