### PR TITLE
Trigger chunk rotation on low global buf memory

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -365,7 +365,7 @@ jboolean JNICALL
 Java_jdk_jfr_internal_JVM_createJFR(JNIEnv *env, jobject obj, jboolean simulateFailure)
 {
 	jboolean rc = JNI_TRUE;
-	J9VMThread *currentThread = (J9VMThread*) env;
+	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
@@ -376,6 +376,11 @@ Java_jdk_jfr_internal_JVM_createJFR(JNIEnv *env, jobject obj, jboolean simulateF
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	if (JNI_OK != vmFuncs->initializeJFR(vm)) {
 		rc = JNI_FALSE;
+	}
+
+	if (!vm->internalVMFunctions->setupChunkMonitor(currentThread)) {
+		rc = JNI_FALSE;
+		goto done;
 	}
 	vmFuncs->internalExitVMToJNI(currentThread);
 
@@ -506,8 +511,7 @@ Java_jdk_jfr_internal_JVM_emitOldObjectSamples(JNIEnv *env, jobject obj, jlong c
 jboolean JNICALL
 Java_jdk_jfr_internal_JVM_shouldRotateDisk(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return JNI_TRUE;
+	return ((J9VMThread *)env)->javaVM->jfrState.shouldRotateDisk;
 }
 
 } /* extern "C" */

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
@@ -141,7 +141,10 @@ Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_String_2(JNIEnv *env, jobject ob
 void JNICALL
 Java_jdk_jfr_internal_JVM_flush__(JNIEnv *env, jclass clazz)
 {
-	Java_com_ibm_oti_vm_VM_jfrDump(env, NULL);
+	/* TODO Need to create a primitive similar to Java_com_ibm_oti_vm_VM_jfrDump
+	 * that flushes buffers to disk, but doesnt close the chunk so more entries
+	 * can be appended.
+	 */
 }
 
 void JNICALL

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5667,6 +5667,7 @@ typedef struct J9InternalVMFunctions {
 	void (*jfrInitializeInternalStructures)(struct J9VMThread *currentThread);
 	void (*jfrEmitDataLoss)(struct J9VMThread *currentThread, U_64 bytes);
 	jboolean (*requestJFREvent)(struct J9VMThread *currentThread, jlong id);
+	BOOLEAN (*setupChunkMonitor)(struct J9VMThread *currentThread);
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	void (*initializeSnapshotClassLoaderObject)(struct J9JavaVM *javaVM, struct J9ClassLoader *classLoader, j9object_t classLoaderObject);
@@ -6200,6 +6201,8 @@ typedef struct JFRState {
 	J9Method *transformToListMethod;
 	J9HashTable *threadObjectJNIRefTable;
 	omrthread_monitor_t threadObjectsMutex;
+	jobject chunkRotationMonitor;
+	jboolean shouldRotateDisk;
 } JFRState;
 
 typedef struct J9ReflectFunctionTable {

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5912,6 +5912,15 @@ void
 tearDownJFR(J9JavaVM *vm);
 
 /**
+ * Set up the chunk rotation monitor.
+ *
+ * @param currentThread[in] the current J9VMThread
+ * @return TRUE on success, FALSE on failure.
+ */
+BOOLEAN
+setupChunkMonitor(J9VMThread *currentThread);
+
+/**
  * Get the type ID for the JFR event type. This operation is
  * thread safe as it internally acquires a mutex. Only
  * subclasses of jdk.jfr.event.Event can be called with this

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -495,6 +495,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jfrInitializeInternalStructures,
 	jfrEmitDataLoss,
 	requestJFREvent,
+	setupChunkMonitor,
 #endif /* defined(J9VM_OPT_JFR) */
 #if defined(J9VM_OPT_SNAPSHOTS)
 	initializeSnapshotClassLoaderObject,

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -75,6 +75,8 @@ static bool addEventIds(J9JavaVM *vm);
 static bool addTypeIds(J9JavaVM *vm);
 #endif /* JAVA_SPEC_VERSION >= 17 */
 static void jfrShutdownInternalStructures(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData);
+static void notifyForChunkRotation(J9VMThread *currentThread);
+static void checkAvailableSpaceInGlobalBuffer(J9VMThread *currentThread);
 
 static void
 freeThreadIDs(J9VMThread *currentThread)
@@ -306,13 +308,18 @@ flushBufferToGlobal(J9VMThread *currentThread, J9VMThread *flushThread)
 	j9tty_printf(PORTLIB, "\n!!! flushing %p of size %u start=%p current=%p\n", flushThread, (U_32)bufferSize, flushThread->jfrBuffer.bufferStart, flushThread->jfrBuffer.bufferCurrent);
 #endif /* defined(DEBUG) */
 
-	if (!areJFRBuffersReadyForWrite(currentThread)) {
+	if (!areJFRBuffersReadyForWrite(flushThread)) {
 		goto done;
 	}
 
 	omrthread_monitor_enter(vm->jfrBufferMutex);
 	if (vm->jfrBuffer.bufferRemaining < bufferSize) {
-		if (!writeOutGlobalBuffer(currentThread, false, false)) {
+		if (isJFRV2SupportEnabled(vm)) {
+			notifyForChunkRotation(currentThread);
+			omrthread_monitor_exit(vm->jfrBufferMutex);
+			success = false;
+			goto done;
+		} else if (!writeOutGlobalBuffer(currentThread, false, false)) {
 			omrthread_monitor_exit(vm->jfrBufferMutex);
 			success = false;
 			goto done;
@@ -330,6 +337,7 @@ flushBufferToGlobal(J9VMThread *currentThread, J9VMThread *flushThread)
 #if defined(DEBUG)
 	memset(flushThread->jfrBuffer.bufferStart, 0, J9JFR_THREAD_BUFFER_SIZE);
 #endif /* defined(DEBUG) */
+	checkAvailableSpaceInGlobalBuffer(currentThread);
 
 done:
 	return success;
@@ -624,9 +632,9 @@ jfrThreadEnd(J9HookInterface **hook, UDATA eventNum, void *eventData, void *user
 {
 	J9VMThreadEndEvent *event = (J9VMThreadEndEvent *)eventData;
 	J9VMThread *currentThread = event->currentThread;
+	PORT_ACCESS_FROM_VMC(currentThread);
 
 #if defined(DEBUG)
-	PORT_ACCESS_FROM_VMC(currentThread);
 	j9tty_printf(PORTLIB, "\n!!! thread end %p\n", currentThread);
 #endif /* defined(DEBUG) */
 
@@ -635,7 +643,6 @@ jfrThreadEnd(J9HookInterface **hook, UDATA eventNum, void *eventData, void *user
 	if (NULL != jfrEvent) {
 		initializeEventFields(currentThread, currentThread, jfrEvent, J9JFR_EVENT_TYPE_THREAD_END);
 	}
-	PORT_ACCESS_FROM_VMC(currentThread);
 	flushBufferToGlobal(currentThread, currentThread);
 
 	/* Free the thread local buffer */
@@ -1604,6 +1611,9 @@ jboolean
 setJFRRecordingFileName(J9JavaVM *vm, char *newFileName)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	if (isJFRV2SupportEnabled(vm)) {
+		vm->jfrState.shouldRotateDisk = JNI_FALSE;
+	}
 	VM_JFRWriter::closeJFRFile(vm);
 	j9mem_free_memory(vm->jfrState.jfrFileName);
 	vm->jfrState.jfrFileName = newFileName;
@@ -1850,9 +1860,11 @@ jfrShutdownInternalStructures(J9HookInterface **hook, UDATA eventNum, void *even
 	internalAcquireVMAccess(currentThread);
 	vmFuncs->j9jni_deleteGlobalRef((JNIEnv *)currentThread, vm->jfrState.jfrEventClassRef, FALSE);
 	vmFuncs->j9jni_deleteGlobalRef((JNIEnv *)currentThread, vm->jfrState.jfrInternalEventClassRef, FALSE);
+	vmFuncs->j9jni_deleteGlobalRef((JNIEnv *)currentThread, vm->jfrState.chunkRotationMonitor, FALSE);
 	internalReleaseVMAccess(currentThread);
 	vm->jfrState.jfrEventClassRef = NULL;
 	vm->jfrState.jfrInternalEventClassRef = NULL;
+	vm->jfrState.chunkRotationMonitor = NULL;
 }
 
 static void
@@ -2330,6 +2342,64 @@ requestJFREvent(J9VMThread *currentThread, jlong id)
 #else /* JAVA_SPEC_VERSION >= 17 */
 	return JNI_FALSE;
 #endif /* JAVA_SPEC_VERSION >= 17 */
+}
+
+BOOLEAN
+setupChunkMonitor(J9VMThread *currentThread)
+{
+	BOOLEAN rc = TRUE;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	j9object_t chunkMonitor = VM_VMHelpers::getStaticFieldObject(currentThread, "jdk/jfr/internal/JVM", "CHUNK_ROTATION_MONITOR", "Ljava/lang/Object;");
+	vm->jfrState.chunkRotationMonitor = vmFuncs->j9jni_createGlobalRef((JNIEnv *)currentThread, chunkMonitor, FALSE);
+
+	if (NULL == vm->jfrState.chunkRotationMonitor) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		rc = FALSE;
+	}
+
+	vm->jfrState.shouldRotateDisk = JNI_FALSE;
+
+	return rc;
+}
+
+static void
+notifyForChunkRotation(J9VMThread *currentThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	omrthread_monitor_t monitorPtr = NULL;
+
+	if (JNI_FALSE == vm->jfrState.shouldRotateDisk) {
+#if defined(DEBUG)
+		PORT_ACCESS_FROM_VMC(currentThread);
+		j9tty_printf(PORTLIB, "\n!!! notifyForChunkRotation called\n");
+#endif /* defined(DEBUG) */
+
+		j9object_t chunkMonitor = J9_JNI_UNWRAP_REFERENCE(vm->jfrState.chunkRotationMonitor);
+		VM_ObjectMonitor::enterObjectMonitor(currentThread, chunkMonitor);
+		VM_ObjectMonitor::getMonitorForNotify(currentThread, chunkMonitor, &monitorPtr, false);
+
+		if (NULL == monitorPtr) {
+			/* If the monitor doesnt exist then no one is waiting on it. */
+		} else {
+			vm->jfrState.shouldRotateDisk = JNI_TRUE;
+			issueWriteBarrier();
+			omrthread_monitor_notify_all(monitorPtr);
+		}
+		VM_ObjectMonitor::exitObjectMonitor(currentThread, chunkMonitor);
+	}
+}
+
+static void
+checkAvailableSpaceInGlobalBuffer(J9VMThread *currentThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+
+	if (isJFRV2SupportEnabled(vm)) {
+		if (vm->jfrBuffer.bufferRemaining < (J9JFR_GLOBAL_BUFFER_SIZE/8)) {
+			notifyForChunkRotation(currentThread);
+		}
+	}
 }
 
 } /* extern "C" */

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1210,6 +1210,7 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 	vm->jfrState.blobFileDescriptor = -1;
 	vm->jfrState.isCreated = FALSE;
 	vm->jfrState.isStarted = FALSE;
+	vm->jfrState.shouldRotateDisk = FALSE;
 #endif /* defined(J9VM_OPT_JFR) */
 	vm->defaultPageSize = j9vmem_supported_page_sizes()[0];
 #if JAVA_SPEC_VERSION >= 19

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -38,6 +38,11 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>
 	</test>
 	-->
+	<test id="Test JFRv2 2min test">
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 200 20000 200</command>
+		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
+		<output type="required" caseSensitive="yes" regex="no">0 / 200 complete</output>
+	</test>
 	<test id="Test JFRv2 with file">
 		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>


### PR DESCRIPTION
This PR introduces a change that allows the VM to notify the JFR
periodic thread to trigger a global JFR buffer flush when there is
memory pressure on the global JFR buffer in JFRv2.

Unlike JFRv1 flushing the global buffer must be synchronized with the
JCL as the JCL may be holding on to invalid metadata if done otherwise.

Related: https://github.com/eclipse-openj9/openj9/issues/23761