### PR TITLE
Update JFR ClassLoaderStatistics event

### DIFF
--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -601,6 +601,18 @@ typedef struct J9JFRPhysicalMemory {
 	U_64 usedSize;
 } J9JFRPhysicalMemory;
 
+typedef struct J9JFRClassLoaderStatistics {
+	J9JFR_EVENT_COMMON_FIELDS
+	struct J9ClassLoader *classLoader;
+	struct J9ClassLoader *parentClassLoader;
+	I_64 classCount;
+	U_64 chunkSize;
+	I_64 blockSize;
+	I_64 hiddenClassCount;
+	U_64 hiddenChunkSize;
+	U_64 hiddenBlockSize;
+} J9JFRClassLoaderStatistics;
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 /* @ddr_namespace: map_to_type=J9CfrError */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -608,6 +608,18 @@ typedef struct J9JFRJavaEventData {
 
 #define J9JFRJAVAEVENTDATA_EVENTDATA(jfrEvent) ((U_8 *)(((J9JFRJavaEventData *)(jfrEvent)) + 1))
 
+typedef struct J9JFRClassLoaderStatistics {
+	J9JFR_EVENT_COMMON_FIELDS
+	struct J9ClassLoader *classLoader;
+	struct J9ClassLoader *parentClassLoader;
+	I_64 classCount;
+	U_64 chunkSize;
+	I_64 blockSize;
+	I_64 hiddenClassCount;
+	U_64 hiddenChunkSize;
+	U_64 hiddenBlockSize;
+} J9JFRClassLoaderStatistics;
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 /* @ddr_namespace: map_to_type=J9CfrError */

--- a/runtime/vm/BufferWriter.hpp
+++ b/runtime/vm/BufferWriter.hpp
@@ -352,6 +352,7 @@ class VM_BufferWriter {
 		va_start(args, format);
 		/* Minus 1 because omrstr_vprintf accounts for null terminator if buffer is null. */
 		uintptr_t totalLength = omrstr_vprintf(NULL, 0, format, args) - 1;
+		va_end(args);
 		if (checkBounds(totalLength)) {
 			va_list args2;
 			va_start(args2, format);
@@ -359,7 +360,6 @@ class VM_BufferWriter {
 			va_end(args2);
 			_cursor += totalLength;
 		}
-		va_end(args);
 	}
 
 	static U_32

--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -1588,6 +1588,44 @@ done:
 }
 
 void
+VM_JFRConstantPoolTypes::addClassLoaderStatisticsEntry(J9JFRClassLoaderStatistics *classLoaderStatisticsData)
+{
+	ClassLoaderStatisticsEntry *entry = (ClassLoaderStatisticsEntry *)pool_newElement(_classLoaderStatisticsTable);
+
+	if (NULL == entry) {
+		_buildResult = OutOfMemory;
+		goto done;
+	}
+
+	entry->ticks = classLoaderStatisticsData->startTicks;
+	entry->classLoaderIndex = addClassLoaderEntry(classLoaderStatisticsData->classLoader);
+	if (isResultNotOKay()) {
+		goto done;
+	}
+
+	if (NULL != classLoaderStatisticsData->parentClassLoader) {
+		entry->parentClassLoaderIndex = addClassLoaderEntry(classLoaderStatisticsData->parentClassLoader);
+		if (isResultNotOKay()) {
+			goto done;
+		}
+	} else {
+		entry->parentClassLoaderIndex = 0;
+	}
+
+	entry->classLoaderData = (U_64)classLoaderStatisticsData->classLoader;
+	entry->classCount = classLoaderStatisticsData->classCount;
+	entry->chunkSize = classLoaderStatisticsData->chunkSize;
+	entry->blockSize = classLoaderStatisticsData->blockSize;
+	entry->hiddenClassCount = classLoaderStatisticsData->hiddenClassCount;
+	entry->hiddenChunkSize = classLoaderStatisticsData->hiddenChunkSize;
+	entry->hiddenBlockSize = classLoaderStatisticsData->hiddenBlockSize;
+
+	_classLoaderStatisticsCount += 1;
+done:
+	return;
+}
+
+void
 VM_JFRConstantPoolTypes::printTables()
 {
 	j9tty_printf(PORTLIB, "--------------- StringUTF8Table ---------------\n");

--- a/runtime/vm/JFRConstantPoolTypes.cpp
+++ b/runtime/vm/JFRConstantPoolTypes.cpp
@@ -1605,6 +1605,44 @@ done:
 }
 
 void
+VM_JFRConstantPoolTypes::addClassLoaderStatisticsEntry(J9JFRClassLoaderStatistics *classLoaderStatisticsData)
+{
+	ClassLoaderStatisticsEntry *entry = (ClassLoaderStatisticsEntry *)pool_newElement(_classLoaderStatisticsTable);
+
+	if (NULL == entry) {
+		_buildResult = OutOfMemory;
+		goto done;
+	}
+
+	entry->ticks = classLoaderStatisticsData->startTicks;
+	entry->classLoaderIndex = addClassLoaderEntry(classLoaderStatisticsData->classLoader);
+	if (isResultNotOKay()) {
+		goto done;
+	}
+
+	if (NULL != classLoaderStatisticsData->parentClassLoader) {
+		entry->parentClassLoaderIndex = addClassLoaderEntry(classLoaderStatisticsData->parentClassLoader);
+		if (isResultNotOKay()) {
+			goto done;
+		}
+	} else {
+		entry->parentClassLoaderIndex = 0;
+	}
+
+	entry->classLoaderData = (U_64)classLoaderStatisticsData->classLoader;
+	entry->classCount = classLoaderStatisticsData->classCount;
+	entry->chunkSize = classLoaderStatisticsData->chunkSize;
+	entry->blockSize = classLoaderStatisticsData->blockSize;
+	entry->hiddenClassCount = classLoaderStatisticsData->hiddenClassCount;
+	entry->hiddenChunkSize = classLoaderStatisticsData->hiddenChunkSize;
+	entry->hiddenBlockSize = classLoaderStatisticsData->hiddenBlockSize;
+
+	_classLoaderStatisticsCount += 1;
+done:
+	return;
+}
+
+void
 VM_JFRConstantPoolTypes::printTables()
 {
 	j9tty_printf(PORTLIB, "--------------- StringUTF8Table ---------------\n");

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -36,7 +36,6 @@
 #include "BufferWriter.hpp"
 #include "JFRUtils.hpp"
 #include "ObjectAccessBarrierAPI.hpp"
-#include "VMHelpers.hpp"
 
 #include <cstring>
 
@@ -585,7 +584,6 @@ private:
 	bool _shouldWriteNativeLibrary;
 	bool _shouldWriteModuleRequire;
 	bool _shouldWriteModuleExport;
-	bool _shouldWriteClassLoaderStatistics;
 
 	/* Processing buffers */
 	StackFrame *_currentStackFrameBuffer;
@@ -898,6 +896,8 @@ public:
 	void addThreadAllocationStatistics(J9JFRThreadAllocationStatistics *threadAlocationData);
 
 	void addThreadObjectEntry(J9JFRThreadObject *tableEntry);
+
+	void addClassLoaderStatisticsEntry(J9JFRClassLoaderStatistics *classLoaderStatisticsData);
 
 	J9Pool *getExecutionSampleTable()
 	{
@@ -1354,11 +1354,6 @@ public:
 		return _shouldWriteModuleExport;
 	}
 
-	bool shouldWriteClassLoaderStatistics()
-	{
-		return _shouldWriteClassLoaderStatistics;
-	}
-
 	/**
 	* Helper to get JFR constantEvents field.
 	*
@@ -1478,7 +1473,7 @@ public:
 				_shouldWriteModuleExport = true;
 				break;
 			case J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS:
-				_shouldWriteClassLoaderStatistics = true;
+				addClassLoaderStatisticsEntry((J9JFRClassLoaderStatistics *)event);
 				break;
 			case J9JFR_EVENT_TYPE_THREAD_DUMP:
 				addThreadDumpEntry((J9JFRThreadDump *)event);
@@ -1524,9 +1519,6 @@ public:
 			}
 			if (_shouldWriteModuleRequire || _shouldWriteModuleExport) {
 				loadModuleRequireAndModuleExportEvents();
-			}
-			if (_shouldWriteClassLoaderStatistics) {
-				loadClassLoaderStatisticsEvents(_currentThread);
 			}
 		}
 
@@ -2059,34 +2051,8 @@ done:
 				}
 			}
 			entry->classLoaderData = (U_64)classLoader;
-			if (classLoader == _vm->anonClassLoader) {
-				entry->classCount = _vm->anonClassCount;
-			} else {
-				entry->classCount = classLoader->loadedClassCount;
-			}
 
-			J9MemorySegment *segment = classLoader->classSegments;
-			while (NULL != segment) {
-				entry->chunkSize += segment->heapAlloc - segment->baseAddress;
-				segment = segment->nextSegmentInClassLoader;
-			}
-
-			entry->blockSize = (I_64)entry->chunkSize;
-
-			J9RAMClassFreeLists *sub4gBlockPtr = &classLoader->sub4gBlock;
-			J9RAMClassFreeLists *frequentlyAccessedBlockPtr = &classLoader->frequentlyAccessedBlock;
-			J9RAMClassFreeLists *inFrequentlyAccessedBlockPtr = &classLoader->inFrequentlyAccessedBlock;
-			UDATA *ramClassSub4gUDATABlockFreeListPtr = sub4gBlockPtr->ramClassUDATABlockFreeList;
-			UDATA *ramClassFreqUDATABlockFreeListPtr = frequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
-			UDATA *ramClassInFreqUDATABlockFreeListPtr = inFrequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
-
-			VM_VMHelpers::subtractUDATABlockChain(ramClassSub4gUDATABlockFreeListPtr, &entry->blockSize);
-			VM_VMHelpers::subtractUDATABlockChain(ramClassFreqUDATABlockFreeListPtr, &entry->blockSize);
-			VM_VMHelpers::subtractUDATABlockChain(ramClassInFreqUDATABlockFreeListPtr, &entry->blockSize);
-
-			VM_VMHelpers::subtractFreeListBlocks(sub4gBlockPtr, &entry->blockSize);
-			VM_VMHelpers::subtractFreeListBlocks(frequentlyAccessedBlockPtr, &entry->blockSize);
-			VM_VMHelpers::subtractFreeListBlocks(inFrequentlyAccessedBlockPtr, &entry->blockSize);
+			VM_JFRUtils::getClassloaderStats(_vm, classLoader, &(entry->classCount), &(entry->chunkSize), &(entry->blockSize));
 
 			entry->hiddenClassCount = 0;
 			entry->hiddenChunkSize = 0;
@@ -2267,7 +2233,6 @@ done:
 		, _shouldWriteNativeLibrary(false)
 		, _shouldWriteModuleRequire(false)
 		, _shouldWriteModuleExport(false)
-		, _shouldWriteClassLoaderStatistics(false)
 		, _previousStackTraceEntry(NULL)
 		, _firstStackTraceEntry(NULL)
 		, _previousThreadEntry(NULL)

--- a/runtime/vm/JFRConstantPoolTypes.hpp
+++ b/runtime/vm/JFRConstantPoolTypes.hpp
@@ -36,7 +36,6 @@
 #include "BufferWriter.hpp"
 #include "JFRUtils.hpp"
 #include "ObjectAccessBarrierAPI.hpp"
-#include "VMHelpers.hpp"
 
 #include <cstring>
 
@@ -592,7 +591,6 @@ private:
 	bool _shouldWriteNativeLibrary;
 	bool _shouldWriteModuleRequire;
 	bool _shouldWriteModuleExport;
-	bool _shouldWriteClassLoaderStatistics;
 
 	/* Processing buffers */
 	StackFrame *_currentStackFrameBuffer;
@@ -907,6 +905,8 @@ public:
 	void addThreadObjectEntry(J9JFRThreadObject *tableEntry);
 
 	void addJavaEventDataEntry(J9JFRJavaEventData *event);
+
+	void addClassLoaderStatisticsEntry(J9JFRClassLoaderStatistics *classLoaderStatisticsData);
 
 	J9Pool *getExecutionSampleTable()
 	{
@@ -1373,11 +1373,6 @@ public:
 		return _shouldWriteModuleExport;
 	}
 
-	bool shouldWriteClassLoaderStatistics()
-	{
-		return _shouldWriteClassLoaderStatistics;
-	}
-
 	/**
 	* Helper to get JFR constantEvents field.
 	*
@@ -1497,7 +1492,7 @@ public:
 				_shouldWriteModuleExport = true;
 				break;
 			case J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS:
-				_shouldWriteClassLoaderStatistics = true;
+				addClassLoaderStatisticsEntry((J9JFRClassLoaderStatistics *)event);
 				break;
 			case J9JFR_EVENT_TYPE_THREAD_DUMP:
 				addThreadDumpEntry((J9JFRThreadDump *)event);
@@ -1546,9 +1541,6 @@ public:
 			}
 			if (_shouldWriteModuleRequire || _shouldWriteModuleExport) {
 				loadModuleRequireAndModuleExportEvents();
-			}
-			if (_shouldWriteClassLoaderStatistics) {
-				loadClassLoaderStatisticsEvents(_currentThread);
 			}
 		}
 
@@ -2081,34 +2073,8 @@ done:
 				}
 			}
 			entry->classLoaderData = (U_64)classLoader;
-			if (classLoader == _vm->anonClassLoader) {
-				entry->classCount = _vm->anonClassCount;
-			} else {
-				entry->classCount = classLoader->loadedClassCount;
-			}
 
-			J9MemorySegment *segment = classLoader->classSegments;
-			while (NULL != segment) {
-				entry->chunkSize += segment->heapAlloc - segment->baseAddress;
-				segment = segment->nextSegmentInClassLoader;
-			}
-
-			entry->blockSize = (I_64)entry->chunkSize;
-
-			J9RAMClassFreeLists *sub4gBlockPtr = &classLoader->sub4gBlock;
-			J9RAMClassFreeLists *frequentlyAccessedBlockPtr = &classLoader->frequentlyAccessedBlock;
-			J9RAMClassFreeLists *inFrequentlyAccessedBlockPtr = &classLoader->inFrequentlyAccessedBlock;
-			UDATA *ramClassSub4gUDATABlockFreeListPtr = sub4gBlockPtr->ramClassUDATABlockFreeList;
-			UDATA *ramClassFreqUDATABlockFreeListPtr = frequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
-			UDATA *ramClassInFreqUDATABlockFreeListPtr = inFrequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
-
-			VM_VMHelpers::subtractUDATABlockChain(ramClassSub4gUDATABlockFreeListPtr, &entry->blockSize);
-			VM_VMHelpers::subtractUDATABlockChain(ramClassFreqUDATABlockFreeListPtr, &entry->blockSize);
-			VM_VMHelpers::subtractUDATABlockChain(ramClassInFreqUDATABlockFreeListPtr, &entry->blockSize);
-
-			VM_VMHelpers::subtractFreeListBlocks(sub4gBlockPtr, &entry->blockSize);
-			VM_VMHelpers::subtractFreeListBlocks(frequentlyAccessedBlockPtr, &entry->blockSize);
-			VM_VMHelpers::subtractFreeListBlocks(inFrequentlyAccessedBlockPtr, &entry->blockSize);
+			VM_JFRUtils::getClassloaderStats(_vm, classLoader, &(entry->classCount), &(entry->chunkSize), &(entry->blockSize));
 
 			entry->hiddenClassCount = 0;
 			entry->hiddenChunkSize = 0;
@@ -2291,7 +2257,6 @@ done:
 		, _shouldWriteNativeLibrary(false)
 		, _shouldWriteModuleRequire(false)
 		, _shouldWriteModuleExport(false)
-		, _shouldWriteClassLoaderStatistics(false)
 		, _previousStackTraceEntry(NULL)
 		, _firstStackTraceEntry(NULL)
 		, _previousThreadEntry(NULL)

--- a/runtime/vm/JFRUtils.hpp
+++ b/runtime/vm/JFRUtils.hpp
@@ -25,6 +25,7 @@
 
 #include "j9.h"
 #include "vm_api.h"
+#include "VMHelpers.hpp"
 
 #if defined(J9VM_OPT_JFR)
 
@@ -70,6 +71,44 @@ public:
 
 		return result;
 	}
+
+	static void
+	getClassloaderStats(J9JavaVM *vm, J9ClassLoader *classLoader, I_64 *classCount, U_64 *chunkSize, I_64 *blockSize)
+	{
+		*classCount = 0;
+		*chunkSize = 0;
+		*blockSize = 0;
+
+		if (classLoader == vm->anonClassLoader) {
+			*classCount = vm->anonClassCount;
+		} else {
+			*classCount = classLoader->loadedClassCount;
+		}
+
+		J9MemorySegment *segment = classLoader->classSegments;
+		while (NULL != segment) {
+			*chunkSize += segment->heapAlloc - segment->baseAddress;
+			segment = segment->nextSegmentInClassLoader;
+		}
+
+		*blockSize = (I_64)(*chunkSize);
+
+		J9RAMClassFreeLists *sub4gBlockPtr = &classLoader->sub4gBlock;
+		J9RAMClassFreeLists *frequentlyAccessedBlockPtr = &classLoader->frequentlyAccessedBlock;
+		J9RAMClassFreeLists *inFrequentlyAccessedBlockPtr = &classLoader->inFrequentlyAccessedBlock;
+		UDATA *ramClassSub4gUDATABlockFreeListPtr = sub4gBlockPtr->ramClassUDATABlockFreeList;
+		UDATA *ramClassFreqUDATABlockFreeListPtr = frequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
+		UDATA *ramClassInFreqUDATABlockFreeListPtr = inFrequentlyAccessedBlockPtr->ramClassUDATABlockFreeList;
+
+		VM_VMHelpers::subtractUDATABlockChain(ramClassSub4gUDATABlockFreeListPtr, blockSize);
+		VM_VMHelpers::subtractUDATABlockChain(ramClassFreqUDATABlockFreeListPtr, blockSize);
+		VM_VMHelpers::subtractUDATABlockChain(ramClassInFreqUDATABlockFreeListPtr, blockSize);
+
+		VM_VMHelpers::subtractFreeListBlocks(sub4gBlockPtr, blockSize);
+		VM_VMHelpers::subtractFreeListBlocks(frequentlyAccessedBlockPtr, blockSize);
+		VM_VMHelpers::subtractFreeListBlocks(inFrequentlyAccessedBlockPtr, blockSize);
+	}
+
 
 };
 

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -204,6 +204,9 @@ jfrEventSize(J9JFREvent *jfrEvent)
 	case J9JFR_EVENT_TYPE_STACKTRACE:
 		size = sizeof(J9JFREventWithStackTrace) + (((J9JFREventWithStackTrace *)jfrEvent)->stackTraceSize * sizeof(UDATA));
 		break;
+	case J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS:
+		size = sizeof(J9JFRClassLoaderStatistics);
+		break;
 	case J9JFR_EVENT_TYPE_JVM_INFORMATION:
 	case J9JFR_EVENT_TYPE_CPU_INFORMATION:
 	case J9JFR_EVENT_TYPE_VIRTUALIZATION_INFORMATION:
@@ -215,7 +218,6 @@ jfrEventSize(J9JFREvent *jfrEvent)
 	case J9JFR_EVENT_TYPE_SYSTEM_PROCESS:
 	case J9JFR_EVENT_TYPE_MODULE_REQUIRE:
 	case J9JFR_EVENT_TYPE_MODULE_EXPORT:
-	case J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS:
 	case J9JFR_EVENT_TYPE_NATIVE_LIBRARY:
 		size = sizeof(J9JFREvent);
 		break;
@@ -2362,12 +2364,82 @@ JfrPeriodicEventSet::requestClassLoadingStatistics(J9VMThread *currentThread)
 	jfrClassLoadingStatistics(currentThread);
 }
 
+struct TempJFRClassLoaderStatistics {
+	TempJFRClassLoaderStatistics *next;
+	struct J9ClassLoader *classLoader;
+	struct J9ClassLoader *parentClassLoader;
+	I_64 classCount;
+	U_64 chunkSize;
+	I_64 blockSize;
+	I_64 hiddenClassCount;
+	U_64 hiddenChunkSize;
+	U_64 hiddenBlockSize;
+};
+
 void
 JfrPeriodicEventSet::requestClassLoaderStatistics(J9VMThread *currentThread)
 {
-	J9JFREvent *jfrEvent = (J9JFREvent *)reserveBuffer(currentThread, currentThread, sizeof(J9JFREvent));
-	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, currentThread, jfrEvent, J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS);
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9ClassLoaderWalkState walkState;
+	J9ClassLoader *classLoader = vmFuncs->allClassLoadersStartDo(&walkState, vm, 0);
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+#if defined(J9VM_THR_PREEMPTIVE)
+	omrthread_monitor_enter(vm->classTableMutex);
+#endif /* defined(J9VM_THR_PREEMPTIVE) */
+
+	TempJFRClassLoaderStatistics *root = NULL;
+
+	while (NULL != classLoader) {
+		TempJFRClassLoaderStatistics *node = (TempJFRClassLoaderStatistics *)j9mem_allocate_memory(sizeof(TempJFRClassLoaderStatistics), J9MEM_CATEGORY_JFR);
+
+		node->classLoader = classLoader;
+		j9object_t parentLoaderObject = J9VMJAVALANGCLASSLOADER_PARENT(currentThread, classLoader->classLoaderObject);
+		if (NULL != parentLoaderObject) {
+			node->parentClassLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, parentLoaderObject);
+		} else {
+			node->parentClassLoader = NULL;
+		}
+
+		VM_JFRUtils::getClassloaderStats(vm, classLoader, &(node->classCount), &(node->chunkSize), &(node->blockSize));
+
+		if (NULL == root) {
+			root = node;
+		} else {
+			node->next = root;
+			root = node;
+		}
+
+		classLoader = vmFuncs->allClassLoadersNextDo(&walkState);
+	}
+
+#if defined(J9VM_THR_PREEMPTIVE)
+	omrthread_monitor_exit(vm->classTableMutex);
+#endif /* defined(J9VM_THR_PREEMPTIVE) */
+
+	vmFuncs->allClassLoadersEndDo(&walkState);
+
+	TempJFRClassLoaderStatistics *node = root;
+	while (NULL != node) {
+		J9JFRClassLoaderStatistics *jfrEvent = (J9JFRClassLoaderStatistics *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRClassLoaderStatistics));
+
+		if (NULL != jfrEvent) {
+			initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS);
+			jfrEvent->classLoader = node->classLoader;
+			jfrEvent->parentClassLoader = node->parentClassLoader;
+			jfrEvent->classCount = node->classCount;
+			jfrEvent->chunkSize = node->chunkSize;
+			jfrEvent->blockSize = node->blockSize;
+
+			jfrEvent->hiddenClassCount = 0;
+			jfrEvent->hiddenChunkSize = 0;
+			jfrEvent->hiddenBlockSize = 0;
+		}
+
+		TempJFRClassLoaderStatistics *oldNode = node;
+		node = node->next;
+		j9mem_free_memory(oldNode);
 	}
 }
 

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -215,6 +215,9 @@ jfrEventSize(J9JFREvent *jfrEvent)
 	case J9JFR_EVENT_TYPE_STACKTRACE:
 		size = sizeof(J9JFREventWithStackTrace) + (((J9JFREventWithStackTrace *)jfrEvent)->stackTraceSize * sizeof(UDATA));
 		break;
