### PR TITLE
Fix bug causing null to be written before the allocated buffer start

### DIFF
--- a/runtime/rastrace/method_trace.c
+++ b/runtime/rastrace/method_trace.c
@@ -613,11 +613,15 @@ traceMethodArguments(J9VMThread* thr, J9UTF8* signature, UDATA* arg0EA, char* bu
 	}
 
 	if (cursor == endOfBuf - 1) {
-		/* insert an ellipsis if the buffer was truncated (assumes the buffer is at least 3 chars long) */
-		*--cursor = '.';
-		*--cursor = '.';
-		*--cursor = '.';
-	} else {
+		/* Insert an ellipsis if the buffer was truncated after
+		 * ensuring the buffer has room to fit at least 3 chars.
+		 */
+		if ((cursor - buf) >= 3) {
+			*--cursor = '.';
+			*--cursor = '.';
+			*--cursor = '.';
+		}
+	} else if (cursor > buf) {
 		/* remove the final comma */
 		*--cursor = '\0';
 	}


### PR DESCRIPTION
In the implementation for the traceMethodArguments where a buffer is populated with the arguments, we had a corner case where in case of method without any arguments, a null could be written into a memory location just before the allocated buffer starts causing a memory corruption. This commit fixes the issue.