### PR TITLE
Add information regarding synchronous compilations in javacore

### DIFF
--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -512,6 +512,8 @@ public:
         }
     }; // CompilationStatsPerInterval
 
+    typedef J9JITSyncCompilationStatistics SyncCompilationStatistics;
+
     static bool createCompilationInfo(J9JITConfig *jitConfig);
     static void freeCompilationInfo(J9JITConfig *jitConfig);
 
@@ -1508,6 +1510,7 @@ public:
 
     struct CompilationStatistics _stats;
     struct CompilationStatsPerInterval _intervalStats;
+    SyncCompilationStatistics _syncCompStats;
     TR_PersistentArray<TR_SignatureCountPair *> *_persistedMethods;
 
     // Must be less than 16 at the JITClient or non-JITServer mode because

--- a/runtime/compiler/control/CompilationRuntime.hpp
+++ b/runtime/compiler/control/CompilationRuntime.hpp
@@ -1510,7 +1510,6 @@ public:
 
     struct CompilationStatistics _stats;
     struct CompilationStatsPerInterval _intervalStats;
-    SyncCompilationStatistics _syncCompStats;
     TR_PersistentArray<TR_SignatureCountPair *> *_persistedMethods;
 
     // Must be less than 16 at the JITClient or non-JITServer mode because

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -861,13 +861,14 @@ void TR::CompilationInfo::freeAllResources()
 
     PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
     for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
-        if (_syncCompStats.longestWaitMethods[i].method != NULL) {
-            j9mem_free_memory(_syncCompStats.longestWaitMethods[i].method);
-            _syncCompStats.longestWaitMethods[i].method = NULL;
+        J9JITLongestSyncComp &longestWaitMethod = _syncCompStats.longestWaitMethods[i];
+        if (longestWaitMethod.method != NULL) {
+            j9mem_free_memory(longestWaitMethod.method);
+            longestWaitMethod.method = NULL;
         }
-        if (_syncCompStats.longestWaitMethods[i].thread != NULL) {
-            j9mem_free_memory(_syncCompStats.longestWaitMethods[i].thread);
-            _syncCompStats.longestWaitMethods[i].thread = NULL;
+        if (longestWaitMethod.thread != NULL) {
+            j9mem_free_memory(longestWaitMethod.thread);
+            longestWaitMethod.thread = NULL;
         }
     }
 }
@@ -6305,7 +6306,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
             _syncCompStats.totalCount++;
             _syncCompStats.totalWaitTime += duration;
 
-            /* Obtain index to insert */
+            /* Obtain index to insert. */
             int idx = -1;
             for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
                 if (_syncCompStats.longestWaitMethods[i].waitTime < duration) {
@@ -6314,14 +6315,14 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
                 }
             }
 
