### PR TITLE
Disable StringLatin.inflate(B->B) Acceleration on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3600,7 +3600,7 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
 
     static const char *enableTRTRE = feGetEnv("TR_enableTRTRE");
     static const bool enableOSW = feGetEnv("TR_noPauseOnSpinWait") == NULL;
-    static const bool disableStringInflateByteToByte = feGetEnv("TR_DisableStringInflateByteToByte") != NULL;
+    static const bool enableStringInflateByteToByte = feGetEnv("TR_EnableStringInflateByteToByte") != NULL;
     static const bool disableStringInflateByteToChar = feGetEnv("TR_DisableStringInflateByteToChar") != NULL;
 
     bool disableCASInlining = !cg->getSupportsInlineUnsafeCompareAndSet();
@@ -3802,7 +3802,7 @@ bool J9::Z::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&resul
             break;
         }
         case TR::java_lang_StringLatin1_inflate_BIBII:
-            if (cg->getSupportsInlineStringLatin1Inflate() && !disableStringInflateByteToByte) {
+            if (cg->getSupportsInlineStringLatin1Inflate() && enableStringInflateByteToByte) {
                 resultReg = TR::TreeEvaluator::inlineStringLatin1Inflate(node, cg);
                 return resultReg != NULL;
             }


### PR DESCRIPTION
This commit by default disables the acceleration for the StringLatin1.inflate(Byte->Byte) API on the Z platform.