### PR TITLE
Avoid warnings related to uses of strchar() and strrchr()

### DIFF
--- a/runtime/bcutil/dynload.c
+++ b/runtime/bcutil/dynload.c
@@ -109,11 +109,11 @@ findLocallyDefinedClass(J9VMThread * vmThread, J9Module * j9module, U_8 * classN
 			if (J9_ARE_NO_BITS_SET(javaVM->runtimeFlags, J9_RUNTIME_JAVA_BASE_MODULE_CREATED)) {
 				module = javaVM->javaBaseModule;
 			} else {
-				char *packageEnd = strrchr((const char*)mbString, '/');
+				const char *packageEnd = strrchr((const char *)mbString, '/');
 
 				if (NULL != packageEnd) {
 					omrthread_monitor_enter(javaVM->classLoaderModuleAndLocationMutex);
-					module = J9_VM_FUNCTION(vmThread, findModuleForPackage)(vmThread, classLoader, mbString, (U_32)((U_8 *)packageEnd - mbString));
+					module = J9_VM_FUNCTION(vmThread, findModuleForPackage)(vmThread, classLoader, mbString, (U_32)((const U_8 *)packageEnd - mbString));
 					omrthread_monitor_exit(javaVM->classLoaderModuleAndLocationMutex);
 				}
 			}
@@ -144,12 +144,12 @@ findLocallyDefinedClass(J9VMThread * vmThread, J9Module * j9module, U_8 * classN
 					&& J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_FIND_MODULE_ON_FAIL)
 				) {
 					J9Module *j9moduleFromPackage = NULL;
-					char *packageEnd = strrchr((const char*)className, '/');
+					const char *packageEnd = strrchr((const char *)className, '/');
 
 					if (NULL != packageEnd) {
 						omrthread_monitor_enter(javaVM->classLoaderModuleAndLocationMutex);
 
-						j9moduleFromPackage = J9_VM_FUNCTION(vmThread, findModuleForPackage)(vmThread, classLoader, className, (U_32)((U_8 *)packageEnd - className));
+						j9moduleFromPackage = J9_VM_FUNCTION(vmThread, findModuleForPackage)(vmThread, classLoader, className, (U_32)((const U_8 *)packageEnd - className));
 
 						if ((NULL != j9moduleFromPackage) && (j9moduleFromPackage != j9module)) {
 							J9ModuleExtraInfo *moduleInfo = J9_VM_FUNCTION(vmThread, findModuleInfoForModule)(vmThread, classLoader, j9moduleFromPackage);

--- a/runtime/jnichk/jnicheck.c
+++ b/runtime/jnichk/jnicheck.c
@@ -2329,20 +2329,20 @@ jniCheckCall(const char* function, JNIEnv* env, jobject receiver, UDATA methodTy
 	J9VMThread *vmThread = (J9VMThread *)env;
 	J9JavaVM *vm = vmThread->javaVM;
 	PORT_ACCESS_FROM_JAVAVM(vm);
-	J9Method *ramMethod = ((J9JNIMethodID*)method)->method;
+	J9Method *ramMethod = ((J9JNIMethodID *)method)->method;
 	J9Class *declaringClass = J9_CLASS_FROM_METHOD(ramMethod);
-	jclass declaringClassRef;
+	jclass declaringClassRef = NULL;
 	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(ramMethod);
 	J9UTF8 *sig = J9ROMMETHOD_SIGNATURE(romMethod);
-	char *returnSig;
+	const char *returnSig = NULL;
 	UDATA novalist = vm->checkJNIData.options & JNICHK_NOVALIST;
 
 	jniCheckNull(env, function, 0, receiver);
 
-	jniCallIn((J9VMThread *) env);
+	jniCallIn(vmThread);
 
 	if (methodType == METHOD_CONSTRUCTOR) {
-		J9UTF8* name = J9ROMMETHOD_NAME(romMethod);
+		const J9UTF8 *name = J9ROMMETHOD_NAME(romMethod);
 		if ( (J9UTF8_DATA(name)[0] != '<') || (J9UTF8_LENGTH(name) != sizeof("<init>") - 1) ) {
 			jniCheckFatalErrorNLS(J9NLS_JNICHK_METHOD_IS_NOT_CONSTRUCTOR, function);
 		}
@@ -2356,11 +2356,10 @@ jniCheckCall(const char* function, JNIEnv* env, jobject receiver, UDATA methodTy
 		}
 	}
 
-	returnSig = strchr((const char*)J9UTF8_DATA(sig), ')') + 1;
+	returnSig = strchr((const char *)J9UTF8_DATA(sig), ')') + 1;
 	if ( (UDATA)*returnSig != returnType && ((UDATA)*returnSig != '[' || returnType != 'L') ) {
 		jniCheckFatalErrorNLS(J9NLS_JNICHK_METHOD_HAS_WRONG_RETURN_TYPE, function, *returnSig);
 	}
-
 
 	declaringClassRef = (jclass)&declaringClass->classObject;
 
@@ -2381,7 +2380,6 @@ jniCheckCall(const char* function, JNIEnv* env, jobject receiver, UDATA methodTy
 			}
 			break;
 	}
-
 }
 
 

--- a/runtime/rastrace/trcmain.c
+++ b/runtime/rastrace/trcmain.c
@@ -1338,7 +1338,7 @@ trcAddComponent(UtModuleInfo *modInfo, const char **format)
 		/*
 		 * Required space following the trace type ?
 		 */
-		if ((thisFormat = strchr(format[i], ' ')) == NULL) {
+		if ((thisFormat = (char *)strchr(format[i], ' ')) == NULL) {
 			rc = OMR_ERROR_ILLEGAL_ARGUMENT;
 			break;
 		}

--- a/runtime/redirector/redirector.c
+++ b/runtime/redirector/redirector.c
@@ -352,12 +352,12 @@ hasEnvOption(const char *envOptions, const char *option)
 static char *
 findStartOfMostRightOption(const char *envOptions, const char *option)
 {
-	char *result = strstr(envOptions, option);
+	const char *result = strstr(envOptions, option);
 	UDATA optionSize = strlen(option);
 	if (NULL != result) {
 		if ((result == envOptions) || OMR_ISSPACE(result[-1])) {
-			char *cursor = result;
-			char *next = NULL;
+			const char *cursor = result;
+			const char *next = NULL;
 			while (NULL != (next = strstr(cursor + optionSize, option))) {
 				if (OMR_ISSPACE(next[-1])) {
 					result = next;
@@ -366,7 +366,8 @@ findStartOfMostRightOption(const char *envOptions, const char *option)
 			}
 		}
 	}
-	return result;
+	/* FIXME this cast should be removed */
+	return (char *)result;
 }
 
 /* Scan the next unsigned number off of the argument string.

--- a/runtime/tests/sharedclassapi/sharedClasses.c
+++ b/runtime/tests/sharedclassapi/sharedClasses.c
@@ -417,7 +417,7 @@ findOption(const char *optionString, char *optionName)
 	size_t optionNameLength = 0;
 	char *trailingCommaPos = NULL;
 	int valueLength = 0;
-	char *optionStart = strstr(optionString, optionName);
+	char *optionStart = (char *)strstr(optionString, optionName);
 
 	if (NULL == optionStart) {
 		char *convertedName = copyAndConvert(optionName);

--- a/runtime/util_core/vmargs_core.c
+++ b/runtime/util_core/vmargs_core.c
@@ -234,7 +234,7 @@ addXOptionsFile(J9PortLibrary* portLib, const char *xOptionsfileArg, J9JavaVMArg
 {
 
 	PORT_ACCESS_FROM_PORT(portLib);
-	char* filePath = strchr(xOptionsfileArg, '=');
+	const char *filePath = strchr(xOptionsfileArg, '=');
 	intptr_t fd = -1;
 	J9JavaVMArgInfo *optArg = NULL;
 	int64_t length = -1;


### PR DESCRIPTION
Newer versions of gcc (15+) complain if the first argument type is incompatible with use of return type. The functions behave as if they're overloaded:
* `char * strchr(char *, char)`
* `const char * strchr(const char *, char)`