### PR TITLE
(v0.62) Delay INNOCUOUSTHREADGROUP.enumerate() to include Common-Cleaner thread

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
+++ b/jcl/src/java.base/share/classes/java/lang/J9VMInternals.java
@@ -117,11 +117,11 @@ final class J9VMInternals {
 					throw new InternalError(e);
 				}
 
-				threads = new Thread[threadGroup.activeCount()];
-				threadGroup.enumerate(threads, false);
-
 				CleanerShutdown.shutdownCleaner();
 
+				// JDK27 Common-Cleaner thread instantiation occurs sometimes after CleanerShutdown.shutdownCleaner().
+				threads = new Thread[threadGroup.activeCount()];
+				threadGroup.enumerate(threads, false);
 				for (Thread t : threads) {
 					String threadName = t.getName();
 					if (threadName.equals("Common-Cleaner") //$NON-NLS-1$


### PR DESCRIPTION
Delay `INNOCUOUSTHREADGROUP.enumerate()` to include `Common-Cleaner` thread

JDK27 `Common-Cleaner` thread instantiation occurs sometimes after `CleanerShutdown.shutdownCleaner()`;
Enabled `thrstatetest` for JDK27+.

Cherry-pick
* https://github.com/eclipse-openj9/openj9/pull/24524

Signed-off-by: Jason Feng <fengj@ca.ibm.com>