### PR TITLE
Implement runtime assumption memory disclaiming

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -3240,8 +3240,28 @@ void TR::CompilationInfo::stopCompilationThreads()
 
     static char *printPersistentMem = feGetEnv("TR_PrintPersistentMem");
     if (printPersistentMem) {
-        if (trPersistentMemory)
+        if (trPersistentMemory) {
             trPersistentMemory->printMemStats();
+
+            // Print number of segments from the global persistent allocator.
+            int32_t globalNumSegments = TR::Compiler->persistentMemory()->_persistentAllocator.get().getNumSegments();
+            fprintf(stderr, "Global persistent allocator: %d segments\n", globalNumSegments);
+        }
+
+        // Print RuntimeAssumption allocator segment count when disclaiming is enabled.
+        if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableRuntimeAssumptionDataDisclaiming)) {
+            int32_t raNumSegments = TR_RuntimeAssumptionTable::getRANumSegments();
+            fprintf(stderr, "RuntimeAssumption allocator: %d segments\n", raNumSegments);
+        }
+
+        // Print IProfiler allocator segment count when disclaiming is enabled.
+        if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableIProfilerDataDisclaiming)) {
+            TR::PersistentAllocator *iprofilerAllocator = TR_IProfiler::allocator();
+            if (iprofilerAllocator) {
+                int32_t iProfilerNumSegments = iprofilerAllocator->getNumSegments();
+                fprintf(stderr, "IProfiler allocator: %d segments\n", iProfilerNumSegments);
+            }
+        }
     }
 
     TR_DataCacheManager::getManager()->printStatistics();

--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -90,6 +90,7 @@
 #include "ilgen/J9ByteCodeIterator.hpp"
 #include "runtime/IProfiler.hpp"
 #include "runtime/HWProfiler.hpp"
+#include "env/RuntimeAssumptionTable.hpp"
 #include "env/SystemSegmentProvider.hpp"
 #if defined(J9VM_OPT_JITSERVER)
 #include "control/JITServerHelpers.hpp"
@@ -4449,6 +4450,23 @@ void disclaimIProfilerSegments(uint64_t crtElapsedTime)
     }
 }
 
+void disclaimRuntimeAssumptionSegments(uint64_t crtElapsedTime)
+{
+    // Find the RuntimeAssumption allocator and traverse all its segments
+    TR::PersistentAllocator *raAllocator = TR_RuntimeAssumptionTable::getRAPersistentAllocator();
+    if (raAllocator) {
+        size_t rssBefore = getRSS_Kb();
+        int numSegDisclaimed = raAllocator->disclaimAllSegments();
+        size_t rssAfter = getRSS_Kb();
+        if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,
+                "t=%u JIT disclaimed %d RuntimeAssumption segments out of %d. RSS before=%zu KB, RSS after=%zu KB, "
+                "delta=%zd KB = %5.2f%%",
+                (uint32_t)crtElapsedTime, numSegDisclaimed, raAllocator->getNumSegments(), rssBefore, rssAfter,
+                rssBefore - rssAfter, ((long)(rssAfter - rssBefore) * 100.0 / rssBefore));
+    }
+}
+
 void disclaimCodeCaches(uint64_t crtElapsedTime)
 {
     size_t rssBefore = getRSS_Kb();
@@ -4469,6 +4487,8 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
     static uint64_t lastClassMemoryDisclaimTime = 0;
     static int32_t lastNumAllocatedCodeCaches = 0;
     static uint64_t lastIProfilerDisclaimTime = 0;
+    static uint64_t lastRADisclaimTime = 0;
+    static uint32_t lastNumCompilationsDuringRADisclaim = 0;
     static uint64_t lastSCCDisclaimTime = 0;
     static uint64_t lastNumAllocatedClassMemorySegments = 0;
     static uint32_t lastNumCompilationsDuringIProfilerDisclaim = 0;
@@ -4587,6 +4607,24 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
         }
     }
 #endif // J9VM_INTERP_PROFILING_BYTECODES
+
+    // Disclaim RuntimeAssumption segments periodically
+    TR::PersistentAllocator *raAllocator = TR_RuntimeAssumptionTable::getRAPersistentAllocator();
+    if (raAllocator && raAllocator->isDisclaimEnabled()) {
+        if (crtElapsedTime > lastRADisclaimTime + TR::Options::_minTimeBetweenMemoryDisclaims &&
+            // Avoid disclaiming if compilations are still to be performed
+            compInfo->getMethodQueueSize() <= TR::CompilationInfo::VERY_SMALL_QUEUE) {
+            // If there were several compilations since the last disclaim, do another
+            // disclaim now. Otherwise, wait for longer to perform the disclaim (note
+            // that runtime can touch the runtime assumption table).
+            if (compInfo->getNumTotalCompilations() > lastNumCompilationsDuringRADisclaim + 5
+                || crtElapsedTime > lastRADisclaimTime + 12 * TR::Options::_minTimeBetweenMemoryDisclaims) {
+                disclaimRuntimeAssumptionSegments(crtElapsedTime);
+                lastRADisclaimTime = crtElapsedTime; // Update the time when disclaim was last performed
+                lastNumCompilationsDuringRADisclaim = compInfo->getNumTotalCompilations();
+            }
+        }
+    }
 }
 
 // this method can be used to produce regular RSS reports

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -2778,6 +2778,7 @@ bool J9::Options::fePreProcess(void *base)
     if (!TR::Compiler->target.isLinux()) {
         self()->setOption(TR_DisableDataCacheDisclaiming);
         self()->setOption(TR_DisableIProfilerDataDisclaiming);
+        self()->setOption(TR_DisableRuntimeAssumptionDataDisclaiming);
         self()->setOption(TR_EnableCodeCacheDisclaiming, false);
         self()->setOption(TR_EnableSharedCacheDisclaiming, false);
     }
