### PR TITLE
Fix format of "skipping test" message

### DIFF
--- a/test/functional/cmdline_options_tester/src/Test.java
+++ b/test/functional/cmdline_options_tester/src/Test.java
@@ -218,7 +218,7 @@ class Test {
 		destroy();
 
 		if (!shouldRun()) {
-			System.out.format("Skipping test which does not apply to Java %d%n.", javaVersion);
+			System.out.format("Skipping test which does not apply to Java %d.%n", javaVersion);
 			return true;
 		}
 


### PR DESCRIPTION
The period should be before the newline, not after it.

See [jdk11 testing](https://openj9-jenkins.osuosl.org/job/Test_openjdk11_j9_sanity.functional_s390x_linux_Personal_testList_1/439/consoleText) for https://github.com/eclipse-openj9/openj9/pull/24095:
```
[2026-06-10T21:31:55.337Z] Testing: test jfr DataLoss - approx 30 seconds
[2026-06-10T21:31:55.337Z] Skipping test which does not apply to Java 11
[2026-06-10T21:31:55.337Z] .Test result: PASSED
```