### PR TITLE
Check RHS for isAuto during aliasing in VectorAPIExpansion

### DIFF
--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -370,6 +370,10 @@ void TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node, bool v
 
             bool aliasTemps = false;
 
+            // Only an aload of an auto can hold a vector value in a temp, so only such a load is aliased
+            // into the temp class to build the web that validateSymRef() later validates.
+            bool isLoadOfAuto = rhs->getOpCodeValue() == TR::aload && rhs->getSymbolReference()->getSymbol()->isAuto();
+
             if (rhs->getOpCode().isFunctionCall()
                 && isVectorAPIMethod(rhs->getSymbolReference()->getSymbol()->castToMethodSymbol())) {
                 // propagate vector info from VectorAPI call to temp
@@ -392,13 +396,13 @@ void TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node, bool v
                     if (boxingAllowed() && !_nodeTable[rhs->getGlobalIndex()]._canVectorize)
                         dontVectorizeNode(node);
                 } // end of Vector API call as RHS
-            } else if (boxingAllowed() && rhs->getOpCodeValue() != TR::aload) {
+            } else if (boxingAllowed() && !isLoadOfAuto) {
                 dontVectorizeNode(node);
 
                 logprintf(_trace, log, "Making #%d a box of unknown type due to node %p\n", id1, node);
             }
 
-            if (rhs->getOpCodeValue() == TR::aload)
+            if (isLoadOfAuto)
                 aliasTemps = true;
 
             alias(node, rhs, aliasTemps);


### PR DESCRIPTION
When const refs are enabled, a load of a known java/lang/Class operand,
such as the species class passed to a Vector API call, ends up as
"aload <const obj ref>". That is a plain aload of a final static symref,
rather than the indirect load it used to be.

While building vector aliases, buildVectorAliases() aliases the RHS of an
astore into the temp class and marks it as a temp (aliasTemps) whenever the
RHS is an aload. For a const-ref aload this is wrong: the static aload gets
aliased into the vector's temp class even though its per-symref _vinfo stays
"unknown". It is a class object, not a vector, so during transformation the
astore is vectorized while isVectorizedOrScalarizedNode() returns false for
the RHS aload, hitting an assertion failure due to the non-vectorized RHS
aload. This resulted in failure running test
jdk/incubator/vector/Float128Vector.java with const refs enabled.

Only an aload of an auto can hold a vector value in a temp, so restrict the
temp aliasing to aloads of autos. A static (const-ref) aload RHS is now boxed
like any other non-vector RHS instead of being aliased into the temp class,
keeping the vectorized/boxed state consistent. This matches the behaviour
with const refs disabled, where the same operand does not get treated as a
plain aload.

This fix is necessary to address functional failures as we prepare for enabling const refs https://github.com/eclipse-openj9/openj9/issues/16616