### PR TITLE
Refactor indexable object hash slot offset calculation

### DIFF
--- a/runtime/gc/gctable.c
+++ b/runtime/gc/gctable.c
@@ -254,6 +254,7 @@ J9MemoryManagerFunctions MemoryManagerFunctions = {
 	j9gc_objaccess_postStoreClassToClassLoader,
 	j9gc_objaccess_postStoreModuleToClassLoader,
 	j9gc_objaccess_getObjectHashCode,
+	j9gc_objaccess_getIndexableObjectHashSlotOffset,
 	j9gc_createJavaLangString,
 	j9gc_createJavaLangStringWithUTFCache,
 	j9gc_internString,

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -2549,6 +2549,12 @@ MM_ObjectAccessBarrier::getObjectHashCode(J9JavaVM *vm, J9Object *object)
 	return _extensions->objectModel.getObjectHashCode(vm, object);
 }
 
+UDATA
+MM_ObjectAccessBarrier::getIndexableObjectHashSlotOffset(J9JavaVM *vm, J9IndexableObject *arrayPtr)
+{
+	return _extensions->indexableObjectModel.getHashcodeOffset(arrayPtr);
+}
+
 void
 MM_ObjectAccessBarrier::setFinalizeLink(j9object_t object, j9object_t value)
 {

--- a/runtime/gc_base/ObjectAccessBarrier.hpp
+++ b/runtime/gc_base/ObjectAccessBarrier.hpp
@@ -459,7 +459,16 @@ public:
 	 * @return the persistent, basic hash code for the object 
 	 */
 	I_32 getObjectHashCode(J9JavaVM *vm, J9Object *object);
-	
+
+	/**
+	 * Determine the byte offset from the start of an indexable object to the hash slot.
+	 *
+	 * @param vm[in] the VM
+	 * @param arrayPtr[in] the indexable object
+	 * @return the offset of the hash slot
+	 */
+	UDATA getIndexableObjectHashSlotOffset(J9JavaVM *vm, J9IndexableObject *arrayPtr);
+
 	/**
 	 * Set the finalize link field of object to value.
 	 * @param object the object to modify

--- a/runtime/gc_base/accessBarrier.cpp
+++ b/runtime/gc_base/accessBarrier.cpp
@@ -779,6 +779,13 @@ j9gc_objaccess_getObjectHashCode(J9JavaVM *vm, J9Object* object)
 	return barrier->getObjectHashCode(vm, object);
 }
 
+UDATA
+j9gc_objaccess_getIndexableObjectHashSlotOffset(J9JavaVM *vm, J9IndexableObject *arrayPtr)
+{
+	MM_ObjectAccessBarrier *barrier = MM_GCExtensions::getExtensions(vm)->accessBarrier;
+	return barrier->getIndexableObjectHashSlotOffset(vm, arrayPtr);
+}
+
 void*
 j9gc_objaccess_jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jarray array, jboolean *isCopy)
 {

--- a/runtime/gc_base/gc_internal.h
+++ b/runtime/gc_base/gc_internal.h
@@ -267,6 +267,7 @@ extern J9_CFUNC void j9gc_objaccess_recentlyAllocatedObject(J9VMThread *vmThread
 extern J9_CFUNC void j9gc_objaccess_postStoreClassToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Class *srcClass);
 extern J9_CFUNC void j9gc_objaccess_postStoreModuleToClassLoader(J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Module *srcModule);
 extern J9_CFUNC I_32 j9gc_objaccess_getObjectHashCode(J9JavaVM *vm, J9Object* object);
+extern J9_CFUNC UDATA j9gc_objaccess_getIndexableObjectHashSlotOffset(J9JavaVM *vm, J9IndexableObject *arrayPtr);
 extern J9_CFUNC void* j9gc_objaccess_jniGetPrimitiveArrayCritical(J9VMThread* vmThread, jarray array, jboolean *isCopy);
 extern J9_CFUNC void j9gc_objaccess_jniReleasePrimitiveArrayCritical(J9VMThread* vmThread, jarray array, void * elems, jint mode);
 extern J9_CFUNC const jchar* j9gc_objaccess_jniGetStringCritical(J9VMThread* vmThread, jstring str, jboolean *isCopy);

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -25,6 +25,7 @@
 #define OBJECTACCESSBARRIERAPI_HPP_
 
 #include "j9cfg.h"
+#include <assert.h>
 
 #if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 #if OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES
@@ -2441,6 +2442,98 @@ public:
 		{
 			return false;
 		}
+	}
+
+	static VMINLINE UDATA
+	inlineIndexableObjectDataSize(U_32 numElements, J9Class *objectClass)
+	{
+		UDATA dataSize = 0;
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+		if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
+			dataSize = (UDATA)numElements * J9ARRAYCLASS_GET_STRIDE(objectClass);
+		} else
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+		{
+			J9ROMArrayClass *romClass = (J9ROMArrayClass *)objectClass->romClass;
+			dataSize = (UDATA)numElements << (romClass->arrayShape & 0x0000FFFF);
+		}
+		return dataSize;
+	}
+
+	static VMINLINE UDATA
+	inlineIndexableObjectHashSlotOffset(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass)
+	{
+		UDATA offset = 0;
+		U_32 numElements = 0;
+		if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+			numElements = ((J9IndexableObjectContiguousCompressed *)objectPointer)->size;
+		} else {
+			numElements = ((J9IndexableObjectContiguousFull *)objectPointer)->size;
+		}
+#if defined(J9VM_ENV_DATA64)
+		if (J9IndexableObjectLayout_NoDataAddr_NoArraylet == vm->indexableObjectLayout) {
+			/* Standard GC. */
+			if (0 != numElements) {
+				/* Hash slot is after array data. */
+				UDATA dataSize = inlineIndexableObjectDataSize(numElements, objectClass);
+				offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
+			} else {
+				/* Zero-length array: hash slot is right after the discontiguous header. */
+				offset = vm->discontiguousIndexableHeaderSize;
+			}
+		} else if (J9IndexableObjectLayout_DataAddr_NoArraylet == vm->indexableObjectLayout) {
+			/* Balanced GC. */
+			if (0 != numElements) {
+				void *dataAddr = NULL;
+				void *inlineDataStart = NULL;
+				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+					dataAddr = ((J9IndexableObjectWithDataAddressContiguousCompressed *)objectPointer)->dataAddr;
+				} else {
+					dataAddr = ((J9IndexableObjectWithDataAddressContiguousFull *)objectPointer)->dataAddr;
+				}
+				inlineDataStart = (void *)((UDATA)objectPointer + vm->contiguousIndexableHeaderSize);
+				if (dataAddr == inlineDataStart) {
+					/* Adjacent data: hash slot is after the array data. */
+					UDATA dataSize = inlineIndexableObjectDataSize(numElements, objectClass);
+					offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
+				} else {
+					/* Non-adjacent data: hash slot is right after the contiguous header. */
+					offset = vm->contiguousIndexableHeaderSize;
+				}
+			} else {
+				/* Zero-length array: hash slot is right after the discontiguous header. */
+				offset = vm->discontiguousIndexableHeaderSize;
+			}
+		} else {
+			/* Arraylet Layout. */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			/* Value types are not compatible with arraylets and shouldn't reach this path. */
+			assert(!J9_IS_J9CLASS_VALUETYPE(objectClass));
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+			offset = vm->memoryManagerFunctions->j9gc_objaccess_getIndexableObjectHashSlotOffset(vm, (J9IndexableObject *)objectPointer);
+		}
+#else /* defined(J9VM_ENV_DATA64) */
+		if (0 != numElements) {
+			/* Contiguous non-zero length array. */
+			UDATA dataSize = inlineIndexableObjectDataSize(numElements, objectClass);
+			offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
+		} else {
+			/*
+			 * If numElements is zero, this could be either a zero-length array
+			 * or an arraylet. Read the second size field, which is non-zero
+			 * for an arraylet.
+			 */
+			U_32 numArrayletElements = ((J9IndexableObjectDiscontiguous *)objectPointer)->size;
+			if (0 == numArrayletElements) {
+				/* Zero length Array. */
+				offset = vm->discontiguousIndexableHeaderSize;
+			} else {
+				/* Arraylet layout. */
+				offset = vm->memoryManagerFunctions->j9gc_objaccess_getIndexableObjectHashSlotOffset(vm, (J9IndexableObject *)objectPointer);
+			}
+		}
+#endif /* defined(J9VM_ENV_DATA64) */
+		return offset;
 	}
 
 protected:

--- a/runtime/gc_include/ObjectAccessBarrierAPI.hpp
+++ b/runtime/gc_include/ObjectAccessBarrierAPI.hpp
@@ -25,6 +25,7 @@
 #define OBJECTACCESSBARRIERAPI_HPP_
 
 #include "j9cfg.h"
+#include <assert.h>
 
 #if defined(OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES)
 #if OMR_OVERRIDE_COMPRESS_OBJECT_REFERENCES
@@ -2441,6 +2442,88 @@ public:
 		{
 			return false;
 		}
+	}
+
+	static VMINLINE UDATA
+	inlineIndexableObjectDataSize(U_32 numElements, J9Class *objectClass)
+	{
+		J9ROMArrayClass *romClass = (J9ROMArrayClass *)objectClass->romClass;
+		return (UDATA)numElements << (romClass->arrayShape & 0x0000FFFF);
+	}
+
+	static VMINLINE UDATA
+	inlineIndexableObjectHashSlotOffset(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass)
+	{
+		UDATA offset = 0;
+		U_32 numElements = 0;
+		if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+			numElements = ((J9IndexableObjectContiguousCompressed *)objectPointer)->size;
+		} else {
+			numElements = ((J9IndexableObjectContiguousFull *)objectPointer)->size;
+		}
+		if (J9IndexableObjectLayout_NoDataAddr_NoArraylet == vm->indexableObjectLayout) {
+			/* Standard GC. */
+			if (0 != numElements) {
+				/* Hash slot is after array data. */
+				UDATA dataSize = 0;
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+				if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
+					dataSize = (UDATA)numElements * J9ARRAYCLASS_GET_STRIDE(objectClass);
+				} else
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+				{
+					dataSize = inlineIndexableObjectDataSize(numElements, objectClass);
+				}
+				offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
+			} else {
+				/* Zero-length array: hash slot is right after the discontiguous header. */
+				offset = vm->discontiguousIndexableHeaderSize;
+			}
+		} else if (J9IndexableObjectLayout_DataAddr_NoArraylet == vm->indexableObjectLayout) {
+#if defined(J9VM_ENV_DATA64)
+			/* Balanced GC. */
+			if (0 != numElements) {
+				void *dataAddr = NULL;
+				void *inlineDataStart = NULL;
+				if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
+					dataAddr = ((J9IndexableObjectWithDataAddressContiguousCompressed *)objectPointer)->dataAddr;
+				} else {
+					dataAddr = ((J9IndexableObjectWithDataAddressContiguousFull *)objectPointer)->dataAddr;
+				}
+				inlineDataStart = (void *)((UDATA)objectPointer + vm->contiguousIndexableHeaderSize);
+				if (dataAddr == inlineDataStart) {
+					/* Adjacent data: hash slot is after the array data. */
+					uintptr_t dataSize = 0;
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+					if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
+						dataSize = (UDATA)numElements * J9ARRAYCLASS_GET_STRIDE(objectClass);
+					} else
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+					{
+						dataSize = inlineIndexableObjectDataSize(numElements, objectClass);
+					}
+					offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
+				} else {
+					/* Non-adjacent data: hash slot is right after the contiguous header. */
+					offset = vm->contiguousIndexableHeaderSize;
+				}
+			} else {
+				/* Zero-length array: hash slot is right after the discontiguous header. */
+				offset = vm->discontiguousIndexableHeaderSize;
+			}
+#else /* defined(J9VM_ENV_DATA64) */
+			/* dataAddr field does not exist on 32-bit platforms, this layout is unreachable. */
+			assert(false);
+#endif /* defined(J9VM_ENV_DATA64) */
+		} else {
+			/* Arraylet Layout. */
+#if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
+			/* Value types are not compatible with arraylets and shouldn't reach this path. */
+			assert(!J9_IS_J9CLASS_VALUETYPE(objectClass));
+#endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
+			offset = vm->memoryManagerFunctions->j9gc_objaccess_getIndexableObjectHashSlotOffset(vm, (J9IndexableObject *)objectPointer);
+		}
+		return offset;
 	}
 
 protected:

