### PR TITLE
Supporting Changes for Patchable JProfiling

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.cpp
@@ -55,6 +55,42 @@ void J9::CodeGenPhase::reportPhase(PhaseValue phase)
 
 int J9::CodeGenPhase::getNumPhases() { return static_cast<int>(TR::CodeGenPhase::LastJ9Phase); }
 
+void J9::CodeGenPhase::performJProfilingPatchSitesInitPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
+{
+    TR::Compilation *comp = cg->comp();
+    if (comp->getOptimizationPlan()->insertPatchableJProfiling() && comp->getRecompilationInfo() != NULL) {
+        uintptr_t key = reinterpret_cast<uintptr_t>(comp->getRecompilationInfo()->getJittedBodyInfo());
+        TR_BlockFrequencyInfo *info = TR_BlockFrequencyInfo::getCurrent(comp);
+        if (info != NULL) {
+            TR::list<TR::Instruction *> *counterBumpInstrList = cg->getJProfilingCounterBumpInstructionList();
+            if (!counterBumpInstrList->empty()) {
+                TR::JProfBFPatchSites *sites = new (comp->trPersistentMemory()) TR::JProfBFPatchSites(comp->trPersistentMemory(), counterBumpInstrList->size(), static_cast<size_t>(cg->getMaxLengthOfIncMemoryInstruction()));
+                for (auto iter = counterBumpInstrList->begin(); iter != counterBumpInstrList->end(); ++iter) {
+                    uint8_t *location = (*iter)->getBinaryEncoding();
+                    sites->add(location, (*iter)->getBinaryLength());
+                }
+                TR_JProfBlockFrequencyCounterSites *patchSites = TR_JProfBlockFrequencyCounterSites::make(comp->fe(), comp->trPersistentMemory(), key, sites, comp->getMetadataAssumptionList());
+                info->addJProfBlockFrequencyCounterPatchSites(patchSites);
+            }
+        }
+        TR_ValueProfileInfo *ValueInfo = TR_ValueProfileInfo::getCurrent(comp);
+        if (valueInfo != NULL) {
+            TR::list<TR::Instruction *> *jProfValueJmpInstrList = cg->getJProfValueBranchInstrList();
+            if (jProfValueJmpInstrList != NULL && !jProfValueJmpInstrList->empty()) {
+                TR::PatchSites *sites = new (comp->trPersistentMemory()) TR::PatchSites(comp->trPersistentMemory(), jProfJmpInstrList->size());
+                for (auto iter = jProfJmpInstrList->begin(); iter != jProfJmpInstrList->end(); ++iter) {
+                    uint8_t *location = (*iter)->getBinaryEncoding();
+                    uint8_t *destination = (*iter)->getLabelSymbol()->getCodeLocation();
+                    sites->add(location, destination);
+                }
+                uintptr_t key = reinterpret_cast<uintptr_t>(comp->getRecompilationInfo()->getJittedBodyInfo());
+                TR_JProfValueSites *valueProfPatchSites = TR_JProfValueSites::make(comp->fe(), comp->trPersistentMemory(), key, sites comp->getMetadataAssumptionList());
+                valueInfo->addJProfValueSites(valueProfPatchSites);
+            }
+        }
+    }
+}
+
 void J9::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
 {
     cg->fixUpProfiledInterfaceGuardTest();
@@ -124,6 +160,8 @@ const char *J9::CodeGenPhase::getName(TR::CodeGenPhase::PhaseValue phase)
             return "IdentifyUnneededByteConvsPhase";
         case FixUpProfiledInterfaceGuardTest:
             return "FixUpProfiledInterfaceGuardTest";
+        case JProfilingPatchSitesInitPhase:
+            return "JProfilingPatchSitesInitPhase";
         default:
             return OMR::CodeGenPhaseConnector::getName(phase);
     }

--- a/runtime/compiler/codegen/J9CodeGenPhase.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.hpp
@@ -48,13 +48,14 @@ protected:
 public:
     void reportPhase(PhaseValue phase);
     static void performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
