### PR TITLE
JFR duration timer thread should be daemon

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/JFR.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/JFR.java
@@ -249,7 +249,7 @@ public class JFR {
 					}
 					VM.startJFR();
 					if (duration > 0) {
-						Timer timer = new Timer();
+						Timer timer = new Timer(true);
 						TimerTask jfrDumpTask = new TimerTask() {
 							public void run() {
 								if (VM.isJFRRecordingStarted()) {


### PR DESCRIPTION
[JFR duration timer thread should be daemon](https://github.com/eclipse-openj9/openj9/commit/33b8385c3ca6aa685440a8e41c8272262458484a) 

A daemon timer thread won't prevent JVM shutdown.

Related to [JFR: zOS IMS termination issue](https://github.ibm.com/runtimes/openj9/issues/922).

Signed-off-by: Jason Feng <fengj@ca.ibm.com>