+	case J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS:
+		size = sizeof(J9JFRClassLoaderStatistics);
+		break;
 	case J9JFR_EVENT_TYPE_JVM_INFORMATION:
 	case J9JFR_EVENT_TYPE_CPU_INFORMATION:
 	case J9JFR_EVENT_TYPE_VIRTUALIZATION_INFORMATION:
@@ -226,7 +229,6 @@ jfrEventSize(J9JFREvent *jfrEvent)
 	case J9JFR_EVENT_TYPE_SYSTEM_PROCESS:
 	case J9JFR_EVENT_TYPE_MODULE_REQUIRE:
 	case J9JFR_EVENT_TYPE_MODULE_EXPORT:
-	case J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS:
 	case J9JFR_EVENT_TYPE_NATIVE_LIBRARY:
 		size = sizeof(J9JFREvent);
 		break;
@@ -2881,15 +2883,78 @@ JfrPeriodicEventSet::requestClassLoadingStatistics(J9VMThread *currentThread)
 	jfrClassLoadingStatistics(currentThread);
 }
 
+struct TempJFRClassLoaderStatistics {
+	TempJFRClassLoaderStatistics *next;
+	struct J9ClassLoader *classLoader;
+};
+
 void
 JfrPeriodicEventSet::requestClassLoaderStatistics(J9VMThread *currentThread)
 {
 	if (!isJFREventEnabled(currentThread->javaVM, JfrClassLoaderStatisticsEvent)) {
 		return;
 	}
-	J9JFREvent *jfrEvent = (J9JFREvent *)reserveBuffer(currentThread, currentThread, sizeof(J9JFREvent));
-	if (NULL != jfrEvent) {
-		initializeEventFields(currentThread, currentThread, jfrEvent, J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS);
+
+	internalReleaseVMAccess(currentThread);
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9ClassLoaderWalkState walkState;
+	J9ClassLoader *classLoader = vmFuncs->allClassLoadersStartDo(&walkState, vm, 0);
+	bool outOfMemory = false;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+
+	TempJFRClassLoaderStatistics *root = NULL;
+
+	while (NULL != classLoader) {
+		TempJFRClassLoaderStatistics *node = (TempJFRClassLoaderStatistics *)j9mem_allocate_memory(sizeof(TempJFRClassLoaderStatistics), J9MEM_CATEGORY_JFR);
+
+		if (NULL == node) {
+			outOfMemory = true;
+			break;
+		}
+
+		node->classLoader = classLoader;
+
+		node->next = root;
+		root = node;
+
+		classLoader = vmFuncs->allClassLoadersNextDo(&walkState);
+	}
+
+	vmFuncs->allClassLoadersEndDo(&walkState);
+	internalAcquireVMAccess(currentThread);
+
+	if (outOfMemory) {
+		setNativeOutOfMemoryError(currentThread, 0, 0);
+	}
+
+	TempJFRClassLoaderStatistics *node = root;
+	while (NULL != node) {
+		J9JFRClassLoaderStatistics *jfrEvent = (J9JFRClassLoaderStatistics *)reserveBuffer(currentThread, currentThread, sizeof(J9JFRClassLoaderStatistics));
+
+		if (NULL != jfrEvent) {
+			initializeEventFields(currentThread, currentThread, (J9JFREvent *)jfrEvent, J9JFR_EVENT_TYPE_CLASS_LOADER_STATISTICS);
+
+			classLoader = node->classLoader;
+			jfrEvent->classLoader = node->classLoader;
+
+			j9object_t parentLoaderObject = J9VMJAVALANGCLASSLOADER_PARENT(currentThread, classLoader->classLoaderObject);
+			if (NULL != parentLoaderObject) {
+				jfrEvent->parentClassLoader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, parentLoaderObject);
+			} else {
+				jfrEvent->parentClassLoader = NULL;
+			}
+
+			VM_JFRUtils::getClassloaderStats(vm, classLoader, &(jfrEvent->classCount), &(jfrEvent->chunkSize), &(jfrEvent->blockSize));
+
+			jfrEvent->hiddenClassCount = 0;
+			jfrEvent->hiddenChunkSize = 0;
+			jfrEvent->hiddenBlockSize = 0;
+		}
+
+		TempJFRClassLoaderStatistics *oldNode = node;
+		node = node->next;
+		j9mem_free_memory(oldNode);
 	}
 }
 


### PR DESCRIPTION
In JFR v2, respond to emit event request immediately instead of deferring to chunk generation. This allows multiple such events to be generated in one chunk.

Related: https://github.com/eclipse-openj9/openj9/issues/24194