### PR TITLE
Reduce getResolvedMethods() usage with flag based class queries

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: IBM Bob
  *******************************************************************************/
 
 #define J9_EXTERNAL_TO_VM
@@ -6235,6 +6236,37 @@ TR_ResolvedMethod *TR_J9VMBase::getResolvedMethodForConstructorWithSig(TR_Memory
     TR_OpaqueClassBlock *classPointer, const char *signature)
 {
     return getResolvedMethodForNameAndSignature(trMemory, classPointer, "<init>", signature);
+}
+
+bool TR_J9VMBase::classHasNativeMethods(TR_OpaqueClassBlock *classPointer)
+{
+    // If this assert fails in the future, classHasNativeMethods() must also
+    // check J9_STARTPC_JNI_NATIVE on the RAM method.
+    static_assert(supportsFastJNI(), "supportsFastJNI() must return true");
+    TR::VMAccessCriticalSection vmCS(this);
+    J9ROMClass *romClass = TR::Compiler->cls.romClassOf(classPointer);
+    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
+    uint32_t numMethods = getNumMethods(classPointer);
+    for (uint32_t i = 0; i < numMethods; i++) {
+        if (romMethod->modifiers & J9AccNative)
+            return true;
+        romMethod = nextROMMethod(romMethod);
+    }
+    return false;
+}
+
+bool TR_J9VMBase::classHasSynchronizedMethods(TR_OpaqueClassBlock *classPointer)
+{
+    TR::VMAccessCriticalSection vmCS(this);
+    J9ROMClass *romClass = TR::Compiler->cls.romClassOf(classPointer);
+    J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);
+    uint32_t numMethods = getNumMethods(classPointer);
+    for (uint32_t i = 0; i < numMethods; i++) {
+        if (romMethod->modifiers & J9AccSynchronized)
+            return true;
+        romMethod = nextROMMethod(romMethod);
+    }
+    return false;
 }
 
 void *TR_J9VMBase::getMethods(TR_OpaqueClassBlock *classPointer)

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -530,6 +530,35 @@ public:
     virtual TR_ResolvedMethod *getResolvedMethodForConstructorWithSig(TR_Memory *trMemory,
         TR_OpaqueClassBlock *classPointer, const char *signature);
 
+    /**
+     * @brief Checks if a class has any native methods
+     *
+     * Acquires VMAccess internally.
+     *
+     * @param classPointer The class to check
+     * @return true if the class has any native methods, false otherwise
+     */
+    virtual bool classHasNativeMethods(TR_OpaqueClassBlock *classPointer);
+
+    /**
+     * @brief Checks if a class has any synchronized methods
+     *
+     * Acquires VMAccess internally.
+     *
+     * @param classPointer The class to check
+     * @return true if the class has any synchronized methods, false otherwise
+     */
+    virtual bool classHasSynchronizedMethods(TR_OpaqueClassBlock *classPointer);
+
+    static constexpr bool supportsFastJNI()
+    {
+#if defined(TR_TARGET_S390) || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER) || defined(TR_TARGET_ARM64)
+        return true;
+#else
+        return false;
+#endif
+    }
+
     virtual TR_OpaqueMethodBlock *getResolvedVirtualMethod(TR_OpaqueClassBlock *classObject, int32_t cpIndex,
         bool ignoreReResolve = true);
     virtual TR_OpaqueMethodBlock *getResolvedInterfaceMethod(TR_OpaqueMethodBlock *ownerMethod,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -1811,15 +1811,6 @@ TR_J9Method::TR_J9Method() {}
 //
 /////////////////////////
 
-static bool supportsFastJNI(TR_FrontEnd *fe)
-{
-#if defined(TR_TARGET_S390) || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER) || defined(TR_TARGET_ARM64)
-    return true;
-#else
-    return false;
-#endif
-}
-
 TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock *aMethod, TR_FrontEnd *fe, TR_Memory *trMemory,
     TR_ResolvedMethod *owner, uint32_t vTableSlot)
     : TR_J9Method(fe, trMemory, aMethod)
