### PR TITLE
Enable transformation of StringLatin1.compareTo() on P and Z

### DIFF
--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -5467,7 +5467,7 @@ bool TR_J9InlinerPolicy::suppressInliningRecognizedInitialCallee(TR_CallSite *ca
             break;
         }
         case TR::java_lang_StringLatin1_compareTo_BBII:
-            if (cg->getSupportsArrayCmpLen() && !comp->target().cpu.isPower() && !comp->target().cpu.isZ()) {
+            if (cg->getSupportsArrayCmpLen()) {
                 return true;
             }
             break;

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -1973,8 +1973,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop *treetop)
             case TR::java_lang_String_encodeASCII:
                 return cg()->getSupportsInlineEncodeASCII();
             case TR::java_lang_StringLatin1_compareTo_BBII:
-                return (
-                    cg()->getSupportsArrayCmpLen() && !comp()->target().cpu.isPower() && !comp()->target().cpu.isZ());
+                return cg()->getSupportsArrayCmpLen();
             case TR::java_lang_StringLatin1_inflate_BIBII:
                 return (cg()->getSupportsArrayTranslateTROTNoBreak() && !comp()->target().cpu.isPower());
             case TR::jdk_internal_util_ArraysSupport_vectorizedMismatch:


### PR DESCRIPTION
This commit enables transformation of StringLatin1.compareTo() on Power and Z platforms.