### PR TITLE
JFR ThreadDump event fixups

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -578,6 +578,13 @@ typedef struct J9JFRDataLoss {
 	U_64 total;
 } J9JFRDataLoss;
 
+typedef struct J9JFRThreadDump {
+	J9JFR_EVENT_COMMON_FIELDS
+	U_8 *result;
+	UDATA resultLength;
+	UDATA bufferSize;
+} J9JFRThreadDump;
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 /* @ddr_namespace: map_to_type=J9CfrError */

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -6020,6 +6020,17 @@ jfrEmitDataLoss(J9VMThread *currentThread, U_64 bytes);
 jboolean
 requestJFREvent(J9VMThread *currentThread, jlong id);
 
+/**
+ * Get a thread dump string for ThreadDump event and write it to the given buffer
+ *
+ * @param[in] currentThread the current J9VMThread
+ * @param[in] buffer the buffer that the thread dump will be written to
+ * @param[in] bufferSize size of the buffer
+ * @return the length of the thread dump string.
+ * */
+UDATA
+getThreadDump(J9VMThread *currentThread, U_8 *buffer, UDATA bufferSize);
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 #ifdef __cplusplus

--- a/runtime/vm/BufferWriter.hpp
+++ b/runtime/vm/BufferWriter.hpp
@@ -350,7 +350,8 @@ class VM_BufferWriter {
 		OMRPORT_ACCESS_FROM_J9PORT(_portLibrary);
 		va_list args;
 		va_start(args, format);
-		uintptr_t totalLength = omrstr_vprintf(NULL, 0, format, args);
+		/* Minus 1 because omrstr_vprintf accounts for null terminator if buffer is null. */
+		uintptr_t totalLength = omrstr_vprintf(NULL, 0, format, args) - 1;
 		if (checkBounds(totalLength)) {
 			omrstr_vprintf((char *)_cursor, _bufferEnd - _cursor, format, args);
 			_cursor += totalLength;

--- a/runtime/vm/JFRChunkWriter.cpp
+++ b/runtime/vm/JFRChunkWriter.cpp
@@ -1210,84 +1210,6 @@ VM_JFRChunkWriter::writeThreadStatisticsEvent(void *anElement, void *userData)
 	writeEventSize(_bufferWriter, dataStart);
 }
 
-static void
-writeObject(J9JavaVM *vm, j9object_t obj, VM_BufferWriter *bufferWriter)
-{
-	J9ROMClass *romClass = NULL;
-	if (J9VM_IS_INITIALIZED_HEAPCLASS_VM(vm, obj)) {
-		romClass = J9VM_J9CLASS_FROM_HEAPCLASS_VM(vm, obj)->romClass;
-	} else {
-		romClass = J9OBJECT_CLAZZ_VM(vm, obj)->romClass;
-	}
-
-	J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
-	bufferWriter->writeFormattedString("%.*s@%p", J9UTF8_LENGTH(className), J9UTF8_DATA(className), obj);
-}
-
-static UDATA
-stackWalkCallback(J9VMThread *vmThread, J9StackWalkState *state)
-{
-	J9JavaVM *vm = vmThread->javaVM;
-	J9ObjectMonitorInfo *monitorInfo = (J9ObjectMonitorInfo *)state->userData2;
-	IDATA *monitorCount = (IDATA *)(&state->userData3);
-	J9Method *method = state->method;
-	J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
-	J9UTF8 *className = J9ROMCLASS_CLASSNAME(methodClass->romClass);
-	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-	J9UTF8 *methodName = J9ROMMETHOD_NAME(romMethod);
-
-	VM_BufferWriter *bufferWriter = (VM_BufferWriter *)state->userData1;
-
-	bufferWriter->writeFormattedString(
-			"at %.*s.%.*s",
-			J9UTF8_LENGTH(className), J9UTF8_DATA(className),
-			J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName));
-
-	if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccNative)) {
-		bufferWriter->writeFormattedString("(Native Method)\n");
-	} else {
-		UDATA offsetPC = state->bytecodePCOffset;
-		bool compiledMethod = (NULL != state->jitInfo);
-		J9UTF8 *sourceFile = getSourceFileNameForROMClass(vm, methodClass->classLoader, methodClass->romClass);
-		if (NULL != sourceFile) {
-			bufferWriter->writeFormattedString(
-					"(%.*s", J9UTF8_LENGTH(sourceFile), J9UTF8_DATA(sourceFile));
-
-			UDATA lineNumber = getLineNumberForROMClass(vm, method, offsetPC);
-
-			if ((UDATA)-1 != lineNumber) {
-				bufferWriter->writeFormattedString(":%zu", lineNumber);
-			}
-
-			if (compiledMethod) {
-				bufferWriter->writeFormattedString("(Compiled Code)");
-			}
-
-			bufferWriter->writeFormattedString(")\n");
-		} else {
-			bufferWriter->writeFormattedString("(Bytecode PC: %zu", offsetPC);
-			if (compiledMethod) {
-				bufferWriter->writeFormattedString("(Compiled Code)");
-			}
-			bufferWriter->writeFormattedString(")\n");
-		}
-
-		/* Use a while loop as there may be more than one lock taken in a stack frame. */
-		while ((0 != *monitorCount) && ((UDATA)monitorInfo->depth == state->framesWalked)) {
-			bufferWriter->writeFormattedString("\t(entered lock: ");
-			writeObject(vm, monitorInfo->object, bufferWriter);
-			bufferWriter->writeFormattedString(")\n");
-
-			monitorInfo += 1;
-			state->userData2 = monitorInfo;
-
-			(*monitorCount) -= 1;
-		}
-	}
-
-	return J9_STACKWALK_KEEP_ITERATING;
-}
-
 void
 VM_JFRChunkWriter::writeNativeLibraryEvent(void *anElement, void *userData)
 {
@@ -1321,181 +1243,32 @@ VM_JFRChunkWriter::writeNativeLibraryEvent(void *anElement, void *userData)
 	entry->name = NULL;
 }
 
