### PR TITLE
Fix PGC edenSurvivalRate overflow issues in CopyForward

### DIFF
--- a/runtime/gc_vlhgc/SchedulingDelegate.cpp
+++ b/runtime/gc_vlhgc/SchedulingDelegate.cpp
@@ -372,7 +372,15 @@ MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, 
 	bool globalSweepHappened = _globalSweepRequired;
 	_globalSweepRequired = false;
 	/* copy out the Eden size of the previous interval (between the last PGC and this one) before we recalculate the next one */
-	uintptr_t edenCountBeforeCollect = getCurrentEdenSizeInRegions(env);
+	/* During GC, the heap may expand to allow the current collection to continue.
+	 * A heap resize triggers an eden size recalculation without allowing further
+	 * heap expansion (heap reconfiguration). As a result, the newly calculated
+	 * eden size can differ significantly from the eden size at the start of the
+	 * collection, causing the SurvivalRate calculation to become inaccurate.
+	 * Therefore, set copyForwardStats->_edenEvacuateRegionCount (instead of getCurrentEdenSizeInRegions(env)) to
+	 * edenCountBeforeCollect.
+	 */
+	uintptr_t edenCountBeforeCollect = copyForwardStats->_edenEvacuateRegionCount;
 	
 	Trc_MM_SchedulingDelegate_partialGarbageCollectCompleted_stats(env->getLanguageVMThread(),
 			copyForwardStats->_edenEvacuateRegionCount,
@@ -384,21 +392,42 @@ MM_SchedulingDelegate::partialGarbageCollectCompleted(MM_EnvironmentVLHGC *env, 
 
 	if (env->_cycleState->_shouldRunCopyForward) {
 		uintptr_t regionSize = _regionManager->getRegionSize();
-		
-		/* count the number of survivor regions allocated specifically to support Eden survivors */
-		uintptr_t edenSurvivorCount = copyForwardStats->_edenSurvivorRegionCount;
+		uintptr_t edenEvacuateBytes = edenCountBeforeCollect * regionSize;
+		/* _copyDiscardBytesEden is excluded from edenSurvivorBytes because it is related with
+		 * a proportion of non-Eden age-0 survivor objects, making it unsuitable for
+		 * estimating Eden survivor bytes.
+		 */
+		/* TODO: _scanBytesEden could underreport the survived objects, since it will not include leaf objects that happen not to be evacuated.
+		 * have some extra stats for that case (leafMarked/leafMarked bytes in source compact group) and add to this.
+		 */
+		uintptr_t edenSurvivorBytes = copyForwardStats->_copyBytesEden;
+		/* nonEdenSurvivorCount non age0 fresh survivor region count (excludes any survivor regions for age0 non-Eden evacuate regions) */
+		/* TODO: replace nonEdenSurvivorCount with nonEdenSurvivorBytes */
 		uintptr_t nonEdenSurvivorCount = copyForwardStats->_nonEdenSurvivorRegionCount;
 		
 		/* estimate how many more regions we would have needed to avoid abort */
 		Assert_MM_true( (0 == copyForwardStats->_scanBytesEden) || copyForwardStats->_aborted || (0 != copyForwardStats->_nonEvacuateRegionCount));
 		Assert_MM_true( (0 == copyForwardStats->_scanBytesNonEden) || copyForwardStats->_aborted || (0 != copyForwardStats->_nonEvacuateRegionCount));
-		edenSurvivorCount += (copyForwardStats->_scanBytesEden + regionSize - 1) / regionSize;
+		edenSurvivorBytes += copyForwardStats->_scanBytesEden;
+		if (edenSurvivorBytes > edenEvacuateBytes) {
+			/* TODO: potential double counting _copyBytesEden due to SCAN_REASON_OVERFLOWED_REGION */
+			Assert_MM_true(copyForwardStats->_aborted);
+			/* when abort is in progress, every Eden object scanned in abort-recovery contributes to _scannedBytes.
+			 * But an object that was partially copied before abort (the copy succeeded,
+			 * the forwarding pointer was installed) is also counted again during the abort scan of the source region.
+			 * So _scanBytesEden might be double-counted, then cause edenSurvivorBytes is bigger than edenEvacuateBytes.
+			 * for the case, set edenSurvivorBytes = edenEvacuateBytes.
+			 */
+			edenSurvivorBytes = edenEvacuateBytes;
+		}
 		nonEdenSurvivorCount += (copyForwardStats->_scanBytesNonEden + regionSize - 1) / regionSize;
 
-		/* Eden count could be 0 in special case, after compaction if there is still no free region for scheduling eden(eden count = 0),
+		/* edenEvacuateBytes could be 0 in special case, after compaction if there is still no free region for scheduling eden(eden count = 0),
 		   will skip update Survival Rate */
-		if (0 != edenCountBeforeCollect) {
-			double thisSurvivalRate = (double)edenSurvivorCount / (double)edenCountBeforeCollect;
+		if (0 != edenEvacuateBytes) {
+			/* SurvivalRate should never be over 1.0 */
+			double thisSurvivalRate = (double)edenSurvivorBytes / (double)edenEvacuateBytes;
+			Assert_MM_true(1.0 >= thisSurvivalRate);
 			updateSurvivalRatesAfterCopyForward(thisSurvivalRate, nonEdenSurvivorCount);
 		}
 


### PR DESCRIPTION
The edenSurvivalRate represents the fraction of Eden regions that
survived a PGC (nominally in the range [0.0, 1.0]).  An overflow
(rate > 1.0) can cause incorrect heap/Eden size adjustments, producing
unexpected allocation spikes and, in extreme cases, out-of-memory
errors.  The issue is not a regression but was exposed by a recent
Eden-resize change.

Four overflow sources are addressed:

1. Incorrect edenCountBeforeCollect (denominator)
   During a PGC the heap may expand, triggering an Eden size
   recalculation.  The newly calculated Eden size can differ
   significantly from the size at collection start, making the survival
   rate inaccurate.  Fix: use copyForwardStats->_edenEvacuateRegionCount
   as the denominator instead of getCurrentEdenSizeInRegions(env).

2. Semantic mismatch between edenSurvivorCount and edenEvacuateCount
   In the first few PGCs after a GMP, previous Eden survivors are
   ADDRESS_ORDERED_MARKED regions with logicalAge == 0.  They enter the
   evacuate set as non-Eden regions, but their surviving objects spill
   into age-0 survivor regions that are counted as Eden survivors.
   This can cause _edenSurvivorRegionCount > _edenEvacuateRegionCount.

3. Over-counting of Eden survivor regions (shared fresh survivors)
   Because Eden and age-0 non-Eden regions share the same compact group,
   they can fill the same fresh survivor regions, causing
   _edenSurvivorRegionCount to be over-counted.

Fix2/3:Use edenEvacuateBytes(=edenCountBeforeCollect * regionSize) and
edenSurvivorBytes(= copyForwardStats->_copyBytesEden) instead of
 edenSurvivorCount and nonEdenSurvivorCount to prevent Semantic mismatch
 and Over-counting issues.

TODO: To improve the accuracy of edenSurvivalRate, edenEvacuateBytes
should exclude the free bytes remaining in evacuated Eden regions
(region->getMemoryPool()->getFreeMemoryAndDarkMatterBytes()),
as they do not represent evacuated live data.

4. _scanBytesEden double-counting (cap)
   During abort recovery, objects that were partially copied (forwarding
   pointer already installed) are scanned again in the source region,
   double-counting their bytes in _scanBytesEden.
   this can push edenSurvivorBytes above edenEvacuateBytes.
   Fix: cap edenSurvivorBytes at edenEvacuateBytes and add an
   assertion that thisSurvivalRate <= 1.0.

Signed-off-by: lhu <linhu@ca.ibm.com>