### PR TITLE
Restrict VarHandleTransformer to Java version  >= 11

### DIFF
--- a/runtime/compiler/optimizer/VarHandleTransformer.cpp
+++ b/runtime/compiler/optimizer/VarHandleTransformer.cpp
@@ -165,7 +165,9 @@ TR::RecognizedMethod TR_VarHandleTransformer::getVarHandleAccessMethod(TR::Node 
  */
 int32_t TR_VarHandleTransformer::perform()
 {
-#if defined(J9VM_OPT_METHOD_HANDLE)
+// VarHandles only exist on JDK11+. On JDK8, java/lang/invoke/VarHandle is absent so any
+// call to it is unresolved
+#if defined(J9VM_OPT_METHOD_HANDLE) && (JAVA_SPEC_VERSION >= 11)
     bool doTrace = comp()->getOption(TR_TraceILGen);
     TR::ResolvedMethodSymbol *methodSymbol = comp()->getMethodSymbol();
     TR_J9VMBase *fej9 = (TR_J9VMBase *)(comp()->fe());
@@ -380,7 +382,7 @@ int32_t TR_VarHandleTransformer::perform()
             }
         }
     }
-#endif /* defined(J9VM_OPT_METHOD_HANDLE) */
+#endif /* defined(J9VM_OPT_METHOD_HANDLE) && (JAVA_SPEC_VERSION >= 11) */
     return 0;
 }
 


### PR DESCRIPTION
VarHandles are only available in JDK11+. It is still possible for a JDK8 build to come across calls to VarHandle-related methods, if for example the class files were generated using JDK11 javac with -source 8 -target 8 options. In such cases, calls to VarHandle-related methods will remain unresolved, and runtime checks would prevent taking the VarHandle path. Yet, during VarHandleTransformer, such not-taken paths in JDK8 would still be evaluated due to the missing Java version guard, resulting in a failed assertion. This new check will prevent such issues.