### PR TITLE
(0.60) Support large Zip files

### DIFF
--- a/runtime/cfdumper/main.c
+++ b/runtime/cfdumper/main.c
@@ -2519,16 +2519,16 @@ processAllFiles(char **files, U_32 flags)
 
 
 static I_32
-processAllInZIP(char* zipFilename, U_32 flags)
+processAllInZIP(char *zipFilename, U_32 flags)
 {
-	J9ROMClass* romClass = NULL;
-	J9CfrClassFile* classfile = NULL;
+	J9ROMClass *romClass = NULL;
+	J9CfrClassFile *classfile = NULL;
 	J9ZipFile zipFile;
 	J9ZipEntry entry;
-	U_8* dataBuffer = NULL;
+	U_8 *dataBuffer = NULL;
 	U_32 dataBufferSize = 1024;
-	I_32 result;
-	IDATA nextEntry;
+	I_32 result = 0;
+	U_64 nextEntry = 0;
 
 	PORT_ACCESS_FROM_PORT(portLib);
 

--- a/runtime/include/vmizip.h
+++ b/runtime/include/vmizip.h
@@ -67,10 +67,10 @@ typedef struct VMIZipEntry
   U_8 *filename;
   U_8 *extraField;
   U_8 *fileComment;
-  I_32 dataPointer;
-  I_32 filenamePointer;
-  I_32 extraFieldPointer;
-  I_32 fileCommentPointer;
+  U_64 dataPointer;
+  U_64 filenamePointer;
+  U_64 extraFieldPointer;
+  U_64 fileCommentPointer;
   U_32 compressedSize;
   U_32 uncompressedSize;
   U_32 crc32;
@@ -93,7 +93,7 @@ typedef struct VMIZipFile
   void *cache;
   void *cachePool;
   IDATA fd;
-  I_64 pointer;
+  U_64 pointer;
   U_8 internalFilename[80];
   U_8 type;
 } VMIZipFile;