+    static void performProcessRelocationPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performAllocateLinkageRegistersPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performPopulateOSRBufferPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performMoveUpArrayLengthStoresPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performInsertEpilogueYieldPointsPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performCompressedReferenceRematerializationPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performIdentifyUnneededByteConvsPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
-
+    static void performJProfilingPatchSitesInitPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     // override base class implementation because new phases are being added
     static int getNumPhases();
     const char *getName();

--- a/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
@@ -29,5 +29,5 @@
 
 // The entries in this file must be kept in sync with codegen/J9CodeGenPhaseFunctionTable.hpp
 FixUpProfiledInterfaceGuardTest, AllocateLinkageRegisters, PopulateOSRBufferPhase, MoveUpArrayLengthStoresPhase,
-    InsertEpilogueYieldPointsPhase, CompressedReferenceRematerializationPhase, IdentifyUnneededByteConvsPhase,
-    LastJ9Phase = IdentifyUnneededByteConvsPhase,
+    InsertEpilogueYieldPointsPhase, CompressedReferenceRematerializationPhase, IdentifyUnneededByteConvsPhase, JProfilingPatchSitesInitPhase,
+    LastJ9Phase = JProfilingPatchSitesInitPhase,

--- a/runtime/compiler/codegen/J9CodeGenPhaseFunctionTable.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhaseFunctionTable.hpp
@@ -35,3 +35,4 @@ TR::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase,
     TR::CodeGenPhase::performInsertEpilogueYieldPointsPhase, // InsertEpilogueYieldPointsPhase
     TR::CodeGenPhase::performCompressedReferenceRematerializationPhase,
     TR::CodeGenPhase::performIdentifyUnneededByteConvsPhase, // IdentifyUnneededByteConvsPhase
+    TR::CodeGenPhase::performJProfilingPatchSitesInitPhase, // JProfilingPatchSitesInitPhase

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4387,6 +4387,34 @@ void J9::CodeGenerator::jitAdd32BitPicToPatchOnClassRedefinition(void *classPoin
     }
 }
 
