### PR TITLE
Distinguish strong from other types of references

### DIFF
--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/LiveSetWalker.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/LiveSetWalker.java
@@ -22,6 +22,8 @@
 package com.ibm.j9ddr.vm29.j9; 
 
 import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
 
 import com.ibm.j9ddr.CorruptDataException;
 import com.ibm.j9ddr.vm29.events.EventManager;
@@ -33,23 +35,27 @@ import com.ibm.j9ddr.vm29.j9.gc.GCObjectIterator;
 import com.ibm.j9ddr.vm29.pointer.VoidPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
+import com.ibm.j9ddr.vm29.pointer.helper.J9ClassHelper;
 import com.ibm.j9ddr.vm29.pointer.helper.J9ObjectHelper;
+import com.ibm.j9ddr.vm29.structure.J9JavaAccessFlags;
+import com.ibm.j9ddr.vm29.structure.J9ROMFieldOffsetWalkState;
+import com.ibm.j9ddr.vm29.types.U32;
+
+import static com.ibm.j9ddr.vm29.j9.J9ObjectFieldOffsetIterator.J9ObjectFieldOffsetIteratorFor;
 
 /*
- * Not written as an Iterator like everyone else because there's no convenient way to save iteration state
+ * Not written as an Iterator like everyone else because there's no convenient way to save iteration state.
  */
