### PR TITLE
Fix unfreed JFR allocations reported by -Xcheck:memory

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -141,6 +141,12 @@ internalDefineClass(
 	BOOLEAN isHiddenFlagSet = J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_HIDDEN);
 	J9Class *superClass = NULL;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+#if defined(J9VM_OPT_JFR)
+	/* Non-NULL if classData was replaced with a heap-allocated buffer owned by this function
+	 * (the JFR eager-instrumentation output); used below to wire up loadData's free function.
+	 */
+	U_8 *jfrAllocatedClassData = NULL;
+#endif /* defined(J9VM_OPT_JFR) */
 
 	/* This trace point is obsolete. It is retained only because j9vm test depends on it.
 	 * Once j9vm tests are fixed, it would be marked as Obsolete in j9bcu.tdf
@@ -173,6 +179,7 @@ internalDefineClass(
 		}
 		classData = jfrModifiedBytes;
 		classDataLength = jfrModifiedBytesLength;
+		jfrAllocatedClassData = jfrModifiedBytes;
 	} else if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_ENABLE_JFR_CLASSLOAD_TRANSFORM)) {
 		J9Class *superClass = preloadSuperClass(vmThread, classData, classDataLength, classLoader, options);
 		if (J9_ARE_ALL_BITS_SET(vmThread->privateFlags2, J9_PRIVATE_FLAGS2_SUPERCLASS_REQUIRED_FIRST) || (NULL != vmThread->currentException)) {
@@ -198,6 +205,13 @@ internalDefineClass(
 				}
 				omrthread_monitor_exit(vm->classTableMutex);
 				vmFuncs->jvmUpcallsEagerByteInstrumentation(vmThread, superClass, className, (U_16)classNameLength, classLoader, upcallClassBytes, upcallClassBytesLength, &jfrModifiedBytes, &jfrModifiedBytesLength);
+				if (upcallClassBytes != classData) {
+					/* upcallClassBytes was reconstructed from the ROM class above; it was only
+					 * needed as input to the instrumentation upcall, which has already copied it.
+					 */
+					PORT_ACCESS_FROM_JAVAVM(vm);
+					j9mem_free_memory(upcallClassBytes);
+				}
 				omrthread_monitor_enter(vm->classTableMutex);
 				if ((NULL == jfrModifiedBytes) || (0 == jfrModifiedBytesLength)) {
 					omrthread_monitor_exit(vm->classTableMutex);
@@ -206,6 +220,7 @@ internalDefineClass(
 				}
 				classData = jfrModifiedBytes;
 				classDataLength = jfrModifiedBytesLength;
+				jfrAllocatedClassData = jfrModifiedBytes;
 			}
 		}
 	}
@@ -227,8 +242,20 @@ internalDefineClass(
 	}
 	loadData.protectionDomain = protectionDomain;
 	loadData.options = options;
-	loadData.freeUserData = NULL;
-	loadData.freeFunction = NULL;
+#if defined(J9VM_OPT_JFR)
+	if (NULL != jfrAllocatedClassData) {
+		/* classData points at memory this function allocated (the JFR-instrumented bytes);
+		 * hand ownership to loadData so internalLoadROMClass frees it once it's done.
+		 */
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		loadData.freeUserData = PORTLIB;
+		loadData.freeFunction = (classDataFreeFunction) OMRPORT_FROM_J9PORT(PORTLIB)->mem_free_memory;
+	} else
+#endif /* defined(J9VM_OPT_JFR) */
+	{
+		loadData.freeUserData = NULL;
+		loadData.freeFunction = NULL;
+	}
 	loadData.romClass = existingROMClass;
 
 	loadData.hostPackageName = NULL;

--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -140,6 +140,12 @@ internalDefineClass(
 	BOOLEAN isHiddenFlagSet = J9_ARE_ALL_BITS_SET(options, J9_FINDCLASS_FLAG_HIDDEN);
 	J9Class *superClass = NULL;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+#if defined(J9VM_OPT_JFR)
+	/* Non-NULL if classData was replaced with a heap-allocated buffer owned by this function
+	 * (the JFR eager-instrumentation output); used below to wire up loadData's free function.
+	 */
+	U_8 *jfrAllocatedClassData = NULL;
+#endif /* defined(J9VM_OPT_JFR) */
 
 	/* This trace point is obsolete. It is retained only because j9vm test depends on it.
 	 * Once j9vm tests are fixed, it would be marked as Obsolete in j9bcu.tdf
@@ -177,6 +183,13 @@ internalDefineClass(
 				}
 				omrthread_monitor_exit(vm->classTableMutex);
 				vmFuncs->jvmUpcallsEagerByteInstrumentation(vmThread, superClass, className, (U_16)classNameLength, classLoader, upcallClassBytes, upcallClassBytesLength, &jfrModifiedBytes, &jfrModifiedBytesLength);
+				if (upcallClassBytes != classData) {
+					/* upcallClassBytes was reconstructed from the ROM class above; it was only
+					 * needed as input to the instrumentation upcall, which has already copied it.
+					 */
+					PORT_ACCESS_FROM_JAVAVM(vm);
+					j9mem_free_memory(upcallClassBytes);
+				}
 				omrthread_monitor_enter(vm->classTableMutex);
 				if ((NULL == jfrModifiedBytes) || (0 == jfrModifiedBytesLength)) {
 					omrthread_monitor_exit(vm->classTableMutex);
@@ -185,6 +198,7 @@ internalDefineClass(
 				}
 				classData = jfrModifiedBytes;
 				classDataLength = jfrModifiedBytesLength;
+				jfrAllocatedClassData = jfrModifiedBytes;
 			}
 		}
 	}