@@ -2936,6 +2937,7 @@ bool J9::Options::fePostProcessJIT(void *base)
     }
 
     if (!self()->getOption(TR_DisableDataCacheDisclaiming) || !self()->getOption(TR_DisableIProfilerDataDisclaiming)
+        || !self()->getOption(TR_DisableRuntimeAssumptionDataDisclaiming)
         || self()->getOption(TR_EnableCodeCacheDisclaiming) || self()->getOption(TR_EnableSharedCacheDisclaiming)) {
         // Check requirements for memory disclaiming (Linux kernel and default page size)
         TR::Options::disableMemoryDisclaimIfNeeded(jitConfig);
@@ -3110,6 +3112,7 @@ bool J9::Options::disableMemoryDisclaimIfNeeded(J9JITConfig *jitConfig)
     if (!compInfo->canDisclaimOnSwap() && !compInfo->canDisclaimOnFile()) {
         TR::Options::getCmdLineOptions()->setOption(TR_DisableDataCacheDisclaiming);
         TR::Options::getCmdLineOptions()->setOption(TR_DisableIProfilerDataDisclaiming);
+        TR::Options::getCmdLineOptions()->setOption(TR_DisableRuntimeAssumptionDataDisclaiming);
         TR::Options::getCmdLineOptions()->setOption(TR_EnableCodeCacheDisclaiming, false);
         if (TR::Options::getVerboseOption(TR_VerbosePerformance)) {
             TR_VerboseLog::writeLineLocked(TR_Vlog_PERF,
@@ -3135,6 +3138,7 @@ bool J9::Options::disableMemoryDisclaimIfNeeded(J9JITConfig *jitConfig)
 #else /* if defined(LINUX) */
     TR::Options::getCmdLineOptions()->setOption(TR_DisableDataCacheDisclaiming);
     TR::Options::getCmdLineOptions()->setOption(TR_DisableIProfilerDataDisclaiming);
+    TR::Options::getCmdLineOptions()->setOption(TR_DisableRuntimeAssumptionDataDisclaiming);
     TR::Options::getCmdLineOptions()->setOption(TR_EnableCodeCacheDisclaiming, false);
     TR::Options::getCmdLineOptions()->setOption(TR_EnableSharedCacheDisclaiming, false);
     return true;

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -734,6 +734,7 @@ J9:
 
     if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableDataCacheDisclaiming)
         || !TR::Options::getCmdLineOptions()->getOption(TR_DisableIProfilerDataDisclaiming)
+        || !TR::Options::getCmdLineOptions()->getOption(TR_DisableRuntimeAssumptionDataDisclaiming)
         || TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming)
         || TR::Options::getCmdLineOptions()->getOption(TR_EnableSharedCacheDisclaiming)) {
         TR::Options::disableMemoryDisclaimIfNeeded(_jitConfig);

--- a/runtime/compiler/env/CHTable.cpp
+++ b/runtime/compiler/env/CHTable.cpp
@@ -23,9 +23,6 @@
 #include "env/CHTable.hpp"
 
 #include "codegen/CodeGenerator.hpp"
-#include "env/FrontEnd.hpp"
-#include "env/CompilerEnv.hpp"
-#include "env/KnownObjectTable.hpp"
 #include "compile/CompilationTypes.hpp"
 #include "compile/TRResolvedMethod.hpp"
 #include "compile/VirtualGuard.hpp"
@@ -33,16 +30,19 @@
 #include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
+#include "env/ClassTableCriticalSection.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/PersistentCHTable.hpp"
-#include "env/PersistentInfo.hpp"
-#include "env/jittypes.h"
+#include "env/FrontEnd.hpp"
 #include "env/j9method.h"
 #include "env/J9RetainedMethodSet.hpp"
-#include "env/ClassTableCriticalSection.hpp"
+#include "env/jittypes.h"
+#include "env/KnownObjectTable.hpp"
+#include "env/PersistentCHTable.hpp"
+#include "env/PersistentInfo.hpp"
+#include "env/RuntimeAssumptionTable.hpp"
+#include "env/VerboseLog.hpp"
 #include "env/VMAccessCriticalSection.hpp"
 #include "env/VMJ9.h"
-#include "env/VerboseLog.hpp"
 #include "il/MethodSymbol.hpp"
 #include "il/ResolvedMethodSymbol.hpp"
 #include "il/Symbol.hpp"
@@ -92,8 +92,19 @@ void TR_PatchJNICallSite::dumpInfo()
 TR_PatchNOPedGuardSiteOnClassExtend *TR_PatchNOPedGuardSiteOnClassExtend::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
     TR_OpaqueClassBlock *clazz, uint8_t *loc, uint8_t *dest, OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchNOPedGuardSiteOnClassExtend *result = new (pm) TR_PatchNOPedGuardSiteOnClassExtend(pm, clazz, loc, dest);
-    result->addToRAT(pm, RuntimeAssumptionOnClassExtend, fe, sentinel);
+    TR_PatchNOPedGuardSiteOnClassExtend *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PatchNOPedGuardSiteOnClassExtend));
+    if (mem) {
+        result = ::new (mem) TR_PatchNOPedGuardSiteOnClassExtend(pm, clazz, loc, dest);
+        result->addToRAT(pm, RuntimeAssumptionOnClassExtend, fe, sentinel);
+    } else {
+        // The thread-local comp object is not NULL during a compilation.
+        // If that's the case, throw a CompilationException to fail this compilation.
+        // Note that std::bad_alloc exception is treated like a scratch-memory exhaution.
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
@@ -101,18 +112,33 @@ TR_PatchNOPedGuardSiteOnMethodOverride *TR_PatchNOPedGuardSiteOnMethodOverride::
     TR_PersistentMemory *pm, TR_OpaqueMethodBlock *method, uint8_t *loc, uint8_t *dest,
     OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchNOPedGuardSiteOnMethodOverride *result
-        = new (pm) TR_PatchNOPedGuardSiteOnMethodOverride(pm, method, loc, dest);
-    result->addToRAT(pm, RuntimeAssumptionOnMethodOverride, fe, sentinel);
+    TR_PatchNOPedGuardSiteOnMethodOverride *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PatchNOPedGuardSiteOnMethodOverride));
+    if (mem) {
+        result = ::new (mem) TR_PatchNOPedGuardSiteOnMethodOverride(pm, method, loc, dest);
+        result->addToRAT(pm, RuntimeAssumptionOnMethodOverride, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_PatchNOPedGuardSiteOnClassRedefinition *TR_PatchNOPedGuardSiteOnClassRedefinition::make(TR_FrontEnd *fe,
     TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, uint8_t *loc, uint8_t *dest, OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchNOPedGuardSiteOnClassRedefinition *result
-        = new (pm) TR_PatchNOPedGuardSiteOnClassRedefinition(pm, clazz, loc, dest);
-    result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionNOP, fe, sentinel);
+    TR_PatchNOPedGuardSiteOnClassRedefinition *result = NULL;
+    void *mem
+        = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PatchNOPedGuardSiteOnClassRedefinition));
+    if (mem) {
+        result = ::new (mem) TR_PatchNOPedGuardSiteOnClassRedefinition(pm, clazz, loc, dest);
+        result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionNOP, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
@@ -120,10 +146,18 @@ TR_PatchMultipleNOPedGuardSitesOnClassRedefinition *TR_PatchMultipleNOPedGuardSi
     TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, TR::PatchSites *sites,
     OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchMultipleNOPedGuardSitesOnClassRedefinition *result
-        = new (pm) TR_PatchMultipleNOPedGuardSitesOnClassRedefinition(pm, clazz, sites);
-    sites->addReference();
-    result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionNOP, fe, sentinel);
+    TR_PatchMultipleNOPedGuardSitesOnClassRedefinition *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(
+        sizeof(TR_PatchMultipleNOPedGuardSitesOnClassRedefinition));
+    if (mem) {
+        result = ::new (mem) TR_PatchMultipleNOPedGuardSitesOnClassRedefinition(pm, clazz, sites);
+        sites->addReference();
+        result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionNOP, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
@@ -131,9 +165,17 @@ TR_PatchNOPedGuardSiteOnStaticFinalFieldModification *TR_PatchNOPedGuardSiteOnSt
     TR_FrontEnd *fe, TR_PersistentMemory *pm, TR_OpaqueClassBlock *clazz, uint8_t *loc, uint8_t *dest,
     OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchNOPedGuardSiteOnStaticFinalFieldModification *result
-        = new (pm) TR_PatchNOPedGuardSiteOnStaticFinalFieldModification(pm, clazz, loc, dest);
-    result->addToRAT(pm, RuntimeAssumptionOnStaticFinalFieldModification, fe, sentinel);
+    TR_PatchNOPedGuardSiteOnStaticFinalFieldModification *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(
+        sizeof(TR_PatchNOPedGuardSiteOnStaticFinalFieldModification));
+    if (mem) {
+        result = ::new (mem) TR_PatchNOPedGuardSiteOnStaticFinalFieldModification(pm, clazz, loc, dest);
+        result->addToRAT(pm, RuntimeAssumptionOnStaticFinalFieldModification, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
@@ -141,51 +183,99 @@ TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification *
 TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
     TR_OpaqueClassBlock *clazz, TR::PatchSites *sites, OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification *result
-        = new (pm) TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification(pm, clazz, sites);
-    sites->addReference();
-    result->addToRAT(pm, RuntimeAssumptionOnStaticFinalFieldModification, fe, sentinel);
+    TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(
+        sizeof(TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification));
+    if (mem) {
+        result = ::new (mem) TR_PatchMultipleNOPedGuardSitesOnStaticFinalFieldModification(pm, clazz, sites);
+        sites->addReference();
+        result->addToRAT(pm, RuntimeAssumptionOnStaticFinalFieldModification, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_PatchJNICallSite *TR_PatchJNICallSite::make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key, uint8_t *pc,
     OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchJNICallSite *result = new (pm) TR_PatchJNICallSite(pm, key, pc);
-    result->addToRAT(pm, RuntimeAssumptionOnRegisterNative, fe, sentinel);
+    TR_PatchJNICallSite *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PatchJNICallSite));
+    if (mem) {
+        result = ::new (mem) TR_PatchJNICallSite(pm, key, pc);
+        result->addToRAT(pm, RuntimeAssumptionOnRegisterNative, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_PreXRecompileOnClassExtend *TR_PreXRecompileOnClassExtend::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
     TR_OpaqueClassBlock *clazz, uint8_t *startPC, OMR::RuntimeAssumption **sentinel)
 {
-    TR_PreXRecompileOnClassExtend *result = new (pm) TR_PreXRecompileOnClassExtend(pm, clazz, startPC);
-    result->addToRAT(pm, RuntimeAssumptionOnClassExtend, fe, sentinel);
+    TR_PreXRecompileOnClassExtend *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PreXRecompileOnClassExtend));
+    if (mem) {
+        result = ::new (mem) TR_PreXRecompileOnClassExtend(pm, clazz, startPC);
+        result->addToRAT(pm, RuntimeAssumptionOnClassExtend, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_PreXRecompileOnMethodOverride *TR_PreXRecompileOnMethodOverride::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
     TR_OpaqueMethodBlock *method, uint8_t *startPC, OMR::RuntimeAssumption **sentinel)
 {
-    TR_PreXRecompileOnMethodOverride *result = new (pm) TR_PreXRecompileOnMethodOverride(pm, method, startPC);
-    result->addToRAT(pm, RuntimeAssumptionOnMethodOverride, fe, sentinel);
+    TR_PreXRecompileOnMethodOverride *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PreXRecompileOnMethodOverride));
+    if (mem) {
+        result = ::new (mem) TR_PreXRecompileOnMethodOverride(pm, method, startPC);
+        result->addToRAT(pm, RuntimeAssumptionOnMethodOverride, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_ClassUnloadRecompile *TR_ClassUnloadRecompile::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
     TR_OpaqueClassBlock *clazz, uint8_t *startPC, OMR::RuntimeAssumption **sentinel)
 {
-    TR_ClassUnloadRecompile *result = new (pm) TR_ClassUnloadRecompile(pm, clazz, startPC);
-    result->addToRAT(pm, RuntimeAssumptionOnClassUnload, fe, sentinel);
+    TR_ClassUnloadRecompile *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_ClassUnloadRecompile));
+    if (mem) {
+        result = ::new (mem) TR_ClassUnloadRecompile(pm, clazz, startPC);
+        result->addToRAT(pm, RuntimeAssumptionOnClassUnload, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_PatchNOPedGuardSiteOnMutableCallSiteChange *TR_PatchNOPedGuardSiteOnMutableCallSiteChange::make(TR_FrontEnd *fe,
     TR_PersistentMemory *pm, uintptr_t key, uint8_t *location, uint8_t *destination, OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchNOPedGuardSiteOnMutableCallSiteChange *result
-        = new (pm) TR_PatchNOPedGuardSiteOnMutableCallSiteChange(pm, key, location, destination);
-    result->addToRAT(pm, RuntimeAssumptionOnMutableCallSiteChange, fe, sentinel);
+    TR_PatchNOPedGuardSiteOnMutableCallSiteChange *result = NULL;
+    void *mem
+        = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PatchNOPedGuardSiteOnMutableCallSiteChange));
+    if (mem) {
+        result = ::new (mem) TR_PatchNOPedGuardSiteOnMutableCallSiteChange(pm, key, location, destination);
+        result->addToRAT(pm, RuntimeAssumptionOnMutableCallSiteChange, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 

--- a/runtime/compiler/env/PersistentAllocator.cpp
+++ b/runtime/compiler/env/PersistentAllocator.cpp
@@ -277,13 +277,14 @@ void *PersistentAllocator::allocateInternal(size_t requestedSize)
             j9thread_monitor_exit(_segmentMonitor);
         }
     }
-#if defined(J9VM_OPT_JITSERVER)
-    if (_isJITServer && allocation) {
-        // keep track of which allocator this block belongs to (global/per client)
+    // Keep track of which allocator this block belongs to.
+    // This failsafe mechanism helps detect allocator mismatches where a block
+    // is allocated with one allocator but freed with another.
+    // Originally implemented for JITServer, now extended to all cases for better debugging.
+    if (allocation) {
         Block *block = reinterpret_cast<Block *>(allocation) - 1;
         block->setNext(reinterpret_cast<Block *>(this));
     }
-#endif
     return allocation;
 }
 
@@ -607,21 +608,18 @@ void PersistentAllocator::freeBlock(Block *block)
 void PersistentAllocator::deallocate(void *mem, size_t) throw()
 {
     Block *block = static_cast<Block *>(mem) - 1;
-#if defined(J9VM_OPT_JITSERVER)
-    if (_isJITServer) {
-        TR_ASSERT_FATAL(block->next() == reinterpret_cast<Block *>(this),
-            "Freeing a block that was created by another allocator or is already on the free list. mem=%p block=%p "
-            "next=%p this=%p",
-            mem, block, block->next(), reinterpret_cast<Block *>(this));
-        block->setNext(NULL);
-    } else {
-        TR_ASSERT_FATAL(block->next() == NULL, "Freeing a block that is already on the free list. block=%p next=%p",
-            block, block->next());
-    }
-#else
-    TR_ASSERT_FATAL(block->next() == NULL, "Freeing a block that is already on the free list. block=%p next=%p", block,
-        block->next());
-#endif
+
+    // Verify that the block is being freed by the same allocator that allocated it.
+    // The _next field stores the allocator pointer during the block's lifetime.
+    // This failsafe mechanism detects allocator mismatches and double-frees.
+    TR_ASSERT_FATAL(block->next() == reinterpret_cast<Block *>(this),
+        "Freeing a block that was created by another allocator or is already on the free list. mem=%p block=%p "
+        "next=%p this=%p",
+        mem, block, block->next(), reinterpret_cast<Block *>(this));
+
+    // Clear the _next field before returning the block to the free list
+    block->setNext(NULL);
+
     freeBlock(block);
 }
 

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -26,9 +26,11 @@
 #include <stddef.h>
 #include <stdint.h>
 #include "env/jittypes.h"
+#include "env/PersistentAllocator.hpp"
 
 class TR_FrontEnd;
 class TR_OpaqueClassBlock;
+class TR_PersistentMemory;
 
 namespace OMR {
 class RuntimeAssumption;
@@ -84,7 +86,48 @@ public:
 
     bool init(); // Must call this during bootstrap on a single thread because it is not MT safe
 
+    /**
+     * @brief Get the dedicated PersistentAllocator for RuntimeAssumptions
+     *
+     * Returns either a dedicated allocator (if TR_UseDedicatedRuntimeAssumptionAllocator is set)
+     * or the global persistent allocator (default).
+     *
+     * @return TR::PersistentAllocator* Pointer to the RuntimeAssumption persistent allocator
+     */
+    static TR::PersistentAllocator *getRAPersistentAllocator() { return _raPersistentAllocator; }
+
+    /**
+     * @brief Allocate persistent memory for RuntimeAssumptions
+     *
+     * This method provides a centralized allocation point for all RuntimeAssumption objects,
+     * making it easy to track and validate allocations. All allocations are tracked under
+     * the TR_Memory::Assumption category.
+     *
+     * @param size Size of memory to allocate in bytes
+     * @return void* Pointer to allocated memory
+     */
     static void *allocateRAPersistentMemory(size_t size);
+
+    /**
+     * @brief Free persistent memory allocated for RuntimeAssumptions
+     *
+     * This method provides a centralized deallocation point for all RuntimeAssumption objects,
+     * ensuring the correct allocator is used and enabling validation.
+     *
+     * @param mem Pointer to memory to free
+     */
+    static void freeRAPersistentMemory(void *mem);
+
+    /**
+     * @brief Get the number of segments allocated by the RuntimeAssumption allocator
+     *
+     * This method returns the number of memory segments that have been allocated
+     * by the dedicated RuntimeAssumption persistent allocator. Useful for memory
+     * usage statistics and debugging.
+     *
+     * @return int Number of segments allocated
+     */
+    static int getRANumSegments() { return _raPersistentAllocator ? _raPersistentAllocator->getNumSegments() : 0; }
 
     static uintptr_t hashCode(uintptr_t key)
     {
@@ -151,6 +194,21 @@ private:
     uint32_t _marked; // Counts the number of assumptions waiting to be removed
     int32_t assumptionCount[LastAssumptionKind]; // this never gets decremented
     int32_t reclaimedAssumptionCount[LastAssumptionKind];
+
+    /**
+     * @brief Static persistent allocator for RuntimeAssumptions
+     *
+     * This can point to either:
+     * - A dedicated PersistentAllocator instance (when TR_UseDedicatedRuntimeAssumptionAllocator env var is set)
+     * - The global persistent allocator from TR::Compiler->persistentMemory() (default behavior)
+     *
+     * Using a direct PersistentAllocator reference (instead of TR_PersistentMemory) avoids
+     * creating a separate PersistentInfo object, which would cause confusion since
+     * RuntimeAssumption code needs to access the global PersistentInfo for the RuntimeAssumptionTable.
+     *
+     * Initialized in init() during JVM bootstrap.
+     */
+    static TR::PersistentAllocator *_raPersistentAllocator;
 };
 
 #endif // RUNTIMEASSUMPTIONTABLE_HPP

--- a/runtime/compiler/runtime/ClassUnloadAssumption.cpp
+++ b/runtime/compiler/runtime/ClassUnloadAssumption.cpp
@@ -23,12 +23,20 @@
 #include <algorithm>
 #include <memory.h>
 #include "j9.h"
+#include "compile/CompilationTypes.hpp"
+#include "control/CompilationRuntime.hpp"
+#include "control/Options.hpp"
+#include "control/Options_inlines.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CHTable.hpp"
+#include "env/jittypes.h"
+#include "env/PersistentAllocator.hpp"
+#include "env/PersistentAllocatorKit.hpp"
 #include "env/PersistentCHTable.hpp"
 #include "env/PersistentInfo.hpp"
-#include "env/jittypes.h"
+#include "env/RawAllocator.hpp"
+#include "env/TRMemory.hpp"
 #include "env/VerboseLog.hpp"
 #include "infra/Monitor.hpp"
 #include "infra/CriticalSection.hpp"
@@ -41,6 +49,7 @@
 #include "omrformatconsts.h"
 
 extern TR::Monitor *assumptionTableMutex;
+extern TR_PersistentMemory *trPersistentMemory;
 
 bool TR_PersistentClassInfo::isInitialized(bool validate)
 {
@@ -133,12 +142,50 @@ void TR_PersistentClassInfo::removeUnloadedSubClasses()
     return;
 }
 
-// Must call this during bootstrap on a single thread because it is not MT safe
+// Static member definition
+TR::PersistentAllocator *TR_RuntimeAssumptionTable::_raPersistentAllocator = NULL;
+
+// Must call this during bootstrap on a single thread because it is not MT safe.
 bool TR_RuntimeAssumptionTable::init()
 {
-    // Set default values for size tables
-    // Sizes need to be determined at bootstrap because in this implementation we cannot grow the tables
-    // A palliative would be to store a hint in te shared class cache
+#ifdef LINUX
+    if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableRuntimeAssumptionDataDisclaiming)) {
+        // Create dedicated PersistentAllocator for RuntimeAssumptions with MEMORY_TYPE_VIRTUAL
+        // to enable memory disclaiming to swap using madvise.
+        uint32_t memoryType = MEMORY_TYPE_VIRTUAL; // Force the usage of mmap for allocation
+        TR::CompilationInfo *compInfo = TR::CompilationInfo::get();
+        if (!compInfo)
+            return false;
+        if (!compInfo->canDisclaimOnSwap())
+            memoryType |= MEMORY_TYPE_DISCLAIMABLE_TO_FILE;
+
+        // Use 1 MB segment size (same as other dedicated allocators in the codebase).
+        TR::PersistentAllocatorKit kit(1 << 20 /*1 MB*/, *TR::Compiler->javaVM, memoryType);
+        _raPersistentAllocator = new (TR::Compiler->rawAllocator) TR::PersistentAllocator(kit);
+
+        if (!_raPersistentAllocator)
+            return false;
+
+        if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance)) {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_INFO,
+                "Using dedicated persistent allocator %p for RuntimeAssumptions (memoryType=0x%x)",
+                _raPersistentAllocator, memoryType);
+        }
+    } else
+#endif // LINUX
+    {
+        // Use global persistent allocator (default, backward compatible).
+        // Get reference to the allocator from the global persistent memory.
+        _raPersistentAllocator = &trPersistentMemory->_persistentAllocator.get();
+
+        if (TR::Options::getCmdLineOptions()->getVerboseOption(TR_VerbosePerformance)) {
+            TR_VerboseLog::writeLineLocked(TR_Vlog_INFO, "Using global persistent allocator for RuntimeAssumptions");
+        }
+    }
+
+    // Set default values for size tables.
+    // Sizes need to be determined at bootstrap because in this implementation we cannot grow the tables.
+    // A palliative would be to store a hint in the shared class cache.
     size_t sizes[LastAssumptionKind];
     for (int32_t i = 0; i < LastAssumptionKind; i++)
         sizes[i] = 251;
@@ -159,9 +206,12 @@ bool TR_RuntimeAssumptionTable::init()
         reclaimedAssumptionCount[i] = 0;
         _tables[i]._spineArraySize = sizes[i];
         size_t storageSize = sizeof(OMR::RuntimeAssumption *) * _tables[i]._spineArraySize;
-        _tables[i]._htSpineArray = (OMR::RuntimeAssumption **)TR_PersistentMemory::jitPersistentAlloc(storageSize);
+
+        // Use dedicated RuntimeAssumption allocator with TR_Memory::Assumption category.
+        _tables[i]._htSpineArray = (OMR::RuntimeAssumption **)allocateRAPersistentMemory(storageSize);
         _tables[i]._markedforDetachCount
-            = (uint32_t *)TR_PersistentMemory::jitPersistentAlloc(sizeof(uint32_t) * _tables[i]._spineArraySize);
+            = (uint32_t *)allocateRAPersistentMemory(sizeof(uint32_t) * _tables[i]._spineArraySize);
+
         if (!_tables[i]._htSpineArray || !_tables[i]._markedforDetachCount)
             return false;
         memset(_tables[i]._htSpineArray, 0, storageSize);
@@ -174,7 +224,21 @@ bool TR_RuntimeAssumptionTable::init()
 
 void *TR_RuntimeAssumptionTable::allocateRAPersistentMemory(size_t size)
 {
-    return TR::Compiler->persistentMemory()->allocatePersistentMemory(size, TR_Memory::Assumption);
+    void *mem = _raPersistentAllocator->allocate(size, std::nothrow);
+    if (mem) {
+        // Update allocation tracking in the global persistent memory.
+        // This ensures proper accounting even when using a dedicated allocator.
+        trPersistentMemory->_totalPersistentAllocations[TR_Memory::Assumption] += size;
+    }
+
+    return mem;
+}
+
+void TR_RuntimeAssumptionTable::freeRAPersistentMemory(void *mem)
+{
+    TR_ASSERT(mem != NULL, "Attempting to free NULL RuntimeAssumption pointer");
+    TR_ASSERT(_raPersistentAllocator != NULL, "RuntimeAssumption allocator not initialized");
+    _raPersistentAllocator->deallocate(mem);
 }
 
 void OMR::RuntimeAssumption::addToRAT(TR_PersistentMemory *persistentMemory, TR_RuntimeAssumptionKind kind,
@@ -259,7 +323,7 @@ void OMR::RuntimeAssumption::dequeueFromListOfAssumptionsForJittedBody()
                 }
 
                 crt->paint();
-                TR_PersistentMemory::jitPersistentFree(crt);
+                TR_RuntimeAssumptionTable::freeRAPersistentMemory(crt);
             }
 
             crt = next;