-public class LiveSetWalker  
-{
-	
-	public interface ObjectVisitor
-	{
+public class LiveSetWalker {
+
+	public interface ObjectVisitor {
 		/**
 		 * @param object object we're visiting
 		 * @param address address of the object we're visiting
 		 * @return whether we should visit this object or not
 		 */
 		public boolean visit(J9ObjectPointer object, VoidPointer address);
-		
+
 		/**
 		 * Called when we are finished visiting an object (we have visited itself and all it's children) in a pre-order walk
 		 * 
@@ -59,44 +65,84 @@ public class LiveSetWalker
 		public void finishVisit(J9ObjectPointer object, VoidPointer address);
 	}
 
+	private static Long referentOffset;
+
+	private static long getReferentOffset(J9ClassPointer j9class) throws CorruptDataException {
+		long offset = -1;
+		J9ClassPointer superclass;
+
+		for (J9ClassPointer clazz = j9class; clazz.notNull(); clazz = superclass) {
+			superclass = J9ClassHelper.superclass(clazz);
+
+			if (clazz.classDepthAndFlags().anyBitsIn(J9JavaAccessFlags.J9AccClassReferenceMask)) {
+				/* The current class is a (strict) subclass of java.lang.ref.Reference.
+				 * Return the offset if known, otherwise move on to its superclass.
+				 */
+				if (referentOffset != null) {
+					offset = referentOffset.longValue();
+					break;
+				}
+			} else if ("java/lang/ref/Reference".equals(J9ClassHelper.getName(clazz))) {
+				U32 fieldFlags = new U32(J9ROMFieldOffsetWalkState.J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE);
+				Iterator<J9ObjectFieldOffset> fields = J9ObjectFieldOffsetIteratorFor(clazz, superclass, fieldFlags);
+
+				while (fields.hasNext()) {
+					J9ObjectFieldOffset field = fields.next();
+					if ("referent".equals(field.getName())) {
+						offset = J9ObjectHelper.headerSize() + field.getOffsetOrAddress().longValue();
+						break;
+					}
+				}
+
+				referentOffset = Long.valueOf(offset);
+				break;
+			} else {
+				/* The current class is neither java.lang.ref.Reference
+				 * nor a subclass: There is no referent field to consider.
+				 */
+				break;
+			}
+		}
+
+		return offset;
+	}
+
 	/*
-	 * Walks the LiveSet in preorder, returns a HashSet of all walked objects.  The HashSet is generated as a byproduct of the walk.
-	 * 
-	 * @return a HashSet containing all visited objects 
+	 * Visits the LiveSet in preorder.
 	 */
-	public static void walkLiveSet(ObjectVisitor visitor, RootSetType rootSetType) throws CorruptDataException
-	{
-		/* TODO: lpnguyen, use something less stupid than a hashSet (markMap?) for this */
-		HashSet<J9ObjectPointer> visitedObjects = new HashSet<J9ObjectPointer>();
-		
-		/* Not using a singleton because we want to allow users to catch corruptData events.  Not worrying about the perf loss taken
-		 * by doing this as walking the live set will probably take an order of magnitude longer anyway
+	public static void walkLiveSet(ObjectVisitor visitor, RootSetType rootSetType) throws CorruptDataException {
+		/* TODO: lpnguyen, use something less stupid than a HashSet (markMap?) for this */
+		Set<J9ObjectPointer> visitedObjects = new HashSet<>();
+
+		/* Not using a singleton because we want to allow users to catch corruptData events.
+		 * Not worrying about the perf loss taken by doing this as walking the live set will
+		 * probably take an order of magnitude longer anyway.
 		 */
 		RootSet rootSet = RootSet.from(rootSetType, false);
-		
+		boolean onlyStronglyReachable = (rootSetType == RootSetType.STRONG_REACHABLE)
+				|| (rootSetType == RootSetType.STRONG_REACHABLE_EXCLUDING_STACK_SLOTS);
+
 		GCIterator rootIterator = rootSet.gcIterator(rootSetType);
 		GCIterator rootAddressIterator = rootSet.gcIterator(rootSetType);
-		
+
 		while (rootIterator.hasNext()) {
 			J9ObjectPointer nextObject = (J9ObjectPointer) rootIterator.next();
 			VoidPointer nextAddress = rootAddressIterator.nextAddress();
-			
+
 			if (nextObject.notNull()) {
-				scanObject(visitedObjects, visitor, nextObject, nextAddress);
+				scanObject(visitedObjects, visitor, nextObject, nextAddress, onlyStronglyReachable);
 			}
 		}
 	}
-	
-	public static void walkLiveSet(ObjectVisitor visitor) throws CorruptDataException
-	{
-		/* TODO: lpnguyen Walking strongly reachable roots but still walking weakly reachable slots (e.g. weak reference referent slot) is somewhat misleading.
-		 * We should add the ability for the recursive walk (i.e. scanObject method) to ignore slots containing a weak reference
-		 */
+
+	public static void walkLiveSet(ObjectVisitor visitor) throws CorruptDataException {
 		walkLiveSet(visitor, RootSetType.STRONG_REACHABLE);
 	}
-	
-	private static void scanObject(HashSet<J9ObjectPointer> visitedObjects, ObjectVisitor visitor, J9ObjectPointer object, VoidPointer address)
-	{	
+
+	private static void scanObject(
+			Set<J9ObjectPointer> visitedObjects,
+			ObjectVisitor visitor, J9ObjectPointer object, VoidPointer address,
+			boolean onlyStronglyReachable) {
 		if (visitedObjects.contains(object)) {
 			return;
 		}
@@ -104,37 +150,51 @@ public class LiveSetWalker
 		if (!visitor.visit(object, address)) {
 			return;
 		}
-		
+
 		visitedObjects.add(object);
-		
-		
+
 		try {
+			J9ClassPointer j9class = J9ObjectHelper.clazz(object);
+			long referentAddr = 0;
+
+			if (onlyStronglyReachable) {
+				long offset = getReferentOffset(j9class);
+
+				if (offset >= 0) {
+					referentAddr = object.getAddress() + offset;
+				}
+			}
+
 			GCObjectIterator objectIterator = GCObjectIterator.fromJ9Object(object, true);
 			GCObjectIterator addressIterator = GCObjectIterator.fromJ9Object(object, true);
+
 			while (objectIterator.hasNext()) {
 				J9ObjectPointer slot = objectIterator.next();
 				VoidPointer addr = addressIterator.nextAddress();
-				if (slot.notNull()) {
-					scanObject(visitedObjects, visitor, slot, addr);
+
+				if (slot.notNull() && (addr.getAddress() != referentAddr)) {
+					scanObject(visitedObjects, visitor, slot, addr, onlyStronglyReachable);
 				}
 			}
-			
-			if (J9ObjectHelper.getClassName(object).equals("java/lang/Class")) {
+
+			String className = J9ClassHelper.getName(j9class);
+
+			if (className.equals("java/lang/Class")) {
 				J9ClassPointer clazz = ConstantPoolHelpers.J9VM_J9CLASS_FROM_HEAPCLASS(object);
-				
-				// Iterate the Object slots
+
+				// Iterate the Object slots.
 				GCClassIterator classIterator = GCClassIterator.fromJ9Class(clazz);
 				GCClassIterator classAddressIterator = GCClassIterator.fromJ9Class(clazz);
-				while(classIterator.hasNext()) {
+				while (classIterator.hasNext()) {
 					J9ObjectPointer slot = classIterator.next();
 					VoidPointer addr = classAddressIterator.nextAddress();
-					
+
 					if (slot.notNull()) {
-						scanObject(visitedObjects, visitor, slot, addr);
-					}				
+						scanObject(visitedObjects, visitor, slot, addr, onlyStronglyReachable);
+					}
 				}
-				
-				// Iterate the Class slots
+
+				// Iterate the Class slots.
 				GCClassIteratorClassSlots classSlotIterator = GCClassIteratorClassSlots.fromJ9Class(clazz);
 				GCClassIteratorClassSlots classSlotAddressIterator = GCClassIteratorClassSlots.fromJ9Class(clazz);
 				while (classSlotIterator.hasNext()) {
@@ -142,14 +202,16 @@ public class LiveSetWalker
 					VoidPointer addr = classSlotAddressIterator.nextAddress();
 					J9ObjectPointer classObject = ConstantPoolHelpers.J9VM_J9CLASS_TO_HEAPCLASS(slot);
 					if (classObject.notNull()) {
-						scanObject(visitedObjects, visitor, classObject, addr);
-					}				
+						scanObject(visitedObjects, visitor, classObject, addr, onlyStronglyReachable);
+					}
 				}
 			}
 		} catch (CorruptDataException e) {
-			EventManager.raiseCorruptDataEvent("Corruption found while walking the live set, object: " + object.getHexAddress(), e, false);
+			EventManager.raiseCorruptDataEvent(
+					"Corruption found while walking the live set, object: " + object.getHexAddress(), e, false);
 		}
-		
+
 		visitor.finishVisit(object, address);
 	}
+
 }

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/RootSet.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/vm29/j9/RootSet.java
@@ -34,73 +34,112 @@ import com.ibm.j9ddr.vm29.pointer.VoidPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ClassPointer;
 import com.ibm.j9ddr.vm29.pointer.generated.J9ObjectPointer;
 
-public class RootSet
-{
-	public enum RootSetType 
-	{
-		ALL(0), STRONG_REACHABLE(1), WEAK_REACHABLE(2), ALL_SLOTS_EXCLUDING_STACK_SLOTS(3), STRONG_REACHABLE_EXCLUDING_STACK_SLOTS(4);
-		
-        private final int value;
+public final class RootSet {
 
-        private RootSetType(final int newValue) { value = newValue; }
+	public static enum RootSetType {
+		ALL,
+		STRONG_REACHABLE,
+		WEAK_REACHABLE,
+		ALL_SLOTS_EXCLUDING_STACK_SLOTS,
+		STRONG_REACHABLE_EXCLUDING_STACK_SLOTS;
 
-        public int getValue() { return value; }	
-	};
-	
-	private static RootSet[] _singletons = new RootSet[RootSetType.values().length];
-	
-	private ArrayList<J9ObjectPointer> _allRoots;
-	private ArrayList<VoidPointer> _allAddresses;
-	
-	private class RootSetScanner extends SimpleRootScanner 
-	{
-		protected RootSetScanner() throws CorruptDataException 
-		{
+		private RootSet rootSetCache;
+
+		private RootSetType() {
+			rootSetCache = null;
+		}
+
+		RootSet createRootSet(boolean useSingleton) throws CorruptDataException {
+			RootSet rootSet = rootSetCache;
+
+			if ((rootSet == null) || !useSingleton) {
+				rootSet = new RootSet(this);
+			}
+
+			if (rootSetCache == null) {
+				rootSetCache = rootSet;
+			}
+
+			return rootSet;
+		}
+
+	}
+
+	private final List<J9ObjectPointer> _allRoots;
+	private final List<VoidPointer> _allAddresses;
+
+	private final class RootSetScanner extends SimpleRootScanner {
+
+		private final boolean onlyStronglyReachable;
+
+		RootSetScanner(RootSetType rootSetType) throws CorruptDataException {
 			super();
+			this.onlyStronglyReachable =
+					   (rootSetType == RootSetType.STRONG_REACHABLE)
+					|| (rootSetType == RootSetType.STRONG_REACHABLE_EXCLUDING_STACK_SLOTS);
 		}
 
 		@Override
-		protected void doClassSlot(J9ClassPointer slot, VoidPointer address)
-		{
+		protected void doClassSlot(J9ClassPointer slot, VoidPointer address) {
 			if (slot.notNull()) {
 				doClass(slot, address);
 			}
 		}
-		
+
 		@Override
-		protected void doSlot(J9ObjectPointer slot, VoidPointer address)
-		{
+		protected void doSlot(J9ObjectPointer slot, VoidPointer address) {
 			if (slot.notNull()) {
 				_allRoots.add(slot);
 				_allAddresses.add(address);
 			}
 		}
-	
+
 		@Override
-		protected void doClass(J9ClassPointer slot, VoidPointer address)
-		{	
-			J9ObjectPointer classObject = J9ObjectPointer.NULL;
-			VoidPointer classObjectSlot = VoidPointer.NULL;
+		protected void doClass(J9ClassPointer slot, VoidPointer address) {
+			J9ObjectPointer classObject;
+			VoidPointer classObjectSlot;
 			try {
 				classObject = slot.classObject();
 				classObjectSlot = VoidPointer.cast(slot.classObjectEA());
-			} catch(CorruptDataException cde) {
-				 raiseCorruptDataEvent("Class: " + slot.getHexAddress() + " has invalid classObject slot", cde, false);
-				 return;
+			} catch (CorruptDataException cde) {
+				raiseCorruptDataEvent("Class: " + slot.getHexAddress() + " has invalid classObject slot", cde, false);
+				return;
 			}
-			
+
 			doSlot(classObject, classObjectSlot);
 		}
+
+		@Override
+		protected void doPhantomReferenceSlot(J9ObjectPointer slot, VoidPointer address) {
+			if (!onlyStronglyReachable) {
+				doSlot(slot, address);
+			}
+		}
+
+		@Override
+		protected void doSoftReferenceSlot(J9ObjectPointer slot, VoidPointer address) {
+			if (!onlyStronglyReachable) {
+				doSlot(slot, address);
+			}
+		}
+
+		@Override
+		protected void doWeakReferenceSlot(J9ObjectPointer slot, VoidPointer address) {
+			if (!onlyStronglyReachable) {
+				doSlot(slot, address);
+			}
+		}
+
 	}
 
-	private RootSet(RootSetType rootSetType) throws CorruptDataException
-	{
+	private RootSet(RootSetType rootSetType) throws CorruptDataException {
 		super();
-		_allRoots = new ArrayList<J9ObjectPointer>();
-		_allAddresses = new ArrayList<VoidPointer>();
-		RootSetScanner rootSetScanner = new RootSetScanner();
-		
-		switch(rootSetType) {
+		_allRoots = new ArrayList<>();
+		_allAddresses = new ArrayList<>();
+
+		RootSetScanner rootSetScanner = new RootSetScanner(rootSetType);
+
+		switch (rootSetType) {
 		case ALL:
 			rootSetScanner.scanAllSlots();
 			break;
@@ -117,67 +156,52 @@ public class RootSet
 		case STRONG_REACHABLE_EXCLUDING_STACK_SLOTS:
 			rootSetScanner.setScanStackSlots(false);
 			rootSetScanner.scanRoots();
+			break;
 		default:
 			throw new UnsupportedOperationException("Invalid rootSetType");
 		}
 	}
-	
+
 	/*
-	 * useSingleton parameter exists primarily so that we can be guaranteed to catch corruptData events (See EventManager) for users
-	 * who want to notified.
+	 * useSingleton parameter exists primarily so that we can be guaranteed to catch
+	 * corruptData events (see EventManager) for users who want to notified.
 	 */
-	protected static RootSet from(RootSetType rootSetType, boolean useSingleton) throws CorruptDataException 
-	{
-		RootSet rootSetToReturn;
-		
-		if (useSingleton) {
-			if (null == _singletons[rootSetType.getValue()]) {
-				rootSetToReturn = new RootSet(rootSetType);
-			} else {
-				rootSetToReturn = _singletons[rootSetType.getValue()]; 
-			}
-		} else {
-			rootSetToReturn = new RootSet(rootSetType);
-		}
-		
-		if (null == _singletons[rootSetType.getValue()]) {
-			_singletons[rootSetType.getValue()] = rootSetToReturn;
-		}
-		
-		return rootSetToReturn;
+	public static RootSet from(RootSetType rootSetType, boolean useSingleton) throws CorruptDataException {
+		return rootSetType.createRootSet(useSingleton);
 	}
-	
-	public static List<J9ObjectPointer> allRoots(RootSetType rootSetType) throws CorruptDataException
-	{
+
+	public static List<J9ObjectPointer> allRoots(RootSetType rootSetType) throws CorruptDataException {
 		RootSet rootSet = new RootSet(rootSetType);
 		return Collections.unmodifiableList(rootSet._allRoots);
 	}
-	
-	public GCIterator gcIterator(RootSetType rootSetType) throws CorruptDataException
-	{
+
+	public GCIterator gcIterator(RootSetType rootSetType) throws CorruptDataException {
 		final Iterator<J9ObjectPointer> rootSetIterator = _allRoots.iterator();
 		final Iterator<VoidPointer> rootSetAddressIterator = _allAddresses.iterator();
-		
+
 		return new GCIterator() {
+			@Override
 			public boolean hasNext() {
 				return rootSetIterator.hasNext();
 			}
 
+			@Override
 			public VoidPointer nextAddress() {
 				rootSetIterator.next();
 				return rootSetAddressIterator.next();
 			}
 
+			@Override
 			public Object next() {
 				rootSetAddressIterator.next();
-				return rootSetIterator.next(); 
+				return rootSetIterator.next();
 			}
 		};
 	}
-	
-	public static GCIterator rootIterator(RootSetType rootSetType) throws CorruptDataException
-	{
+
+	public static GCIterator rootIterator(RootSetType rootSetType) throws CorruptDataException {
 		final RootSet rootSet = RootSet.from(rootSetType, true);
 		return rootSet.gcIterator(rootSetType);
 	}
+
 }


### PR DESCRIPTION
Add a cache to hold the offset of `Reference.referent` to recognize non-strong object references in `LiveSetWalker`.

Improve `RootSet` by simplifying its internal cache mechanism.

Examining a system dump produced by code similar to the sample in #23866 now looks like this:
```
> !anyrootpathfindall 0x7fff8e910

========================================
class ddr/OnlyPhantomlyReachable@0x0000000706232CA0
  java/lang/ref/PhantomReference@0x00000007FFF931D0
    ddr/OnlyPhantomlyReachable$Test@0x00000007FFF8E910
> !strongrootpathfindall 0x7fff8e910
> !isobjectalive  0x7fff8e910
Object is not live
```

Fixes: https://github.com/eclipse-openj9/openj9/issues/23866.