### PR TITLE
Add XX:[-|+]MemoryDisclaim option

### DIFF
--- a/runtime/compiler/control/HookedByTheJit.cpp
+++ b/runtime/compiler/control/HookedByTheJit.cpp
@@ -4508,7 +4508,8 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
 #if defined(J9VM_OPT_SHARED_CLASSES) && defined(LINUX)
     TR_J9VMBase *fej9 = TR_J9VMBase::get(jitConfig, compInfo->getSamplerThread(), TR_J9VMBase::AOT_VM);
     TR_J9SharedCache *sharedCache = fej9->sharedCache();
-    if (sharedCache && sharedCache->isDisclaimEnabled()) {
+    if (sharedCache && sharedCache->isDisclaimEnabled()
+        && TR::Options::getCmdLineOptions()->getOption(TR_EnableSharedCacheDisclaiming)) {
         // Ensure we don't do it too often
         if (crtElapsedTime > lastSCCDisclaimTime + TR::Options::_minTimeBetweenSCCDisclaims) {
             // Disclaim if there were many AOT compilations/loads since the last disclaim
@@ -4528,7 +4529,8 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
     }
 #endif // defined(J9VM_OPT_SHARED_CLASSES) && defined(LINUX)
 
-    if (TR_DataCacheManager::getManager()->isDisclaimEnabled()) {
+    if (TR_DataCacheManager::getManager()->isDisclaimEnabled()
+        && !TR::Options::getCmdLineOptions()->getOption(TR_DisableDataCacheDisclaiming)) {
         // Ensure we don't do it too often
         if (crtElapsedTime > lastDataCacheDisclaimTime + TR::Options::_minTimeBetweenMemoryDisclaims) {
             // Disclaim if at least one data cache has been allocated since the last disclaim
@@ -4543,7 +4545,8 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
     }
 
     // Use logic similar to Data caches above
-    if (TR::CodeCacheManager::instance()->isDisclaimEnabled()) {
+    if (TR::CodeCacheManager::instance()->isDisclaimEnabled()
+        && TR::Options::getCmdLineOptions()->getOption(TR_EnableCodeCacheDisclaiming)) {
         // Ensure we don't do it too often
         if (crtElapsedTime > lastCodeCacheDisclaimTime + TR::Options::_minTimeBetweenMemoryDisclaims) {
             // Disclaim if at least one code cache has been allocated since the last disclaim
@@ -4590,7 +4593,8 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
 #if defined(J9VM_INTERP_PROFILING_BYTECODES)
     if (!TR::Options::getCmdLineOptions()->getOption(TR_DisableInterpreterProfiling)) {
         TR::PersistentAllocator *iprofilerAllocator = TR_IProfiler::allocator();
-        if (iprofilerAllocator->isDisclaimEnabled()) {
+        if (iprofilerAllocator->isDisclaimEnabled()
+            && !TR::Options::getCmdLineOptions()->getOption(TR_DisableIProfilerDataDisclaiming)) {
             if (crtElapsedTime > lastIProfilerDisclaimTime + TR::Options::_minTimeBetweenMemoryDisclaims &&
                 // Avoid disclaiming IProfiler segments if IProfiler is still active
                 returnIprofilerState() == IPROFILING_STATE_OFF &&
@@ -4610,7 +4614,8 @@ void memoryDisclaimLogic(TR::CompilationInfo *compInfo, uint64_t crtElapsedTime,
 
     // Disclaim RuntimeAssumption segments periodically
     TR::PersistentAllocator *raAllocator = TR_RuntimeAssumptionTable::getRAPersistentAllocator();
-    if (raAllocator && raAllocator->isDisclaimEnabled()) {
+    if (raAllocator && raAllocator->isDisclaimEnabled()
+        && !TR::Options::getCmdLineOptions()->getOption(TR_DisableRuntimeAssumptionDataDisclaiming)) {
         if (crtElapsedTime > lastRADisclaimTime + TR::Options::_minTimeBetweenMemoryDisclaims &&
             // Avoid disclaiming if compilations are still to be performed
             compInfo->getMethodQueueSize() <= TR::CompilationInfo::VERY_SMALL_QUEUE) {

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -446,8 +446,10 @@ J9::ExternalOptionsMetadata J9::Options::_externalOptionsMetadata[J9::ExternalOp
     {                   "-XX:+TrackAOTDependencies",         EXACT_MATCH, -1,  true }, // = 77
     {                   "-XX:-TrackAOTDependencies",         EXACT_MATCH, -1,  true }, // = 78
     {               "-XX:+JITServerUseProfileCache",         EXACT_MATCH, -1,  true }, // = 79
-    {               "-XX:-JITServerUseProfileCache",         EXACT_MATCH, -1,  true }  // = 80
-    // TR_NumExternalOptions                                                              = 81
+    {               "-XX:-JITServerUseProfileCache",         EXACT_MATCH, -1,  true }, // = 80
+    {                         "-XX:+MemoryDisclaim",         EXACT_MATCH, -1,  true }, // = 81
+    {                         "-XX:-MemoryDisclaim",         EXACT_MATCH, -1,  true }  // = 82
+    // TR_NumExternalOptions                                                              = 83
 };
 
 //************************************************************************
@@ -2777,8 +2779,11 @@ bool J9::Options::fePreProcess(void *base)
     // Forcing inlining of unrecognized intrinsics needs more performance investigation
     self()->setOption(TR_DisableInliningUnrecognizedIntrinsics);
 
-    // Memory disclaiming is available only on Linux
-    if (!TR::Compiler->target.isLinux()) {
+    int32_t xxPlusMemoryDisclaim = J9::Options::getExternalOptionIndex(J9::ExternalOptions::XXplusMemoryDisclaim);
+    int32_t xxMinusMemoryDisclaim = J9::Options::getExternalOptionIndex(J9::ExternalOptions::XXminusMemoryDisclaim);
+
+    // Memory disclaiming is available only on Linux or if memory disclaiming isn't disabled
+    if (!TR::Compiler->target.isLinux() || xxMinusMemoryDisclaim > xxPlusMemoryDisclaim) {
         self()->setOption(TR_DisableDataCacheDisclaiming);
         self()->setOption(TR_DisableIProfilerDataDisclaiming);
         self()->setOption(TR_DisableRuntimeAssumptionDataDisclaiming);

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -142,7 +142,9 @@ enum ExternalOptions {
     XXminusTrackAOTDependencies = 78,
     XXplusJITServerUseProfileCache = 79,
     XXminusJITServerUseProfileCache = 80,
-    TR_NumExternalOptions = 81
+    XXplusMemoryDisclaim = 81,
+    XXminusMemoryDisclaim = 82,
+    TR_NumExternalOptions = 83
 };
 
 /**

--- a/runtime/compiler/control/OptionsPostRestore.cpp
+++ b/runtime/compiler/control/OptionsPostRestore.cpp
@@ -113,7 +113,9 @@ void J9::OptionsPostRestore::iterateOverExternalOptions()
             case J9::ExternalOptions::Xaotcolon:
             case J9::ExternalOptions::Xnoaot:
             case J9::ExternalOptions::XXplusMergeCompilerOptions:
-            case J9::ExternalOptions::XXminusMergeCompilerOptions: {
+            case J9::ExternalOptions::XXminusMergeCompilerOptions:
+            case J9::ExternalOptions::XXminusMemoryDisclaim:
+            case J9::ExternalOptions::XXplusMemoryDisclaim: {
                 // These will have already been consumed
             } break;
 
@@ -601,6 +603,20 @@ void J9::OptionsPostRestore::preProcessInternalCompilerOptions()
         J9::Options::getExternalOptionString(J9::ExternalOptions::XXplusMergeCompilerOptions), 0);
     _argIndexMergeOptionsDisabled = FIND_AND_CONSUME_RESTORE_ARG(EXACT_MATCH,
         J9::Options::getExternalOptionString(J9::ExternalOptions::XXminusMergeCompilerOptions), 0);
+
+    uint32_t argIndexDisableMemoryDisclaim = FIND_AND_CONSUME_RESTORE_ARG(EXACT_MATCH,
+        J9::Options::getExternalOptionString(J9::ExternalOptions::XXminusMemoryDisclaim), 0);
+
+    uint32_t argIndexMemoryDisclaim = FIND_AND_CONSUME_RESTORE_ARG(EXACT_MATCH,
+        J9::Options::getExternalOptionString(J9::ExternalOptions::XXplusMemoryDisclaim), 0);
+
+    if (argIndexDisableMemoryDisclaim > argIndexMemoryDisclaim) {
+        TR::Options::getCmdLineOptions()->setOption(TR_DisableDataCacheDisclaiming);
+        TR::Options::getCmdLineOptions()->setOption(TR_DisableIProfilerDataDisclaiming);
+        TR::Options::getCmdLineOptions()->setOption(TR_DisableRuntimeAssumptionDataDisclaiming);
+        TR::Options::getCmdLineOptions()->setOption(TR_EnableCodeCacheDisclaiming, false);
+        TR::Options::getCmdLineOptions()->setOption(TR_EnableSharedCacheDisclaiming, false);
+    }
 }
 
 void J9::OptionsPostRestore::postProcessInternalCompilerOptions()


### PR DESCRIPTION
Add a command line option to disable memory disclaiming. The semantics are as follows.
- If -XX:-MemoryDisclaim and -XX:+MemoryDisclaim are both specified, the latter option (as seen on the command line) takes precedence.
- If -XX:-MemoryDisclaim is specified, then data cache, IProfiler, runtime assumption, code cache and shared class cache disclaiming are all disabled
- If any -Xjit: Command line option specifies any of the above options, it takes precedence.

Address issue: https://github.com/eclipse-openj9/openj9/issues/24509