### PR TITLE
Revert "Revert: Restore 32-bit Coded Restrictions to CodeCache Page Sizes on P"

### DIFF
--- a/runtime/compiler/runtime/J9CodeCacheManager.cpp
+++ b/runtime/compiler/runtime/J9CodeCacheManager.cpp
@@ -271,7 +271,16 @@ TR::CodeCacheMemorySegment *J9::CodeCacheManager::allocateCodeCacheSegment(size_
     if (config.largeCodePageSize() > pageSizes[0])
         largeCodePageSize = config.largeCodePageSize();
 
-    if (largeCodePageSize > 0) {
+#if defined(TR_TARGET_POWER) && defined(TR_HOST_POWER) && !defined(TR_HOST_64BIT)
+    /* Use largeCodePageSize on PPC only if its 16M.
+     If we pass in any pagesize other than the default page size, the port library picks the shared memory api to
+     allocate which wastes memory */
+    size_t sixteenMegs = 16 * 1024 * 1024;
+    if (largeCodePageSize == sixteenMegs)
+#else
+    if (largeCodePageSize > 0)
+#endif
+    {
         vmemParams.pageSize = largeCodePageSize;
         vmemParams.pageFlags = config.largeCodePageFlags();
 


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#24253

See https://github.com/eclipse-openj9/openj9/pull/24253#issuecomment-4975481171