### PR TITLE
AArch64: Add "const" to variables for feGetEnv()

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9CodeGenerator.cpp
@@ -69,12 +69,12 @@ void J9::ARM64::CodeGenerator::initialize()
     cg->setSupportsPrimitiveArrayCopy();
     cg->setSupportsReferenceArrayCopy();
 
-    static char *disableMonitorCacheLookup = feGetEnv("TR_disableMonitorCacheLookup");
+    static const char *disableMonitorCacheLookup = feGetEnv("TR_disableMonitorCacheLookup");
     if (!disableMonitorCacheLookup) {
         comp->setOption(TR_EnableMonitorCacheLookup);
     }
 
-    static bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
+    static const bool disableInlineVectorizedMismatch = feGetEnv("TR_disableInlineVectorizedMismatch") != NULL;
     if (cg->getSupportsArrayCmpLen() && !disableInlineVectorizedMismatch) {
         cg->setSupportsInlineVectorizedMismatch();
     }
@@ -84,34 +84,35 @@ void J9::ARM64::CodeGenerator::initialize()
     if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableFastStringIndexOf))) {
         cg->setSupportsInlineStringIndexOf();
     }
-    static bool disableInlineStrIdxOfStr = feGetEnv("TR_disableInlineStrIdxOfStr") != NULL;
+    static const bool disableInlineStrIdxOfStr = feGetEnv("TR_disableInlineStrIdxOfStr") != NULL;
     if ((!TR::Compiler->om.canGenerateArraylets()) && (!comp->getOption(TR_DisableFastStringIndexOf))
         && !disableInlineStrIdxOfStr) {
         cg->setSupportsInlineStringIndexOfString();
     }
-    static bool disableInlineStringLatin1Inflate = feGetEnv("TR_disableInlineStringLatin1Inflate") != NULL;
+    static const bool disableInlineStringLatin1Inflate = feGetEnv("TR_disableInlineStringLatin1Inflate") != NULL;
     if ((!TR::Compiler->om.canGenerateArraylets()) && (!disableInlineStringLatin1Inflate)) {
         cg->setSupportsInlineStringLatin1Inflate();
     }
     if (comp->fej9()->hasFixedFrameC_CallingConvention())
         cg->setHasFixedFrameC_CallingConvention();
 
-    static bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
+    static const bool disableCASInlining = feGetEnv("TR_DisableCASInlining") != NULL;
     if (!disableCASInlining) {
         cg->setSupportsInlineUnsafeCompareAndSet();
     }
 
-    static bool disableCAEInlining = feGetEnv("TR_DisableCAEInlining") != NULL;
+    static const bool disableCAEInlining = feGetEnv("TR_DisableCAEInlining") != NULL;
     if (!disableCAEInlining) {
         cg->setSupportsInlineUnsafeCompareAndExchange();
     }
 
-    static bool disableInlineStringCodingHasNegatives = feGetEnv("TR_DisableInlineStringCodingHasNegatives") != NULL;
+    static const bool disableInlineStringCodingHasNegatives
+        = feGetEnv("TR_DisableInlineStringCodingHasNegatives") != NULL;
     if (!TR::Compiler->om.canGenerateArraylets() && !disableInlineStringCodingHasNegatives) {
         cg->setSupportsInlineStringCodingHasNegatives();
     }
 #if JAVA_SPEC_VERSION >= 19
-    static bool disableInlineStringCodingCountPositives
+    static const bool disableInlineStringCodingCountPositives
         = feGetEnv("TR_DisableInlineStringCodingCountPositives") != NULL;
     if (!TR::Compiler->om.canGenerateArraylets() && !disableInlineStringCodingCountPositives) {
         cg->setSupportsInlineStringCodingCountPositives();

--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3936,7 +3936,7 @@ TR::Register *J9::ARM64::TreeEvaluator::multianewArrayEvaluator(TR::Node *node, 
     // The number of dimensions should always be an iconst
     TR_ASSERT_FATAL(secondChild->getOpCodeValue() == TR::iconst, "dims of multianewarray must be iconst");
     uint32_t nDims = secondChild->get32bitIntegralValue();
-    static bool disableInlineMultianewArray = feGetEnv("TR_DisableInlineMultianewArray") != NULL;
+    static const bool disableInlineMultianewArray = feGetEnv("TR_DisableInlineMultianewArray") != NULL;
 
     // Get the size of the elements in the leaf components
     int32_t leafArrayElementSize = TR::Compiler->om.getTwoDimensionalArrayComponentSize(node->getThirdChild());
@@ -6742,7 +6742,7 @@ static TR::Register *inlineIntrinsicIndexOf(TR::Node *node, TR::CodeGenerator *c
  */
 static TR::Register *inlineIntrinsicStringIndexOfString(TR::Node *node, TR::CodeGenerator *cg, bool isLatin1)
 {
-    static bool verboseInlineStrIdxOfStr = (feGetEnv("TR_verboseInlineStrIdxOfStr") != NULL);
+    static const bool verboseInlineStrIdxOfStr = (feGetEnv("TR_verboseInlineStrIdxOfStr") != NULL);
     if (verboseInlineStrIdxOfStr) {
         fprintf(stderr, "*%s.indexOfString(): %s @%s\n", isLatin1 ? "Latin1" : "UTF16", cg->comp()->signature(),
             cg->comp()->getHotnessName());
@@ -7543,7 +7543,7 @@ bool J9::ARM64::CodeGenerator::inlineDirectCall(TR::Node *node, TR::Register *&r
         bool disableCAEInlining = !cg->getSupportsInlineUnsafeCompareAndExchange();
         switch (methodSymbol->getRecognizedMethod()) {
             case TR::java_lang_Thread_onSpinWait: {
-                static char *disableOSW = feGetEnv("TR_noYieldOnSpinWait");
+                static const char *disableOSW = feGetEnv("TR_noYieldOnSpinWait");
                 if (!disableOSW) {
                     generateInstruction(cg, TR::InstOpCode::yield, node);
 


### PR DESCRIPTION
This commit adds the "const" keyword to the variables for controlling the JIT behavior with feGetEnv().