### PR TITLE
Use value-based hashing and equality for JVMTI object tags

### DIFF
--- a/runtime/jvmti/jvmtiHelpers.cpp
+++ b/runtime/jvmti/jvmtiHelpers.cpp
@@ -23,6 +23,9 @@
 #include "jvmtiHelpers.h"
 #include "jvmti_internal.h"
 #include "j9cp.h"
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+#include "ObjectHash.hpp"
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 
 #if JAVA_SPEC_VERSION >= 19
 #include "HeapIteratorAPI.h"
@@ -322,7 +325,11 @@ allocateEnvironment(J9InvocationJavaVM * invocationJavaVM, jint version, void **
 			if (j9env->threadDataPool == NULL) {
 				goto fail;
 			}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			j9env->objectTagTable = hashTableNew(OMRPORT_FROM_J9PORT(vm->portLibrary), J9_GET_CALLSITE(), 0, sizeof(J9JVMTIObjectTag), sizeof(jlong), 0, J9MEM_CATEGORY_JVMTI, hashObjectTag, hashEqualObjectTag, NULL, vm);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			j9env->objectTagTable = hashTableNew(OMRPORT_FROM_J9PORT(vm->portLibrary), J9_GET_CALLSITE(), 0, sizeof(J9JVMTIObjectTag), sizeof(jlong), 0, J9MEM_CATEGORY_JVMTI, hashObjectTag, hashEqualObjectTag, NULL, NULL);
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			if (j9env->objectTagTable == NULL) {
 				goto fail;
 			}
@@ -933,14 +940,58 @@ getCurrentClass(J9Class * clazz)
 static UDATA
 hashObjectTag(void *entry, void *userData)
 {
-	return ((UDATA) ((J9JVMTIObjectTag *) entry)->ref) / sizeof(UDATA);
+	j9object_t ref = ((J9JVMTIObjectTag *)entry)->ref;
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	/* Skip VT logic for dead entries (bit 0 of ref marks a dead entry). */
+	if ((NULL != ref) && J9JVMTI_OBJECT_TAG_REF_LIVE_ENTRY(ref)) {
+		J9JavaVM *vm = (J9JavaVM *)userData;
+		J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
+
+		if (NULL != currentThread) {
+			J9Class *clazz = J9OBJECT_CLAZZ(currentThread, ref);
+
+			if ((NULL != clazz) && J9_IS_J9CLASS_VALUETYPE(clazz)) {
+				bool oomOccurred = false;
+				I_32 hashCode = VM_ObjectHash::inlineObjectHashCode(vm, ref, &oomOccurred);
+				/* Return 0 on OOM */
+				return oomOccurred ? 0 : (UDATA)(U_32)hashCode;
+			}
+		}
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
+	return ((UDATA)ref) / sizeof(UDATA);
 }
 
 
 static UDATA
 hashEqualObjectTag(void *lhsEntry, void *rhsEntry, void *userData)
 {
-	return (((J9JVMTIObjectTag *) lhsEntry)->ref == ((J9JVMTIObjectTag *) rhsEntry)->ref);
+	j9object_t lhsRef = ((J9JVMTIObjectTag *)lhsEntry)->ref;
+	j9object_t rhsRef = ((J9JVMTIObjectTag *)rhsEntry)->ref;
+
+	if (lhsRef == rhsRef) {
+		return 1;
+	}
+
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	/* Skip VT logic for dead entries (bit 0 of ref marks a dead entry). */
+	if ((NULL != lhsRef)
+		&& (NULL != rhsRef)
+		&& J9JVMTI_OBJECT_TAG_REF_LIVE_ENTRY(lhsRef)
+		&& J9JVMTI_OBJECT_TAG_REF_LIVE_ENTRY(rhsRef)
+	) {
+		J9JavaVM *vm = (J9JavaVM *)userData;
+		J9VMThread *currentThread = vm->internalVMFunctions->currentVMThread(vm);
+
+		if (NULL != currentThread) {
+			return vm->internalVMFunctions->valueTypeCapableAcmp(currentThread, lhsRef, rhsRef);
+		}
+	}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
+	return 0;
 }
 
 

--- a/runtime/jvmti/jvmtiHook.c
+++ b/runtime/jvmti/jvmtiHook.c
@@ -2421,7 +2421,11 @@ jvmtiHookGCEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 	taggedObject = hashTableStartDo(j9env->objectTagTable, &hashState);
 	while (taggedObject != NULL) {
 		if (taggedObject->ref == NULL) {
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			taggedObject->ref = (j9object_t)((UDATA)deletedHead | J9JVMTI_OBJECT_TAG_DEAD_ENTRY_BIT);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			taggedObject->ref = (j9object_t) deletedHead;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			deletedHead = (J9JVMTIObjectTag *) taggedObject;
 		}
 		taggedObject = hashTableNextDo(&hashState);
@@ -2458,7 +2462,11 @@ jvmtiHookGCEnd(J9HookInterface** hook, UDATA eventNum, void* eventData, void* us
 				}
 #endif /* J9VM_OPT_JAVA_OFFLOAD_SUPPORT */
 			}
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			deletedHead = J9JVMTI_OBJECT_TAG_REF_NEXT(taggedObject->ref);
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			deletedHead = (J9JVMTIObjectTag *) taggedObject->ref;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 			hashTableRemove(j9env->objectTagTable, taggedObject);
 		} while (deletedHead != NULL);
 	}

--- a/runtime/oti/jvmtiInternal.h
+++ b/runtime/oti/jvmtiInternal.h
@@ -100,6 +100,17 @@ typedef struct J9JVMTIObjectTag {
 	jlong tag;
 } J9JVMTIObjectTag;
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+/* Bit 0 of ref marks an object tag entry as part of the dead-entry chain. */
+#define J9JVMTI_OBJECT_TAG_DEAD_ENTRY_BIT ((UDATA)1)
+/* True when ref points to a live object (dead-entry bit is clear). */
+#define J9JVMTI_OBJECT_TAG_REF_LIVE_ENTRY(ref) \
+	J9_ARE_NO_BITS_SET((UDATA)(ref), J9JVMTI_OBJECT_TAG_DEAD_ENTRY_BIT)
+/* Extract the next-chain pointer from a dead-entry ref by clearing the dead-entry bit. */
+#define J9JVMTI_OBJECT_TAG_REF_NEXT(ref) \
+	((J9JVMTIObjectTag *)((UDATA)(ref) & ~J9JVMTI_OBJECT_TAG_DEAD_ENTRY_BIT))
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 #define J9JVMTI_WATCHED_FIELD_BITS_PER_FIELD 2
 #define J9JVMTI_WATCHED_FIELDS_PER_UDATA \
 	((sizeof(UDATA) * 8) / J9JVMTI_WATCHED_FIELD_BITS_PER_FIELD)


### PR DESCRIPTION
Fix related to issue:https://github.com/eclipse-openj9/openj9/issues/24134

In hashObjectTag, use convertObjectToHash to hash value types by
 their contents. In hashEqualObjectTag, use valueTypeCapableAcmp
 to compare value types by value, allowing equivalent value objects to resolve
 to the same object tag.