### PR TITLE
Disable compact layout command line tests

### DIFF
--- a/test/functional/cmdLineTests/valuetypeddrtests/exclude.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/exclude.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Copyright IBM Corp. and others 2026
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+<suite id="Value Type DDR Tests Excluded Test Case List">
+	<platform id="all"/>
+	<exclude id="Run !j9object compactLayoutAddr to verify compact layout field offsets" platform="all"><reason>Compact layouts disabled by default, https://github.com/eclipse-openj9/openj9/issues/21251</reason></exclude>
+	<exclude id="Run !flatobject compactLayoutAddr to verify all compact layout field offsets and values" platform="all"><reason>Compact layouts disabled by default, https://github.com/eclipse-openj9/openj9/issues/21251</reason></exclude>
+	<exclude id="Run !fj9object compactByteAddr to verify byte field offsets" platform="all"><reason>Compact layouts disabled by default, https://github.com/eclipse-openj9/openj9/issues/21251</reason></exclude>
+	<exclude id="Run !fj9object compactShortAddr to verify short field offsets" platform="all"><reason>Compact layouts disabled by default, https://github.com/eclipse-openj9/openj9/issues/21251</reason></exclude>
+	<exclude id="Run !fj9object compactByteShortAddr to verify mixed byte/short field offsets" platform="all"><reason>Compact layouts disabled by default, https://github.com/eclipse-openj9/openj9/issues/21251</reason></exclude>
+</suite>

--- a/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/flattenedvaluetypeddrtests.xml
@@ -197,7 +197,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !j9object $compactLayoutAddr$ to verify compact layout field offsets">
+	<test id="Run !j9object compactLayoutAddr to verify compact layout field offsets">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!j9object $compactLayoutAddr$</input>
@@ -211,7 +211,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !flatobject $compactLayoutAddr$ to verify all compact layout field offsets and values">
+	<test id="Run !flatobject compactLayoutAddr to verify all compact layout field offsets and values">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!flatobject $compactLayoutAddr$</input>

--- a/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/playlist.xml
@@ -42,7 +42,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
 			-config $(Q)$(TEST_RESROOT)$(D)flattenedvaluetypeddrtests.xml$(Q) \
-			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
+			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError \
+			-xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q); \
 			${TEST_STATUS}
 		</command>
 		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse-openj9/openj9/issues/1511 for updates -->
@@ -81,7 +82,8 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 			-DCPDL=$(Q)$(P)$(Q) \
 			-jar $(CMDLINETESTER_JAR) \
 			-config $(Q)$(TEST_RESROOT)$(D)unflattenedvaluetypeddrtests.xml$(Q) \
-			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError; \
+			-outputLimit 1000 -explainExcludes -nonZeroExitWhenError \
+			-xids all,$(PLATFORM) -xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q); \
 			${TEST_STATUS}
 		</command>
 		<!-- Tests excluded on zos because it does not support DDR yet. Please see https://github.com/eclipse-openj9/openj9/issues/1511 for updates -->

--- a/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
+++ b/test/functional/cmdLineTests/valuetypeddrtests/unflattenedvaluetypeddrtests.xml
@@ -160,7 +160,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !fj9object $compactByteAddr$ to verify byte field offsets">
+	<test id="Run !fj9object compactByteAddr to verify byte field offsets">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $compactByteAddr$</input>
@@ -173,7 +173,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !fj9object $compactShortAddr$ to verify short field offsets">
+	<test id="Run !fj9object compactShortAddr to verify short field offsets">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $compactShortAddr$</input>
@@ -186,7 +186,7 @@
 		<output regex="no" type="failure">Problem running command</output>
 	</test>
 
-	<test id="Run !fj9object $compactByteShortAddr$ to verify mixed byte/short field offsets">
+	<test id="Run !fj9object compactByteShortAddr to verify mixed byte/short field offsets">
 		<command command="$JDMPVIEW_EXE$">
 			<arg>-core $DUMPFILE$</arg>
 			<input>!fj9object $compactByteShortAddr$</input>


### PR DESCRIPTION
Compact layouts are currently disabled by default.

Fixes: https://github.com/eclipse-openj9/openj9/issues/24364
Related: https://github.com/eclipse-openj9/openj9/issues/21251

Fixes failing extended.functional tests https://hyc-runtimes-jenkins.swg-devops.com/job/Test_openjdkValhalla_j9_extended.functional_x86-64_linux_valhalla_Nightly/1871/