### PR TITLE
(0.60) Fix invokeinterface IllegalAccessError handling

### DIFF
--- a/runtime/codert_vm/cnathelp.cpp
+++ b/runtime/codert_vm/cnathelp.cpp
@@ -1605,7 +1605,12 @@ old_slow_jitLookupInterfaceMethod(J9VMThread *currentThread)
 	if (0 == vTableOffset) {
 		setCurrentExceptionFromJIT(currentThread, J9VMCONSTANTPOOL_JAVALANGINCOMPATIBLECLASSCHANGEERROR, NULL);
 	} else {
-		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
+		J9Method *method = *(J9Method **)((UDATA)receiverClass + vTableOffset);
+		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+		if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccPublic)) {
+			/* Ensure the correct method will be in the exception message. */
+			currentThread->javaVM->internalVMFunctions->shouldThrowIllegalAccessForAbstractInvokeInterface(currentThread, romMethod, receiverClass, &method);
+		}
 		TIDY_BEFORE_THROW();
 		currentThread->javaVM->internalVMFunctions->setIllegalAccessErrorNonPublicInvokeInterface(currentThread, method);
 	}
@@ -1664,7 +1669,10 @@ old_fast_jitLookupDynamicPublicInterfaceMethod(J9VMThread *currentThread)
 	Assert_CodertVM_false(0 == vTableOffset);
 	/* The receiver's implementation is required to be public */
 	J9Method *method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
