### PR TITLE
Replace uses of getName(TR::Snippet)

### DIFF
--- a/runtime/compiler/aarch64/codegen/ARM64RecompilationSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/ARM64RecompilationSnippet.cpp
@@ -57,7 +57,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64RecompilationSnippet *snippet)
 {
     uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), cursor, getName(snippet));
+    printSnippetLabel(log, snippet, cursor);
 
     int32_t distance;
     distance = *((int32_t *)cursor) & 0x03ffffff; // imm26

--- a/runtime/compiler/aarch64/codegen/CallSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/CallSnippet.cpp
@@ -409,7 +409,10 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64CallSnippet *snippet)
     TR::SymbolReference *methodSymRef = callNode->getSymbolReference();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(methodSymRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(methodSymRef));
+    log->printc(')');
 
     bufferPos = printARM64ArgumentsFlush(log, callNode, bufferPos, snippet->getSizeOfArguments());
 
@@ -632,7 +635,10 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64VirtualUnresolvedSnippet *snippe
     TR::SymbolReference *callSymRef = snippet->getNode()->getSymbolReference();
     uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), cursor, getName(snippet), getName(callSymRef));
+    printSnippetLabel(log, snippet, cursor);
+    log->prints(" (");
+    log->prints(getName(callSymRef));
+    log->printc(')');
 
     int32_t distance = getBLDistance(cursor);
     printPrefix(log, NULL, cursor, ARM64_INSTRUCTION_LENGTH);
@@ -784,7 +790,10 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64InterfaceCallSnippet *snippet)
     TR::SymbolReference *callSymRef = snippet->getNode()->getSymbolReference();
     uint8_t *cursor = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), cursor, getName(snippet), getName(callSymRef));
+    printSnippetLabel(log, snippet, cursor);
+    log->prints(" (");
+    log->prints(getName(callSymRef));
+    log->printc(')');
 
     int32_t distance = getBLDistance(cursor);
     printPrefix(log, NULL, cursor, ARM64_INSTRUCTION_LENGTH);

--- a/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
+++ b/runtime/compiler/aarch64/codegen/StackCheckFailureSnippet.cpp
@@ -123,7 +123,7 @@ void TR_Debug::print(OMR::Logger *log, TR::ARM64StackCheckFailureSnippet *snippe
     TR::SymbolReference *sofRef = _comp->getSymRefTab()->findOrCreateStackOverflowSymbolRef(bodySymbol);
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     TR::Machine *machine = _cg->machine();
     TR::RealRegister *x9 = machine->getRealRegister(TR::RealRegister::x9);

--- a/runtime/compiler/x/codegen/CallSnippet.cpp
+++ b/runtime/compiler/x/codegen/CallSnippet.cpp
@@ -414,7 +414,7 @@ void TR_Debug::print(OMR::Logger *log, TR::X86PicDataSnippet *snippet)
         uint32_t offset = bufferPos - _cg->getCodeStart();
         log->printf("\n\n" POINTER_PRINTF_FORMAT " %08x %*s", bufferPos, offset, 65, " <<< VPic Data >>>");
     } else {
-        printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+        printSnippetLabel(log, snippet, bufferPos);
     }
 
     TR::SymbolReference *methodSymRef = snippet->getMethodSymRef();
@@ -541,8 +541,9 @@ void TR_Debug::print(OMR::Logger *log, TR::X86PicDataSnippet *snippet)
             }
         }
 
-        if (_comp->target().is64Bit())
-            printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+        if (_comp->target().is64Bit()) {
+            printSnippetLabel(log, snippet, bufferPos);
+        }
 
         // Call through vtable.
         //

--- a/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
+++ b/runtime/compiler/x/codegen/CheckFailureSnippet.cpp
@@ -77,7 +77,10 @@ void TR_Debug::print(OMR::Logger *log, TR::X86CheckFailureSnippet *snippet)
     TR::MethodSymbol *sym = symRef->getSymbol()->castToMethodSymbol();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(symRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(symRef));
+    log->printc(')');
 
     if (snippet->getRequiredFPstackPop()) {
         printPrefix(log, NULL, bufferPos, 2);
@@ -191,7 +194,10 @@ void TR_Debug::print(OMR::Logger *log, TR::X86BoundCheckWithSpineCheckSnippet *s
     TR::MethodSymbol *sym = symRef->getSymbol()->castToMethodSymbol();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(symRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(symRef));
+    log->printc(')');
 
     log->printf("\t\t\t\t\t\t\t\t\t%s bound check with spine check snippet", commentString());
 }
@@ -211,7 +217,10 @@ void TR_Debug::print(OMR::Logger *log, TR::X86SpineCheckSnippet *snippet)
     TR::MethodSymbol *sym = symRef->getSymbol()->castToMethodSymbol();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(symRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(symRef));
+    log->printc(')');
 
     log->printf("\t\t\t\t\t\t\t\t\t%s spine check snippet", commentString());
 }