@@ -281,9 +345,10 @@ bool OMR::RuntimeAssumption::enqueueInListOfAssumptionsForJittedBody(OMR::Runtim
     if (*sentinel == NULL) // sentinel does not exist yet
     {
         // Create a special RuntimeAssumption to play role of a sentinel
-        *sentinel = new (PERSISTENT_NEW) TR::SentinelRuntimeAssumption();
-        if (*sentinel == NULL) // ran ouf of memory during runtime
+        void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR::SentinelRuntimeAssumption));
+        if (mem == NULL) // ran out of memory during runtime
             return false;
+        *sentinel = ::new (mem) TR::SentinelRuntimeAssumption();
     }
     this->setNextAssumptionForSameJittedBody((*sentinel)->getNextAssumptionForSameJittedBodyEvenIfDead());
     (*sentinel)->setNextAssumptionForSameJittedBody(this);
@@ -316,7 +381,7 @@ void TR_RuntimeAssumptionTable::purgeAssumptionListHead(OMR::RuntimeAssumption *
     assumptionList->dequeueFromListOfAssumptionsForJittedBody();
     incReclaimedAssumptionCount(assumptionList->getAssumptionKind());
 
-    TR_PersistentMemory::jitPersistentFree(assumptionList);
+    TR_RuntimeAssumptionTable::freeRAPersistentMemory(assumptionList);
 
     assumptionList = next;
 }
