### PR TITLE
JFR instrumentation fix

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/JFRClassTransformer.java
+++ b/jcl/src/java.base/share/classes/java/lang/JFRClassTransformer.java
@@ -24,10 +24,25 @@ package java.lang;
 
 import jdk.internal.org.objectweb.asm.*;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 final class JFRClassTransformer {
+
+    /*[IF JAVA_SPEC_VERSION == 17]*/
+    private static Method bytesForEagerInstrumentation;
+
+    static {
+        try {
+            Class<?> jfrUpCallClass = Class.forName("jdk.jfr.internal.JVMUpcalls");
+            bytesForEagerInstrumentation = jfrUpCallClass.getDeclaredMethod("bytesForEagerInstrumentation", long.class, boolean.class, Class.class, byte[].class);
+            bytesForEagerInstrumentation.setAccessible(true);
+        } catch (ReflectiveOperationException e) {
+            throw new RuntimeException(e);
+        }
+    }
+    /*[ENDIF] JAVA_SPEC_VERSION == 17 */
 
     private static final String EVENT_HANDLER_FIELD = "eventHandler";
     private static final String START_TIME_FIELD = "startTime";
@@ -124,7 +139,7 @@ final class JFRClassTransformer {
 	 * @param addMethods whether to add the JFR event handler methods
 	 * @return the transformed class bytes
 	 */
-    static byte[] transformClass(byte[] classBytes, boolean addMethods) {
+    static byte[] transformClass(byte[] classBytes) {
         List<FieldDescriptor> fields = new ArrayList<>();
 
         fields.add(FieldDescriptor.staticField(EVENT_HANDLER_FIELD, OBJECT_DESC));
@@ -135,35 +150,62 @@ final class JFRClassTransformer {
 
         List<MethodDescriptor> methods = new ArrayList<>();
 
-        if (addMethods) {
-            methods.add(MethodDescriptor.publicMethod("isEnabled", "()Z", mv -> {
-                mv.visitInsn(Opcodes.ICONST_0);
-                mv.visitInsn(Opcodes.IRETURN);
-                mv.visitMaxs(1, 1);
-            }));
+        methods.add(MethodDescriptor.publicMethod("isEnabled", "()Z", mv -> {
+            mv.visitInsn(Opcodes.ICONST_0);
+            mv.visitInsn(Opcodes.IRETURN);
+            mv.visitMaxs(1, 1);
+        }));
 
-            methods.add(MethodDescriptor.publicMethod("shouldCommit", "()Z", mv -> {
-                mv.visitInsn(Opcodes.ICONST_0);
-                mv.visitInsn(Opcodes.IRETURN);
-                mv.visitMaxs(1, 1);
-            }));
+        methods.add(MethodDescriptor.publicMethod("shouldCommit", "()Z", mv -> {
+            mv.visitInsn(Opcodes.ICONST_0);
+            mv.visitInsn(Opcodes.IRETURN);
+            mv.visitMaxs(1, 1);
+        }));
 
-            methods.add(MethodDescriptor.publicMethod("commit", "()V", mv -> {
-                mv.visitInsn(Opcodes.RETURN);
-                mv.visitMaxs(0, 1);
-            }));
+        methods.add(MethodDescriptor.publicMethod("commit", "()V", mv -> {
+            mv.visitInsn(Opcodes.RETURN);
+            mv.visitMaxs(0, 1);
+        }));
 
-            methods.add(MethodDescriptor.publicMethod("end", "()V", mv -> {
-                mv.visitInsn(Opcodes.RETURN);
-                mv.visitMaxs(0, 1);
-            }));
+        methods.add(MethodDescriptor.publicMethod("end", "()V", mv -> {
+            mv.visitInsn(Opcodes.RETURN);
+            mv.visitMaxs(0, 1);
+        }));
 
-            methods.add(MethodDescriptor.publicMethod("begin", "()V", mv -> {
-                mv.visitInsn(Opcodes.RETURN);
-                mv.visitMaxs(0, 1);
-            }));
-        }
+        methods.add(MethodDescriptor.publicMethod("begin", "()V", mv -> {
+            mv.visitInsn(Opcodes.RETURN);
+            mv.visitMaxs(0, 1);
+        }));
 
         return addFieldsAndMethods(classBytes, fields, methods);
     }
+
+    /*[IF JAVA_SPEC_VERSION == 17]*/
+    static byte[] transformJFREventClass(byte[] classBytes) {
+        ClassReader reader = new ClassReader(classBytes);
+        ClassWriter writer = new ClassWriter(reader, ClassWriter.COMPUTE_MAXS);
+
+        ClassVisitor visitor = new ClassVisitor(Opcodes.ASM7, writer) {
+            @Override
+            public MethodVisitor visitMethod(int access, String name, String descriptor, String signature, String[] exceptions) {
+                // Remove the ACC_FINAL flag from the method access modifiers
+                int modifiedAccess = access & ~Opcodes.ACC_FINAL;
+                return super.visitMethod(modifiedAccess, name, descriptor, signature, exceptions);
+            }
+        };
+
+        reader.accept(visitor, 0);
+        return writer.toByteArray();
+    }
+
+    static byte[] transformClassAndInvokebytesForEagerInstrumentation(long traceId, boolean forceInstrumentation, Class<?> superClass, byte[] oldBytes) throws ReflectiveOperationException {
+        try {
+            oldBytes = transformClass(oldBytes);
+            return (byte[])bytesForEagerInstrumentation.invoke(null, traceId, forceInstrumentation, superClass, oldBytes);
+        } catch (Throwable t) {
+            t.printStackTrace();
+            throw t;
+        }
+    }
+    /*[ENDIF] JAVA_SPEC_VERSION == 17 */
 }

--- a/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
+++ b/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
@@ -40,13 +40,11 @@ final class JFRHelpers {
 	private static Class<?> logTagClass;
 	private static Class<?> logLeveLClass;
 	private static Class<?> loggerClass;
-	private static Class<?> jfrUpCallClass;
 	private static Object[] logTagValues;
 	private static Object[] logLevelValues;
 	private static Method log;
 	/*[IF JAVA_SPEC_VERSION >= 17]*/
 	private static Method logEvent;
-	private static Method bytesForEagerInstrumentation;
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 	private static volatile boolean jfrClassesInitialized = false;
 	private static String jfrCMDLineOption = null;
@@ -249,7 +247,6 @@ final class JFRHelpers {
 				logTagClass = Class.forName("jdk.jfr.internal.LogTag");
 				logLeveLClass = Class.forName("jdk.jfr.internal.LogLevel");
 				loggerClass = Class.forName("jdk.jfr.internal.Logger");
-				jfrUpCallClass = Class.forName("jdk.jfr.internal.JVMUpcalls");
 
 				Module javabase = System.class.getModule();
 				Module jdkJFR = jfrjvmClass.getModule();
@@ -267,12 +264,9 @@ final class JFRHelpers {
 
 				/*[IF JAVA_SPEC_VERSION >= 17]*/
 				logEvent = loggerClass.getDeclaredMethod("logEvent", new Class[]{logLeveLClass, String[].class, boolean.class});
-				bytesForEagerInstrumentation = jfrUpCallClass.getDeclaredMethod("bytesForEagerInstrumentation", long.class, boolean.class, Class.class, byte[].class);
-				bytesForEagerInstrumentation.setAccessible(true);
 				/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 				Unsafe.getUnsafe().ensureClassInitialized(jfrjvmClass);
-				Unsafe.getUnsafe().ensureClassInitialized(jfrUpCallClass);
 				Unsafe.getUnsafe().ensureClassInitialized(Class.forName("jdk.jfr.events.AbstractJDKEvent"));
 				jfrClassesInitialized = true;
 			} catch (ReflectiveOperationException e) {
@@ -320,16 +314,6 @@ final class JFRHelpers {
 	/*[ENDIF] JAVA_SPEC_VERSION >= 17 */
 
 	/*[IF JAVA_SPEC_VERSION == 17]*/
-	private static byte[] transformClassAndInvokebytesForEagerInstrumentation(long traceId, boolean forceInstrumentation, Class<?> superClass, byte[] oldBytes, boolean addMethods) throws ReflectiveOperationException {
-		try {
-			oldBytes = JFRClassTransformer.transformClass(oldBytes, addMethods);
-			return (byte[])bytesForEagerInstrumentation.invoke(null, traceId, forceInstrumentation, superClass, oldBytes);
-		} catch (Throwable t) {
-			t.printStackTrace();
-			throw t;
-		}
-	}
-
 	private static List<?> transformToList(Object[] array) {
 		if (array == null) {
 			return Collections.emptyList();

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -54,6 +54,7 @@ static void freeAnonROMClass(J9JavaVM *vm, J9ROMClass *romClass);
 
 
 #if defined(J9VM_OPT_JFR)
+J9_DECLARE_CONSTANT_UTF8(jfrEventClassUTF8, "jdk/jfr/Event");
 /*
  * This function is used to preload the superclass of a class that is being defined. It requires th CTM to be held
  * by the caller. This function releases the CTM if there is a failure (OOM, exception, etc) or if the superClass is
@@ -152,7 +153,27 @@ internalDefineClass(
 	classLoader = GET_CLASS_LOADER_FROM_ID(vm, classLoader);
 
 #if defined(J9VM_OPT_JFR)
-	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_ENABLE_JFR_CLASSLOAD_TRANSFORM)) {
+	if (vmFuncs->isJFRV2SupportEnabled(vm)
+		&& J9UTF8_DATA_EQUALS(J9UTF8_DATA(&jfrEventClassUTF8), J9UTF8_LENGTH(&jfrEventClassUTF8), className, classNameLength)
+		&& (vm->systemClassLoader == classLoader)
+	) {
+		U_8 *jfrModifiedBytes = NULL;
+		UDATA jfrModifiedBytesLength = 0;
+		U_8 *upcallClassBytes = classData;
+		U_32 upcallClassBytesLength = classDataLength;
+
+		omrthread_monitor_exit(vm->classTableMutex);
+		vmFuncs->jvmUpcallsTransformJFREventClass(vmThread, upcallClassBytes, upcallClassBytesLength, &jfrModifiedBytes, &jfrModifiedBytesLength);
+		omrthread_monitor_enter(vm->classTableMutex);
+
+		if ((NULL == jfrModifiedBytes) || (0 == jfrModifiedBytesLength)) {
+			omrthread_monitor_exit(vm->classTableMutex);
+			vmFuncs->setCurrentExceptionUTF(vmThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+			return NULL;
+		}
+		classData = jfrModifiedBytes;
+		classDataLength = jfrModifiedBytesLength;
+	} else if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_ENABLE_JFR_CLASSLOAD_TRANSFORM)) {
 		J9Class *superClass = preloadSuperClass(vmThread, classData, classDataLength, classLoader, options);
 		if (J9_ARE_ALL_BITS_SET(vmThread->privateFlags2, J9_PRIVATE_FLAGS2_SUPERCLASS_REQUIRED_FIRST) || (NULL != vmThread->currentException)) {
 			/* CTM is already released in this case. */

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5730,6 +5730,7 @@ typedef struct J9InternalVMFunctions {
 	jlong (*getTypeId)(struct J9VMThread *currentThread, struct J9Class *clazz);
 	void (*jvmUpcallsEagerByteInstrumentation)(struct J9VMThread *currentThread, struct J9Class *superClass, U_8 *className, U_16 classNameLength, struct J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 	j9object_t (*jvmUpcallTransformArrayToList)(struct J9VMThread *currentThread, j9object_t array);
+	void (*jvmUpcallsTransformJFREventClass)(struct J9VMThread *currentThread, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 	void (*jfrInitializeInternalStructures)(struct J9VMThread *currentThread);
 	void (*jfrEmitDataLoss)(struct J9VMThread *currentThread, U_64 bytes);
 	jboolean (*requestJFREvent)(struct J9VMThread *currentThread, jlong id);
@@ -6267,6 +6268,7 @@ typedef struct JFRState {
 	jclass jfrEventClassRef;
 	J9Method *onRetransformUpcallMethod;
 	J9Method *transformToListMethod;
+	J9Method *transformJFREventClassMethod;
 	J9HashTable *threadObjectJNIRefTable;
 	omrthread_monitor_t threadObjectsMutex;
 	jobject chunkRotationMonitor;

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5727,6 +5727,7 @@ typedef struct J9InternalVMFunctions {
 	jlong (*getTypeId)(struct J9VMThread *currentThread, struct J9Class *clazz);
 	void (*jvmUpcallsEagerByteInstrumentation)(struct J9VMThread *currentThread, struct J9Class *superClass, U_8 *className, U_16 classNameLength, struct J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 	j9object_t (*jvmUpcallTransformArrayToList)(struct J9VMThread *currentThread, j9object_t array);
+	void (*jvmUpcallsTransformJFREventClass)(struct J9VMThread *currentThread, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 	void (*jfrInitializeInternalStructures)(struct J9VMThread *currentThread);
 	void (*jfrEmitDataLoss)(struct J9VMThread *currentThread, U_64 bytes);
 	jboolean (*requestJFREvent)(struct J9VMThread *currentThread, jlong id);
@@ -6264,6 +6265,7 @@ typedef struct JFRState {
 	jclass jfrEventClassRef;
 	J9Method *onRetransformUpcallMethod;
 	J9Method *transformToListMethod;
+	J9Method *transformJFREventClassMethod;
 	J9HashTable *threadObjectJNIRefTable;
 	omrthread_monitor_t threadObjectsMutex;
 	jobject chunkRotationMonitor;

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5991,6 +5991,20 @@ shutdownJFRIDs(J9JavaVM *vm);
 void
 jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClass, U_8 *className, U_16 classNameLength, J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 
+
+/**
+ * Call the JFR transformJFREventClass method to transform the jdk.jfr.Event class.
+ * This removes the final modifier from methods so we can add these methods in subclasses.
+ *
+ * @param currentThread[in] the current J9VMThread
+ * @param classData[in] the class data
+ * @param classDataLength[in] the length of the class data
+ * @param newClassData[out] the transformed class data
+ * @param newClassDataLength[out] the length of the transformed class data
+ */
+void
+jvmUpcallsTransformJFREventClass(J9VMThread *currentThread, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
+
 /**
  * Call the JFR transform array to list method to transform an array to a list. Current exception will
  * be set if there is a failure.

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -493,6 +493,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	getTypeId,
 	jvmUpcallsEagerByteInstrumentation,
 	jvmUpcallTransformArrayToList,
+	jvmUpcallsTransformJFREventClass,
 	jfrInitializeInternalStructures,
 	jfrEmitDataLoss,
 	requestJFREvent,

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -45,12 +45,16 @@ J9_DECLARE_CONSTANT_UTF8(initJFRUTF8, "initJFRv2");
 J9_DECLARE_CONSTANT_UTF8(initJFRSigUTF8, "()V");
 J9_DECLARE_CONSTANT_NAS(initJFRNAS, initJFRUTF8, initJFRSigUTF8);
 J9_DECLARE_CONSTANT_UTF8(jfrHelpersUTF8, "java/lang/JFRHelpers");
+J9_DECLARE_CONSTANT_UTF8(jfrClassTransformerUTF8, "java/lang/JFRClassTransformer");
 J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationUTF8, "transformClassAndInvokebytesForEagerInstrumentation");
-J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationSigUTF8, "(JZLjava/lang/Class;[BZ)[B");
+J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationSigUTF8, "(JZLjava/lang/Class;[B)[B");
 J9_DECLARE_CONSTANT_NAS(bytesForEagerInstrumentationNAS, bytesForEagerInstrumentationUTF8, bytesForEagerInstrumentationSigUTF8);
 J9_DECLARE_CONSTANT_UTF8(transformToListUTF8, "transformToList");
 J9_DECLARE_CONSTANT_UTF8(transformToListSigUTF8, "([Ljava/lang/Object;)Ljava/util/List;");
 J9_DECLARE_CONSTANT_NAS(transformToListNAS, transformToListUTF8, transformToListSigUTF8);
+J9_DECLARE_CONSTANT_UTF8(transformJFREventClassUTF8, "transformJFREventClass");
+J9_DECLARE_CONSTANT_UTF8(transformJFREventClassSigUTF8, "([B)[B");
+J9_DECLARE_CONSTANT_NAS(transformJFREventClassNAS, transformJFREventClassUTF8, transformJFREventClassSigUTF8);
 J9_DECLARE_CONSTANT_UTF8(jfrInternalEventClassUTF8, "jdk/internal/event/Event");
 J9_DECLARE_CONSTANT_UTF8(jfrEventClassUTF8, "jdk/jfr/Event");
 
@@ -1953,7 +1957,7 @@ getTypeIdImpl(J9VMThread *currentThread, J9ClassLoader *classLoader, J9UTF8 *cla
 		}
 		J9Class *eventClass = J9VMJAVALANGCLASS_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrEventClassRef));
 		if (!isSameOrSuperClassOf(eventClass, clazz)
-			|| J9_ARE_NO_BITS_SET(clazz->romClass->modifiers, J9AccAbstract)
+			|| J9_ARE_ANY_BITS_SET(clazz->romClass->modifiers, J9AccAbstract)
 		) {
 			return -1;
 		}
@@ -2019,8 +2023,6 @@ getTypeIdImpl(J9VMThread *currentThread, J9ClassLoader *classLoader, J9UTF8 *cla
 			vm->jfrState.jfrEventEnabledFlagsSize = jfrEventEnabledFlagsArraySize;
 		}
 #endif /* JAVA_SPEC_VERSION >= 17 */
-
-	classLoader->typeIDs = typeIDTable;
 	}
 
 	jfrTypeID->className = className;
@@ -2031,8 +2033,13 @@ getTypeIdImpl(J9VMThread *currentThread, J9ClassLoader *classLoader, J9UTF8 *cla
 		jfrTypeID = &entry;
 		jfrTypeID->id = vm->jfrState.typeIDcount;
 		jfrTypeID->free = freeName;
-		jfrTypeID->isEvent = FALSE;
-		jfrTypeID->eventClass = NULL;
+		if (NULL != clazz) {
+			jfrTypeID->isEvent = TRUE;
+			jfrTypeID->eventClass = clazz;
+		} else {
+			jfrTypeID->isEvent = FALSE;
+			jfrTypeID->eventClass = NULL;
+		}
 
 		vm->jfrState.typeIDcount += 1;
 		Assert_VM_true(vm->jfrState.typeIDcount > 0);
@@ -2156,7 +2163,7 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 	jlong traceID = 0;
 	j9object_t inputByteArray = NULL;
 	j9object_t outputByteArray = NULL;
-	UDATA args[6];
+	UDATA args[5];
 	BOOLEAN freeName = FALSE;
 
 	U_8 buf[J9JFR_CLASSNAME_BUFFER_SIZE + sizeof(U_16)];
@@ -2187,25 +2194,29 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 
 	if (NULL == vm->jfrState.onRetransformUpcallMethod) {
 		PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, inputByteArray);
-		J9Class *jfrHelpersClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrHelpersUTF8), J9UTF8_LENGTH(&jfrHelpersUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
-		if (NULL == jfrHelpersClass) {
+		J9Class *jfrClassTransformerClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrClassTransformerUTF8), J9UTF8_LENGTH(&jfrClassTransformerUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+		if (NULL == jfrClassTransformerClass) {
 			goto popInputArrayAndDone;
 		}
-		vm->jfrState.onRetransformUpcallMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrHelpersClass, (J9ROMNameAndSignature *)&bytesForEagerInstrumentationNAS, jfrHelpersClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
+		vm->jfrState.onRetransformUpcallMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrClassTransformerClass, (J9ROMNameAndSignature *)&bytesForEagerInstrumentationNAS, jfrClassTransformerClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
 		if (NULL == vm->jfrState.onRetransformUpcallMethod) {
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			goto popInputArrayAndDone;
 		}
+		vmFuncs->initializeClass(currentThread, jfrClassTransformerClass);
 		inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+
+		if (VM_VMHelpers::exceptionPending(currentThread)) {
+			goto done;
+		}
 	}
 	args[0] = 0;
 	args[1] = (UDATA)traceID;
 	args[2] = (UDATA)FALSE;
 	args[3] = (UDATA)superClass->classObject;
 	args[4] = (UDATA)inputByteArray;
-	args[5] = (UDATA)(BOOLEAN)!isSameOrSuperClassOf(J9VMJAVALANGCLASS_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrEventClassRef)), superClass);
 
-	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.onRetransformUpcallMethod, TRUE, 6, args);
+	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.onRetransformUpcallMethod, TRUE, 5, args);
 	outputByteArray = (j9object_t)currentThread->returnValue;
 
 	if (VM_VMHelpers::exceptionPending(currentThread) || (NULL == outputByteArray)) {
@@ -2253,6 +2264,72 @@ jvmUpcallTransformArrayToList(J9VMThread *currentThread, j9object_t array)
 
 done:
 	return result;
+}
+
+void
+jvmUpcallsTransformJFREventClass(J9VMThread *currentThread, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9MemoryManagerFunctions *mmfns = vm->memoryManagerFunctions;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	j9object_t inputByteArray = NULL;
+	j9object_t outputByteArray = NULL;
+	UDATA args[2];
+
+	inputByteArray = mmfns->J9AllocateIndexableObject(currentThread, vm->byteReflectClass->arrayClass, (U_32)classDataLength, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+	if (NULL == inputByteArray) {
+		vmFuncs->setHeapOutOfMemoryError(currentThread);
+		goto done;
+	}
+
+	VM_ArrayCopyHelpers::memcpyToArray(currentThread, inputByteArray, (UDATA)0, classDataLength, (void *)classData);
+
+	if (NULL == vm->jfrState.transformJFREventClassMethod) {
+		PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, inputByteArray);
+		J9Class *jfrClassTransformerClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrClassTransformerUTF8), J9UTF8_LENGTH(&jfrClassTransformerUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+		if (NULL == jfrClassTransformerClass) {
+			goto popInputArrayAndDone;
+		}
+		vm->jfrState.transformJFREventClassMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrClassTransformerClass, (J9ROMNameAndSignature *)&transformJFREventClassNAS, jfrClassTransformerClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
+		if (NULL == vm->jfrState.transformJFREventClassMethod) {
+			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+			goto popInputArrayAndDone;
+		}
+		vmFuncs->initializeClass(currentThread, jfrClassTransformerClass);
+		inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+
+		if (VM_VMHelpers::exceptionPending(currentThread)) {
+			goto done;
+		}
+	}
+
+	args[0] = 0;
+	args[1] = (UDATA)inputByteArray;
+
+	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.transformJFREventClassMethod, TRUE, 2, args);
+	outputByteArray = (j9object_t)currentThread->returnValue;
+
+	if (VM_VMHelpers::exceptionPending(currentThread) || (NULL == outputByteArray)) {
+		goto done;
+	}
+
+	*newClassDataLength = (jint)J9INDEXABLEOBJECT_SIZE(currentThread, outputByteArray);
+	*newClassData = (U_8 *)j9mem_allocate_memory(*newClassDataLength, OMRMEM_CATEGORY_VM);
+	if (NULL == *newClassData) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto done;
+	}
+
+	VM_ArrayCopyHelpers::memcpyFromArray(currentThread, outputByteArray, (UDATA)0, (UDATA)0, *newClassDataLength, *newClassData);
+
+done:
+	return;
+
+popInputArrayAndDone:
+	inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+	goto done;
+
 }
 
 #if JAVA_SPEC_VERSION >= 17

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -45,12 +45,16 @@ J9_DECLARE_CONSTANT_UTF8(initJFRUTF8, "initJFRv2");
 J9_DECLARE_CONSTANT_UTF8(initJFRSigUTF8, "()V");
 J9_DECLARE_CONSTANT_NAS(initJFRNAS, initJFRUTF8, initJFRSigUTF8);
 J9_DECLARE_CONSTANT_UTF8(jfrHelpersUTF8, "java/lang/JFRHelpers");
+J9_DECLARE_CONSTANT_UTF8(jfrClassTransformerUTF8, "java/lang/JFRClassTransformer");
 J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationUTF8, "transformClassAndInvokebytesForEagerInstrumentation");
-J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationSigUTF8, "(JZLjava/lang/Class;[BZ)[B");
+J9_DECLARE_CONSTANT_UTF8(bytesForEagerInstrumentationSigUTF8, "(JZLjava/lang/Class;[B)[B");
 J9_DECLARE_CONSTANT_NAS(bytesForEagerInstrumentationNAS, bytesForEagerInstrumentationUTF8, bytesForEagerInstrumentationSigUTF8);
 J9_DECLARE_CONSTANT_UTF8(transformToListUTF8, "transformToList");
 J9_DECLARE_CONSTANT_UTF8(transformToListSigUTF8, "([Ljava/lang/Object;)Ljava/util/List;");
 J9_DECLARE_CONSTANT_NAS(transformToListNAS, transformToListUTF8, transformToListSigUTF8);
+J9_DECLARE_CONSTANT_UTF8(transformJFREventClassUTF8, "transformJFREventClass");
+J9_DECLARE_CONSTANT_UTF8(transformJFREventClassSigUTF8, "([B)[B");
+J9_DECLARE_CONSTANT_NAS(transformJFREventClassNAS, transformJFREventClassUTF8, transformJFREventClassSigUTF8);
 J9_DECLARE_CONSTANT_UTF8(jfrInternalEventClassUTF8, "jdk/internal/event/Event");
 J9_DECLARE_CONSTANT_UTF8(jfrEventClassUTF8, "jdk/jfr/Event");
 
@@ -1791,7 +1795,7 @@ getTypeIdImpl(J9VMThread *currentThread, J9ClassLoader *classLoader, J9UTF8 *cla
 		}
 		J9Class *eventClass = J9VMJAVALANGCLASS_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrEventClassRef));
 		if (!isSameOrSuperClassOf(eventClass, clazz)
-			|| J9_ARE_NO_BITS_SET(clazz->romClass->modifiers, J9AccAbstract)
+			|| J9_ARE_ANY_BITS_SET(clazz->romClass->modifiers, J9AccAbstract)
 		) {
 			return -1;
 		}
@@ -1843,8 +1847,6 @@ getTypeIdImpl(J9VMThread *currentThread, J9ClassLoader *classLoader, J9UTF8 *cla
 			}
 		}
 #endif /* JAVA_SPEC_VERSION >= 17 */
-
-	classLoader->typeIDs = typeIDTable;
 	}
 
 	jfrTypeID->className = className;
@@ -1855,8 +1857,13 @@ getTypeIdImpl(J9VMThread *currentThread, J9ClassLoader *classLoader, J9UTF8 *cla
 		jfrTypeID = &entry;
 		jfrTypeID->id = vm->jfrState.typeIDcount;
 		jfrTypeID->free = freeName;
-		jfrTypeID->isEvent = FALSE;
-		jfrTypeID->eventClass = NULL;
+		if (NULL != clazz) {
+			jfrTypeID->isEvent = TRUE;
+			jfrTypeID->eventClass = clazz;
+		} else {
+			jfrTypeID->isEvent = FALSE;
+			jfrTypeID->eventClass = NULL;
+		}
 
 		vm->jfrState.typeIDcount += 1;
 		Assert_VM_true(vm->jfrState.typeIDcount > 0);
@@ -1980,7 +1987,7 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 	jlong traceID = 0;
 	j9object_t inputByteArray = NULL;
 	j9object_t outputByteArray = NULL;
-	UDATA args[6];
+	UDATA args[5];
 	BOOLEAN freeName = FALSE;
 
 	U_8 buf[J9JFR_CLASSNAME_BUFFER_SIZE + sizeof(U_16)];
@@ -2011,25 +2018,29 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 
 	if (NULL == vm->jfrState.onRetransformUpcallMethod) {
 		PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, inputByteArray);
-		J9Class *jfrHelpersClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrHelpersUTF8), J9UTF8_LENGTH(&jfrHelpersUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
-		if (NULL == jfrHelpersClass) {
+		J9Class *jfrClassTransformerClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrClassTransformerUTF8), J9UTF8_LENGTH(&jfrClassTransformerUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+		if (NULL == jfrClassTransformerClass) {
 			goto popInputArrayAndDone;
 		}
-		vm->jfrState.onRetransformUpcallMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrHelpersClass, (J9ROMNameAndSignature *)&bytesForEagerInstrumentationNAS, jfrHelpersClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
+		vm->jfrState.onRetransformUpcallMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrClassTransformerClass, (J9ROMNameAndSignature *)&bytesForEagerInstrumentationNAS, jfrClassTransformerClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
 		if (NULL == vm->jfrState.onRetransformUpcallMethod) {
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			goto popInputArrayAndDone;
 		}
+		vmFuncs->initializeClass(currentThread, jfrClassTransformerClass);
 		inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+
+		if (VM_VMHelpers::exceptionPending(currentThread)) {
+			goto done;
+		}
 	}
 	args[0] = 0;
 	args[1] = (UDATA)traceID;
 	args[2] = (UDATA)FALSE;
 	args[3] = (UDATA)superClass->classObject;
 	args[4] = (UDATA)inputByteArray;
-	args[5] = (UDATA)(BOOLEAN)!isSameOrSuperClassOf(J9VMJAVALANGCLASS_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrEventClassRef)), superClass);
 
-	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.onRetransformUpcallMethod, TRUE, 6, args);
+	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.onRetransformUpcallMethod, TRUE, 5, args);
 	outputByteArray = (j9object_t)currentThread->returnValue;
 
 	if (VM_VMHelpers::exceptionPending(currentThread) || (NULL == outputByteArray)) {
@@ -2077,6 +2088,72 @@ jvmUpcallTransformArrayToList(J9VMThread *currentThread, j9object_t array)
 
 done:
 	return result;
+}
+
+void
+jvmUpcallsTransformJFREventClass(J9VMThread *currentThread, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9MemoryManagerFunctions *mmfns = vm->memoryManagerFunctions;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	j9object_t inputByteArray = NULL;
+	j9object_t outputByteArray = NULL;
+	UDATA args[2];
+
+	inputByteArray = mmfns->J9AllocateIndexableObject(currentThread, vm->byteReflectClass->arrayClass, (U_32)classDataLength, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+	if (NULL == inputByteArray) {
+		vmFuncs->setHeapOutOfMemoryError(currentThread);
+		goto done;
+	}
+
+	VM_ArrayCopyHelpers::memcpyToArray(currentThread, inputByteArray, (UDATA)0, classDataLength, (void *)classData);
+
+	if (NULL == vm->jfrState.transformJFREventClassMethod) {
+		PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, inputByteArray);
+		J9Class *jfrClassTransformerClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrClassTransformerUTF8), J9UTF8_LENGTH(&jfrClassTransformerUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+		if (NULL == jfrClassTransformerClass) {
+			goto popInputArrayAndDone;
+		}
+		vm->jfrState.transformJFREventClassMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrClassTransformerClass, (J9ROMNameAndSignature *)&transformJFREventClassNAS, jfrClassTransformerClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
+		if (NULL == vm->jfrState.transformJFREventClassMethod) {
+			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+			goto popInputArrayAndDone;
+		}
+		vmFuncs->initializeClass(currentThread, jfrClassTransformerClass);
+		inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+
+		if (VM_VMHelpers::exceptionPending(currentThread)) {
+			goto done;
+		}
+	}
+
+	args[0] = 0;
+	args[1] = (UDATA)inputByteArray;
+
+	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.transformJFREventClassMethod, TRUE, 2, args);
+	outputByteArray = (j9object_t)currentThread->returnValue;
+
+	if (VM_VMHelpers::exceptionPending(currentThread) || (NULL == outputByteArray)) {
+		goto done;
+	}
+
+	*newClassDataLength = (jint)J9INDEXABLEOBJECT_SIZE(currentThread, outputByteArray);
+	*newClassData = (U_8 *)j9mem_allocate_memory(*newClassDataLength, OMRMEM_CATEGORY_VM);
+	if (NULL == *newClassData) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto done;
+	}
+
+	VM_ArrayCopyHelpers::memcpyFromArray(currentThread, outputByteArray, (UDATA)0, (UDATA)0, *newClassDataLength, *newClassData);
+
+done:
+	return;
+
+popInputArrayAndDone:
+	inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+	goto done;
+
 }
 
 #if JAVA_SPEC_VERSION >= 17

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -26,20 +26,20 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 
 <suite id="JFR v2 Tests" timeout="3000">
 	<test id="Test JFRv2 cmdline option - no options">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording -version</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording -Xshare:off -version</command>
 		<output type="success" caseSensitive="yes" regex="no">OpenJ9</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 	</test>
 	<!-- See https://github.com/eclipse-openj9/openj9/issues/23980
 	<test id="Test JFRv2 cmdline option - memcheck">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -version</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xshare:off -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -version</command>
 		<output type="success" caseSensitive="yes" regex="no">OpenJ9</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>
 	</test>
 	-->
 	<test id="Test JFRv2 2min test">
-		<command>$EXE$ -Xtrace:print={j9vm.760,j9vm.773,j9vm.819} -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 200 20000 200</command>
+		<command>$EXE$ -Xtrace:print={j9vm.760,j9vm.773,j9vm.819} -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Xshare:off --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 200 20000 200</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="required" caseSensitive="yes" regex="no">0 / 200 complete</output>
 		<output type="failure" caseSensitive="yes" regex="no">omrthread_create(jfrSamplingThreadProc) failed</output>
@@ -47,7 +47,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">Buffer overflow happened while generating thread dump string</output>
 	</test>
 	<test id="Test JFRv2 with file">
-		<command>$EXE$ -Xtrace:print={j9vm.760,j9vm.773,j9vm.819} -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
+		<command>$EXE$ -Xtrace:print={j9vm.760,j9vm.773,j9vm.819} -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Xshare:off --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="required" caseSensitive="yes" regex="no">0 / 100 complete</output>
 		<output type="failure" caseSensitive="yes" regex="no">omrthread_create(jfrSamplingThreadProc) failed</output>
@@ -103,13 +103,13 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
 	</test>
 	<test id="Test JFRv2 with JMX">
-		<command>$EXE$ -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -version</command>
+		<command>$EXE$ -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Xshare:off -version</command>
 		<output type="success" caseSensitive="yes" regex="no">OpenJ9</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 	</test>
 	<!-- See https://github.com/eclipse-openj9/openj9/issues/23980
 	<test id="Test JFRv2 with JMX and memcheck">
-		<command>$EXE$ -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -version</command>
+		<command>$EXE$ -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -Dcom.sun.management.jmxremote -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.local.only=false  -Dcom.sun.management.jmxremote.port=9898 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=test1.jfr -Xshare:off -version</command>
 		<output type="success" caseSensitive="yes" regex="no">OpenJ9</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>
@@ -144,7 +144,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="failure" caseSensitive="yes" regex="no">jfr print: could not read recording</output>
 	</test>
 	<test id="Test JFRv2 with profile config">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording:filename=profile.jfr,dumponexit=true,settings=profile.jfc --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording:filename=profile.jfr,dumponexit=true,settings=profile.jfc -Xshare:off --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>
 		<output type="required" caseSensitive="yes" regex="no">0 / 100 complete</output>
 	</test>


### PR DESCRIPTION
- Remove final keywords in methods of jdk.jfr.Event so subclasses can be instrumented
- Always add methods to event classes
- Bug fix in JVM_getAllEventClasses()