+void J9::CodeGenerator::initJProfCounterBumpInstrList()
+{
+    TR::Compilation *comp = self()->comp();
+    _jProfilingCounterBumpInstructionList = new (comp->trHeapMemory())
+        TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
+}
+
+void J9::CodeGenerator::addInstrToJProfCounterBumpInstrList(TR::Instruction *instr)
+{
+    TR_ASSERT_FATAL(_jProfilingCounterBumpInstructionList != NULL,
+        "Adding JProfiling Block counter increment instruction to list without initializing list\n");
+    _jProfilingCounterBumpInstructionList->push_front(instr);
+}
+
+void J9::CodeGenerator::initJProfValueBranchInstrList()
+{
+    TR::Compilation *comp = self()->comp();
+    __jProfilingValueProfilingBranchInstructions = new (comp->trHeapMemory())
+        TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
+}
+
+void J9::CodeGenerator::addInstrToJProfValueBranchInstrList(TR::Instruction *instr)
+{
+    TR_ASSERT_FATAL(__jProfilingValueProfilingBranchInstructions != NULL,
+        "Adding JProfiling Value Branch instruction to list without initializing list\n");
+    __jProfilingValueProfilingBranchInstructions->push_front(instr);
+}
+
 void J9::CodeGenerator::createHWPRecords()
 {
     if (self()->comp()->getPersistentInfo()->isRuntimeInstrumentationEnabled()

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -406,6 +406,9 @@ private:
 
     TR_BitVector *_liveMonitors;
 
+    TR::list<TR::Instruction *> *_jProfilingCounterBumpInstructionList;
+    TR::list<TR::Instruction *> *_jProfilingValueProfilingBranchInstructions;
+
 protected:
     // isTemporaryBased storageReferences just have a symRef but some other routines expect a node so use the below to
     // fill in this symRef on this node
@@ -426,6 +429,20 @@ public:
 
     // J9
     int32_t getInternalPtrMapBit() { return 31; }
+
+    // Patchable JProfiling
+    void initJProfCounterBumpInstrList();
+    void addInstrToJProfCounterBumpInstrList(TR::Instruction *instr);
+
+    TR::list<TR::Instruction *> *getJProfilingCounterBumpInstructionList()
+    {
+        return _jProfilingCounterBumpInstructionList;
+    }
+
+    void initJProfValueBranchInstrList();
+    void addInstrToJProfValueBranchInstrList(TR::Instruction *instr);
+
+    TR::list<TR::Instruction *> *getJProfValueBranchInstrList() { return _jProfilingValueProfilingBranchInstructions; }
 
     // --------------------------------------------------------------------------
     // GPU

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -51,6 +51,7 @@ enum TR_RuntimeAssumptionKind {
     RuntimeAssumptionOnStaticFinalFieldModification,
     RuntimeAssumptionOnMutableCallSiteChange,
     RuntimeAssumptionOnMethodBreakPoint,
+    RuntimeAssumptionOnPatchJProfBlockFreqCounters,
     LastAssumptionKind,
     // If you add another kind, add its name to the runtimeAssumptionKindNames array
     RuntimeAssumptionSentinel // This is special as there is no hashtable associated with it and we only create one of

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -52,6 +52,7 @@ enum TR_RuntimeAssumptionKind {
     RuntimeAssumptionOnMutableCallSiteChange,
     RuntimeAssumptionOnMethodBreakPoint,
     RuntimeAssumptionOnPatchJProfBlockFreqCounters,
+    RuntimeAssumptionOnPatchJProfValueBranch,
     LastAssumptionKind,
     // If you add another kind, add its name to the runtimeAssumptionKindNames array
     RuntimeAssumptionSentinel // This is special as there is no hashtable associated with it and we only create one of
@@ -70,6 +71,7 @@ char const * const runtimeAssumptionKindNames[LastAssumptionKind] = {
     "StaticFinalFieldModification",
     "MutableCallSiteChange",
     "OnMethodBreakpoint",
+    "OnPatchJProfValueBranch",
 };
 
 struct TR_RatHT {

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -67,7 +67,9 @@
 #include "runtime/ExternalProfiler.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "runtime/J9ValueProfiler.hpp"
-
+#if defined(TR_TARGET_X86)
+#include "x/runtime/X86Runtime.hpp"
+#endif
 //*************************************************************************
 //
 // Optimization passes to insert recompilation counters, etc
@@ -2762,4 +2764,84 @@ TR_PersistentProfileInfo *TR_JProfilerThread::deleteProfileInfo(TR_PersistentPro
     }
 
     return next;
+}
+
+TR_JProfBlockFrequencyCounterSites *TR_JProfBlockFrequencyCounterSites::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
+    uintptr_t key, TR::JProfBFPatchSites *sites, OMR::RuntimeAssumption **sentinel)
+{
+    TR_JProfBlockFrequencyCounterSites *res = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_JProfBlockFrequencyCounterSites));
+    if (mem) {
+        res = ::new (mem) TR_JProfBlockFrequencyCounterSites(pm, key, sites);
+        res->addToRAT(pm, RuntimeAssumptionOnPatchJProfBlockFreqCounters, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
+
+    return res;
+}
+
+void TR_JProfBlockFrequencyCounterSites::compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey)
+{
+    // Instead of patching flag, this routine will update the whole instruction
+    // (E.g, 6 Bytes on Z with NOP. PatchSites will hold two pointers, first one
+    // will have a location to update, second one is the original instruction
+    // which we would be caching. If modifying instruction to be NOP, the second
+    // entry would not be used, but in case if if we are enabling the profiling
+    // again, we will  update. NOP with the instruction to update counter which
+    // is already stored in the patch site second entry. _patchFlag zero means
+    // data collection is ON, in that case update all the increment code with
+    // NOP.
+    if (disableDataCollection && _patchFlag == 0) {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+            uint8_t instructionLength = *(uint8_t *)(_patchSites->getBumpInstructionPointer(i));
+#if defined(TR_TARGET_S390)
+            *(uint16_t *)cursor = 0xC004;
+#elif defined(TR_TARGET_X86)
+            if (instructionLength == 2) {
+                *(uint16_t *)cursor = 0x9066;
+            } else if (instructionLength == 3) {
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                // byte 2
+                cursor[2] = 0x00;
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = 0x1F0F
+            } else if (instructionLength == 4) {
+                *(uint32_t *)cursor = 0x00401F0F;
+            } else {
+                TR_ASSERT_FATAL(0, "Unexpected instruction lenght - Can not patch");
+            }
+#endif
+            _patchFlag = 1;
+        }
+    } else if (_patchFlag == 1) {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+            uint8_t *bumpInstruction = _patchSites->getBumpInstructionPointer(i);
+            uint8_t instructionLength = *bumpInstruction;
+            bumpInstruction += sizeof(uint8_t);
+#if defined(TR_TARGET_S390)
+            *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+#elif defined(TR_TARGET_X86)
+            if (instructionLength == 2) {
+                *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+            } else if (instructionLength == 3) {
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                cursor[2] = *(uint8_t *)(bumpInstruction + 2);
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+            } else if (instructionLength == 4) {
+                *(uint32_t *)cursor = *(uint32_t *)(bumpInstruction);
+            } else {
+                TR_ASSERT_FATAL(0, "Unexpected instruction lenght - Can not patch");
+            }
+#endif
+            _patchFlag = 0;
+        }
+    }
 }

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2845,3 +2845,66 @@ void TR_JProfBlockFrequencyCounterSites::compensate(TR_FrontEnd *vm, bool disabl
         }
     }
 }
