### PR TITLE
Override OMR::CodeCacheManager::destroy()

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.hpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.hpp
@@ -70,6 +70,7 @@ public:
     TR_J9VMBase *fej9();
 
     TR::CodeCache *initialize(bool useConsolidatedCache, uint32_t numberOfCodeCachesToCreateAtStartup);
+    void destroy() { } // must override OMR::CodeCacheManager::destroy()
 
     bool isSufficientPhysicalMemoryAvailableForAllocation(size_t requestedCodeCacheSize);
     void addCodeCache(TR::CodeCache *codeCache);


### PR DESCRIPTION
OMR's version of this function performs a lot of cleanup that OpenJ9 handles differently. With this change, destroy is overriden with an empty implementation.