### PR TITLE
Add TR::SimplifierWithReassociation to J9 Simplifier.hpp

### DIFF
--- a/runtime/compiler/optimizer/Simplifier.hpp
+++ b/runtime/compiler/optimizer/Simplifier.hpp
@@ -24,6 +24,7 @@
 #define TR_SIMPLIFIER_INCL
 
 #include "optimizer/J9Simplifier.hpp"
+#include "optimizer/OMRSimplifier.hpp"
 
 namespace TR {
 class OptimizationManager;
@@ -35,6 +36,13 @@ class Simplifier : public J9::Simplifier {
 public:
     Simplifier(TR::OptimizationManager *manager)
         : J9::Simplifier(manager)
+    {}
+};
+
+class SimplifierWithReassociation : public OMR::SimplifierWithReassociation {
+public:
+    SimplifierWithReassociation(TR::OptimizationManager *manager)
+        : OMR::SimplifierWithReassociation(manager)
     {}
 };
 


### PR DESCRIPTION
- OMR will introduce OMR::SimplifierWithReassociation, a new subclass of Simplifier that enables reassociation-based tree simplification by default. The J9-specific Simplifier.hpp shadows the OMR one in J9 builds, so TR::SimplifierWithReassociation must be declared here as well to make it visible to OMRSmallOptimizer.cpp.