### PR TITLE
Apply clang-format check to the proper branch

### DIFF
--- a/buildenv/jenkins/clang_format/clangFormatCheck.groovy
+++ b/buildenv/jenkins/clang_format/clangFormatCheck.groovy
@@ -45,7 +45,7 @@ timestamps {
                         }
                     }
                     stage('Format Check') {
-                        sh "bash buildenv/jenkins/clang_format/clangFormatCheck.sh"
+                        sh "bash buildenv/jenkins/clang_format/clangFormatCheck.sh origin/${ghprbTargetBranch}"
                     }
                     stage('Cleanup Infra') {
                         sh "bash buildenv/jenkins/clang_format/cleanupInfra.sh"

--- a/buildenv/jenkins/clang_format/clangFormatCheck.sh
+++ b/buildenv/jenkins/clang_format/clangFormatCheck.sh
@@ -21,7 +21,10 @@
 # SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
 ###############################################################################
 
-allFiles=$(git diff -C --diff-filter=ACM --name-only origin/master HEAD -- | grep '^runtime/compiler/')
+# Optional argument identifies the target branch of the pull request.
+targetBranch="${1:-origin/master}"
+
+allFiles=$(git diff -C --diff-filter=ACM --name-only "$targetBranch" HEAD -- | grep '^runtime/compiler/')
 if [ x"$allFiles" = x ] ; then
     echo "There are no files to check for code formatting."
 else


### PR DESCRIPTION
Noticed that the format check for https://github.com/eclipse-openj9/openj9/pull/24396 should have used the `v0.60.0-release` branch instead of the `master` branch; see https://openj9-jenkins.osuosl.org/job/PullRequest-Clang-Format-Check/2500.