### PR TITLE
Revert "Fix gaurd condition in jfr local buffer writer"

### DIFF
--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -263,7 +263,7 @@ areJFRBuffersReadyForWrite(J9VMThread *currentThread)
 	bool result = true;
 	J9JavaVM *vm = currentThread->javaVM;
 
-	if ((!vm->jfrState.isCreated)
+	if ((!vm->jfrState.isStarted)
 	|| (NULL == currentThread->jfrBuffer.bufferStart)
 	|| (NULL == vm->jfrBuffer.bufferCurrent)
 	) {
@@ -292,7 +292,7 @@ writeOutGlobalBuffer(J9VMThread *currentThread, bool finalWrite, bool dumpCalled
 	j9tty_printf(PORTLIB, "\n!!! writing global buffer %p of size %p\n", currentThread, vm->jfrBuffer.bufferSize - vm->jfrBuffer.bufferRemaining);
 #endif /* defined(DEBUG) */
 
-	if (vm->jfrState.isCreated && (NULL != vm->jfrBuffer.bufferCurrent)) {
+	if (vm->jfrState.isStarted && (NULL != vm->jfrBuffer.bufferCurrent)) {
 		VM_JFRWriter::flushJFRDataToFile(currentThread, finalWrite, dumpCalled);
 
 		/* Reset the buffer */


### PR DESCRIPTION
Reverts eclipse-openj9/openj9#24388

Likely causing failures in https://github.com/eclipse-openj9/openj9/issues/23120 and https://github.com/eclipse-openj9/openj9/issues/24389