-            if (idx >= 0) {
-                /* Remove the shortest wait-time */
+            if (0 <= idx) {
+                /* Remove the shortest wait-time. */
                 J9JITLongestSyncComp &lastMethod = _syncCompStats.longestWaitMethods[J9_LONGEST_SYNC_COMP - 1];
-                if (lastMethod.method != NULL) {
+                if (NULL != lastMethod.method) {
                     j9mem_free_memory(lastMethod.method);
                     lastMethod.method = NULL;
                 }
-                if (lastMethod.thread != NULL) {
+                if (NULL != lastMethod.thread) {
                     j9mem_free_memory(lastMethod.thread);
                     lastMethod.thread = NULL;
                 }
@@ -6339,18 +6340,18 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
 
                 uint32_t totalLen = J9UTF8_LENGTH(className) + J9UTF8_LENGTH(name) + J9UTF8_LENGTH(signature) + 2;
                 char *templongestWaitMethod = (char *)j9mem_allocate_memory(totalLen, J9MEM_CATEGORY_JIT);
-                if (templongestWaitMethod != NULL) {
-                    snprintf(templongestWaitMethod, totalLen, "%.*s.%.*s%.*s", J9UTF8_LENGTH(className),
+                if (NULL != templongestWaitMethod) {
+                    j9str_printf(templongestWaitMethod, totalLen, "%.*s.%.*s%.*s", J9UTF8_LENGTH(className),
                         J9UTF8_DATA(className), J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(signature),
                         J9UTF8_DATA(signature));
                 }
                 _syncCompStats.longestWaitMethods[idx].method = templongestWaitMethod;
 
-                char *threadName = getOMRVMThreadName(vmThread->omrVMThread);
-                uint32_t len = strlen(threadName) + 1;
-                char *tempThread = (char *)j9mem_allocate_memory(len, J9MEM_CATEGORY_JIT);
-                if (tempThread != NULL) {
-                    memcpy(tempThread, threadName, len);
+                const char *threadName = getOMRVMThreadName(vmThread->omrVMThread);
+                uint32_t len = strlen(threadName);
+                char *tempThread = (char *)j9mem_allocate_memory(len + 1, J9MEM_CATEGORY_JIT);
+                if (NULL != tempThread) {
+                    memcpy(tempThread, threadName, len + 1);
                 }
                 _syncCompStats.longestWaitMethods[idx].thread = tempThread;
                 releaseOMRVMThreadName(vmThread->omrVMThread);

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -807,6 +807,7 @@ bool TR::CompilationInfo::createCompilationInfo(J9JITConfig *jitConfig)
         memset(alloc, 0, sizeof(TR::CompilationInfo));
         _compilationRuntime = new (alloc) TR::CompilationInfo(jitConfig);
         jitConfig->compilationRuntime = (void *)_compilationRuntime;
+        jitConfig->syncCompStats = &_compilationRuntime->_syncCompStats;
 #ifdef DEBUG
         if (debug("traceThreadCompile"))
             _compilationRuntime->_traceCompiling = true;
@@ -857,6 +858,18 @@ void TR::CompilationInfo::freeAllResources()
     }
 
     freeAllCompilationThreads();
+
+    PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
+    for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+        if (_syncCompStats.longestWaitMethods[i].method != NULL) {
+            j9mem_free_memory(_syncCompStats.longestWaitMethods[i].method);
+            _syncCompStats.longestWaitMethods[i].method = NULL;
+        }
+        if (_syncCompStats.longestWaitMethods[i].thread != NULL) {
+            j9mem_free_memory(_syncCompStats.longestWaitMethods[i].thread);
+            _syncCompStats.longestWaitMethods[i].thread = NULL;
+        }
+    }
 }
 
 void TR::CompilationInfo::freeCompilationInfo(J9JITConfig *jitConfig)
@@ -6182,6 +6195,12 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
         //
         entry->_numThreadsWaiting++;
 
+        uint64_t waitStart = 0;
+        PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
+        if (!async) {
+            waitStart = j9time_hires_clock();
+        }
+
         // Release the compilation monitor
         //
         debugPrint(vmThread, "\tapplication thread releasing compilation monitor\n");
@@ -6278,6 +6297,65 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
         entry->_numThreadsWaiting--;
+
+        if (!async) {
+            uint64_t waitEnd = j9time_hires_clock();
+            uint64_t duration = j9time_hires_delta(waitStart, waitEnd, J9PORT_TIME_DELTA_IN_MICROSECONDS);
+
+            _syncCompStats.totalCount++;
+            _syncCompStats.totalWaitTime += duration;
+
+            /* Obtain index to insert */
+            int idx = -1;
+            for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+                if (_syncCompStats.longestWaitMethods[i].waitTime < duration) {
+                    idx = i;
+                    break;
+                }
+            }
+
+            if (idx >= 0) {
+                /* Remove the shortest wait-time */
+                J9JITLongestSyncComp &lastMethod = _syncCompStats.longestWaitMethods[J9_LONGEST_SYNC_COMP - 1];
+                if (lastMethod.method != NULL) {
+                    j9mem_free_memory(lastMethod.method);
+                    lastMethod.method = NULL;
+                }
+                if (lastMethod.thread != NULL) {
+                    j9mem_free_memory(lastMethod.thread);
+                    lastMethod.thread = NULL;
+                }
+                for (int i = J9_LONGEST_SYNC_COMP - 1; i > idx; i--) {
+                    _syncCompStats.longestWaitMethods[i] = _syncCompStats.longestWaitMethods[i - 1];
+                }
+
+                _syncCompStats.longestWaitMethods[idx].waitTime = duration;
+                _syncCompStats.longestWaitMethods[idx].waitTimeEnd = j9time_current_time_millis();
+
+                J9UTF8 *className;
+                J9UTF8 *name;
+                J9UTF8 *signature;
+                getClassNameSignatureFromMethod(method, className, name, signature);
+
+                uint32_t totalLen = J9UTF8_LENGTH(className) + J9UTF8_LENGTH(name) + J9UTF8_LENGTH(signature) + 2;
+                char *templongestWaitMethod = (char *)j9mem_allocate_memory(totalLen, J9MEM_CATEGORY_JIT);
+                if (templongestWaitMethod != NULL) {
+                    snprintf(templongestWaitMethod, totalLen, "%.*s.%.*s%.*s", J9UTF8_LENGTH(className),
+                        J9UTF8_DATA(className), J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(signature),
+                        J9UTF8_DATA(signature));
+                }
+                _syncCompStats.longestWaitMethods[idx].method = templongestWaitMethod;
+
+                char *threadName = getOMRVMThreadName(vmThread->omrVMThread);
+                uint32_t len = strlen(threadName) + 1;
+                char *tempThread = (char *)j9mem_allocate_memory(len, J9MEM_CATEGORY_JIT);
+                if (tempThread != NULL) {
+                    memcpy(tempThread, threadName, len);
+                }
+                _syncCompStats.longestWaitMethods[idx].thread = tempThread;
+                releaseOMRVMThreadName(vmThread->omrVMThread);
+            }
+        }
 
         TR_ASSERT_FATAL(!(entry->_freeTag & (ENTRY_DEALLOCATED | ENTRY_IN_POOL_FREE)),
             "Java thread waking up with a freed entry");

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -21,7 +21,6 @@
  * Assisted-by: IBM Bob
  *******************************************************************************/
 
-#include <cstdint>
 #define J9_EXTERNAL_TO_VM
 
 #if SOLARIS || AIXPPC || LINUX || OSX
@@ -808,7 +807,6 @@ bool TR::CompilationInfo::createCompilationInfo(J9JITConfig *jitConfig)
         memset(alloc, 0, sizeof(TR::CompilationInfo));
         _compilationRuntime = new (alloc) TR::CompilationInfo(jitConfig);
         jitConfig->compilationRuntime = (void *)_compilationRuntime;
-        jitConfig->syncCompStats = &_compilationRuntime->_syncCompStats;
 #ifdef DEBUG
         if (debug("traceThreadCompile"))
             _compilationRuntime->_traceCompiling = true;
@@ -861,8 +859,9 @@ void TR::CompilationInfo::freeAllResources()
     freeAllCompilationThreads();
 
     PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
+    J9JITSyncCompilationStatistics &syncCompStats = _jitConfig->syncCompStats;
     for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
-        J9JITLongestSyncComp &longestWaitMethod = _syncCompStats.longestWaitMethods[i];
+        J9JITLongestSyncComp &longestWaitMethod = syncCompStats.longestWaitMethods[i];
         if (longestWaitMethod.methodName != NULL) {
             j9mem_free_memory(longestWaitMethod.methodName);
             longestWaitMethod.methodName = NULL;
@@ -6303,14 +6302,15 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
         if (!async) {
             uint64_t waitEnd = j9time_hires_clock();
             uint64_t duration = j9time_hires_delta(waitStart, waitEnd, J9PORT_TIME_DELTA_IN_MICROSECONDS);
+            J9JITSyncCompilationStatistics &syncCompStats = _jitConfig->syncCompStats;
 
-            _syncCompStats.totalCount++;
-            _syncCompStats.totalWaitTime += duration;
+            syncCompStats.totalCount++;
+            syncCompStats.totalWaitTime += duration;
 
             /* Obtain index to insert. */
-            int idx = -1;
+            int32_t idx = -1;
             for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
-                if (_syncCompStats.longestWaitMethods[i].waitTime < duration) {
+                if (syncCompStats.longestWaitMethods[i].waitTime < duration) {
                     idx = i;
                     break;
                 }
@@ -6318,7 +6318,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
 
             if (0 <= idx) {
                 /* Remove the shortest wait-time. */
-                J9JITLongestSyncComp &lastMethod = _syncCompStats.longestWaitMethods[J9_NUM_LONGEST_SYNC_COMP - 1];
+                J9JITLongestSyncComp &lastMethod = syncCompStats.longestWaitMethods[J9_NUM_LONGEST_SYNC_COMP - 1];
                 if (NULL != lastMethod.methodName) {
                     j9mem_free_memory(lastMethod.methodName);
                     lastMethod.methodName = NULL;
@@ -6328,11 +6328,11 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
                     lastMethod.threadName = NULL;
                 }
                 for (int32_t i = J9_NUM_LONGEST_SYNC_COMP - 1; i > idx; i--) {
-                    _syncCompStats.longestWaitMethods[i] = _syncCompStats.longestWaitMethods[i - 1];
+                    syncCompStats.longestWaitMethods[i] = syncCompStats.longestWaitMethods[i - 1];
                 }
 
-                _syncCompStats.longestWaitMethods[idx].waitTime = duration;
-                _syncCompStats.longestWaitMethods[idx].waitTimeEnd = j9time_current_time_millis();
+                syncCompStats.longestWaitMethods[idx].waitTime = duration;
+                syncCompStats.longestWaitMethods[idx].waitTimeEnd = j9time_current_time_millis();
 
                 J9UTF8 *className = NULL;
                 J9UTF8 *name = NULL;
@@ -6346,7 +6346,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
                         J9UTF8_DATA(className), J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(signature),
                         J9UTF8_DATA(signature));
                 }
-                _syncCompStats.longestWaitMethods[idx].methodName = templongestWaitMethod;
+                syncCompStats.longestWaitMethods[idx].methodName = templongestWaitMethod;
 
                 const char *threadName = getOMRVMThreadName(vmThread->omrVMThread);
                 uint32_t len = strlen(threadName);
@@ -6354,7 +6354,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
                 if (NULL != tempThread) {
                     memcpy(tempThread, threadName, len + 1);
                 }
-                _syncCompStats.longestWaitMethods[idx].threadName = tempThread;
+                syncCompStats.longestWaitMethods[idx].threadName = tempThread;
                 releaseOMRVMThreadName(vmThread->omrVMThread);
             }
         }

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -21,6 +21,7 @@
  * Assisted-by: IBM Bob
  *******************************************************************************/
 
+#include <cstdint>
 #define J9_EXTERNAL_TO_VM
 
 #if SOLARIS || AIXPPC || LINUX || OSX
@@ -860,15 +861,15 @@ void TR::CompilationInfo::freeAllResources()
     freeAllCompilationThreads();
 
     PORT_ACCESS_FROM_JITCONFIG(_jitConfig);
-    for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+    for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
         J9JITLongestSyncComp &longestWaitMethod = _syncCompStats.longestWaitMethods[i];
-        if (longestWaitMethod.method != NULL) {
-            j9mem_free_memory(longestWaitMethod.method);
-            longestWaitMethod.method = NULL;
+        if (longestWaitMethod.methodName != NULL) {
+            j9mem_free_memory(longestWaitMethod.methodName);
+            longestWaitMethod.methodName = NULL;
         }
-        if (longestWaitMethod.thread != NULL) {
-            j9mem_free_memory(longestWaitMethod.thread);
-            longestWaitMethod.thread = NULL;
+        if (longestWaitMethod.threadName != NULL) {
+            j9mem_free_memory(longestWaitMethod.threadName);
+            longestWaitMethod.threadName = NULL;
         }
     }
 }
@@ -6308,7 +6309,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
 
             /* Obtain index to insert. */
             int idx = -1;
-            for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+            for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
                 if (_syncCompStats.longestWaitMethods[i].waitTime < duration) {
                     idx = i;
                     break;
@@ -6317,25 +6318,25 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
 
             if (0 <= idx) {
                 /* Remove the shortest wait-time. */
-                J9JITLongestSyncComp &lastMethod = _syncCompStats.longestWaitMethods[J9_LONGEST_SYNC_COMP - 1];
-                if (NULL != lastMethod.method) {
-                    j9mem_free_memory(lastMethod.method);
-                    lastMethod.method = NULL;
+                J9JITLongestSyncComp &lastMethod = _syncCompStats.longestWaitMethods[J9_NUM_LONGEST_SYNC_COMP - 1];
+                if (NULL != lastMethod.methodName) {
+                    j9mem_free_memory(lastMethod.methodName);
+                    lastMethod.methodName = NULL;
                 }
-                if (NULL != lastMethod.thread) {
-                    j9mem_free_memory(lastMethod.thread);
-                    lastMethod.thread = NULL;
+                if (NULL != lastMethod.threadName) {
+                    j9mem_free_memory(lastMethod.threadName);
+                    lastMethod.threadName = NULL;
                 }
-                for (int i = J9_LONGEST_SYNC_COMP - 1; i > idx; i--) {
+                for (int32_t i = J9_NUM_LONGEST_SYNC_COMP - 1; i > idx; i--) {
                     _syncCompStats.longestWaitMethods[i] = _syncCompStats.longestWaitMethods[i - 1];
                 }
 
                 _syncCompStats.longestWaitMethods[idx].waitTime = duration;
                 _syncCompStats.longestWaitMethods[idx].waitTimeEnd = j9time_current_time_millis();
 
-                J9UTF8 *className;
-                J9UTF8 *name;
-                J9UTF8 *signature;
+                J9UTF8 *className = NULL;
+                J9UTF8 *name = NULL;
+                J9UTF8 *signature = NULL;
                 getClassNameSignatureFromMethod(method, className, name, signature);
 
                 uint32_t totalLen = J9UTF8_LENGTH(className) + J9UTF8_LENGTH(name) + J9UTF8_LENGTH(signature) + 2;
@@ -6345,7 +6346,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
                         J9UTF8_DATA(className), J9UTF8_LENGTH(name), J9UTF8_DATA(name), J9UTF8_LENGTH(signature),
                         J9UTF8_DATA(signature));
                 }
-                _syncCompStats.longestWaitMethods[idx].method = templongestWaitMethod;
+                _syncCompStats.longestWaitMethods[idx].methodName = templongestWaitMethod;
 
                 const char *threadName = getOMRVMThreadName(vmThread->omrVMThread);
                 uint32_t len = strlen(threadName);
@@ -6353,7 +6354,7 @@ void *TR::CompilationInfo::compileOnSeparateThread(J9VMThread *vmThread, TR::IlG
                 if (NULL != tempThread) {
                     memcpy(tempThread, threadName, len + 1);
                 }
-                _syncCompStats.longestWaitMethods[idx].thread = tempThread;
+                _syncCompStats.longestWaitMethods[idx].threadName = tempThread;
                 releaseOMRVMThreadName(vmThread->omrVMThread);
             }
         }

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -297,6 +297,9 @@
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_4BYTES 0xFFFFFFFF
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_2BYTES 0xFFFF
 
+/* Constant for information regarding longest synchronous compilations */
+#define J9_LONGEST_SYNC_COMP 3
+
 #if JAVA_SPEC_VERSION >= 19
 #define J9JVMTI_MAX_TLS_KEYS 124
 typedef void(*j9_tls_finalizer_t)(void *);
@@ -4376,6 +4379,23 @@ typedef struct J9ClassCastParms {
 	struct J9Class* castClass;
 } J9ClassCastParms;
 
+typedef struct J9JITLongestSyncComp {
+	/* microseconds (us) */
+	uint64_t waitTime;
+	/* absolute timestamp */
+	uint64_t waitTimeEnd;
+	char* method;
+	char* thread;
+} J9JITLongestSyncComp;
+
+typedef struct J9JITSyncCompilationStatistics {
+	uint32_t totalCount;
+	/* microseconds (us) */
+    uint64_t totalWaitTime;
+	/* sorted in increasing order */
+	J9JITLongestSyncComp longestWaitMethods[J9_LONGEST_SYNC_COMP];
+} J9JITSyncCompilationStatistics;
+
 /* @ddr_namespace: map_to_type=J9JITConfig */
 
 typedef struct J9JITConfig {
@@ -4649,6 +4669,7 @@ typedef struct J9JITConfig {
 	IDATA verboseOutputLevel;
 	omrthread_monitor_t compilationMonitor;
 	void* compilationInfo;
+	J9JITSyncCompilationStatistics *syncCompStats;
 	void* aotCompilationInfo;
 	void* pseudoTOC;
 	void* i2jTransition;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -297,7 +297,7 @@
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_4BYTES 0xFFFFFFFF
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_2BYTES 0xFFFF
 
-/* Constant for information regarding longest synchronous compilations */
+/* Constant for information regarding longest synchronous compilations. */
 #define J9_LONGEST_SYNC_COMP 3
 
 #if JAVA_SPEC_VERSION >= 19
@@ -4380,20 +4380,16 @@ typedef struct J9ClassCastParms {
 } J9ClassCastParms;
 
 typedef struct J9JITLongestSyncComp {
-	/* microseconds (us) */
-	uint64_t waitTime;
-	/* absolute timestamp */
-	uint64_t waitTimeEnd;
-	char* method;
-	char* thread;
+	uint64_t waitTime; /* microseconds */
+	uint64_t waitTimeEnd; /* absolute timestamp */
+	char *method;
+	char *thread;
 } J9JITLongestSyncComp;
 
 typedef struct J9JITSyncCompilationStatistics {
 	uint32_t totalCount;
-	/* microseconds (us) */
-    uint64_t totalWaitTime;
-	/* sorted in increasing order */
-	J9JITLongestSyncComp longestWaitMethods[J9_LONGEST_SYNC_COMP];
+	uint64_t totalWaitTime; /* microseconds */
+	J9JITLongestSyncComp longestWaitMethods[J9_LONGEST_SYNC_COMP]; /* sorted in increasing order */
 } J9JITSyncCompilationStatistics;
 
 /* @ddr_namespace: map_to_type=J9JITConfig */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -298,7 +298,7 @@
 #define J9_CATCHTYPE_VALUE_FOR_SYNTHETIC_HANDLER_2BYTES 0xFFFF
 
 /* Constant for information regarding longest synchronous compilations. */
-#define J9_LONGEST_SYNC_COMP 3
+#define J9_NUM_LONGEST_SYNC_COMP 3
 
 #if JAVA_SPEC_VERSION >= 19
 #define J9JVMTI_MAX_TLS_KEYS 124
@@ -4382,14 +4382,14 @@ typedef struct J9ClassCastParms {
 typedef struct J9JITLongestSyncComp {
 	uint64_t waitTime; /* microseconds */
 	uint64_t waitTimeEnd; /* absolute timestamp */
-	char *method;
-	char *thread;
+	char *methodName;
+	char *threadName;
 } J9JITLongestSyncComp;
 
 typedef struct J9JITSyncCompilationStatistics {
 	uint32_t totalCount;
 	uint64_t totalWaitTime; /* microseconds */
-	J9JITLongestSyncComp longestWaitMethods[J9_LONGEST_SYNC_COMP]; /* sorted in increasing order */
+	J9JITLongestSyncComp longestWaitMethods[J9_NUM_LONGEST_SYNC_COMP]; /* sorted in increasing order */
 } J9JITSyncCompilationStatistics;
 
 /* @ddr_namespace: map_to_type=J9JITConfig */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -4389,7 +4389,7 @@ typedef struct J9JITLongestSyncComp {
 typedef struct J9JITSyncCompilationStatistics {
 	uint32_t totalCount;
 	uint64_t totalWaitTime; /* microseconds */
-	J9JITLongestSyncComp longestWaitMethods[J9_NUM_LONGEST_SYNC_COMP]; /* sorted in increasing order */
+	J9JITLongestSyncComp longestWaitMethods[J9_NUM_LONGEST_SYNC_COMP]; /* sorted in decreasing order */
 } J9JITSyncCompilationStatistics;
 
 /* @ddr_namespace: map_to_type=J9JITConfig */
@@ -4665,7 +4665,7 @@ typedef struct J9JITConfig {
 	IDATA verboseOutputLevel;
 	omrthread_monitor_t compilationMonitor;
 	void* compilationInfo;
-	J9JITSyncCompilationStatistics *syncCompStats;
+	J9JITSyncCompilationStatistics syncCompStats;
 	void* aotCompilationInfo;
 	void* pseudoTOC;
 	void* i2jTransition;

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -307,6 +307,7 @@ private :
 	void writeMonitorSection(void);
 	void writeThreadSection(void);
 	void writeClassSection(void);
+	void writeSynchronousCompilationSection(void);
 #if defined(OMR_OPT_CUDA)
 	void writeCudaSection(void);
 #endif /* defined(OMR_OPT_CUDA) */
@@ -556,6 +557,7 @@ JavaCoreDumpWriter::JavaCoreDumpWriter(
 	CALL_PROTECT(writeSharedClassSection, _Error);
 #endif
 	CALL_PROTECT(writeClassSection, _Error);
+	CALL_PROTECT(writeSynchronousCompilationSection, _Error);
 	CALL_PROTECT(writeTrailer, _Error);
 
 	/* Record the status of the operation */
@@ -2913,6 +2915,78 @@ JavaCoreDumpWriter::writeHookSection(void)
 
 	/* Write the section trailer */
 	_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
+}
+
+void
+JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
+{
+	char timeStamp[_MaximumTimeStampLength + 1];
+	PORT_ACCESS_FROM_PORT(_PortLibrary);
+	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+
+	J9JITConfig *jitConfig = _VirtualMachine->jitConfig;
+    if (NULL == jitConfig || NULL == jitConfig->syncCompStats) {
+        return;
+    }
+
+	J9JITSyncCompilationStatistics *stats = jitConfig->syncCompStats;
+
+	_OutputStream.writeCharacters("0SECTION       Synchronous compilations info dump routine\n");
+	_OutputStream.writeCharacters("NULL           ==============================\n");
+	_OutputStream.writeCharacters("1NOTE          This data is reset after each javacore file is written\n");
+	_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
+	_OutputStream.writeCharacters("1JITSYNCSTATS  Synchronous Compilation Statistics\n");
+    _OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
+	_OutputStream.writeCharacters("2JITSYNCCOUNT  Total synchronous compilations: ");
+    _OutputStream.writeInteger(stats->totalCount, "%u");
+    _OutputStream.writeCharacters("\n");
+	_OutputStream.writeCharacters("2JITTOTALWAIT  Total application wait time: ");
+    _OutputStream.writeInteger(stats->totalWaitTime, "%llu");
+    _OutputStream.writeCharacters("us\n");
+	for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+		if (stats->longestWaitMethods[i].waitTime == 0 || stats->longestWaitMethods[i].method == NULL)
+			break;
+		_OutputStream.writeCharacters("2JITLONGEST    ");
+		_OutputStream.writeInteger64(i + 1, "%zu");
+		_OutputStream.writeCharacters(". Longest Synchronous Compilation\n");
+
+		_OutputStream.writeCharacters("3JITWAITTIME   Wait time: ");
+		_OutputStream.writeInteger(stats->longestWaitMethods[i].waitTime, "%llu");
+		_OutputStream.writeCharacters("us\n");
+
+		_OutputStream.writeCharacters("3JITENDTIME    Wait time end: ");
+		omrstr_ftime_ex(timeStamp, _MaximumTimeStampLength, "%Y-%m-%dT%H:%M:%S",
+						stats->longestWaitMethods[i].waitTimeEnd, OMRSTR_FTIME_FLAG_LOCAL);
+		timeStamp[_MaximumTimeStampLength] = '\0';
+		_OutputStream.writeCharacters(timeStamp);
+		_OutputStream.writeInteger64(stats->longestWaitMethods[i].waitTimeEnd % 1000, ".%03llu");
+		_OutputStream.writeCharacters("\n");
+
+		_OutputStream.writeCharacters("3JITMETHOD     Method: ");
+		_OutputStream.writeCharacters(stats->longestWaitMethods[i].method);
+		_OutputStream.writeCharacters("\n");
+
+		if (stats->longestWaitMethods[i].thread != NULL) {
+			_OutputStream.writeCharacters("3JITTHREAD     Thread: ");
+			_OutputStream.writeCharacters(stats->longestWaitMethods[i].thread);
+			_OutputStream.writeCharacters("\n");
+		}
+	}
+
+	stats->totalCount = 0;
+    stats->totalWaitTime = 0;
+	for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+		stats->longestWaitMethods[i].waitTime = 0;
+		stats->longestWaitMethods[i].waitTimeEnd = 0;
+        if (stats->longestWaitMethods[i].method != NULL) {
+            j9mem_free_memory(stats->longestWaitMethods[i].method);
+            stats->longestWaitMethods[i].method = NULL;
+        }
+		if (stats->longestWaitMethods[i].thread != NULL) {
+            j9mem_free_memory(stats->longestWaitMethods[i].thread);
+            stats->longestWaitMethods[i].thread = NULL;
+        }
+    }
 }
 
 #if defined(OMR_OPT_CUDA)

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -2925,9 +2925,9 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
 	J9JITConfig *jitConfig = _VirtualMachine->jitConfig;
-    if (NULL == jitConfig || NULL == jitConfig->syncCompStats) {
-        return;
-    }
+	if ((NULL == jitConfig) || (NULL == jitConfig->syncCompStats)) {
+		return;
+	}
 
 	J9JITSyncCompilationStatistics *stats = jitConfig->syncCompStats;
 
@@ -2936,57 +2936,58 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 	_OutputStream.writeCharacters("1NOTE          This data is reset after each javacore file is written\n");
 	_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
 	_OutputStream.writeCharacters("1JITSYNCSTATS  Synchronous Compilation Statistics\n");
-    _OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
+	_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
 	_OutputStream.writeCharacters("2JITSYNCCOUNT  Total synchronous compilations: ");
-    _OutputStream.writeInteger(stats->totalCount, "%u");
-    _OutputStream.writeCharacters("\n");
+	_OutputStream.writeInteger(stats->totalCount, "%u");
+	_OutputStream.writeCharacters("\n");
 	_OutputStream.writeCharacters("2JITTOTALWAIT  Total application wait time: ");
-    _OutputStream.writeInteger(stats->totalWaitTime, "%llu");
-    _OutputStream.writeCharacters("us\n");
+	_OutputStream.writeInteger(stats->totalWaitTime, "%llu");
+	_OutputStream.writeCharacters("us\n");
 	for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
-		if (stats->longestWaitMethods[i].waitTime == 0 || stats->longestWaitMethods[i].method == NULL)
+		J9JITLongestSyncComp &longestWaitMethod = stats->longestWaitMethods[i];
+		if ((0 == longestWaitMethod.waitTime) || (NULL == longestWaitMethod.method)) {
 			break;
+		}
 		_OutputStream.writeCharacters("2JITLONGEST    ");
 		_OutputStream.writeInteger64(i + 1, "%zu");
 		_OutputStream.writeCharacters(". Longest Synchronous Compilation\n");
 
 		_OutputStream.writeCharacters("3JITWAITTIME   Wait time: ");
-		_OutputStream.writeInteger(stats->longestWaitMethods[i].waitTime, "%llu");
+		_OutputStream.writeInteger(longestWaitMethod.waitTime, "%llu");
 		_OutputStream.writeCharacters("us\n");
 
 		_OutputStream.writeCharacters("3JITENDTIME    Wait time end: ");
 		omrstr_ftime_ex(timeStamp, _MaximumTimeStampLength, "%Y-%m-%dT%H:%M:%S",
-						stats->longestWaitMethods[i].waitTimeEnd, OMRSTR_FTIME_FLAG_LOCAL);
+						longestWaitMethod.waitTimeEnd, OMRSTR_FTIME_FLAG_LOCAL);
 		timeStamp[_MaximumTimeStampLength] = '\0';
 		_OutputStream.writeCharacters(timeStamp);
-		_OutputStream.writeInteger64(stats->longestWaitMethods[i].waitTimeEnd % 1000, ".%03llu");
+		_OutputStream.writeInteger64(longestWaitMethod.waitTimeEnd % 1000, ".%03llu");
 		_OutputStream.writeCharacters("\n");
 
 		_OutputStream.writeCharacters("3JITMETHOD     Method: ");
-		_OutputStream.writeCharacters(stats->longestWaitMethods[i].method);
+		_OutputStream.writeCharacters(longestWaitMethod.method);
 		_OutputStream.writeCharacters("\n");
 
-		if (stats->longestWaitMethods[i].thread != NULL) {
-			_OutputStream.writeCharacters("3JITTHREAD     Thread: ");
-			_OutputStream.writeCharacters(stats->longestWaitMethods[i].thread);
-			_OutputStream.writeCharacters("\n");
-		}
+		_OutputStream.writeCharacters("3JITTHREAD     Thread: ");
+		_OutputStream.writeCharacters(longestWaitMethod.thread);
+		_OutputStream.writeCharacters("\n");
 	}
 
 	stats->totalCount = 0;
-    stats->totalWaitTime = 0;
+	stats->totalWaitTime = 0;
 	for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
-		stats->longestWaitMethods[i].waitTime = 0;
-		stats->longestWaitMethods[i].waitTimeEnd = 0;
-        if (stats->longestWaitMethods[i].method != NULL) {
-            j9mem_free_memory(stats->longestWaitMethods[i].method);
-            stats->longestWaitMethods[i].method = NULL;
-        }
-		if (stats->longestWaitMethods[i].thread != NULL) {
-            j9mem_free_memory(stats->longestWaitMethods[i].thread);
-            stats->longestWaitMethods[i].thread = NULL;
-        }
-    }
+		J9JITLongestSyncComp &longestWaitMethod = stats->longestWaitMethods[i];
+		longestWaitMethod.waitTime = 0;
+		longestWaitMethod.waitTimeEnd = 0;
+		if (NULL != longestWaitMethod.method) {
+			j9mem_free_memory(longestWaitMethod.method);
+			longestWaitMethod.method = NULL;
+		}
+		if (NULL != longestWaitMethod.thread) {
+			j9mem_free_memory(longestWaitMethod.thread);
+			longestWaitMethod.thread = NULL;
+		}
+	}
 }
 
 #if defined(OMR_OPT_CUDA)

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -21,7 +21,6 @@
  *******************************************************************************/
 
 /* Includes */
-#include <cstdint>
 #if defined(AIXPPC)
 #include <sys/time.h>
 #endif /* defined(AIXPPC) */
@@ -2926,11 +2925,11 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
 
 	J9JITConfig *jitConfig = _VirtualMachine->jitConfig;
-	if ((NULL == jitConfig) || (NULL == jitConfig->syncCompStats)) {
+	if (NULL == jitConfig) {
 		return;
 	}
 
-	J9JITSyncCompilationStatistics *stats = jitConfig->syncCompStats;
+	J9JITSyncCompilationStatistics &stats = jitConfig->syncCompStats;
 
 	_OutputStream.writeCharacters("0SECTION       Synchronous compilations info dump routine\n");
 	_OutputStream.writeCharacters("NULL           ==============================\n");
@@ -2939,13 +2938,13 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 	_OutputStream.writeCharacters("1JITSYNCSTATS  Synchronous Compilation Statistics\n");
 	_OutputStream.writeCharacters("NULL           ------------------------------------------------------------------------\n");
 	_OutputStream.writeCharacters("2JITSYNCCOUNT  Total synchronous compilations: ");
-	_OutputStream.writeInteger(stats->totalCount, "%u");
+	_OutputStream.writeInteger(stats.totalCount, "%u");
 	_OutputStream.writeCharacters("\n");
 	_OutputStream.writeCharacters("2JITTOTALWAIT  Total application wait time: ");
-	_OutputStream.writeInteger64(stats->totalWaitTime, "%llu");
+	_OutputStream.writeInteger64(stats.totalWaitTime, "%llu");
 	_OutputStream.writeCharacters("us\n");
-	for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
-		J9JITLongestSyncComp &longestWaitMethod = stats->longestWaitMethods[i];
+	for (UDATA i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
+		J9JITLongestSyncComp &longestWaitMethod = stats.longestWaitMethods[i];
 		if ((0 == longestWaitMethod.waitTime) || (NULL == longestWaitMethod.methodName)) {
 			break;
 		}
@@ -2959,7 +2958,7 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 
 		_OutputStream.writeCharacters("3JITENDTIME    Wait time end: ");
 		omrstr_ftime_ex(timeStamp, _MaximumTimeStampLength, "%Y-%m-%dT%H:%M:%S",
-						longestWaitMethod.waitTimeEnd, OMRSTR_FTIME_FLAG_LOCAL);
+				longestWaitMethod.waitTimeEnd, OMRSTR_FTIME_FLAG_LOCAL);
 		timeStamp[_MaximumTimeStampLength] = '\0';
 		_OutputStream.writeCharacters(timeStamp);
 		_OutputStream.writeInteger64(longestWaitMethod.waitTimeEnd % 1000, ".%03llu");
@@ -2974,10 +2973,10 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 		_OutputStream.writeCharacters("\n");
 	}
 
-	stats->totalCount = 0;
-	stats->totalWaitTime = 0;
-	for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
-		J9JITLongestSyncComp &longestWaitMethod = stats->longestWaitMethods[i];
+	stats.totalCount = 0;
+	stats.totalWaitTime = 0;
+	for (UDATA i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
+		J9JITLongestSyncComp &longestWaitMethod = stats.longestWaitMethods[i];
 		longestWaitMethod.waitTime = 0;
 		longestWaitMethod.waitTimeEnd = 0;
 		if (NULL != longestWaitMethod.methodName) {

--- a/runtime/rasdump/javadump.cpp
+++ b/runtime/rasdump/javadump.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 /* Includes */
+#include <cstdint>
 #if defined(AIXPPC)
 #include <sys/time.h>
 #endif /* defined(AIXPPC) */
@@ -2941,15 +2942,15 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 	_OutputStream.writeInteger(stats->totalCount, "%u");
 	_OutputStream.writeCharacters("\n");
 	_OutputStream.writeCharacters("2JITTOTALWAIT  Total application wait time: ");
-	_OutputStream.writeInteger(stats->totalWaitTime, "%llu");
+	_OutputStream.writeInteger64(stats->totalWaitTime, "%llu");
 	_OutputStream.writeCharacters("us\n");
-	for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+	for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
 		J9JITLongestSyncComp &longestWaitMethod = stats->longestWaitMethods[i];
-		if ((0 == longestWaitMethod.waitTime) || (NULL == longestWaitMethod.method)) {
+		if ((0 == longestWaitMethod.waitTime) || (NULL == longestWaitMethod.methodName)) {
 			break;
 		}
 		_OutputStream.writeCharacters("2JITLONGEST    ");
-		_OutputStream.writeInteger64(i + 1, "%zu");
+		_OutputStream.writeInteger(i + 1, "%zu");
 		_OutputStream.writeCharacters(". Longest Synchronous Compilation\n");
 
 		_OutputStream.writeCharacters("3JITWAITTIME   Wait time: ");
@@ -2965,27 +2966,27 @@ JavaCoreDumpWriter::writeSynchronousCompilationSection(void)
 		_OutputStream.writeCharacters("\n");
 
 		_OutputStream.writeCharacters("3JITMETHOD     Method: ");
-		_OutputStream.writeCharacters(longestWaitMethod.method);
+		_OutputStream.writeCharacters(longestWaitMethod.methodName);
 		_OutputStream.writeCharacters("\n");
 
 		_OutputStream.writeCharacters("3JITTHREAD     Thread: ");
-		_OutputStream.writeCharacters(longestWaitMethod.thread);
+		_OutputStream.writeCharacters(longestWaitMethod.threadName);
 		_OutputStream.writeCharacters("\n");
 	}
 
 	stats->totalCount = 0;
 	stats->totalWaitTime = 0;
-	for (int i = 0; i < J9_LONGEST_SYNC_COMP; i++) {
+	for (int32_t i = 0; i < J9_NUM_LONGEST_SYNC_COMP; i++) {
 		J9JITLongestSyncComp &longestWaitMethod = stats->longestWaitMethods[i];
 		longestWaitMethod.waitTime = 0;
 		longestWaitMethod.waitTimeEnd = 0;
-		if (NULL != longestWaitMethod.method) {
-			j9mem_free_memory(longestWaitMethod.method);
-			longestWaitMethod.method = NULL;
+		if (NULL != longestWaitMethod.methodName) {
+			j9mem_free_memory(longestWaitMethod.methodName);
+			longestWaitMethod.methodName = NULL;
 		}
-		if (NULL != longestWaitMethod.thread) {
-			j9mem_free_memory(longestWaitMethod.thread);
-			longestWaitMethod.thread = NULL;
+		if (NULL != longestWaitMethod.threadName) {
+			j9mem_free_memory(longestWaitMethod.threadName);
+			longestWaitMethod.threadName = NULL;
 		}
 	}
 }


### PR DESCRIPTION
Added a struct in J9JITConfig to store information regarding synchronous compilations and print them in javacore file.

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)


```
NULL           ------------------------------------------------------------------------
0SECTION       Synchronous compilations info dump routine
NULL           ==============================
1NOTE          This data is reset after each javacore file is written
NULL           ------------------------------------------------------------------------
1JITSYNCSTATS  Synchronous Compilation Statistics
NULL           ------------------------------------------------------------------------
2JITSYNCCOUNT  Total synchronous compilations: 793
2JITTOTALWAIT  Total application wait time: 1239420us
2JITLONGEST    1. Longest Synchronous Compilation
3JITWAITTIME   Wait time: 29445us
3JITENDTIME    Wait time end: 2026-07-23T14:52:20.902
3JITMETHOD     Method: jdk/internal/classfile/impl/StackMapGenerator.processBlock(Ljdk/internal/classfile/impl/RawBytecodeHelper;)Z
3JITTHREAD     Thread: (unnamed thread)
2JITLONGEST    2. Longest Synchronous Compilation
3JITWAITTIME   Wait time: 18123us
3JITENDTIME    Wait time end: 2026-07-23T14:52:22.000
3JITMETHOD     Method: java/lang/Class.getEnumConstantsShared()[Ljava/lang/Object;
3JITTHREAD     Thread: main
2JITLONGEST    3. Longest Synchronous Compilation
3JITWAITTIME   Wait time: 18063us
3JITENDTIME    Wait time end: 2026-07-23T14:52:22.018
3JITMETHOD     Method: java/lang/Access.getEnumConstantsShared(Ljava/lang/Class;)[Ljava/lang/Enum;
3JITTHREAD     Thread: main
```