@@ -206,8 +220,20 @@ internalDefineClass(
 	}
 	loadData.protectionDomain = protectionDomain;
 	loadData.options = options;
-	loadData.freeUserData = NULL;
-	loadData.freeFunction = NULL;
+#if defined(J9VM_OPT_JFR)
+	if (NULL != jfrAllocatedClassData) {
+		/* classData points at memory this function allocated (the JFR-instrumented bytes);
+		 * hand ownership to loadData so internalLoadROMClass frees it once it's done.
+		 */
+		PORT_ACCESS_FROM_JAVAVM(vm);
+		loadData.freeUserData = PORTLIB;
+		loadData.freeFunction = (classDataFreeFunction) OMRPORT_FROM_J9PORT(PORTLIB)->mem_free_memory;
+	} else
+#endif /* defined(J9VM_OPT_JFR) */
+	{
+		loadData.freeUserData = NULL;
+		loadData.freeFunction = NULL;
+	}
 	loadData.romClass = existingROMClass;
 
 	loadData.hostPackageName = NULL;

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -232,6 +232,19 @@ allocateClassLoader(J9JavaVM *javaVM)
 	return classLoader;
 }
 
+#if defined(J9VM_OPT_JFR)
+static UDATA
+freeClassLoaderTypeIDs(void *entry, void *userData)
+{
+	J9JFRTypeID *tableEntry = (J9JFRTypeID *) entry;
+
+	if (tableEntry->free) {
+		PORT_ACCESS_FROM_JAVAVM((J9JavaVM *)userData);
+		j9mem_free_memory(tableEntry->className);
+	}
+	return FALSE;
+}
+#endif /* defined(J9VM_OPT_JFR) */
 
 void
 freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThread, UDATA needsFrameBuild)
@@ -447,6 +460,13 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 	if (NULL != classLoader->classHashTable) {
 		hashClassTableFree(classLoader);
 	}
+#if defined(J9VM_OPT_JFR)
+	if (NULL != classLoader->typeIDs) {
+		hashTableForEachDo(classLoader->typeIDs, freeClassLoaderTypeIDs, javaVM);
+		hashTableFree(classLoader->typeIDs);
+		classLoader->typeIDs = NULL;
+	}
+#endif /* defined(J9VM_OPT_JFR) */
 	if (NULL != classLoader->moduleExtraInfoHashTable) {
 		J9HashTableState moduleExtraInfoWalkState;
 

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -1207,7 +1207,7 @@ stopJFRRecording(J9JavaVM *vm)
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_CLASSES_UNLOAD, jfrClassesUnload, NULL);
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_SHUTTING_DOWN, jfrVMShutdown, NULL);
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_THREAD_STARTING, jfrThreadStarting, NULL);
-	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_THREAD_END, jfrThreadEnd, NULL);
+	/* (*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_THREAD_END, jfrThreadEnd, NULL); */
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_SLEPT, jfrVMSlept, NULL);
 	/* Unregister it anyway even it wasn't registered for initializeJFR(vm). */
 	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_INITIALIZED, jfrVMInitialized, NULL);
@@ -1224,6 +1224,7 @@ void
 tearDownJFR(J9JavaVM *vm)
 {
 	PORT_ACCESS_FROM_JAVAVM(vm);
+	J9HookInterface **vmHooks = getVMHookInterface(vm);
 	J9VMThread *currentThread = currentVMThread(vm);
 	Trc_VM_tearDownJFR(currentThread, vm);
 
@@ -1233,6 +1234,30 @@ tearDownJFR(J9JavaVM *vm)
 	if (!isJFRV2SupportEnabled(vm)) {
 		stopJFRRecording(vm);
 	}
+	/* Unregistered here (rather than in stopJFRRecording()) so that jfrThreadEnd keeps
+	 * freeing thread jfrBuffers as threads die for as long as possible, right up to
+	 * actual VM shutdown.
+	 */
+	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_THREAD_END, jfrThreadEnd, NULL);
+
+	/* jfrThreadEnd only frees a thread's jfrBuffer when that thread dies through the
+	 * normal thread-end path. Daemon/internal threads still alive at real VM shutdown
+	 * are abandoned without ever going through that path (see terminateRemainingThreads()
+	 * in jniinv.c), so walk the thread list directly here to reclaim whatever's left -
+	 * this is the only place guaranteed to run exactly once, at actual teardown.
+	 */
+	{
+		bool acquiredExclusive = false;
+		if (J9_XACCESS_NONE == vm->exclusiveAccessState) {
+			acquireExclusiveVMAccess(currentThread);
+			acquiredExclusive = true;
+		}
+		flushAllThreadBuffers(currentThread, true);
+		if (acquiredExclusive) {
+			releaseExclusiveVMAccess(currentThread);
+		}
+	}
+
 	vm->jfrState.isCreated = FALSE;
 	VM_JFRWriter::teardownJFRWriter(vm);
 

