### PR TITLE
Fix AccessFlag test failures for Valhalla identity classes

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -42,10 +42,11 @@ import java.security.PrivilegedExceptionAction;
 import java.security.Permissions;
 import java.security.ProtectionDomain;
 import java.util.Collection;
-/*[IF INLINE-TYPES]*/
+/*[IF JAVA_SPEC_VERSION >= 28]*/
 import java.util.Collections;
 import jdk.internal.misc.PreviewFeatures;
-/*[ENDIF] INLINE-TYPES */
+import jdk.internal.reflect.PreviewAccessFlags;
+/*[ENDIF] JAVA_SPEC_VERSION >= 28 */
 import java.util.HashMap;
 /*[IF (JAVA_SPEC_VERSION >= 16) | INLINE-TYPES]*/
 import java.util.HashSet;
@@ -6187,37 +6188,42 @@ public Class<?>[] getNestMembers()
 	public Set<AccessFlag> accessFlags() {
 		final int rawModifiers = getModifiersImpl();
 		final boolean isArrayClass = isArray();
-		/* Uses the implementation from getModifiers() and adds SUPER access flag to
-		 * the mask, instead of directly invoking getModifiers(), because the SUPER flag
-		 * may or may not be set in the rawModifiers.
+		/* Mask raw modifier bits to the supported access flags, including ACC_IDENTITY
+		 * when preview features are enabled.
 		 */
 		int maskedModifiers = rawModifiers;
 		AccessFlag.Location location = AccessFlag.Location.CLASS;
+/*[IF JAVA_SPEC_VERSION >= 28]*/
+		final boolean previewEnabled = PreviewFeatures.isEnabled();
+/*[ENDIF] JAVA_SPEC_VERSION >= 28 */
+
 		if (isArrayClass) {
 			maskedModifiers &= Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
 					| Modifier.ABSTRACT | Modifier.FINAL;
+/*[IF JAVA_SPEC_VERSION >= 28]*/
+			maskedModifiers |= previewEnabled ? ACC_IDENTITY : 0;
+/*[ENDIF] JAVA_SPEC_VERSION >= 28 */
 			location = AccessFlag.Location.INNER_CLASS;
 		} else {
 			maskedModifiers &= Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
 					| Modifier.STATIC | Modifier.FINAL | Modifier.INTERFACE
 					| Modifier.ABSTRACT | SYNTHETIC | ENUM | ANNOTATION
 					| AccessFlag.SUPER.mask() | AccessFlag.MODULE.mask();
+/*[IF JAVA_SPEC_VERSION >= 28]*/
+			maskedModifiers |= previewEnabled ? ACC_IDENTITY : 0;
+/*[ENDIF] JAVA_SPEC_VERSION >= 28 */
 			if (isMemberClass() || isLocalClass() || isAnonymousClass()) {
 				location = AccessFlag.Location.INNER_CLASS;
 			}
 		}
 
-		Set<AccessFlag> flags = AccessFlag.maskToAccessFlags(maskedModifiers, location);
-/*[IF INLINE-TYPES]*/
-		if (PreviewFeatures.isEnabled()) {
-			if (isArrayClass || (rawModifiers & ACC_IDENTITY) != 0) {
-				flags = new HashSet<>(flags);
-				flags.add(AccessFlag.IDENTITY);
-				flags = Collections.unmodifiableSet(flags);
-			}
-		}
-/*[ENDIF] INLINE-TYPES */
-		return flags;
+/*[IF JAVA_SPEC_VERSION >= 28]*/
+		return previewEnabled
+				? PreviewAccessFlags.maskToAccessFlags(maskedModifiers, location)
+				: AccessFlag.maskToAccessFlags(maskedModifiers, location);
+/*[ELSE] JAVA_SPEC_VERSION >= 28 */
+		return AccessFlag.maskToAccessFlags(maskedModifiers, location);
+/*[ENDIF] JAVA_SPEC_VERSION >= 28 */
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/Class.java
+++ b/jcl/src/java.base/share/classes/java/lang/Class.java
@@ -43,8 +43,8 @@ import java.security.Permissions;
 import java.security.ProtectionDomain;
 import java.util.Collection;
 /*[IF INLINE-TYPES]*/
-import java.util.Collections;
 import jdk.internal.misc.PreviewFeatures;
+import jdk.internal.reflect.PreviewAccessFlags;
 /*[ENDIF] INLINE-TYPES */
 import java.util.HashMap;
 /*[IF (JAVA_SPEC_VERSION >= 16) | INLINE-TYPES]*/
@@ -6193,11 +6193,19 @@ public Class<?>[] getNestMembers()
 		 */
 		int maskedModifiers = rawModifiers;
 		AccessFlag.Location location = AccessFlag.Location.CLASS;
+/*[IF INLINE-TYPES]*/
+		final boolean previewEnabled = PreviewFeatures.isEnabled();
+/*[ENDIF] INLINE-TYPES */
+
 		if (isArrayClass) {
 			maskedModifiers &= Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
 					| Modifier.ABSTRACT | Modifier.FINAL;
+/*[IF INLINE-TYPES]*/
+			maskedModifiers |= previewEnabled ? ACC_IDENTITY : 0;
+/*[ENDIF] INLINE-TYPES */
 			location = AccessFlag.Location.INNER_CLASS;
 		} else {
+			/* ACC_SUPER is reused for ACC_IDENTITY when Valhalla preview features are enabled. */
 			maskedModifiers &= Modifier.PUBLIC | Modifier.PRIVATE | Modifier.PROTECTED
 					| Modifier.STATIC | Modifier.FINAL | Modifier.INTERFACE
 					| Modifier.ABSTRACT | SYNTHETIC | ENUM | ANNOTATION
@@ -6207,17 +6215,13 @@ public Class<?>[] getNestMembers()
 			}
 		}
 
