### PR TITLE
(0.60) Cache pinning support status in the Interpreter

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -191,10 +191,14 @@ private:
 #endif
 	MM_ObjectAllocationAPI _objectAllocate;
 	MM_ObjectAccessBarrierAPI _objectAccessBarrier;
+#if JAVA_SPEC_VERSION >= 24
+	const bool _pinningSupportEnabled;
+#endif /* JAVA_SPEC_VERSION >= 24 */
 
 protected:
 
 public:
+
 
 /*
  * Function members
@@ -1211,7 +1215,7 @@ obj:
 			rc = objectMonitorEnterNonBlocking(_currentThread, obj);
 			if (J9_OBJECT_MONITOR_BLOCKING == rc) {
 #if JAVA_SPEC_VERSION >= 24
-				if (VM_ContinuationHelpers::isYieldableVirtualThread(_currentThread)) {
+				if (_pinningSupportEnabled && VM_ContinuationHelpers::isYieldableVirtualThread(_currentThread)) {
 					/* Try to yield the virtual thread if it will be blocked. */
 					updateVMStruct(REGISTER_ARGS);
 					rc = preparePinnedVirtualThreadForUnmount(_currentThread, obj, false);
@@ -1225,7 +1229,7 @@ obj:
 			}
 		}
 #if JAVA_SPEC_VERSION >= 24
-		if (rc == (UDATA)obj) {
+		if (_pinningSupportEnabled && (rc == (UDATA)obj)) {
 			J9VMContinuation *continuation = _currentThread->currentContinuation;
 			if (NULL != continuation) {
 				if (J9_ARE_ALL_BITS_SET(continuation->runtimeFlags, J9VM_CONTINUATION_RUNTIMEFLAG_JVMTI_CONTENDED_MONITOR_ENTER_RECORDED)) {
@@ -3041,7 +3045,7 @@ done:
 		{
 			if (VM_ObjectMonitor::getMonitorForNotify(_currentThread, receiver, &monitorPtr, true)) {
 #if JAVA_SPEC_VERSION >= 24
-				if (J9_ARE_ANY_BITS_SET(_vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)) {
+				if (_pinningSupportEnabled) {
 					j9objectmonitor_t lock = 0;
 					j9objectmonitor_t *lockEA = NULL;
 					J9ObjectMonitor *objectMonitor = NULL;
@@ -6001,7 +6005,7 @@ ffi_OOM:
 		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
 #if JAVA_SPEC_VERSION >= 24
-		if (J9_ARE_ANY_BITS_SET(_vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION)
+		if (_pinningSupportEnabled
 		&& (_currentThread->ownedMonitorCount > 0)
 		&& !isFinished
 		) {
@@ -10392,7 +10396,6 @@ public:
 #if defined(LOCAL_LITERALS)
 		J9Method *_literals = vmThread->literals;
 #endif
-
 		DEBUG_MUST_HAVE_VM_ACCESS(vmThread);
 		vmThread->jitStackFrameFlags = 0;
 
@@ -12496,6 +12499,9 @@ noUpdate:
 #endif
 		, _objectAllocate(currentThread)
 		, _objectAccessBarrier(currentThread)
+#if JAVA_SPEC_VERSION >= 24
+		, _pinningSupportEnabled(J9_ARE_ANY_BITS_SET(currentThread->javaVM->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_YIELD_PINNED_CONTINUATION))
+#endif /* JAVA_SPEC_VERSION >= 24 */
 	{
 	}
 };


### PR DESCRIPTION
Backport of https://github.com/eclipse-openj9/openj9/pull/24271

co-author: Ravali Yatham <rayatha1@in.ibm.com>