@@ -431,7 +496,7 @@ void TR_RuntimeAssumptionTable::reclaimMarkedAssumptionsFromRAT(int32_t cleanupC
 
                         cursor->reclaim();
                         cursor->paint(); // RAS
-                        TR_PersistentMemory::jitPersistentFree(cursor);
+                        TR_RuntimeAssumptionTable::freeRAPersistentMemory(cursor);
                         cleanupCount--;
                     } else {
                         prev = cursor;
@@ -721,25 +786,49 @@ void TR_UnloadedClassPicSite::dumpInfo()
 TR_RedefinedClassRPicSite *TR_RedefinedClassRPicSite::make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
     uint8_t *picLocation, uint32_t size, OMR::RuntimeAssumption **sentinel)
 {
-    TR_RedefinedClassRPicSite *result = new (pm) TR_RedefinedClassRPicSite(pm, key, picLocation, size);
-    result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionPIC, fe, sentinel);
-    // FAR:: we should replace RuntimeAssumptionOnClassRedefinitionPIC by result->getAssumptionKind();
+    TR_RedefinedClassRPicSite *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_RedefinedClassRPicSite));
+    if (mem) {
+        result = ::new (mem) TR_RedefinedClassRPicSite(pm, key, picLocation, size);
+        result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionPIC, fe, sentinel);
+        // FAR:: we should replace RuntimeAssumptionOnClassRedefinitionPIC by result->getAssumptionKind();
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_RedefinedClassUPicSite *TR_RedefinedClassUPicSite::make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
     uint8_t *picLocation, uint32_t size, OMR::RuntimeAssumption **sentinel)
 {
-    TR_RedefinedClassUPicSite *result = new (pm) TR_RedefinedClassUPicSite(pm, key, picLocation, size);
-    result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionUPIC, fe, sentinel);
+    TR_RedefinedClassUPicSite *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_RedefinedClassUPicSite));
+    if (mem) {
+        result = ::new (mem) TR_RedefinedClassUPicSite(pm, key, picLocation, size);
+        result->addToRAT(pm, RuntimeAssumptionOnClassRedefinitionUPIC, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
 TR_UnloadedClassPicSite *TR_UnloadedClassPicSite::make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
     uint8_t *picLocation, uint32_t size, TR_RuntimeAssumptionKind kind, OMR::RuntimeAssumption **sentinel)
 {
-    TR_UnloadedClassPicSite *result = new (pm) TR_UnloadedClassPicSite(pm, key, picLocation, size);
-    result->addToRAT(pm, RuntimeAssumptionOnClassUnload, fe, sentinel);
+    TR_UnloadedClassPicSite *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_UnloadedClassPicSite));
+    if (mem) {
+        result = ::new (mem) TR_UnloadedClassPicSite(pm, key, picLocation, size);
+        result->addToRAT(pm, RuntimeAssumptionOnClassUnload, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -384,7 +384,12 @@ J9JITExceptionTable *TR_RelocationRuntime::prepareRelocateAOTCodeAndData(J9VMThr
                 // assumption be created.
                 // Another alternative is to create a sentinel entry right away to avoid
                 // having to allocate one at runtime and possibly running out of memory
-                OMR::RuntimeAssumption *raList = new (PERSISTENT_NEW) TR::SentinelRuntimeAssumption();
+                void *mem
+                    = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR::SentinelRuntimeAssumption));
+                if (mem == NULL)
+                    return NULL; // fail
+                OMR::RuntimeAssumption *raList = ::new (mem) TR::SentinelRuntimeAssumption();
+
                 comp->setMetadataAssumptionList(
                     raList); // copy this list to the compilation object as well (same view as for a JIT compilation)
                 static_cast<TR::SentinelRuntimeAssumption *>(*comp->getMetadataAssumptionList())

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -123,6 +123,8 @@ void jitAddPicToPatchOnClassRedefinition(void *classPointer, void *addressToBePa
     J9JavaVM *vm = jitConfig->javaVM;
     J9VMThread *vmThread = vm->internalVMFunctions->currentVMThread(vm);
     J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)addressToBePatched);
