### PR TITLE
Remove obsolete subspace reset

### DIFF
--- a/runtime/gc_realtime/RealtimeGC.cpp
+++ b/runtime/gc_realtime/RealtimeGC.cpp
@@ -194,7 +194,7 @@ void
 MM_RealtimeGC::mainSetupForGC(MM_EnvironmentBase *env)
 {
 	/* Reset memory pools of associated memory spaces */
-	env->_cycleState->_activeSubSpace->reset();
+	env->_cycleState->_activeSubSpace->reset(env);
 	
 	_workPackets->reset(env);	
 	

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -422,13 +422,6 @@ MM_MemorySubSpaceTarok::completeFreelistRebuildRequired(MM_EnvironmentBase *env)
  */
 
 void
-MM_MemorySubSpaceTarok::reset()
-{
-	/* unused in Tarok collectors */
-	Assert_MM_unreachable();
-}
-
-void
 MM_MemorySubSpaceTarok::reset(MM_EnvironmentBase *env)
 {
 	/* unused in Tarok collectors */

--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.hpp
@@ -247,7 +247,6 @@ public:
 	virtual MM_MemorySubSpace *getDefaultMemorySubSpace();
 	virtual MM_MemorySubSpace *getTenureMemorySubSpace();
 
-	virtual void reset();
 	virtual void reset(MM_EnvironmentBase *env);
 	virtual void rebuildFreeList(MM_EnvironmentBase *env);
 	


### PR DESCRIPTION
A new MemorySubSpace reset() method is introduced that requires Environment to be passed. Remove the old one and make users use the new one.