### PR TITLE
Add infrastructure to recompile method in the face of phase change

### DIFF
--- a/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/codegen/CodeGenPhaseToPerform.hpp
@@ -27,7 +27,7 @@
 
 ReserveCodeCachePhase, FixUpProfiledInterfaceGuardTest,
 
-    InliningReportPhase,
+    RecompDueToPhaseChangeCode, InliningReportPhase,
 
     PopulateOSRBufferPhase, MoveUpArrayLengthStoresPhase, InsertEpilogueYieldPointsPhase, CleanUpFlagsPhase,
     LowerTreesPhase, InsertDebugCountersPhase, CompressedReferenceRematerializationPhase, AllocateLinkageRegisters,

--- a/runtime/compiler/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.cpp
@@ -60,6 +60,11 @@ void J9::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGener
     cg->fixUpProfiledInterfaceGuardTest();
 }
 
+void J9::CodeGenPhase::performRecompDueToPhaseChangeCode(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
+{
+    cg->insertRecompDueToPhaseChangeCode();
+}
+
 void J9::CodeGenPhase::performAllocateLinkageRegistersPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
 {
     TR::Compilation *comp = cg->comp();
@@ -124,6 +129,8 @@ const char *J9::CodeGenPhase::getName(TR::CodeGenPhase::PhaseValue phase)
             return "IdentifyUnneededByteConvsPhase";
         case FixUpProfiledInterfaceGuardTest:
             return "FixUpProfiledInterfaceGuardTest";
+        case RecompDueToPhaseChangeCode:
+            return "RecompDueToPhaseChangeCode";
         default:
             return OMR::CodeGenPhaseConnector::getName(phase);
     }

--- a/runtime/compiler/codegen/J9CodeGenPhase.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.hpp
@@ -48,6 +48,7 @@ protected:
 public:
     void reportPhase(PhaseValue phase);
     static void performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
+    static void performRecompDueToPhaseChangeCode(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performAllocateLinkageRegistersPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performPopulateOSRBufferPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performMoveUpArrayLengthStoresPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);

--- a/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhaseEnum.hpp
@@ -28,6 +28,6 @@
 #include "codegen/OMRCodeGenPhaseEnum.hpp"
 
 // The entries in this file must be kept in sync with codegen/J9CodeGenPhaseFunctionTable.hpp
-FixUpProfiledInterfaceGuardTest, AllocateLinkageRegisters, PopulateOSRBufferPhase, MoveUpArrayLengthStoresPhase,
-    InsertEpilogueYieldPointsPhase, CompressedReferenceRematerializationPhase, IdentifyUnneededByteConvsPhase,
-    LastJ9Phase = IdentifyUnneededByteConvsPhase,
+FixUpProfiledInterfaceGuardTest, RecompDueToPhaseChangeCode, AllocateLinkageRegisters, PopulateOSRBufferPhase,
+    MoveUpArrayLengthStoresPhase, InsertEpilogueYieldPointsPhase, CompressedReferenceRematerializationPhase,
+    IdentifyUnneededByteConvsPhase, LastJ9Phase = IdentifyUnneededByteConvsPhase,

--- a/runtime/compiler/codegen/J9CodeGenPhaseFunctionTable.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhaseFunctionTable.hpp
@@ -28,7 +28,7 @@
 #include "codegen/OMRCodeGenPhaseFunctionTable.hpp"
 
 // The entries in this file must be kept in sync with codegen/J9CodeGenPhaseEnum.hpp
-TR::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase,
+TR::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase, TR::CodeGenPhase::performRecompDueToPhaseChangeCode,
     TR::CodeGenPhase::performAllocateLinkageRegistersPhase, // AllocateLinkageRegisters
     TR::CodeGenPhase::performPopulateOSRBufferPhase, // PopulateOSRBufferPhase
     TR::CodeGenPhase::performMoveUpArrayLengthStoresPhase, // MoveUpArrayLengthStoresPhase

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3611,6 +3611,47 @@ bool J9::CodeGenerator::willGenerateNOPForVirtualGuard(TR::Node *node)
     return true;
 }
 
