### PR TITLE
(0.60) JFR duration timer thread should be daemon

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -560,7 +560,7 @@ public class DiagnosticUtils {
 					}
 					VM.startJFR();
 					if (duration > 0) {
-						Timer timer = new Timer();
+						Timer timer = new Timer(true);
 						TimerTask jfrDumpTask = new TimerTask() {
 							public void run() {
 								if (VM.isJFRRecordingStarted()) {


### PR DESCRIPTION
[JFR duration timer thread should be daemon](https://github.com/eclipse-openj9/openj9/commit/dc8b90b8fd0a62d23415588c94715cbfe2ee17a6) 

A daemon timer thread won't prevent JVM shutdown.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/24285

Signed-off-by: Jason Feng <fengj@ca.ibm.com>