### PR TITLE
Remove store sync in PGC

### DIFF
--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -827,8 +827,7 @@ MM_CopyForwardScheme::acquireEmptyRegion(MM_EnvironmentVLHGC *env, MM_ReservedRe
 			Assert_MM_true(newRegion->getReferenceObjectList()->isPhantomListEmpty());
 
 			setRegionAsSurvivor(env, newRegion, true);
-			/* Make sure that all the attributes set are visible to other CPUs, before exposing the region in a globally visible list */
-			MM_AtomicOperations::storeSync();
+
 			insertRegionIntoLockedList(env, regionList, newRegion);
 		} else {
 			/* record that we failed to expand so that we stop trying during this collection */


### PR DESCRIPTION
A store sync was recently added, speculating that it's needed to synchronize the stores of region attributes before adding to the list of new regions, mid PGC.

After all, such a sync should not be needed, because the locking operation associated with push-to-list operations has an implicit sync.

While the frequency of this operation is rather low (no perf benefit from the change), it's not good to create a bad precedent that would be potentially cloned in other similar situations.