### PR TITLE
Fix arraycmplen node to be properly anchored by treetop

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -872,6 +872,14 @@ void J9::RecognizedCallTransformer::process_jdk_internal_util_ArraysSupport_vect
     mismatchByteIndex->setAndIncChild(2, lengthToCompare);
     mismatchByteIndex->setSymbolReference(getSymRefTab()->findOrCreateArrayCmpLenSymbol());
 
+    // Mark arraycmplen as inlinedByCG as it is an intrinsic that should not be treated as a regular call by the
+    // inliner
+    mismatchByteIndex->getSymbolReference()->getSymbol()->castToMethodSymbol()->setIsInlinedByCG();
+
+    // Anchor the arraycmplen call node with a treetop since it has the Call property
+    TR::Node *arraycmplenAnchorNode = TR::Node::create(TR::treetop, 1, mismatchByteIndex);
+    TR::TreeTop *arraycmplenTreeTop = TR::TreeTop::create(comp(), treetop->getPrevTreeTop(), arraycmplenAnchorNode);
+
     TR::Node *invertedRemainder = TR::Node::create(node, TR::ixor, 2,
         TR::Node::create(node, TR::l2i, 1,
             TR::Node::create(node, TR::lshr, 2, TR::Node::create(node, TR::land, 2, lengthInBytes, mask),


### PR DESCRIPTION
The arraycmplen node has the isCall property, which means it should follow the same structural requirements as other call nodes: it must be anchored by a treetop node and be the first child of that treetop. Previously, arraycmplen was used directly in calculations without proper anchoring, which violated these requirements.

This commit addresses two related issues:

1. Missing treetop anchor: The arraycmplen node was not wrapped in a treetop node, even though nodes with the Call property should be anchored. This could lead to incorrect reference counting and potential issues with IL tree structure validation.

2. Missing isInlinedByCG flag: Without the setIsInlinedByCG() flag, if the inliner were to encounter this node (once properly anchored), it would attempt to process it as a regular method call, potentially causing crashes.

This ensures proper IL structure and prevents potential inliner issues.

@nbhuiyan 