### PR TITLE
Increase SCC disclaim frequency under -Xtune:footprint

### DIFF
--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -608,6 +608,9 @@ void J9::Options::setTuneFootprintOptions(J9JITConfig *jitConfig)
 
     // reduce the malloc-trim period
     _mallocTrimPeriod = 1;
+
+    // Increase the frequency of SCC disclaim (every second)
+    _minTimeBetweenSCCDisclaims = 1000; // 3000 --> 1000 ms
 }
 
 struct vmX {


### PR DESCRIPTION
This change slightly improves footprint (app dependent) at the expense of a small throughput loss.