### PR TITLE
Fix testSCCacheManagement "Did not expect to find file" failure

### DIFF
--- a/test/functional/CacheManagement/configs/config.defaults
+++ b/test/functional/CacheManagement/configs/config.defaults
@@ -34,17 +34,17 @@ cmd.destroyNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,d
 cmd.destroyAllCaches=%java_exe% -Xshareclasses:destroyAll%1%
 cmd.destroyAllSnapshots=%java_exe% -Xshareclasses:destroyAllSnapshots%1%
 cmd.runSimpleJavaProgramWithPersistentCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,verbose -cp . SimpleApp
-cmd.runSimpleJavaProgramWithNonPersistentCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,nonpersistent,verbose -cp . SimpleApp
+cmd.runSimpleJavaProgramWithNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,nonpersistent,verbose -cp . SimpleApp
 cmd.runSimpleJavaProgram=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,verbose -cp . SimpleApp
 cmd.listAllCaches=%java_exe% -Xshareclasses:listAllCaches%1%
-cmd.createNonPersistentCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,nonpersistent,verbose -cp . SimpleApp
+cmd.createNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -XX:SharedCacheHardLimit=16m -Xscmx16m -Xshareclasses:name=%1%,nonpersistent,verbose -cp . SimpleApp
 cmd.createCacheSnapshot=%java_exe% -Xshareclasses:name=%1%,nonpersistent,snapshotCache
 cmd.expireAllCaches=%java_exe% -Xshareclasses:expire=0,verbose%1% -cp . SimpleApp
 cmd.createIncompatibleCache=%java_exe% -Xshareclasses:name=%1%,verbose -cp . SimpleApp
 cmd.runPrintStats=%java_exe% -Xshareclasses:name=%1%,printStats%2%,verbose%3%
 cmd.runPrintAllStats=%java_exe% -Xshareclasses:name=%1%,printAllStats,verbose%2%
 cmd.runResetPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,verbose -cp . ResetApp
-cmd.runResetNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,nonpersistent,verbose -cp . ResetApp
+cmd.runResetNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -Xshareclasses:name=%1%,reset,nonpersistent,verbose -cp . ResetApp
 cmd.runComplexJavaProgram=%java_exe% -Xshareclasses:name=%1%,verbose -Dconfig.properties=%2% %apploc% tests.sharedclasses.options.TestCorruptedCaches04Helper %1% 
 cmd.runSimpleJavaProgramWithPersistentCachePlusOptions=%java_exe% -Xshareclasses:name=%1%,verbose  %2% -cp . SimpleApp
 cmd.runSimpleJavaProgramWithPersistentCacheCheckStringTable=%java_exe% -Xtrace:none=j9shr.1547 -Xshareclasses:name=%1%,verbose,checkStringTable,verboseIntern -cp . SimpleApp
@@ -53,5 +53,5 @@ cmd.runInfiniteLoopJavaProgramWithNonPersistentCache=%java_exe% -Xshareclasses:n
 cmd.expireAllCachesWithTime=%java_exe% -Xshareclasses:expire=%1%,verbose%2% -cp . SimpleApp
 cmd.runHanoiProgramWithCache=%java_exe% -XX:SharedCacheHardLimit=16m -Xshareclasses:name=%1%,verbose %2% -cp utils.jar org.openj9.test.ivj.Hanoi 15
 cmd.runSimpleJavaProgramWithAgentWithPersistentCache=%java_exe% -Xshareclasses:name=%1%,verbose -agentlib:jvmtitest=test:%2%,args:%3% -cp . SimpleApp
-cmd.runSimpleJavaProgramWithAgentWithNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,verbose -agentlib:jvmtitest=test:%2%,args:%3% -cp . SimpleApp
+cmd.runSimpleJavaProgramWithAgentWithNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -Xshareclasses:name=%1%,nonpersistent,verbose -agentlib:jvmtitest=test:%2%,args:%3% -cp . SimpleApp
 cmd.checkJavaVersion=%java_exe% -version

--- a/test/functional/CacheManagement/src/config.base.properties
+++ b/test/functional/CacheManagement/src/config.base.properties
@@ -28,16 +28,17 @@ cmd.destroyPersistentCache=%java_exe% -Xshareclasses:name=%1%,destroy
 cmd.destroyNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,destroy
 cmd.destroyAllCaches=%java_exe% -Xshareclasses:destroyAll%1%
 cmd.runSimpleJavaProgramWithPersistentCache=%java_exe% -Xshareclasses:name=%1%,verbose -classpath %apploc%/testcode.jar SimpleApp
-cmd.runSimpleJavaProgramWithNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.runSimpleJavaProgramWithNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -Xshareclasses:name=%1%,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
 cmd.runSimpleJavaProgram=%java_exe% -Xshareclasses:name=%1%,verbose -classpath %apploc%/testcode.jar SimpleApp
 cmd.destroyPersistentCache=%java_exe% -Xshareclasses:name=%1%,destroy
 cmd.listAllCaches=%java_exe% -Xshareclasses:listAllCaches%1%
-cmd.createNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.createNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -Xshareclasses:name=%1%,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
 cmd.expireAllCaches=%java_exe% -Xshareclasses:expire=0,verbose%1% -classpath %apploc%/testcode.jar SimpleApp
 cmd.createIncompatibleCache=%java5_exe% -Xshareclasses:name=%1%,verbose -classpath %apploc%/testcode.jar SimpleApp
 cmd.runPrintStats=%java_exe% -Xshareclasses:name=%1%,printStats,verbose%2%
 cmd.runPrintAllStats=%java_exe% -Xshareclasses:name=%1%,printAllStats,verbose%2%
 cmd.runResetPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,verbose -classpath %apploc%/testcode.jar ResetApp
-cmd.runResetNonPersistentCache=%java_exe% -Xshareclasses:name=%1%,reset,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
+cmd.runResetNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -Xshareclasses:name=%1%,reset,nonpersistent,verbose -classpath %apploc%/testcode.jar SimpleApp
 cmd.runComplexJavaProgram=%java_exe% -Xshareclasses:name=%1%,verbose -Dconfig.properties=%2% -classpath %apploc% tests.sharedclasses.options.TestCorruptedCaches04Helper %1% 
 cmd.runSimpleJavaProgramWithPersistentCacheCheckStringTable=%java_exe% -Xtrace:none=j9shr.1547 -Xshareclasses:name=%1%,verbose,checkStringTable,verboseIntern -classpath %apploc%/testcode.jar SimpleApp
+cmd.runSimpleJavaProgramWithAgentWithNonPersistentCache=%java_exe% -Dibm.java9.forceCommonCleanerShutdown=true -Xshareclasses:name=%1%,nonpersistent,verbose -agentlib:jvmtitest=test:%2%,args:%3% -cp . SimpleApp


### PR DESCRIPTION
Add -Dibm.java9.forceCommonCleanerShutdown=true to the
non-persistent cache commands so the CommonCleaner is
shut down during JVM shutdown, allowing the shared
cache attach count to be decremented before the cache
is destroyed.

Fixes:  https://github.com/eclipse-openj9/openj9/issues/24198

