### PR TITLE
Add missing exclusive access for thread iteration

### DIFF
--- a/runtime/jcl/common/com_ibm_oti_vm_VM.cpp
+++ b/runtime/jcl/common/com_ibm_oti_vm_VM.cpp
@@ -262,7 +262,9 @@ Java_com_ibm_oti_vm_VM_startJFR(JNIEnv *env, jclass unused)
 
 	if (!vmFuncs->isJFRRecordingStarted(vm)) {
 		/* this is to initalize JFR late after VM startup */
+		vmFuncs->internalEnterVMFromJNI(currentThread);
 		rc = vmFuncs->initializeJFR(vm);
+		vmFuncs->internalExitVMToJNI(currentThread);
 	}
 
 	return rc;

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -377,6 +377,7 @@ Java_jdk_jfr_internal_JVM_createJFR(JNIEnv *env, jobject obj, jboolean simulateF
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	if (JNI_OK != vmFuncs->initializeJFR(vm)) {
 		rc = JNI_FALSE;
+		goto done;
 	}
 
 	if (!vm->internalVMFunctions->setupChunkMonitor(currentThread)) {

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -710,6 +710,9 @@ jfrStartSamplingThread(J9JavaVM *vm)
 {
 	/* Start the sampler thread. */
 	IDATA rc = omrthread_create(&(vm->jfrSamplerThread), vm->defaultOSStackSize, J9THREAD_PRIORITY_NORMAL, FALSE, jfrSamplingThreadProc, (void *)vm);
+
+	Assert_VM_mustNotHaveVMAccess(currentVMThread(vm));
+
 	if (0 == rc) {
 		omrthread_monitor_enter(vm->jfrSamplerMutex);
 		while (J9JFR_SAMPLER_STATE_UNINITIALIZED == vm->jfrSamplerState) {
@@ -950,9 +953,12 @@ initializeJFR(J9JavaVM *vm)
 
 	U_8 *buffer = NULL;
 	UDATA timeSuccess = 0;
+	J9VMThread *currentThread = currentVMThread(vm);
 	J9VMThread *walkThread = NULL;
+	J9HookInterface **vmHooks = getVMHookInterface(vm);
 
 	Assert_VM_false(vm->jfrState.isCreated);
+	Assert_VM_mustHaveVMAccess(currentThread);
 
 	/* Register async handler for execution samples. */
 	vm->jfrAsyncKey = J9RegisterAsyncEvent(vm, jfrExecutionSampleCallback, NULL);
@@ -1031,6 +1037,7 @@ initializeJFR(J9JavaVM *vm)
 		goto fail;
 	}
 
+	acquireExclusiveVMAccess(currentThread);
 	/* Go through existing threads. */
 	walkThread = J9_LINKED_LIST_START_DO(vm->mainThread);
 	while (NULL != walkThread) {
@@ -1049,6 +1056,12 @@ initializeJFR(J9JavaVM *vm)
 
 		walkThread = J9_LINKED_LIST_NEXT_DO(vm->mainThread, walkThread);
 	}
+
+	if ((*vmHooks)->J9HookRegisterWithCallSite(vmHooks, J9HOOK_VM_THREAD_CREATED, jfrThreadCreated, OMR_GET_CALLSITE(), NULL)) {
+		goto done;
+	}
+
+	releaseExclusiveVMAccess(currentThread);
 
 	vm->jfrState.isCreated = TRUE;
 
@@ -1070,8 +1083,10 @@ BOOLEAN
 startJFRRecording(J9JavaVM *vm)
 {
 	J9HookInterface **vmHooks = getVMHookInterface(vm);
+	J9VMThread *currentThread = currentVMThread(vm);
 	BOOLEAN rc = FALSE;
 
+	Assert_VM_mustHaveVMAccess(currentThread);
 	Assert_VM_false(vm->jfrState.isStarted);
 	Assert_VM_true(vm->jfrState.isCreated);
 
@@ -1110,7 +1125,9 @@ startJFRRecording(J9JavaVM *vm)
 		goto done;
 	}
 
+	internalReleaseVMAccess(currentThread);
 	jfrStartSamplingThread(vm);
+	internalAcquireVMAccess(currentThread);
 
 	vm->jfrState.isStarted = TRUE;
 
@@ -2216,7 +2233,8 @@ JfrPeriodicEventSet::requestCPULoad(J9VMThread *currentThread)
 void
 JfrPeriodicEventSet::requestThreadCPULoad(J9VMThread *currentThread)
 {
-	jfrThreadCPULoad(currentThread, currentThread);
+	J9JavaVM *vm = currentThread->javaVM;
+	J9SignalAsyncEvent(vm, NULL, vm->jfrThreadCPULoadAsyncKey);
 }
 
 void

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -107,4 +107,30 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">Found additional fields in mirror class</output>
 		<output type="failure" caseSensitive="yes" regex="no">Error</output>
 	</test>
+	<test id="test jfr summary - approx 5 seconds">
+		<command>$JFR_EXE$ summary testrecording.jfr</command>
+		<output type="required" caseSensitive="yes" regex="no">Version: 2.1</output>
+		<output type="required" caseSensitive="yes" regex="no">jdk.ExecutionSample</output>
+		<output type="success" caseSensitive="yes" regex="no">jdk.CPULoad</output>
+		<output type="success" caseSensitive="yes" regex="no">jdk.JavaThreadStatistics</output>
+		<output type="success" caseSensitive="yes" regex="no">jdk.ClassLoadingStatistics</output>
+		<output type="success" caseSensitive="yes" regex="no">jdk.ThreadCPULoad</output>
+		<output type="required" caseSensitive="yes" regex="no">jdk.Metadata</output>
+	</test>
+	<test id="test jfr execution sample - approx 5 seconds">
+		<command>$JFR_EXE$ print --xml --events "ExecutionSample" --stack-depth 1 testrecording.jfr</command>
+		<output type="required" caseSensitive="yes" regex="no">http://www.w3.org/2001/XMLSchema-instance</output>
+		<output type="required" caseSensitive="yes" regex="no">jdk.ExecutionSample</output>
+		<output type="required" caseSensitive="yes" regex="no">startTime</output>
+		<output type="required" caseSensitive="yes" regex="no">sampledThread</output>
+		<output type="required" caseSensitive="yes" regex="no">stackTrace</output>
+		<output type="required" caseSensitive="yes" regex="no">frames</output>
+		<output type="success" caseSensitive="yes" regex="no">STATE_RUNNABLE</output>
+		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
+	</test>
+	<test id="Test JFRv2 with profile config">
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording:filename=profile.jfr,dumponexit=true,settings=profile.jfc --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
+		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
+		<output type="required" caseSensitive="yes" regex="no">0 / 100 complete</output>
+	</test>
 </suite>


### PR DESCRIPTION
Acquire exclusive when allocating the local JFR buffers so if any new
threads are created in this period they must wait for the iteration to
complete. After the iteration is complete the thread creation hook is
added so new threads will trigger that.

Also instead of requesting threadCPU sample on the requestor thread,
trigger the async check so threadCPU is captured on all threads.