### PR TITLE
Disable transform Unsafe.setMemory by default on Z

### DIFF
--- a/runtime/compiler/z/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/z/codegen/J9CodeGenerator.cpp
@@ -3460,7 +3460,7 @@ bool J9::Z::CodeGenerator::canUseRelativeLongInstructions(int64_t value)
 
 bool J9::Z::CodeGenerator::canTransformUnsafeSetMemory()
 {
-    static bool enableUnsafeSetMemoryAcceleration = (feGetEnv("TR_DisableUnsafeSetMemoryAcceleration") == NULL);
+    static bool enableUnsafeSetMemoryAcceleration = (feGetEnv("TR_EnableUnsafeSetMemoryAcceleration") != NULL);
     return (enableUnsafeSetMemoryAcceleration && self()->comp()->target().is64Bit());
 }
 


### PR DESCRIPTION
Flips the env variable check to a environment variable responsible for enabling the transformating of Unsafe.setMemory. This represents the default/old value of canTransformUnsafeSetMemory for Z, when the variable is not set manually.