### PR TITLE
Avoid compilation failures with memcpy/memset and cfi_startproc

### DIFF
--- a/runtime/compiler/control/rossa.cpp
+++ b/runtime/compiler/control/rossa.cpp
@@ -1292,7 +1292,6 @@ extern "C" jint onLoadInternal(J9JavaVM *javaVM, J9JITConfig *jitConfig, char *x
         = (TR::CodeCacheManager *)j9mem_allocate_memory(sizeof(TR::CodeCacheManager), J9MEM_CATEGORY_JIT);
     if (codeCacheManager == NULL)
         return -1;
-    memset(codeCacheManager, 0, sizeof(TR::CodeCacheManager));
 
     // must initialize manager using the global (not thread specific) fe because current thread isn't guaranteed to live
     // longer than the manager

--- a/runtime/compiler/ras/HashTable.cpp
+++ b/runtime/compiler/ras/HashTable.cpp
@@ -180,7 +180,7 @@ void TR_HashTable::remove(TR_HashIndex index)
         // to put in its place.
         TR_HashIndex firstCollision;
         if ((firstCollision = _table[index].getCollisionChain()) != 0) {
-            memcpy(_table + index, _table + firstCollision, sizeof(TR_HashTableEntry));
+            _table[index] = _table[firstCollision];
             _table[firstCollision].setCollisionChain(_nextFree);
             _table[firstCollision].invalidate();
             _nextFree = firstCollision;
@@ -287,7 +287,7 @@ void TR_HashTable::growAndRehash(TR_HashTableEntry *oldTable, TR_HashIndex oldSi
             if (index > _highestIndex)
                 _highestIndex = index;
 
-            memcpy(_table + index, oldTable + i, sizeof(TR_HashTableEntry));
+            _table[index] = oldTable[i];
             _table[index].setCollisionChain(0);
         }
     }

--- a/runtime/libffi/aarch64/sysv.S
+++ b/runtime/libffi/aarch64/sysv.S
@@ -76,8 +76,8 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
    x5 closure
 */
 
-	cfi_startproc
 CNAME(ffi_call_SYSV):
+	cfi_startproc
 	/* Sign the lr with x1 since that is where it will be stored */
 	SIGN_LR_WITH_REG(x1)
 
@@ -268,8 +268,8 @@ CNAME(ffi_closure_SYSV_V):
 #endif
 
 	.align	4
-	cfi_startproc
 CNAME(ffi_closure_SYSV):
+	cfi_startproc
 	SIGN_LR
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
@@ -500,8 +500,8 @@ CNAME(ffi_go_closure_SYSV_V):
 #endif
 
 	.align	4
-	cfi_startproc
 CNAME(ffi_go_closure_SYSV):
+	cfi_startproc
 	stp     x29, x30, [sp, #-ffi_closure_SYSV_FS]!
 	cfi_adjust_cfa_offset (ffi_closure_SYSV_FS)
 	cfi_rel_offset (x29, 0)


### PR DESCRIPTION
This commit changes some files to avoid compilation errors with recent Xcode versions.

- Remove unnecessary memset()
- Change memcpy() to an assignment
- Change the locations of "cfi_startproc" lines in an assembly code file (based on libffi/libffi#857)

Co-authored-by: Kevin Grigorenko <kevin.grigorenko@us.ibm.com>

Depends on https://github.com/eclipse-omr/omr/pull/8321.