### PR TITLE
Remove sampler mutex in jfr shutdown

### DIFF
--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -1134,8 +1134,6 @@ stopJFRRecording(J9JavaVM *vm)
 			}
 		}
 		omrthread_monitor_exit(vm->jfrSamplerMutex);
-		omrthread_monitor_destroy(vm->jfrSamplerMutex);
-		vm->jfrSamplerMutex = NULL;
 	}
 	vm->jfrSamplerState = J9JFR_SAMPLER_STATE_UNINITIALIZED;
 
@@ -1207,6 +1205,8 @@ tearDownJFR(J9JavaVM *vm)
 		J9UnregisterAsyncEvent(vm, vm->jfrThreadCPULoadAsyncKey);
 		vm->jfrThreadCPULoadAsyncKey = -1;
 	}
+	omrthread_monitor_destroy(vm->jfrSamplerMutex);
+	vm->jfrSamplerMutex = NULL;
 }
 
 static I_64


### PR DESCRIPTION
Current the `vm->jfrSamplerMutex` is dealloced in stopJFRREcording which is incorrect as the recording can be stopped and started multiple times.

Instead the mutex should be dealloced in JFR shutdown.

Fixes https://github.com/eclipse-openj9/openj9/issues/24241