### PR TITLE
Restore interpretation of os.arch = x86_64 on macOS

### DIFF
--- a/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GetNativeDirectory.java
+++ b/debugtools/DDR_Autoblob/src/com/ibm/j9ddr/autoblob/GetNativeDirectory.java
@@ -80,7 +80,7 @@ public class GetNativeDirectory
 		}
 
 		// if the current system is AMD64 use x86 as the osArch
-		else if (osArch.equals("amd64")) {
+		else if (osArch.equals("amd64") || osArch.equals("x86_64")) {
 			osArch = "x86";
 		}
 

--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/LayoutStrPreprocessor.java
@@ -56,7 +56,7 @@ import jdk.incubator.foreign.ValueLayout;
 final class LayoutStrPreprocessor {
 	private static final String osName = System.getProperty("os.name");
 	private static final String arch = System.getProperty("os.arch");
-	private static final boolean isX86_64 = arch.equals("amd64");
+	private static final boolean isX86_64 = arch.equals("amd64") || arch.equals("x86_64");
 	private static final boolean isLinuxS390x = arch.equals("s390x") && osName.equals("Linux");
 
 	/*[IF JAVA_SPEC_VERSION == 17]*/

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/DowncallTests.java
@@ -57,7 +57,7 @@ import jdk.incubator.foreign.ValueLayout;
 public class DowncallTests {
 	private static final String osName = System.getProperty("os.name");
 	private static final String arch = System.getProperty("os.arch");
-	private static final boolean isX64 = arch.equals("amd64");
+	private static final boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
 	private static final boolean isWinX64 = osName.startsWith("Windows") && isX64;
 	private static final boolean isLinuxAarch64 = osName.equals("Linux") && arch.equals("aarch64");
 	/* The padding of struct is not required on Power in terms of VaList */

--- a/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
+++ b/test/functional/Java17andUp/src_170/org/openj9/test/jep389/valist/UpcallTests.java
@@ -57,7 +57,7 @@ import jdk.incubator.foreign.ValueLayout;
 public class UpcallTests {
 	private static final String osName = System.getProperty("os.name");
 	private static final String arch = System.getProperty("os.arch");
-	private static final boolean isX64 = arch.equals("amd64");
+	private static final boolean isX64 = arch.equals("amd64") || arch.equals("x86_64");
 	private static final boolean isWinX64 = osName.startsWith("Windows") && isX64;
 	private static final boolean isLinuxAarch64 = osName.equals("Linux") && arch.equals("aarch64");
 	/* The padding of struct is not required on Power in terms of VaList */

--- a/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
+++ b/test/functional/Java8andUp/src/org/openj9/test/contendedfields/ContendedFieldsTests.java
@@ -59,7 +59,7 @@ public class ContendedFieldsTests {
 			CACHE_LINE_SIZE = 128;
 		} else if (osArch.startsWith("s390")) {
 			CACHE_LINE_SIZE = 256;
-		} else if (osArch.equals("amd64") || osArch.equals("x86")) {
+		} else if (osArch.equals("amd64") || osArch.equals("x86") || osArch.equals("x86_64")) {
 			CACHE_LINE_SIZE = 64;
 		} else if (osArch.equals("aarch64")) {
 			String osName = System.getProperty("os.name");

--- a/test/functional/VM_Test/src/j9vm/runner/Runner.java
+++ b/test/functional/VM_Test/src/j9vm/runner/Runner.java
@@ -73,7 +73,7 @@ public class Runner {
 				return PPC;
 			} else if (archSpec.startsWith("s390")) {
 				return S390X;
-			} else if (archSpec.equals("amd64") || archSpec.equals("x86")) {
+			} else if (archSpec.equals("amd64") || archSpec.equals("x86") || archSpec.equals("x86_64")) {
 				return X86;
 			} else {
 				System.out.println("Runner couldn't determine underlying architecture. Got OS Arch:" + archSpec);


### PR DESCRIPTION
Corrects https://github.com/eclipse-openj9/openj9/pull/24202, fixes https://github.com/eclipse-openj9/openj9/issues/24214.
