### PR TITLE
Marking arraytranslate as inlined by codegen in J9RecognizedCallTransformer

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -355,6 +355,10 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     arrayTranslateNode->setAndIncChild(4, length);
     arrayTranslateNode->setAndIncChild(5, stoppingNode);
 
+    // Mark arraytranslateNode as inlinedByCG as it is an intrinsic that should not be treated as a regular call by the
+    // inliner
+    arrayTranslateNode->getSymbolReference()->getSymbol()->castToMethodSymbol()->setIsInlinedByCG();
+    TR::Node *arraytranslateAnchorNode = TR::Node::create(TR::treetop, 1, arrayTranslateNode);
     TR::CFG *cfg = comp()->getFlowGraph();
 
     // if (length < 0) { call the original method }
@@ -382,7 +386,7 @@ void J9::RecognizedCallTransformer::process_java_lang_StringLatin1_inflate_BIBII
     TR::Node *ifCmpNode5 = TR::Node::createif(TR::ificmplt, ishrNode, iaddNode2);
     TR::TreeTop *ifCmpTreeTop5 = TR::TreeTop::create(comp(), ifCmpTreeTop4, ifCmpNode5);
 
-    TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arrayTranslateNode);
+    TR::TreeTop *arrayTranslateTreeTop = TR::TreeTop::create(comp(), ifCmpTreeTop5, arraytranslateAnchorNode);
 
     TR::Block *ifCmpBlock1 = ifCmpTreeTop1->getEnclosingBlock();
     TR::Block *ifCmpBlock2


### PR DESCRIPTION
Fixes [#24114](https://github.com/eclipse-openj9/openj9/issues/24114)

Fixed JITServer crash caused by PR #24014 (reverted in #24116). The inliner was treating the wrapped arraytranslate node as a regular call, causing a NULL pointer dereference. 

This fix marks the arraytranslate node as `isInlinedByCG()` so the inliner skips it, preventing the crash while maintaining the necessary treetop wrapper.

@nbhuiyan @hzongaro