### PR TITLE
Valhalla removes the constructor IdentityException(Class<?> clazz)

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
+++ b/jcl/src/java.base/share/classes/java/lang/ref/Reference.java
@@ -232,7 +232,7 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	void initReference (T r) {
 /*[IF INLINE-TYPES]*/
 		if ((null != r) && r.getClass().isValue()) {
-			throw new IdentityException(r.getClass());
+			throw new IdentityException(r.getClass().getName() + " is not an identity class");
 		}
 /*[ENDIF] INLINE-TYPES */
 		state = STATE_INITIAL;
@@ -249,7 +249,7 @@ public abstract sealed class Reference<T> extends Object permits PhantomReferenc
 	void initReference (T r, ReferenceQueue q) {
 /*[IF INLINE-TYPES]*/
 		if ((null != r) && r.getClass().isValue()) {
-			throw new IdentityException(r.getClass());
+			throw new IdentityException(r.getClass().getName() + " is not an identity class");
 		}
 /*[ENDIF] INLINE-TYPES */
 		/*[PR 101461] Reference should allow null queues */


### PR DESCRIPTION
[Valhalla removes the constructor IdentityException(Class<?> clazz)](https://github.com/eclipse-openj9/openj9/commit/a9b76080468a32cb944516990b4516e84ed8954e) 

Fix the [compilation error](https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Build_JDKnext_x86-64_linux_valhalla_Nightly/2300/consoleFull):
```
21:20:25  /home/jenkins/workspace/Build_JDKnext_x86-64_linux_valhalla_Nightly/build/linux-x86_64-server-release/support/j9jcl/java.base/share/classes/java/lang/ref/Reference.java:177: error: incompatible types: Class<CAP#1> cannot be converted to String
21:20:25  			throw new IdentityException(r.getClass());
21:20:25  			                                      ^
21:20:25    where CAP#1 is a fresh type-variable:
21:20:25      CAP#1 extends Object from capture of ? extends Object
```

Signed-off-by: Jason Feng <fengj@ca.ibm.com>