@@ -1836,12 +1827,16 @@ TR_ResolvedJ9Method::TR_ResolvedJ9Method(TR_OpaqueMethodBlock *aMethod, TR_Front
     _romLiterals = (J9ROMConstantPoolItem *)((UDATA)romClassPtr() + sizeof(J9ROMClass));
     _vTableSlot = vTableSlot;
     _j9classForNewInstance = NULL;
-    if (supportsFastJNI(fe)) {
+    if (TR_J9VMBase::supportsFastJNI()) {
         TR_J9VMBase *j9fe = (TR_J9VMBase *)_fe;
         // a non-NULL target address is returned for both JNI natives and non-JNI natives with FastJNI replacements,
         // NULL otherwise properties will be non-zero IFF the target address points to a FastJNI replacement
         _jniTargetAddress = j9fe->getJ9JITConfig()->javaVM->internalVMFunctions->jniNativeMethodProperties(
             j9fe->vmThread(), _ramMethod, &_jniProperties);
+        // This assert ensures that the simplification made in classHasNativeMethods() (checking only J9AccNative)
+        // remains valid.
+        TR_ASSERT(!_jniTargetAddress || (_romMethod->modifiers & J9AccNative),
+            "Method has a non-NULL jniTargetAddress but is not declared native");
 
         // check for user specified FastJNI override
         if (TR::Options::getJniAccelerator() != NULL
@@ -5224,7 +5219,7 @@ void *TR_ResolvedJ9Method::addressContainingIsOverriddenBit() { return &ramMetho
 
 bool TR_ResolvedJ9Method::isJNINative()
 {
-    if (!supportsFastJNI(_fe)) {
+    if (!TR_J9VMBase::supportsFastJNI()) {
         return (((UDATA)ramMethod()->constantPool) & J9_STARTPC_JNI_NATIVE) != 0;
     }
     return _jniTargetAddress != NULL;

--- a/runtime/compiler/ilgen/ClassLookahead.cpp
+++ b/runtime/compiler/ilgen/ClassLookahead.cpp
@@ -76,17 +76,14 @@ int32_t TR_ClassLookahead::perform()
     if (!isClassInitialized)
         return 0;
 
+    if (fej9->classHasNativeMethods(_classPointer)) {
+        _classInfo->setCannotTrustStaticFinal();
+        return 0;
+    }
+
     TR_ScratchList<TR_ResolvedMethod> resolvedMethodsInClass(comp()->trMemory());
     fej9->getResolvedMethods(comp()->trMemory(), _classPointer, &resolvedMethodsInClass);
-
-    ListIterator<TR_ResolvedMethod> resolvedMethIt(&resolvedMethodsInClass);
     TR_ResolvedMethod *resolvedMethod = NULL;
-    for (resolvedMethod = resolvedMethIt.getFirst(); resolvedMethod; resolvedMethod = resolvedMethIt.getNext()) {
-        if (resolvedMethod->isNative() || resolvedMethod->isJNINative() || resolvedMethod->isJITInternalNative()) {
-            _classInfo->setCannotTrustStaticFinal();
-            return 0;
-        }
-    }
 
     bool b = comp()->getNeedsClassLookahead();
     comp()->setNeedsClassLookahead(false);

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -3152,20 +3152,7 @@ bool TR_EscapeAnalysis::restrictCandidates(TR::Node *node, TR::Node *reason, res
 
                 TR_J9VMBase *fej9 = (TR_J9VMBase *)(fe());
                 if (_parms && fej9->hasTwoWordObjectHeader()) {
-                    TR_ScratchList<TR_ResolvedMethod> resolvedMethodsInClass(trMemory());
-                    fej9->getResolvedMethods(trMemory(), (TR_OpaqueClassBlock *)candidate->_class,
-                        &resolvedMethodsInClass);
-                    bool containsSyncMethod = false;
-                    ListIterator<TR_ResolvedMethod> resolvedIt(&resolvedMethodsInClass);
-                    TR_ResolvedMethod *resolvedMethod;
-                    for (resolvedMethod = resolvedIt.getFirst(); resolvedMethod;
-                         resolvedMethod = resolvedIt.getNext()) {
-                        if (resolvedMethod->isSynchronized()) {
-                            containsSyncMethod = true;
-                            break;
-                        }
-                    }
-                    if (!containsSyncMethod) {
+                    if (!fej9->classHasSynchronizedMethods((TR_OpaqueClassBlock *)candidate->_class)) {
                         logprintf(trace(), log, "   Make [%p] non-local because of node [%p]\n", candidate->_node,
                             reason);
                         wasRestricted = true;


### PR DESCRIPTION
I added and used two new frontend methods that check method flags directly on j9methods without creating expensive `TR_ResolvedMethod` objects:

- `classHasNativeMethods()`: checks `J9AccNative` and `J9_STARTPC_JNI_NATIVE` 
  flags directly on RAM/ROM methods
- `classHasSynchronizedMethods()`: checks `J9AccSynchronized` flag directly 
  on ROM methods

Issue: #23591 
Related PRs: #24088 and https://github.com/eclipse-omr/omr/pull/8293