### PR TITLE
Memory subspace reset

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -428,6 +428,14 @@ MM_MemorySubSpaceTarok::reset()
 	Assert_MM_unreachable();
 }
 
+void
+MM_MemorySubSpaceTarok::reset(MM_EnvironmentBase *env)
+{
+	/* unused in Tarok collectors */
+	Assert_MM_unreachable();
+}
+
+
 /**
  * As opposed to reset, which will empty out, this will fill out as if everything is free
  */

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -248,6 +248,7 @@ public:
 	virtual MM_MemorySubSpace *getTenureMemorySubSpace();
 
 	virtual void reset();
+	virtual void reset(MM_EnvironmentBase *env);
 	virtual void rebuildFreeList(MM_EnvironmentBase *env);
 	
 	virtual void resetLargestFreeEntry();


### PR DESCRIPTION
Add a variant of the reset method with Environment being passed to make compiler happy.

The original variant is to be eventually removed, but only once OMR change (https://github.com/eclipse-omr/omr/pull/8284) promote.

Fixes: https://github.com/eclipse-openj9/openj9/issues/24156