### PR TITLE
Update boolean comparison in JVM_setEnabled

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -386,7 +386,7 @@ Java_jdk_jfr_internal_JVM_setEnabled(JNIEnv *env, jobject obj, jlong eventTypeId
 		&& (0 <= eventTypeId)
 		&& (eventTypeId < vm->jfrState.jfrEventEnabledFlagsSize)
 	) {
-		vm->jfrState.jfrEventEnabledFlags[(UDATA)eventTypeId] = (JNI_TRUE == enabled) ? 1 : 0;
+		vm->jfrState.jfrEventEnabledFlags[(UDATA)eventTypeId] = enabled ? 1 : 0;
 	}
 }
 


### PR DESCRIPTION
Previously the native implementation of `JVM.setEnabled()` compared enabled 
against `JNI_TRUE` before setting the flag; now it uses 
enabled directly.