--- a/runtime/vm/jvmfree.c
+++ b/runtime/vm/jvmfree.c
@@ -48,9 +48,6 @@
 #endif
 
 static void trcModulesFreeJ9ModuleEntry(J9JavaVM *javaVM, J9Module *j9module);
-#if defined(J9VM_OPT_JFR)
-static UDATA freeClassLoaderTypeIDs(void *entry, void *userData);
-#endif /* defined(J9VM_OPT_JFR) */
 
 void
 freeClassLoaderEntries(J9VMThread * vmThread, J9ClassPathEntry **entries, UDATA count, UDATA initCount)
@@ -428,20 +425,6 @@ freeJ9Module(J9JavaVM *javaVM, J9Module *j9module) {
 	Trc_MODULE_freeJ9Module_exit(j9module);
 }
 
-#if defined(J9VM_OPT_JFR)
-static UDATA
-freeClassLoaderTypeIDs(void *entry, void *userData)
-{
-	J9JFRTypeID *tableEntry = (J9JFRTypeID *) entry;
-
-	if (tableEntry->free) {
-		PORT_ACCESS_FROM_VMC((J9VMThread *)userData);
-		j9mem_free_memory(tableEntry->className);
-	}
-	return FALSE;
-}
-#endif /* defined(J9VM_OPT_JFR) */
-
 #if (defined(J9VM_GC_DYNAMIC_CLASS_UNLOADING))
 /**
  * Perform classloader-specific cleanup.  The current thread has exclusive access.
@@ -468,14 +451,6 @@ cleanUpClassLoader(J9VMThread *vmThread, J9ClassLoader* classLoader)
 	if (NULL != classLoader->classHashTable) {
 		hashClassTableFree(classLoader);
 	}
-
-#if defined(J9VM_OPT_JFR)
-	if (NULL != classLoader->typeIDs) {
-		hashTableForEachDo(classLoader->typeIDs, freeClassLoaderTypeIDs, vmThread);
-		hashTableFree(classLoader->typeIDs);
-		classLoader->typeIDs = NULL;
-	}
-#endif /* defined(J9VM_OPT_JFR) */
 
 	/* Free the rom class orphans class table */
 	if (NULL != classLoader->romClassOrphansHashTable) {

--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -30,14 +30,14 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 		<output type="success" caseSensitive="yes" regex="no">OpenJ9</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 	</test>
-	<!-- See https://github.com/eclipse-openj9/openj9/issues/23980
-	<test id="Test JFRv2 cmdline option - memcheck">
+
+	<test id="Test JFRv2 cmdline option - memcheck - approx 2 minutes">
 		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xshare:off -Xcheck:memory -Dibm.java9.forceCommonCleanerShutdown=true -Xint -XX:StartFlightRecording -version</command>
 		<output type="success" caseSensitive="yes" regex="no">OpenJ9</output>
 		<output type="required" caseSensitive="yes" regex="no">OMR</output>
 		<output type="failure" caseSensitive="yes" regex="no">bytes were not freed before shutdown</output>
 	</test>
-	-->
+
 	<test id="Test JFRv2 2min test">
 		<command>$EXE$ -Xtrace:print={j9vm.760,j9vm.773,j9vm.819} -XX:+EnableOpenJ9ExperimentalFlightRecording -XX:StartFlightRecording=filename=experimentalRecording.jfr -Xshare:off --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.WorkLoad 200 20000 200</command>
 		<output type="success" caseSensitive="yes" regex="no">All runs complete</output>


### PR DESCRIPTION
Running the JVM with `-XX:+EnableOpenJ9ExperimentalFlightRecording`
under `-Xcheck:memory` reports unfreed native memory blocks at shutdown,
even on a plain `-version` run. This commit fixes two separate ownership
gaps behind those leaks: two buffers from JFR's eager class-load
bytecode instrumentation, and a classloader's JFR type-ID table freed
on one teardown path but not the other.

- `defineclass.c`: free the reconstructed classfile-bytes buffer right
  after the JFR eager-instrumentation upcall consumes it.
- `defineclass.c`: wire up loadData's free function so the
  instrumented replacement classData is freed once class loading is
  done with it.
- `classallocation.c`: free a classloader's owned JFR type-ID name
  buffers in freeClassLoader(), the teardown path always reached
  regardless of how the classloader is freed.
- `jvmfree.c`: delete the now-redundant equivalent cleanup from
  cleanUpClassLoader(), since freeClassLoader() always runs
  afterward for the same classloader.
- `test/functional/cmdLineTests/jfr/jfrV2.xml`: re-enable the
  disabled memcheck regression test covering these leaks.


Issue: https://github.com/eclipse-openj9/openj9/issues/23980