### PR TITLE
Add J9 equivalents for canTransformUnsafeSetMemory

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -138,6 +138,13 @@ public:
 
     TR::Linkage *createLinkageForCompilation();
 
+    /**
+     * @brief Answers whether Unsafe.setMemory transformation to arrayset is supported.
+     *
+     * @return : true if the transformation is supported; false otherwise.
+     */
+    bool canTransformUnsafeSetMemory() { return false; }
+
     bool enableAESInHardwareTransformations() { return false; }
 
     bool isMethodInAtomicLongGroup(TR::RecognizedMethod rm);

--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -474,6 +474,15 @@ bool J9::Compilation::canTransformConverterMethod(TR::RecognizedMethod rm)
     }
 }
 
+bool J9::Compilation::canTransformUnsafeSetMemory()
+{
+    if (!self()->getOptions()->realTimeGC() && !TR::Compiler->om.canGenerateArraylets()
+        && !self()->getOption(TR_DisableUnsafe) && self()->cg()->canTransformUnsafeSetMemory())
+        return true;
+
+    return false;
+}
+
 bool J9::Compilation::useCompressedPointers()
 {
     // FIXME: probably have to query the GC as well

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -191,6 +191,8 @@ public:
     bool canTransformConverterMethod(TR::RecognizedMethod method);
     bool isConverterMethod(TR::RecognizedMethod method);
 
+    bool canTransformUnsafeSetMemory();
+
     bool useCompressedPointers();
     bool useAnchors();
 

--- a/runtime/compiler/p/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.cpp
@@ -197,6 +197,8 @@ bool J9::Power::CodeGenerator::canEmitDataForExternallyRelocatableInstructions()
     return !self()->comp()->compileRelocatableCode();
 }
 
+bool J9::Power::CodeGenerator::canTransformUnsafeSetMemory() { return (comp()->target().is64Bit()); }
+
 // Get or create the TR::Linkage object that corresponds to the given linkage
 // convention.
 // Even though this method is common, its implementation is machine-specific.

--- a/runtime/compiler/p/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/p/codegen/J9CodeGenerator.hpp
@@ -90,6 +90,8 @@ public:
 
     bool canEmitDataForExternallyRelocatableInstructions();
 
+    bool canTransformUnsafeSetMemory();
+
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
     bool suppressInliningOfCryptoMethod(TR::RecognizedMethod method);
     bool inlineCryptoMethod(TR::Node *node, TR::Register *&resultReg);

--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3458,6 +3458,12 @@ bool J9::Z::CodeGenerator::canUseRelativeLongInstructions(int64_t value)
     return OMR::CodeGeneratorConnector::canUseRelativeLongInstructions(value);
 }
 
+bool J9::Z::CodeGenerator::canTransformUnsafeSetMemory()
+{
+    static bool enableUnsafeSetMemoryAcceleration = (feGetEnv("TR_DisableUnsafeSetMemoryAcceleration") == NULL);
+    return (enableUnsafeSetMemoryAcceleration && self()->comp()->target().is64Bit());
+}
+
 TR::Instruction *J9::Z::CodeGenerator::generateVMCallHelperPrePrologue(TR::Instruction *cursor)
 {
     TR::Compilation *comp = self()->comp();

--- a/runtime/compiler/z/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.hpp
@@ -84,6 +84,13 @@ public:
     bool alwaysGeneratesAKnownCleanSign(TR::Node *node);
     bool alwaysGeneratesAKnownPositiveCleanSign(TR::Node *node);
     bool canUseRelativeLongInstructions(int64_t value);
+
+    /**
+     * @brief Answers whether Unsafe.setMemory transformation to arrayset is supported.
+     *
+     * @return : true if the transformation is supported; false otherwise.
+     */
+    bool canTransformUnsafeSetMemory();
     TR_RawBCDSignCode alwaysGeneratedSign(TR::Node *node);
 
     uint32_t getPDMulEncodedSize(TR::Node *pdmul, TR_PseudoRegister *multiplicand, TR_PseudoRegister *multiplier);


### PR DESCRIPTION
Adds J9 equivalents for the bool `canTransformUnsafeSetMemory` , in preparedness to remove the same from OMR via https://github.com/eclipse-omr/omr/pull/8301