--- a/runtime/oti/ObjectHash.hpp
+++ b/runtime/oti/ObjectHash.hpp
@@ -457,14 +457,12 @@ private:
 						J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
 						if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
 							I_32 storedHash = 0;
+							UDATA hashSlotOffset = 0;
 							if (J9CLASS_IS_ARRAY(fieldClazz)) {
-								if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
-									storedHash = inlineIndexableObjectHashCodeCompressed(vm, fieldObject, fieldClazz);
-								} else {
-									storedHash = inlineIndexableObjectHashCodeFull(vm, fieldObject, fieldClazz);
-								}
+								hashSlotOffset = MM_ObjectAccessBarrierAPI::inlineIndexableObjectHashSlotOffset(vm, fieldObject, fieldClazz);
+								storedHash = *(I_32 *)((UDATA)fieldObject + hashSlotOffset);
 							} else {
-								UDATA hashSlotOffset = fieldClazz->backfillOffset;
+								hashSlotOffset = fieldClazz->backfillOffset;
 								storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
 							}
 							if (0 != storedHash) {
@@ -640,14 +638,12 @@ mixHash:
 						J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
 						if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
 							I_32 storedHash = 0;
+							UDATA hashSlotOffset = 0;
 							if (J9CLASS_IS_ARRAY(fieldClazz)) {
-								if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
-									storedHash = inlineIndexableObjectHashCodeCompressed(vm, fieldObject, fieldClazz);
-								} else {
-									storedHash = inlineIndexableObjectHashCodeFull(vm, fieldObject, fieldClazz);
-								}
+								hashSlotOffset = MM_ObjectAccessBarrierAPI::inlineIndexableObjectHashSlotOffset(vm, fieldObject, fieldClazz);
+								storedHash = *(I_32 *)((UDATA)fieldObject + hashSlotOffset);
 							} else {
-								UDATA hashSlotOffset = fieldClazz->backfillOffset;
+								hashSlotOffset = fieldClazz->backfillOffset;
 								storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
 							}
 							if (0 != storedHash) {
@@ -761,91 +757,6 @@ public:
 	}
 
 	/**
-	 * Fetch objectPointer's hashcode when objectPointer is a contiguous object.
-	 *
-	 * @pre objectPointer must be a valid object reference
-	 *
-	 * @param vm			a java VM
-	 * @param objectPointer 	a valid object reference
-	 * @param objectClass 	class of objectPointer
-	 * @param offset 	objectPointer size offset
-	 */
-	static VMINLINE I_32
-	inlineIndexableContiguousObjectHashCode(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass, UDATA offset)
-	{
-		uintptr_t dataSize = 0;
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-		if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
-			dataSize = offset * J9ARRAYCLASS_GET_STRIDE(objectClass);
-		} else
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-		{
-			J9ROMArrayClass *romClass = (J9ROMArrayClass *)objectClass->romClass;
-			dataSize = offset << (romClass->arrayShape & 0x0000FFFF);
-		}
-		offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
-		return *(I_32 *)((UDATA)objectPointer + offset);
-	}
-
-	/**
-	 * Fetch the objectPointer's hashcode when compressed references are enabled.
-	 *
-	 * @pre objectPointer must be a valid object reference
-	 *
-	 * @param vm			a java VM
-	 * @param objectPointer 	a valid object reference
-	 * @param objectClass 	class of objectPointer
-	 */
-	static VMINLINE I_32
-	inlineIndexableObjectHashCodeCompressed(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass)
-	{
-		I_32 hashValue = 0;
-		UDATA offset = ((J9IndexableObjectContiguousCompressed *)objectPointer)->size;
-		if (0 != offset) {
-			hashValue = inlineIndexableContiguousObjectHashCode(vm, objectPointer, objectClass, offset);
-		} else {
-			if (0 == ((J9IndexableObjectDiscontiguousCompressed *)objectPointer)->size) {
-				/* Zero-sized array */
-				hashValue = *(I_32 *)((UDATA)objectPointer + vm->discontiguousIndexableHeaderSize);
-			} else {
-				/* Discontiguous array */
-				hashValue = vm->memoryManagerFunctions->j9gc_objaccess_getObjectHashCode(vm, objectPointer);
-			}
-		}
-
-		return hashValue;
-	}
-
-	/**
-	 * Fetch the objectPointer's hashcode when compressed references are disabled.
-	 *
-	 * @pre objectPointer must be a valid object reference
-	 *
-	 * @param vm			a java VM
-	 * @param objectPointer 	a valid object reference
-	 * @param objectClass 	class of objectPointer
-	 */
-	static VMINLINE I_32
-	inlineIndexableObjectHashCodeFull(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass)
-	{
-		I_32 hashValue = 0;
-		UDATA offset = ((J9IndexableObjectContiguousFull *)objectPointer)->size;
-		if (0 != offset) {
-			hashValue = inlineIndexableContiguousObjectHashCode(vm, objectPointer, objectClass, offset);
-		} else {
-			if (0 == ((J9IndexableObjectDiscontiguousFull *)objectPointer)->size) {
-				/* Zero-sized array */
-				hashValue = *(I_32 *)((UDATA)objectPointer + vm->discontiguousIndexableHeaderSize);
-			} else {
-				/* Discontiguous array */
-				hashValue = vm->memoryManagerFunctions->j9gc_objaccess_getObjectHashCode(vm, objectPointer);
-			}
-		}
-
-		return hashValue;
-	}
-
-	/**
 	 * Fetch the objectPointer's hashcode.
 	 * Requires VM access for the hash computation
 	 * of value objects.
@@ -876,11 +787,8 @@ public:
 
 			if (J9_ARE_ANY_BITS_SET(flags, OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
 				if (J9CLASS_IS_ARRAY(objectClass)) {
-					if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
-						hashValue = inlineIndexableObjectHashCodeCompressed(vm, objectPointer, objectClass);
-					} else {
-						hashValue = inlineIndexableObjectHashCodeFull(vm, objectPointer, objectClass);
-					}
+					UDATA hashSlotOffset = MM_ObjectAccessBarrierAPI::inlineIndexableObjectHashSlotOffset(vm, objectPointer, objectClass);
+					hashValue = *(I_32 *)((UDATA)objectPointer + hashSlotOffset);
 				} else {
 					hashValue = *(I_32 *)((UDATA)objectPointer + objectClass->backfillOffset);
 				}

--- a/runtime/oti/ObjectHash.hpp
+++ b/runtime/oti/ObjectHash.hpp
@@ -166,6 +166,18 @@ public:
  */
 private:
 
