### PR TITLE
Prevent Eden from exceeding free heap after a heap resize failure

### DIFF
--- a/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
+++ b/runtime/gc_vlhgc/MemorySubSpaceTarok.cpp
@@ -942,7 +942,9 @@ MM_MemorySubSpaceTarok::performResize(MM_EnvironmentBase *env, MM_AllocateDescri
 		resizeAmount = -(intptr_t)performContract(env, allocDescription);
 	} else if (_expansionSize != 0) {
 		resizeAmount = performExpand(env);
-	} else {
+	}
+
+	if (0 == resizeAmount) {
 		/**
 		 * In case there is no heap resize, check if there is the case that free size is smaller than eden size
 		 * due to the conflict between eden resize and heap resize, recalculateEdenSize if it happens.


### PR DESCRIPTION
Currently, we protect against the eden size exceeding the available free heap space when no heap resize occurs. Extend this protection to handle heap resize failures (both expansion and contraction).

For successful heap resize operations, heapReconfigured() is invoked, which triggers calculateEdenSize() to recalculate and adjust the eden size.