### PR TITLE
Fix createTempsForCall's handling of not-collected references

### DIFF
--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -2484,6 +2484,13 @@ void J9::TransformUtil::createTempsForCall(TR::Optimization *opt, TR::TreeTop *c
         TR::SymbolReference *newSymbolReference
             = comp->getSymRefTab()->createTemporary(comp->getMethodSymbol(), dataType);
 
+        // An address type child is not necessarily a collected reference. The vft load
+        // child of an indirect call is one example. Storing such a value in a collected
+        // temp would have the GC treat the slot's contents as a regular object pointer,
+        // so mark the temp as not collected when the child is not a collected reference
+        if (dataType == TR::Address && child->isNotCollected())
+            newSymbolReference->getSymbol()->setNotCollected();
+
         TR::Node *storeNode = TR::Node::createStore(callNode, newSymbolReference, child);
         TR::TreeTop *storeTree = TR::TreeTop::create(comp, storeNode);
         logprintf(trace, log, "Creating store node %p for child %p\n", storeNode, child);


### PR DESCRIPTION
An address type child is not necessarily a collected reference. The vft load child of an indirect call is one example. Storing such a value in a collected temp would have the GC treat the slot's contents as a regular object pointer, resulting in stack slot validation failures. This commit fixes this problem by marking the created address-type temp as not collected when the child is not a collected reference, based on computeIsCollectedReference() analysis done through Node::isNotCollected().

This fixes the following issue seen during PR testing of #24304:

```
14:50:31  test TestSegmentCopy.testByteCopySizes(NATIVE, ARRAY): success [43ms]
14:50:31  stderr:
14:50:31  00007F50E070B100: Object neither in heap nor stack-allocated in thread AgentVMThread
14:50:31  00007F50E070B100:	O-Slot=00007F501800A7A0
14:50:31  00007F50E070B100:	O-Slot value=00007F5018213C00
14:50:31  00007F50E070B100:	PC=00007F5056F7137D
14:50:31  00007F50E070B100:	framesWalked=2
14:50:31  00007F50E070B100:	arg0EA=00007F501800A810
14:50:31  00007F50E070B100:	walkSP=00007F501800A578
14:50:31  00007F50E070B100:	literals=0000000000000000
14:50:31  00007F50E070B100:	jitInfo=00007F50AE1DA638
14:50:31  00007F50E070B100:	method=00007F50180202B8 (TestSegmentCopy.testByteCopySizes(LTestSegmentCopy$SegmentKind;LTestSegmentCopy$SegmentKind;)V) (JIT)
14:50:31  00007F50E070B100:	stack=00007F5018004398-00007F501800B420
14:50:31  18:50:27.531 0x7f503c003c00    j9mm.479    *   ** ASSERTION FAILED ** at /home/jenkins/workspace/Build_JDK25_x86-64_linux_Personal/openj9/runtime/gc_glue_java/ScavengerRootScanner.hpp:108: ((MM_StackSlotValidator(MM_StackSlotValidator::NOT_ON_HEAP, *slotPtr, stackLocation, walkState).validate(_env)))
```