### PR TITLE
(0.62) Reject multiple Signature attributes

### DIFF
--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -179,6 +179,7 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 #if JAVA_SPEC_VERSION >= 11
 	BOOLEAN nestAttributeRead = FALSE;
+	BOOLEAN signatureAttributeRead = FALSE;
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
 	if (NULL != syntheticFound) {
@@ -221,6 +222,17 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 			break;
 
 		case CFR_ATTRIBUTE_Signature:
+#if JAVA_SPEC_VERSION >= 11
+			/* JVMS 4.7.9: There may be at most one Signature attribute in the attributes table of a
+			 * ClassFile, field_info, method_info, or record_component_info structure.
+			 */
+			if (signatureAttributeRead) {
+				errorCode = J9NLS_CFR_ERR_MULTIPLE_SIGNATURE_ATTRIBUTES__ID;
+				offset = address;
+				goto _errorFound;
+			}
+			signatureAttributeRead = TRUE;
+#endif /* JAVA_SPEC_VERSION >= 11 */
 			if (!ALLOC_CAST(attrib, J9CfrAttributeSignature, J9CfrAttribute)) {
 				return -2;
 			}

--- a/runtime/nls/cfre/cfrerr.nls
+++ b/runtime/nls/cfre/cfrerr.nls
@@ -1862,3 +1862,11 @@ J9NLS_CFR_ERR_LOADABLEDESCRIPTORS_INVALID_SIGNATURE.explanation=The LoadableDesc
 J9NLS_CFR_ERR_LOADABLEDESCRIPTORS_INVALID_SIGNATURE.system_action=The JVM will throw a java.lang.ClassFormatError.
 J9NLS_CFR_ERR_LOADABLEDESCRIPTORS_INVALID_SIGNATURE.user_response=Contact the provider of the classfile for a corrected version.
 # END NON-TRANSLATABLE
+
+# Signature is not translatable
+J9NLS_CFR_ERR_MULTIPLE_SIGNATURE_ATTRIBUTES=Multiple Signature attributes
+# START NON-TRANSLATABLE
+J9NLS_CFR_ERR_MULTIPLE_SIGNATURE_ATTRIBUTES.explanation=A ClassFile, field_info, method_info, or record_component_info structure may have at most one Signature attribute.
+J9NLS_CFR_ERR_MULTIPLE_SIGNATURE_ATTRIBUTES.system_action=The JVM will throw a classloading related exception such as java.lang.ClassFormatError.
+J9NLS_CFR_ERR_MULTIPLE_SIGNATURE_ATTRIBUTES.user_response=Contact the provider of the classfile for a corrected version.
+# END NON-TRANSLATABLE


### PR DESCRIPTION
- Add a guard to detect multiple Signature attributes in ClassFile, field_info, method_info, and record_component_info structures.
- Throw ClassFormatError as per JVMS 4.7.9.

Port https://github.com/eclipse-openj9/openj9/pull/24458