+
+TR_JProfValueSites *TR_JProfValueSites::make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
+    TR::PatchSites *sites, OMR::RuntimeAssumption **sentinel)
+{
+    TR_JProfValueSites *res = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_JProfValueSites));
+    if (mem) {
+        res = ::new (mem) TR_JProfValueSites(pm, key, sites);
+        res->addToRAT(pm, RuntimeAssumptionOnPatchJProfValueBranch, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumption");
+    }
+    return res;
+}
+
+void TR_JProfValueSites::compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey)
+{
+    if (disableDataCollection) {
+        for (size_t i; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+#if defined(TR_TARGET_S390)
+            *(cursor + 1) &= 0x0F;
+#elif defined(TR_TARGET_X86)
+            if (*cursor == 0xeb) {
+                *(cursor + 1) = 0x00;
+            } else {
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                cursor[2] = 0x00;
+                cursor[3] = 0x00;
+                cursor[4] = 0x00;
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = 0x00e9;
+            }
+#endif
+        }
+    } else {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+#if defined(TR_TARGET_S390)
+            *(cursor + 1) |= 0xF0;
+#elif defined(TR_TARGET_X86)
+            uint8_t *destination = _patchSites->getDestination(i);
+            intptr_t destinationDistance = destination - cursor;
+            if (-126 <= destinationDistance && destinationDistance <= 129) {
+                intptr_t displacement = destinationDistance - 2;
+                *(uint16_t *)cursor = 0xeb + (displacement << 8);
+            } else {
+                intptrt_t displacement = destinationDistance - 5;
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                cursor[2] = (displacement >> 8);
+                cursor[3] = (displacement >> 16);
+                cursor[4] = (displacement >> 24);
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = 0xe9 + ((displacement & 0xff) << 8);
+            }
+#endif
+        }
+    }
+}

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -39,6 +39,7 @@
 #include "env/VMJ9.h"
 #include "infra/TRlist.hpp"
 #include "runtime/J9ValueProfiler.hpp"
+#include "runtime/J9RuntimeAssumptions.hpp"
 
 #define PROFILING_INVOCATION_COUNT (2)
 
@@ -714,6 +715,20 @@ public:
         _counterDerivationInfo = counterDerivationInfo;
     }
 
