### PR TITLE
Set jenkins build failure explicitly before the scope closes

### DIFF
--- a/buildenv/jenkins/jobs/pipelines/Pipeline-Initialize.groovy
+++ b/buildenv/jenkins/jobs/pipelines/Pipeline-Initialize.groovy
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: IBM Bob
  *******************************************************************************/
 
 SETUP_LABEL = (params.SETUP_LABEL) ? params.SETUP_LABEL : 'worker'
@@ -67,5 +68,10 @@ timestamps {
             }
         }
     }
-    buildFile.build_all()
+    try {
+        buildFile.build_all()
+    } catch (e) {
+        currentBuild.result = 'FAILURE'
+        throw e
+    }
 }


### PR DESCRIPTION
Jenkins jobs may fail although all test jobs passed. Examples:
https://openj9-jenkins.osuosl.org/job/Pipeline_Build_Test_JDK8_aarch64_linux/3148/
https://openj9-jenkins.osuosl.org/job/Pipeline_Build_Test_JDK8_ppc64le_linux/3274/

The analysis by IBM Bob as follows:

When `extended.system`'s `build()` step returns (job done at 02:08), the SUCCESS branch in `build_with_slack()` queues a `node {}` request on `SETUP_LABEL`. Because that agent is busy with other parallel branches finishing at the same time, the Jenkins CPS scheduler processes other pending continuations first — including the outer pipeline teardown. By the time the `node {}` slot is granted (02:31), the `timestamps {}` scope has already closed and Jenkins flags the entire pipeline FAILURE.

Ensure that if steps run outside the `timestamps {}` scope, the pipeline result is explicitly set before the outer scope closes rather than being inferred as FAILURE by Jenkins.

Assisted-by: IBM Bob