+	static VMINLINE I_32
+	inlineGetStoredObjectHashCode(J9JavaVM *vm, j9object_t object, J9Class *clazz)
+	{
+		UDATA hashSlotOffset = 0;
+		if (J9CLASS_IS_ARRAY(clazz)) {
+			hashSlotOffset = MM_ObjectAccessBarrierAPI::inlineIndexableObjectHashSlotOffset(vm, object, clazz);
+		} else {
+			hashSlotOffset = clazz->backfillOffset;
+		}
+		return *(I_32 *)((UDATA)object + hashSlotOffset);
+	}
+
 	static VMINLINE void
 	setHasBeenHashed(J9JavaVM *vm, j9object_t objectPtr)
 	{
@@ -456,17 +468,7 @@ private:
 					if (NULL != fieldObject) {
 						J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
 						if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
-							I_32 storedHash = 0;
-							if (J9CLASS_IS_ARRAY(fieldClazz)) {
-								if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
-									storedHash = inlineIndexableObjectHashCodeCompressed(vm, fieldObject, fieldClazz);
-								} else {
-									storedHash = inlineIndexableObjectHashCodeFull(vm, fieldObject, fieldClazz);
-								}
-							} else {
-								UDATA hashSlotOffset = fieldClazz->backfillOffset;
-								storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
-							}
+							I_32 storedHash = inlineGetStoredObjectHashCode(vm, fieldObject, fieldClazz);
 							if (0 != storedHash) {
 								datum = (U_32)storedHash;
 								goto mixHash;
@@ -639,17 +641,7 @@ mixHash:
 					if (NULL != fieldObject) {
 						J9Class *fieldClazz = J9OBJECT_CLAZZ(currentThread, fieldObject);
 						if (J9_ARE_ANY_BITS_SET(J9OBJECT_FLAGS_FROM_CLAZZ(currentThread, fieldObject), OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
-							I_32 storedHash = 0;
-							if (J9CLASS_IS_ARRAY(fieldClazz)) {
-								if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
-									storedHash = inlineIndexableObjectHashCodeCompressed(vm, fieldObject, fieldClazz);
-								} else {
-									storedHash = inlineIndexableObjectHashCodeFull(vm, fieldObject, fieldClazz);
-								}
-							} else {
-								UDATA hashSlotOffset = fieldClazz->backfillOffset;
-								storedHash = objectAccessBarrier.inlineMixedObjectReadI32(currentThread, fieldObject, hashSlotOffset);
-							}
+							I_32 storedHash = inlineGetStoredObjectHashCode(vm, fieldObject, fieldClazz);
 							if (0 != storedHash) {
 								entry->hashValue = mix(entry->hashValue, (U_32)storedHash);
 								entry->numBytesHashed += 4;
@@ -761,91 +753,6 @@ public:
 	}
 
 	/**
-	 * Fetch objectPointer's hashcode when objectPointer is a contiguous object.
-	 *
-	 * @pre objectPointer must be a valid object reference
-	 *
-	 * @param vm			a java VM
-	 * @param objectPointer 	a valid object reference
-	 * @param objectClass 	class of objectPointer
-	 * @param offset 	objectPointer size offset
-	 */
-	static VMINLINE I_32
-	inlineIndexableContiguousObjectHashCode(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass, UDATA offset)
-	{
-		uintptr_t dataSize = 0;
-#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
-		if (J9_IS_J9CLASS_FLATTENED(objectClass)) {
-			dataSize = offset * J9ARRAYCLASS_GET_STRIDE(objectClass);
-		} else
-#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
-		{
-			J9ROMArrayClass *romClass = (J9ROMArrayClass *)objectClass->romClass;
-			dataSize = offset << (romClass->arrayShape & 0x0000FFFF);
-		}
-		offset = ROUND_UP_TO_POWEROF2(dataSize + vm->contiguousIndexableHeaderSize, sizeof(I_32));
-		return *(I_32 *)((UDATA)objectPointer + offset);
-	}
-
-	/**
-	 * Fetch the objectPointer's hashcode when compressed references are enabled.
-	 *
-	 * @pre objectPointer must be a valid object reference
-	 *
-	 * @param vm			a java VM
-	 * @param objectPointer 	a valid object reference
-	 * @param objectClass 	class of objectPointer
-	 */
-	static VMINLINE I_32
-	inlineIndexableObjectHashCodeCompressed(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass)
-	{
-		I_32 hashValue = 0;
-		UDATA offset = ((J9IndexableObjectContiguousCompressed *)objectPointer)->size;
-		if (0 != offset) {
-			hashValue = inlineIndexableContiguousObjectHashCode(vm, objectPointer, objectClass, offset);
-		} else {
-			if (0 == ((J9IndexableObjectDiscontiguousCompressed *)objectPointer)->size) {
-				/* Zero-sized array */
-				hashValue = *(I_32 *)((UDATA)objectPointer + vm->discontiguousIndexableHeaderSize);
-			} else {
-				/* Discontiguous array */
-				hashValue = vm->memoryManagerFunctions->j9gc_objaccess_getObjectHashCode(vm, objectPointer);
-			}
-		}
-
-		return hashValue;
-	}
-
-	/**
-	 * Fetch the objectPointer's hashcode when compressed references are disabled.
-	 *
-	 * @pre objectPointer must be a valid object reference
-	 *
-	 * @param vm			a java VM
-	 * @param objectPointer 	a valid object reference
-	 * @param objectClass 	class of objectPointer
-	 */
-	static VMINLINE I_32
-	inlineIndexableObjectHashCodeFull(J9JavaVM *vm, j9object_t objectPointer, J9Class *objectClass)
-	{
-		I_32 hashValue = 0;
-		UDATA offset = ((J9IndexableObjectContiguousFull *)objectPointer)->size;
-		if (0 != offset) {
-			hashValue = inlineIndexableContiguousObjectHashCode(vm, objectPointer, objectClass, offset);
-		} else {
-			if (0 == ((J9IndexableObjectDiscontiguousFull *)objectPointer)->size) {
-				/* Zero-sized array */
-				hashValue = *(I_32 *)((UDATA)objectPointer + vm->discontiguousIndexableHeaderSize);
-			} else {
-				/* Discontiguous array */
-				hashValue = vm->memoryManagerFunctions->j9gc_objaccess_getObjectHashCode(vm, objectPointer);
-			}
-		}
-
-		return hashValue;
-	}
-
-	/**
 	 * Fetch the objectPointer's hashcode.
 	 * Requires VM access for the hash computation
 	 * of value objects.
@@ -875,15 +782,7 @@ public:
 			UDATA flags = J9OBJECT_FLAGS_FROM_CLAZZ_VM(vm, objectPointer);
 
 			if (J9_ARE_ANY_BITS_SET(flags, OBJECT_HEADER_HAS_BEEN_MOVED_IN_CLASS)) {
-				if (J9CLASS_IS_ARRAY(objectClass)) {
-					if (J9JAVAVM_COMPRESS_OBJECT_REFERENCES(vm)) {
-						hashValue = inlineIndexableObjectHashCodeCompressed(vm, objectPointer, objectClass);
-					} else {
-						hashValue = inlineIndexableObjectHashCodeFull(vm, objectPointer, objectClass);
-					}
-				} else {
-					hashValue = *(I_32 *)((UDATA)objectPointer + objectClass->backfillOffset);
-				}
+				hashValue = inlineGetStoredObjectHashCode(vm, objectPointer, objectClass);
 #if defined(J9VM_OPT_VALHALLA_VALUE_TYPES)
 				if (0 == hashValue) {
 					if (J9_IS_J9CLASS_VALUETYPE(objectClass)) {

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5230,6 +5230,7 @@ typedef struct J9MemoryManagerFunctions {
 	void  ( *j9gc_objaccess_postStoreClassToClassLoader)(struct J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Class *srcClass) ;
 	void  ( *j9gc_objaccess_postStoreModuleToClassLoader)(struct J9VMThread *vmThread, J9ClassLoader *destClassLoader, J9Module *srcModule) ;
 	I_32  ( *j9gc_objaccess_getObjectHashCode)(struct J9JavaVM *vm, J9Object* object) ;
+	UDATA  ( *j9gc_objaccess_getIndexableObjectHashSlotOffset)(struct J9JavaVM *vm, J9IndexableObject *arrayPtr) ;
 	j9object_t  ( *j9gc_createJavaLangString)(struct J9VMThread *vmThread, U_8 *data, UDATA length, UDATA stringFlags) ;
 	j9object_t  ( *j9gc_createJavaLangStringWithUTFCache)(struct J9VMThread *vmThread, struct J9UTF8 *utf) ;
 	j9object_t  ( *j9gc_internString)(struct J9VMThread *vmThread, j9object_t sourceString) ;

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -421,6 +421,12 @@
 			<variation>-Xgcpolicy:gencon -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=0</variation>
 			<variation>-Xgcpolicy:gencon -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=9999</variation>
 			<variation>-Xgcpolicy:gencon -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=2</variation>
+			<variation>-Xgcpolicy:balanced -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=0</variation>
+			<variation>-Xgcpolicy:balanced -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=9999</variation>
+			<variation>-Xgcpolicy:balanced -XX:+EnableArrayFlattening -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=99999 -XX:hashMaxRecDepth=2</variation>
+			<variation>-Xgcpolicy:balanced -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=0</variation>
+			<variation>-Xgcpolicy:balanced -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=9999</variation>
+			<variation>-Xgcpolicy:balanced -XX:-EnableArrayFlattening -XX:-EnableFlattening -XX:hashMaxRecDepth=2</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(JVM_OPTIONS) \
 		--enable-preview \


### PR DESCRIPTION
- Replace inlineIndexableContiguousObjectHashCode, inlineIndexableObjectHashCodeCompressed, and inlineIndexableObjectHashCodeFull with a single helper function.
- Add single helper inlineIndexableObjectHashSlotOffset which handles hash offset calculation for indexable types.
- Handles Standard, Balanced off-heap, and Arraylet cases.
- Add external GC function j9gc_objaccess_getIndexableObjectHashSlotOffset which handles hash slot offset computation for Arraylets.
- Add tests to verify if the correct hash slot is read for arrays with Balanced GC.