+    void addJProfBlockFrequencyCounterPatchSites(TR_JProfBlockFrequencyCounterSites *patchSites)
+    {
+        _jProfilingBlockFrequencyCounterPatchSites = patchSites;
+    }
+
+    TR_JProfBlockFrequencyCounterSites *getJProfBlockFrequencyCounterPatchSites()
+    {
+        return _jProfilingBlockFrequencyCounterPatchSites;
+    }
+
+    void setTimestampDataCollectionStarted(uint64_t timeStamp) { _timeStampWhenDataCollectionStarted = timeStamp; }
+
+    uint64_t getTimestampDataCollectionStarted() { return _timeStampWhenDataCollectionStarted; }
+
     void setEntryBlockNumber(int32_t number) { _entryBlockNumber = number; }
 
     bool isJProfilingData() { return _counterDerivationInfo != NULL; }
@@ -820,6 +835,9 @@ private:
     // Following flag is checked at runtime to know if we have queued this method for recompilation and skip the
     // profiling code
     int32_t _isQueuedForRecompilation;
+    void *_startPCOfBodyCollectingProfilingData;
+    uint64_t _timeStampWhenDataCollectionStarted;
+    TR_JProfBlockFrequencyCounterSites *_jProfilingBlockFrequencyCounterPatchSites;
 };
 
 TR_BlockFrequencyInfo *TR_BlockFrequencyInfo::get(TR_PersistentProfileInfo *profileInfo)

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -521,9 +521,13 @@ public:
 
     void dumpInfo(OMR::Logger *log);
 
+    void addJProfValueSites(TR_JProfValueSites *patchSites) { _jProfValueProfSites = patchSites; }
+    TR_JProfValueSites *getJProfValueSites() { return _jProfValueProfSites; }
+
 private:
     TR_AbstractProfilerInfo *_values[LastProfiler];
     TR_CallSiteInfo *_callSiteInfo;
+    TR_JProfValueSites *_jProfValueProfSites;
 };
 
 TR_ValueProfileInfo *TR_ValueProfileInfo::get(TR_PersistentProfileInfo *profileInfo)
@@ -744,6 +748,16 @@ public:
     TR::Node *generateBlockRawCountCalculationSubTree(TR::Compilation *comp, int32_t blockNumber, TR::Node *node);
     TR::Node *generateBlockRawCountCalculationSubTree(TR::Compilation *comp, TR::Node *node, bool trace);
     void dumpInfo(OMR::Logger *log);
+
+    void setJProfBlockFrequencyCounterSites(TR_JProfBlockFrequencyCounterSites *patchSites)
+    {
+        _jProfilingBlockFrequencyCounterPatchSites = patchSites;
+    }
+
+    TR_JProfBlockFrequencyCounterSites *getJProfBlockFrequencyCounterSites()
+    {
+        return _jProfilingBlockFrequencyCounterPatchSites;
+    }
 
     int32_t getCallCount();
     int32_t getMaxRawCount(int32_t callerIndex);

--- a/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
@@ -101,4 +101,127 @@ public:
     virtual uintptr_t hashCode() { return TR_RuntimeAssumptionTable::hashCode((uintptr_t)getPicLocation()); }
 };
 
