### PR TITLE
Make VectorAPI intrinsics pure functions

### DIFF
--- a/runtime/compiler/il/J9MethodSymbol.cpp
+++ b/runtime/compiler/il/J9MethodSymbol.cpp
@@ -34,6 +34,9 @@
  */
 bool J9::MethodSymbol::isPureFunction()
 {
+    if (self()->getRecognizedMethod() >= TR::FirstVectorMethod && self()->getRecognizedMethod() <= TR::LastVectorMethod)
+        return true;
+
     switch (self()->getRecognizedMethod()) {
         case TR::java_lang_Math_abs_I:
         case TR::java_lang_Math_abs_L:


### PR DESCRIPTION
- VectorAPI intrinsics can be considered pure functions since they don't read or modify any existing fields or statics