### PR TITLE
Interpret system property "os.arch" consistently

### DIFF
--- a/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GetNativeDirectory.java
+++ b/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GetNativeDirectory.java
@@ -75,7 +75,7 @@ public class GetNativeDirectory
 		String osArch = System.getProperty("os.arch");
 
 		// if the current system is a 390 machine use 390 as the osArch
-		if (osArch.length() >= 4 && osArch.substring(0, 4).equals("s390")) {
+		if (osArch.startsWith("s390")) {
 			osArch = "390";
 		}
 
@@ -87,13 +87,6 @@ public class GetNativeDirectory
 		// if the current system is PPC64 use ppc as the osArch
 		else if (osArch.equals("ppc64")) {
 			osArch = "ppc";
-		}
-
-		// if the current system is i?86 where ? is a digit use x86
-		else if (osArch.length() == 4 && osArch.charAt(0) == 'i'
-				&& Character.isDigit(osArch.charAt(1))
-				&& osArch.substring(2).equals("86")) {
-			osArch = "x86";
 		}
 
 		return osArch;

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
@@ -56,7 +56,7 @@ import jdk.incubator.foreign.ValueLayout;
 final class LayoutStrPreprocessor {
 	private static final String osName = System.getProperty("os.name");
 	private static final String arch = System.getProperty("os.arch");
-	private static final boolean isX86_64 = arch.equals("amd64") || arch.equals("x86_64");
+	private static final boolean isX86_64 = arch.equals("amd64");
 	private static final boolean isLinuxS390x = arch.equals("s390x") && osName.equals("Linux");
 
 	/*[IF JAVA_SPEC_VERSION == 17]*/

--- a/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/dumpreader/Dump.java
+++ b/jcl/src/openj9.dtfj/share/classes/com/ibm/dtfj/corereaders/zos/dumpreader/Dump.java
@@ -173,7 +173,7 @@ public final class Dump extends ImageInputStreamImpl {
 	 * @throws FileNotFoundException
 	 */
 	private Dump(String filename, SearchListener[] listeners, boolean buildAddressSpaces, ImageInputStream instream, boolean createCacheFile) throws FileNotFoundException {
-		log.fine("opening dump " + filename+" stream "+instream);
+		log.fine("opening dump " + filename + " stream " + instream);
 		this.filename = filename;
 		if (listeners != null)
 			throw new Error("tbc");
@@ -191,8 +191,9 @@ public final class Dump extends ImageInputStreamImpl {
 			}
 			return;
 		} catch (Exception e) {
-			if (!System.getProperty("os.arch").equals("390")) {
-				FileNotFoundException e2 = new FileNotFoundException("Could not find: " + filename+ " stream " + instream);
+			/* The call to openMvsDataset() below is only reasonable on z/OS. */
+			if (!System.getProperty("os.name").equals("z/OS")) {
+				FileNotFoundException e2 = new FileNotFoundException("Could not find: " + filename + " stream " + instream);
 				e2.initCause(e);
 				throw e2;
 			}

--- a/test/functional/JIT_Test/src/jit/test/loopReduction/Main.java
+++ b/test/functional/JIT_Test/src/jit/test/loopReduction/Main.java
@@ -36,10 +36,9 @@ public class Main {
       }
       String hardware = System.getProperty("os.arch");
       int perfRating = 2000; // rough guide to speed of hardware for reasonable testing
-      if (hardware.equalsIgnoreCase("x86")) {
+      if (hardware.equals("x86")) {
          perfRating = 4000;
-      }
-      else if (hardware.equalsIgnoreCase("s390")) {
+      } else if (hardware.equals("s390")) {
          perfRating = 1500;
       }
       if (context.timed()) {

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithStructTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/upcall/UpcallMHWithStructTests.java
@@ -63,12 +63,12 @@ import jdk.incubator.foreign.ValueLayout;
 @Test(groups = { "level.sanity" })
 public class UpcallMHWithStructTests {
 	private static final String osName = System.getProperty("os.name");
-	private static final String arch = System.getProperty("os.arch").toLowerCase();
+	private static final String arch = System.getProperty("os.arch");
 	private static final boolean isAixOS = osName.equals("AIX");
 	private static final boolean isWinOS = osName.startsWith("Windows");
 	/* The padding of struct is not required on Linux/s390x and Windows/x64 */
-	private static boolean isStructPaddingNotRequired = isWinOS && (arch.equals("amd64") || arch.equals("x86_64"))
-														|| osName.equals("Linux") && arch.equals("s390x");
+	private static boolean isStructPaddingNotRequired = (osName.equals("Linux") && arch.equals("s390x"))
+														|| (isWinOS && arch.equals("amd64"));
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinOS || isAixOS) ? C_LONG_LONG : C_LONG;
 	private static CLinker clinker = CLinker.getInstance();

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/ApiTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/ApiTests.java
@@ -49,11 +49,11 @@ import jdk.incubator.foreign.ValueLayout;
 @Test(groups = { "level.sanity" })
 public class ApiTests {
 	private static final String osName = System.getProperty("os.name");
-	private static final String arch = System.getProperty("os.arch").toLowerCase();
+	private static final String arch = System.getProperty("os.arch");
 	private static final boolean isAixOS = osName.equals("AIX");
-	private static boolean isWinX64 = osName.startsWith("Windows") && (arch.equals("amd64") || arch.equals("x86_64"));
-	private static boolean isMacOsAarch64 = osName.equals("Mac OS X") && arch.contains("aarch64");
-	private static boolean isSysVPPC64le = osName.equals("Linux") && arch.contains("ppc64");
+	private static boolean isWinX64 = osName.startsWith("Windows") && arch.equals("amd64");
+	private static boolean isMacOsAarch64 = osName.equals("Mac OS X") && arch.equals("aarch64");
+	private static boolean isSysVPPC64le = osName.equals("Linux") && arch.equals("ppc64le");
 	/* long long is 64 bits on AIX/ppc64, which is the same as Windows */
 	private static ValueLayout longLayout = (isWinX64 || isAixOS) ? C_LONG_LONG : C_LONG;
 

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
@@ -56,8 +56,8 @@ import jdk.incubator.foreign.ValueLayout;
 @Test(groups = { "level.sanity" })
 public class DowncallTests {
 	private static final String osName = System.getProperty("os.name");
-	private static final String arch = System.getProperty("os.arch").toLowerCase();
-	private static final boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
+	private static final String arch = System.getProperty("os.arch");
+	private static final boolean isX64 = arch.equals("amd64");
 	private static final boolean isWinX64 = osName.startsWith("Windows") && isX64;
 	private static final boolean isLinuxAarch64 = osName.equals("Linux") && arch.equals("aarch64");
 	/* The padding of struct is not required on Power in terms of VaList */

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
@@ -56,9 +56,9 @@ import jdk.incubator.foreign.ValueLayout;
 @Test(groups = { "level.sanity" })
 public class UpcallTests {
 	private static final String osName = System.getProperty("os.name");
-	private static final String arch = System.getProperty("os.arch").toLowerCase();
-	private static final boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
-	private static final boolean isWinX64 = osName.startsWith("Windows") && (arch.equals("amd64") || arch.equals("x86_64"));
+	private static final String arch = System.getProperty("os.arch");
+	private static final boolean isX64 = arch.equals("amd64");
+	private static final boolean isWinX64 = osName.startsWith("Windows") && isX64;
 	private static final boolean isLinuxAarch64 = osName.equals("Linux") && arch.equals("aarch64");
 	/* The padding of struct is not required on Power in terms of VaList */
 	private static final boolean isStructPaddingNotRequired = arch.startsWith("ppc64");

--- a/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
@@ -58,10 +58,10 @@ public class ContendedFieldsTests {
 		if (osArch.startsWith("ppc")) {
 			CACHE_LINE_SIZE = 128;
 		} else if (osArch.startsWith("s390")) {
-			CACHE_LINE_SIZE = 256;			
-		} else if (osArch.startsWith("amd64") || osArch.startsWith("x86")) {
-			CACHE_LINE_SIZE = 64;			
-		} else if (osArch.startsWith("aarch64")) {
+			CACHE_LINE_SIZE = 256;
+		} else if (osArch.equals("amd64") || osArch.equals("x86")) {
+			CACHE_LINE_SIZE = 64;
+		} else if (osArch.equals("aarch64")) {
 			String osName = System.getProperty("os.name");
 			if (osName.equals("Mac OS X")) {
 				CACHE_LINE_SIZE = 128;

--- a/test/functional/Java8andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/TimersTest.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/java/lang/management/ThreadMXBean/TimersTest.java
@@ -92,11 +92,11 @@ public class TimersTest extends ThreadMXBeanTestCase {
 		String osName = System.getProperty("os.name");
 		if (osName.equals("Linux")) {
 			String osVersion = System.getProperty("os.version");
-			String osArch = System.getProperty("os.arch").toLowerCase();
-			
+			String osArch = System.getProperty("os.arch");
+
 			logger.debug("Linux Info: " + osName + " " + osArch + " " + osVersion);
 
-			if (osArch.contains("x86") || osArch.contains("amd64")) {
+			if (osArch.equals("x86") || osArch.equals("amd64")) {
 				if (!isLinuxVersionPostRedhat5(osVersion)) {
 					logger.debug(osName + " " + osArch + " " + osVersion + " does not report correct CPU times.");
 					if (ignoreLinuxVersionCheck) {

--- a/test/functional/TestUtilitiesJ9/src/org/openj9/test/java/lang/management/ThreadMXBean/ThreadMXBeanTestCaseCommon.java
+++ b/test/functional/TestUtilitiesJ9/src/org/openj9/test/java/lang/management/ThreadMXBean/ThreadMXBeanTestCaseCommon.java
@@ -69,9 +69,9 @@ public abstract class ThreadMXBeanTestCaseCommon {
 	public static boolean isBadGettimeofdayPlatform() {
 		String osName = System.getProperty("os.name"); //$NON-NLS-1$
 		if (osName.equals("Linux")) { //$NON-NLS-1$
-			String osVersion = System.getProperty("os.version");  //$NON-NLS-1$
-			String osArch = System.getProperty("os.arch").toLowerCase();  //$NON-NLS-1$
-			if (osArch.contains("x86") || osArch.contains("amd64")) {  //$NON-NLS-1$ //$NON-NLS-2$
+			String osArch = System.getProperty("os.arch"); //$NON-NLS-1$
+			if (osArch.equals("amd64") || osArch.equals("x86")) { //$NON-NLS-1$ //$NON-NLS-2$
+				String osVersion = System.getProperty("os.version"); //$NON-NLS-1$
 				if (!isLinuxVersionPostRedhat5(osVersion)) {
 					return true;
 				}

--- a/test/functional/VM_Test/src/j9vm/runner/Runner.java
+++ b/test/functional/VM_Test/src/j9vm/runner/Runner.java
@@ -64,16 +64,16 @@ public class Runner {
 		UNKNOWN;
 
 		public static OSArch current() {
-			String archSpec = System.getProperty("os.arch", "?").toLowerCase();
+			String archSpec = System.getProperty("os.arch", "?");
 
 			/* Get arch from spec string. */
-			if (archSpec.contains("aarch64")) {
+			if (archSpec.equals("aarch64")) {
 				return AARCH64;
-			} else if (archSpec.contains("ppc")) {
+			} else if (archSpec.startsWith("ppc")) {
 				return PPC;
-			} else if (archSpec.contains("s390")) {
+			} else if (archSpec.startsWith("s390")) {
 				return S390X;
-			} else if (archSpec.contains("amd64") || archSpec.contains("x86")) {
+			} else if (archSpec.equals("amd64") || archSpec.equals("x86")) {
 				return X86;
 			} else {
 				System.out.println("Runner couldn't determine underlying architecture. Got OS Arch:" + archSpec);

--- a/test/functional/cmdline_options_tester/src/Test.java
+++ b/test/functional/cmdline_options_tester/src/Test.java
@@ -97,7 +97,7 @@ class Test {
 	static final long CORE_SPACING_MILLIS = Long.getLong("cmdline.coreintervalms", 60 * 1000).longValue();
 
 	static final String archName = System.getProperty("os.arch");
-	static final boolean isRiscv = archName.toLowerCase().contains("riscv");
+	static final boolean isRiscv = archName.equals("riscv");
 	static final int javaVersion;
 
 	static {

--- a/test/functional/cmdline_options_tester/src/TestConfigParser.java
+++ b/test/functional/cmdline_options_tester/src/TestConfigParser.java
@@ -38,8 +38,6 @@ class TestConfigParser {
 	private boolean _debugCmdOnTimeout;
 	private String _modeHints;
 
-	private static final boolean isRiscv = System.getProperty("os.arch").toLowerCase().contains("riscv");
-
 	/**
 	 * If true, the test suite will print out the full output for each test case, regardless of whether
 	 * it passed or failed.
@@ -167,7 +165,7 @@ class TestConfigParser {
 						String timeout = attributes.get("timeout");
 
 						/* Set 16 hours (57600 secs) for timeout on RISC-V due to the lack of JIT. */
-						timeout = isRiscv ? "57600" : timeout;
+						timeout = Test.isRiscv ? "57600" : timeout;
 
 						_currentTest = new Test(id, timeout, _debugCmdOnTimeout);
 					} else {


### PR DESCRIPTION
Only anticipate values of these macro definitions in `omrport.h`:
* OMRPORT_ARCH_AARCH64 "aarch64"
* OMRPORT_ARCH_ARM     "arm"
* OMRPORT_ARCH_HAMMER  "amd64"
* OMRPORT_ARCH_PPC     "ppc"
* OMRPORT_ARCH_PPC64   "ppc64"
* OMRPORT_ARCH_PPC64LE "ppc64le"
* OMRPORT_ARCH_RISCV   "riscv"
* OMRPORT_ARCH_S390    "s390"
* OMRPORT_ARCH_S390X   "s390x"
* OMRPORT_ARCH_X86     "x86"

There is not need to:
* use `toLowerCase()` or `contains()`
* consider `x86_64` (will see `amd64` instead)
* check for `i386`, `i486`, etc.

Accessing a dump dataset should only be attempted on z/OS; that requires use of `os.name` instead of `os.arch`.