-		Set<AccessFlag> flags = AccessFlag.maskToAccessFlags(maskedModifiers, location);
 /*[IF INLINE-TYPES]*/
-		if (PreviewFeatures.isEnabled()) {
-			if (isArrayClass || (rawModifiers & ACC_IDENTITY) != 0) {
-				flags = new HashSet<>(flags);
-				flags.add(AccessFlag.IDENTITY);
-				flags = Collections.unmodifiableSet(flags);
-			}
-		}
+		return previewEnabled
+				? PreviewAccessFlags.maskToAccessFlags(maskedModifiers, location)
+				: AccessFlag.maskToAccessFlags(maskedModifiers, location);
+/*[ELSE] INLINE-TYPES */
+		return AccessFlag.maskToAccessFlags(maskedModifiers, location);
 /*[ENDIF] INLINE-TYPES */
-		return flags;
 	}
 
 	/**

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -3104,8 +3104,6 @@ j9bcutil_readClassFileBytes(J9PortLibrary *portLib,
 				goto _errorFound;
 			}
 		}
-	} else {
-		classfile->accessFlags &= ~CFR_ACC_IDENTITY;
 	}
 #endif /* defined(J9VM_OPT_VALHALLA_VALUE_TYPES) */
 


### PR DESCRIPTION
Update Class.accessFlags() to add ACC_IDENTITY when Valhalla
preview features are enabled and convert the resulting modifiers
using the preview-aware access flag handling.

Fixes: https://github.com/eclipse-openj9/openj9/issues/24126

here is the passing sanity functional build : https://hyc-runtimes-jenkins.swg-devops.com/view/OpenJ9%20-%20Personal/job/Pipeline_Build_Test_JDKnext_x86-64_linux_valhalla/2991/

here is the Valhalla related openjdk test: https://hyc-runtimes-jenkins.swg-devops.com/view/Valhalla%20Tests/job/Test_JDKnext_valhalla_openjdk_x86-64_linux/181/

Previous PR closed due to merge conflict: https://github.com/eclipse-openj9/openj9/pull/24465
