### PR TITLE
Option to compile with GCR during idle

### DIFF
--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8425,7 +8425,7 @@ TR_MethodMetaData *TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrar
                         if (TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableSVMDuringStartup))
                             options->setOption(TR_UseSymbolValidationManager, false);
                     }
-
+                    static const char *compileWithGCRDuringIdle = feGetEnv("TR_CompileWithGCRDuringIdle");
                     // See if we need to insert GCR trees
                     if (!details.supportsInvalidation()
                         || options->getOptLevel()
@@ -8434,8 +8434,9 @@ TR_MethodMetaData *TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrar
                         options->setOption(TR_DisableGuardedCountingRecompilations);
                     } else if (vm->isAOT_DEPRECATED_DO_NOT_USE()
                         || (options->getOptLevel() < warm
-                            && !(that->_methodBeingCompiled->_jitStateWhenQueued == IDLE_STATE
-                                && that->getCompilationInfo()->getPersistentInfo()->getJitState() == IDLE_STATE))) {
+                            && (!(that->_methodBeingCompiled->_jitStateWhenQueued == IDLE_STATE
+                                    && that->getCompilationInfo()->getPersistentInfo()->getJitState() == IDLE_STATE)
+                                || compileWithGCRDuringIdle))) {
                         options->setInsertGCRTrees(); // This is a recommendation not a directive
                     }
 


### PR DESCRIPTION
In order the conserve CPU when the application running on top of the JVM is idle, the JIT will not insert GCR (guarded counting recompilation) code in methods that are queued for compilation during idle phase and are scheduled for compilation in idle phase. Such methods will be compiled at lower optimization levels and their only recourse for upgrade is sampling. The logic behind such a heuristic is that compilations triggered while the application is idling cannot be important for performance.
However, when load is applied for the first time to the application, there is a small window of time (< 500 ms) needed by the JVM to detect that the app is no longer idle. During this window, methods that could be important for performance are still compiled at lower opt levels and without GCR IL trees.

To aid with diagnosis of such performance issues, this commit adds an environment variable called `TR_CompileWithGCRDuringIdle`, which, when set, will disable the idle heuristic mentioned above, forcing the JIT to insert GCR IL trees in the compiled bodies.