+/**
+ * @brief
+ *    A runtime assumption for patching the block frequency counter increment
+ *    instructions in the compiled body that is collecting JProfiling data.
+ *    It provides means to patch the instruction to turn off / turn on profiling
+ *    data collection.
+ */
+class TR_JProfBlockFrequencyCounterSites : public OMR::ValueModifyRuntimeAssumption {
+protected:
+    /**
+     * @brief Construct a new tr TR_JProfBlockFrequencyCounterSites object
+     *
+     * @param pm TR_PersistentMemory object for allocating the runtime assumption
+     * @param key key against which this runtime assumption is stored in table
+     * @param sites TR::JProfBFPatchSites object that contains the information to
+     *              accommodate patching instructons in the compiled method with JProfiling
+     *              to turn-on / turn off data collection.
+     */
+    TR_JProfBlockFrequencyCounterSites(TR_PersistentMemory *pm, uintptr_t key, TR::JProfBFPatchSites *sites)
+        : OMR::ValueModifyRuntimeAssumption(pm, key)
+        , _patchSites(sites)
+        , _patchFlag(Enabled)
+    {}
+
+    enum State {
+        Enabled,
+        Disabled
+    };
+
+public:
+    /**
+     * @brief Get the first instruction in the _patchSites for patching
+     *
+     * @return uint8_t* first instruction pointer in the _patchSites
+     */
+    virtual uint8_t *getFirstAssumingPC() { return _patchSites->getFirstLocation(); }
+
+    /**
+     * @brief Get the last instruction in the _patchSites for patching
+     *
+     * @return uint8_t* last instruction pointer in the _patchSites
+     */
+    virtual uint8_t *getLastAssumingPC() { return _patchSites->getLastLocation(); }
+
+    /**
+     * @brief
+     *    Goes through the instruction list for the compiled method which
+     *    increments static counters in JProfiling Data for block frequencies,
+     *    and patches them to diasble / enable Profiling Data Collection.
+     *
+     * @param vm TR_FrontEnd vm object
+     * @param disableDataCollection boolean flag to disable / enable data collection
+     * @param newKey
+     */
+    virtual void compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey);
+
+    virtual void dumpInfo() { return; }
+
+    /**
+     * @brief Get the Runtime Assumption Kind
+     *
+     * @return TR_RuntimeAssumptionKind
+     */
+    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnPatchJProfBlockFreqCounters; }
+
+    /**
+     * @brief Construct a new TR_JProfBlockFrequencyCounterSites runtime assumption for the method
+     *
+     * @param fe TR_FrontEnd object to facilitate adding constructed runtime assumption to RAT
+     * @param pm TR_PersistentMemory Persistent Memory object to allocate the persistent object
+     * @param key key using which the runtime assumption will be added in the RAT
+     * @param sites TR::JProfBFPatchSites object containing information about
+     *                instructions to be patched in method
+     * @param sentinel Setinnel node for the RAT
+     * @return TR_JProfBlockFrequencyCounterSites* returns constructed TR_JProfBlockFrequencyCounterSites object for
+     * this method.
+     */
+    static TR_JProfBlockFrequencyCounterSites *make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
+        TR::JProfBFPatchSites *sites, OMR::RuntimeAssumption **sentinel);
+
+    /**
+     * @brief Cleans up data structure associated with this runtime assumption.
+     *
+     */
+    void reclaim() { TR::JProfBFPatchSites::reclaim(_patchSites); }
+
+    /**
+     * @brief Get TR::JProfBFPatchSites object containing information about instructions to be patched in method.
+     *
+     * @return TR::JProfBFPatchSites*
+     */
+    TR::JProfBFPatchSites *getPatchSites() { return _patchSites; }
+
+    /**
+     * @brief Compares this runtime assumption with another one.
+     *
+     * @param other Other Runtime Assumption agains which this one will be compared.alignas
+     * @return true if equal
+     * @return false if not equal
+     */
+    virtual bool equals(OMR::RuntimeAssumption &other)
+    {
+        if (other.getAssumptionKind() != RuntimeAssumptionOnPatchJProfBlockFreqCounters)
+            return false;
+
+        TR_JProfBlockFrequencyCounterSites *otherSite = reinterpret_cast<TR_JProfBlockFrequencyCounterSites *>(&other);
+        return _patchSites->equals(otherSite->getPatchSites());
+    }
+
+private:
+    /**
+     * @brief TR::JProfBFPatchSites object containing list of instruction addresses in this compiled code and the
+     * instruciton itself that updates static counters to facilitate patching of the sites to turn on / off profiling
+     * data collection.
+     */
+    TR::JProfBFPatchSites *_patchSites;
+
+    /**
+     * @brief A flag to indicate the current status of body associated with this runtime assumption.
+     *
+     */
+    uint8_t _patchFlag;
+};
 #endif

--- a/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
@@ -224,4 +224,105 @@ private:
      */
     uint8_t _patchFlag;
 };
