### PR TITLE
Correct use of J9VM_OPT_VALHALLA_VALUE_TYPES

### DIFF
--- a/runtime/rasdump/heapdump.cpp
+++ b/runtime/rasdump/heapdump.cpp
@@ -2315,13 +2315,13 @@ int BinaryHeapDumpWriter::getObjectHashCode(j9object_t object) {
 #else /* defined(J9VM_OPT_NEW_OBJECT_HASH) */
 	int hashCode = (object->flags & OBJECT_HEADER_HASH_MASK) >> 16;
 	if (hashCode == 0) {
-#if defined(J9VM_OPT_VALHALLA_VALUETYPES)
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 		/* Do not compute hash code for value objects during heap dump
 		 * generation (it could trigger GC): Just return zero.
 		 */
-#else /* defined(J9VM_OPT_VALHALLA_VALUETYPES) */
+#else /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		objectHashCode(_VirtualMachine, object);
-#endif /* defined(J9VM_OPT_VALHALLA_VALUETYPES) */
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 		hashCode = (object->flags & OBJECT_HEADER_HASH_MASK) >> 16;
 	}
 #endif /* defined(J9VM_OPT_NEW_OBJECT_HASH) */


### PR DESCRIPTION
`J9VM_OPT_VALHALLA_VALUETYPES` (without the final underscore) is never defined.