### PR TITLE
Separate jfr creation and recording

### DIFF
--- a/runtime/jcl/common/com_ibm_oti_vm_VM.cpp
+++ b/runtime/jcl/common/com_ibm_oti_vm_VM.cpp
@@ -262,7 +262,7 @@ Java_com_ibm_oti_vm_VM_startJFR(JNIEnv *env, jclass unused)
 
 	if (!vmFuncs->isJFRRecordingStarted(vm)) {
 		/* this is to initalize JFR late after VM startup */
-		rc = vmFuncs->initializeJFR(vm, TRUE);
+		rc = vmFuncs->initializeJFR(vm);
 	}
 
 	return rc;

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -47,7 +47,11 @@ Java_jdk_jfr_internal_JVM_registerNatives(JNIEnv *env, jclass clazz)
 void JNICALL
 Java_jdk_jfr_internal_JVM_beginRecording(JNIEnv *env, jobject obj)
 {
-	Java_com_ibm_oti_vm_VM_startJFR(env, NULL);
+	J9VMThread *currentThread = (J9VMThread*) env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vmFuncs->startJFRRecording(vm);
 }
 
 jlong JNICALL
@@ -69,13 +73,25 @@ Java_jdk_jfr_internal_JVM_emitEvent(JNIEnv *env, jobject obj, jlong eventTypeId,
 	J9VMThread *currentThread = (J9VMThread *)env;
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	return vmFuncs->requestJFREvent(currentThread, eventTypeId);
+	jboolean result = JNI_FALSE;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	result = vmFuncs->requestJFREvent(currentThread, eventTypeId);
+	vmFuncs->internalExitVMToJNI(currentThread);
+
+	return result;
 }
 
 void JNICALL
 Java_jdk_jfr_internal_JVM_endRecording(JNIEnv *env, jobject obj)
 {
-	Java_com_ibm_oti_vm_VM_stopJFR(env, NULL);
+	J9VMThread *currentThread = (J9VMThread*) env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->stopJFRRecording(vm);
+	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
 jobject JNICALL
@@ -289,6 +305,9 @@ Java_jdk_jfr_internal_JVM_setMemorySize(JNIEnv *env, jobject obj, jlong size)
 void JNICALL
 Java_jdk_jfr_internal_JVM_setOutput(JNIEnv *env, jobject obj, jstring file)
 {
+	if (NULL == file) {
+		Java_com_ibm_oti_vm_VM_jfrDump(env, NULL);
+	}
 	Java_com_ibm_oti_vm_VM_setJFRRecordingFileName(env, NULL, file);
 }
 
@@ -346,11 +365,19 @@ jboolean JNICALL
 Java_jdk_jfr_internal_JVM_createJFR(JNIEnv *env, jobject obj, jboolean simulateFailure)
 {
 	jboolean rc = JNI_TRUE;
+	J9VMThread *currentThread = (J9VMThread*) env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
 
 	if (simulateFailure) {
 		rc = JNI_FALSE;
 		goto done;
 	}
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	if (JNI_OK != vmFuncs->initializeJFR(vm)) {
+		rc = JNI_FALSE;
+	}
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 done:
 	return rc;
@@ -360,6 +387,13 @@ jboolean JNICALL
 Java_jdk_jfr_internal_JVM_destroyJFR(JNIEnv *env, jobject obj)
 {
 	jboolean rc = JNI_TRUE;
+	J9VMThread *currentThread = (J9VMThread*) env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->tearDownJFR(vm);
+	vmFuncs->internalExitVMToJNI(currentThread);
 
 	return rc;
 }
@@ -473,7 +507,7 @@ jboolean JNICALL
 Java_jdk_jfr_internal_JVM_shouldRotateDisk(JNIEnv *env, jobject obj)
 {
 	// TODO: implementation
-	return JNI_FALSE;
+	return JNI_TRUE;
 }
 
 } /* extern "C" */

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
@@ -141,7 +141,7 @@ Java_jdk_jfr_internal_JVM_getTypeId__Ljava_lang_String_2(JNIEnv *env, jobject ob
 void JNICALL
 Java_jdk_jfr_internal_JVM_flush__(JNIEnv *env, jclass clazz)
 {
-	// TODO: implementation
+	Java_com_ibm_oti_vm_VM_jfrDump(env, NULL);
 }
 
 void JNICALL

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5642,10 +5642,13 @@ typedef struct J9InternalVMFunctions {
 	I_32 (*invoke31BitJNI_OnXLoad)(struct J9JavaVM *vm, void *handle, jboolean isOnLoad, void *reserved);
 #endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */
 #if defined(J9VM_OPT_JFR)
-	jint (*initializeJFR)(struct J9JavaVM *vm, BOOLEAN lateInit);
+	jint (*initializeJFR)(struct J9JavaVM *vm);
+	BOOLEAN (*startJFRRecording)(struct J9JavaVM *vm);
+	void (*stopJFRRecording)(struct J9JavaVM *vm);
 	jboolean (*isJFREnabled)(struct J9JavaVM *vm);
 	jboolean (*isJFRV2SupportEnabled)(struct J9JavaVM *vm);
 	jboolean (*isJFRRecordingStarted)(struct J9JavaVM *vm);
+	jboolean (*isJFRCreated)(struct J9JavaVM *vm);
 	void (*jfrDump)(struct J9VMThread *currentThread, BOOLEAN finalWrite);
 	void (*enableJFRRecordingOnThread)(struct J9VMThread *currentThread, j9object_t threadObject);
 	void (*disableJFRRecordingOnThread)(struct J9VMThread *currentThread, j9object_t threadObject);
@@ -6179,6 +6182,7 @@ typedef struct JFRState {
 	void *constantEvents;
 	BOOLEAN isConstantEventsInitialized;
 	BOOLEAN isStarted;
+	BOOLEAN isCreated;
 	omrthread_monitor_t isConstantEventsInitializedMutex;
 	omrthread_process_time_t prevProcCPUTimes;
 	int64_t prevProcTimestamp;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5752,7 +5752,25 @@ hasMemoryScope(J9VMThread *walkThread, j9object_t scope);
  * @returns JNI_OK on success, JNI error code on failure
  */
 jint
-initializeJFR(J9JavaVM *vm, BOOLEAN lateInit);
+initializeJFR(J9JavaVM *vm);
+
+/**
+ * Start JFR recording.
+ *
+ * @param vm[in] the J9JavaVM
+ *
+ * @returns TRUE on success, FALSE on failure
+ */
+BOOLEAN
+startJFRRecording(J9JavaVM *vm);
+
+/**
+ * Stop JFR recording.
+ *
+ * @param vm[in] the J9JavaVM
+ */
+void
+stopJFRRecording(J9JavaVM *vm);
 
 /**
  * Initialize JFR v2. This is the more complete version of J9 JFR support
@@ -5794,6 +5812,16 @@ isJFRV2SupportEnabled(J9JavaVM *vm);
  */
 jboolean
 isJFRRecordingStarted(J9JavaVM *vm);
+
+/**
+ * Check if JFR has been created.
+ *
+ * @param vm[in] the J9JavaVM
+ *
+ * @returns JNI_TRUE if JFR has been created, JNI_FALSE otherwise
+ */
+jboolean
+isJFRCreated(J9JavaVM *vm);
 
 /**
  * Flush all the thread buffers and write out the global buffer.

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -471,9 +471,12 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* defined(J9VM_ZOS_3164_INTEROPERABILITY) && (JAVA_SPEC_VERSION >= 17) */
 #if defined(J9VM_OPT_JFR)
 	initializeJFR,
+	startJFRRecording,
+	stopJFRRecording,
 	isJFREnabled,
 	isJFRV2SupportEnabled,
 	isJFRRecordingStarted,
+	isJFRCreated,
 	jfrDump,
 	enableJFRRecordingOnThread,
 	disableJFRRecordingOnThread,

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -301,14 +301,14 @@ flushBufferToGlobal(J9VMThread *currentThread, J9VMThread *flushThread)
 	UDATA bufferSize = flushThread->jfrBuffer.bufferCurrent - flushThread->jfrBuffer.bufferStart;
 	bool success = true;
 
-	if (!areJFRBuffersReadyForWrite(currentThread)) {
-		goto done;
-	}
-
 #if defined(DEBUG)
 	PORT_ACCESS_FROM_VMC(currentThread);
 	j9tty_printf(PORTLIB, "\n!!! flushing %p of size %u start=%p current=%p\n", flushThread, (U_32)bufferSize, flushThread->jfrBuffer.bufferStart, flushThread->jfrBuffer.bufferCurrent);
 #endif /* defined(DEBUG) */
+
+	if (!areJFRBuffersReadyForWrite(currentThread)) {
+		goto done;
+	}
 
 	omrthread_monitor_enter(vm->jfrBufferMutex);
 	if (vm->jfrBuffer.bufferRemaining < bufferSize) {
@@ -935,20 +935,17 @@ jfrGCHeapSummary(OMR_VMThread *omrVMThread, U_32 gcWhenID)
 }
 
 jint
-initializeJFR(J9JavaVM *vm, BOOLEAN lateInit)
+initializeJFR(J9JavaVM *vm)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
 	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 	jint rc = JNI_ERR;
-	J9HookInterface **vmHooks = getVMHookInterface(vm);
 
 	U_8 *buffer = NULL;
 	UDATA timeSuccess = 0;
+	J9VMThread *walkThread = NULL;
 
-	if (lateInit && vm->jfrState.isStarted) {
-		Trc_VM_initializeJFR_isStarted();
-		goto done;
-	}
+	Assert_VM_false(vm->jfrState.isCreated);
 
 	/* Register async handler for execution samples. */
 	vm->jfrAsyncKey = J9RegisterAsyncEvent(vm, jfrExecutionSampleCallback, NULL);
@@ -958,46 +955,6 @@ initializeJFR(J9JavaVM *vm, BOOLEAN lateInit)
 
 	vm->jfrThreadCPULoadAsyncKey = J9RegisterAsyncEvent(vm, jfrThreadCPULoadCallback, NULL);
 	if (vm->jfrThreadCPULoadAsyncKey < 0) {
-		goto fail;
-	}
-
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_THREAD_CREATED, jfrThreadCreated, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASSES_UNLOAD, jfrClassesUnload, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_SHUTTING_DOWN, jfrVMShutdown, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_THREAD_STARTING, jfrThreadStarting, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_THREAD_END, jfrThreadEnd, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_SLEPT, jfrVMSlept, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if (!lateInit) {
-		if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_INITIALIZED, jfrVMInitialized, OMR_GET_CALLSITE(), NULL)) {
-			goto fail;
-		}
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_MONITOR_WAITED, jfrVMMonitorWaited, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_MONITOR_CONTENDED_ENTERED, jfrVMMonitorEntered, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_UNPARKED, jfrVMThreadParked, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_SYSTEM_GC_CALLED, jfrSystemGC, OMR_GET_CALLSITE(), NULL)) {
-		goto fail;
-	}
-	/* Register GC-related hooks via gc_base */
-	if (0 != (vm->memoryManagerFunctions->j9gc_register_jfr_hooks(vm))) {
 		goto fail;
 	}
 
@@ -1067,31 +1024,34 @@ initializeJFR(J9JavaVM *vm, BOOLEAN lateInit)
 		goto fail;
 	}
 