@@ -332,7 +341,10 @@ void TR_Debug::print(OMR::Logger *log, TR::X86CheckFailureSnippetWithResolve *sn
     TR::MethodSymbol *sym = symRef->getSymbol()->castToMethodSymbol();
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(symRef));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(symRef));
+    log->printc(')');
 
     TR::SymbolReference *methodSymRef = snippet->getNode()->getSymbolReference();
     TR::MethodSymbol *methodSymbol = methodSymRef->getSymbol()->castToMethodSymbol();

--- a/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/ForceRecompilationSnippet.cpp
@@ -81,7 +81,7 @@ uint8_t *TR::X86ForceRecompilationSnippet::emitSnippetBody()
 void TR_Debug::print(OMR::Logger *log, TR::X86ForceRecompilationSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
 
     TR::SymbolReference *helper
         = _cg->getSymRef(_comp->target().is64Bit() ? TR_AMD64induceRecompilation : TR_IA32induceRecompilation);

--- a/runtime/compiler/x/codegen/GuardedDevirtualSnippet.cpp
+++ b/runtime/compiler/x/codegen/GuardedDevirtualSnippet.cpp
@@ -128,8 +128,8 @@ uint8_t *TR::X86GuardedDevirtualSnippet::emitSnippetBody()
 void TR_Debug::print(OMR::Logger *log, TR::X86GuardedDevirtualSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet),
-        "out of line full virtual call sequence");
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (out of line full virtual call sequence)");
 
 #if defined(TR_TARGET_64BIT)
     TR::Node *callNode = snippet->getNode();

--- a/runtime/compiler/x/codegen/J9Snippet.cpp
+++ b/runtime/compiler/x/codegen/J9Snippet.cpp
@@ -20,6 +20,43 @@
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
  *******************************************************************************/
 
+#include "ras/Logger.hpp"
 #include "codegen/Snippet.hpp"
 
 TR::X86GuardedDevirtualSnippet *J9::X86::Snippet::getGuardedDevirtualSnippet() { return NULL; }
+
+void J9::X86::Snippet::printName(OMR::Logger *log)
+{
+    const char *name;
+
+    switch (getKind()) {
+        case TR::Snippet::IsCall:
+            name = "Call Snippet";
+            break;
+        case TR::Snippet::IsVPicData:
+            name = "VPic Data";
+            break;
+        case TR::Snippet::IsIPicData:
+            name = "IPic Data";
+            break;
+        case TR::Snippet::IsForceRecompilation:
+            name = "Force Recompilation Snippet";
+            break;
+        case TR::Snippet::IsRecompilation:
+            name = "Recompilation Snippet";
+            break;
+        case TR::Snippet::IsGuardedDevirtual:
+            name = "Guarded Devirtual Snippet";
+            break;
+        default:
+            name = NULL;
+            break;
+    }
+
+    if (name) {
+        log->prints(name);
+    } else {
+        // Delegate to superclass to print name
+        J9::Snippet::printName(log);
+    }
+}

--- a/runtime/compiler/x/codegen/J9Snippet.hpp
+++ b/runtime/compiler/x/codegen/J9Snippet.hpp
@@ -46,6 +46,10 @@ class LabelSymbol;
 class Node;
 } // namespace TR
 
+namespace OMR {
+class Logger;
+} // namespace OMR
+
 namespace J9 { namespace X86 {
 
 class OMR_EXTENSIBLE Snippet : public J9::Snippet {
@@ -59,6 +63,11 @@ public:
     {}
 
     virtual TR::X86GuardedDevirtualSnippet *getGuardedDevirtualSnippet();
+
+    /**
+     * @copydoc OMR::Snippet::printName(OMR::Logger *)
+     */
+    void printName(OMR::Logger *log);
 };
 
 }} // namespace J9::X86

--- a/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
+++ b/runtime/compiler/x/codegen/J9UnresolvedDataSnippet.cpp
@@ -536,7 +536,7 @@ uint32_t J9::X86::UnresolvedDataSnippet::getLength(int32_t estimatedSnippetStart
 void TR_Debug::print(OMR::Logger *log, TR::UnresolvedDataSnippet *snippet)
 {
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet));
+    printSnippetLabel(log, snippet, bufferPos);
     log->printf(" for instr [%s]", getName(snippet->getDataReferenceInstruction()));
 
     if (_comp->target().is64Bit()) {

--- a/runtime/compiler/x/codegen/RecompilationSnippet.cpp
+++ b/runtime/compiler/x/codegen/RecompilationSnippet.cpp
@@ -57,7 +57,10 @@ void TR_Debug::print(OMR::Logger *log, TR::X86RecompilationSnippet *snippet)
 
     uint8_t *bufferPos = snippet->getSnippetLabel()->getCodeLocation();
 
-    printSnippetLabel(log, snippet->getSnippetLabel(), bufferPos, getName(snippet), getName(snippet->getDestination()));
+    printSnippetLabel(log, snippet, bufferPos);
+    log->prints(" (");
+    log->prints(getName(snippet->getDestination()));
+    log->printc(')');
 
     printPrefix(log, NULL, bufferPos, 5);
     log->printf("call\t%s \t\t%s Helper Address = " POINTER_PRINTF_FORMAT, getName(snippet->getDestination()),


### PR DESCRIPTION
Use the new API that outputs to the Logger directly.

Breaking dependence on eclipse-omr/omr#8341