### PR TITLE
Aarch64: Implement Integer and Long compareUnsigned intrinsic

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -117,6 +117,12 @@ void J9::ARM64::CodeGenerator::initialize()
         cg->setSupportsInlineStringCodingCountPositives();
     }
 #endif /* JAVA_SPEC_VERSION >= 19 */
+
+    static const bool disableCompareUnsignedInlining = feGetEnv("TR_DisableCompareUnsignedInlining") != NULL;
+    if (!disableCompareUnsignedInlining) {
+        cg->setSupportsInlineIntegerCompareUnsigned();
+        cg->setSupportsInlineLongCompareUnsigned();
+    }
 }
 
 TR::Linkage *J9::ARM64::CodeGenerator::createLinkage(TR_LinkageConventions lc)

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -7635,6 +7635,45 @@ static TR::Register *inlineHasNegativesOrCountPositives(TR::Node *node, bool isH
     return indexReg;
 }
 
+/**
+ * \brief
+ *   Generate inlined instructions equivalent to java/lang/Integer.compareUnsigned or java/lang/Long.compareUnsigned
+ *
+ * \param node
+ *   The tree node
+ *
+ * \param isInt
+ *   True when the method to be inlined is Integer.compareUnsigned, false when the method is Long.compareUnsigned
+ *
+ * \param cg
+ *   The Code Generator
+ */
+static TR::Register *inlineIntegerLongCompareUnsigned(TR::Node *node, bool isInt, TR::CodeGenerator *cg)
+{
+    TR::LabelSymbol *doneLabel = generateLabelSymbol(cg);
+
+    TR::Register *aReg = cg->evaluate(node->getChild(0));
+    TR::Register *bReg = cg->evaluate(node->getChild(1));
+    TR::Register *zeroReg = cg->allocateRegister();
+    TR::Register *resultReg = cg->allocateRegister();
+
+    TR::RegisterDependencyConditions *dependencies = RegDeps(0, 1, cg);
+    dependencies->addPostCondition(zeroReg, TR::RealRegister::xzr);
+
+    generateCompareInstruction(cg, node, aReg, bReg, !isInt);
+    generateCSetInstruction(cg, node, resultReg, TR::CC_HI, false);
+    generateTrg1Src2Instruction(cg, TR::InstOpCode::sbcw, node, resultReg, resultReg, zeroReg);
+    generateLabelInstruction(cg, TR::InstOpCode::label, node, doneLabel, dependencies);
+
+    cg->stopUsingRegister(zeroReg);
+    cg->decReferenceCount(node->getChild(0));
+    cg->decReferenceCount(node->getChild(1));
+
+    node->setRegister(resultReg);
+
+    return resultReg;
+}
+
 bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resultReg)
 {
     TR::CodeGenerator *cg = self();
@@ -7805,6 +7844,19 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
                 }
                 break;
             }
+
+            case TR::java_lang_Integer_compareUnsigned:
+                if (cg->getSupportsInlineIntegerCompareUnsigned()) {
+                    resultReg = inlineIntegerLongCompareUnsigned(node, true /* isInt */, cg);
+                    return true;
+                }
+                break;
+            case TR::java_lang_Long_compareUnsigned:
+                if (cg->getSupportsInlineLongCompareUnsigned()) {
+                    resultReg = inlineIntegerLongCompareUnsigned(node, false /* isInt */, cg);
+                    return true;
+                }
+                break;
 
             case TR::sun_misc_Unsafe_compareAndSwapLong_jlObjectJJJ_Z: {
                 // As above, we only want to inline the JNI methods, so add an explicit test for isNative()


### PR DESCRIPTION
This PR implements Integer.compareUnsigned() and Long.compareUnsigned() as intrinsics on aarch64. See https://github.com/eclipse-openj9/openj9/pull/24108

Signed-off-by: Sabrina Lee <sabrinalee@ibm.com>