-	if (lateInit) {
-		/* Go through existing threads. */
-		J9VMThread *walkThread = J9_LINKED_LIST_START_DO(vm->mainThread);
-		while (NULL != walkThread) {
-			/* only initialize a thread once */
-			if (NULL == walkThread->jfrBuffer.bufferStart) {
-				U_8 *buffer = (U_8 *)j9mem_allocate_memory(J9JFR_THREAD_BUFFER_SIZE, J9MEM_CATEGORY_JFR);
-				if (NULL == buffer) {
-					goto fail;
-				} else {
-					walkThread->jfrBuffer.bufferStart = buffer;
-					walkThread->jfrBuffer.bufferCurrent = buffer;
-					walkThread->jfrBuffer.bufferSize = J9JFR_THREAD_BUFFER_SIZE;
-					walkThread->jfrBuffer.bufferRemaining = J9JFR_THREAD_BUFFER_SIZE;
-				}
+	/* Go through existing threads. */
+	walkThread = J9_LINKED_LIST_START_DO(vm->mainThread);
+	while (NULL != walkThread) {
+		/* only initialize a thread once */
+		if (NULL == walkThread->jfrBuffer.bufferStart) {
+			U_8 *buffer = (U_8 *)j9mem_allocate_memory(J9JFR_THREAD_BUFFER_SIZE, J9MEM_CATEGORY_JFR);
+			if (NULL == buffer) {
+				goto fail;
+			} else {
+				walkThread->jfrBuffer.bufferStart = buffer;
+				walkThread->jfrBuffer.bufferCurrent = buffer;
+				walkThread->jfrBuffer.bufferSize = J9JFR_THREAD_BUFFER_SIZE;
+				walkThread->jfrBuffer.bufferRemaining = J9JFR_THREAD_BUFFER_SIZE;
 			}
-
-			walkThread = J9_LINKED_LIST_NEXT_DO(vm->mainThread, walkThread);
 		}
 
-		jfrStartSamplingThread(vm);
+		walkThread = J9_LINKED_LIST_NEXT_DO(vm->mainThread, walkThread);
+	}
+
+	vm->jfrState.isCreated = TRUE;
+
+	if (!isJFRV2SupportEnabled(vm)) {
+		if (!startJFRRecording(vm)) {
+			goto fail;
+		}
 	}
 
 done:
-	vm->jfrState.isStarted = TRUE;
 	rc = JNI_OK;
 	return rc;
 fail:
@@ -1099,16 +1059,69 @@ fail:
 	goto done;
 }
 
-void
-tearDownJFR(J9JavaVM *vm)
+BOOLEAN
+startJFRRecording(J9JavaVM *vm)
 {
-	PORT_ACCESS_FROM_JAVAVM(vm);
+	J9HookInterface **vmHooks = getVMHookInterface(vm);
+	BOOLEAN rc = FALSE;
+
+	Assert_VM_false(vm->jfrState.isStarted);
+	Assert_VM_true(vm->jfrState.isCreated);
+
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_THREAD_CREATED, jfrThreadCreated, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_CLASSES_UNLOAD, jfrClassesUnload, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_SHUTTING_DOWN, jfrVMShutdown, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_THREAD_STARTING, jfrThreadStarting, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_THREAD_END, jfrThreadEnd, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_SLEPT, jfrVMSlept, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_MONITOR_WAITED, jfrVMMonitorWaited, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_MONITOR_CONTENDED_ENTERED, jfrVMMonitorEntered, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_UNPARKED, jfrVMThreadParked, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_SYSTEM_GC_CALLED, jfrSystemGC, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+	/* Register GC-related hooks via gc_base */
+	if (0 != (vm->memoryManagerFunctions->j9gc_register_jfr_hooks(vm))) {
+		goto done;
+	}
+
+	jfrStartSamplingThread(vm);
+
+	vm->jfrState.isStarted = TRUE;
+
+	rc = TRUE;
+done:
+	return rc;
+}
+
+void
+stopJFRRecording(J9JavaVM *vm)
+{
 	J9VMThread *currentThread = currentVMThread(vm);
 	J9HookInterface **vmHooks = getVMHookInterface(vm);
-
 	Assert_VM_mustHaveVMAccess(currentThread);
-
 	internalReleaseVMAccess(currentThread);
+
+	Assert_VM_true(vm->jfrState.isStarted);
+	vm->jfrState.isStarted = FALSE;
 
 	/* Stop the sampler thread */
 	if (NULL != vm->jfrSamplerMutex) {
@@ -1124,13 +1137,9 @@ tearDownJFR(J9JavaVM *vm)
 		omrthread_monitor_destroy(vm->jfrSamplerMutex);
 		vm->jfrSamplerMutex = NULL;
 	}
-
-	internalAcquireVMAccess(currentThread);
-
-	vm->jfrState.isStarted = FALSE;
 	vm->jfrSamplerState = J9JFR_SAMPLER_STATE_UNINITIALIZED;
 
-	VM_JFRWriter::teardownJFRWriter(vm);
+	internalAcquireVMAccess(currentThread);
 
 	/* Unhook all the events */
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_THREAD_CREATED, jfrThreadCreated, NULL);
@@ -1139,7 +1148,7 @@ tearDownJFR(J9JavaVM *vm)
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_THREAD_STARTING, jfrThreadStarting, NULL);
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_THREAD_END, jfrThreadEnd, NULL);
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_SLEPT, jfrVMSlept, NULL);
-	/* Unregister it anyway even it wasn't registered for initializeJFR(vm, TRUE). */
+	/* Unregister it anyway even it wasn't registered for initializeJFR(vm). */
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_INITIALIZED, jfrVMInitialized, NULL);
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_MONITOR_WAITED, jfrVMMonitorWaited, NULL);
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_MONITOR_CONTENDED_ENTERED, jfrVMMonitorEntered, NULL);
@@ -1147,6 +1156,22 @@ tearDownJFR(J9JavaVM *vm)
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_SYSTEM_GC_CALLED, jfrSystemGC, NULL);
 	/* Deregister GC-related hooks via gc_base */
 	vm->memoryManagerFunctions->j9gc_deregister_jfr_hooks(vm);
