### PR TITLE
Fix constref sorting on z/OS

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -5056,6 +5056,26 @@ void CPGSearchState::enqueue(Place p, TR_OpaqueClassBlock *owningClass)
     }
 }
 
+struct OwningClassCmp {
+    const TR::vector<TR_OpaqueClassBlock *, TR::Region &> &_owningClasses;
+
+    OwningClassCmp(const TR::vector<TR_OpaqueClassBlock *, TR::Region &> &owningClasses)
+        : _owningClasses(owningClasses)
+    {
+        // empty
+    }
+
+    bool operator()(TR::KnownObjectTable::Index i, TR::KnownObjectTable::Index j) const
+    {
+        // Use known object index as a tiebreaker, just because it will read
+        // better in log output.
+        std::less<TR_OpaqueClassBlock *> lt;
+        TR_OpaqueClassBlock *classI = _owningClasses[i];
+        TR_OpaqueClassBlock *classJ = _owningClasses[j];
+        return classI == classJ ? i < j : lt(classI, classJ);
+    }
+};
+
 } // anonymous namespace
 
 void J9::CodeGenerator::sortConstRefs()
@@ -5305,38 +5325,15 @@ void J9::CodeGenerator::sortConstRefs()
         log->println();
     }
 
-// Temporarily disable the sorting step on z/OS due to lack of support of the
-// variant of std::sort used here in the version of XLC used for z/OS builds,
-// resulting in a build error. This temporary measure is meant to allow other
-// platforms to benefit from const refs sorting while an alternative
-// implementation is worked on for z/OS.
-#if !defined(J9ZOS390)
     // Now that owning classes are assigned, sort the const refs by owning class.
     // The important thing is really just grouping by owning class, which ensures
     // that we'll create no more than one const ref array per class.
-    struct OwningClassCmp {
-        const TR::vector<TR_OpaqueClassBlock *, TR::Region &> &_owningClasses;
-
-        OwningClassCmp(const TR::vector<TR_OpaqueClassBlock *, TR::Region &> &owningClasses)
-            : _owningClasses(owningClasses)
-        {
-            // empty
-        }
-
-        bool operator()(TR::KnownObjectTable::Index i, TR::KnownObjectTable::Index j) const
-        {
-            // Use known object index as a tiebreaker, just because it will read
-            // better in log output.
-            std::less<TR_OpaqueClassBlock *> lt;
-            TR_OpaqueClassBlock *classI = _owningClasses[i];
-            TR_OpaqueClassBlock *classJ = _owningClasses[j];
-            return classI == classJ ? i < j : lt(classI, classJ);
-        }
-    };
-
     OwningClassCmp cmp(_constRefOwningClasses);
+#if defined(J9ZOS390)
+    std::stable_sort(_constRefSortOrder.begin(), _constRefSortOrder.end(), cmp);
+#else
     std::sort(_constRefSortOrder.begin(), _constRefSortOrder.end(), cmp);
-#endif // !defined(J9ZOS390)
+#endif
 
     if (trace) {
         log->prints("const ref sort order (with owning class):\n");


### PR DESCRIPTION
Constref sorting had previously been disabled on z/OS because the sorting approach used on other platforms was not accepted by the XLC compiler used in z/OS builds. This left z/OS without constref sorting.

**further context**: [issue 16616](https://github.com/eclipse-openj9/openj9/issues/16616#issuecomment-3937656964)
### Solution
This PR enables constref sorting on z/OS using a platform-specific approach:

- z/OS builds: Use ```std::stable_sort``` (compatible with XLC compiler)

- All other platforms: Continue using ```std::sort``` (optimal performance)

Additionally, ```OwningClassCmp``` was moved from local function scope to file scope to satisfy XLC's linkage requirements. The comparator logic itself is unchanged: const refs are still ordered primarily by owning class identity, with known object index used as the tie breaker.
### Performance Analysis
I chose this approach as a fix for the original issue because it solves the z/OS compiler compatibility problem without introducing a custom sorting implementation. I measured the performance of std::stable_sort against std::sort to determine whether we should switch all platforms. The benchmark results show measurable overhead:

for 10 items, ```std::stable_sort``` was slightly faster than ```std::sort``` and took about 0.948x the time of ```std::sort```
for 50 items, ```std::stable_sort``` took about 28% more time than ```std::sort```
for 100 items, ```std::stable_sort``` took about 3.1 times as long as ```std::sort```
for 500 items, ```std::stable_sort``` took about 3.2 times as long as ```std::sort```
for 1000 items, ```std::stable_sort``` took about 1.7 times as long as ```std::sort```
for 5000 items, ```std::stable_sort``` took about 2.2 times as long as ```std::sort```

@vijaysun-omr @mpirvu @0xdaryl @ymanton 

If anyone has any feedback or questions please let me know.