### PR TITLE
Remove delete region collection set pass

### DIFF
--- a/runtime/gc_vlhgc/CollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/CollectionSetDelegate.cpp
@@ -163,8 +163,10 @@ MM_CollectionSetDelegate::createNurseryCollectionSet(MM_EnvironmentVLHGC *env)
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	while (NULL != (region = regionIterator.nextRegion())) {
 		Assert_MM_true(MM_RegionValidator(region).validate(env));
-		Assert_MM_false(region->_markData._shouldMark);
-		Assert_MM_false(region->_reclaimData._shouldReclaim);
+		/* Might have been set by previous PGC */
+		region->_markData._shouldMark = false;
+		region->_reclaimData._shouldReclaim = false;
+
 		if (region->containsObjects()) {
 			bool regionHasCriticalRegions = (0 != region->_criticalRegionsInUse);
 			bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
@@ -452,24 +454,6 @@ MM_CollectionSetDelegate::createRegionCollectionSetForPartialGC(MM_EnvironmentVL
 }
 
 void
-MM_CollectionSetDelegate::deleteRegionCollectionSetForPartialGC(MM_EnvironmentVLHGC *env)
-{
-	Assert_MM_true(MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
-
-	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
-	MM_HeapRegionDescriptorVLHGC *region = NULL;
-	while (NULL != (region = regionIterator.nextRegion())) {
-		/* there shouldn't be any regions that have some occupancy but not marked left if the increment is done */
-		Assert_MM_false(MM_HeapRegionDescriptor::ADDRESS_ORDERED == region->getRegionType());
-		Assert_MM_true(MM_RegionValidator(region).validate(env));
-
-		region->_markData._shouldMark = false;
-		region->_reclaimData._shouldReclaim = false;
-		region->_markData._noEvacuation = false;
-	}
-}
-
-void
 MM_CollectionSetDelegate::createRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env)
 {
 	Assert_MM_true(MM_CycleState::CT_GLOBAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
@@ -478,27 +462,14 @@ MM_CollectionSetDelegate::createRegionCollectionSetForGlobalGC(MM_EnvironmentVLH
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	while (NULL != (region = regionIterator.nextRegion())) {
 		Assert_MM_true(MM_RegionValidator(region).validate(env));
-		Assert_MM_false(region->_reclaimData._shouldReclaim);
+		/* Have been set by previous GlobalGC */
+		region->_reclaimData._shouldReclaim = false;
+		/* Not really used for Global GC, but let's clear it, too - might have been set by previous PGC */
+		region->_markData._shouldMark = false;
 		if (region->containsObjects()) {
 			region->_reclaimData._shouldReclaim = true;
 			region->_compactData._shouldCompact = false;
 		}
-	}
-}
-
-void
-MM_CollectionSetDelegate::deleteRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env)
-{
-	Assert_MM_true(MM_CycleState::CT_GLOBAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
-
-	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
-	MM_HeapRegionDescriptorVLHGC *region = NULL;
-	while (NULL != (region = regionIterator.nextRegion())) {
-		/* there shouldn't be any regions that have some occupancy but not marked left */
-		Assert_MM_false(MM_HeapRegionDescriptor::ADDRESS_ORDERED == region->getRegionType());
-		Assert_MM_true(MM_RegionValidator(region).validate(env));
-
-		region->_reclaimData._shouldReclaim = false;
 	}
 }
 

--- a/runtime/gc_vlhgc/CollectionSetDelegate.hpp
+++ b/runtime/gc_vlhgc/CollectionSetDelegate.hpp
@@ -159,25 +159,11 @@ public:
 	void createRegionCollectionSetForPartialGC(MM_EnvironmentVLHGC *env);
 
 	/**
-	 * Delete the internal representation of the set of regions that participated in the collection cycle.
-	 * This should only be called during a partial garbage collect.
-	 * @param env[in] The main GC thread
-	 */
-	void deleteRegionCollectionSetForPartialGC(MM_EnvironmentVLHGC *env);
-
-	/**
 	 * Build the internal representation of the set of regions that are to be collected for this cycle.
 	 * This should only be called during a global garbage collect.
 	 * @param env[in] The main GC thread
 	 */
 	void createRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env);
-
-	/**
-	 * Delete the internal representation of the set of regions that participated in the collection cycle.
-	 * This should only be called during a global garbage collect.
-	 * @param env[in] The main GC thread
-	 */
-	void deleteRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Record pre-sweep region information in order to calculate rate of return on tracing for age groups.

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -798,7 +798,10 @@ MM_CopyForwardScheme::acquireEmptyRegion(MM_EnvironmentVLHGC *env, MM_ReservedRe
 
 			Assert_MM_true(NULL == newRegion->getUnfinalizedObjectList()->getHeadOfList());
 			Assert_MM_true(NULL == newRegion->getContinuationObjectList()->getHeadOfList());
-			Assert_MM_false(newRegion->_markData._shouldMark);
+			/* Might have been set by a PGC in past, and contracted meanwhile,
+			 * so it would be missed to clear at the start of PGC. */
+			newRegion->_markData._shouldMark = false;
+			newRegion->_reclaimData._shouldReclaim = false;
 
 			/*
 			 * set logical age here to have a compact groups working properly

--- a/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
+++ b/runtime/gc_vlhgc/IncrementalGenerationalGC.cpp
@@ -1231,12 +1231,6 @@ MM_IncrementalGenerationalGC::runGlobalGarbageCollection(MM_EnvironmentVLHGC *en
 	_reclaimDelegate.estimateReclaimableRegions(env, _schedulingDelegate.getAverageEmptinessOfCopyForwardedRegions(), &reclaimableRegions, &defragmentReclaimableRegions);
 	_schedulingDelegate.globalGarbageCollectCompleted(env, reclaimableRegions, defragmentReclaimableRegions);
 
-	if (_extensions->tarokUseProjectedSurvivalCollectionSet) {
-		_projectedSurvivalCollectionSetDelegate.deleteRegionCollectionSetForGlobalGC(env);
-	} else {
-		_collectionSetDelegate.deleteRegionCollectionSetForGlobalGC(env);
-	}
-
 	env->_cycleState->_markMap = NULL;
 	env->_cycleState->_currentIncrement = 0;
 
@@ -1465,12 +1459,6 @@ MM_IncrementalGenerationalGC::postProcessPGCUsingCopyForward(MM_EnvironmentVLHGC
 	UDATA reclaimableRegions = 0;
 	_reclaimDelegate.estimateReclaimableRegions(env, _schedulingDelegate.getAverageEmptinessOfCopyForwardedRegions(), &reclaimableRegions, &defragmentReclaimableRegions);
 	_schedulingDelegate.partialGarbageCollectCompleted(env, reclaimableRegions, defragmentReclaimableRegions);
-
-	if (_extensions->tarokUseProjectedSurvivalCollectionSet) {
-		_projectedSurvivalCollectionSetDelegate.deleteRegionCollectionSetForPartialGC(env);
-	} else {
-		_collectionSetDelegate.deleteRegionCollectionSetForPartialGC(env);
-	}
 
 	Assert_MM_false(_workPacketsForGlobalGC->getOverflowFlag());
 	Assert_MM_false(_workPacketsForPartialGC->getOverflowFlag());

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.cpp
@@ -174,8 +174,10 @@ MM_ProjectedSurvivalCollectionSetDelegate::createNurseryCollectionSet(MM_Environ
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	while (NULL != (region = regionIterator.nextRegion())) {
 		Assert_MM_true(MM_RegionValidator(region).validate(env));
-		Assert_MM_false(region->_markData._shouldMark);
-		Assert_MM_false(region->_reclaimData._shouldReclaim);
+		/* Might have been set by previous PGC */
+		region->_markData._shouldMark = false;
+		region->_reclaimData._shouldReclaim = false;
+
 		if (region->containsObjects()) {
 			bool regionHasCriticalRegions = (0 != region->_criticalRegionsInUse);
 			bool isSelectionForCopyForward = env->_cycleState->_shouldRunCopyForward;
@@ -452,24 +454,6 @@ MM_ProjectedSurvivalCollectionSetDelegate::createRegionCollectionSetForPartialGC
 }
 
 void
-MM_ProjectedSurvivalCollectionSetDelegate::deleteRegionCollectionSetForPartialGC(MM_EnvironmentVLHGC *env)
-{
-	Assert_MM_true(MM_CycleState::CT_PARTIAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
-
-	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
-	MM_HeapRegionDescriptorVLHGC *region = NULL;
-	while (NULL != (region = regionIterator.nextRegion())) {
-		/* there shouldn't be any regions that have some occupancy but not marked left if the increment is done */
-		Assert_MM_false(MM_HeapRegionDescriptor::ADDRESS_ORDERED == region->getRegionType());
-		Assert_MM_true(MM_RegionValidator(region).validate(env));
-
-		region->_markData._shouldMark = false;
-		region->_markData._noEvacuation = false;
-		region->_reclaimData._shouldReclaim = false;
-	}
-}
-
-void
 MM_ProjectedSurvivalCollectionSetDelegate::createRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env)
 {
 	Assert_MM_true(MM_CycleState::CT_GLOBAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
@@ -478,28 +462,16 @@ MM_ProjectedSurvivalCollectionSetDelegate::createRegionCollectionSetForGlobalGC(
 	MM_HeapRegionDescriptorVLHGC *region = NULL;
 	while (NULL != (region = regionIterator.nextRegion())) {
 		Assert_MM_true(MM_RegionValidator(region).validate(env));
-		Assert_MM_false(region->_reclaimData._shouldReclaim);
+		/* Have been set by previous GlobalGC */
+		region->_reclaimData._shouldReclaim = false;
+		/* Not really used for Global GC, but let's clear it, too - might have been set by previous PGC */
+		region->_markData._shouldMark = false;
+
 		if (region->containsObjects()) {
 			region->_reclaimData._shouldReclaim = true;
 			region->_defragmentationTarget = false;
 			region->_compactData._shouldCompact = false;
 		}
-	}
-}
-
-void
-MM_ProjectedSurvivalCollectionSetDelegate::deleteRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env)
-{
-	Assert_MM_true(MM_CycleState::CT_GLOBAL_GARBAGE_COLLECTION == env->_cycleState->_collectionType);
-
-	GC_HeapRegionIteratorVLHGC regionIterator(_regionManager);
-	MM_HeapRegionDescriptorVLHGC *region = NULL;
-	while (NULL != (region = regionIterator.nextRegion())) {
-		/* there shouldn't be any regions that have some occupancy but not marked left */
-		Assert_MM_false(MM_HeapRegionDescriptor::ADDRESS_ORDERED == region->getRegionType());
-		Assert_MM_true(MM_RegionValidator(region).validate(env));
-
-		region->_reclaimData._shouldReclaim = false;
 	}
 }
 

--- a/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.hpp
+++ b/runtime/gc_vlhgc/ProjectedSurvivalCollectionSetDelegate.hpp
@@ -234,25 +234,11 @@ public:
 	void createRegionCollectionSetForPartialGC(MM_EnvironmentVLHGC *env);
 
 	/**
-	 * Delete the internal representation of the set of regions that participated in the collection cycle.
-	 * This should only be called during a partial garbage collect.
-	 * @param env[in] The main GC thread
-	 */
-	void deleteRegionCollectionSetForPartialGC(MM_EnvironmentVLHGC *env);
-
-	/**
 	 * Build the internal representation of the set of regions that are to be collected for this cycle.
 	 * This should only be called during a global garbage collect.
 	 * @param env[in] The main GC thread
 	 */
 	void createRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env);
-
-	/**
-	 * Delete the internal representation of the set of regions that participated in the collection cycle.
-	 * This should only be called during a global garbage collect.
-	 * @param env[in] The main GC thread
-	 */
-	void deleteRegionCollectionSetForGlobalGC(MM_EnvironmentVLHGC *env);
 
 	/**
 	 * Record pre-sweep region information in order to calculate rate of return on tracing for age groups.


### PR DESCRIPTION
Remove passes at the end of Balanced cycles that reset shouldMark and shouldReclaim flags.

To compensate, these flags are now reset at the start of next GC, piggybacked to an existing pass.

A non-functional change - just a simplification.