### PR TITLE
Add TR_RuntimeAssumptionTable::allocateRAPersistentMemory() API

### DIFF
--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -84,6 +84,8 @@ public:
 
     bool init(); // Must call this during bootstrap on a single thread because it is not MT safe
 
+    static void *allocateRAPersistentMemory(size_t size);
+
     static uintptr_t hashCode(uintptr_t key)
     {
         return (key >> 2) * 2654435761u;

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -172,6 +172,11 @@ bool TR_RuntimeAssumptionTable::init()
     return true;
 }
 
+void *TR_RuntimeAssumptionTable::allocateRAPersistentMemory(size_t size)
+{
+    return TR::Compiler->persistentMemory()->allocatePersistentMemory(size, TR_Memory::Assumption);
+}
+
 void OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory *persistentMemory, TR_RuntimeAssumptionKind kind,
     TR_FrontEnd *fe, OMR::RuntimeAssumption **sentinel)
 {


### PR DESCRIPTION
This change is part of a multi stage commit which implements disclaiming of runtime assumption memory.
Te newly introduced API (`allocateRAPersistentMemory()`) is going to be used in the omr project in `OMR::Compilation::Compilation()` and, later, in in several other places in the openj9 project. At the moment `allocateRAPersistentMemory()` does not change anything: runtime assumptions are still going to be allocated with the global peristent allocator. Later-on, the implementation of `allocateRAPersistentMemory()` will change to use a dedicated persistent allocator.