-static void
-writeThreadInfo(J9VMThread *currentThread, J9VMThread *walkThread, VM_BufferWriter *bufferWriter)
+void
+VM_JFRChunkWriter::writeThreadDumpEvent(void *anElement, void *userData)
 {
-	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	UDATA javaTID = 0;
-	UDATA osTID = ((J9AbstractThread *)walkThread->osThread)->tid;
-	UDATA javaPriority = 0;
-	UDATA state = J9VMTHREAD_STATE_UNKNOWN;
-	const char *stateStr = "?";
-	j9object_t monitorObject = NULL;
-	char *threadName = NULL;
-	j9object_t threadObject = walkThread->threadObject;
+	ThreadDumpEntry *entry = (ThreadDumpEntry *)anElement;
+	VM_JFRChunkWriter *writer = (VM_JFRChunkWriter *)userData;
+	VM_BufferWriter *bufferWriter = writer->_bufferWriter;
+	PORT_ACCESS_FROM_JAVAVM(writer->_vm);
 
-	if (NULL != threadObject) {
-		javaTID = J9VMJAVALANGTHREAD_TID(currentThread, threadObject);
-		javaPriority = vmFuncs->getJavaThreadPriority(vm, walkThread);
+	/* Reserve size field. */
+	U_8 *dataStart = reserveEventSize(bufferWriter);
 
-		/* Get thread state and monitor */
-		state = getVMThreadObjectState(walkThread, &monitorObject, NULL, NULL);
-		switch (state) {
-		case J9VMTHREAD_STATE_RUNNING:
-			stateStr = "R";
-			break;
-		case J9VMTHREAD_STATE_BLOCKED:
-			stateStr = "B";
-			break;
-		case J9VMTHREAD_STATE_WAITING:
-		case J9VMTHREAD_STATE_WAITING_TIMED:
-		case J9VMTHREAD_STATE_SLEEPING:
-			stateStr = "CW";
-			break;
-		case J9VMTHREAD_STATE_PARKED:
-		case J9VMTHREAD_STATE_PARKED_TIMED:
-			stateStr = "P";
-			break;
-		case J9VMTHREAD_STATE_SUSPENDED:
-			stateStr = "S";
-			break;
-		case J9VMTHREAD_STATE_DEAD:
-			stateStr = "Z";
-			break;
-		case J9VMTHREAD_STATE_INTERRUPTED:
-			stateStr = "I";
-			break;
-		case J9VMTHREAD_STATE_UNKNOWN:
-			stateStr = "?";
-			break;
-		default:
-			stateStr = "??";
-			break;
-		}
+	bufferWriter->writeLEB128(ThreadDumpID);
 
-	/* Get thread name */
-	#if JAVA_SPEC_VERSION >= 21
-		if (IS_JAVA_LANG_VIRTUALTHREAD(currentThread, threadObject)) {
-			/* For VirtualThread, get name from threadObject directly. */
-			j9object_t nameObject = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
-			threadName = getVMThreadNameFromString(currentThread, nameObject);
-		} else
-	#endif /* JAVA_SPEC_VERSION >= 21 */
-		{
-			threadName = getOMRVMThreadName(walkThread->omrVMThread);
-			releaseOMRVMThreadName(walkThread->omrVMThread);
-		}
-	} else {
-		threadName = getOMRVMThreadName(walkThread->omrVMThread);
-		releaseOMRVMThreadName(walkThread->omrVMThread);
+	/* Write start time. */
+	bufferWriter->writeLEB128(entry->ticks);
+
+	/* Write result. */
+	writer->writeUTF8String(entry->result, entry->resultLength);
+
+	if (J9_ARE_NO_BITS_SET(writer->_vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_JFR_V2_SUPPORT)) {
+		/* entry->result was originally allocated by loadThreadDumpEvents() in JFR v1 */
+		j9mem_free_memory(entry->result);
 	}
 
-	bufferWriter->writeFormattedString(
-			"\"%s\" J9VMThread: %p tid: %zd nid: %zd prio: %zd state: %s rawStateValue: 0x%zX",
-			threadName,
-			walkThread,
-			javaTID,
-			osTID,
-			javaPriority,
-			stateStr,
-			state);
-
-	if (J9VMTHREAD_STATE_BLOCKED == state) {
-		bufferWriter->writeFormattedString(" blocked on: ");
-	} else if ((J9VMTHREAD_STATE_WAITING == state) || (J9VMTHREAD_STATE_WAITING_TIMED == state)) {
-		bufferWriter->writeFormattedString(" waiting on: ");
-	} else if ((J9VMTHREAD_STATE_PARKED == state) || (J9VMTHREAD_STATE_PARKED_TIMED == state)) {
-		bufferWriter->writeFormattedString(" parked on: ");
-	} else {
-		bufferWriter->writeFormattedString("\n");
-		return;
-	}
-
-	if (NULL != monitorObject) {
-		writeObject(vm, monitorObject, bufferWriter);
-	} else {
-		bufferWriter->writeFormattedString("<unknown>");
-	}
-	bufferWriter->writeFormattedString("\n");
-}
-
-static void
-writeStacktrace(J9VMThread *currentThread, J9VMThread *walkThread, VM_BufferWriter *bufferWriter)
-{
-	J9JavaVM *vm = currentThread->javaVM;
-	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
-	J9StackWalkState stackWalkState = {0};
-	const size_t maxMonitorInfosPerThread = 32;
-	J9ObjectMonitorInfo monitorInfos[maxMonitorInfosPerThread];
-	memset(monitorInfos, 0, sizeof(monitorInfos));
-
-	IDATA monitorCount = vmFuncs->getOwnedObjectMonitors(currentThread, walkThread, monitorInfos, maxMonitorInfosPerThread, FALSE);
-
-	stackWalkState.walkThread = walkThread;
-	stackWalkState.flags =
-			J9_STACKWALK_ITERATE_FRAMES
-			| J9_STACKWALK_INCLUDE_NATIVES
-			| J9_STACKWALK_VISIBLE_ONLY
-			| J9_STACKWALK_RECORD_BYTECODE_PC_OFFSET
-			| J9_STACKWALK_NO_ERROR_REPORT;
-	stackWalkState.skipCount = 0;
-	stackWalkState.frameWalkFunction = stackWalkCallback;
-	stackWalkState.userData1 = bufferWriter;
-	stackWalkState.userData2 = monitorInfos;
-	stackWalkState.userData3 = (void *)monitorCount;
-
-	vmFuncs->haltThreadForInspection(currentThread, walkThread);
-	vm->walkStackFrames(currentThread, &stackWalkState);
-	vmFuncs->resumeThreadForInspection(currentThread, walkThread);
-
-	bufferWriter->writeFormattedString("\n");
-}
-
-U_8 *
-VM_JFRChunkWriter::writeThreadDumpEvent()
-{
-	/* reserve size field */
-	U_8 *dataStart = reserveEventSize();
-
-	_bufferWriter->writeLEB128(ThreadDumpID);
-
-	/* write start time */
-	_bufferWriter->writeLEB128(j9time_nano_time());
-
-	const U_64 bufferSize = THREAD_DUMP_EVENT_SIZE_PER_THREAD * _vm->peakThreadCount;
-	U_8 *resultBuffer = (U_8 *)j9mem_allocate_memory(sizeof(U_8) * bufferSize, J9MEM_CATEGORY_JFR);
-
-	if (NULL != resultBuffer) {
-		VM_BufferWriter resultWriter(privatePortLibrary, resultBuffer, bufferSize);
-		J9VMThread *walkThread = J9_LINKED_LIST_START_DO(_vm->mainThread);
-		UDATA numThreads = 0;
-		J9InternalVMFunctions *vmFuncs = _vm->internalVMFunctions;
-
-		Assert_VM_mustHaveVMAccess(_currentThread);
-		vmFuncs->acquireExclusiveVMAccess(_currentThread);
-
-		while (NULL != walkThread) {
-			writeThreadInfo(_currentThread, walkThread, &resultWriter);
-			writeStacktrace(_currentThread, walkThread, &resultWriter);
-
-			walkThread = J9_LINKED_LIST_NEXT_DO(_vm->mainThread, walkThread);
-			numThreads += 1;
-		}
-		resultWriter.writeFormattedString("Number of threads: %zd", numThreads);
-
-		vmFuncs->releaseExclusiveVMAccess(_currentThread);
-
-		writeUTF8String(resultWriter.getBufferStart(), resultWriter.getSize());
-		j9mem_free_memory(resultBuffer);
-	} else {
-		_buildResult = OutOfMemory;
-	}
-
-	/* write size */
-	writeEventSize(dataStart);
-
-	return dataStart;
+	/* Write size. */
+	writeEventSize(bufferWriter, dataStart);
 }
 
 void

--- a/runtime/vm/JFRChunkWriter.hpp
+++ b/runtime/vm/JFRChunkWriter.hpp
@@ -229,7 +229,6 @@ private:
 	static constexpr int CLASS_LOADER_STATISTICS_EVENT_SIZE = (3 * LEB128_32_SIZE) + (9 * LEB128_64_SIZE);
 	static constexpr int THREAD_CONTEXT_SWITCH_RATE_SIZE = sizeof(float) + (3 * sizeof(I_64));
 	static constexpr int THREAD_STATISTICS_EVENT_SIZE = (6 * sizeof(U_64)) + sizeof(U_32);
-	static constexpr int THREAD_DUMP_EVENT_SIZE_PER_THREAD = 1000;
 	static constexpr int SYSTEM_PROCESS_EVENT_SIZE = (4 * sizeof(U_64)) + 32 /* pid string */;
 	static constexpr int NATIVE_LIBRARY_ADDRESS_SIZE = (4 * sizeof(U_64)) + (2 * sizeof(UDATA)) + sizeof(U_8);
 	static constexpr int SYSTEM_GC_EVENT_SIZE = (2 * LEB128_64_SIZE) + (3 * LEB128_32_SIZE) + sizeof(U_8);
@@ -486,6 +485,8 @@ done:
 
 			pool_do(_constantPoolTypes.getNativeLibraryTable(), &writeNativeLibraryEvent, this);
 
+			pool_do(_constantPoolTypes.getThreadDumpTable(), &writeThreadDumpEvent, this);
+
 			if (J9_ARE_NO_BITS_SET(_vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_JFR_V2_SUPPORT)) {
 				/* Only write constant events in first chunk. */
 				if (0 == _vm->jfrState.jfrChunkCount) {
@@ -507,10 +508,6 @@ done:
 				}
 
 				writePhysicalMemoryEvent();
-
-				if (dumpCalled) {
-					writeThreadDumpEvent();
-				}
 			} else {
 				if (_constantPoolTypes.shouldWriteJVMInformation()) {
 					writeJVMInformationEvent();
@@ -546,10 +543,6 @@ done:
 
 				if (_constantPoolTypes.shouldWritePhysicalMemory()) {
 					writePhysicalMemoryEvent();
-				}
-
-				if (_constantPoolTypes.shouldWriteThreadDump()) {
-					writeThreadDumpEvent();
 				}
 			}
 
@@ -910,8 +903,6 @@ done:
 
 	void writeStringLiteral(const char *string, UDATA len);
 
-	void writeFormattedString(const char *format, ...);
-
 	U_8 *writeThreadStateCheckpointEvent();
 
 	U_8 *writePackageCheckpointEvent();
@@ -945,8 +936,6 @@ done:
 	U_8 *writeVirtualizationInformationEvent();
 
 	U_8 *writeOSInformationEvent();
-
-	U_8 *writeThreadDumpEvent();
 
 	void writeNarrowOOPModeTypesEvent();
 
@@ -994,6 +983,7 @@ done:
 
 	static void writeDataLossEvent(void *anElement, void *userData);
 
+	static void writeThreadDumpEvent(void *anElement, void *userData);
 
 	UDATA
 	calculateRequiredBufferSize()
@@ -1073,7 +1063,7 @@ done:
 
 		requiredBufferSize += _constantPoolTypes.getThreadStatisticsCount() * THREAD_STATISTICS_EVENT_SIZE;
 
-		requiredBufferSize += _vm->peakThreadCount * THREAD_DUMP_EVENT_SIZE_PER_THREAD;
+		requiredBufferSize += _constantPoolTypes.getThreadDumpCount() * _vm->peakThreadCount * VM_JFRUtils::THREAD_DUMP_EVENT_SIZE_PER_THREAD;
 
 		requiredBufferSize += (_constantPoolTypes.getSystemProcessCount() * SYSTEM_PROCESS_EVENT_SIZE)
 				+ _constantPoolTypes.getSystemProcessStringSizeTotal();

--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -1528,6 +1528,26 @@ done:
 }
 
 void
+VM_JFRConstantPoolTypes::addThreadDumpEntry(J9JFRThreadDump *threadDumpData)
+{
+	ThreadDumpEntry *entry = (ThreadDumpEntry *)pool_newElement(_threadDumpTable);
+
+	if (NULL == entry) {
+		_buildResult = OutOfMemory;
+		goto done;
+	}
+
+	entry->ticks = threadDumpData->startTicks;
+	entry->result = threadDumpData->result;
+	entry->resultLength = threadDumpData->resultLength;
+
+	_threadDumpCount += threadDumpData->resultLength;
+
+done:
+	return;
+}
+
+void
 VM_JFRConstantPoolTypes::printTables()
 {
 	j9tty_printf(PORTLIB, "--------------- StringUTF8Table ---------------\n");

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -455,6 +455,12 @@ struct DataLossEntry {
 	U_64 total;
 };
 
+struct ThreadDumpEntry {
+	I_64 ticks;
+	U_8 *result;
+	UDATA resultLength;
+};
+
 struct JFRConstantEvents {
 	JVMInformationEntry JVMInfoEntry;
 	CPUInformationEntry CPUInfoEntry;
@@ -547,6 +553,8 @@ private:
 	UDATA _networkUtilizationCount;
 	J9Pool *_dataLossTable;
 	UDATA _dataLossCount;
+	J9Pool *_threadDumpTable;
+	UDATA _threadDumpCount;
 
 	/* Periodic events. */
 	bool _shouldWriteJVMInformation;
@@ -563,7 +571,6 @@ private:
 	bool _shouldWriteModuleRequire;
 	bool _shouldWriteModuleExport;
 	bool _shouldWriteClassLoaderStatistics;
-	bool _shouldWriteThreadDump;
 
 	/* Processing buffers */
 	StackFrame *_currentStackFrameBuffer;
@@ -870,6 +877,8 @@ public:
 	void addNetworkUtilizationEntry(J9JFRNetworkUtilization *networkUtilizationData);
 	void addDataLossEntry(J9JFRDataLoss *dataLossData);
 
+	void addThreadDumpEntry(J9JFRThreadDump *threadDumpData);
+
 	void addThreadObjectEntry(J9JFRThreadObject *tableEntry);
 
 	J9Pool *getExecutionSampleTable()
@@ -1030,6 +1039,16 @@ public:
 	UDATA getDataLossCount()
 	{
 		return _dataLossCount;
+	}
+
+	J9Pool *getThreadDumpTable()
+	{
+		return _threadDumpTable;
+	}
+
+	UDATA getThreadDumpCount()
+	{
+		return _threadDumpCount;
 	}
 
 	UDATA getThreadStartCount()
@@ -1307,11 +1326,6 @@ public:
 		return _shouldWriteClassLoaderStatistics;
 	}
 
-	bool shouldWriteThreadDump()
-	{
-		return _shouldWriteThreadDump;
-	}
-
 	/**
 	* Helper to get JFR constantEvents field.
 	*
@@ -1434,7 +1448,7 @@ public:
 				_shouldWriteClassLoaderStatistics = true;
 				break;
 			case J9JFR_EVENT_TYPE_THREAD_DUMP:
-				_shouldWriteThreadDump = true;
+				addThreadDumpEntry((J9JFRThreadDump *)event);
 				break;
 			case J9JFR_EVENT_TYPE_DATA_LOSS:
 				addDataLossEntry((J9JFRDataLoss *)event);
@@ -1458,6 +1472,7 @@ public:
 				loadNativeLibraries(_currentThread);
 				loadModuleRequireAndModuleExportEvents();
 				loadClassLoaderStatisticsEvents(_currentThread);
+				loadThreadDumpEvents(_currentThread);
 			}
 		} else {
 			if (_shouldWriteSystemProcess) {
@@ -2045,6 +2060,38 @@ done:
 		vmFuncs->allClassLoadersEndDo(&walkState);
 	}
 
+	/**
+	 * @brief Generate and add ThreadDump events to _threadDumpTable.
+	 * This function is only used by JFR v1.
+	 *
+	 * @param currentThread[in] The pointer to the current J9VMThread
+	 */
+	void loadThreadDumpEvents(J9VMThread *currentThread)
+	{
+		J9JavaVM *vm = currentThread->javaVM;
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		UDATA bufferSize = vm->peakThreadCount * VM_JFRUtils::THREAD_DUMP_EVENT_SIZE_PER_THREAD;
+		ThreadDumpEntry *entry = (ThreadDumpEntry *)pool_newElement(_threadDumpTable);
+
+		if (NULL == entry) {
+			_buildResult = OutOfMemory;
+			goto done;
+		}
+
+		entry->ticks = (I_64)j9time_nano_time();
+		entry->result = (U_8 *)j9mem_allocate_memory(sizeof(U_8) * bufferSize, J9MEM_CATEGORY_JFR);
+		if (NULL == entry->result) {
+			_buildResult = OutOfMemory;
+			goto done;
+		}
+		entry->resultLength = getThreadDump(currentThread, entry->result, bufferSize);
+
+		_threadDumpCount += 1;
+
+	done:
+		return;
+	}
+
 	VM_JFRConstantPoolTypes(J9VMThread *currentThread)
 		: _currentThread(currentThread)
 		, _vm(currentThread->javaVM)
@@ -2121,6 +2168,8 @@ done:
 		, _networkUtilizationCount(0)
 		, _dataLossTable(NULL)
 		, _dataLossCount(0)
+		, _threadDumpTable(NULL)
+		, _threadDumpCount(0)
 		, _shouldWriteJVMInformation(false)
 		, _shouldWriteCPUInformationEvent(false)
 		, _shouldWriteVirtualizationInformationEvent(false)
@@ -2135,7 +2184,6 @@ done:
 		, _shouldWriteModuleRequire(false)
 		, _shouldWriteModuleExport(false)
 		, _shouldWriteClassLoaderStatistics(false)
-		, _shouldWriteThreadDump(false)
 		, _previousStackTraceEntry(NULL)
 		, _firstStackTraceEntry(NULL)
 		, _previousThreadEntry(NULL)
@@ -2356,6 +2404,12 @@ done:
 			goto done;
 		}
 
+		_threadDumpTable = pool_new(sizeof(ThreadDumpEntry), 0, sizeof(U_64), 0, J9_GET_CALLSITE(), OMRMEM_CATEGORY_VM, POOL_FOR_PORT(privatePortLibrary));
+		if (NULL == _threadDumpTable) {
+			_buildResult = OutOfMemory;
+			goto done;
+		}
+
 		/* Add reserved index for default entries. For strings zero is the empty or NUll string.
 		 * For package zero is the deafult package, for Module zero is the unnamed module. ThreadGroup
 		 * zero is NULL threadGroup.
@@ -2461,6 +2515,7 @@ done:
 		pool_kill(_gcHeapSummaryTable);
 		pool_kill(_networkUtilizationTable);
 		pool_kill(_dataLossTable);
+		pool_kill(_threadDumpTable);
 		freeNetworkInterfaceNames();
 		j9mem_free_memory(_globalStringTable);
 	}

--- a/runtime/vm/JFRUtils.hpp
+++ b/runtime/vm/JFRUtils.hpp
@@ -47,6 +47,7 @@ private:
 protected:
 
 public:
+	static constexpr int THREAD_DUMP_EVENT_SIZE_PER_THREAD = 1000;
 
 	/*
 	 * Function members

--- a/runtime/vm/j9vm.tdf
+++ b/runtime/vm/j9vm.tdf
@@ -1054,3 +1054,5 @@ TraceEvent=Trc_VM_internalCreateRAMClassDone_hotswapping_set_state Overhead=1 Le
 TraceEvent=Trc_VM_internalCreateRAMClassDone_bootstrap_state Overhead=1 Level=2 Template="className (%.*s), state(%p)->classObject is NULL"
 
 TraceExit-Exception=Trc_VM_objectMonitorExit_Exit_ValueType Overhead=1 Level=4 Template="IllegalMonitorState in objectMonitorExit. obj=%p is a value type."
+
+TraceException=Trc_VM_JFR_getThreadDump_bufferOverflow NoEnv Overhead=1 Level=1 Template="Buffer overflow happened while generating thread dump string."

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -182,6 +182,9 @@ jfrEventSize(J9JFREvent *jfrEvent)
 	case J9JFR_EVENT_TYPE_DATA_LOSS:
 		size = sizeof(J9JFRDataLoss);
 		break;
+	case J9JFR_EVENT_TYPE_THREAD_DUMP:
+		size = sizeof(J9JFRThreadDump) + (((J9JFRThreadDump *)jfrEvent)->bufferSize * sizeof(U_8));
+		break;
 	case J9JFR_EVENT_TYPE_JVM_INFORMATION:
 	case J9JFR_EVENT_TYPE_CPU_INFORMATION:
 	case J9JFR_EVENT_TYPE_VIRTUALIZATION_INFORMATION:
@@ -196,7 +199,6 @@ jfrEventSize(J9JFREvent *jfrEvent)
 	case J9JFR_EVENT_TYPE_MODULE_EXPORT:
 	case J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS:
 	case J9JFR_EVENT_TYPE_NATIVE_LIBRARY:
-	case J9JFR_EVENT_TYPE_THREAD_DUMP:
 		size = sizeof(J9JFREvent);
 		break;
 	default:
@@ -2302,10 +2304,40 @@ JfrPeriodicEventSet::requestExecutionSample(J9VMThread *currentThread)
 void
 JfrPeriodicEventSet::requestThreadDump(J9VMThread *currentThread)
 {
-	J9JFREvent *jfrEvent = (J9JFREvent *)reserveBuffer(currentThread, currentThread, sizeof(J9JFREvent));
-	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, currentThread, jfrEvent, J9JFR_EVENT_TYPE_THREAD_DUMP);
+	J9JavaVM *vm = currentThread->javaVM;
+
+	const U_64 bufferSize = VM_JFRUtils::THREAD_DUMP_EVENT_SIZE_PER_THREAD * vm->peakThreadCount;
+	const UDATA eventSize = bufferSize + sizeof(J9JFRThreadDump);
+	J9JFRThreadDump *jfrEvent = NULL;
+
+	omrthread_monitor_enter(vm->jfrBufferMutex);
+	if (eventSize > vm->jfrBuffer.bufferRemaining) {
+		if (isJFRV2SupportEnabled(vm)) {
+			notifyForChunkRotation(currentThread);
+			omrthread_monitor_exit(vm->jfrBufferMutex);
+			return;
+		} else {
+			if (!writeOutGlobalBuffer(currentThread, false, false)) {
+				omrthread_monitor_exit(vm->jfrBufferMutex);
+				return;
+			}
+		}
 	}
+	jfrEvent = (J9JFRThreadDump *)vm->jfrBuffer.bufferCurrent;
+	vm->jfrBuffer.bufferCurrent += eventSize;
+	vm->jfrBuffer.bufferRemaining -= eventSize;
+	omrthread_monitor_exit(vm->jfrBufferMutex);
+
+	U_8 *buffer = NULL;
+	UDATA length = 0;
+	buffer = (U_8 *)(jfrEvent + 1);
+	length = getThreadDump(currentThread, buffer, bufferSize);
+
+	initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_THREAD_DUMP);
+	jfrEvent->bufferSize = bufferSize;
+	jfrEvent->result = buffer;
+	jfrEvent->resultLength = length;
+	return;
 }
 
 void
@@ -2443,6 +2475,250 @@ jfrClassInitialize(J9HookInterface **hook, UDATA eventNum, void *eventData, void
 
 	/* getTypeIdImpl will add clazz to the TypeID table. */
 	getTypeIdImpl(currentThread, clazz->classLoader, J9ROMCLASS_CLASSNAME(clazz->romClass), FALSE, clazz);
+}
+
+static void
+writeObject(J9JavaVM *vm, j9object_t obj, VM_BufferWriter *bufferWriter)
+{
+	J9ROMClass *romClass = NULL;
+	if (J9VM_IS_INITIALIZED_HEAPCLASS_VM(vm, obj)) {
+		romClass = J9VM_J9CLASS_FROM_HEAPCLASS_VM(vm, obj)->romClass;
+	} else {
+		romClass = J9OBJECT_CLAZZ_VM(vm, obj)->romClass;
+	}
+
+	J9UTF8 *className = J9ROMCLASS_CLASSNAME(romClass);
+	bufferWriter->writeFormattedString("%.*s@%p", J9UTF8_LENGTH(className), J9UTF8_DATA(className), obj);
+}
+
+static UDATA
+stackWalkCallback(J9VMThread *vmThread, J9StackWalkState *state)
+{
+	J9JavaVM *vm = vmThread->javaVM;
+	J9ObjectMonitorInfo *monitorInfo = (J9ObjectMonitorInfo *)state->userData2;
+	IDATA *monitorCount = (IDATA *)(&state->userData3);
+	J9Method *method = state->method;
+	J9Class *methodClass = J9_CLASS_FROM_METHOD(method);
+	J9UTF8 *className = J9ROMCLASS_CLASSNAME(methodClass->romClass);
+	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+	J9UTF8 *methodName = J9ROMMETHOD_NAME(romMethod);
+
+	VM_BufferWriter *bufferWriter = (VM_BufferWriter *)state->userData1;
+
+	bufferWriter->writeFormattedString(
+			"at %.*s.%.*s",
+			J9UTF8_LENGTH(className), J9UTF8_DATA(className),
+			J9UTF8_LENGTH(methodName), J9UTF8_DATA(methodName));
+
+	if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccNative)) {
+		bufferWriter->writeFormattedString("(Native Method)\n");
+	} else {
+		UDATA offsetPC = state->bytecodePCOffset;
+		bool compiledMethod = (NULL != state->jitInfo);
+		J9UTF8 *sourceFile = getSourceFileNameForROMClass(vm, methodClass->classLoader, methodClass->romClass);
+		if (NULL != sourceFile) {
+			bufferWriter->writeFormattedString(
+					"(%.*s", J9UTF8_LENGTH(sourceFile), J9UTF8_DATA(sourceFile));
+
+			UDATA lineNumber = getLineNumberForROMClass(vm, method, offsetPC);
+
+			if ((UDATA)-1 != lineNumber) {
+				bufferWriter->writeFormattedString(":%zu", lineNumber);
+			}
+
+			if (compiledMethod) {
+				bufferWriter->writeFormattedString("(Compiled Code)");
+			}
+
+			bufferWriter->writeFormattedString(")\n");
+		} else {
+			bufferWriter->writeFormattedString("(Bytecode PC: %zu", offsetPC);
+			if (compiledMethod) {
+				bufferWriter->writeFormattedString("(Compiled Code)");
+			}
+			bufferWriter->writeFormattedString(")\n");
+		}
+
+		/* Use a while loop as there may be more than one lock taken in a stack frame. */
+		while ((0 != *monitorCount) && ((UDATA)monitorInfo->depth == state->framesWalked)) {
+			bufferWriter->writeFormattedString("\t(entered lock: ");
+			writeObject(vm, monitorInfo->object, bufferWriter);
+			bufferWriter->writeFormattedString(")\n");
+
+			monitorInfo += 1;
+			state->userData2 = monitorInfo;
+
+			(*monitorCount) -= 1;
+		}
+	}
+
+	return J9_STACKWALK_KEEP_ITERATING;
+}
+
+static void
+writeThreadInfo(J9VMThread *currentThread, J9VMThread *walkThread, VM_BufferWriter *bufferWriter)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	UDATA javaTID = 0;
+	UDATA osTID = ((J9AbstractThread *)walkThread->osThread)->tid;
+	UDATA javaPriority = 0;
+	UDATA state = J9VMTHREAD_STATE_UNKNOWN;
+	const char *stateStr = "?";
+	j9object_t monitorObject = NULL;
+	char *threadName = NULL;
+	j9object_t threadObject = walkThread->threadObject;
+
+	if (NULL != threadObject) {
+		javaTID = J9VMJAVALANGTHREAD_TID(currentThread, threadObject);
+		javaPriority = vmFuncs->getJavaThreadPriority(vm, walkThread);
+
+		/* Get thread state and monitor */
+		state = getVMThreadObjectState(walkThread, &monitorObject, NULL, NULL);
+		switch (state) {
+		case J9VMTHREAD_STATE_RUNNING:
+			stateStr = "R";
+			break;
+		case J9VMTHREAD_STATE_BLOCKED:
+			stateStr = "B";
+			break;
+		case J9VMTHREAD_STATE_WAITING:
+		case J9VMTHREAD_STATE_WAITING_TIMED:
+		case J9VMTHREAD_STATE_SLEEPING:
+			stateStr = "CW";
+			break;
+		case J9VMTHREAD_STATE_PARKED:
+		case J9VMTHREAD_STATE_PARKED_TIMED:
+			stateStr = "P";
+			break;
+		case J9VMTHREAD_STATE_SUSPENDED:
+			stateStr = "S";
+			break;
+		case J9VMTHREAD_STATE_DEAD:
+			stateStr = "Z";
+			break;
+		case J9VMTHREAD_STATE_INTERRUPTED:
+			stateStr = "I";
+			break;
+		case J9VMTHREAD_STATE_UNKNOWN:
+			stateStr = "?";
+			break;
+		default:
+			stateStr = "??";
+			break;
+		}
+
+	/* Get thread name */
+	#if JAVA_SPEC_VERSION >= 21
+		if (IS_JAVA_LANG_VIRTUALTHREAD(currentThread, threadObject)) {
+			/* For VirtualThread, get name from threadObject directly. */
+			j9object_t nameObject = J9VMJAVALANGTHREAD_NAME(currentThread, threadObject);
+			threadName = getVMThreadNameFromString(currentThread, nameObject);
+		} else
+	#endif /* JAVA_SPEC_VERSION >= 21 */
+		{
+			threadName = getOMRVMThreadName(walkThread->omrVMThread);
+			releaseOMRVMThreadName(walkThread->omrVMThread);
+		}
+	} else {
+		threadName = getOMRVMThreadName(walkThread->omrVMThread);
+		releaseOMRVMThreadName(walkThread->omrVMThread);
+	}
+
+	bufferWriter->writeFormattedString(
+			"\"%s\" J9VMThread: %p tid: %zd nid: %zd prio: %zd state: %s rawStateValue: 0x%zX",
+			threadName,
+			walkThread,
+			javaTID,
+			osTID,
+			javaPriority,
+			stateStr,
+			state);
+
+	if (J9VMTHREAD_STATE_BLOCKED == state) {
+		bufferWriter->writeFormattedString(" blocked on: ");
+	} else if ((J9VMTHREAD_STATE_WAITING == state) || (J9VMTHREAD_STATE_WAITING_TIMED == state)) {
+		bufferWriter->writeFormattedString(" waiting on: ");
+	} else if ((J9VMTHREAD_STATE_PARKED == state) || (J9VMTHREAD_STATE_PARKED_TIMED == state)) {
+		bufferWriter->writeFormattedString(" parked on: ");
+	} else {
+		bufferWriter->writeFormattedString("\n");
+		return;
+	}
+
+	if (NULL != monitorObject) {
+		writeObject(vm, monitorObject, bufferWriter);
+	} else {
+		bufferWriter->writeFormattedString("<unknown>");
+	}
+	bufferWriter->writeFormattedString("\n");
+}
+
+static void
+writeStacktrace(J9VMThread *currentThread, J9VMThread *walkThread, VM_BufferWriter *bufferWriter)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9StackWalkState stackWalkState = {0};
+	const size_t maxMonitorInfosPerThread = 32;
+	J9ObjectMonitorInfo monitorInfos[maxMonitorInfosPerThread];
+	memset(monitorInfos, 0, sizeof(monitorInfos));
+
+	IDATA monitorCount = vmFuncs->getOwnedObjectMonitors(currentThread, walkThread, monitorInfos, maxMonitorInfosPerThread, FALSE);
+
+	stackWalkState.walkThread = walkThread;
+	stackWalkState.flags =
+			J9_STACKWALK_ITERATE_FRAMES
+			| J9_STACKWALK_INCLUDE_NATIVES
+			| J9_STACKWALK_VISIBLE_ONLY
+			| J9_STACKWALK_RECORD_BYTECODE_PC_OFFSET
+			| J9_STACKWALK_NO_ERROR_REPORT;
+	stackWalkState.skipCount = 0;
+	stackWalkState.frameWalkFunction = stackWalkCallback;
+	stackWalkState.userData1 = bufferWriter;
+	stackWalkState.userData2 = monitorInfos;
+	stackWalkState.userData3 = (void *)monitorCount;
+
+	vmFuncs->haltThreadForInspection(currentThread, walkThread);
+	vm->walkStackFrames(currentThread, &stackWalkState);
+	vmFuncs->resumeThreadForInspection(currentThread, walkThread);
+
+	bufferWriter->writeFormattedString("\n");
+}
+
+UDATA
+getThreadDump(J9VMThread *currentThread, U_8 *buffer, UDATA bufferSize)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	VM_BufferWriter resultWriter(privatePortLibrary, buffer, bufferSize);
+	J9VMThread *walkThread = J9_LINKED_LIST_START_DO(vm->mainThread);
+	UDATA numThreads = 0;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	/* JMC skips the first part splitted by "\n\n" so write something here. */
+	resultWriter.writeFormattedString("Thread dump:\n\n");
+
+	Assert_VM_mustHaveVMAccess(currentThread);
+	vmFuncs->acquireExclusiveVMAccess(currentThread);
+
+	while (NULL != walkThread) {
+		writeThreadInfo(currentThread, walkThread, &resultWriter);
+		writeStacktrace(currentThread, walkThread, &resultWriter);
+
+		walkThread = J9_LINKED_LIST_NEXT_DO(vm->mainThread, walkThread);
+		numThreads += 1;
+	}
+	resultWriter.writeFormattedString("Number of threads: %zd", numThreads);
+
+	if (resultWriter.overflowOccurred()) {
+		Trc_VM_JFR_getThreadDump_bufferOverflow();
+	}
+
+	vmFuncs->releaseExclusiveVMAccess(currentThread);
+
+	return resultWriter.getSize();
 }
 
 } /* extern "C" */


### PR DESCRIPTION
- Store event in JFR buffer as event can be emitted multiple times in one chunk in JFR v2
- Fixes https://github.com/eclipse-openj9/openj9/issues/24195 by avoiding unexpected null characters being written

Related: https://github.com/eclipse-openj9/openj9/issues/24194