+}
+
+void
+tearDownJFR(J9JavaVM *vm)
+{
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	J9VMThread *currentThread = currentVMThread(vm);
+
+	Assert_VM_mustHaveVMAccess(currentThread);
+	Assert_VM_true(vm->jfrState.isCreated);
+
+	if (!isJFRV2SupportEnabled(vm)) {
+		stopJFRRecording(vm);
+	}
+	vm->jfrState.isCreated = FALSE;
+	VM_JFRWriter::teardownJFRWriter(vm);
 
 	freeThreadIDs(currentThread);
 
@@ -1265,6 +1290,12 @@ jboolean
 isJFRRecordingStarted(J9JavaVM *vm)
 {
 	return vm->jfrState.isStarted ? JNI_TRUE : JNI_FALSE;
+}
+
+jboolean
+isJFRCreated(J9JavaVM *vm)
+{
+	return vm->jfrState.isCreated ? JNI_TRUE : JNI_FALSE;
 }
 
 // TODO: add thread state parameter

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -1208,6 +1208,8 @@ initializeJavaVM(void * osMainThread, J9JavaVM ** vmPtr, J9CreateJavaVMParams *c
 #if defined(J9VM_OPT_JFR)
 	vm->loadedClassCount = 0;
 	vm->jfrState.blobFileDescriptor = -1;
+	vm->jfrState.isCreated = FALSE;
+	vm->jfrState.isStarted = FALSE;
 #endif /* defined(J9VM_OPT_JFR) */
 	vm->defaultPageSize = j9vmem_supported_page_sizes()[0];
 #if JAVA_SPEC_VERSION >= 19


### PR DESCRIPTION
This PR separates creating/destroy the JFR recording infratstructure
from starting the and stopping the recording. With this patch the JFR
infratstructure is created when the JFR subsystem is enabled and allows
the JCL to write to the buffers very early in the startup process.

This PR also fixes a places where VMAccess is not acquired properly. It
also implements the flush native to write out buffers to file. And adds
the auto flush when the output file is set to NULL.

Fixes https://github.com/eclipse-openj9/openj9/issues/24075
Fixes https://github.com/eclipse-openj9/openj9/issues/23998