### PR TITLE
Remove "FIXME" lines appearing in vlog

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -5322,9 +5322,6 @@ static void jitStateLogic(J9JITConfig *jitConfig, TR::CompilationInfo *compInfo,
             compInfo->_intervalStats._numRecompilationsInInterval, compInfo->getMethodQueueSize(), javaVM->phase,
             avgJvmCpuUtil);
     }
-    if (TR::Options::getVerboseOption(TR_VerboseJitMemory)) {
-        TR_VerboseLog::writeLine(TR_Vlog_MEMORY, "FIXME: Report JIT memory usage");
-    }
 
     // Allocate the tracking hashtable if needed
     // Note that timeToAllocateTrackingHT will be set to something useful only if TR_UseIdleTime option is set


### PR DESCRIPTION
When -Xjit:verbose={jitMemory} is specified the JIT will print to verbose logs some stats regarding persistent memory usage. However, some "FIXME" lines are also printed.
This commit eliminates the printing of those "FIXME" lines.