### PR TITLE
Delay INNOCUOUSTHREADGROUP.enumerate() to include Common-Cleaner thread

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -117,11 +117,11 @@ final class J9VMInternals {
 					throw new InternalError(e);
 				}
 
-				threads = new Thread[threadGroup.activeCount()];
-				threadGroup.enumerate(threads, false);
-
 				CleanerShutdown.shutdownCleaner();
 
+				// JDK27 Common-Cleaner thread instantiation occurs sometimes after CleanerShutdown.shutdownCleaner().
+				threads = new Thread[threadGroup.activeCount()];
+				threadGroup.enumerate(threads, false);
 				for (Thread t : threads) {
 					String threadName = t.getName();
 					if (threadName.equals("Common-Cleaner") //$NON-NLS-1$

--- a/test/functional/NativeTest/playlist.xml
+++ b/test/functional/NativeTest/playlist.xml
@@ -516,10 +516,6 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 				<version>8</version>
 				<impl>ibm</impl>
 			</disable>
-			<disable>
-				<comment>https://github.com/eclipse-openj9/openj9/issues/20835</comment>
-				<version>27+</version>
-			</disable>
 		</disables>
 		<command>$(ADD_JVM_LIB_DIR_TO_LIBPATH) \
 			$(SQ)$(JAVA_SHARED_LIBRARIES_DIR)$(D)thrstatetest$(SQ) $(JVM_OPTIONS) -Djava.home=$(THRSTATETEST_JRE_HOME) -Dcom.ibm.tools.attach.enable=no -Dibm.java9.forceCommonCleanerShutdown=true ; \


### PR DESCRIPTION
Delay `INNOCUOUSTHREADGROUP.enumerate()` to include `Common-Cleaner` thread

JDK27 `Common-Cleaner` thread instantiation occurs sometimes after `CleanerShutdown.shutdownCleaner()`;
Enabled `thrstatetest` for JDK27+.

closes https://github.com/eclipse-openj9/openj9/issues/20835

Signed-off-by: Jason Feng <fengj@ca.ibm.com>