### PR TITLE
Prevent JITServer from attempting a cross-compilation

### DIFF
--- a/runtime/compiler/net/CommunicationStream.cpp
+++ b/runtime/compiler/net/CommunicationStream.cpp
@@ -43,6 +43,20 @@ void CommunicationStream::initConfigurationFlags()
         CONFIGURATION_FLAGS |= JITServerCompressedRef;
     }
     CONFIGURATION_FLAGS |= JAVA_SPEC_VERSION & JITServerJavaVersionMask;
+
+    uint32_t arch = 0;
+    if (TR::Compiler->target.cpu.isX86())
+        arch = JITServerCompatibilityFlags::JITServerArchX86;
+    else if (TR::Compiler->target.cpu.isPower())
+        arch = TR::Compiler->target.cpu.isLittleEndian() ? JITServerCompatibilityFlags::JITServerArchPowerLE
+                                                         : JITServerCompatibilityFlags::JITServerArchPowerBE;
+    else if (TR::Compiler->target.cpu.isZ())
+        arch = JITServerCompatibilityFlags::JITServerArchZ;
+    else if (TR::Compiler->target.cpu.isARM())
+        arch = JITServerCompatibilityFlags::JITServerArchARM;
+    else if (TR::Compiler->target.cpu.isARM64())
+        arch = JITServerCompatibilityFlags::JITServerArchARM64;
+    CONFIGURATION_FLAGS |= arch << JITServerCompatibilityFlags::JITServerArchShift;
 }
 
 bool CommunicationStream::useSSL()
@@ -143,6 +157,15 @@ std::string CommunicationStream::showFullVersionIncompatibility(uint64_t serverF
     if (serverCompressesRefs != clientCompressesRefs)
         return "compressed refs: server " + std::to_string(serverCompressesRefs) + ", client "
             + std::to_string(clientCompressesRefs);
+
+    uint32_t serverArch = (serverFlags & JITServerCompatibilityFlags::JITServerArchMask)
+        >> JITServerCompatibilityFlags::JITServerArchShift;
+    uint32_t clientArch = (clientFlags & JITServerCompatibilityFlags::JITServerArchMask)
+        >> JITServerCompatibilityFlags::JITServerArchShift;
+    if (serverArch != clientArch) {
+        const std::string archNames[] = { "", "X86", "PowerLittleEndian", "PowerBigEndian", "Z", "ARM", "ARM64" };
+        return "architecture: server " + archNames[serverArch] + ", client " + archNames[clientArch];
+    }
 
     return "full version: server " + std::to_string(serverFullVersion) + ", client "
         + std::to_string(clientFullVersion);

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -37,6 +37,18 @@ namespace JITServer {
 enum JITServerCompatibilityFlags {
     JITServerJavaVersionMask = 0x00000FFF,
     JITServerCompressedRef = 0x00001000,
+
+    // Platform Architecture
+    JITServerArchX86 = 1,
+    JITServerArchPowerLE = 2,
+    JITServerArchPowerBE = 3,
+    JITServerArchZ = 4,
+    JITServerArchARM = 5,
+    JITServerArchARM64 = 6,
+
+    // Bit layout configuration for architecture field
+    JITServerArchShift = 13,
+    JITServerArchMask = 0xE000,
 };
 
 class CommunicationStream {


### PR DESCRIPTION
JITServer doesn't support cross-compilation, incase of an attempt the server should refuse the connection rather than generating code the client cannot execute.

Signed-off-by: Dev Agarwal [dev.agarwal@ibm.com](mailto:dev.agarwal@ibm.com)