### PR TITLE
Add implementation for JFR counterTime

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -58,8 +58,9 @@ Java_jdk_jfr_internal_JVM_beginRecording(JNIEnv *env, jobject obj)
 jlong JNICALL
 Java_jdk_jfr_internal_JVM_counterTime(JNIEnv *env, jclass clazz)
 {
-	// TODO: implementation
-	return 0;
+	J9VMThread *currentThread = (J9VMThread *) env;
+	PORT_ACCESS_FROM_VMC(currentThread);
+	return (jlong) j9time_nano_time();
 }
 
 jboolean JNICALL
@@ -543,8 +544,7 @@ Java_jdk_jfr_internal_JVM_isAvailable(JNIEnv *env, jobject obj)
 jdouble JNICALL
 Java_jdk_jfr_internal_JVM_getTimeConversionFactor(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return 0.0;
+	return 1.0;
 }
 
 jlong JNICALL

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_jdk17andUp.cpp
@@ -106,8 +106,13 @@ Java_jdk_jfr_internal_JVM_isExcluded__Ljava_lang_Thread_2(JNIEnv *env, jobject o
 jlong JNICALL
 Java_jdk_jfr_internal_JVM_getChunkStartNanos(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return 0;
+	J9VMThread *currentThread = (J9VMThread *) env;
+	J9JavaVM *vm = currentThread->javaVM;
+
+	if (!vm->internalVMFunctions->isJFRRecordingStarted(vm)) {
+		return -1;
+	}
+	return (jlong) vm->jfrState.chunkStartTime;
 }
 
 jlong JNICALL


### PR DESCRIPTION
Add native implementations for three` jdk.jfr.internal.JVM` methods:

- `counterTime()`: returns a monotonic timestamp via the port
  library's j9time_nano_time().
- `getTimeConversionFactor()`: returns 1.0, since counterTime()
  already returns nanoseconds and needs no further scaling.
- `getChunkStartNanos()`: returns vm->jfrState.chunkStartTime.
  Returns -1 if JFR recording has not been started, guarded via
  isJFRRecordingStarted().

Verified with `test/jdk/jdk/jfr/jvm/TestCounterTime.java`, which
checks that counterTime() is positive and strictly increasing
across calls.

Fixes: https://github.com/eclipse-openj9/openj9/issues/23725