### PR TITLE
Always inline small MemorySegment accessors in JDK 21+

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -698,6 +698,8 @@ FirstJ9Method = LastOMRMethod + 1,
 
     jdk_internal_foreign_layout_ValueLayouts_AbstractValueLayout_accessHandle,
     jdk_internal_foreign_AbstractMemorySegmentImpl_reinterpret, java_lang_foreign_MemorySegment_method,
+    jdk_internal_foreign_MemorySegmentImpl_unsafeGetBase, jdk_internal_foreign_MemorySegmentImpl_unsafeGetOffset,
+    jdk_internal_foreign_MemorySegmentImpl_maxAlignMask,
 
     // Clone and Deep Copy
     java_lang_J9VMInternals_is32Bit, java_lang_J9VMInternals_isClassModifierPublic,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2817,9 +2817,10 @@ void TR_ResolvedJ9Method::construct()
     };
 #endif /* JAVA_SPEC_VERSION >= 15 */
 
-    static X PreconditionsMethods[]
-        = { { x(TR::jdk_internal_util_Preconditions_checkIndex, "checkIndex", "(IILjava/util/function/BiFunction;)I") },
-              { TR::unknownMethod } };
+    static X PreconditionsMethods[] = { { x(TR::jdk_internal_util_Preconditions_checkIndex, "checkIndex",
+                                            "(IILjava/util/function/BiFunction;)I") },
+        { x(TR::jdk_internal_util_Preconditions_checkIndex, "checkIndex", "(JJLjava/util/function/BiFunction;)J") },
+        { TR::unknownMethod } };
 
     static X VectorSupportMethods[] = {
 #if JAVA_SPEC_VERSION <= 21
@@ -4542,6 +4543,14 @@ void TR_ResolvedJ9Method::construct()
             } else if ((classNameLen == 31) && !strncmp(className, "java/lang/foreign/MemorySegment", 31)) {
                 if (nameLen >= 3 && (!strncmp(name, "get", 3) || !strncmp(name, "set", 3)))
                     setRecognizedMethodInfo(TR::java_lang_foreign_MemorySegment_method);
+            } else if (((classNameLen == 44) && !strncmp(className, "jdk/internal/foreign/NativeMemorySegmentImpl", 44))
+                || ((classNameLen >= 42) && !strncmp(className, "jdk/internal/foreign/HeapMemorySegmentImpl", 42))) {
+                if (nameLen == 13 && !strncmp(name, "unsafeGetBase", 13))
+                    setRecognizedMethodInfo(TR::jdk_internal_foreign_MemorySegmentImpl_unsafeGetBase);
+                else if (nameLen == 15 && !strncmp(name, "unsafeGetOffset", 15))
+                    setRecognizedMethodInfo(TR::jdk_internal_foreign_MemorySegmentImpl_unsafeGetOffset);
+                else if (nameLen == 12 && !strncmp(name, "maxAlignMask", 12))
+                    setRecognizedMethodInfo(TR::jdk_internal_foreign_MemorySegmentImpl_maxAlignMask);
             }
 #endif
             else if ((classNameLen >= 59 + 3 && classNameLen <= 59 + 7)

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -344,6 +344,13 @@ bool TR_J9InlinerPolicy::alwaysWorthInlining(TR_ResolvedMethod *calleeMethod, TR
         // AbstractMemorySegmentImpl.reinterpret methods call Reflection.getCallerClass
         case TR::jdk_internal_foreign_AbstractMemorySegmentImpl_reinterpret:
 
+        // Trivial segment accessors on the hot path of every FFM VarHandle access. They sit
+        // below inlined LambdaForm frames whose unreliable block frequencies would otherwise
+        // let the frequency-scaled size threshold reject them
+        case TR::jdk_internal_foreign_MemorySegmentImpl_unsafeGetBase:
+        case TR::jdk_internal_foreign_MemorySegmentImpl_unsafeGetOffset:
+        case TR::jdk_internal_foreign_MemorySegmentImpl_maxAlignMask:
+
         // we rely on inlining compareAndSwap so we see the inner native call and can special case it
         case TR::com_ibm_jit_JITHelpers_compareAndSwapIntInObject:
         case TR::com_ibm_jit_JITHelpers_compareAndSwapLongInObject:


### PR DESCRIPTION
Every java.lang.foreign VarHandle access bottoms out in a small set of trivial accessors on the segment implementation classes: NativeMemorySegmentImpl/HeapMemorySegmentImpl.unsafeGetBase, unsafeGetOffset and maxAlignMask - and in the (long, long) overload of jdk.internal.util.Preconditions.checkIndex reached from AbstractMemorySegmentImpl.checkBounds.

These methods are only a handful of bytecodes each, but they are reached through inlined LambdaForm frames whose block frequencies are unreliable. The frequency-scaled size estimate the inliner produces for them may be large enough that they can fall below the inlining threshold, so the access path is left with uninlined calls that also block the optimizations that depend on the accessors being inlined.

This commit adds recognizing of the three segment accessors and adds them to TR_J9InlinerPolicy::alwaysWorthInlining so they bypass the size adjustment heuristics. Also adds recognizing the (long, long) overload of Preconditions.checkIndex alongside the existing (int, int) overload. Both map to the same recognized method and so receive the same always-worth-inlining treatment. This addresses the per-access overhead these calls leave on the FFM access path.