+    // TODO: follow the pattern from jitAddPicToPatchOnClassUnload and write
+    // 0x0101dead to the addressToBePatched, if we cannot allocate the assumption.
     createClassRedefinitionPicSite(classPointer, addressToBePatched, sizeof(uintptr_t), unresolved,
         (OMR::RuntimeAssumption **)(&metaData->runtimeAssumptionList));
 }
@@ -132,6 +134,8 @@ void jitAdd32BitPicToPatchOnClassRedefinition(void *classPointer, void *addressT
     J9JavaVM *vm = jitConfig->javaVM;
     J9VMThread *vmThread = vm->internalVMFunctions->currentVMThread(vm);
     J9JITExceptionTable *metaData = jitConfig->jitGetExceptionTableFromPC(vmThread, (UDATA)addressToBePatched);
+    // TODO: follow the pattern from jitAdd32BitPicToPatchOnClassUnload and write
+    // 0x0101dead to the addressToBePatched, if we cannot allocate the assumption.
     createClassRedefinitionPicSite(classPointer, addressToBePatched, 4, unresolved,
         (OMR::RuntimeAssumption **)(&metaData->runtimeAssumptionList));
 }

--- a/runtime/compiler/runtime/RuntimeAssumptions.cpp
+++ b/runtime/compiler/runtime/RuntimeAssumptions.cpp
@@ -20,21 +20,21 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
-#include "runtime/RuntimeAssumptions.hpp"
-
-#include "env/FrontEnd.hpp"
+#include "control/CompilationRuntime.hpp"
+#include "control/CompilationThread.hpp"
+#include "compile/CompilationTypes.hpp"
 #include "control/Recompilation.hpp"
 #include "control/RecompilationInfo.hpp"
 #include "env/CHTable.hpp"
 #include "env/CompilerEnv.hpp"
