### PR TITLE
Implement fast and slow value object hash paths

### DIFF
--- a/runtime/jcl/common/mgmtthread.c
+++ b/runtime/jcl/common/mgmtthread.c
@@ -2083,6 +2083,7 @@ saveObjectRefs(JNIEnv *env, ThreadInfo *info)
 				info->lockedMonitors.arr_safe[i].clazz =
 					vmfns->j9jni_createLocalRef(env, J9VM_J9CLASS_TO_HEAPCLASS(J9OBJECT_CLAZZ((J9VMThread *)env, object)));
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+				Assert_JCL_mustHaveVMAccess((J9VMThread *)env);
 				hashValue = objectHashCode(vm, object, &oomOccurred);
 				if (oomOccurred) {
 					exc = J9VMCONSTANTPOOL_JAVALANGOUTOFMEMORYERROR;

--- a/runtime/jvmti/jvmtiObject.c
+++ b/runtime/jvmti/jvmtiObject.c
@@ -100,6 +100,7 @@ jvmtiGetObjectHashCode(jvmtiEnv *env,
 
 		obj = *((j9object_t *)object);
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		Assert_JVMTI_mustHaveVMAccess(currentThread);
 		hash = (jint)objectHashCode(vm, obj, &oomOccurred);
 		if (JNI_FALSE == oomOccurred) {
 			rv_hash_code = hash;

--- a/runtime/oti/ObjectHash.hpp
+++ b/runtime/oti/ObjectHash.hpp
@@ -46,32 +46,41 @@ class VM_ObjectHash
  */
 private:
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
-	struct ValueTypeHashQueueEntry {
+	struct ValueTypeHashStackEntry {
 		j9object_t objectPointer;
 		J9Class *clazz;
 		UDATA startOffset;
+
+		 /* Murmur3 hash of the current entry. */
+		U_32 hashValue;
+		/* Number of bytes hashed while processing current entry. */
+		U_32 numBytesHashed;
+
+		/* Field iterator state of the current entry. */
+		J9ROMFieldOffsetWalkState walkState;
+		/* Next field to process wthin the current entry. */
+		J9ROMFieldOffsetWalkResult *currentField;
+
+		/* Index of the parent entry, -1 for the root entry. */
+		IDATA parentIndex;
 	};
 
-	struct ValueTypeHashQueue {
+	struct ValueTypeHashStack {
 		J9JavaVM * const vm;
-		ValueTypeHashQueueEntry *entries;
-		UDATA head;
-		UDATA tail;
+		ValueTypeHashStackEntry *entries;
+		IDATA top;
 		UDATA capacity;
-		bool full;
-		ValueTypeHashQueueEntry space[128];
+		ValueTypeHashStackEntry space[128];
 
-		ValueTypeHashQueue(J9JavaVM *vm)
+		ValueTypeHashStack(J9JavaVM *vm)
 			: vm(vm)
 			, entries(space)
-			, head(0)
-			, tail(0)
+			, top(-1)
 			, capacity(sizeof(space) / sizeof(space[0]))
-			, full(false)
 		{
 		}
 
-		~ValueTypeHashQueue()
+		~ValueTypeHashStack()
 		{
 			PORT_ACCESS_FROM_JAVAVM(vm);
 			if (space != entries) {
@@ -80,67 +89,72 @@ private:
 		}
 
 		/**
-		 * Append an entry to this queue.
+		 * Push a new entry to the stack.
+		 * The stack follows a DFS traversal.
 		 *
 		 * Handles transition from internal space to heap space on overflow.
 		 *
-		 * @param objectPointer  a pointer to an object to be queued
+		 * @param objectPointer  a pointer to an object to be added to the stack
 		 * @param clazz          the class of that object
 		 * @param startOffset    the starting offset in that object
-		 * @return true if successful, false if additional space could not be allocated
+		 * @param parentIndex    index of the parent entry (-1 for root)
+		 * @return true on success, false if heap allocation failed
 		 */
 		VMINLINE bool
-		append(j9object_t objectPointer, J9Class *clazz, UDATA startOffset)
+		append(j9object_t objectPointer, J9Class *clazz, UDATA startOffset, IDATA parentIndex)
 		{
-			if (full) {
+			UDATA newTop = (UDATA)(top + 1);
+			if (newTop == capacity) {
 				PORT_ACCESS_FROM_JAVAVM(vm);
 				UDATA newCapacity = capacity * 2;
-				ValueTypeHashQueueEntry *newEntries = (ValueTypeHashQueueEntry *)j9mem_allocate_memory(newCapacity * sizeof(ValueTypeHashQueueEntry), OMRMEM_CATEGORY_VM);
+				ValueTypeHashStackEntry *newEntries = (ValueTypeHashStackEntry *)j9mem_allocate_memory(newCapacity * sizeof(ValueTypeHashStackEntry), OMRMEM_CATEGORY_VM);
 				if (NULL == newEntries) {
 					return false;
 				}
-				/* Because this queue is full, head and tail are equal. */
-				UDATA size = capacity - head;
-				memcpy(newEntries, &entries[head], size * sizeof(ValueTypeHashQueueEntry));
-				if (0 != head) {
-					memcpy(&newEntries[size], entries, head * sizeof(ValueTypeHashQueueEntry));
-				}
+				memcpy(newEntries, entries, capacity * sizeof(ValueTypeHashStackEntry));
 				if (space != entries) {
 					j9mem_free_memory(entries);
 				}
 				entries = newEntries;
-				head = 0;
-				tail = capacity;
 				capacity = newCapacity;
-				full = false;
 			}
-
-			entries[tail].objectPointer = objectPointer;
-			entries[tail].clazz = clazz;
-			entries[tail].startOffset = startOffset;
-			tail = (tail + 1) % capacity;
-			if (tail == head) {
-				full = true;
-			}
+			ValueTypeHashStackEntry *frame = &entries[newTop];
+			frame->objectPointer = objectPointer;
+			frame->clazz = clazz;
+			frame->startOffset = startOffset;
+			frame->hashValue = 0;
+			frame->numBytesHashed = 0;
+			frame->currentField = NULL;
+			frame->parentIndex = parentIndex;
+			top = (IDATA)newTop;
 			return true;
 		}
 
 		/**
-		 * Copy the entry at the head of this queue.
-		 *
-		 * @param entry a pointer to space to receive the entry
-		 * @return true if the queue was not empty
+		 * @return true if the stack is empty.
 		 */
 		VMINLINE bool
-		remove(ValueTypeHashQueueEntry *entry)
+		isEmpty(void)
 		{
-			if ((head != tail) || full) {
-				*entry = entries[head];
-				head = (head + 1) % capacity;
-				full = false;
-				return true;
-			}
-			return false;
+			return -1 == top;
+		}
+
+		/**
+		 * @return a pointer to the top entry.
+		 */
+		VMINLINE ValueTypeHashStackEntry *
+		peek(void)
+		{
+			return &entries[top];
+		}
+
+		/**
+		 * Remove the top entry.
+		 */
+		VMINLINE void
+		remove(void)
+		{
+			top -= 1;
 		}
 	};
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
@@ -281,191 +295,392 @@ private:
 
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	/**
-	 * Calculate hashcode for valuetypes by hashing all its fields iteratively.
-	 * Use inlineConvertValueToHash for reference fields.
-	 * Use a queue to iterate through the fields of a valuetype.
+	 * Initialize the hash value of the current entry.
+	 *
+	 * @param vm     a java VM
+	 * @param frame  the entry to initialize
+	 */
+	static VMINLINE void
+	initHashFrame(J9JavaVM *vm, ValueTypeHashStackEntry *frame)
+	{
+		frame->hashValue = getSalt(vm, (UDATA)frame->objectPointer, true);
+		frame->hashValue = mix(frame->hashValue, (U_32)(UDATA)frame->clazz);
+		frame->numBytesHashed = sizeof(UDATA);
+		frame->currentField = vm->internalVMFunctions->fieldOffsetsStartDo(
+				vm,
+				frame->clazz->romClass,
+				VM_VMHelpers::getSuperclass(frame->clazz),
+				&frame->walkState,
+				J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE,
+				frame->clazz->flattenedClassCache);
+	}
+
+	/**
+	 * Push an entry for value object field.
+	 * Update the parent entry's iterator to the next field.
+	 * Initialize the child entry's hash.
+	 *
+	 * @param vm            a java VM
+	 * @param currentThread the current VM thread
+	 * @param stack         the stack
+	 * @param entry         the parent entry
+	 * @param childObject   the child object to hash
+	 * @param childClazz    class of child Object
+	 * @param childStart    startOffset for the child object
+	 * @return true on success, false on OOM
+	 */
+	static VMINLINE bool
+	pushChildFrame(J9JavaVM *vm, J9VMThread *currentThread, ValueTypeHashStack *stack, ValueTypeHashStackEntry *entry, j9object_t childObject, J9Class *childClazz, UDATA childStart)
+	{
+		IDATA parentIndex = stack->top;
+		/* Advance the parent's iterator. */
+		entry->currentField = vm->internalVMFunctions->fieldOffsetsNextDo(&entry->walkState);
+		if (!stack->append(childObject, childClazz, childStart, parentIndex)) {
+			return false;
+		}
+		initHashFrame(vm, stack->peek());
+		return true;
+	}
+
+	/**
+	 * Fast-path recursive hash computation for value objects.
+	 * Used if recursive depth is less than the default value.
+	 *
+	 * @param vm                 a java VM
+	 * @param currentThread      the current VM thread
+	 * @param objectPointer      the value object being hashed
+	 * @param clazz              class of the value object
+	 * @param startOffset        offset to start reading fields from
+	 * @param depth              current recursion depth
+	 * @param[out] depthExceeded set to true if depth limit is hit
+	 * @param[out] oomOccurred   set to true if an OOM occurred
+	 * @return finalized hash, or 0 if depthExceeded or oomOccurred
+	 */
+	static I_32
+	recursiveValueObjectHash(J9JavaVM *vm, J9VMThread *currentThread, j9object_t objectPointer, J9Class *clazz, UDATA startOffset, UDATA depth, bool *depthExceeded, bool *oomOccurred)
+	{
+		if (depth >= vm->hashMaxRecDepth) {
+			*depthExceeded = true;
+			return 0;
+		}
+
+		MM_ObjectAccessBarrierAPI objectAccessBarrier(currentThread);
+		I_32 hashValue = getSalt(vm, (UDATA)objectPointer, true);
+		hashValue = mix(hashValue, (U_32)(UDATA)clazz);
+		U_32 numBytesHashed = sizeof(UDATA);
+
+		J9ROMFieldOffsetWalkState walkState;
+		J9ROMFieldOffsetWalkResult *result = vm->internalVMFunctions->fieldOffsetsStartDo(
+				vm,
+				clazz->romClass,
+				VM_VMHelpers::getSuperclass(clazz),
+				&walkState,
+				J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE,
+				clazz->flattenedClassCache);
+
+		while (NULL != result->field) {
+			UDATA fieldOffset = startOffset + result->offset;
+			U_8 sigChar = *J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(&result->field->nameAndSignature));
+
+			switch (sigChar) {
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			case 'Z': /* boolean */
+			case 'B': /* byte */ {
+				U_32 datum = (U_32)objectAccessBarrier.inlineMixedObjectReadU8(currentThread, objectPointer, fieldOffset);
+				hashValue = mix(hashValue, datum);
+				numBytesHashed += 1;
+				break;
+			}
+			case 'C': /* char */
+			case 'S': /* short */ {
+				U_32 datum = (U_32)objectAccessBarrier.inlineMixedObjectReadU16(currentThread, objectPointer, fieldOffset);
+				hashValue = mix(hashValue, datum);
+				numBytesHashed += 2;
+				break;
+			}
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+			case 'Z': /* boolean */
+			case 'B': /* byte */
+			case 'C': /* char */
+			case 'S': /* short */
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+			case 'I': /* int */
+			case 'F': /* float */ {
+				U_32 datum = objectAccessBarrier.inlineMixedObjectReadU32(currentThread, objectPointer, fieldOffset);
+				hashValue = mix(hashValue, datum);
+				numBytesHashed += 4;
+				break;
+			}
+			case 'J': /* long */
+			case 'D': /* double */ {
+				U_64 datum = objectAccessBarrier.inlineMixedObjectReadU64(currentThread, objectPointer, fieldOffset);
+				hashValue = mix(hashValue, (U_32)(datum & 0xffffffff));
+				hashValue = mix(hashValue, (U_32)(datum >> 32));
+				numBytesHashed += 8;
+				break;
+			}
+			case '[':
+			case 'L': {
+				U_32 datum = 0;
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+				if (J9ROMFIELD_IS_NULL_RESTRICTED(result->field)) {
+					if (vm->internalVMFunctions->isFlattenableFieldFlattened(clazz, result->field)) {
+						/* Null-restricted flattened field. */
+						J9Class *flatClazz = vm->internalVMFunctions->getFlattenableFieldType(clazz, result->field);
+						datum = (U_32)recursiveValueObjectHash(vm, currentThread, objectPointer, flatClazz, fieldOffset, depth + 1, depthExceeded, oomOccurred);
+					} else {
+						/* Non-flattened null-restricted value object field. */
+						j9object_t fieldObject = objectAccessBarrier.inlineMixedObjectReadObject(currentThread, objectPointer, fieldOffset);
+						if (NULL != fieldObject) {
+							J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
+							if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
+								I_32 storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, fieldClazz->backfillOffset);
+								if (0 != storedHash) {
+									datum = (U_32)storedHash;
+									goto mixHash;
+								}
+							}
+							datum = (U_32)recursiveValueObjectHash(vm, currentThread, fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread), depth + 1, depthExceeded, oomOccurred);
+						}
+					}
+				} else
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+				{
+					j9object_t fieldObject = objectAccessBarrier.inlineMixedObjectReadObject(currentThread, objectPointer, fieldOffset);
+					if (NULL != fieldObject) {
+						J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
+						if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
+							I_32 storedHash = 0;
+							if (J9CLASS_IS_ARRAY(fieldClazz)) {
+								if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+									storedHash = inlineIndexableObjectHashCodeCompressed(vm, fieldObject, fieldClazz);
+								} else {
+									storedHash = inlineIndexableObjectHashCodeFull(vm, fieldObject, fieldClazz);
+								}
+							} else {
+								UDATA hashSlotOffset = fieldClazz->backfillOffset;
+								storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
+							}
+							if (0 != storedHash) {
+								datum = (U_32)storedHash;
+								goto mixHash;
+							}
+							datum = (U_32)recursiveValueObjectHash(vm, currentThread, fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread), depth + 1, depthExceeded, oomOccurred);
+						} else if (J9_IS_J9CLASS_VALUETYPE(fieldClazz)) {
+							datum = (U_32)recursiveValueObjectHash(vm, currentThread, fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread), depth + 1, depthExceeded, oomOccurred);
+						} else {
+							datum = (U_32)inlineObjectHashCode(vm, fieldObject, oomOccurred);
+						}
+					}
+				}
+				if (*depthExceeded) {
+					return 0;
+				}
+mixHash:
+				hashValue = mix(hashValue, datum);
+				numBytesHashed += 4;
+				break;
+			}
+			default:
+				/* Invalid field signature. Should assert but we are in util. */
+				break;
+			}
+
+			result = vm->internalVMFunctions->fieldOffsetsNextDo(&walkState);
+		}
+
+		I_32 finalHash = (I_32)finalizeMurmur3Hash(hashValue, numBytesHashed);
+		if (0 == finalHash) {
+			/* Hash code for value types should not be zero. */
+			return 1;
+		}
+		return finalHash;
+	}
+
+	/**
+	 * Calculate the hash code for a value object.
+	 * Use the recursive fast path first.
+	 * If the recursion depth exceeds the default value.
+	 * switch to the iterative DFS approach.
+	 * The iterative approach uses a stack to traverse the fields.
+	 * Requires VM access.
 	 *
 	 * @param vm                a java VM
-	 * @param objectPointer     a valid valuetype object
-	 * @param clazz             class of the valuetye object
+	 * @param currentThread     the current VM thread
+	 * @param objectPointer     a valid value object
+	 * @param clazz             class of the value object
 	 * @param startOffset       offset to start reading fields from
-	 * @param[out] oomOccurred  true if an OOM occurred during hash computation
-	 * @return the calculated hash code or 0 if an OOM occurred
+	 * @param[out] oomOccurred  set to true if an OOM occurred
+	 * @return the finalized hash code, or 0 if an OOM occurred
 	 */
 	static I_32
 	convertValueObjectAtOffsetToHash(J9JavaVM *vm, J9VMThread *currentThread, j9object_t objectPointer, J9Class *clazz, UDATA startOffset, bool *oomOccurred)
 	{
+		/* Fast path: recursive approach. */
+		bool depthExceeded = false;
+		I_32 hashValue = recursiveValueObjectHash(vm, currentThread, objectPointer, clazz, startOffset, 0, &depthExceeded, oomOccurred);
+		if (false == depthExceeded) {
+			return hashValue;
+		}
+
+		/* Slow path: iterative DFS traversal of the stack. */
 		MM_ObjectAccessBarrierAPI objectAccessBarrier(currentThread);
-		I_32 hashValue = getSalt(vm, (UDATA)objectPointer, true);
-		U_32 numBytesHashed = 0;
-		ValueTypeHashQueue queue(vm);
-		ValueTypeHashQueueEntry entry = {objectPointer, clazz, startOffset};
-		bool oom = false;
+		ValueTypeHashStack stack(vm);
 
-		hashValue = mix(hashValue, (U_32)(UDATA)clazz);
-		numBytesHashed = sizeof(UDATA);
+		if (!stack.append(objectPointer, clazz, startOffset, -1)) {
+			*oomOccurred = true;
+			return 0;
+		}
+		initHashFrame(vm, stack.peek());
 
-		while (true) {
-			J9ROMFieldOffsetWalkState state;
-			J9ROMFieldOffsetWalkResult *result = vm->internalVMFunctions->fieldOffsetsStartDo(
-					vm, entry.clazz->romClass, VM_VMHelpers::getSuperclass(entry.clazz), &state,
-					J9VM_FIELD_OFFSET_WALK_INCLUDE_INSTANCE, entry.clazz->flattenedClassCache);
-			while (NULL != result->field) {
-				UDATA fieldOffset = entry.startOffset + result->offset;
-				J9UTF8 *signature = J9ROMNAMEANDSIGNATURE_SIGNATURE(&result->field->nameAndSignature);
-				U_8 *sigChar = J9UTF8_DATA(signature);
-				switch (*sigChar) {
-#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
-				case 'Z': /* boolean */
-				case 'B': /* byte */ {
-					U_32 datum = (U_32)objectAccessBarrier.inlineMixedObjectReadU8(currentThread, entry.objectPointer, fieldOffset);
-					hashValue = mix(hashValue, datum);
-					numBytesHashed += 1;
-					break;
-				}
-				case 'C': /* char */
-				case 'S': /* short */ {
-					U_32 datum = (U_32)objectAccessBarrier.inlineMixedObjectReadU16(currentThread, entry.objectPointer, fieldOffset);
-					hashValue = mix(hashValue, datum);
-					numBytesHashed += 2;
-					break;
-				}
-#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
-				case 'Z': /* boolean */
-				case 'B': /* byte */
-				case 'C': /* char */
-				case 'S': /* short */
-#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
-				case 'I': /* int */
-				case 'F': /* float */ {
-					U_32 datum = objectAccessBarrier.inlineMixedObjectReadU32(currentThread, entry.objectPointer, fieldOffset);
-					hashValue = mix(hashValue, datum);
-					numBytesHashed += 4;
-					break;
-				}
+		while (!stack.isEmpty()) {
+			ValueTypeHashStackEntry *entry = stack.peek();
 
-				case 'J': /* long */
-				case 'D': /* double */ {
-					U_64 datum = objectAccessBarrier.inlineMixedObjectReadU64(currentThread, entry.objectPointer, fieldOffset);
-					hashValue = mix(hashValue, (U_32)(datum & 0xffffffff));
-					hashValue = mix(hashValue, (U_32)(datum >> 32));
-					numBytesHashed += 8;
-					break;
+			/* Once all the fields of the current entry are processed, finalize its hash and mix it into the parent entry's hash. */
+			if (NULL == entry->currentField->field) {
+				U_32 finalHash = finalizeMurmur3Hash(entry->hashValue, entry->numBytesHashed);
+				if (0 == finalHash) {
+					/* Hash code for value types should not be zero. */
+					finalHash = 1;
 				}
+				IDATA parentIdx = entry->parentIndex;
+				stack.remove();
 
-				case '[':
-				case 'L': {
-					U_32 datum = 0;
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-					if (J9ROMFIELD_IS_NULL_RESTRICTED(result->field)) {
-						if (vm->internalVMFunctions->isFlattenableFieldFlattened(entry.clazz, result->field)) {
-							/* Null-restricted flattened field. */
-							J9Class *flatClazz = vm->internalVMFunctions->getFlattenableFieldType(entry.clazz, result->field);
-							if (!queue.append(entry.objectPointer, flatClazz, fieldOffset)) {
-								hashValue = 0;
-								oom = true;
-								goto done;
-							}
-						} else {
-							/* Null-restricted non-flattened field. */
-							j9object_t fieldObject = objectAccessBarrier.inlineMixedObjectReadObject(currentThread, entry.objectPointer, fieldOffset);
-							if (NULL != fieldObject) {
-								J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
-								UDATA flags = J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject);
-								bool addToQueue = true;
-								if (J9_ARE_ANY_BITS_SET(flags, OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
-									UDATA hashSlotOffset = fieldClazz->backfillOffset;
-									I_32 storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
-									if (0 != storedHash) {
-										datum = (U_32)storedHash;
-										hashValue = mix(hashValue, datum);
-										numBytesHashed += 4;
-										addToQueue = false;
-									}
-								}
-								if (addToQueue) {
-									if (!queue.append(fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread))) {
-										hashValue = 0;
-										oom = true;
-										goto done;
-									}
-								}
-							}
-						}
-					} else
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-					{
-						j9object_t fieldObject = objectAccessBarrier.inlineMixedObjectReadObject(currentThread, entry.objectPointer, fieldOffset);
-						if (NULL != fieldObject) {
-							J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
-							UDATA flags = J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject);
-							if (J9_ARE_ANY_BITS_SET(flags, OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
-								bool addToQueue = true;
-								I_32 storedHash = 0;
-								if (J9CLASS_IS_ARRAY(fieldClazz)) {
-									if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
-										storedHash = inlineIndexableObjectHashCodeCompressed(vm, fieldObject, fieldClazz);
-									} else {
-										storedHash = inlineIndexableObjectHashCodeFull(vm, fieldObject, fieldClazz);
-									}
-								} else {
-									UDATA hashSlotOffset = fieldClazz->backfillOffset;
-									storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
-								}
-								if (0 != storedHash) {
-									datum = (U_32)storedHash;
-									hashValue = mix(hashValue, datum);
-									numBytesHashed += 4;
-									addToQueue = false;
-								}
-								if (addToQueue) {
-									if (!queue.append(fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread))) {
-										hashValue = 0;
-										oom = true;
-										goto done;
-									}
-								}
-							} else if (J9_IS_J9CLASS_VALUETYPE(fieldClazz)) {
-								if (!queue.append(fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread))) {
-									hashValue = 0;
-									oom = true;
-									goto done;
-								}
-							} else {
-								datum = (U_32)inlineObjectHashCode(vm, fieldObject, oomOccurred);
-								if (*oomOccurred) {
-									hashValue = 0;
-									oom = true;
-									goto done;
-								}
-								hashValue = mix(hashValue, datum);
-								numBytesHashed += 4;
-							}
-						}
-					}
-					break;
+				if (-1 == parentIdx) {
+					/* Final hash value. */
+					return (I_32)finalHash;
 				}
-				default:
-					/* Invalid field signature. Should assert but we are in util. */
-					break;
-				}
-				result = vm->internalVMFunctions->fieldOffsetsNextDo(&state);
+				ValueTypeHashStackEntry *parent = &stack.entries[parentIdx];
+				parent->hashValue = mix(parent->hashValue, finalHash);
+				parent->numBytesHashed += 4;
+				continue;
 			}
-			if (!queue.remove(&entry)) {
+
+			J9ROMFieldOffsetWalkResult *result = entry->currentField;
+			UDATA fieldOffset = entry->startOffset + result->offset;
+			U_8 sigChar = *J9UTF8_DATA(J9ROMNAMEANDSIGNATURE_SIGNATURE(&result->field->nameAndSignature));
+
+			switch (sigChar) {
+#if defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS)
+			case 'Z': /* boolean */
+			case 'B': /* byte */ {
+				U_32 datum = (U_32)objectAccessBarrier.inlineMixedObjectReadU8(currentThread, entry->objectPointer, fieldOffset);
+				entry->hashValue = mix(entry->hashValue, datum);
+				entry->numBytesHashed += 1;
 				break;
 			}
+			case 'C': /* char */
+			case 'S': /* short */ {
+				U_32 datum = (U_32)objectAccessBarrier.inlineMixedObjectReadU16(currentThread, entry->objectPointer, fieldOffset);
+				entry->hashValue = mix(entry->hashValue, datum);
+				entry->numBytesHashed += 2;
+				break;
+			}
+#else /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+			case 'Z': /* boolean */
+			case 'B': /* byte */
+			case 'C': /* char */
+			case 'S': /* short */
+#endif /* defined(J9VM_OPT_VALHALLA_COMPACT_LAYOUTS) */
+			case 'I': /* int */
+			case 'F': /* float */ {
+				U_32 datum = objectAccessBarrier.inlineMixedObjectReadU32(currentThread, entry->objectPointer, fieldOffset);
+				entry->hashValue = mix(entry->hashValue, datum);
+				entry->numBytesHashed += 4;
+				break;
+			}
+			case 'J': /* long */
+			case 'D': /* double */ {
+				U_64 datum = objectAccessBarrier.inlineMixedObjectReadU64(currentThread, entry->objectPointer, fieldOffset);
+				entry->hashValue = mix(entry->hashValue, (U_32)(datum & 0xffffffff));
+				entry->hashValue = mix(entry->hashValue, (U_32)(datum >> 32));
+				entry->numBytesHashed += 8;
+				break;
+			}
+			case '[':
+			case 'L': {
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+				if (J9ROMFIELD_IS_NULL_RESTRICTED(result->field)) {
+					if (vm->internalVMFunctions->isFlattenableFieldFlattened(entry->clazz, result->field)) {
+						/* Null-restricted non-flattened field. */
+						J9Class *flatClazz = vm->internalVMFunctions->getFlattenableFieldType(entry->clazz, result->field);
+						if (!pushChildFrame(vm, currentThread, &stack, entry, entry->objectPointer, flatClazz, fieldOffset)) {
+							goto oom;
+						}
+						continue;
+					}
+					/* Non-flattened null-restricted value object field. */
+					j9object_t fieldObject = objectAccessBarrier.inlineMixedObjectReadObject(currentThread, entry->objectPointer, fieldOffset);
+					if (NULL != fieldObject) {
+						J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
+						if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
+							I_32 storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, fieldClazz->backfillOffset);
+							if (0 != storedHash) {
+								entry->hashValue = mix(entry->hashValue, (U_32)storedHash);
+								entry->numBytesHashed += 4;
+								break;
+							}
+						}
+						if (!pushChildFrame(vm, currentThread, &stack, entry, fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread))) {
+							goto oom;
+						}
+						continue;
+					}
+				} else
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+				{
+					j9object_t fieldObject = objectAccessBarrier.inlineMixedObjectReadObject(currentThread, entry->objectPointer, fieldOffset);
+					if (NULL != fieldObject) {
+						J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
+						if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
+							I_32 storedHash = 0;
+							if (J9CLASS_IS_ARRAY(fieldClazz)) {
+								if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+									storedHash = inlineIndexableObjectHashCodeCompressed(vm, fieldObject, fieldClazz);
+								} else {
+									storedHash = inlineIndexableObjectHashCodeFull(vm, fieldObject, fieldClazz);
+								}
+							} else {
+								UDATA hashSlotOffset = fieldClazz->backfillOffset;
+								storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
+							}
+							if (0 != storedHash) {
+								entry->hashValue = mix(entry->hashValue, (U_32)storedHash);
+								entry->numBytesHashed += 4;
+								break;
+							}
+							if (!pushChildFrame(vm, currentThread, &stack, entry, fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread))) {
+								goto oom;
+							}
+							continue;
+						} else if (J9_IS_J9CLASS_VALUETYPE(fieldClazz)) {
+							if (!pushChildFrame(vm, currentThread, &stack, entry, fieldObject, fieldClazz, J9VMTHREAD_OBJECT_HEADER_SIZE(currentThread))) {
+								goto oom;
+							}
+							continue;
+						} else {
+							U_32 datum = (U_32)inlineObjectHashCode(vm, fieldObject, oomOccurred);
+							if (*oomOccurred) {
+								goto oom;
+							}
+							entry->hashValue = mix(entry->hashValue, datum);
+							entry->numBytesHashed += 4;
+						}
+					}
+				}
+				break;
+			}
+			default:
+				/* Invalid field signature. Should assert but we are in util. */
+				break;
+			}
+
+			entry->currentField = vm->internalVMFunctions->fieldOffsetsNextDo(&entry->walkState);
 		}
 