@@ -101,17 +101,17 @@ typedef struct VMIZipFile
 typedef struct VMIZipFunctionTable {
 	I_32 (*zip_closeZipFile) (VMInterface * vmi, VMIZipFile * zipFile) ;
 	void (*zip_freeZipEntry) (VMInterface * vmi, VMIZipEntry * entry) ;
-	I_32 (*zip_getNextZipEntry) (VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * zipEntry, IDATA * nextEntryPointer, I_32 flags) ;
+	I_32 (*zip_getNextZipEntry) (VMInterface *vmi, VMIZipFile *zipFile, VMIZipEntry *zipEntry, U_64 *nextEntryPointer, I_32 flags) ;
 	I_32 (*zip_getZipEntry) (VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, const char *filename, I_32 flags) ;
 	I_32 (*zip_getZipEntryComment) (VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, U_8 * buffer, U_32 bufferSize) ;
 	I_32 (*zip_getZipEntryData) (VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, U_8 * buffer, U_32 bufferSize) ;
 	I_32 (*zip_getZipEntryExtraField) (VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, U_8 * buffer, U_32 bufferSize) ;
-	I_32 (*zip_getZipEntryFromOffset) (VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, IDATA offset, I_32 flags) ;
-	I_32 (*zip_getZipEntryRawData) (VMInterface * vm, VMIZipFile * zipFile, VMIZipEntry * entry, U_8 * buffer, U_32 bufferSize, U_32 offset) ;
+	I_32 (*zip_getZipEntryFromOffset) (VMInterface *vmi, VMIZipFile *zipFile, VMIZipEntry *entry, U_64 offset, I_32 flags) ;
+	I_32 (*zip_getZipEntryRawData) (VMInterface *vm, VMIZipFile *zipFile, VMIZipEntry *entry, U_8 *buffer, U_32 bufferSize, U_64 offset) ;
 	void (*zip_initZipEntry) (VMInterface * vmi, VMIZipEntry * entry) ;
 	I_32 (*zip_openZipFile) (VMInterface * vmi, char *filename, VMIZipFile * zipFile, I_32 flags) ;
-	void (*zip_resetZipFile) (VMInterface * vmi, VMIZipFile * zipFile, IDATA * nextEntryPointer) ;
-	IDATA (*zipCache_enumElement) (void *handle, char *nameBuf, UDATA nameBufSize, UDATA * offset) ;
+	void (*zip_resetZipFile) (VMInterface *vmi, VMIZipFile *zipFile, U_64 *nextEntryPointer) ;
+	IDATA (*zipCache_enumElement) (void *handle, char *nameBuf, UDATA nameBufSize, U_64 *offset) ;
 	IDATA (*zipCache_enumGetDirName) (void *handle, char *nameBuf, UDATA nameBufSize) ;
 	void (*zipCache_enumKill) (void *handle) ;
 	IDATA (*zipCache_enumNew) (void * zipCache, char *directoryName, void **handle) ;

--- a/runtime/include/zip_api.h
+++ b/runtime/include/zip_api.h
@@ -67,18 +67,18 @@ extern "C" {
 typedef struct J9ZipFunctionTable {
 	void (*zip_freeZipComment)(J9PortLibrary * portLib, U_8 * commentString);
 	void (*zip_freeZipEntry)(J9PortLibrary * portLib, J9ZipEntry * entry);
-	I_32 (*zip_getNextZipEntry)(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* zipEntry, IDATA* nextEntryPointer, BOOLEAN readDataPointer);
+	I_32 (*zip_getNextZipEntry)(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *zipEntry, U_64 *nextEntryPointer, BOOLEAN readDataPointer);
 	I_32 (*zip_getZipComment)(J9PortLibrary* portLib, J9ZipFile *zipFile, U_8 ** commentString, UDATA * commentLength);
 	I_32 (*zip_getZipEntry)(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry, const char *filename, IDATA fileNameLength, U_32 flags);
 	I_32 (*zip_getZipEntryComment)(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * entry, U_8 * buffer, U_32 bufferSize);
 	I_32 (*zip_getZipEntryData)(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entry, U_8* buffer, U_32 bufferSize);
 	I_32 (*zip_getZipEntryExtraField)(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entry, U_8* buffer, U_32 bufferSize);
-	I_32 (*zip_getZipEntryFromOffset)(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * entry, IDATA offset, BOOLEAN readDataPointer);
-	I_32 (*zip_getZipEntryRawData)(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entry, U_8* buffer, U_32 bufferSize, U_32 offset);
+	I_32 (*zip_getZipEntryFromOffset)(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * entry, U_64 offset, BOOLEAN readDataPointer);
+	I_32 (*zip_getZipEntryRawData)(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry, U_8 *buffer, U_32 bufferSize, U_64 offset);
 	void (*zip_initZipEntry)(J9PortLibrary* portLib, J9ZipEntry* entry);
 	I_32 (*zip_openZipFile)(J9PortLibrary *portLib, char *filename, J9ZipFile *zipFile, J9ZipCachePool *cachePool, U_32 flags);
 	I_32 (*zip_releaseZipFile)(J9PortLibrary* portLib, struct J9ZipFile* zipFile);
-	void (*zip_resetZipFile)(J9PortLibrary* portLib, J9ZipFile* zipFile, IDATA *nextEntryPointer);
+	void (*zip_resetZipFile)(J9PortLibrary *portLib, J9ZipFile *zipFile, U_64 *nextEntryPointer);
 } J9ZipFunctionTable;
 
 /* ---------------- zcpool.c ---------------- */
@@ -110,7 +110,8 @@ BOOLEAN zipCachePool_addRef(J9ZipCachePool *zcp, J9ZipCache *zipCache);
 * @param zipTimeStamp
 * @return J9ZipCache *
 */
-J9ZipCache * zipCachePool_findCache(J9ZipCachePool *zcp, char const *zipFileName, IDATA zipFileNameLength, IDATA zipFileSize, I_64 zipTimeStamp);
+J9ZipCache *
+zipCachePool_findCache(J9ZipCachePool *zcp, char const *zipFileName, IDATA zipFileNameLength, I_64 zipFileSize, I_64 zipTimeStamp);
 
 
 /**
@@ -179,7 +180,7 @@ void zfree(void* opaque, void* address);
 * @return BOOLEAN
 */
 BOOLEAN 
-zipCache_addElement(J9ZipCache * zipCache, char *elementName, IDATA elementNameLength, UDATA elementOffset);
+zipCache_addElement(J9ZipCache *zipCache, char *elementName, IDATA elementNameLength, U_64 elementOffset);
 
 
 /**
@@ -191,7 +192,7 @@ zipCache_addElement(J9ZipCache * zipCache, char *elementName, IDATA elementNameL
 * @return IDATA
 */
 IDATA 
-zipCache_enumElement(void *handle, char *nameBuf, UDATA nameBufSize, UDATA * offset);
+zipCache_enumElement(void *handle, char *nameBuf, UDATA nameBufSize, U_64 *offset);
 
 
 /**
@@ -231,9 +232,9 @@ zipCache_enumNew(J9ZipCache * zipCache, char *directoryName, void **handle);
 * @param *elementName
 * @param elementNameLength
 * @param searchDirList
-* @return UDATA
+* @return U_64
 */
-UDATA 
+U_64
 zipCache_findElement(J9ZipCache * zipCache, const char *elementName, IDATA elementNameLength, BOOLEAN searchDirList);
 
 
@@ -256,7 +257,7 @@ zipCache_kill(J9ZipCache * zipCache);
 * @return J9ZipCache *
 */
 J9ZipCache *
-zipCache_new(J9PortLibrary * portLib, char *zipName, IDATA zipNameLength, IDATA zipFileSize, I_64 zipTimeStamp);
+zipCache_new(J9PortLibrary *portLib, char *zipName, IDATA zipNameLength, I_64 zipFileSize, I_64 zipTimeStamp);
 
 
 /**
@@ -264,7 +265,8 @@ zipCache_new(J9PortLibrary * portLib, char *zipName, IDATA zipNameLength, IDATA 
 * @param zipCache
 * @param startCentralDir
 */
-void zipCache_setStartCentralDir(J9ZipCache * zipCache, IDATA startCentralDir);
+void
+zipCache_setStartCentralDir(J9ZipCache *zipCache, U_64 startCentralDir);
 
 
 /**
@@ -404,7 +406,7 @@ zip_freeZipEntry(J9PortLibrary * portLib, J9ZipEntry * entry);
 * @return I_32
 */
 I_32 
-zip_getNextZipEntry(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* zipEntry, IDATA* nextEntryPointer, BOOLEAN readDataPointer);
+zip_getNextZipEntry(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *zipEntry, U_64 *nextEntryPointer, BOOLEAN readDataPointer);
 
 
 /**
@@ -478,7 +480,7 @@ zip_getZipEntryData(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entr
 * @return I_32
 */
 I_32 
-zip_getZipEntryRawData(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entry, U_8* buffer, U_32 bufferSize, U_32 offset);
+zip_getZipEntryRawData(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry, U_8 *buffer, U_32 bufferSize, U_64 offset);
 
 
 /**
@@ -504,7 +506,7 @@ zip_getZipEntryExtraField(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry
 * @return I_32
 */
 I_32 
-zip_getZipEntryFromOffset(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * entry, IDATA offset, BOOLEAN readDataPointer);
+zip_getZipEntryFromOffset(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry, U_64 offset, BOOLEAN readDataPointer);
 
 
 /**
@@ -564,7 +566,7 @@ zip_openZipFile(J9PortLibrary *portLib, char *filename, J9ZipFile *zipFile, J9Zi
 * @return void
 */
 void 
-zip_resetZipFile(J9PortLibrary* portLib, J9ZipFile* zipFile, IDATA *nextEntryPointer);
+zip_resetZipFile(J9PortLibrary *portLib, J9ZipFile *zipFile, U_64 *nextEntryPointer);
 
 
 void

--- a/runtime/include/zipsup.h
+++ b/runtime/include/zipsup.h
@@ -41,6 +41,9 @@ extern "C" {
 
 #include "j9port.h"
 
+/* Allow DDR to distinguish dumps from older ones that predate 64-bit support. */
+#define ZIP64_SUPPORT 1
+
 typedef struct J9ZipCachePool J9ZipCachePool;
 
 #define J9WSRP IDATA
@@ -85,18 +88,9 @@ typedef struct J9ZipCentralEnd {
     U_16 diskNumber;
     U_16 dirStartDisk;
     U_16 thisDiskEntries;
-#if defined(J9VM_ENV_DATA64)
-    /* entries in the central dir <= INT32_MAX */
-    I_32 totalEntries;
-    /* size of the central dir <= LLONG_MAX */
-    I_64 dirSize;
-    /* offset of the central dir <= LLONG_MAX */
-    I_64 dirOffset;
-#else /* defined(J9VM_ENV_DATA64) */
-    U_16 totalEntries;
-    U_32 dirSize;
-    U_32 dirOffset;
-#endif /* defined(J9VM_ENV_DATA64) */
+    U_32 totalEntries; /**< entries in the central dir <= INT32_MAX */
+    U_64 dirSize; /**< size of the central dir <= INT64_MAX */
+    U_64 dirOffset; /**< offset of the central dir <= INT64_MAX */
     U_16 commentLength;
     U_8* comment;
     U_64 endCentralDirRecordPosition;
@@ -107,10 +101,10 @@ typedef struct J9ZipEntry {
     U_8* filename;
     U_8* extraField;
     U_8* fileComment;
-    U_32 dataPointer;
-    U_32 filenamePointer;
-    U_32 extraFieldPointer;
-    I_32 fileCommentPointer;
+    U_64 dataPointer;
+    U_64 filenamePointer;
+    U_64 extraFieldPointer;
+    U_64 fileCommentPointer;
     U_32 compressedSize;
     U_32 uncompressedSize;
     U_32 crc32;
@@ -132,7 +126,7 @@ typedef struct J9ZipFile {
     struct J9ZipCache* cache;
     void* cachePool;
     IDATA fd;
-    I_64 pointer;
+    U_64 pointer;
     U_8 internalFilename[80];
     U_8 type;
 } J9ZipFile;
@@ -147,7 +141,7 @@ typedef struct J9ZipChunkHeader {
 
 typedef struct J9ZipFileEntry {
     UDATA nameLength;
-    UDATA zipFileOffset;
+    U_64 zipFileOffset;
 } J9ZipFileEntry;
 
 typedef struct J9ZipFileRecord {
@@ -162,7 +156,7 @@ typedef struct J9ZipDirEntry {
     J9WSRP next;
     J9WSRP fileList;
     J9WSRP dirList;
-    UDATA zipFileOffset;
+    U_64 zipFileOffset;
 } J9ZipDirEntry;
 
 #define J9ZIPDIRENTRY_NEXT(base) WSRP_GET((base)->next, struct J9ZipDirEntry*)
@@ -171,9 +165,9 @@ typedef struct J9ZipDirEntry {
 
 typedef struct J9ZipCacheEntry {
     J9WSRP zipFileName;
-    IDATA zipFileSize;
+    I_64 zipFileSize;
     I_64 zipTimeStamp;
-    IDATA startCentralDir;
+    I_64 startCentralDir; /**< should be U_64 (due to DDR limitation), read/write will use U_64 */
     J9WSRP currentChunk;
     J9WSRP chunkActiveDir;
     struct J9ZipDirEntry root;

--- a/runtime/vm/vmizip.c
+++ b/runtime/vm/vmizip.c
@@ -37,7 +37,7 @@
 #define EXIT()
 #endif
 
-I_32 
+I_32
 vmizip_getZipEntryData(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, U_8 * buffer, U_32 bufferSize) 
 {
 	J9VMInterface* j9vmi = (J9VMInterface*)vmi;
@@ -45,16 +45,16 @@ vmizip_getZipEntryData(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * en
 	return zip_getZipEntryData(PORTLIB, (J9ZipFile *)zipFile, (J9ZipEntry *)entry, buffer, bufferSize);
 }
 
-I_32 
-vmizip_getZipEntryRawData(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, U_8 * buffer, U_32 bufferSize, U_32 offset) 
+I_32
+vmizip_getZipEntryRawData(VMInterface *vmi, VMIZipFile *zipFile, VMIZipEntry *entry, U_8 *buffer, U_32 bufferSize, U_64 offset)
 {
-	J9VMInterface* j9vmi = (J9VMInterface*)vmi;
+	J9VMInterface *j9vmi = (J9VMInterface *)vmi;
 	PORT_ACCESS_FROM_JAVAVM(j9vmi->javaVM);
 	return zip_getZipEntryRawData(PORTLIB, (J9ZipFile *)zipFile, (J9ZipEntry *)entry, buffer, bufferSize, offset);
 }
 
 I_32
-vmizip_getZipEntryFromOffset(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, IDATA offset, I_32 flags) 
+vmizip_getZipEntryFromOffset(VMInterface *vmi, VMIZipFile *zipFile, VMIZipEntry *entry, U_64 offset, I_32 flags)
 {
 	J9VMInterface* j9vmi = (J9VMInterface*)vmi;
 	PORT_ACCESS_FROM_JAVAVM(j9vmi->javaVM);
@@ -62,22 +62,22 @@ vmizip_getZipEntryFromOffset(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntr
 }
 
 void
-vmizip_resetZipFile(VMInterface * vmi, VMIZipFile * zipFile, IDATA * nextEntryPointer)
+vmizip_resetZipFile(VMInterface *vmi, VMIZipFile *zipFile, U_64 *nextEntryPointer)
 {
 	J9VMInterface* j9vmi = (J9VMInterface*)vmi;
 	PORT_ACCESS_FROM_JAVAVM(j9vmi->javaVM);
 	zip_resetZipFile(PORTLIB, (J9ZipFile *)zipFile, nextEntryPointer);
 }
 
-I_32 
-vmizip_getNextZipEntry(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * zipEntry, IDATA * nextEntryPointer, I_32 flags)
+I_32
+vmizip_getNextZipEntry(VMInterface *vmi, VMIZipFile *zipFile, VMIZipEntry *zipEntry, U_64 *nextEntryPointer, I_32 flags)
 {
 	J9VMInterface* j9vmi = (J9VMInterface*)vmi;
 	PORT_ACCESS_FROM_JAVAVM(j9vmi->javaVM);
 	return zip_getNextZipEntry(PORTLIB, (J9ZipFile *)zipFile, (J9ZipEntry *)zipEntry, nextEntryPointer, (BOOLEAN)((flags & (I_32)ZIP_FLAG_READ_DATA_POINTER) != 0));
 }
 
-I_32 
+I_32
 vmizip_getZipEntry(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, const char *filename, I_32 flags)
 {
 	J9VMInterface* j9vmi = (J9VMInterface*)vmi;
@@ -107,7 +107,7 @@ vmizip_getZipEntryWithSize(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry 
 	return zip_getZipEntry(PORTLIB, (J9ZipFile *) zipFile, (J9ZipEntry *) entry, filename, filenameLength, zipEntryFlags);
 }
 
-I_32 
+I_32
 vmizip_getZipEntryExtraField(VMInterface * vmi, VMIZipFile * zipFile, VMIZipEntry * entry, U_8 * buffer, U_32 bufferSize)
 {
 	J9VMInterface* j9vmi = (J9VMInterface*)vmi;
@@ -308,9 +308,9 @@ vmizipCache_enumNew(void * zipCache, char *directoryName, void **handle)
 {
 	return zipCache_enumNew((J9ZipCache *)zipCache, directoryName, handle);
 }
-	
-IDATA 
-vmizipCache_enumElement(void *handle, char *nameBuf, UDATA nameBufSize, UDATA * offset)
+
+IDATA
+vmizipCache_enumElement(void *handle, char *nameBuf, UDATA nameBufSize, U_64 *offset)
 {
 	return zipCache_enumElement(handle, nameBuf, nameBufSize, offset);
 }

--- a/runtime/zip/zcpool.c
+++ b/runtime/zip/zcpool.c
@@ -128,8 +128,8 @@ BOOLEAN zipCachePool_addRef(J9ZipCachePool *zcp, J9ZipCache *zipCache)
  * @return the matching zip cache
  * @return NULL if no match is found.
  */
-
-J9ZipCache * zipCachePool_findCache(J9ZipCachePool *zcp, char const *zipFileName, IDATA zipFileNameLength, IDATA zipFileSize, I_64 zipTimeStamp)
+J9ZipCache *
+zipCachePool_findCache(J9ZipCachePool *zcp, char const *zipFileName, IDATA zipFileNameLength, I_64 zipFileSize, I_64 zipTimeStamp)
 {
 	J9ZipCache *zipCache;
 	J9ZipCachePoolEntry *entry;

--- a/runtime/zip/zip_internal.h
+++ b/runtime/zip/zip_internal.h
@@ -76,7 +76,7 @@ struct J9ZipCachePool  {
 	I_64 zipTimeStamp;
 	char const *zipFileName;
 	IDATA zipFileNameLength;
-	IDATA zipFileSize;
+	I_64 zipFileSize;
 	MUTEX mutex;
 	IDATA hookInitRC;
 	void* userData;
@@ -148,16 +148,16 @@ typedef struct J9ZipCacheTraversal {
 * @return BOOLEAN
 */
 BOOLEAN 
-zipCache_isSameZipFile(J9ZipCache * zipCache, IDATA zipTimeStamp, IDATA zipFileSize, const char *zipFileName, IDATA zipFileNameLength);
+zipCache_isSameZipFile(J9ZipCache *zipCache, IDATA zipTimeStamp, I_64 zipFileSize, const char *zipFileName, IDATA zipFileNameLength);
 
 
 /**
 * @brief
 * @param zipCache
-* @return IDATA
+* @return U_64
 */
-IDATA 
-zipCache_getStartCentralDir(J9ZipCache * zipCache);
+U_64
+zipCache_getStartCentralDir(J9ZipCache *zipCache);
 
 
 /**

--- a/runtime/zip/zipcache.c
+++ b/runtime/zip/zipcache.c
@@ -47,17 +47,15 @@
  */
 #define ZIP_CACHE_VERSION 1
 
-#define UDATA_TOP_BIT    (((UDATA)1)<<(sizeof(UDATA)*8-1))
-#define ISCLASS_BIT    UDATA_TOP_BIT
-#define NOT_FOUND	((UDATA) (~0))
-#define OFFSET_MASK	(~ISCLASS_BIT)
-#define	IMPLICIT_ENTRY	(~ISCLASS_BIT)
-
+#define ISCLASS_BIT (((U_64)1) << ((sizeof(U_64) * 8) - 1))
+#define NOT_FOUND (~(U_64)0)
+#define OFFSET_MASK (~ISCLASS_BIT)
+#define IMPLICIT_ENTRY (~ISCLASS_BIT)
 
 void zipCache_freeChunk (J9PortLibrary * portLib, J9ZipChunkHeader *chunk);
 J9ZipDirEntry *zipCache_searchDirListCaseInsensitive (J9ZipDirEntry * dirEntry, const char *namePtr, UDATA nameSize, BOOLEAN isClass);
 J9ZipChunkHeader *zipCache_allocateChunk (J9PortLibrary * portLib);
-J9ZipFileEntry *zipCache_addToFileList (J9PortLibrary * portLib, J9ZipCacheEntry * zce, J9ZipDirEntry * dirEntry, const char *namePtr, IDATA nameSize, BOOLEAN isClass, UDATA elementOffset);
+J9ZipFileEntry *zipCache_addToFileList (J9PortLibrary *portLib, J9ZipCacheEntry *zce, J9ZipDirEntry *dirEntry, const char *namePtr, IDATA nameSize, BOOLEAN isClass, U_64 elementOffset);
 static UDATA *zipCache_reserveEntry (J9ZipCacheEntry *zce, J9ZipChunkHeader * chunk, UDATA entryBytes, UDATA stringBytes, char **namePtrOut);
 J9ZipFileEntry *zipCache_searchFileList (J9ZipDirEntry * dirEntry, const char *namePtr, UDATA nameSize, BOOLEAN isClass);
 J9ZipDirEntry *zipCache_addToDirList (J9PortLibrary * portLib, J9ZipCacheEntry * zce, J9ZipDirEntry * dirEntry,const char *namePtr, IDATA nameSize, BOOLEAN isClass);
@@ -91,10 +89,9 @@ void zipCache_walkCache(J9PortLibrary * portLib, J9ZipCacheEntry *zce, J9ZipDirE
  * @param[in] zipNameLength
  *
  * @return the new zip cache if one was successfully created, NULL otherwise
- *
-*/
-
-J9ZipCache *zipCache_new(J9PortLibrary * portLib, char *zipName, IDATA zipNameLength, IDATA zipFileSize, I_64 zipTimeStamp)
+ */
+J9ZipCache *
+zipCache_new(J9PortLibrary *portLib, char *zipName, IDATA zipNameLength, I_64 zipFileSize, I_64 zipTimeStamp)
 {
 	J9ZipChunkHeader *chunk;
 	J9ZipCacheInternal *zci;
@@ -155,11 +152,12 @@ J9ZipCache *zipCache_new(J9PortLibrary * portLib, char *zipName, IDATA zipNameLe
  * @param[in] zipCache the zip cache to modify
  * @param[in] startCentralDir the offset to the central dir in the zip file
 */
-void zipCache_setStartCentralDir(J9ZipCache * zipCache, IDATA startCentralDir)
+void
+zipCache_setStartCentralDir(J9ZipCache *zipCache, U_64 startCentralDir)
 {
 	J9ZipCacheInternal *zci = (J9ZipCacheInternal *)zipCache;
 	J9ZipCacheEntry *zce = zci->entry;
-	zce->startCentralDir = startCentralDir;
+	zce->startCentralDir = (I_64)startCentralDir;
 }
 
 
@@ -437,7 +435,9 @@ BOOLEAN zipCache_isCopied(J9ZipCache * zipCache) {
  * 
  * @return TRUE if the parameters match this zip cache
  */
-BOOLEAN zipCache_isSameZipFile(J9ZipCache * zipCache, IDATA zipTimeStamp, IDATA zipFileSize, const char *zipFileName, IDATA zipFileNameLength) {
+BOOLEAN
+zipCache_isSameZipFile(J9ZipCache *zipCache, IDATA zipTimeStamp, I_64 zipFileSize, const char *zipFileName, IDATA zipFileNameLength)
+{
 	J9ZipCacheInternal *zci = (J9ZipCacheInternal *)zipCache;
 	J9ZipCacheEntry *zce = zci->entry;
 	const char *localZipFileName;
@@ -472,10 +472,12 @@ BOOLEAN zipCache_isSameZipFile(J9ZipCache * zipCache, IDATA zipTimeStamp, IDATA 
  * 
  * @return the startCentralDir of the cache
  */
-IDATA zipCache_getStartCentralDir(J9ZipCache *zipCache) {
+U_64
+zipCache_getStartCentralDir(J9ZipCache *zipCache)
+{
 	J9ZipCacheInternal *zci = (J9ZipCacheInternal *)zipCache;
 	J9ZipCacheEntry *zce = zci->entry;
-	return zce->startCentralDir;
+	return (U_64)zce->startCentralDir;
 }
 
 
@@ -550,7 +552,7 @@ J9ZipDirEntry *zipCache_copyDirEntry(J9ZipCacheEntry *orgzce, J9ZipDirEntry *org
 */
 
 BOOLEAN 
-zipCache_addElement(J9ZipCache * zipCache, char *elementName, IDATA elementNameLength, UDATA elementOffset)
+zipCache_addElement(J9ZipCache *zipCache, char *elementName, IDATA elementNameLength, U_64 elementOffset)
 {
 	J9PortLibrary * portLib = zipCache->portLib;
 	J9ZipCacheInternal *zci = (J9ZipCacheInternal *)zipCache;
@@ -646,7 +648,7 @@ zipCache_addElement(J9ZipCache * zipCache, char *elementName, IDATA elementNameL
  * @return -1 if no element of that name has been explicitly added to the cache.
  *
 */
-UDATA
+U_64
 zipCache_findElement(J9ZipCache * zipCache, const char *elementName, IDATA elementNameLength, BOOLEAN searchDirList)
 {
 	J9ZipCacheInternal *zci = (J9ZipCacheInternal *)zipCache;
@@ -821,14 +823,15 @@ J9ZipDirEntry *zipCache_addToDirList(J9PortLibrary * portLib, J9ZipCacheEntry *z
 /* If possible, the new file entry will be appended to the active zipFileRecord. */
 /* Otherwise, a new zipFileRecord will be allocated to hold the new zipFileEntry. */
 
-J9ZipFileEntry *zipCache_addToFileList(J9PortLibrary *portLib, J9ZipCacheEntry *zce, J9ZipDirEntry * dirEntry, const char *namePtr, IDATA nameSize,
-									 BOOLEAN isClass, UDATA elementOffset)
+J9ZipFileEntry *
+zipCache_addToFileList(J9PortLibrary *portLib, J9ZipCacheEntry *zce, J9ZipDirEntry *dirEntry,
+		const char *namePtr, IDATA nameSize, BOOLEAN isClass, U_64 elementOffset)
 {
-	J9ZipFileEntry *entry;
-	J9ZipFileRecord *record;
+	J9ZipFileEntry *entry = NULL;
+	J9ZipFileRecord *record = NULL;
 	J9ZipChunkHeader *chunk = ZIP_SRP_GET(zce->currentChunk, J9ZipChunkHeader *);
 	J9ZipDirEntry *chunkActiveDir = ZIP_SRP_GET(zce->chunkActiveDir, J9ZipDirEntry *);
-	char *name;
+	char *name = NULL;
 
 	if (chunkActiveDir == dirEntry) {
 		entry = (J9ZipFileEntry *) zipCache_reserveEntry(zce, chunk, sizeof(*entry), nameSize, &name);
@@ -1111,9 +1114,9 @@ IDATA zipCache_enumNew(J9ZipCache * zipCache, char *directoryName, void **handle
  * @return the required size of nameBuf if nameBufSize is insufficient to hold the entire name (does not skip the element)
  *
  * @see zipCache_enumNew
-*
-*/
-IDATA zipCache_enumElement(void *handle, char *nameBuf, UDATA nameBufSize, UDATA * offset)
+ */
+IDATA
+zipCache_enumElement(void *handle, char *nameBuf, UDATA nameBufSize, U_64 *offset)
 {
 	J9ZipCacheTraversal *traversal = (J9ZipCacheTraversal *) handle;
 	J9ZipCacheInternal *zci = (J9ZipCacheInternal *)traversal->zipCache;

--- a/runtime/zip/zipsup.c
+++ b/runtime/zip/zipsup.c
@@ -89,18 +89,18 @@ struct workBuffer {
 	UDATA cntr;
 };
 
-static I_32 zip_populateCache (J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipCentralEnd *endEntry, IDATA startCentralDir);
+static I_32 zip_populateCache (J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd *endEntry, U_64 startCentralDir);
 static I_32 inflateData (struct workBuffer* workBuf, U_8* inputBuffer, U_32 inputBufferSize, U_8* outputBuffer, U_32 outputBufferSize);
 I_32 scanForDataDescriptor (J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipEntry* zipEntry);
 void zdatafree (void* opaque, void* address);
 static I_32 readZipEntry (J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *zipEntry,
-		const char *filename, IDATA filenameLength, IDATA *enumerationPointer, IDATA *entryStart, BOOLEAN findDirectory, BOOLEAN readDataPointer);
+		const char *filename, IDATA filenameLength, U_64 *enumerationPointer, U_64 *entryStart, BOOLEAN findDirectory, BOOLEAN readDataPointer);
 I_32 scanForCentralEnd (J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipCentralEnd* endEntry);
 void* zdataalloc (void* opaque, U_32 items, U_32 size);
 static I_32 getZipEntryUsingDirectory(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry,
 		const char *fileName, IDATA fileNameLength, BOOLEAN readDataPointer);
 static BOOLEAN isSeekFailure(I_64 seekResult, I_64 expectedValue);
-static BOOLEAN isOutside4Gig(I_64 value);
+static BOOLEAN isUnsupported(I_64 value);
 
 #if defined(J9VM_THR_PREEMPTIVE)
 #include "omrthread.h"
@@ -199,21 +199,23 @@ openFailed:
 /**
  * @param seekResult actual result of the seek
  * @param expectedValue expected seek result
- * @return true if seekResult is negative or larger than the maximum U_32 positive value or does not match the expected position
+ * @return true if seekResult is too big or does not match the expected position
  */
 static VMINLINE BOOLEAN
-isSeekFailure(I_64 seekResult, I_64 expectedValue) {
-	return isOutside4Gig(seekResult) || (seekResult != expectedValue);
+isSeekFailure(I_64 seekResult, I_64 expectedValue)
+{
+	return isUnsupported(seekResult) || (seekResult != expectedValue);
 }
 
 /**
  * @param value value to test
  * @param expectedValue expected seek result
- * @return true if seekResult is negative or larger than the maximum U_32 positive value
+ * @return true if seekResult is too big
  */
 static VMINLINE BOOLEAN
-isOutside4Gig(I_64 value) {
-	return (value < 0) || (value > UINT32_MAX);
+isUnsupported(I_64 value)
+{
+	return value < 0;
 }
 
 /*
@@ -293,7 +295,7 @@ static I_32 inflateData(struct workBuffer* workBuf, U_8* inputBuffer, U_32 input
  			    ZIP_ERR_OUT_OF_MEMORY if can't allocate memory
 */
 I_32
-zip_getZipComment(J9PortLibrary* portLib, J9ZipFile *zipFile, U_8 ** commentString, UDATA * commentLength)
+zip_getZipComment(J9PortLibrary *portLib, J9ZipFile *zipFile, U_8 **commentString, UDATA *commentLength)
 {
 	U_8 *current;
 	U_8 buffer[SCAN_CHUNK_SIZE + MIN_ZIPFILE_SIZE];
@@ -314,14 +316,14 @@ zip_getZipComment(J9PortLibrary* portLib, J9ZipFile *zipFile, U_8 ** commentStri
 	*commentString = NULL;
 	*commentLength = 0;
 	seekResult = j9file_seek(zipFile->fd, 0, EsSeekEnd);
-	if (isOutside4Gig(seekResult)) {
+	if (isUnsupported(seekResult)) {
 		zipFile->pointer = -1;
 		EXIT();
 		return ZIP_ERR_FILE_READ_ERROR;
 	}
 	fileSize = seekResult;
-	zipFile->pointer = (U_32) fileSize;
-	while (TRUE)  {
+	zipFile->pointer = fileSize;
+	while (TRUE) {
 		I_64 size = 0;
 		I_64 i = 0;
 		/* Fill the buffer. */
@@ -343,13 +345,13 @@ zip_getZipComment(J9PortLibrary* portLib, J9ZipFile *zipFile, U_8 ** commentStri
 		}
 		bytesAlreadyRead += size;
 		seekResult = j9file_seek(zipFile->fd, fileSize-bytesAlreadyRead, EsSeekSet);
-		if (isOutside4Gig(seekResult)) {
+		if (isUnsupported(seekResult)) {
 			zipFile->pointer = -1;
 			EXIT();
 			return ZIP_ERR_FILE_READ_ERROR;
 		}
-		zipFile->pointer = (U_32) seekResult;
-		if(readFromEnd == FALSE) {
+		zipFile->pointer = seekResult;
+		if (!readFromEnd) {
 			/* First scan of SCAN_CHUNK_SIZE should find ECDR
 			 * if not then zipfile comment starts near 1k*n boundary
 			 * where n is 1..64 (one eg is comment size of 1003 bytes),
@@ -367,7 +369,7 @@ zip_getZipComment(J9PortLibrary* portLib, J9ZipFile *zipFile, U_8 ** commentStri
 			EXIT();
 			return ZIP_ERR_FILE_READ_ERROR;
 		}
-		zipFile->pointer += (U_32) size;
+		zipFile->pointer += size;
 		dataSize = 0;
 		/* Scan the buffer (backwards) for CentralEnd signature = PK^E^F. */
 		for (i = size; i--; dataSize++, commentOffsetFromEnd++)
@@ -432,7 +434,7 @@ zip_getZipComment(J9PortLibrary* portLib, J9ZipFile *zipFile, U_8 ** commentStri
 								/* Buffer may not be able to hold complete comment string, so get it from file */
 								zipFile->pointer =  zipFile->pointer - dataSize + ZIPFILE_COMMENT_OFFSET;
 								seekResult = j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
-								if (isOutside4Gig(seekResult)) {
+								if (isUnsupported(seekResult)) {
 									zipFile->pointer = -1;
 									j9mem_free_memory(*commentString);
 									EXIT();
@@ -501,12 +503,12 @@ zip_freeZipComment(J9PortLibrary * portLib, U_8 * commentString)
 I_32
 scanForZipCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd *endEntry)
 {
-	U_8 *current;
+	U_8 *current = NULL;
 	U_8 buffer[SCAN_CHUNK_SIZE + MIN_ZIPFILE_SIZE];
 	I_32 state = 0;
 	I_64 size = 0;
 	U_32 dataSize = 0;
-	I_64 seekResult;
+	I_64 seekResult = 0;
 	I_64 fileSize = 0;
 	I_64 bytesAlreadyRead = 0;
 	BOOLEAN readFromEnd = TRUE;
@@ -515,17 +517,17 @@ scanForZipCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	seekResult = j9file_seek(zipFile->fd, 0, EsSeekEnd);
-	if (isOutside4Gig(seekResult)) {
+	if (isUnsupported(seekResult)) {
 		zipFile->pointer = -1;
 		return ZIP_ERR_FILE_READ_ERROR;
 	}
 	fileSize = seekResult;
-	zipFile->pointer = (U_32) fileSize;
+	zipFile->pointer = fileSize;
 
-	while(TRUE)  {
-		I_64 i;
+	while (TRUE) {
+		I_64 i = 0;
 		/* Fill the buffer. */
-		if (bytesAlreadyRead == fileSize)  {
+		if (bytesAlreadyRead == fileSize) {
 			zipFile->pointer = -1;
 			return ZIP_ERR_FILE_CORRUPT;
 		}
@@ -536,12 +538,12 @@ scanForZipCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd
 		}
 		bytesAlreadyRead += size;
 		seekResult = j9file_seek(zipFile->fd, fileSize-bytesAlreadyRead, EsSeekSet);
-		if (isOutside4Gig(seekResult)) {
+		if (isUnsupported(seekResult)) {
 			zipFile->pointer = -1;
 			return ZIP_ERR_FILE_READ_ERROR;
 		}
-		zipFile->pointer = (U_32)seekResult;
-		if(readFromEnd == FALSE) {
+		zipFile->pointer = seekResult;
+		if (!readFromEnd) {
 			/* First scan of SCAN_CHUNK_SIZE should find ECDR
 			 * if not then zipfile comments are greater than 1002 bytes,
 			 * so read 22(size of ECDR) more bytes in 2nd and later scans
@@ -555,7 +557,7 @@ scanForZipCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd
 				zipFile->pointer = -1;
 				return ZIP_ERR_FILE_READ_ERROR;
 		}
-		zipFile->pointer += (U_32) size;
+		zipFile->pointer += size;
 
 		/* Scan the buffer (backwards) for CentralEnd signature = PK^E^F. */
 		for (i = size; i--; dataSize++)
@@ -610,7 +612,6 @@ scanForZipCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd
 	}
 }
 
-#if defined(J9VM_ENV_DATA64)
 /**
  * Read ZIP64 central end header, update the J9ZipCentralEnd provided.
  *
@@ -629,26 +630,26 @@ readZip64CentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd 
 	U_8 buffer[ZIP64_EOCD_SIZE];
 	I_64 seekResult = -1;
 	U_8 *current = NULL;
-	I_64 totalEntries = -1;
-	I_64 dirSize = -1;
-	I_64 dirOffset = -1;
+	U_64 totalEntries = -1;
+	U_64 dirSize = -1;
+	U_64 dirOffset = -1;
 
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	seekResult = j9file_seek(zipFile->fd, endEntry->endCentralDirRecordPosition, EsSeekSet);
 	/* The size limit should be removed by the issue https://github.com/eclipse-openj9/openj9/issues/23441 */
-	if (isOutside4Gig(seekResult)) {
+	if (isUnsupported(seekResult)) {
 		zipFile->pointer = -1;
 		return ZIP_ERR_FILE_READ_ERROR;
 	}
-	zipFile->pointer = (U_32) seekResult;
+	zipFile->pointer = seekResult;
 	if (ZIP64_EOCD_SIZE != j9file_read( zipFile->fd, buffer, ZIP64_EOCD_SIZE)) {
 		zipFile->pointer = -1;
 		return ZIP_ERR_FILE_READ_ERROR;
 	}
 	zipFile->pointer += ZIP64_EOCD_SIZE;
 
-	if (('P' != buffer[0]) || ('K' != buffer[1]) || 6 != buffer[2] || 6 != buffer[3]) {
+	if (('P' != buffer[0]) || ('K' != buffer[1]) || (6 != buffer[2]) || (6 != buffer[3])) {
 		zipFile->pointer = -1;
 		return ZIP_ERR_FILE_CORRUPT;
 	}
@@ -657,11 +658,11 @@ readZip64CentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd 
 	ZIP_NEXT_U64(totalEntries, current);
 	ZIP_NEXT_U64(dirSize, current);
 	ZIP_NEXT_U64(dirOffset, current);
-	if ((totalEntries < 0) || (dirSize < 0) || (dirOffset < 0) || (totalEntries > INT32_MAX)) {
+	if ((dirSize > INT64_MAX) || (dirOffset > INT64_MAX) || (totalEntries > INT32_MAX)) {
 		zipFile->pointer = -1;
 		return ZIP_ERR_FILE_TOO_BIG;
 	}
-	endEntry->totalEntries = (I_32)totalEntries;
+	endEntry->totalEntries = (U_32)totalEntries;
 	endEntry->dirSize = dirSize;
 	endEntry->dirOffset = dirOffset;
 
@@ -689,11 +690,11 @@ scanForZip64CentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralE
 	U_8 *current = NULL;
 
 	seekResult = j9file_seek(zipFile->fd, endEntry->endCentralDirRecordPosition - ZIP64_EOCD_LOCATOR_SIZE, EsSeekSet);
-	if (isOutside4Gig(seekResult)) {
+	if (isUnsupported(seekResult)) {
 		zipFile->pointer = -1;
 		return ZIP_ERR_FILE_READ_ERROR;
 	}
-	zipFile->pointer = (U_32) seekResult;
+	zipFile->pointer = seekResult;
 	if (ZIP64_EOCD_LOCATOR_SIZE != j9file_read( zipFile->fd, buffer, ZIP64_EOCD_LOCATOR_SIZE)) {
 		zipFile->pointer = -1;
 		return ZIP_ERR_FILE_READ_ERROR;
@@ -707,7 +708,6 @@ scanForZip64CentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralE
 	ZIP_NEXT_U64(endEntry->endCentralDirRecordPosition, current);
 	return readZip64CentralEnd(portLib, zipFile, endEntry);
 }
-#endif /* defined(J9VM_ENV_DATA64) */
 
 /**
  * Scan ZIP or ZIP64 central end headers. Read from zipFile and update the J9ZipCentralEnd provided.
@@ -729,7 +729,6 @@ scanForCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd *e
 		return result;
 	}
 
-#if defined(J9VM_ENV_DATA64)
 	/* Scan for ZIP64 central end header(if present). */
 	if ((UINT32_MAX == endEntry->dirOffset) || (UINT32_MAX == endEntry->dirSize) || (UINT16_MAX == endEntry->totalEntries)) {
 		result = scanForZip64CentralEnd(portLib, zipFile, endEntry);
@@ -737,7 +736,6 @@ scanForCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd *e
 			return result;
 		}
 	}
-#endif /* defined(J9VM_ENV_DATA64) */
 
 	return result;
 }
@@ -751,18 +749,18 @@ scanForCentralEnd(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd *e
 */
 I_32 scanForDataDescriptor(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipEntry* zipEntry)
 {
-	U_8 *current;
-	U_8 buffer[SCAN_CHUNK_SIZE], descriptor[16];
+	U_8 *current = NULL;
+	U_8 buffer[SCAN_CHUNK_SIZE];
+	U_8 descriptor[16];
 	I_32 state = 0;
-	U_32 dataSize, blockPointer;
-	I_64 seekResult;
+	U_64 dataSize = 0;
+	U_64 blockPointer = 0;
+	I_64 seekResult = 0;
 
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	/* Skip ahead and read the data descriptor. The compressed size should be 0. */
-	if (zipFile->pointer != (IDATA)(zipEntry->dataPointer + zipEntry->compressedSize))  {
-		zipFile->pointer = (U_32) zipEntry->dataPointer + zipEntry->compressedSize;
-	}
+	zipFile->pointer = zipEntry->dataPointer + zipEntry->compressedSize;
 	seekResult = j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 	if (isSeekFailure(seekResult, zipFile->pointer)) {
 		zipFile->pointer = -1;
@@ -783,8 +781,8 @@ I_32 scanForDataDescriptor(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipEntr
 			zipFile->pointer = -1;
 			return ZIP_ERR_FILE_READ_ERROR;
 		}
-		zipFile->pointer += (U_32) size;
-		blockPointer += (U_32) size;
+		zipFile->pointer += size;
+		blockPointer += size;
 
 		/* Scan the buffer. */
 		for(i = 0; i < size; i++, dataSize++) {
@@ -822,11 +820,11 @@ I_32 scanForDataDescriptor(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipEntr
 							current = &buffer[i + 1];
 						} else {
 							seekResult = j9file_seek(zipFile->fd, zipEntry->dataPointer + dataSize + 1, EsSeekSet);
-							if (isOutside4Gig(seekResult)) {
+							if (isUnsupported(seekResult)) {
 								zipFile->pointer = -1;
 								return ZIP_ERR_FILE_READ_ERROR;
 							}
-							zipFile->pointer = (U_32) seekResult;
+							zipFile->pointer = seekResult;
 							if( j9file_read( zipFile->fd, descriptor, 12 ) != 12) {
 								zipFile->pointer = -1;
 								return ZIP_ERR_FILE_READ_ERROR;
@@ -848,11 +846,11 @@ I_32 scanForDataDescriptor(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipEntr
 
 						/* Header looked bogus. Reset the pointer and continue scanning. */
 						seekResult = j9file_seek(zipFile->fd, zipEntry->dataPointer + blockPointer, EsSeekSet);
-						if (isOutside4Gig(seekResult)) {
+						if (isUnsupported(seekResult)) {
 							zipFile->pointer = -1;
 							return ZIP_ERR_FILE_READ_ERROR;
 						}
-						zipFile->pointer = (U_32) seekResult;
+						zipFile->pointer = seekResult;
 					}
 					else state = 0;
 					break;
@@ -874,35 +872,34 @@ I_32 scanForDataDescriptor(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipEntr
 			ZIP_ERR_OUT_OF_MEMORY
 			ZIP_ERR_INTERNAL_ERROR
 */
-static I_32 zip_populateCache(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipCentralEnd *endEntry, IDATA startCentralDir)
+static I_32
+zip_populateCache(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCentralEnd *endEntry, U_64 startCentralDir)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	I_32 result = 0;
 	IDATA bufferSize = ZIP_WORK_BUFFER_SIZE;
-	IDATA unreadSize = 0;
+	I_64 unreadSize = 0;
 	IDATA bufferedSize = 0;
 	IDATA bytesToRead = 0;
-	IDATA filenameCopied;
+	IDATA filenameCopied = 0;
 	J9ZipEntry entry;
 	U_8 *buffer = NULL;
 	U_8 *filename = NULL;
 	IDATA filenameSize = 256;  /* Should be sufficient for most filenames */
-	U_8 *current;
-	U_32 sig;
-	U_32 localHeaderOffset;
-	I_64 seekResult;
-	J9ZipCachePool *cachePool;
+	U_8 *current = NULL;
+	U_32 sig = 0;
+	U_64 localHeaderOffset = 0;
+	I_64 seekResult = 0;
+	J9ZipCachePool *cachePool = NULL;
 	BOOLEAN freeFilename = FALSE;
 	BOOLEAN freeBuffer = FALSE;
 
 	if (!zipFile->cache)  return ZIP_ERR_INTERNAL_ERROR;
 
-	unreadSize = endEntry->dirSize + 4 /* slop */;
+	unreadSize = (I_64)endEntry->dirSize + 4 /* slop */;
 
-	if (zipFile->pointer != startCentralDir)  {
-		zipFile->pointer = (U_32) startCentralDir;
-	}
+	zipFile->pointer = startCentralDir;
 	seekResult = j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 	if (isSeekFailure(seekResult, zipFile->pointer)) {
 		zipFile->pointer = -1;
@@ -925,7 +922,9 @@ static I_32 zip_populateCache(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipC
 	}
 
 	/* No point in allocating more than we'll actually need.. */
-	if (bufferSize > unreadSize)  bufferSize = unreadSize;
+	if (bufferSize > unreadSize) {
+		bufferSize = (IDATA)unreadSize;
+	}
 
 	if (buffer == NULL) {
 		freeBuffer = freeFilename = TRUE;
@@ -937,40 +936,39 @@ static I_32 zip_populateCache(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipC
 
 		buffer = j9mem_allocate_memory(bufferSize, J9MEM_CATEGORY_VM_JCL);
 	}
-	if(!buffer && (bufferSize > 4096))	 {
+	if (!buffer && (bufferSize > 4096)) {
 		/* Not enough memory, fall back to a smaller buffer! */
 		bufferSize = 4096;
 		buffer = j9mem_allocate_memory(bufferSize, J9MEM_CATEGORY_VM_JCL);
 	}
-	if(!buffer)	{
+	if (!buffer) {
 		result = ZIP_ERR_OUT_OF_MEMORY;
 		goto finished;
 	}
 	
-	while(unreadSize)  {
+	while (0 != unreadSize) {
 		I_64 readResult = 0;
 		/* Read as much as needed into buffer. */
-		bytesToRead = bufferSize-bufferedSize;
-		if (bytesToRead > unreadSize)  bytesToRead = unreadSize;
-		readResult = j9file_read(zipFile->fd, buffer+bufferedSize, bytesToRead);
+		bytesToRead = bufferSize - bufferedSize;
+		if (bytesToRead > unreadSize) {
+			bytesToRead = (IDATA)unreadSize;
+		}
+		readResult = j9file_read(zipFile->fd, buffer + bufferedSize, bytesToRead);
 		if (readResult < 0)  {
 			result = ZIP_ERR_FILE_READ_ERROR;
 			zipFile->pointer = -1;
 			goto finished;
 		}
-		zipFile->pointer += (U_32) readResult;
-		unreadSize -= (U_32) readResult;
-		bufferedSize += (U_32) readResult;
+		zipFile->pointer += (U_64)readResult;
+		unreadSize -= readResult;
+		bufferedSize += (IDATA)readResult;
 		current = buffer;
 
 		/* consume entries until we run out. */
-		while ( current+46 < buffer+bufferedSize )  {
-			IDATA entryPointer;
-
-			entryPointer = (IDATA)(zipFile->pointer + (current-(buffer+bufferedSize)));
-
+		while ((current + 46) < (buffer + bufferedSize)) {
+			I_64 entryPointer = zipFile->pointer + (current - (buffer + bufferedSize));
 			ZIP_NEXT_U32(sig, current);
-			if(sig == ZIP_CentralEnd)  {
+			if (ZIP_CentralEnd == sig) {
 				/* We're done here. */
 				result = 0;
 				goto finished;
@@ -1034,23 +1032,26 @@ static I_32 zip_populateCache(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipC
 					result = ZIP_ERR_FILE_CORRUPT;
 					goto finished;
 				}
-				bytesToRead = bufferSize-bufferedSize;
-				if (bytesToRead > unreadSize)  bytesToRead = unreadSize;
-				readResult = j9file_read(zipFile->fd, buffer+bufferedSize, bytesToRead);
+				bytesToRead = bufferSize - bufferedSize;
+				if (bytesToRead > unreadSize) {
+					bytesToRead = (IDATA)unreadSize;
+				}
+				readResult = j9file_read(zipFile->fd, buffer + bufferedSize, bytesToRead);
 				if (readResult < 0)  {
 					result = ZIP_ERR_FILE_READ_ERROR;
 					zipFile->pointer = -1;
 					goto finished;
 				}
-				zipFile->pointer += (U_32) readResult;
-				unreadSize -= (U_32) readResult;
-				bufferedSize += (U_32) readResult;
+				zipFile->pointer += (U_64)readResult;
+				unreadSize -= readResult;
+				bufferedSize += (IDATA)readResult;
 				current = buffer;
 			}
 			filename[entry.filenameLength] = '\0';  /* null-terminate */
 
-			if (((entry.compressionMethod == ZIP_CM_Deflated)&&(entry.flags & 0x8))
-				|| (entry.fileCommentLength != 0))  {
+			if (((ZIP_CM_Deflated == entry.compressionMethod) && (0 != (entry.flags & 0x8)))
+				|| (0 != entry.fileCommentLength)
+			) {
 				/* Either local header doesn't know the compressedSize, or this entry has a file
 					comment.  In either case, cache the central header instead of the local header
 					so we can find the information we need later. */
@@ -1069,24 +1070,24 @@ static I_32 zip_populateCache(J9PortLibrary* portLib, J9ZipFile *zipFile, J9ZipC
 
 			/* Skip the data and comment. */
 			bytesToRead = entry.extraFieldLength + entry.fileCommentLength;
-			if (bufferedSize - (current-buffer) >= bytesToRead)  {
+			if ((bufferedSize - (current - buffer)) >= bytesToRead) {
 				current += bytesToRead;
 			} else  {
 				/* The rest of the buffer is uninteresting.  Skip ahead to where the good stuff is */
-				bytesToRead -= (bufferedSize - (current-buffer));
-				current = buffer+bufferedSize;
+				bytesToRead -= (bufferedSize - (current - buffer));
+				current = buffer + bufferedSize;
 				unreadSize -= bytesToRead;
 		
 				seekResult = j9file_seek(zipFile->fd, bytesToRead, EsSeekCur);
-				if (isOutside4Gig(seekResult)) {
+				if (isUnsupported(seekResult)) {
 					zipFile->pointer = -1;
 					result = ZIP_ERR_FILE_READ_ERROR;
 					goto finished;
 				}
-				zipFile->pointer = (U_32) seekResult;
+				zipFile->pointer = seekResult;
 			}
 		}
-		bufferedSize -= (current-buffer);
+		bufferedSize -= (current - buffer);
 		memmove(buffer, current, bufferedSize);
 	}
 
@@ -1114,31 +1115,33 @@ finished:
 			ZIP_ERR_NO_MORE_ENTRIES
 */
 static I_32
-readZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * zipEntry, const char *filename, IDATA filenameLength,
-		IDATA * enumerationPointer, IDATA * entryStart, BOOLEAN findDirectory, BOOLEAN readDataPointer)
+readZipEntry(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *zipEntry, const char *filename, IDATA filenameLength,
+		U_64 *enumerationPointer, U_64 *entryStart, BOOLEAN findDirectory, BOOLEAN readDataPointer)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 
 	I_32 result = 0;
 	U_8 buffer[46 + 128];
-	U_8 *current;
-	U_32 sig;
+	U_8 *current = NULL;
+	U_32 sig = 0;
 	I_64 readLength = 0;
-	I_64 seekResult;
-	I_64 readResult= 0;
-	U_8 *readBuffer;
-	IDATA currentEntryPointer, localEntryPointer;
-	I_64 headerSize;
+	I_64 seekResult = 0;
+	I_64 readResult = 0;
+	U_8 *readBuffer = NULL;
+	U_64 currentEntryPointer = 0;
+	U_64 localEntryPointer = 0;
+	I_64 headerSize = 0;
 
   retry:
-	if (entryStart)
-		*entryStart = (IDATA)zipFile->pointer;
+	if (NULL != entryStart) {
+		*entryStart = zipFile->pointer;
+	}
 	readBuffer = NULL;
 	/* Guess how many bytes we'll need to read.  If we guess correctly we will do fewer I/O operations */
 	headerSize = 30;			/* local zip header size */
 	if ((NULL != zipFile->cache)
-			&& ((IDATA) zipFile->pointer >= zipCache_getStartCentralDir(zipFile->cache))
-			) {
+		&& (zipFile->pointer >= zipCache_getStartCentralDir(zipFile->cache))
+	) {
 		headerSize = 46;		/* central zip header size */
 	}
 	readLength = headerSize + (filename ? filenameLength : 128);
@@ -1151,21 +1154,21 @@ readZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * zipEntry
 	if (readLength <= sizeof(buffer)) {
 		current = buffer;
 	} else {
-		current = readBuffer = j9mem_allocate_memory((IDATA) readLength, J9MEM_CATEGORY_VM_JCL);
+		current = readBuffer = j9mem_allocate_memory((IDATA)readLength, J9MEM_CATEGORY_VM_JCL);
 		if (!readBuffer)
 			return ZIP_ERR_OUT_OF_MEMORY;
 	}
 
-	currentEntryPointer = localEntryPointer = (IDATA)zipFile->pointer;
+	currentEntryPointer = localEntryPointer = zipFile->pointer;
 
-	readResult = j9file_read(zipFile->fd, current, (IDATA) readLength);
+	readResult = j9file_read(zipFile->fd, current, (IDATA)readLength);
 	if ((readResult < 22) || (filename && !(readResult == readLength || (findDirectory && readResult == (readLength-1))))) {
 		/* We clearly didn't get enough bytes */
 		result = ZIP_ERR_FILE_READ_ERROR;
 		goto finished;
 	}
-	zipFile->pointer += (U_32) readResult;
-	readLength = (U_32) readResult;		/* If it's not enough, we'll catch that later */
+	zipFile->pointer += readResult;
+	readLength = readResult; /* If it's not enough, we'll catch that later. */
 	ZIP_NEXT_U32(sig, current);
 
 	if (enumerationPointer) {
@@ -1178,12 +1181,12 @@ readZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * zipEntry
 		/* We failed to predict a data descriptor here.  This should be an error (i.e. only happens in malformed zips?) 
 		   but, but we will silently skip over it */
 		seekResult = j9file_seek(zipFile->fd, currentEntryPointer + 16, EsSeekSet);
-		if (isOutside4Gig(seekResult)) {
+		if (isUnsupported(seekResult)) {
 			zipFile->pointer = -1;
 			result = ZIP_ERR_FILE_READ_ERROR;
 			goto finished;
 		}
-		zipFile->pointer = (U_32) seekResult;
+		zipFile->pointer = seekResult;
 
 		if (zipFile->pointer == currentEntryPointer + 16) {
 			if (readBuffer) {
@@ -1255,12 +1258,12 @@ readZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * zipEntry
 	if (readLength > zipEntry->filenameLength) {
 		readLength = zipEntry->filenameLength;
 	}
-	memcpy(zipEntry->filename, current, (IDATA) readLength);
+	memcpy(zipEntry->filename, current, (IDATA)readLength);
 
 	/* Read the rest of the filename if necessary.  Allocate space in J9ZipEntry for it! */
 	if (readLength < zipEntry->filenameLength) {
 		readResult = j9file_read(zipFile->fd, zipEntry->filename + readLength,
-				(IDATA) (zipEntry->filenameLength - readLength));
+				(IDATA)(zipEntry->filenameLength - readLength));
 		if (readResult != (zipEntry->filenameLength - readLength)) {
 			result = ZIP_ERR_FILE_READ_ERROR;
 			goto finished;
@@ -1283,8 +1286,8 @@ readZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * zipEntry
 		}
 	}
 
-	zipEntry->filenamePointer = (U_32) (currentEntryPointer + headerSize);
-	zipEntry->extraFieldPointer = (U_32) (localEntryPointer + 30 + zipEntry->filenameLength);
+	zipEntry->filenamePointer = currentEntryPointer + headerSize;
+	zipEntry->extraFieldPointer = localEntryPointer + 30 + zipEntry->filenameLength;
 	/* Must always set the dataPointer as it may be used by scanForDataDescriptor()
 	 * when reading a local header.
 	 */
@@ -1299,8 +1302,8 @@ readZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * zipEntry
 		U_8 *buf2 = buf;
 		U_16 lost;
 		/* Also, we know where the comment is */
-		zipEntry->fileCommentPointer = (U_32) (currentEntryPointer + headerSize +
-			zipEntry->filenameLength + zipEntry->extraFieldLength);
+		zipEntry->fileCommentPointer = currentEntryPointer + headerSize
+			+ zipEntry->filenameLength + zipEntry->extraFieldLength;
 		/* Fix the dataPointer when reading the central directory. The extraFieldLength in the central
 		 * directory gives the size of the extra field data in the central directory, not the size of
 		 * the extra field data in the corresponding local entry.
@@ -1310,7 +1313,7 @@ readZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * zipEntry
 				if ( j9file_read( zipFile->fd, buf, 2 ) == 2 ) {
 					ZIP_NEXT_U16( lost, buf2 );
 					zipEntry->dataPointer = zipEntry->extraFieldPointer + lost;
-					zipFile->pointer = (U_32) (localEntryPointer + 30);
+					zipFile->pointer = localEntryPointer + 30;
 				}
 			}
 		}
@@ -1425,19 +1428,21 @@ zip_searchCache(J9PortLibrary * portLib, char *filename, J9ZipCachePool *cachePo
 
 	PORT_ACCESS_FROM_PORT(portLib);
 	I_32 result = 0;
-	I_64 timeStamp, actualFileSize;
-	IDATA fileSize, filenameLength;
+	I_64 timeStamp = 0;
+	I_64 actualFileSize = 0;
+	I_64 fileSize = 0;
+	IDATA filenameLength = 0;
 
 	*cache = NULL;
 	/* Check the cachePool for a suitable cache. */
 	filenameLength = strlen((const char*)filename);
 	timeStamp = j9file_lastmod((const char*)filename);
 	actualFileSize = j9file_length((const char*)filename);
-	if (isOutside4Gig(actualFileSize)) {
+	if (isUnsupported(actualFileSize)) {
 		result = ZIP_ERR_INTERNAL_ERROR;
 		goto finished;
 	}
-	fileSize = (IDATA) actualFileSize;
+	fileSize = actualFileSize;
 	*cache = zipCachePool_findCache(cachePool, (const char*)filename, filenameLength, fileSize, timeStamp);
 
 finished:
@@ -1466,12 +1471,13 @@ finished:
  * @return	ZIP_ERR_INTERNAL_ERROR if there was an internal error
  */
 I_32
-zip_setupCache(J9PortLibrary * portLib, J9ZipFile *zipFile, J9ZipCache *cache, J9ZipCachePool *cachePool)
+zip_setupCache(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipCache *cache, J9ZipCachePool *cachePool)
 {
 	PORT_ACCESS_FROM_PORT(portLib);	
 	I_32 result = 0;
 	I_64 timeStamp, actualFileSize;
-	IDATA fileSize, filenameLength;
+	I_64 fileSize = 0;
+	IDATA filenameLength = 0;
 
 	if (zipFile->cache)  {
 		if (zipFile->cachePool)  {
@@ -1491,11 +1497,11 @@ zip_setupCache(J9PortLibrary * portLib, J9ZipFile *zipFile, J9ZipCache *cache, J
 	filenameLength = strlen((const char*)zipFile->filename);
 	timeStamp = j9file_lastmod((const char*)zipFile->filename);
 	actualFileSize = j9file_length((const char*)zipFile->filename);
-	if (isOutside4Gig(actualFileSize)) {
+	if (isUnsupported(actualFileSize)) {
 		result = ZIP_ERR_INTERNAL_ERROR;
 		goto finished;
 	}
-	fileSize = (IDATA) actualFileSize;
+	fileSize = actualFileSize;
 
 	zipFile->cachePool = cachePool;
 
@@ -1554,7 +1560,7 @@ zip_readCacheData(J9PortLibrary * portLib, J9ZipFile *zipFile)
 {
 	I_32 result = 0;
 	J9ZipCentralEnd endEntry;
-	IDATA startCentralDir;
+	U_64 startCentralDir = 0;
 	
 	/* zip_setupCache() must have already been called. */
 	if (!zipFile->cachePool || !zipFile->cache) {
@@ -1570,7 +1576,7 @@ zip_readCacheData(J9PortLibrary * portLib, J9ZipFile *zipFile)
 	/* Find and read the end-of-central-dir record. */
 	result = scanForCentralEnd(portLib, zipFile, &endEntry);
 	if (result == 0) {
-		startCentralDir = (IDATA)((UDATA)endEntry.dirOffset);
+		startCentralDir = endEntry.dirOffset;
 		zipCache_setStartCentralDir(zipFile->cache, startCentralDir);
 		result = zip_populateCache(portLib, zipFile, &endEntry, startCentralDir);
 	}
@@ -1666,15 +1672,16 @@ void zip_freeZipEntry(J9PortLibrary * portLib, J9ZipEntry * entry)
  *
  * @see zip_freeZipEntry
  *
-*/
-I_32 zip_getNextZipEntry(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* zipEntry, IDATA* nextEntryPointer, BOOLEAN readDataPointer)
+ */
+I_32
+zip_getNextZipEntry(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *zipEntry, U_64 *nextEntryPointer, BOOLEAN readDataPointer)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 	I_32 result = 0;
 	BOOLEAN retryAllowed = TRUE;
-	IDATA pointer;
-	IDATA entryStart;
-	I_64 seekResult;
+	U_64 pointer = 0;
+	U_64 entryStart = 0;
+	I_64 seekResult = 0;
 
 	ENTER();
 
@@ -1686,9 +1693,7 @@ retry:
 	pointer = *nextEntryPointer;
 
 	/* Seek to the entry's position in the file. */
-	if (pointer != zipFile->pointer)  {
-		zipFile->pointer = (U_32) pointer;
-	}
+	zipFile->pointer = pointer;
 	seekResult =  j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 	if (isSeekFailure(seekResult, zipFile->pointer)) {
 		zipFile->pointer = -1;
@@ -1749,7 +1754,7 @@ retry:
  * @return 	ZIP_ERR_OUT_OF_MEMORY if there is not enough memory to complete this call
  *
  * @see zip_freeZipEntry
-*/
+ */
 
 I_32
 zip_getZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry *entry, const char *filename, IDATA fileNameLength, U_32 flags)
@@ -1757,7 +1762,7 @@ zip_getZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry *entry,
 	PORT_ACCESS_FROM_PORT(portLib);
 	I_32 status = 0;
 	I_32 result = 0;
-	IDATA position = -1;
+	U_64 position = -1;
 	BOOLEAN retryAllowed = TRUE;
 	I_64 seekResult = -1;
 	BOOLEAN findDirectory = J9_ARE_ANY_BITS_SET(flags, J9ZIP_GETENTRY_FIND_DIRECTORY);
@@ -1771,17 +1776,15 @@ zip_getZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry *entry,
   retry:
 	if (zipFile->cache) {
 		/* Look up filename in the cache. */
-		position = (IDATA) zipCache_findElement(zipFile->cache, filename, fileNameLength, findDirectory);
-		if (-1 == position) {
+		position = zipCache_findElement(zipFile->cache, filename, fileNameLength, findDirectory);
+		if (((U_64)-1) == position) {
 			/* Note: we assume the cache is still valid here */
 			status = ZIP_ERR_ENTRY_NOT_FOUND;
 			goto finished;
 		}
 
 		/* Seek to the entry's position in the file. */
-		if (zipFile->pointer != position) {
-			zipFile->pointer = (U_32) position;
-		}
+		zipFile->pointer = position;
 		seekResult =  j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 		if (isSeekFailure(seekResult, zipFile->pointer)) {
 			zipFile->pointer = -1;
@@ -1816,10 +1819,7 @@ zip_getZipEntry(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry *entry,
 		position = 0;
 		zip_resetZipFile(PORTLIB, zipFile, &position);
 		while (TRUE) {
-
-			if (zipFile->pointer != position) {
-				zipFile->pointer = (U_32) position;
-			}
+			zipFile->pointer = position;
 			seekResult = j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 			if (isSeekFailure(seekResult, zipFile->pointer)) {
 				zipFile->pointer = -1;
@@ -1876,8 +1876,8 @@ getZipEntryUsingDirectory(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry
 	U_8 defaultBuffer[128]; /* must be at least CENTRAL_FILEHEADER_SIZE */
 	U_8 *readBuffer = defaultBuffer;
 	U_16 entryCount = 0;
-	I_64 nextEntryPointer = 0;
-	I_64 offsetCorrection = 0; /* this is the size of any crud before the first local file header */
+	U_64 nextEntryPointer = 0;
+	U_64 offsetCorrection = 0; /* this is the size of any crud before the first local file header */
 
 	if (fileNameLength > sizeof(defaultBuffer)) {
 		readBuffer = j9mem_allocate_memory(fileNameLength, J9MEM_CATEGORY_VM_JCL);
@@ -1932,7 +1932,7 @@ getZipEntryUsingDirectory(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry
 					break;
 				}
 				if (0 == strncmp(fileName, (const char*)readBuffer, fileNameLength)) {
-					zipFile->pointer = (U_32) (localHeaderOffset + offsetCorrection);
+					zipFile->pointer = localHeaderOffset + offsetCorrection;
 					seekResult = j9file_seek(zipFile->fd,zipFile->pointer, EsSeekSet); /* go to the actual entry */
 					if (isSeekFailure(seekResult, zipFile->pointer)) {
 						result = ZIP_ERR_FILE_READ_ERROR;
@@ -1975,7 +1975,7 @@ getZipEntryUsingDirectory(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry
  *
  * @see zip_freeZipEntry
  *
-*/
+ */
 I_32 zip_getZipEntryData(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entry, U_8* buffer, U_32 bufferSize)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
@@ -2016,9 +2016,7 @@ I_32 zip_getZipEntryData(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry*
 	if(entry->compressionMethod == ZIP_CM_Stored) {
 		IDATA readResult = 0;
 		/* No compression - just read the data in. */
-		if (zipFile->pointer != entry->dataPointer)  {
-			zipFile->pointer = (U_32) entry->dataPointer;
-		}
+		zipFile->pointer = entry->dataPointer;
 		seekResult =  j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 		if (isSeekFailure(seekResult, zipFile->pointer)) {
 			zipFile->pointer = -1;
@@ -2052,13 +2050,11 @@ I_32 zip_getZipEntryData(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry*
 			}
 		}
 		readBuffer = zdataalloc(&wb, 1, entry->compressedSize);
-		if(!readBuffer) {
+		if (!readBuffer) {
 			result = ZIP_ERR_OUT_OF_MEMORY;
 			goto finished;
 		}
-		if (zipFile->pointer != entry->dataPointer)  {
-			zipFile->pointer = entry->dataPointer;
-		}
+		zipFile->pointer = entry->dataPointer;
 		seekResult =  j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 		if (isSeekFailure(seekResult, zipFile->pointer)) {
 			zipFile->pointer = -1;
@@ -2115,13 +2111,14 @@ finished:
  *
  * @see zip_freeZipEntry
  *
-*/
-I_32 zip_getZipEntryRawData(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entry, U_8* buffer, U_32 bufferSize, U_32 offset)
+ */
+I_32
+zip_getZipEntryRawData(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry, U_8 *buffer, U_32 bufferSize, U_64 offset)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 
-	I_32 result;
-	I_64 seekResult;
+	I_32 result = 0;
+	I_64 seekResult = 0;
 	I_64 readResult = 0;
 
 	ENTER();
@@ -2133,20 +2130,18 @@ I_32 zip_getZipEntryRawData(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEnt
 	}
 
 	/* Just read the data in.  Widen the data to check for overflow. */
-	if (zipFile->pointer != (entry->dataPointer + (U_64) offset))  {
-		zipFile->pointer = (entry->dataPointer + offset);
-	}
+	zipFile->pointer = entry->dataPointer + offset;
 	seekResult =  j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 	if (isSeekFailure(seekResult, zipFile->pointer)) {
 		result = ZIP_ERR_FILE_READ_ERROR;
 		goto finished;
 	}
 	readResult = j9file_read(zipFile->fd, buffer, bufferSize);
-	if (readResult != (I_64) bufferSize) {
+	if (readResult != (I_64)bufferSize) {
 		result = ZIP_ERR_FILE_READ_ERROR;
 		goto finished;
 	}
-	zipFile->pointer += (U_32) readResult;
+	zipFile->pointer += (U_64)readResult;
 	EXIT();
 	return 0;
 
@@ -2179,7 +2174,7 @@ finished:
  * @return 	ZIP_ERR_BUFFER_TOO_SMALL if the buffer was non-Null but not large enough to hold the contents of entry
  *
  * @see zip_freeZipEntry
-*/
+ */
 I_32 zip_getZipEntryExtraField(J9PortLibrary* portLib, J9ZipFile* zipFile, J9ZipEntry* entry, U_8* buffer, U_32 bufferSize)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
@@ -2211,9 +2206,7 @@ I_32 zip_getZipEntryExtraField(J9PortLibrary* portLib, J9ZipFile* zipFile, J9Zip
 		entry->extraField = extraFieldBuffer;
 	}
 
-	if (zipFile->pointer != entry->extraFieldPointer)  {
-		zipFile->pointer = entry->extraFieldPointer;
-	}
+	zipFile->pointer = entry->extraFieldPointer;
 	seekResult = j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 	if (isSeekFailure(seekResult, zipFile->pointer)) {
 		zipFile->pointer = -1;
@@ -2262,10 +2255,9 @@ finished:
  * @return	ZIP_ERR_ENTRY_NOT_FOUND if entry is not found
  * @return 	ZIP_ERR_OUT_OF_MEMORY  if there is not enough memory to complete this call
  * @return 	ZIP_ERR_BUFFER_TOO_SMALL if buffer is too small to hold the comment for zipFile
-*/
-
-I_32 zip_getZipEntryComment(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * entry, U_8 * buffer,
-							U_32 bufferSize)
+ */
+I_32
+zip_getZipEntryComment(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry, U_8 *buffer, U_32 bufferSize)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
 
@@ -2300,9 +2292,7 @@ I_32 zip_getZipEntryComment(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipE
 		entry->fileComment = fileCommentBuffer;
 	}
 
-	if (zipFile->pointer != entry->fileCommentPointer) {
-		zipFile->pointer = entry->fileCommentPointer;
-	}
+	zipFile->pointer = entry->fileCommentPointer;
 	seekResult =  j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
 	if (isSeekFailure(seekResult, zipFile->pointer)) {
 		zipFile->pointer = -1;
@@ -2366,7 +2356,7 @@ zip_shutdownZipCachePoolHookInterface(J9ZipCachePool *cachePool)
 
 /**
  * Public API for retrieving the hook interface from J9ZipCachePool struct  
-*/
+ */
 J9HookInterface** zip_getVMZipCachePoolHookInterface(J9ZipCachePool *cachePool)
 {
 	if (cachePool)
@@ -2400,7 +2390,7 @@ J9HookInterface** zip_getVMZipCachePoolHookInterface(J9ZipCachePool *cachePool)
  * @return	ZIP_ERR_UNKNOWN_FILE_TYPE if the file type is not known
  * @return	ZIP_ERR_UNSUPPORTED_FILE_TYPE if the file type is unsupported
  * @return	ZIP_ERR_OUT_OF_MEMORY if we are out of memory
-*/
+ */
 I_32
 zip_openZipFile(J9PortLibrary *portLib, char *filename, J9ZipFile *zipFile, J9ZipCachePool *cachePool, U_32 flags)
 {
@@ -2544,12 +2534,9 @@ finished:
  * @param[in] portLib the port library
  * @param[in] zipFile the zip being read from
  * @param[out] nextEntryPointer will be reset to the first entry in the file
- *
- * @return none
- *
- * 
-*/
-void zip_resetZipFile(J9PortLibrary* portLib, J9ZipFile* zipFile, IDATA *nextEntryPointer)
+ */
+void
+zip_resetZipFile(J9PortLibrary *portLib, J9ZipFile *zipFile, U_64 *nextEntryPointer)
 {
 	*nextEntryPointer = 0;
 	if (zipFile) {
@@ -2562,7 +2549,7 @@ void zip_resetZipFile(J9PortLibrary* portLib, J9ZipFile* zipFile, IDATA *nextEnt
 			J9ZipCentralEnd endEntry;
 			result = scanForCentralEnd(portLib, zipFile, &endEntry);
 			if (result == 0) {
-				*nextEntryPointer = (IDATA)((UDATA)endEntry.dirOffset);
+				*nextEntryPointer = endEntry.dirOffset;
 			}
 		}
 		if (cachePool) {
@@ -2592,20 +2579,19 @@ void zip_resetZipFile(J9PortLibrary* portLib, J9ZipFile* zipFile, IDATA *nextEnt
  * @return 	ZIP_ERR_OUT_OF_MEMORY if there is not enough memory to complete this call
  *
  * @see zip_freeZipEntry
-*/
-I_32 zip_getZipEntryFromOffset(J9PortLibrary * portLib, J9ZipFile * zipFile, J9ZipEntry * entry, IDATA offset, BOOLEAN readDataPointer)
+ */
+I_32
+zip_getZipEntryFromOffset(J9PortLibrary *portLib, J9ZipFile *zipFile, J9ZipEntry *entry, U_64 offset, BOOLEAN readDataPointer)
 {
 	PORT_ACCESS_FROM_PORT(portLib);
-	I_32 result;
-	I_64 seekResult;
+	I_32 result = 0;
+	I_64 seekResult = 0;
 
 	ENTER();
 
-	if (zipFile->pointer != offset) {
-		zipFile->pointer = (U_32) offset;
-	}
+	zipFile->pointer = offset;
 	seekResult = j9file_seek(zipFile->fd, zipFile->pointer, EsSeekSet);
-	if (isOutside4Gig(seekResult) || (zipFile->pointer != offset)) {
+	if (isUnsupported(seekResult) || (zipFile->pointer != offset)) {
 		zipFile->pointer = -1;
 		EXIT();
 		return ZIP_ERR_FILE_READ_ERROR;
@@ -2619,7 +2605,7 @@ I_32 zip_getZipEntryFromOffset(J9PortLibrary * portLib, J9ZipFile * zipFile, J9Z
 
 /*
 	cached alloc management for zip_getZipEntryData.
-*/
+ */
 void* zdataalloc(void* opaque, U_32 items, U_32 size)
 {
 	UDATA* returnVal = 0;
@@ -2661,7 +2647,7 @@ void* zdataalloc(void* opaque, U_32 items, U_32 size)
 
 /*
 	cached alloc management for zip_getZipEntryData.
-*/
+ */
 void zdatafree(void* opaque, void* address)
 {
 	struct workBuffer *wb = (struct workBuffer*)opaque;


### PR DESCRIPTION
The changes are to remove the 4GB size limit of Zip files and support LARGE FILE for JVM in 64-bit and 32-bit environments.

Fixes: #23441, #23458