-	if (J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)) {
+	J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+	if (J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)
+		&& !vm->internalVMFunctions->shouldThrowIllegalAccessForAbstractInvokeInterface(currentThread, romMethod, receiverClass, &method)
+	) {
 		slowPath = NULL;
 		JIT_RETURN_UDATA(vTableOffset);
 	} else {
@@ -3720,8 +3728,11 @@ fast_jitLookupInterfaceMethod(J9VMThread *currentThread, J9Class *receiverClass,
 	UDATA iTableOffset = indexAndLiteralsEA[1];
 	UDATA vTableOffset = convertITableOffsetToVTableOffset(currentThread, receiverClass, interfaceClass, iTableOffset);
 	if (0 != vTableOffset) {
-		J9Method* method = *(J9Method**)((UDATA)receiverClass + vTableOffset);
-		if (J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)) {
+		J9Method *method = *(J9Method **)((UDATA)receiverClass + vTableOffset);
+		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+		if (J9_ARE_ANY_BITS_SET(J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers, J9AccPublic)
+			&& !currentThread->javaVM->internalVMFunctions->shouldThrowIllegalAccessForAbstractInvokeInterface(currentThread, romMethod, receiverClass, &method)
+		) {
 			slowPath = NULL;
 			JIT_RETURN_UDATA(vTableOffset);
 		}

--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -8912,8 +8912,33 @@ jint JNICALL Java_java_lang_invoke_InterfaceHandle_convertITableIndexToVTableInd
     UDATA *itableArray = (UDATA *)(itableEntry + 1);
     UDATA vTableOffset = itableArray[itableIndex];
     J9Method *method = *(J9Method **)((UDATA)receiverClass + vTableOffset);
-    if ((J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers & J9AccPublic) == 0)
+    J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
+    if ((romMethod->modifiers & J9AccPublic) == 0)
         return -1;
+
+    /* IllegalAccessError takes priority over AbstractMethodError when the selected
+     * method is abstract but the method that invokeinterface selection would resolve
+     * to is not accessible (not public on Java 8, neither public nor private on 11+).
+     * This mirrors the interpreter check in VM_MHInterpreter::dispatchLoop (the
+     * J9_METHOD_HANDLE_KIND_INTERFACE case) so the JIT-compiled InterfaceHandle thunk
+     * throws the same exception as the interpreter. A negative return tells
+     * InterfaceHandle.vtableOffset() to throw IllegalAccessError. Non-negative returns
+     * keep the existing behaviour: dispatch through the vtable slot, where an abstract
+     * target lands on the AbstractMethodError-throwing stub.
+     */
+    if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccAbstract)) {
+        J9VMThread *vmThread = (J9VMThread *)env;
+        J9JavaVM *javaVM = vmThread->javaVM;
+        bool hadVMAccess = J9_ARE_ANY_BITS_SET(vmThread->publicFlags, J9_PUBLIC_FLAGS_VM_ACCESS);
+        if (!hadVMAccess)
+            javaVM->internalVMFunctions->internalEnterVMFromJNI(vmThread);
+        BOOLEAN throwIllegalAccess = javaVM->internalVMFunctions->shouldThrowIllegalAccessForAbstractInvokeInterface(
+            vmThread, romMethod, receiverClass, &method);
+        if (!hadVMAccess)
+            javaVM->internalVMFunctions->internalExitVMToJNI(vmThread);
+        if (throwIllegalAccess)
+            return -1;
+    }
 
     return (vTableOffset - sizeof(J9Class)) / sizeof(intptr_t);
 #if 0 // TODO:JSR292: We probably want to do something more like this instead, so it will properly handle exceptional

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5508,6 +5508,7 @@ typedef struct J9InternalVMFunctions {
 #endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	void  ( *fatalRecursiveStackOverflow)(struct J9VMThread *currentThread) ;
 	void  ( *setIllegalAccessErrorNonPublicInvokeInterface)(struct J9VMThread *currentThread, J9Method *method) ;
+	BOOLEAN  ( *shouldThrowIllegalAccessForAbstractInvokeInterface)(struct J9VMThread *currentThread, J9ROMMethod *romMethod, J9Class *receiverClass, J9Method **foundMethod) ;
 	IDATA ( *createThreadWithCategory)(omrthread_t* handle, UDATA stacksize, UDATA priority, UDATA suspend, omrthread_entrypoint_t entrypoint, void* entryarg, U_32 category) ;
 	IDATA ( *attachThreadWithCategory)(omrthread_t* handle, U_32 category) ;
 	struct J9Method* ( *searchClassForMethod)(J9Class *clazz, U_8 *name, UDATA nameLength, U_8 *sig, UDATA sigLength) ;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -1166,6 +1166,19 @@ setIncompatibleClassChangeErrorForDefaultConflict(J9VMThread * vmThread, J9Metho
 void
 setIllegalAccessErrorNonPublicInvokeInterface(J9VMThread *vmThread, J9Method *method);
 
+/**
+ * Check if IllegalAccessError should be thrown for abstract invokeinterface.
+ * IllegalAccessError takes priority over AbstractMethodError if the selected method
+ * is not public (Java 8) or neither public nor private (Java 11+).
+ *
+ * @param vmThread the current thread
+ * @param romMethod the ROM method being checked
+ * @param receiverClass the receiver class
+ * @param foundMethod will be updated if IllegalAccessError should be thrown
+ * @return TRUE if IllegalAccessError should be thrown, FALSE otherwise
+ */
+BOOLEAN
+shouldThrowIllegalAccessForAbstractInvokeInterface(J9VMThread *vmThread, J9ROMMethod *romMethod, J9Class *receiverClass, J9Method **foundMethod);
 
 /**
  * Error message helper for throwing IllegalAccessError when receiver class is not the same or subtype of current

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -1732,30 +1732,6 @@ obj:
 		J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(_sendMethod);
 		if (romMethod->modifiers & J9AccAbstract) {
 			exception = J9VMCONSTANTPOOL_JAVALANGABSTRACTMETHODERROR;
-			/* If the method class is an interface, do the special checks to throw the correct error */
-			J9Class *methodClass = J9_CLASS_FROM_METHOD(_sendMethod);
-			if (J9ROMCLASS_IS_INTERFACE(methodClass->romClass)) {
-				J9Method *method = (J9Method*)javaLookupMethod(
-						_currentThread,
-						J9OBJECT_CLAZZ(_currentThread, *(j9object_t*)_arg0EA),
-						&romMethod->nameAndSignature,
-						NULL,
-						J9_LOOK_VIRTUAL | J9_LOOK_NO_THROW | J9_LOOK_INVOKE_INTERFACE);
-				if (NULL != method) {
-					U_32 modifiers = J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers;
-					/* Finding a public method means it is necessarily abstract (this function only handles exceptional cases) */
-					if (J9_ARE_NO_BITS_SET(modifiers, J9AccPublic)) {
-						/* Starting with JDK11, private methods expressly do not override any methods from
-						 * superclass/superinterfaces, so AbstractMethodError is the correct error to throw.
-						 * For default or protected methods or JDK levels prior to 11, throw IllegalAccessError.
-						 */
-						if ((J2SE_VERSION(_vm) < J2SE_V11) || (J9_ARE_NO_BITS_SET(modifiers, J9AccPrivate))) {
-							exception = J9VMCONSTANTPOOL_JAVALANGILLEGALACCESSERROR;
-							_sendMethod = method;
-						}
-					}
-				}
-			}
 		}
 		updateVMStruct(REGISTER_ARGS);
 		j9object_t detailMessage = methodToString(_currentThread, _sendMethod);
@@ -8436,7 +8412,9 @@ foundITableCache:
 						_sendMethod = *(J9Method**)((UDATA)receiverClass + ((UDATA*)(iTable + 1))[methodIndex]);
 					}
 					romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(_sendMethod);
-					if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccPublic | J9AccPrivate)) {
+					if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccPublic | J9AccPrivate)
+						|| shouldThrowIllegalAccessForAbstractInvokeInterface(_currentThread, romMethod, receiverClass, &_sendMethod)
+					) {
 						/* We need a frame to describe the method arguments (in particular, for the case where we got here directly from the JIT) */
 						buildMethodFrame(REGISTER_ARGS, _sendMethod, jitStackFrameFlags(REGISTER_ARGS, 0));
 						updateVMStruct(REGISTER_ARGS);
@@ -8445,23 +8423,6 @@ foundITableCache:
 						rc = GOTO_THROW_CURRENT_EXCEPTION;
 						goto done;
 					}
