### PR TITLE
Cache stringConstant results on JITServer to reduce ResolvedMethod_stringConstant messages

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -289,7 +289,7 @@ TR::CompilationInfoPerThreadRemote::CompilationInfoPerThreadRemote(TR::Compilati
     , _fieldAttributesCache(NULL)
     , _staticAttributesCache(NULL)
     , _nullClassSignatureCache(NULL)
-    , _isUnresolvedStrCache(NULL)
+    , _stringConstantCache(NULL)
     , _classUnloadReadMutexDepth(0)
     , _aotCacheStore(false)
     , _methodIndex((uint32_t)-1)
@@ -1705,32 +1705,16 @@ bool TR::CompilationInfoPerThreadRemote::classIsInNullClassSignatureCache(const 
     return _nullClassSignatureCache->find(clsp) != _nullClassSignatureCache->end();
 }
 
-/**
- * @brief Method executed by JITServer to cache unresolved string
- *
- * @param ramClass The ramClass of interest as part of the key
- * @param cpIndex The cpIndex of interest as part of the key
- * @param stringAttrs The value we are going to cache
- * @return void
- */
-void TR::CompilationInfoPerThreadRemote::cacheIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
-    const TR_IsUnresolvedString &stringAttrs)
+void TR::CompilationInfoPerThreadRemote::cacheStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
+    const TR_StringConstantData &data)
 {
-    cacheToPerCompilationMap(_isUnresolvedStrCache, std::make_pair(ramClass, cpIndex), stringAttrs);
+    cacheToPerCompilationMap(_stringConstantCache, std::make_pair(ramClass, cpIndex), data);
 }
 