-		hashValue = finalizeMurmur3Hash(hashValue, numBytesHashed);
-		/* Hash code for value types should not be zero. */
-		if (0 == hashValue) {
-			hashValue = 1;
-		}
-done:
-		if (oom) {
-			*oomOccurred = oom;
-		}
-		return hashValue;
+oom:
+		*oomOccurred = true;
+		return 0;
 	}
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 protected:
@@ -474,6 +689,7 @@ public:
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 	/**
 	 * Convert object to hash, handling both regular objects and ValueTypes.
+	 * Requires VM access.
 	 *
 	 * @param vm               a java VM
 	 * @param currentThread    the current VM Thread
@@ -551,8 +767,17 @@ public:
 	static VMINLINE I_32
 	inlineIndexableContiguousObjectHashCode(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass, UDATA offset)
 	{
-		J9ROMArrayClass *romClass = (J9ROMArrayClass *)objectClass->romClass;
-		offset = ROUND_UP_TO_POWEROF2((offset << (romClass->arrayShape & 0x0000FFFF)) + vm->contiguousIndexableHeaderSize, sizeof(I_32));
+		uintptr_t dataSize = 0;
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+		if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
+			dataSize = offset * J9ARRAYCLASS_GET_STRIDE(objectClass);
+		} else
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+		{
+			J9ROMArrayClass *romClass = (J9ROMArrayClass *)objectClass->romClass;
+			dataSize = offset << (romClass->arrayShape & 0x0000FFFF);
+		}
+		offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
 		return *(I_32 *)((UDATA)objectPointer + offset);
 	}
 
@@ -616,7 +841,8 @@ public:
 
 	/**
 	 * Fetch the objectPointer's hashcode.
-	 *
+	 * Requires VM access for the hash computation
+	 * of value objects.
 	 * @pre objectPointer must be a valid object reference
 	 *
 	 * @param vm               a java VM

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6729,6 +6729,9 @@ typedef struct J9JavaVM {
 #endif /* defined(WIN32) */
 #endif /* defined(J9VM_INTERP_ATOMIC_FREE_JNI_USES_FLUSH) */
 	omrthread_monitor_t constantDynamicMutex;
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	UDATA hashMaxRecDepth;
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 	UDATA valueFlatteningThreshold;
 	omrthread_monitor_t valueTypeVerificationMutex;

