### PR TITLE
Value classes may inherit fields from abstract superclasses

### DIFF
--- a/runtime/vm/ObjectFieldInfo.cpp
+++ b/runtime/vm/ObjectFieldInfo.cpp
@@ -153,8 +153,8 @@ ObjectFieldInfo::calculateTotalFieldsSizeAndBackfill()
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 		accumulator += _totalFlatFieldDoubleBytes + _totalFlatFieldRefBytes + _totalFlatFieldSingleBytes;
 
-		/* ValueTypes cannot be subtyped and their superClass contains no fields */
-		if (!isValue()) {
+		/* Value objects may inherit fields from abstract superclasses. */
+		if (!isValue() || (_superclassFieldsSize > 0)) {
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 			/* if the superclass is not end aligned but we have doubleword fields, use the space before the first field as the backfill */
 			if (


### PR DESCRIPTION
Update object layout to account for superclass fields in value classes.

This fixes runtime/valhalla/inlinetypes/AcmpTest.java

Personal builds:
https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline-Build-Test-Personal/33889/
https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/111/