-#include "env/PersistentCHTable.hpp"
+#include "env/FrontEnd.hpp"
 #include "env/jittypes.h"
+#include "env/PersistentCHTable.hpp"
 #include "env/VerboseLog.hpp"
-#include "infra/Monitor.hpp"
-#include "infra/CriticalSection.hpp"
-#include "control/CompilationRuntime.hpp"
-#include "control/CompilationThread.hpp"
 #include "env/VMJ9.h"
+#include "infra/CriticalSection.hpp"
+#include "infra/Monitor.hpp"
+#include "runtime/RuntimeAssumptions.hpp"
 
 namespace TR {
 class Monitor;
@@ -48,11 +48,23 @@ TR_PatchNOPedGuardSiteOnClassPreInitialize *TR_PatchNOPedGuardSiteOnClassPreInit
     TR_PersistentMemory *persistentMemory, char *sig, uint32_t sigLen, uint8_t *loc, uint8_t *dest,
     OMR::RuntimeAssumption **sentinel)
 {
-    char *persistentSig = (char *)persistentMemory->allocatePersistentMemory(sizeof(char) * sigLen);
-    memcpy(persistentSig, sig, sigLen);
-    TR_PatchNOPedGuardSiteOnClassPreInitialize *result = new (PERSISTENT_NEW)
-        TR_PatchNOPedGuardSiteOnClassPreInitialize(persistentMemory, persistentSig, sigLen, loc, dest);
-    result->addToRAT(persistentMemory, RuntimeAssumptionOnClassPreInitialize, fe, sentinel);
+    TR_PatchNOPedGuardSiteOnClassPreInitialize *result = NULL;
+    char *persistentSig = (char *)TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(char) * sigLen);
+    void *mem = persistentSig
+        ? TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PatchNOPedGuardSiteOnClassPreInitialize))
+        : NULL;
+    if (mem) {
+        memcpy(persistentSig, sig, sigLen);
+        result = ::new (mem)
+            TR_PatchNOPedGuardSiteOnClassPreInitialize(persistentMemory, persistentSig, sigLen, loc, dest);
+        result->addToRAT(persistentMemory, RuntimeAssumptionOnClassPreInitialize, fe, sentinel);
+    } else {
+        if (persistentSig)
+            TR_RuntimeAssumptionTable::freeRAPersistentMemory(persistentSig);
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 
@@ -85,7 +97,7 @@ void TR_PatchNOPedGuardSiteOnClassPreInitialize::reclaim()
 {
     TR_ASSERT_FATAL(_key != 0, "Attempt to reclaim an already freed _key");
 
-    jitPersistentFree((void *)_key);
+    TR_RuntimeAssumptionTable::freeRAPersistentMemory((void *)_key);
     _key = 0;
 }
 
@@ -111,9 +123,16 @@ TR_PatchNOPedGuardSiteOnMethodBreakPoint *TR_PatchNOPedGuardSiteOnMethodBreakPoi
     TR_PersistentMemory *pm, TR_OpaqueMethodBlock *method, uint8_t *location, uint8_t *destination,
     OMR::RuntimeAssumption **sentinel)
 {
-    TR_PatchNOPedGuardSiteOnMethodBreakPoint *result
-        = new (pm) TR_PatchNOPedGuardSiteOnMethodBreakPoint(pm, method, location, destination);
-    result->addToRAT(pm, RuntimeAssumptionOnMethodBreakPoint, fe, sentinel);
+    TR_PatchNOPedGuardSiteOnMethodBreakPoint *result = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_PatchNOPedGuardSiteOnMethodBreakPoint));
+    if (mem) {
+        result = ::new (mem) TR_PatchNOPedGuardSiteOnMethodBreakPoint(pm, method, location, destination);
+        result->addToRAT(pm, RuntimeAssumptionOnMethodBreakPoint, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
     return result;
 }
 


### PR DESCRIPTION
This commit creates a new JIT persistent memory allocator that will be used solely for allocating runtime assumptions. Because runtime assumptions are kept grouped together in dedicated memory segments, their memory can be disclaimed to swap/file.
Runtime assumption memory disclaiming will be enabled by default (linux only), but the user can disable it with `-Xjit:disableRuntimeAssumptionDataDisclaiming`.
Note that, if the machine where the JVM is running is not suitable for disclaiming (e.g. disk too slow, linux kernel too old, etc), the disclaim functionality will be turned off internally.
The default frequency for disclaim operations is once every 5000 ms. (configurable with -Xjit:minTimeBetweenMemoryDisclaims=<NNN>). The frequency drops to once every 60 sec if very few compilations have been performed since the previous disclaim operation. Experiments have shown that, if JIT compilations do not occur, memory used for runtime assumption does not become resident again.

Depends on: https://github.com/eclipse-omr/omr/pull/8320