--- a/runtime/oti/jvminit.h
+++ b/runtime/oti/jvminit.h
@@ -387,6 +387,7 @@ enum INIT_STAGE {
 #define VMOPT_ROMMETHODSORTTHRESHOLD_EQUALS "-XX:ROMMethodSortThreshold="
 #define VMOPT_ENABLEFLATTENING "-XX:+EnableFlattening"
 #define VMOPT_DISABLEFLATTENING "-XX:-EnableFlattening"
+#define VMOPT_HASHMAXRECDEPTH_EQUALS "-XX:hashMaxRecDepth="
 #define VMOPT_VALUEFLATTENINGTHRESHOLD_EQUALS "-XX:ValueTypeFlatteningThreshold="
 #define VMOPT_VTARRAYFLATTENING_EQUALS "-XX:+EnableArrayFlattening"
 #define VMOPT_VTDISABLEARRAYFLATTENING_EQUALS "-XX:-EnableArrayFlattening"

--- a/runtime/util/ObjectHash.cpp
+++ b/runtime/util/ObjectHash.cpp
@@ -21,6 +21,7 @@
  *******************************************************************************/
 
 #include "util_api.h"
+#include "ut_j9vmutil.h"
 #include "ObjectHash.hpp"
 
 extern "C" {
@@ -61,6 +62,7 @@ objectHashCode(J9JavaVM *vm, j9object_t objectPointer
 I_32
 convertObjectToHash(J9JavaVM *vm, J9VMThread *currentThread, j9object_t objectPointer, J9Class *clazz)
 {
+	Assert_VMUtil_mustHaveVMAccess(currentThread);
 	bool oomOccurred = false;
 	I_32 result = VM_ObjectHash::inlineConvertObjectToHash(vm, currentThread, objectPointer, &oomOccurred);
 	/* Return 0 if OOM occurs, skipping OOM handling from GC code. */

--- a/runtime/util/vmutil.tdf
+++ b/runtime/util/vmutil.tdf
@@ -61,3 +61,4 @@ TraceEvent=Trc_Util_annhelp_SearchForFieldAnnotation Obsolete Noenv Overhead=1 L
 TraceEvent=Trc_Util_annhelp_SearchForFieldAnnotation Overhead=1 Level=5 Template="Search for field annotation: annotation=%.*s cpIndex=%zu clazz=%p romFieldShape=%p result=%zu"
 TraceEvent=Trc_Util_annhelp_skipAnnotationElementError Overhead=1 Level=5 Template="Error when skipping annotation: annotation=%.*s targetAnnotation=%.*s index=%p constantPool=%p"
 TraceEvent=Trc_Util_annhelp_SearchForMethodAnnotation Overhead=1 Level=5 Template="Search for method annotation: annotation=%.*s romMethod=%p result=%zu"
+TraceAssert=Assert_VMUtil_mustHaveVMAccess noEnv Overhead=1 Level=1 Assert="(P1)->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS"

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -3380,6 +3380,7 @@ done:
 		/* Caller has null-checked obj already */
 		_pc += 3;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		Assert_VM_mustHaveVMAccess(_currentThread);
 		bool oomOccurred = false;
 		I_32 hashValue = VM_ObjectHash::inlineObjectHashCode(_vm, obj, &oomOccurred);
 		if (oomOccurred) {

--- a/runtime/vm/FastJNI_java_lang_J9VMInternals.cpp
+++ b/runtime/vm/FastJNI_java_lang_J9VMInternals.cpp
@@ -25,6 +25,7 @@
 #include "j9protos.h"
 #include "j9consts.h"
 #include "objhelp.h"
+#include "ut_j9vm.h"
 #include "vm_internal.h"
 #include "ObjectHash.hpp"
 #include "VMHelpers.hpp"
@@ -51,6 +52,7 @@ jint JNICALL
 Fast_java_lang_J9VMInternals_identityHashCode(J9VMThread *currentThread, j9object_t objectPointer)
 {
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+	Assert_VM_mustHaveVMAccess(currentThread);
 	bool oomOccurred = false;
 	I_32 hashValue = VM_ObjectHash::inlineObjectHashCode(currentThread->javaVM, objectPointer, &oomOccurred);
 	if (oomOccurred) {

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -890,6 +890,7 @@ setClassLoadingConstraintError(J9VMThread * currentThread, J9ClassLoader * initi
 		U_8 * existingClassName = J9UTF8_DATA(existingClassNameUTF);
 		UDATA msgLen = 0;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		Assert_VM_mustHaveVMAccess(currentThread);
 		jboolean oomOccurred = JNI_FALSE;
 		I_32 hashValue = 0;
 		hashValue = objectHashCode(currentThread->javaVM, initiatingLoaderObject, &oomOccurred);
@@ -964,6 +965,7 @@ setClassLoadingConstraintSignatureError(J9VMThread *currentThread, J9ClassLoader
 
 		UDATA msgLen = 0;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		Assert_VM_mustHaveVMAccess(currentThread);
 		jboolean oomOccurred = JNI_FALSE;
 		I_32 hashValue = 0;
 		hashValue = objectHashCode(currentThread->javaVM, loader1Object, &oomOccurred);
@@ -1048,6 +1050,7 @@ setClassLoadingConstraintOverrideError(J9VMThread *currentThread, J9UTF8 *newCla
 
 		UDATA msgLen = 0;
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+		Assert_VM_mustHaveVMAccess(currentThread);
 		jboolean oomOccurred = JNI_FALSE;
 		I_32 hashValue = 0;
 		hashValue = objectHashCode(currentThread->javaVM, loader1Object, &oomOccurred);

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -2968,6 +2968,16 @@ VMInitStages(J9JavaVM *vm, IDATA stage, void* reserved)
 				}
 			}
 
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			vm->hashMaxRecDepth = 16;
+			if ((argIndex = FIND_AND_CONSUME_VMARG(STARTSWITH_MATCH, VMOPT_HASHMAXRECDEPTH_EQUALS, NULL)) >= 0) {
+				UDATA depth = 0;
+				char *optname = VMOPT_HASHMAXRECDEPTH_EQUALS;
+				GET_INTEGER_VALUE(argIndex, optname, depth);
+				vm->hashMaxRecDepth = depth;
+			}
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+
 #if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
 			{
 				IDATA enableFlattening  = FIND_AND_CONSUME_VMARG(EXACT_MATCH, VMOPT_ENABLEFLATTENING, NULL);

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -406,4 +406,43 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>ValueTypeHashCodeTests</testCaseName>
+		<variations>
+			<variation>-Xgcpolicy:optthruput -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=0</variation>
+			<variation>-Xgcpolicy:optthruput -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=9999</variation>
+			<variation>-Xgcpolicy:optthruput -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=2</variation>
+			<variation>-Xgcpolicy:optthruput -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=0</variation>
+			<variation>-Xgcpolicy:optthruput -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=9999</variation>
+			<variation>-Xgcpolicy:optthruput -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=2</variation>
+			<variation>-Xgcpolicy:gencon -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=0</variation>
+			<variation>-Xgcpolicy:gencon -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=9999</variation>
+			<variation>-Xgcpolicy:gencon -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=2</variation>
+			<variation>-Xgcpolicy:gencon -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=0</variation>
+			<variation>-Xgcpolicy:gencon -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=9999</variation>
+			<variation>-Xgcpolicy:gencon -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=2</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
+		--enable-preview \
+		--add-opens java.base/jdk.internal.misc=ALL-UNNAMED \
+		--add-exports java.base/jdk.internal.value=ALL-UNNAMED \
+		-cp $(Q)$(LIB_DIR)$(D)asm.jar$(P)$(RESOURCES_DIR)$(P)$(TESTNG)$(P)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		org.testng.TestNG -d $(REPORTDIR) $(Q)$(TEST_RESROOT)$(D)testng.xml$(Q) -testnames ValueTypeHashCodeTests \
+		-groups $(TEST_GROUP) \
+		-excludegroups $(DEFAULT_EXCLUDE); \
+			$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTestClasses.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTestClasses.java
@@ -254,4 +254,27 @@ public class ValueTypeTestClasses {
 			this.vy = vy;
 		}
 	}
+
+	static value class ValueTypePoint3D {
+		@NullRestricted
+		final ValueTypePoint2D point;
+		@NullRestricted
+		final ValueTypeInt z;
+		ValueTypePoint3D(ValueTypePoint2D point, ValueTypeInt z) {
+			this.point = point;
+			this.z = z;
+		}
+	}
+
+	static value class ValueTypeLine3D {
+		@NullRestricted
+		final ValueTypePoint3D start;
+		@NullRestricted
+		final ValueTypePoint3D end;
+		ValueTypeLine3D(ValueTypePoint3D start, ValueTypePoint3D end) {
+			this.start = start;
+			this.end = end;
+		}
+	}
+
 }

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeTests.java
@@ -3156,6 +3156,54 @@ public class ValueTypeTests {
 		assertEquals(h2, h2_afterGC);
 	}
 
+	/* Hash code of value object with nested fields. */
+	@Test(priority=1)
+	static public void testValueTypeHashCodeWithNestedFields() throws Throwable {
+		ValueTypePoint2D p2d = new ValueTypePoint2D(new ValueTypeInt(1), new ValueTypeInt(2));
+		ValueTypePoint3D pt1 = new ValueTypePoint3D(p2d, new ValueTypeInt(3));
+		ValueTypePoint3D pt2 = new ValueTypePoint3D(p2d, new ValueTypeInt(4));
+		Object l1 = new ValueTypeLine3D(pt1, pt2);
+		Object l2 = new ValueTypeLine3D(pt1, pt2);
+		Object l3 = new ValueTypeLine3D(new ValueTypePoint3D(new ValueTypePoint2D(new ValueTypeInt(9), new ValueTypeInt(9)), new ValueTypeInt(9)),
+				pt2);
+		int h1 = l1.hashCode();
+		int h2 = l2.hashCode();
+		int h3 = l3.hashCode();
+
+		System.gc();
+
+		int h1_afterGC = l1.hashCode();
+		int h2_afterGC = l2.hashCode();
+		int h3_afterGC = l3.hashCode();
+
+		assertEquals(h1, h2);
+		assertNotEquals(h1, h3);
+		assertEquals(h1, h1_afterGC);
+		assertEquals(h2, h2_afterGC);
+		assertEquals(h3, h3_afterGC);
+	}
+
+	/* Test hash of large flattened array allocated in the sparse heap with Balanced GC. */
+	@Test(priority=1)
+	static public void testHashCodeOfFlattenedArray() throws Throwable {
+		ValueTypePoint2D defaultVal = new ValueTypePoint2D(new ValueTypeInt(1), new ValueTypeInt(2));
+		Object arr1 = ValueClass.newNullRestrictedAtomicArray(ValueTypePoint2D.class, 200000, defaultVal);
+		Object arr2 = ValueClass.newNullRestrictedAtomicArray(ValueTypePoint2D.class, 200000, defaultVal);
+
+		int h1 = arr1.hashCode();
+		int h2 = arr2.hashCode();
+
+		System.gc();
+
+		int h1_afterGC = arr1.hashCode();
+		int h2_afterGC = arr2.hashCode();
+
+		assertNotEquals(h1, h2);
+		assertEquals(h1, h1_afterGC);
+		assertEquals(h2, h2_afterGC);
+	}
+
+
 	@Test(priority = 1, expectedExceptions = ClassFormatError.class,
 		expectedExceptionsMessageRegExp = ".*A non-interface class must have at least one of ACC_FINAL, ACC_IDENTITY, or ACC_ABSTRACT flags set.*")
 	static public void testNonInterfaceClassMustHaveFinalIdentityAbstractSet() throws Throwable {

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -65,4 +65,21 @@
 			<class name="org.openj9.test.lworld.StrictFieldTests"/>
 		</classes>
 	</test>
+	<test name="ValueTypeHashCodeTests">
+		<classes>
+			<class name="org.openj9.test.lworld.ValueTypeTests">
+				<methods>
+					<include name="testValueClassHashCode"/>
+					<include name="testValueTypeHashCodeWithNullRestrictedFields"/>
+					<include name="testValueTypeHashCodeWithIdentityField"/>
+					<include name="testValueTypeHashCodeWithNullReference"/>
+					<include name="testValueTypeHashCodeWithSameIdentityField"/>
+					<include name="testHashCodeOfEmptyValueClasses"/>
+					<include name="testHashCodeOfSimilarValueClasses"/>
+					<include name="testValueTypeHashCodeWithNestedFields"/>
+					<include name="testHashCodeOfFlattenedArray"/>
+				</methods>
+			</class>
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
- Use the recursive fast path for value object hash computation.
- Use the fast path while the recursion depth is below J9_VALUE_TYPE_HASH_DEPTH_LIMIT.
- Switch to the iterative path when the recursion depth limit is exceeded.
- Use a DFS-based stack to traverse value object fields in the iterative path.
- Add -XX:hashMaxRecDepth debug option to override default recursion depth.
- Add VM access assertions to all callers of convertValueObjectAtOffsetToHash.
- Add variations to run value object hash tests for different values of hashMaxRecDepth.
- Update inlineIndexableContiguousObjectHashCode to compute the correct data size for flattened arrays and handle data allocated in the sparse heap.
- Add test to verify hash of large flattened array allocated in sparse heap with balanced GC.

Fixes: #24087