### PR TITLE
Fix the SCC shutdown code

### DIFF
--- a/runtime/jcl/common/shared.c
+++ b/runtime/jcl/common/shared.c
@@ -280,7 +280,7 @@ createCPEntries(JNIEnv* env, jint helperID, jint urlCount, J9ClassPathEntry*** c
 	newCacheItem->header.magic = CP_MAGIC;
 	newCacheItem->header.type = CP_TYPE_CLASSPATH;
 	newCacheItem->header.id = helperID;
-	newCacheItem->header.jclData = cpEntries;
+	newCacheItem->header.jclData = (J9ClassPathEntry*)cpePtrArray;
 	newCacheItem->header.cpData = NULL;
 
 	newCacheItem->entryCount = urlCount;

--- a/runtime/shared/shrclssup.c
+++ b/runtime/shared/shrclssup.c
@@ -493,12 +493,19 @@ IDATA J9VMDllMain(J9JavaVM* vm, IDATA stage, void* reserved)
 	case LIBRARIES_ONUNLOAD :
 	case JVM_EXIT_STAGE :
 		j9shr_guaranteed_exit(vm, FALSE);
-		break;
-
-	case HEAP_STRUCTURES_FREED :
+#if JAVA_SPEC_VERSION > 8
 		if (vm != NULL) {
 			j9shr_shutdown(vm);
 		}
+#endif /* #if JAVA_SPEC_VERSION > 8 */
+		break;
+
+	case HEAP_STRUCTURES_FREED :
+#if JAVA_SPEC_VERSION == 8
+		if (vm != NULL) {
+			j9shr_shutdown(vm);
+		}
+#endif /* JAVA_SPEC_VERSION == 8 */
 		break;
 
 	default :


### PR DESCRIPTION
1. Move SCC shutdown to JVM_EXIT_STAGE in Java 11+
2. Shutdown code uses J9GenericByID->jclData to free the memory of class path entries, so it should point to the head of original allocated memory.

Fixes #19199