+void J9::CodeGenerator::insertRecompDueToPhaseChangeCode()
+{
+    TR::Compilation *comp = self()->comp();
+
+    if (!comp->getOption(TR_EnableRecompDueToPatchedNopableGuards) || comp->getMethodHotness() < hot
+        || comp->getOptimizationPlan()->getDoNotInsertPhaseChangeRecomp() || comp->isProfilingCompilation())
+        return;
+
+    OMR::Logger *log = comp->log();
+    TR::NodeChecklist checklist(comp);
+    TR::CFG *cfg = comp->getFlowGraph();
+    bool callToRecompDueToPhaseChangeAdded = false;
+    for (TR::AllBlockIterator iter(cfg, comp); iter.currentBlock() != NULL; ++iter) {
+        TR::Block *block = iter.currentBlock();
+        TR::TreeTop *treeTop = block->getLastRealTreeTop();
+        TR::Node *node = treeTop->getNode();
+        if (node->getOpCode().isIf() && node->isTheVirtualGuardForAGuardedInlinedCall()
+            && node->isNopableInlineGuard()) {
+            TR::Node *callNode = node->getVirtualCallNodeForGuard();
+            // If we have a callNode for this nopable virtual guard and have not yet
+            // inserted a recompilation trigger for it, insert a call to trigger
+            // recompilation due to phase change before the virtual call tree.
+            // The checklist prevents inserting duplicate triggers for the same callNode
+            // shared by multiple guards.
+            if (callNode != NULL && !checklist.contains(callNode)) {
+                TR::TreeTop *cursor = node->getVirtualCallTreeForGuard();
+                TR::TreeTop *recompCallTT = TR::TransformUtil::generateRetranslateCallerWithPrepTrees(callNode,
+                    TR_PersistentMethodInfo::RecompDueToPhaseChange, comp);
+                logprintf(comp->getOption(TR_TraceCG), log,
+                    "Inserting call to recompile method before call node n%dn\n", callNode->getGlobalIndex());
+                cursor->insertBefore(recompCallTT);
+                checklist.add(callNode);
+                if (!callToRecompDueToPhaseChangeAdded) {
+                    comp->getRecompilationInfo()->getJittedBodyInfo()->setCanRecompileDueToPhaseChange();
+                    callToRecompDueToPhaseChangeAdded = true;
+                }
+            }
+        }
+    }
+}
+
 /** \brief
  *       Following codegen phase walks the blocks in the CFG and checks for the virtual guard performing TR_MethodTest
  *       and guarding an inlined interface call.

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3611,6 +3611,42 @@ bool J9::CodeGenerator::willGenerateNOPForVirtualGuard(TR::Node *node)
     return true;
 }
 
+void J9::CodeGenerator::insertRecompDueToPhaseChangeCode()
+{
+    TR::Compilation *comp = self()->comp();
+
+    if (!comp->getOption(TR_EnableRecompDueToPatchedNopableGuards) || comp->getMethodHotness() < hot
+        || comp->getOptimizationPlan()->getDoNotInsertPhaseChangeRecomp() || comp->isProfilingCompilation())
+        return;
+
+    OMR::Logger *log = comp->log();
+    TR::NodeChecklist checklist(comp);
+    TR::CFG *cfg = comp->getFlowGraph();
+    for (TR::AllBlockIterator iter(cfg, comp); iter.currentBlock() != NULL; ++iter) {
+        TR::Block *block = iter.currentBlock();
+        TR::TreeTop *treeTop = block->getLastRealTreeTop();
+        TR::Node *node = treeTop->getNode();
+        if (node->getOpCode().isIf() && node->isTheVirtualGuardForAGuardedInlinedCall()
+            && node->isNopableInlineGuard()) {
+            TR::Node *callNode = node->getVirtualCallNodeForGuard();
+            // If we have a callNode for this nopable virtual guard and have not yet
+            // inserted a recompilation trigger for it, insert a call to trigger
+            // recompilation due to phase change before the virtual call tree.
+            // The checklist prevents inserting duplicate triggers for the same callNode
+            // shared by multiple guards.
+            if (callNode != NULL && !checklist.contains(callNode)) {
+                TR::TreeTop *cursor = node->getVirtualCallTreeForGuard();
+                TR::TreeTop *recompCallTT = TR::TransformUtil::generateRetranslateCallerWithPrepTrees(callNode,
+                    TR_PersistentMethodInfo::RecompDueToPhaseChange, comp);
+                logprintf(comp->getOption(TR_TraceCG), log,
+                    "Inserting call to recompile method before call node n%dn\n", callNode->getGlobalIndex());
+                cursor->insertBefore(recompCallTT);
+                checklist.add(callNode);
+            }
+        }
+    }
+}
+
 /** \brief
  *       Following codegen phase walks the blocks in the CFG and checks for the virtual guard performing TR_MethodTest
  *       and guarding an inlined interface call.

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -121,6 +121,20 @@ public:
 
     /**
      * \brief
+     *    Goes through all nopable virtual guards in this method and inserts
+     *    calls to recompile the method due to a phase change, placed before the
+     *    virtual call tree for each guard node. At runtime, if a nopable virtual
+     *    guard has been patched and we are taking the slow path to call the virtual
+     *    method instead of executing the optimized inlined code, the inserted call
+     *    will trigger recompilation and attribute it to the phase change event.
+     *    This should only be done at very high optimization levels, as the
+     *    performance cost of patching nopable guards in such a compilation is
+     *    significant.
+     */
+    void insertRecompDueToPhaseChangeCode();
+
+    /**
+     * \brief
      *      This query is used by both fixUpProfiledInterfaceGuardTest (a codegen level optimization) and virtual guard
      * evaluators to decide whether a NOP guard should be generated. It's used on all platforms and compilation phases
      * so that the decision of generating VG NOPs is made in a consistent way.

--- a/runtime/compiler/control/CompilationThread.cpp
+++ b/runtime/compiler/control/CompilationThread.cpp
@@ -8290,6 +8290,9 @@ TR_MethodMetaData *TR::CompilationInfoPerThreadBase::wrappedCompile(J9PortLibrar
                             if (methodInfo->getNumberOfInlinedMethodRedefinition() >= 2)
                                 options->setOption(TR_DisableNextGenHCR);
 
+                            if (methodInfo->getHasRecompiledDueToPhaseChange()) {
+                                p->_optimizationPlan->setDoNotInsertPhaseChangeRecomp(true);
+                            }
                             // If this method has been invalidated due to unloading of
                             // inlined code, then from now on we should only inline
                             // methods that will not be unloaded before this one.
@@ -10276,6 +10279,9 @@ void TR::CompilationInfoPerThreadBase::logCompilationSuccess(J9VMThread *vmThrea
                             break;
                         case TR_PersistentMethodInfo::RecompDueToJProfiling:
                             recompReason = 'J';
+                            break;
+                        case TR_PersistentMethodInfo::RecompDueToPhaseChange:
+                            recompReason = 'P';
                             break;
                         case TR_PersistentMethodInfo::RecompDueToInlinedMethodRedefinition:
                             recompReason = 'H';

--- a/runtime/compiler/control/J9CompilationStrategy.cpp
+++ b/runtime/compiler/control/J9CompilationStrategy.cpp
@@ -136,6 +136,28 @@ TR_OptimizationPlan *J9::CompilationStrategy::processEvent(TR_MethodEvent *event
                 hotnessLevel = bodyInfo->getHotness();
                 plan = TR_OptimizationPlan::alloc(hotnessLevel);
                 *newPlanCreated = true;
+            } else if (methodInfo->getReasonForRecompilation() == TR_PersistentMethodInfo::RecompDueToPhaseChange) {
+                TR_Hotness currentHotnessLevel = bodyInfo->getHotness();
+                hotnessLevel = currentHotnessLevel;
+                bool insertInstrumentation = false;
+                if (currentHotnessLevel == scorching) {
+                    hotnessLevel = veryHot;
+                    insertInstrumentation = true;
+                } else if (currentHotnessLevel == veryHot) {
+                    hotnessLevel = hot;
+                    insertInstrumentation = true;
+                }
+                plan = TR_OptimizationPlan::alloc(hotnessLevel);
+                // Recompilation of the method due to phase change is a one-time
+                // event per method. Update plan and persistent method info to
+                // prevent inserting the recompilation trigger due to phase change
+                // repeatedly.
+                plan->setDoNotInsertPhaseChangeRecomp(true);
+                methodInfo->setHasRecompiledDueToPhaseChange();
+                if (insertInstrumentation) {
+                    plan->setInsertInstrumentation();
+                }
+                *newPlanCreated = true;
             } else {
                 hotnessLevel = TR::Recompilation::getNextCompileLevel(event->_oldStartPC);
                 plan = TR_OptimizationPlan::alloc(hotnessLevel);

--- a/runtime/compiler/control/J9CompilationStrategy.cpp
+++ b/runtime/compiler/control/J9CompilationStrategy.cpp
@@ -136,6 +136,28 @@ TR_OptimizationPlan *J9::CompilationStrategy::processEvent(TR_MethodEvent *event
                 hotnessLevel = bodyInfo->getHotness();
                 plan = TR_OptimizationPlan::alloc(hotnessLevel);
                 *newPlanCreated = true;
+            } else if (methodInfo->getReasonForRecompilation() == TR_PersistentMethodInfo::RecompDueToPhaseChange) {
+                TR_Hotness currentHotnessLevel = bodyInfo->getHotness();
+                hotnessLevel = currentHotnessLevel;
+                bool insertInstrumentation = false;
+                if (currentHotnessLevel == scorching) {
+                    hotnessLevel = veryHot;
+                    insertInstrumentation = true;
+                } else if (currentHotnessLevel == veryHot) {
+                    hotnessLevel = hot;
+                    insertInstrumentation = true;
+                }
+                plan = TR_OptimizationPlan::alloc(hotnessLevel);
+                // Recompilation of the method due to phase change is a one-time
+                // event per method. Update plan and persistent method info to
+                // prevent inserting the recompilation trigger due to phase change
+                // repeatedly.
+                plan->setDoNotInsertPhaseChangeRecomp(true);
+                methodInfo->setHasRecompiledDueToPhaseChange();
+                if (insertInstrumentation) {
+                    plan->setInsertInstrumentation(true);
+                }
+                *newPlanCreated = true;
             } else {
                 hotnessLevel = TR::Recompilation::getNextCompileLevel(event->_oldStartPC);
                 plan = TR_OptimizationPlan::alloc(hotnessLevel);

--- a/runtime/compiler/control/J9CompilationStrategy.cpp
+++ b/runtime/compiler/control/J9CompilationStrategy.cpp
@@ -149,10 +149,9 @@ TR_OptimizationPlan *J9::CompilationStrategy::processEvent(TR_MethodEvent *event
                 }
                 plan = TR_OptimizationPlan::alloc(hotnessLevel);
                 // Recompilation of the method due to phase change is a one-time
-                // event per method. Update plan and persistent method info to
-                // prevent inserting the recompilation trigger due to phase change
+                // event per method. Update persistent method info to prevent
+                // inserting the recompilation trigger due to phase change
                 // repeatedly.
-                plan->setDoNotInsertPhaseChangeRecomp(true);
                 methodInfo->setHasRecompiledDueToPhaseChange();
                 if (insertInstrumentation) {
                     plan->setInsertInstrumentation(true);

--- a/runtime/compiler/control/J9Recompilation.cpp
+++ b/runtime/compiler/control/J9Recompilation.cpp
@@ -388,7 +388,8 @@ bool J9::Recompilation::couldBeCompiledAgain()
 {
     TR_ResolvedMethod *bondMethod = NULL;
     return self()->shouldBeCompiledAgain() || _compilation->usesPreexistence() || _compilation->getOption(TR_EnableHCR)
-        || _compilation->retainedMethods()->bondMethods().next(&bondMethod);
+        || _compilation->retainedMethods()->bondMethods().next(&bondMethod)
+        || self()->getJittedBodyInfo()->getCanRecompileDueToPhaseChange();
 }
 
 bool J9::Recompilation::shouldBeCompiledAgain() { return TR::Options::canJITCompile() && !_doNotCompileAgain; }

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -132,6 +132,10 @@ public:
 
     bool profilingDisabled() { return _flags.testAny(ProfilingDisabled); }
 
+    void setHasRecompiledDueToPhaseChange() { _flags.set(HasRecompiledDueToPhaseChange); }
+
+    bool getHasRecompiledDueToPhaseChange() { return _flags.testAny(HasRecompiledDueToPhaseChange); }
+
     void setDisableMiscSamplingCounterDecrementation() { _flags.set(DisableMiscSamplingCounterDecrementation); }
 
     bool disableMiscSamplingCounterDecrementation() { return _flags.testAny(DisableMiscSamplingCounterDecrementation); }
@@ -305,6 +309,7 @@ public:
         RecompDueToJProfiling = 0x000B0000,
         RecompDueToInlinedMethodRedefinition = 0x000C0000,
         RecompDueToCRIU = 0x000D0000,
+        RecompDueToPhaseChange = 0x000E0000,
 
         // NOTE: recompilations due to EDO decrementation cannot be tracked precisely
         // because they are triggered from a snippet (must change the code for snippet)
@@ -322,6 +327,10 @@ public:
         IsInDataCache = 0x00800000, // This TR_PersistentMethodInfo is stored in the datacache for AOT
 
         IsInhibitRecompilation = 0x01000000,
+
+        HasRecompiledDueToPhaseChange
+            = 0x02000000, // Flag is set on persistent method info to prevent further compilations of this method with
+                          // recompilation trigger due to phase change.
 
         lastFlag = 0x80000000
     };

--- a/runtime/compiler/control/RecompilationInfo.hpp
+++ b/runtime/compiler/control/RecompilationInfo.hpp
@@ -489,6 +489,10 @@ public:
 
     void setUsesJProfiling() { _flags.set(UsesJProfiling, true); }
 
+    bool getCanRecompileDueToPhaseChange() { return _flags.testAny(CanRecompileDueToPhaseChange); }
+
+    void setCanRecompileDueToPhaseChange() { _flags.set(CanRecompileDueToPhaseChange, true); }
+
     // used in dump recompilations
     void *getStartPCAfterPreviousCompile() { return _startPCAfterPreviousCompile; }
 
@@ -573,7 +577,8 @@ public:
         UsesGCR = 0x0800,
         ReducedWarm = 0x1000, // Warm body was optimized to a lesser extent (NoServer) to reduce compilation time
         UsesSamplingJProfiling = 0x2000, // Body has samplingJProfiling code
-        UsesJProfiling = 0x4000 // Body has jProfiling code
+        UsesJProfiling = 0x4000, // Body has jProfiling code
+        CanRecompileDueToPhaseChange = 0x8000 // Body has code to identify phase change and recompile
     };
 
     // ### IMPORTANT ###

--- a/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
+++ b/runtime/compiler/z/codegen/CodeGenPhaseToPerform.hpp
@@ -27,7 +27,7 @@
 
 ReserveCodeCachePhase, FixUpProfiledInterfaceGuardTest,
 
-    InliningReportPhase,
+    RecompDueToPhaseChangeCode, InliningReportPhase,
 
     InMemoryLoadStoreMarkingPhase, PopulateOSRBufferPhase, MoveUpArrayLengthStoresPhase, InsertEpilogueYieldPointsPhase,
     CleanUpFlagsPhase, SetBranchOnCountFlagPhase, LowerTreesPhase, InsertDebugCountersPhase,


### PR DESCRIPTION
This PR adds following set of changes. 
1. Infrastructure to facilitate recompilation in the face of the phase change in application. If a recompilation is triggered such way, the infrastructure prepares the optimization plan to trigger the recompilation with profiling enabled and updates the persistent method info with the flag so that further recompilation due to same reason can be avoided.
2. Scans through the call target of the Nopable Inlined Guards and inserts a call to trigger recompilation if the nopable guard in the method has been patched.