-#if JAVA_SPEC_VERSION == 8
-					if (J9_ARE_ALL_BITS_SET(romMethod->modifiers, J9AccAbstract)
-						&& !J9ROMCLASS_IS_INTERFACE(J9_CLASS_FROM_METHOD(_sendMethod)->romClass)
-					) {
-						/* If resulting method is abstract an error will be
-						 * thrown in throwUnsatisfiedLinkOrAbstractMethodError.
-						 * Return the interface class's method so the correct
-						 * exception handling is used.
-						 */
-						_sendMethod = (J9Method*)javaLookupMethod(
-							_currentThread,
-							interfaceClass,
-							&romMethod->nameAndSignature,
-							NULL,
-							J9_LOOK_INTERFACE | J9_LOOK_NO_THROW | J9_LOOK_INVOKE_INTERFACE);
-					}
-#endif /* JAVA_SPEC_VERSION == 8 */
 					profileInvokeReceiver(REGISTER_ARGS, receiverClass, _literals, _sendMethod);
 					_pc += offset;
 					goto done;
@@ -10079,7 +10040,9 @@ foundITable:
 		_sendMethod = *(J9Method **)(((UDATA)receiverClass) + vTableOffset);
 
 		romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(_sendMethod);
-		if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccPublic | J9AccPrivate)) {
+		if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccPublic | J9AccPrivate)
+			|| shouldThrowIllegalAccessForAbstractInvokeInterface(_currentThread, romMethod, receiverClass, &_sendMethod)
+		) {
 			if (fromJIT) {
 				_sp -= 1;
 				buildJITResolveFrame(REGISTER_ARGS);

--- a/runtime/vm/MHInterpreter.inc
+++ b/runtime/vm/MHInterpreter.inc
@@ -183,7 +183,9 @@ VM_MHInterpreter::dispatchLoop(j9object_t methodHandle)
 				method = convertITableIndexToVirtualMethod(receiverClazz, interfaceClazz, getVMSlot(methodHandle));
 				if (NULL != method) {
 					J9ROMMethod *romMethod = J9_ROM_METHOD_FROM_RAM_METHOD(method);
-					if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccPublic)) {
+					if (J9_ARE_NO_BITS_SET(romMethod->modifiers, J9AccPublic)
+						|| shouldThrowIllegalAccessForAbstractInvokeInterface(_currentThread, romMethod, receiverClazz, &method)
+					) {
 						prepareForExceptionThrow(_currentThread);
 						setIllegalAccessErrorNonPublicInvokeInterface(_currentThread, method);
 						goto throwCurrentException;

--- a/runtime/vm/exceptionsupport.c
+++ b/runtime/vm/exceptionsupport.c
@@ -1208,6 +1208,33 @@ setIllegalAccessErrorNonPublicInvokeInterface(J9VMThread *vmThread, J9Method *me
 	j9mem_free_memory(msg);
 }
 
+BOOLEAN
+shouldThrowIllegalAccessForAbstractInvokeInterface(J9VMThread *vmThread, J9ROMMethod *romMethod, J9Class *receiverClass, J9Method **foundMethod)
+{
+	if (J9_ARE_ANY_BITS_SET(romMethod->modifiers, J9AccAbstract)) {
+		J9Method *method = (J9Method *)javaLookupMethod(
+			vmThread,
+			receiverClass,
+			&romMethod->nameAndSignature,
+			NULL,
+			J9_LOOK_VIRTUAL | J9_LOOK_NO_THROW | J9_LOOK_INVOKE_INTERFACE);
+		if (NULL != method) {
+			U_32 modifiers = J9_ROM_METHOD_FROM_RAM_METHOD(method)->modifiers;
+			if (
+#if JAVA_SPEC_VERSION == 8
+				J9_ARE_NO_BITS_SET(modifiers, J9AccPublic)
+#else /* JAVA_SPEC_VERSION == 8 */
+				J9_ARE_NO_BITS_SET(modifiers, J9AccPublic | J9AccPrivate)
+#endif /* JAVA_SPEC_VERSION == 8 */
+			) {
+				*foundMethod = method;
+				return TRUE;
+			}
+		}
+	}
+	return FALSE;
+}
+
 void  
 setThreadForkOutOfMemoryError(J9VMThread * vmThread, U_32 moduleName, U_32 messageNumber)
 {

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -345,6 +345,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 #endif /* defined(J9VM_OPT_METHOD_HANDLE) */
 	fatalRecursiveStackOverflow,
 	setIllegalAccessErrorNonPublicInvokeInterface,
+	shouldThrowIllegalAccessForAbstractInvokeInterface,
 	createThreadWithCategory,
 	attachThreadWithCategory,
 	searchClassForMethod,


### PR DESCRIPTION
In invokeinterface IllegalAccessError should take
precedence over AbstractMethod error when:

-  For Java 8 the selected method is not public
- For Java 11 the selected method is neither public nor private

throwUnsatisfiedLinkOrAbstractMethodError has relied on the assumption that invokeinterface will pass it an abstract interface method for handling. This is an error prone approach since found abstract
 method could be a class and an abstract interface method may not exist.

This change moves the IllegalAccessError handling into invokeinterface logic for bytecode and method handles logic.

Port from: https://github.com/eclipse-openj9/openj9/pull/24392