### PR TITLE
JFR tests require to disable class sharing

### DIFF
--- a/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/attachAPI/TestJcmd.java
@@ -78,7 +78,8 @@ public class TestJcmd extends AttachApiTest {
 	private static final String DIAGNOSTICS_OPTION_SEPARATOR = ",";
 
 	private static final ArrayList<String> TEST_JFR_VM_ARGS = new ArrayList<>(Arrays.asList(
-			"-XX:+EnableOpenJ9ExperimentalFlightRecording"));
+			"-XX:+EnableOpenJ9ExperimentalFlightRecording",
+			"-Xshareclasses:none"));
 
 	/*
 	 * Contains strings expected to be contained in the outputs of various commands


### PR DESCRIPTION
[JFR tests require disables class sharing](https://github.com/eclipse-openj9/openj9/commit/c9528466ef5f8457c3d95cae3ed882d80fe05521) 

Related to
* https://github.com/eclipse-openj9/openj9/issues/24141

Signed-off-by: Jason Feng <fengj@ca.ibm.com>