### PR TITLE
Skip keepalive class registration during peeking ILGen

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -2044,7 +2044,20 @@ bool J9::TransformUtil::transformIndirectLoadChainImpl(TR::Compilation *comp, TR
                         // class won't be unloaded while this body is still valid, so
                         // the keepalive is redundant but harmless.
                         //
-                        comp->addKeepaliveClass(clazz);
+                        // This must be skipped for peeking ILGen, as the peeking IL
+                        // is always discared, with no guarantees that the peeked method
+                        // would eventually be inlined. In such cases, a keepalive class
+                        // would be registered for an entire compilation simply through
+                        // peeking during ECS, and there is no mechanism to un-register
+                        // the keepalive class. This would not be a problem if the peeked
+                        // method registering the keepalive class got inlined eventually,
+                        // but if not, then the registered class lives in a class loader
+                        // that has no lifetime relationship with the final compiled body,
+                        // resulting in keepalive constrefs not having a reachable owning
+                        // class in the const provenance graph.
+                        if (!comp->isPeekingMethod()) {
+                            comp->addKeepaliveClass(clazz);
+                        }
                     } else {
                         return false;
                     }


### PR DESCRIPTION
When transformIndirectLoadChain() constant-folds a loadaddr of a J9Class, it registers the class as a keepalive to prevent unloading while the compiled body remains valid. However, this is problematic during peeking ILGen.

The issue is that peeking IL is always discarded, with no guarantee that the peeked method will eventually be inlined. If a keepalive class is registered during peeking, it persists for the entire compilation with no mechanism to un-register it. This creates a lifetime mismatch: the registered class may live in a class loader that has no relationship with the final compiled body, resulting in keepalive constrefs without a reachable owning class in the const provenance graph.

This change guards the addKeepaliveClass() call with a check for isPeekingMethod(), skipping keepalive registration when generating IL for peeking purposes. The keepalive is only registered when the IL is being generated for actual inlining, ensuring proper lifetime semantics and const provenance graph integrity.

This fix is necessary to address functional failures as we prepare for enabling const refs #16616