### PR TITLE
Fix NullPointerException handling for null-restricted arrays in arraycopy

### DIFF
--- a/runtime/vm/ValueTypeHelpers.hpp
+++ b/runtime/vm/ValueTypeHelpers.hpp
@@ -594,6 +594,11 @@ done:
 					srcObject = VM_VMHelpers::popObjectInSpecialFrame(currentThread);
 				}
 
+				/* Null cannot be stored into a null-restricted array. */
+				if ((NULL == copyObject) && J9_IS_J9ARRAYCLASS_NULL_RESTRICTED((J9ArrayClass *)destClazz)) {
+					return -2;
+				}
+
 				if (typeChecksRequired) {
 					if (!VM_VMHelpers::objectArrayStoreAllowed(currentThread, destObject, copyObject)) {
 						return -1;

--- a/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeSystemArraycopyTests.java
+++ b/test/functional/Valhalla/src_qtypes/org/openj9/test/lworld/ValueTypeSystemArraycopyTests.java
@@ -649,21 +649,21 @@ public class ValueTypeSystemArraycopyTests {
 		try {
 			initArraysForASETest(); // ifArray3[ARRAY_SIZE/2] is NULL
 			testIFVT(ifArray3, nullRestrictedVtArrayDst);
-		} catch (java.lang.ArrayStoreException ase1) {
+		} catch (java.lang.ArrayStoreException | java.lang.NullPointerException ex1) {
 			try {
 				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
 				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 
 				initArraysForASETest();
 				testIFVT(ifArray3, nullRestrictedVtArrayDst);
-			} catch (java.lang.ArrayStoreException ase2) {
+			} catch (java.lang.ArrayStoreException | java.lang.NullPointerException ex2) {
 				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
 				// pass
 				return;
 			}
 		}
 
-		Assert.fail("Expect an ArrayStoreException. No exception or wrong kind of exception thrown");
+		Assert.fail("Expect an ArrayStoreException or NullPointerException. No exception or wrong kind of exception thrown");
 	}
 
 	@Test(priority=1)
@@ -672,14 +672,14 @@ public class ValueTypeSystemArraycopyTests {
 		try {
 			initArraysForASETest(); // ifArray3[ARRAY_SIZE/2] is NULL
 			testIFIF(ifArray3, nullRestrictedVtArrayDst);
-		} catch (java.lang.ArrayStoreException ase1) {
+		} catch (java.lang.ArrayStoreException | java.lang.NullPointerException ex1) {
 			try {
 				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
 				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 
 				initArraysForASETest();
 				testIFIF(ifArray3, nullRestrictedVtArrayDst);
-			} catch (java.lang.ArrayStoreException ase2) {
+			} catch (java.lang.ArrayStoreException | java.lang.NullPointerException ex2) {
 				checkResultsPartial(ifArray3, nullRestrictedVtArrayDst, ARRAY_SIZE/2);
 				checkNullRestrictedVTArrayAfterException(ARRAY_SIZE/2);
 				// pass
@@ -687,7 +687,7 @@ public class ValueTypeSystemArraycopyTests {
 			}
 		}
 
-		Assert.fail("Expect a ArrayStoreException. No exception or wrong kind of exception thrown");
+		Assert.fail("Expect an ArrayStoreException or NullPointerException. No exception or wrong kind of exception thrown");
 	}
 
 	@Test(priority=1)
@@ -776,7 +776,7 @@ public class ValueTypeSystemArraycopyTests {
 		checkResults(nullRestrictedVtArraySrc, vtArrayDst);
 	}
 
-	@Test(priority=1, invocationCount=2, expectedExceptions=ArrayStoreException.class)
+	@Test(priority=1, invocationCount=2, expectedExceptions={ArrayStoreException.class, NullPointerException.class})
 	static public void testSystemArrayCopy29() throws Throwable {
 		initArraysToCopyNullToNullRestrictedArray();
 		testVTVT(vtArraySrc, nullRestrictedVtArrayDst);


### PR DESCRIPTION
Fix related to issue: #24255 
Throw NullPointerException for null values copied into null-restricted arrays.

Passing OpenJDK test(ArrayCopyStoreNull.java) link:https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/61608/
Passing sanity.functional test(testSystemArrayCopy) link:https:https://hyc-runtimes-jenkins.swg-devops.com/view/Test_grinder/job/Grinder/61609/