### PR TITLE
Revert: Restore 32-bit Coded Restrictions to CodeCache Page Sizes on P

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -271,16 +271,7 @@ TR::CodeCacheMemorySegment *J9::CodeCacheManager::allocateCodeCacheSegment(size_
     if (config.largeCodePageSize() > pageSizes[0])
         largeCodePageSize = config.largeCodePageSize();
 
-#if defined(TR_TARGET_POWER) && defined(TR_HOST_POWER) && !defined(TR_HOST_64BIT)
-    /* Use largeCodePageSize on PPC only if its 16M.
-     If we pass in any pagesize other than the default page size, the port library picks the shared memory api to
-     allocate which wastes memory */
-    size_t sixteenMegs = 16 * 1024 * 1024;
-    if (largeCodePageSize == sixteenMegs)
-#else
-    if (largeCodePageSize > 0)
-#endif
-    {
+    if (largeCodePageSize > 0) {
         vmemParams.pageSize = largeCodePageSize;
         vmemParams.pageFlags = config.largeCodePageFlags();
 


### PR DESCRIPTION
Reverts https://github.com/eclipse-openj9/openj9/pull/22623

RTC 153064

32-bit test build http://vmfarm.rtp.raleigh.ibm.com/build_info.php?build_id=120596