### PR TITLE
Throw an exception in JVM.createJFR(true)

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -498,6 +498,7 @@ Java_jdk_jfr_internal_JVM_createJFR(JNIEnv *env, jobject obj, jboolean simulateF
 
 	if (simulateFailure) {
 		rc = JNI_FALSE;
+		throwNewIllegalStateException(env, (char *)"Unable to start Jfr");
 		goto done;
 	}
 	vmFuncs->internalEnterVMFromJNI(currentThread);


### PR DESCRIPTION
Fixes: https://github.com/eclipse-openj9/openj9/issues/23717