### PR TITLE
Improve consistency of interpreting system property "os.name"

### DIFF
--- a/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GetNativeDirectory.java
+++ b/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GetNativeDirectory.java
@@ -47,20 +47,22 @@ public class GetNativeDirectory
 
 	public static String getOSShortName()
 	{
-		// get the osName and make it lowercase
-		String osName = System.getProperty("os.name").toLowerCase();
+		// get the os name
+		String osName = System.getProperty("os.name");
 
-		// set the shortname to the osName if the current system is AIX this is all that is needed
+		// default the shortname to the osName
 		String osShortName = osName;
 
-		// if we are on z/OS remove the slash
-		if (osName.equals("z/os")) {
-			osShortName = "zos";
-		}
-
-		// if we are on a Windows machine use win as the shortname
-		if (osName.length() >= 6 && osName.substring(0, 6).equals("window")) {
+		if (osName.equals("AIX")) {
+			osShortName = "aix";
+		} else if (osName.equals("Linux")) {
+			osShortName = "linux";
+		} else if (osName.equals("Mac OS X")) {
+			osShortName = "mac";
+		} else if (osName.startsWith("Windows")) {
 			osShortName = "win";
+		} else if (osName.equals("z/OS")) {
+			osShortName = "zos";
 		}
 
 		return osShortName;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/BufferedMemory.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/memory/BufferedMemory.java
@@ -79,19 +79,19 @@ public class BufferedMemory extends AbstractMemory implements IProcess, IAddress
 
 	@Override
 	public Platform getPlatform() {
-		String platform = System.getProperty("os.name").toLowerCase();
-		if (platform.contains("aix")) {
+		String platform = System.getProperty("os.name");
+		if (platform.equals("AIX")) {
 			return Platform.AIX;
-		} else if (platform.contains("windows")) {
-			return Platform.WINDOWS;
-		} else if (platform.contains("z/os")) {
-			return Platform.ZOS;
-		} else if (platform.contains("linux")) {
+		} else if (platform.equals("Linux")) {
 			return Platform.LINUX;
-		} else if (platform.contains("mac")) {
+		} else if (platform.equals("Mac OS X")) {
 			return Platform.OSX;
+		} else if (platform.startsWith("Windows")) {
+			return Platform.WINDOWS;
+		} else if (platform.equals("z/OS")) {
+			return Platform.ZOS;
 		} else {
-			//do not expect to reach here
+			// do not expect to reach here
 			throw new InternalError("Unsupported platform");
 		}
 	}

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/TDumpReader.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/TDumpReader.java
@@ -115,7 +115,7 @@ public class TDumpReader implements ICoreFileReader
 		 */
 		if (!new File(path).exists()
 			/*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
-			&& !(System.getProperty("os.name").toLowerCase().contains("z/os") && com.ibm.jzos.ZFile.exists("//'" + path + "'"))
+			&& !(System.getProperty("os.name").equals("z/OS") && com.ibm.jzos.ZFile.exists("//'" + path + "'"))
 			/*[ENDIF] PLATFORM-mz31 | PLATFORM-mz64 */
 		) {
 			return DumpTestResult.FILE_NOT_FOUND;

--- a/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/dumpreader/Dump.java
+++ b/debugtools/DDR_VM/src/com/ibm/j9ddr/corereaders/tdump/zebedee/dumpreader/Dump.java
@@ -173,7 +173,7 @@ public final class Dump extends ImageInputStreamImpl {
              * is ignored: This must have the proper control flow ignoring those comments.
              */
             /*[IF PLATFORM-mz31 | PLATFORM-mz64]*/
-            if (System.getProperty("os.name").toLowerCase().contains("z/os")) {
+            if (System.getProperty("os.name").equals("z/OS")) {
                 try {
                     raf = new MVSFileReader(filename);
                 } catch (Exception ex) {

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
@@ -57,7 +57,7 @@ final class LayoutStrPreprocessor {
 	private static final String osName = System.getProperty("os.name");
 	private static final String arch = System.getProperty("os.arch");
 	private static final boolean isX86_64 = arch.equals("amd64") || arch.equals("x86_64");
-	private static final boolean isLinuxS390x = arch.equals("s390x") && osName.startsWith("Linux");
+	private static final boolean isLinuxS390x = arch.equals("s390x") && osName.equals("Linux");
 
 	/*[IF JAVA_SPEC_VERSION == 17]*/
 	private static final String VARARGS_ATTR_NAME;
@@ -71,13 +71,13 @@ final class LayoutStrPreprocessor {
 				VARARGS_ATTR_NAME = "abi/sysv/varargs";
 			}
 		} else if (arch.equals("aarch64")) {
-			if (osName.startsWith("Mac")) {
+			if (osName.equals("Mac OS X")) {
 				VARARGS_ATTR_NAME = "abi/aarch64/stack_varargs";
 			} else {
 				VARARGS_ATTR_NAME = "abi/sysv/varargs";
 			}
 		} else if (arch.startsWith("ppc64")) {
-			if (osName.startsWith("Linux")) {
+			if (osName.equals("Linux")) {
 				VARARGS_ATTR_NAME = "abi/ppc64/sysv/varargs";
 			} else {
 				VARARGS_ATTR_NAME = "abi/ppc64/aix/varargs";

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/IPC.java
@@ -102,21 +102,21 @@ public class IPC {
 	static {
 		Properties props = VM.internalGetProperties();
 		String osName = props.getProperty("os.name"); //$NON-NLS-1$
-		boolean tempIsZos = false;
-		boolean tempIsWindows = false;
 		boolean tempIsLinux = false;
+		boolean tempIsWindows = false;
+		boolean tempIsZos = false;
 		if (null != osName) {
-			if (osName.equalsIgnoreCase("z/OS")) { //$NON-NLS-1$
-				tempIsZos = true;
+			if (osName.equals("Linux")) { //$NON-NLS-1$
+				tempIsLinux = true;
 			} else if (osName.startsWith("Windows")) { //$NON-NLS-1$
 				tempIsWindows = true;
-			} else if (osName.startsWith("Linux")) { //$NON-NLS-1$
-				tempIsLinux = true;
+			} else if (osName.equals("z/OS")) { //$NON-NLS-1$
+				tempIsZos = true;
 			}
 		}
-		isZOS = tempIsZos;
-		isWindows = tempIsWindows;
 		isLinux = tempIsLinux;
+		isWindows = tempIsWindows;
+		isZOS = tempIsZos;
 
 		String propUseFileLockWatchdog = props.getProperty(COM_IBM_TOOLS_ATTACH_USE_FILELOCK_WATCHDOG);
 		if (propUseFileLockWatchdog == null) {

--- a/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
+++ b/jcl/src/java.management/share/classes/com/ibm/java/lang/management/internal/ManagementUtils.java
@@ -91,10 +91,10 @@ public final class ManagementUtils {
 		Properties properties = com.ibm.oti.vm.VM.internalGetProperties();
 		String thisOs = properties.getProperty("os.name"); //$NON-NLS-1$
 
-		isUnix = "aix".equalsIgnoreCase(thisOs) //$NON-NLS-1$
-				|| "linux".equalsIgnoreCase(thisOs) //$NON-NLS-1$
-				|| "mac os x".equalsIgnoreCase(thisOs) //$NON-NLS-1$
-				|| "z/OS".equalsIgnoreCase(thisOs); //$NON-NLS-1$
+		isUnix = "AIX".equals(thisOs) //$NON-NLS-1$
+				|| "Linux".equals(thisOs) //$NON-NLS-1$
+				|| "Mac OS X".equals(thisOs) //$NON-NLS-1$
+				|| "z/OS".equals(thisOs); //$NON-NLS-1$
 
 		VERBOSE_MODE = properties.getProperty("com.ibm.lang.management.verbose") != null; //$NON-NLS-1$
 	}

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/ExtendedOperatingSystemMXBeanImpl.java
@@ -532,7 +532,7 @@ public class ExtendedOperatingSystemMXBeanImpl extends OperatingSystemMXBeanImpl
 			if ((null != osName) && (null != hwModel)) {
 				boolean isEmuTmp = false;
 
-				if (osName.equalsIgnoreCase("z/OS")) { //$NON-NLS-1$
+				if (osName.equals("z/OS")) { //$NON-NLS-1$
 					isEmuTmp = isZosHardwareEmulated(hwModel);
 				}
 

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/javacore/JCImageProcess.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/image/javacore/JCImageProcess.java
@@ -250,15 +250,15 @@ public class JCImageProcess implements ImageProcess {
 
 			if (systemType == null) {
 				// system type unavailable
-			} else if (systemType.equalsIgnoreCase("AIX")) {
+			} else if (systemType.equals("AIX")) {
 				name = SignalName.forAIX(signal);
-			} else if (systemType.equalsIgnoreCase("Linux")) {
+			} else if (systemType.equals("Linux")) {
 				name = SignalName.forLinux(signal);
-			} else if (systemType.equalsIgnoreCase("Mac OS X")) {
+			} else if (systemType.equals("Mac OS X")) {
 				name = SignalName.forOSX(signal);
-			} else if (systemType.regionMatches(true, 0, "Windows", 0, 7)) {
+			} else if (systemType.startsWith("Windows")) {
 				name = SignalName.forWindows(signal);
-			} else if (systemType.equalsIgnoreCase("z/OS")) {
+			} else if (systemType.equals("z/OS")) {
 				name = SignalName.forZOS(signal);
 			}
 		} catch (CorruptDataException | DataUnavailable e) {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/FileManager.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/FileManager.java
@@ -91,7 +91,7 @@ public abstract class FileManager {
 			// cannot perform the check so default to true to allow processing to continue blind
 			return true;
 		}
-		if (os.toLowerCase().contains("z/os")) { //$NON-NLS-1$
+		if (os.equals("z/OS")) { //$NON-NLS-1$
 			// z/OS check
 			// Look for it as an MVS data set. The MVSImageInputStream constructor throws FNFE if the file does not exist
 			try {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/SimpleFileManager.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/utils/file/SimpleFileManager.java
@@ -124,10 +124,7 @@ public class SimpleFileManager extends FileManager {
 		}
 		/*[IF PLATFORM-mz31 | PLATFORM-mz64 | VENDOR_UMA]*/
 		String os = System.getProperty("os.name"); //$NON-NLS-1$
-		if (os == null) {
-			throw new IOException("Cannot determine the system type from os.name"); //$NON-NLS-1$
-		}
-		if (os.toLowerCase().contains("z/os")) { //$NON-NLS-1$
+		if ("z/OS".equals(os)) { //$NON-NLS-1$
 			// z/OS check
 			// Look for it as an MVS data set. The MVSImageInputStream constructor throws FNFE if the file does not exist
 			try {

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/extract/Main.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/jvm/j9/dump/extract/Main.java
@@ -500,7 +500,7 @@ public class Main {
 
 			// Add the debugger extension library into the zip, available only on AIX.
 			String osName = System.getProperty("os.name"); //$NON-NLS-1$
-			if ("AIX".equalsIgnoreCase(osName)) { //$NON-NLS-1$
+			if ("AIX".equals(osName)) { //$NON-NLS-1$
 				files.add("libdbx_j9.so"); //$NON-NLS-1$
 			}
 		} catch (Exception e) {

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/HexdumpCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/HexdumpCommand.java
@@ -90,7 +90,7 @@ public class HexdumpCommand extends BaseJdmpviewCommand {
 		boolean is_zOSdump = false;
 
 		try {
-			is_zOSdump = ctx.getImage().getSystemType().toLowerCase().contains("z/os");
+			is_zOSdump = ctx.getImage().getSystemType().equals("z/OS");
 		} catch (CorruptDataException | DataUnavailable e) {
 			// unable to get the dump OS type, continue without the additional z/OS EBCDIC option
 		}

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/OpenCommand.java
@@ -273,8 +273,8 @@ public class OpenCommand extends BaseJdmpviewCommand {
 
 		try {
 			boolean hasLibError = true; // flag to indicate if native libs are required but not present
-			String os = cc.getImage().getSystemType().toLowerCase();
-			if (os.contains("linux") || os.contains("aix")) {
+			String os = cc.getImage().getSystemType();
+			if (os.equals("Linux") || os.equals("AIX")) {
 				if (cc.getProcess() != null) {
 					Iterator<?> modules = cc.getProcess().getLibraries();
 					if (modules.hasNext()) {

--- a/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/infocommands/InfoThreadCommand.java
+++ b/jcl/src/openj9.dtfjview/share/classes/com/ibm/jvm/dtfjview/commands/infocommands/InfoThreadCommand.java
@@ -102,7 +102,7 @@ public class InfoThreadCommand extends BaseJdmpviewCommand {
 
 	public void doCommand(String[] args) {
 		try {
-			_is_zOS = ctx.getImage().getSystemType().toLowerCase().contains("z/os");
+			_is_zOS = ctx.getImage().getSystemType().equals("z/OS");
 		} catch (DataUnavailable e) {
 			out.print(Exceptions.getDataUnavailableString());
 		} catch (CorruptDataException e) {

--- a/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
+++ b/jcl/src/openj9.jvm/share/classes/com/ibm/jvm/Dump.java
@@ -104,7 +104,7 @@ import openj9.management.internal.InvalidDumpOptionExceptionBase;
 public class Dump {
 
 	private static final String SystemRequestPrefix =
-		"z/OS".equalsIgnoreCase(com.ibm.oti.vm.VM.internalGetProperties().getProperty("os.name")) //$NON-NLS-1$ //$NON-NLS-2$
+		"z/OS".equals(com.ibm.oti.vm.VM.internalGetProperties().getProperty("os.name")) //$NON-NLS-1$ //$NON-NLS-2$
 			? "system:dsn=" //$NON-NLS-1$
 			: "system:file="; //$NON-NLS-1$
 

--- a/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
+++ b/sourcetools/com.ibm.jpp.preprocessor/com/ibm/jpp/om/JavaPreprocessor.java
@@ -127,7 +127,7 @@ public class JavaPreprocessor {
 	private static final Charset charset;
 
 	static {
-		if ("z/OS".equalsIgnoreCase(System.getProperty("os.name"))) { //$NON-NLS-1$ //$NON-NLS-2$
+		if ("z/OS".equals(System.getProperty("os.name"))) { //$NON-NLS-1$ //$NON-NLS-2$
 			charset = Charset.forName("IBM-1047"); //$NON-NLS-1$
 		} else {
 			charset = StandardCharsets.US_ASCII;

--- a/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
+++ b/test/functional/CacheManagement/src/tests/sharedclasses/TestUtils.java
@@ -890,28 +890,27 @@ public class TestUtils {
 			checkFileExists(getCacheFileLocationForNonPersistentCache(cachename).replace("memory","semaphore"));
 		}
 	}
-	
+
 	public static void checkFileExistsForCacheSnapshot(String cachename) {
 		checkFileExists(getCacheFileLocationForCacheSnapshot(cachename));
 	}
-	
-		
+
 	public static boolean isWindows() {
-		return System.getProperty("os.name").toLowerCase().startsWith("windows");
+		return getOS().startsWith("Windows");
 	}
 
 	public static boolean isMVS() {
-		return System.getProperty("os.name").toLowerCase().startsWith("z/os");
+		return getOS().equals("z/OS");
 	}
-	
+
 	public static boolean isLinux() {
-		return System.getProperty("os.name").toLowerCase().startsWith("linux");
+		return getOS().equals("Linux");
 	}
-	
+
 	public static String getOS() {
 		return System.getProperty("os.name");
 	}
-	
+
 	public static boolean isCompressedRefEnabled() {
 		checkJavaVersion();
 		if (messageOccurred("Compressed References")) {

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestClassExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestClassExt.java
@@ -272,7 +272,7 @@ public class TestClassExt extends DDRExtTesterBase {
 				new String[] {});
 		String[] outputLines = null;
 		String listAddress = null;
-		if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+		if (System.getProperty("os.name").startsWith("Windows")) {
 			outputLines = dumpAllSegmentsOutput.split("\n");
 		} else {
 			outputLines = dumpAllSegmentsOutput.split(Constants.NL);

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestSharedClassesExt.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/junit/TestSharedClassesExt.java
@@ -226,7 +226,7 @@ public class TestSharedClassesExt extends DDRExtTesterBase {
 			// extract the j9rommethod address
 			String address = null;
 			String[] outputLines = null;
-			if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+			if (System.getProperty("os.name").startsWith("Windows")) {
 				outputLines = findAotOutput.split("\n");
 			} else {
 				outputLines = findAotOutput.split(Constants.NL);
@@ -297,7 +297,7 @@ public class TestSharedClassesExt extends DDRExtTesterBase {
 			// extract the j9rommethod address
 			String address = null;
 			String[] outputLines = null;
-			if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+			if (System.getProperty("os.name").startsWith("Windows")) {
 				outputLines = findAotOutput.split("\n");
 			} else {
 				outputLines = findAotOutput.split(Constants.NL);
@@ -332,7 +332,7 @@ public class TestSharedClassesExt extends DDRExtTesterBase {
 			fail("Prerequisite command shrc stats output is null");
 		} else {
 			String[] statsOutputLines = null;
-			if (System.getProperty("os.name").toLowerCase().contains("windows")) {
+			if (System.getProperty("os.name").startsWith("Windows")) {
 				statsOutputLines = statsOutput.split("\n");
 			} else {
 				statsOutputLines = statsOutput.split(Constants.NL);

--- a/test/functional/DDR_Test/src/j9vm/test/ddrext/util/CoreDumpGenerator.java
+++ b/test/functional/DDR_Test/src/j9vm/test/ddrext/util/CoreDumpGenerator.java
@@ -82,7 +82,7 @@ public class CoreDumpGenerator {
 		log.debug("Current Dir: " + currentDir);
 
 		try {
-			if (os.contains("windows") || os.contains("Windows")) {
+			if (os.startsWith("Windows")) {
 				// TO_DO:Change drive from C: to L:
 				// String drive = dumpLocation.substring(0,
 				// dumpLocation.indexOf(":")+1);
@@ -157,17 +157,8 @@ public class CoreDumpGenerator {
 		Process process = null;
 
 		try {
-
-			/*
-			 * if (System.getProperty("os.name").contains("windows")||System.
-			 * getProperty("os.name").contains("Windows")){ process =
-			 * runtime.exec("cmd /c start run.bat"); }else{
-			 */
 			File workDir = new File("/bin");
 			process = runtime.exec("/bin/bash", null, workDir);
-			// process.waitFor();
-			// }
-
 		} catch (IOException e) {
 			e.printStackTrace();
 		}

--- a/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
+++ b/test/functional/JIT_Test/src/jit/test/jitserver/JITServerTest.java
@@ -179,7 +179,7 @@ public class JITServerTest {
 
 	private static String[] infoOfProcessUsingPort(int port) {
 		String[] output = {};
-		if (System.getProperty("os.name").toLowerCase().contains("linux")) {
+		if (System.getProperty("os.name").equals("Linux")) {
 			try {
 				Process proc = new ProcessBuilder("lsof", "-i", ":" + port).start();
 				proc.waitFor();

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOpenJ9DiagnosticsMXBean.java
@@ -545,7 +545,7 @@ public class TestOpenJ9DiagnosticsMXBean {
 	 * @return a boolean indicating if it is zOS and system dump agent
 	 */
 	private static boolean isZOSSystemAgent(String agent) {
-		if ("z/OS".equalsIgnoreCase(os) && "system".equals(agent)) {
+		if ("z/OS".equals(os) && "system".equals(agent)) {
 			return true;
 		} else {
 			return false;
@@ -600,4 +600,3 @@ public class TestOpenJ9DiagnosticsMXBean {
 		remoteServer.waitFor();
 	}
 }
-

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestOperatingSystemMXBean.java
@@ -125,7 +125,7 @@ public class TestOperatingSystemMXBean {
 		 * on Z and OSX.
 		 */
 		String osName = System.getProperty("os.name", "");
-		if (osName.equalsIgnoreCase("z/OS") || osName.equalsIgnoreCase("mac os x")) {
+		if (osName.equals("z/OS") || osName.equals("Mac OS X")) {
 			isSupportedOS = false;
 		} else {
 			isSupportedOS = true;

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean_SM.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestSharedClassMemoryMXBean_SM.java
@@ -108,7 +108,7 @@ public class TestSharedClassMemoryMXBean_SM {
 	@Test
 	public void testSeSharedClassSoftmxSizeWithSecurityManager() throws Exception {
 		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+			if (!System.getProperty("os.name").equals("AIX")) {
 				/*
 				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
 				 */
@@ -126,7 +126,7 @@ public class TestSharedClassMemoryMXBean_SM {
 	@Test
 	public void testSeSharedClassMaxAotWithSecurityManager() throws Exception {
 		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+			if (!System.getProperty("os.name").equals("AIX")) {
 				/*
 				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
 				 */
@@ -144,7 +144,7 @@ public class TestSharedClassMemoryMXBean_SM {
 	@Test
 	public void testSeSharedClassMinAotWithSecurityManager() throws Exception {
 		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+			if (!System.getProperty("os.name").equals("AIX")) {
 				/*
 				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
 				 */
@@ -162,7 +162,7 @@ public class TestSharedClassMemoryMXBean_SM {
 	@Test
 	public void testSeSharedClassMaxJitDataWithSecurityManager() throws Exception {
 		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+			if (!System.getProperty("os.name").equals("AIX")) {
 				/*
 				 * It hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
 				 */
@@ -180,7 +180,7 @@ public class TestSharedClassMemoryMXBean_SM {
 	@Test
 	public void testSeSharedClassMinJitDataWithSecurityManager() throws Exception {
 		try {
-			if (!System.getProperty("os.name").toLowerCase().contains("aix")) {
+			if (!System.getProperty("os.name").equals("AIX")) {
 				/*
 				 * It on hangs on AIX 64 bit at line: socket = serverSock.accept() in ProcessRunner.initializeCommunication()
 				 */

--- a/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestUtil.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/java/lang/management/TestUtil.java
@@ -31,10 +31,10 @@ public final class TestUtil {
 	static {
 		String osName = System.getProperty("os.name"); //$NON-NLS-1$ 
 
-		isUnix = "aix".equalsIgnoreCase(osName) //$NON-NLS-1$
-				|| "linux".equalsIgnoreCase(osName) //$NON-NLS-1$
-				|| "mac os x".equalsIgnoreCase(osName) //$NON-NLS-1$
-				|| "z/OS".equalsIgnoreCase(osName); //$NON-NLS-1$
+		isUnix = "AIX".equals(osName) //$NON-NLS-1$
+				|| "Linux".equals(osName) //$NON-NLS-1$
+				|| "Mac OS X".equals(osName) //$NON-NLS-1$
+				|| "z/OS".equals(osName); //$NON-NLS-1$
 	}
 
 	/**

--- a/test/functional/JLM_Tests/src/org/openj9/test/management/TestOperatingSystemMXBean.java
+++ b/test/functional/JLM_Tests/src/org/openj9/test/management/TestOperatingSystemMXBean.java
@@ -258,7 +258,7 @@ public class TestOperatingSystemMXBean {
 					"Invalid Swap Memory Info retrieved , Free Swap size cannot be greater than total Swap Size. getTotalSwapSpaceSize() & getFreeSwapSpaceSize() API's failed ");
 
 		} else {
-			if ((-1 == totalSwap) && (osname.equalsIgnoreCase("z/OS") == false)) {
+			if ((-1 == totalSwap) && (osname.equals("z/OS") == false)) {
 				/*
 				 * An error has occurred since getTotalSwapSpaceSize() has returned -1.
 				 * -1 can also mean it is not supported, but we exclude these tests on
@@ -266,7 +266,7 @@ public class TestOperatingSystemMXBean {
 				 */
 				Assert.fail("Error: getTotalSwapSpaceSize() API returned -1, test failed");
 			}
-			if ((-1 == freeSwap) && (osname.equalsIgnoreCase("z/OS") == false)) {
+			if ((-1 == freeSwap) && (osname.equals("z/OS") == false)) {
 				/*
 				 * An error has occurred since getFreeSwapSpaceSize() has returned -1.
 				 * -1 can also mean it is not supported, but we exclude these tests on
@@ -307,7 +307,7 @@ public class TestOperatingSystemMXBean {
 					"Free Physical Memory size " + freeMemory + " cannot be greater than total Physical Memory Size " + totalMemory);
 			}
 		} else {
-			if ((-1 == totalMemory) && (false == osname.equalsIgnoreCase("z/OS"))) {
+			if ((-1 == totalMemory) && (false == osname.equals("z/OS"))) {
 				/*
 				 * An error has occurred since getTotalPhysicalMemorySize() has returned -1.
 				 * -1 can also mean it is not supported, but we exclude these tests on
@@ -315,7 +315,7 @@ public class TestOperatingSystemMXBean {
 				 */
 				Assert.fail("getTotalPhysicalMemorySize() API returned -1, test failed");
 			}
-			if ((-1 == freeMemory) && (false == osname.equalsIgnoreCase("z/OS"))) {
+			if ((-1 == freeMemory) && (false == osname.equals("z/OS"))) {
 				/*
 				 * An error has occurred since getFreePhysicalMemorySize() has returned -1.
 				 * -1 can also mean it is not supported, but we exclude these tests on
@@ -343,7 +343,7 @@ public class TestOperatingSystemMXBean {
 		if (-1 != processVirtualMem) {
 			Assert.assertTrue(processVirtualMem > 0,
 					"Invalid Process Virtual Memory Size retrieved, ProcessVirtualMemory cannot be less than 0");
-		} else if ((-1 == processVirtualMem) && (osname.equalsIgnoreCase("AIX") || osname.equalsIgnoreCase("z/OS"))) {
+		} else if ((-1 == processVirtualMem) && (osname.equals("AIX") || osname.equals("z/OS"))) {
 			/* API not supported on AIX for now, so we ignore the -1 */
 			logger.warn(
 					"getCommittedVirtualMemorySize() not supported on AIX and z/OS, Process Virtual Memory Size: <undefined for platform>");
@@ -910,6 +910,6 @@ public class TestOperatingSystemMXBean {
 
 	private static boolean isPlatformZOS() {
 		String osName = System.getProperty("os.name");
-		return osName.equalsIgnoreCase("z/OS");
+		return osName.equals("z/OS");
 	}
 }

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/DuplicateStructTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/DuplicateStructTests.java
@@ -58,9 +58,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class DuplicateStructTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows. */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static MethodType mt = MethodType.methodType(MemorySegment.class, MemorySegment.class, MemorySegment.class);

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/InvalidDownCallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/InvalidDownCallTests.java
@@ -59,9 +59,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class InvalidDownCallTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests1.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests1.java
@@ -53,9 +53,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class PrimitiveTypeTests1 {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests2.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests2.java
@@ -54,9 +54,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class PrimitiveTypeTests2 {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests3.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/PrimitiveTypeTests3.java
@@ -54,9 +54,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class PrimitiveTypeTests3 {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/StructTests1.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/StructTests1.java
@@ -68,9 +68,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class StructTests1 {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/StructTests2.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/downcall/StructTests2.java
@@ -66,9 +66,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class StructTests2 {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/MultiUpcallMHTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/MultiUpcallMHTests.java
@@ -53,9 +53,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class MultiUpcallMHTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithMixedSigStruTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithMixedSigStruTests.java
@@ -61,9 +61,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class UpcallMHWithMixedSigStruTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithPrimTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithPrimTests.java
@@ -51,9 +51,9 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class UpcallMHWithPrimTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithStructTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithStructTests.java
@@ -62,13 +62,13 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class UpcallMHWithStructTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static String arch = System.getProperty("os.arch").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final String arch = System.getProperty("os.arch").toLowerCase();
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* The padding of struct is not required on Linux/s390x and Windows/x64 */
 	private static boolean isStructPaddingNotRequired = isWinOS && (arch.equals("amd64") || arch.equals("x86_64"))
-														|| osName.contains("linux") && arch.equals("s390x");
+														|| osName.equals("Linux") && arch.equals("s390x");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMethodHandles.java
@@ -59,9 +59,9 @@ import jdk.incubator.foreign.ValueLayout;
 public class UpcallMethodHandles {
 	private static final Lookup lookup = MethodHandles.lookup();
 	private static ResourceScope scope = ResourceScope.newImplicitScope();
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/ApiTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/ApiTests.java
@@ -48,12 +48,12 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class ApiTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static String arch = System.getProperty("os.arch").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinX64 = osName.contains("win") && (arch.equals("amd64") || arch.equals("x86_64"));
-	private static boolean isMacOsAarch64 = osName.contains("mac") && arch.contains("aarch64");
-	private static boolean isSysVPPC64le = osName.contains("linux") && arch.contains("ppc64");
+	private static final String osName = System.getProperty("os.name");
+	private static final String arch = System.getProperty("os.arch").toLowerCase();
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static boolean isWinX64 = osName.startsWith("Windows") && (arch.equals("amd64") || arch.equals("x86_64"));
+	private static boolean isMacOsAarch64 = osName.equals("Mac OS X") && arch.contains("aarch64");
+	private static boolean isSysVPPC64le = osName.equals("Linux") && arch.contains("ppc64");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinX64 || isAixOS) ? C_LONG_LONG : C_LONG;
 

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
@@ -55,14 +55,14 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class DowncallTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static String arch = System.getProperty("os.arch").toLowerCase();
-	static boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
-	private static boolean isWinX64 = osName.contains("win") && isX64;
-	private static boolean isLinuxAarch64 = osName.contains("linux") && arch.equals("aarch64");
+	private static final String osName = System.getProperty("os.name");
+	private static final String arch = System.getProperty("os.arch").toLowerCase();
+	private static final boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
+	private static final boolean isWinX64 = osName.startsWith("Windows") && isX64;
+	private static final boolean isLinuxAarch64 = osName.equals("Linux") && arch.equals("aarch64");
 	/* The padding of struct is not required on Power in terms of VaList */
-	private static boolean isStructPaddingNotRequired = arch.startsWith("ppc64");
-	private static boolean isAixOS = osName.contains("aix");
+	private static final boolean isStructPaddingNotRequired = arch.startsWith("ppc64");
+	private static final boolean isAixOS = osName.equals("AIX");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinX64 || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
@@ -55,14 +55,14 @@ import jdk.incubator.foreign.ValueLayout;
  */
 @Test(groups = { "level.sanity" })
 public class UpcallTests {
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static String arch = System.getProperty("os.arch").toLowerCase();
-	static boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
-	private static boolean isWinX64 = osName.contains("win") && (arch.equals("amd64") || arch.equals("x86_64"));
-	private static boolean isLinuxAarch64 = osName.contains("linux") && arch.equals("aarch64");
+	private static final String osName = System.getProperty("os.name");
+	private static final String arch = System.getProperty("os.arch").toLowerCase();
+	private static final boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
+	private static final boolean isWinX64 = osName.startsWith("Windows") && (arch.equals("amd64") || arch.equals("x86_64"));
+	private static final boolean isLinuxAarch64 = osName.equals("Linux") && arch.equals("aarch64");
 	/* The padding of struct is not required on Power in terms of VaList */
-	private static boolean isStructPaddingNotRequired = arch.startsWith("ppc64");
-	private static boolean isAixOS = osName.contains("aix");
+	private static final boolean isStructPaddingNotRequired = arch.startsWith("ppc64");
+	private static final boolean isAixOS = osName.equals("AIX");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinX64 || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/VaListUpcallMethodHandles.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/VaListUpcallMethodHandles.java
@@ -59,9 +59,9 @@ public class VaListUpcallMethodHandles {
 	private static ResourceScope scope = ResourceScope.newImplicitScope();
 	private static SegmentAllocator allocator = SegmentAllocator.arenaAllocator(scope);
 
-	private static String osName = System.getProperty("os.name").toLowerCase();
-	private static boolean isAixOS = osName.contains("aix");
-	private static boolean isWinOS = osName.contains("win");
+	private static final String osName = System.getProperty("os.name");
+	private static final boolean isAixOS = osName.equals("AIX");
+	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/PrimitiveTypeTests1.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/PrimitiveTypeTests1.java
@@ -50,7 +50,7 @@ import java.util.Arrays;
  */
 @Test(groups = { "level.sanity" })
 public class PrimitiveTypeTests1 {
-	private static final boolean isZos = "z/OS".equalsIgnoreCase(System.getProperty("os.name"));
+	private static final boolean isZos = "z/OS".equals(System.getProperty("os.name"));
 	private static Linker linker = Linker.nativeLinker();
 	private static Arena arena = Arena.ofAuto();
 

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests1.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests1.java
@@ -59,7 +59,7 @@ import java.lang.invoke.VarHandle;
  */
 @Test(groups = { "level.sanity" })
 public class StructTests1 {
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 	private static Linker linker = Linker.nativeLinker();
 
 	static {

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests2.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/downcall/StructTests2.java
@@ -59,7 +59,7 @@ import java.lang.invoke.VarHandle;
  */
 @Test(groups = { "level.sanity" })
 public class StructTests2 {
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 	private static Linker linker = Linker.nativeLinker();
 
 	static {

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/upcall/UpcallMHWithMixedSigStruTests.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/upcall/UpcallMHWithMixedSigStruTests.java
@@ -56,7 +56,7 @@ import java.lang.invoke.VarHandle;
  */
 @Test(groups = { "level.sanity" })
 public class UpcallMHWithMixedSigStruTests {
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 	private static Linker linker = Linker.nativeLinker();
 
 	static {

--- a/test/functional/Java21Only/src/org/openj9/test/jep442/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java21Only/src/org/openj9/test/jep442/upcall/UpcallMethodHandles.java
@@ -57,7 +57,7 @@ import java.lang.invoke.VarHandle;
 public class UpcallMethodHandles {
 	private static final Lookup lookup = MethodHandles.lookup();
 	private static Arena arena = Arena.ofAuto();
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 
 	static final MethodType MT_Bool_Bool_MemSegmt = methodType(boolean.class, boolean.class, MemorySegment.class);
 	static final MethodType MT_Segmt_Bool_MemSegmt = methodType(MemorySegment.class, boolean.class, MemorySegment.class);

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests1.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/PrimitiveTypeTests1.java
@@ -50,7 +50,7 @@ import java.nio.charset.Charset;
  */
 @Test(groups = { "level.sanity" })
 public class PrimitiveTypeTests1 {
-	private static final boolean isZos = "z/OS".equalsIgnoreCase(System.getProperty("os.name"));
+	private static final boolean isZos = "z/OS".equals(System.getProperty("os.name"));
 	private static Linker linker = Linker.nativeLinker();
 	private static Arena arena = Arena.ofAuto();
 

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/StructTests1.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/StructTests1.java
@@ -59,7 +59,7 @@ import java.lang.invoke.VarHandle;
  */
 @Test(groups = { "level.sanity" })
 public class StructTests1 {
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 	private static Linker linker = Linker.nativeLinker();
 
 	static {

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/StructTests2.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/downcall/StructTests2.java
@@ -59,7 +59,7 @@ import java.lang.invoke.VarHandle;
  */
 @Test(groups = { "level.sanity" })
 public class StructTests2 {
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 	private static Linker linker = Linker.nativeLinker();
 
 	static {

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/upcall/UpcallMHWithMixedSigStruTests.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/upcall/UpcallMHWithMixedSigStruTests.java
@@ -56,7 +56,7 @@ import java.lang.invoke.VarHandle;
  */
 @Test(groups = { "level.sanity" })
 public class UpcallMHWithMixedSigStruTests {
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 	private static Linker linker = Linker.nativeLinker();
 
 	static {

--- a/test/functional/Java22andUp/src/org/openj9/test/jep454/upcall/UpcallMethodHandles.java
+++ b/test/functional/Java22andUp/src/org/openj9/test/jep454/upcall/UpcallMethodHandles.java
@@ -57,7 +57,7 @@ import java.lang.invoke.VarHandle;
 public class UpcallMethodHandles {
 	private static final Lookup lookup = MethodHandles.lookup();
 	private static Arena arena = Arena.ofAuto();
-	private static boolean isAixOS = System.getProperty("os.name").toLowerCase().contains("aix");
+	private static final boolean isAixOS = System.getProperty("os.name").equals("AIX");
 
 	static final MethodType MT_Bool_Bool_MemSegmt = methodType(boolean.class, boolean.class, MemorySegment.class);
 	static final MethodType MT_Segmt_Bool_MemSegmt = methodType(MemorySegment.class, boolean.class, MemorySegment.class);

--- a/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
@@ -63,7 +63,7 @@ public class ContendedFieldsTests {
 			CACHE_LINE_SIZE = 64;			
 		} else if (osArch.startsWith("aarch64")) {
 			String osName = System.getProperty("os.name");
-			if (osName.startsWith("Mac OS X")) {
+			if (osName.equals("Mac OS X")) {
 				CACHE_LINE_SIZE = 128;
 			} else {
 				CACHE_LINE_SIZE = 64;

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/TimersTest.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/TimersTest.java
@@ -89,8 +89,8 @@ public class TimersTest extends ThreadMXBeanTestCase {
 			return;
 		}
 
-		String osName = System.getProperty("os.name").toLowerCase();
-		if (osName.contains("linux")) {
+		String osName = System.getProperty("os.name");
+		if (osName.equals("Linux")) {
 			String osVersion = System.getProperty("os.version");
 			String osArch = System.getProperty("os.arch").toLowerCase();
 			
@@ -108,7 +108,7 @@ public class TimersTest extends ThreadMXBeanTestCase {
 				}
 			}
 		}
-		if (osName.contains("win") || osName.contains("aix")) {
+		if (osName.equals("AIX") || osName.startsWith("Windows")) {
 			supportsUserTimes = true;
 		}
 		logger.debug("os.name: " + osName + " supportsUserTimes: "

--- a/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/vmArguments/VmArgumentTests.java
@@ -718,7 +718,7 @@ public class VmArgumentTests {
 	 */
 	@Test
 	public void testLD_LIBRARY_PATH() {
-		if (!OS_NAME_PROPERTY.startsWith("Linux")) {
+		if (!OS_NAME_PROPERTY.equals("Linux")) {
 			logger.debug("Skipping " + testName + " on non-Linux systems");
 			return;
 		}
@@ -738,7 +738,7 @@ public class VmArgumentTests {
 
 	@Test
 	public void testLD_LIBRARY_PATH_And_LIBPATH() {
-		if (!OS_NAME_PROPERTY.startsWith("AIX")) {
+		if (!OS_NAME_PROPERTY.equals("AIX")) {
 			logger.debug("Skipping " + testName + " on non-AIX systems");
 			return;
 		}
@@ -764,7 +764,7 @@ public class VmArgumentTests {
 
 	@Test
 	public void testLIBPATH() {
-		if (!OS_NAME_PROPERTY.startsWith("z/OS")) {
+		if (!OS_NAME_PROPERTY.equals("z/OS")) {
 			logger.debug("Skipping " + testName + " on non-z/OS systems");
 			return;
 		}

--- a/test/functional/TestUtilities/src/org/openj9/test/util/PlatformInfo.java
+++ b/test/functional/TestUtilities/src/org/openj9/test/util/PlatformInfo.java
@@ -26,8 +26,8 @@ public class PlatformInfo {
 	private static final String OS_ARCH = "os.arch"; //$NON-NLS-1$
 	private static final String osName = System.getProperty(OS_NAME);
 	private static final String osArch = System.getProperty(OS_ARCH);
-	private static final boolean isPlatformZOS = (osName != null) && osName.toLowerCase().startsWith("z/os"); //$NON-NLS-1$
-	private	static final boolean isOpenJ9Status = 
+	private static final boolean isPlatformZOS = "z/OS".equals(osName); //$NON-NLS-1$
+	private static final boolean isOpenJ9Status =
 			System.getProperty("java.vm.vendor").contains("OpenJ9"); //$NON-NLS-1$ //$NON-NLS-2$
 
 	public static boolean isWindows() {
@@ -35,7 +35,7 @@ public class PlatformInfo {
 	}
 
 	public static boolean isMacOS() {
-		return ((null != osName) && osName.startsWith("Mac OS"));
+		return ((null != osName) && osName.equals("Mac OS X"));
 	}
 
 	public static boolean isZOS() {

--- a/test/functional/TestUtilitiesJ9/src/org/openj9/test/java/lang/management/ThreadMXBean/ThreadMXBeanTestCaseCommon.java
+++ b/test/functional/TestUtilitiesJ9/src/org/openj9/test/java/lang/management/ThreadMXBean/ThreadMXBeanTestCaseCommon.java
@@ -67,8 +67,8 @@ public abstract class ThreadMXBeanTestCaseCommon {
 	}
 
 	public static boolean isBadGettimeofdayPlatform() {
-		String osName = System.getProperty("os.name").toLowerCase();  //$NON-NLS-1$
-		if (osName.contains("linux")) {  //$NON-NLS-1$
+		String osName = System.getProperty("os.name"); //$NON-NLS-1$
+		if (osName.equals("Linux")) { //$NON-NLS-1$
 			String osVersion = System.getProperty("os.version");  //$NON-NLS-1$
 			String osArch = System.getProperty("os.arch").toLowerCase();  //$NON-NLS-1$
 			if (osArch.contains("x86") || osArch.contains("amd64")) {  //$NON-NLS-1$ //$NON-NLS-2$

--- a/test/functional/VM_Test/src/com/ibm/j9/numa/NumaTestWrapper.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/numa/NumaTestWrapper.java
@@ -36,8 +36,8 @@ public class NumaTestWrapper {
 		String command = parseCommand(args);
 		
 		try {
-			String platform = System.getProperty("os.name").toLowerCase();
-			boolean checkTracepoints = ((null != platform) && (command.indexOf("gcpolicy:balanced") != -1) && (platform.indexOf("linux") != -1));
+			String platform = System.getProperty("os.name");
+			boolean checkTracepoints = "Linux".equals(platform) && command.contains("gcpolicy:balanced");
 			
 			Process proc = Runtime.getRuntime().exec(command);
 			InputStream errStream = proc.getErrorStream();

--- a/test/functional/VM_Test/src/j9vm/runner/Runner.java
+++ b/test/functional/VM_Test/src/j9vm/runner/Runner.java
@@ -36,18 +36,18 @@ public class Runner {
 		UNKNOWN;
 
 		public static OSName current() {
-			String osSpec = System.getProperty("os.name", "?").toLowerCase();
+			String osSpec = System.getProperty("os.name", "?");
 
 			/* Get OS from the spec string. */
-			if (osSpec.contains("aix")) {
+			if (osSpec.equals("AIX")) {
 				return AIX;
-			} else if (osSpec.contains("linux")) {
+			} else if (osSpec.equals("Linux")) {
 				return LINUX;
-			} else if (osSpec.contains("mac")) {
+			} else if (osSpec.equals("Mac OS X")) {
 				return MAC;
-			} else if (osSpec.contains("windows")) {
+			} else if (osSpec.startsWith("Windows")) {
 				return WINDOWS;
-			} else if (osSpec.contains("z/os")) {
+			} else if (osSpec.equals("z/OS")) {
 				return ZOS;
 			} else {
 				System.out.println("Runner couldn't determine underlying OS. Got OS Name:" + osSpec);

--- a/test/functional/VM_Test/src/j9vm/test/thread/NativePriorityTest.java
+++ b/test/functional/VM_Test/src/j9vm/test/thread/NativePriorityTest.java
@@ -72,7 +72,7 @@ public class NativePriorityTest {
 		System.out.println("osName = " + osName);
 		OS_NAMES currentOS = null;
 		
-		if (osName.contains(OS_NAMES.Windows.toString())) {
+		if (osName.startsWith("Windows")) {
 			currentOS = OS_NAMES.Windows;
 		} else {
 			try {

--- a/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
+++ b/test/functional/cmdLineTests/SystemPropertiesTest/src/SysPropTest.java
@@ -39,7 +39,7 @@ public class SysPropTest
 		String argEncoding = args[0];
 		/* check -Dtestkey=TestVa?lue? */
 		try {
-			boolean isWindows = System.getProperty("os.name").contains("Windows");
+			boolean isWindows = System.getProperty("os.name").startsWith("Windows");
 			String osEncoding = "";
 			String strTestProp;
 

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/LibertyServerControl.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/LibertyServerControl.java
@@ -40,7 +40,7 @@ import java.util.List;
  * Example: java LibertyServerControl /path/to/wlp create myServer
  */
 public class LibertyServerControl {
-    private static final boolean IS_WINDOWS = System.getProperty("os.name").toLowerCase().contains("win");
+    private static final boolean IS_WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
     public static void main(String[] args) {
         if (args.length < 3) {

--- a/test/functional/cmdline_options_tester/src/Test.java
+++ b/test/functional/cmdline_options_tester/src/Test.java
@@ -512,9 +512,7 @@ class Test {
 	}
 
 	public static boolean isLinux() {
-		String osName = System.getProperty("os.name", "<unknown>");
-
-		return osName.toLowerCase().contains("linux");
+		return "Linux".equals(System.getProperty("os.name"));
 	}
 
 	public static int getPID(Process process) throws Exception {


### PR DESCRIPTION
Code now consistently uses these conditions:
- AIX:     `equals("AIX")`
- Linux:   `equals("Linux")`
- macOS:   `equals("Mac OS X")`
- Windows: `startsWith("Windows")`
- z/OS:    `equals("z/OS")`

By avoiding unnecessary use of `toLowerCase()` or `toUpperCase()` we avoid problems like described in https://github.com/eclipse-openj9/openj9/issues/24120.