### PR TITLE
Revert "Wrap arraytranslate node in treetop in J9RecognizedCallTransformer"

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -355,8 +355,6 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     arrayTranslateNode->setAndIncChild(4, length);
     arrayTranslateNode->setAndIncChild(5, stoppingNode);
 
-    TR::Node *arraytranslateAnchorNode = TR::Node::create(TR::treetop, 1, arrayTranslateNode);
-
     TR::CFG *cfg = comp()->getFlowGraph();
 
     // if (length < 0) { call the original method }
@@ -384,7 +382,8 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     TR::Node *ifCmpNode5 = TR::Node::createif(TR::ificmplt, ishrNode, iaddNode2);
     TR::TreeTop *ifCmpTreeTop5 = TR::TreeTop::create(comp(), ifCmpTreeTop4, ifCmpNode5);
 
-    TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arraytranslateAnchorNode);
+    TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arrayTranslateNode);
+
     TR::Block *ifCmpBlock1 = ifCmpTreeTop1->getEnclosingBlock();
     TR::Block *ifCmpBlock2
         = ifCmpBlock1->split(ifCmpTreeTop2, cfg, true /* fixUpCommoning */, true /* copyExceptionSuccessors */);


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#24014 due to crashes in JITServer tests