### PR TITLE
Create -Xjit:excludeAndDontInline={regex} option

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: IBM Bob
  *******************************************************************************/
 
 #include "control/J9Options.hpp"
@@ -533,6 +534,34 @@ const char *J9::Options::limitOption(const char *option, void *base, TR::OptionT
     }
 }
 
+const char *J9::Options::excludeAndDontInlineOption(const char *option, void *base, TR::OptionTable *entry)
+{
+    // This option maps the input to both exclude= and dontInline= options.
+    // First, process as exclude option.
+    const char *result = J9::Options::limitOption(option, base, entry);
+    if (!result)
+        return NULL;
+
+    // Then, process as dontInline option using the same approach as setRegex.
+    TR::SimpleRegex *regex = TR::SimpleRegex::create(option);
+    if (!regex) {
+        J9JITConfig *jitConfig = (J9JITConfig *)base;
+        PORT_ACCESS_FROM_JAVAVM(jitConfig->javaVM);
+        j9tty_printf(PORTLIB, "<JIT: Bad regular expression for excludeAndDontInline at --> '%s'>\n", option);
+        return NULL;
+    }
+
+    // Set the dontInline regex using the setter method.
+    // We need to set it in the appropriate options object (JIT or AOT).
+    TR::Options *opts = (J9::Options::getJITCmdLineOptions() == NULL) ? TR::Options::getAOTCmdLineOptions()
+                                                                      : TR::Options::getJITCmdLineOptions();
+
+    if (opts)
+        opts->setDontInline(regex);
+
+    return result;
+}
+
 const char *J9::Options::limitfileOption(const char *option, void *base, TR::OptionTable *entry)
 {
     if (!J9::Options::getDebug() && !J9::Options::createDebug())
@@ -964,6 +993,8 @@ TR::OptionTable OMR::Options::_feOptions[] = {
     { "dltPostponeThreshold=", "M<nnn>\tNumber of dlt attempts inv. count for a method is seen not advancing",
      TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_dltPostponeThreshold, 0, "F%d", NOT_IN_SUBSET },
     { "exclude=", "D<xxx>\tdo not compile methods beginning with xxx", TR::Options::limitOption, 1, 0, "P%s" },
+    { "excludeAndDontInline=", "D<xxx>\tdo not compile or inline methods beginning with xxx",
+     TR::Options::excludeAndDontInlineOption, 1, 0, "P%s" },
     { "expensiveCompWeight=", "M<nnn>\tweight of a comp request to be considered expensive",
      TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_expensiveCompWeight, 0, "F%d", NOT_IN_SUBSET },
     { "experimentalClassLoadPhaseInterval=", "O<nnn>\tnumber of sampling ticks to stay in a class load phase",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: IBM Bob
  *******************************************************************************/
 
 #ifndef J9_OPTIONS_INCL
@@ -614,6 +615,7 @@ public:
 
     static bool useCompressedPointers();
     static const char *limitOption(const char *option, void *, TR::OptionTable *entry);
+    static const char *excludeAndDontInlineOption(const char *option, void *, TR::OptionTable *entry);
     static const char *inlinefileOption(const char *option, void *, TR::OptionTable *entry);
     static const char *limitfileOption(const char *option, void *, TR::OptionTable *entry);
     static const char *versionOption(const char *option, void *, TR::OptionTable *entry);


### PR DESCRIPTION
When diagnosing JIT problems it may be useful to exclude a method from being JIT compiled with `-Xjit:exclude={regex}`. However, many times this is not enough because the problematic method can be inlined into other JIT compiled methods and thus the generated code could still be faulty. While the user can provide separate options that cover both situations (`-Xjit:exclude{m},dontInline={m}`) it may be better to have a single option, say: `-Xjit:excludeAndDontInline={m}`

This commit implements the functionality of a such a composite option.

Note 1: if the option is specified under -Xjit:, then the indicated methods will not be inlined into jitted bodies but they could be inlined into AOTed methods. Similarly, if the option is specified under -Xaot:, then the indicated methods will not be inlined into AOT bodies, but they could be inlined into jitted bodies. From the "exclude" point of view, it does not matter if the option appears under -Xaot or under -Xjit; in either case the method will not be compiled at all (JIT or AOT).

Note 2: if the option is specified multiple times under-Xjit or -Xaot, then the "exclude" behavior is additive (union of the sets of methods specified by each `excludeAndDontInline={}` instance). On the other hand, when it comes to inlining behavior, only the set of methods specified in the last `excludeAndDontInline={}` instance will take effect. This is the same effect as if `exclude={}` and `dontInline={}` options were specified separately.


Depends on: https://github.com/eclipse-omr/omr/pull/8294

Assisted-by: IBM Bob