### PR TITLE
Valhalla adds Unsafe.NON_FLAT_LAYOUT

### DIFF
--- a/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
+++ b/jcl/src/java.base/share/classes/jdk/internal/misc/Unsafe.java
@@ -6711,6 +6711,12 @@ public final class Unsafe {
 	/*[IF INLINE-TYPES]*/
 
 	/**
+	 * The layout value to be checked,
+	 * other values represent some kind of flat layout opaque to Java code.
+	 */
+	public static final int NON_FLAT_LAYOUT = 0;
+
+	/**
 	 * Determines the size of the header for a specified value class
 	 *
 	 * @param clz the specified value class


### PR DESCRIPTION
[Valhalla adds Unsafe.NON_FLAT_LAYOUT](https://github.com/eclipse-openj9/openj9/commit/cd2eaa1e4ec4f2514cae75616bde23f4333d774e) 

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/pull/46

Signed-off-by: Jason Feng <fengj@ca.ibm.com>