### PR TITLE
Exclude static_assert from zOS compilation

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -6282,7 +6282,9 @@ bool TR_J9VMBase::classHasNativeMethods(TR_OpaqueClassBlock *classPointer)
 {
     // If this assert fails in the future, classHasNativeMethods() must also
     // check J9_STARTPC_JNI_NATIVE on the RAM method.
+#if !defined(J9ZOS390)
     static_assert(supportsFastJNI(), "supportsFastJNI() must return true");
+#endif
     TR::VMAccessCriticalSection vmCS(this);
     J9ROMClass *romClass = TR::Compiler->cls.romClassOf(classPointer);
     J9ROMMethod *romMethod = J9ROMCLASS_ROMMETHODS(romClass);

--- a/runtime/compiler/env/VMJ9.h
+++ b/runtime/compiler/env/VMJ9.h
@@ -550,7 +550,11 @@ public:
      */
     virtual bool classHasSynchronizedMethods(TR_OpaqueClassBlock *classPointer);
 
+#if defined(J9ZOS390)
+    static bool supportsFastJNI()
+#else
     static constexpr bool supportsFastJNI()
+#endif
     {
 #if defined(TR_TARGET_S390) || defined(TR_TARGET_X86) || defined(TR_TARGET_POWER) || defined(TR_TARGET_ARM64)
         return true;


### PR DESCRIPTION
The `static_assert` on `supportsFastJNI()` does not compile on zOS because `constexpr` is not supported on non-literal classes there.

Fixes the zOS compilation failure introduced by #24223.