+
+/**
+ * @brief A runtime assumption for patching guards that controls execution of
+ * JProfiling Value code. This assumption can patch the branch both ways - From
+ * unconditional Jump to NOP and vice-versa.
+ */
+class TR_JProfValueSites : public OMR::LocationRedirectRuntimeAssumption {
+protected:
+    /**
+     * @brief Construct a new TR_JProfValueSites assumption for the method.
+     *
+     * @param pm TR_PersistentMemory object for allocating the runtime assumption
+     * @param key key against which this runtime assumption is stored in table
+     * @param sites TR::PatchSites object that contains the list of location and
+     *              destination pairs.
+     */
+    TR_JProfValueSites(TR_PersistentMemory *pm, uintptr_t key, TR::PatchSites *sites)
+        : OMR::LocationRedirectRuntimeAssumption(pm, key)._patchSites(sites)
+    {}
+
+public:
+    /**
+     * @brief Get the location of first instruction in _patchsites for patching
+     *
+     * @return uint8_t* First instruction pointer in _patchsites
+     */
+    virtual uint8_t *getFirstAssumingPC() { return _patchSites->getFirstLocation(); }
+
+    /**
+     * @brief Get the location of last instruction in _patchsites for patching
+     *
+     * @return uint8_t*  Last instruction pointer in _patchsites
+     */
+    virtual uint8_t *getLastAssumingPC() { return _patchSites->getLastLocation(); }
+
+    /**
+     * @brief Goes through the list of instruction and location pair in the
+     * _patchSites and based on the passed boolean, patches the instruction from
+     * unconditional jump to NOP and vice-versa.
+     *
+     * @param vm TR_FrontEnd vm object
+     * @param disableDataCollection boolean flag to disable / enable data collection
+     * @param newKey
+     */
+    virtual void compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey);
+
+    virtual void dumpInfo() { return; }
+
+    /**
+     * @brief Get the Assumption Kind object
+     *
+     * @return TR_RuntimeAssumptionKind
+     */
+    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnPatchJProfValueBranch; }
+
+    /**
+     * @brief Construct a new TR_JProfValueSites runtime assumption for the method
+     *
+     * @param fe TR_FrontEnd object to facilitate adding constructed runtime assumption to RAT
+     * @param pm TR_PersistentMemory Persistent Memory object to allocate the persistent object
+     * @param key key using which the runtime assumption will be added in the RAT
+     * @param sites TR::PatchSites object containing information about
+     *                instructions to be patched in method
+     * @param sentinel Setinnel node for the RAT
+     * @return TR_JProfValueSites* returns constructed TR_JProfValueSites object for
+     * this method.
+     */
+    static TR_JProfValueSites *make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key, TR::PatchSites *sites,
+        OMR::RuntimeAssumption **sentinel);
+
+    /**
+     * @brief Cleans up data structure associated with this runtime assumption.
+     */
+    void reclaim() { TR::PatchSites::reclaim(_patchSites); }
+
+    /**
+     * @brief et TR::PatchSites object containing information about instructions to be patched in method.
+     *
+     * @return TR::PatchSites*
+     */
+    TR::PatchSites *getPatchSites() { return _patchSites; }
+
+    /**
+     * @brief Compares this runtime assumption with another one.
+     *
+     * @param other Other Runtime Assumption agains which this one will be compared.alignas
+     * @return true if equal
+     * @return false if not equal
+     */
+    virtual bool equals(OMR::RuntimeAssumption &other)
+    {
+        if (other.getAssumptionKind() != RuntimeAssumptionOnPatchJProfValueBranch)
+            return false;
+
+        TR_JProfValueSites *otherSite = reinterpret_cast<TR_JProfValueSites *>(&other);
+        return _patchSites->equals(otherSite->getPatchSites());
+    }
+
+private:
+    TR::PatchSites *_patchSites;
+};
 #endif


### PR DESCRIPTION
This PR adds following three changes. 

1. [Add lists in codegenerator to hold key profiling instructions](https://github.com/eclipse-openj9/openj9/commit/f0c4c6247b351b79855ffa08167c3c1f77c230dd)
2. [Add the runtime assumption for patching for JProfiling](https://github.com/eclipse-openj9/openj9/commit/b9cc8fdce330e1938cbc4049bc7ea69c2a1597fb)
3. [Codegen phase to perform initialization for PatchableJProfiling](https://github.com/eclipse-openj9/openj9/commit/0c4539a12f1eccd1806f38b8535d4dfac6697e1b)