-/**
- * @brief Method executed by JITServer to retrieve unresolved string
- *
- * @param ramClass The ramClass of interest as part of the key
- * @param cpIndex The cpIndex of interest as part of the key
- * @param attrs The value to be set by the API
- * @return returns true if found in cache else false
- */
-bool TR::CompilationInfoPerThreadRemote::getCachedIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
-    TR_IsUnresolvedString &stringAttrs)
+bool TR::CompilationInfoPerThreadRemote::getCachedStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
+    TR_StringConstantData &data)
 {
-    return getCachedValueFromPerCompilationMap(_isUnresolvedStrCache, std::make_pair(ramClass, cpIndex), stringAttrs);
+    return getCachedValueFromPerCompilationMap(_stringConstantCache, std::make_pair(ramClass, cpIndex), data);
 }
 
 /**
@@ -1745,7 +1729,7 @@ void TR::CompilationInfoPerThreadRemote::clearPerCompilationCaches()
     clearPerCompilationCache(_fieldAttributesCache);
     clearPerCompilationCache(_staticAttributesCache);
     clearPerCompilationCache(_nullClassSignatureCache);
-    clearPerCompilationCache(_isUnresolvedStrCache);
+    clearPerCompilationCache(_stringConstantCache);
 }
 
 /**

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -128,8 +128,8 @@ public:
     void addClassToNullClassSignatureCache(const ClassLoaderStringPair &clsp);
     bool classIsInNullClassSignatureCache(const ClassLoaderStringPair &clsp);
 
-    void cacheIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, const TR_IsUnresolvedString &stringAttrs);
-    bool getCachedIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_IsUnresolvedString &stringAttrs);
+    void cacheStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, const TR_StringConstantData &data);
+    bool getCachedStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_StringConstantData &data);
 
     void clearPerCompilationCaches();
     void deleteClientSessionData(uint64_t clientId, TR::CompilationInfo *compInfo, J9VMThread *compThread);
@@ -226,7 +226,7 @@ private:
     FieldOrStaticAttrTable_t *_fieldAttributesCache;
     FieldOrStaticAttrTable_t *_staticAttributesCache;
     NullClassSignatureCache_t *_nullClassSignatureCache;
-    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_IsUnresolvedString> *_isUnresolvedStrCache;
+    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_StringConstantData> *_stringConstantCache;
     int32_t _classUnloadReadMutexDepth;
     bool _aotCacheStore; // True if the result of this compilation will be stored in AOT cache
     uint32_t _methodIndex; // Index of the method being compiled in the array of methods of its defining class

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -985,25 +985,29 @@ TR_ResolvedMethod *TR_ResolvedJ9JITServerMethod::getResolvedVirtualMethod(TR::Co
 void *TR_ResolvedJ9JITServerMethod::stringConstant(I_32 cpIndex)
 {
     TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
+    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
+    TR_StringConstantData data;
+    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data))
+        return data._stringConstant;
     _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
     auto recv = _stream->read<void *, bool, bool>();
-
-    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
-    compInfoPT->cacheIsUnresolvedStr((TR_OpaqueClassBlock *)_ramClass, cpIndex,
-        TR_IsUnresolvedString(std::get<1>(recv), std::get<2>(recv)));
+    compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex,
+        TR_StringConstantData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv)));
     return std::get<0>(recv);
 }
 
 bool TR_ResolvedJ9JITServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
 {
     auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
-    TR_IsUnresolvedString stringAttrs;
-    if (compInfoPT->getCachedIsUnresolvedStr((TR_OpaqueClassBlock *)_ramClass, cpIndex, stringAttrs)) {
-        return optimizeForAOT ? stringAttrs._optimizeForAOTTrueResult : stringAttrs._optimizeForAOTFalseResult;
+    TR_StringConstantData data;
+    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data)) {
+        return optimizeForAOT ? data._optimizeForAOTTrueResult : data._optimizeForAOTFalseResult;
     } else {
-        _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedString, _remoteMirror, cpIndex,
-            optimizeForAOT);
-        return std::get<0>(_stream->read<bool>());
+        _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
+        auto recv = _stream->read<void *, bool, bool>();
+        compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex,
+            TR_StringConstantData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv)));
+        return optimizeForAOT ? std::get<1>(recv) : std::get<2>(recv);
     }
 }
 

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -985,21 +985,23 @@ TR_ResolvedMethod *TR_ResolvedJ9JITServerMethod::getResolvedVirtualMethod(TR::Co
 void *TR_ResolvedJ9JITServerMethod::stringConstant(I_32 cpIndex)
 {
     TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
+    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
+    TR_StringConstantData data;
+    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data))
+        return data._stringConstant;
     _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
     auto recv = _stream->read<void *, bool, bool>();
-
-    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
-    compInfoPT->cacheIsUnresolvedStr((TR_OpaqueClassBlock *)_ramClass, cpIndex,
-        TR_IsUnresolvedString(std::get<1>(recv), std::get<2>(recv)));
+    compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex,
+        TR_StringConstantData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv)));
     return std::get<0>(recv);
 }
 
 bool TR_ResolvedJ9JITServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
 {
     auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
-    TR_IsUnresolvedString stringAttrs;
-    if (compInfoPT->getCachedIsUnresolvedStr((TR_OpaqueClassBlock *)_ramClass, cpIndex, stringAttrs)) {
-        return optimizeForAOT ? stringAttrs._optimizeForAOTTrueResult : stringAttrs._optimizeForAOTFalseResult;
+    TR_StringConstantData data;
+    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data)) {
+        return optimizeForAOT ? data._optimizeForAOTTrueResult : data._optimizeForAOTFalseResult;
     } else {
         _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedString, _remoteMirror, cpIndex,
             optimizeForAOT);

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -104,6 +104,24 @@ struct TR_IsUnresolvedString {
     bool _optimizeForAOTFalseResult;
 };
 
+struct TR_StringConstantData {
+    TR_StringConstantData()
+        : _stringConstant(NULL)
+        , _optimizeForAOTTrueResult(false)
+        , _optimizeForAOTFalseResult(false)
+    {}
+
+    TR_StringConstantData(void *stringConstant, bool optimizeForAOTTrueResult, bool optimizeForAOTFalseResult)
+        : _stringConstant(stringConstant)
+        , _optimizeForAOTTrueResult(optimizeForAOTTrueResult)
+        , _optimizeForAOTFalseResult(optimizeForAOTFalseResult)
+    {}
+
+    void *_stringConstant;
+    bool _optimizeForAOTTrueResult;
+    bool _optimizeForAOTFalseResult;
+};
+
 // define a hash function for TR_ResolvedMethodKey
 namespace std {
 template<> struct hash<TR_ResolvedMethodKey> {


### PR DESCRIPTION
Caches the result of `stringConstant(cpIndex)` on the JITServer side to avoid sending repeated `ResolvedMethod_stringConstant` messages to the client for the same `(class, cpIndex)` pair within a compilation.

The cache uses `(TR_OpaqueClassBlock *, int32_t)` as the key, mirroring the existing `isUnresolvedString` cache, since `cpIndex` refers to a constant pool which is associated with a class rather than an individual resolved method.

Issue: https://github.ibm.com/runtimes/rt-tr-common-repo/issues/30