### PR TITLE
Optimize storeStoreFence() to no-op on x86

### DIFF
--- a/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
+++ b/runtime/compiler/codegen/J9RecognizedMethodsEnum.hpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: Claude
  *******************************************************************************/
 
 #ifndef J9_RECOGNIZEDMETHODS_ENUM_INCL
@@ -293,6 +294,7 @@ FirstJ9Method = LastOMRMethod + 1,
     sun_misc_Unsafe_copyMemory, sun_misc_Unsafe_setMemory,
 
     sun_misc_Unsafe_loadFence, sun_misc_Unsafe_storeFence, sun_misc_Unsafe_fullFence,
+    jdk_internal_misc_Unsafe_storeStoreFence,
 
     sun_misc_Unsafe_ensureClassInitialized, sun_misc_Unsafe_allocateInstance,
     sun_misc_Unsafe_allocateUninitializedArray0,

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: Claude
  *******************************************************************************/
 
 #include "env/j9method.h"
@@ -2787,6 +2788,7 @@ void TR_ResolvedJ9Method::construct()
         { x(TR::sun_misc_Unsafe_loadFence, "loadFence", "()V") },
         { x(TR::sun_misc_Unsafe_storeFence, "storeFence", "()V") },
         { x(TR::sun_misc_Unsafe_fullFence, "fullFence", "()V") },
+        { x(TR::jdk_internal_misc_Unsafe_storeStoreFence, "storeStoreFence", "()V") },
 
         { x(TR::sun_misc_Unsafe_ensureClassInitialized, "ensureClassInitialized", "(Ljava/lang/Class;)V") },
         { x(TR::sun_misc_Unsafe_allocateInstance, "allocateInstance", "(Ljava/lang/Class;)Ljava/lang/Object;") },
@@ -4856,6 +4858,7 @@ void TR_ResolvedJ9Method::setRecognizedMethodInfo(TR::RecognizedMethod rm)
                 case TR::sun_misc_Unsafe_loadFence:
                 case TR::sun_misc_Unsafe_storeFence:
                 case TR::sun_misc_Unsafe_fullFence:
+                case TR::jdk_internal_misc_Unsafe_storeStoreFence:
                 case TR::sun_misc_Unsafe_ensureClassInitialized:
                 case TR::sun_misc_Unsafe_getAndAddInt:
                 case TR::sun_misc_Unsafe_getAndSetInt:

--- a/runtime/compiler/optimizer/InlinerTempForJ9.cpp
+++ b/runtime/compiler/optimizer/InlinerTempForJ9.cpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: Claude
  *******************************************************************************/
 #include <algorithm>
 #include "j9cfg.h"
@@ -2265,9 +2266,12 @@ bool TR_J9InlinerPolicy::createUnsafeGet(TR::ResolvedMethodSymbol *calleeSymbol,
     return true;
 }
 
-bool TR_J9InlinerPolicy::createUnsafeFence(TR::TreeTop *callNodeTreeTop, TR::Node *callNode, TR::ILOpCodes opCode)
+bool TR_J9InlinerPolicy::createUnsafeFence(
+    TR::TreeTop *callNodeTreeTop, TR::Node *callNode, TR::ILOpCodes opCode, bool canOmitSync)
 {
     TR::Node *fenceNode = TR::Node::createWithSymRef(callNode, opCode, 0, callNode->getSymbolReference());
+    if (canOmitSync)
+        fenceNode->setOmitSync(true);
     TR::Node::recreate(callNode, TR::PassThrough);
     TR::TreeTop *fenceTop = TR::TreeTop::create(comp(), fenceNode);
     callNodeTreeTop->insertAfter(fenceTop);
@@ -2671,6 +2675,8 @@ bool TR_J9InlinerPolicy::inlineUnsafeCall(TR::ResolvedMethodSymbol *calleeSymbol
             return createUnsafeFence(callNodeTreeTop, callNode, TR::storeFence);
         case TR::sun_misc_Unsafe_fullFence:
             return createUnsafeFence(callNodeTreeTop, callNode, TR::fullFence);
+        case TR::jdk_internal_misc_Unsafe_storeStoreFence:
+            return createUnsafeFence(callNodeTreeTop, callNode, TR::storeFence, true);
 
         case TR::sun_misc_Unsafe_staticFieldBase:
             return false; // todo
@@ -2803,6 +2809,7 @@ bool TR_J9InlinerPolicy::isInlineableJNI(TR_ResolvedMethod *method, TR::Node *ca
         case TR::sun_misc_Unsafe_loadFence:
         case TR::sun_misc_Unsafe_storeFence:
         case TR::sun_misc_Unsafe_fullFence:
+        case TR::jdk_internal_misc_Unsafe_storeStoreFence:
             return true;
 
         case TR::sun_misc_Unsafe_staticFieldBase:

--- a/runtime/compiler/optimizer/J9Inliner.hpp
+++ b/runtime/compiler/optimizer/J9Inliner.hpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: Claude
  *******************************************************************************/
 
 #ifndef INLINERTEMPFORJ9_INCL
@@ -283,7 +284,7 @@ protected:
         TR::DataType, TR::Symbol::MemoryOrdering ordering = TR::Symbol::MemoryOrdering::Transparent,
         bool needNullCheck = false, bool isUnaligned = false);
     TR::Node *createUnsafeAddressWithOffset(TR::Node *);
-    bool createUnsafeFence(TR::TreeTop *, TR::Node *, TR::ILOpCodes);
+    bool createUnsafeFence(TR::TreeTop *, TR::Node *, TR::ILOpCodes, bool canOmitSync = false);
 
     TR::Node *createUnsafeMonitorOp(TR::ResolvedMethodSymbol *calleeSymbol, TR::ResolvedMethodSymbol *callerSymbol,
         TR::TreeTop *callNodeTreeTop, TR::Node *unsafeCall, bool isEnter);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -18,6 +18,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: Claude
  *******************************************************************************/
 
 #include <assert.h>
@@ -3789,11 +3790,18 @@ TR::Register *J9::X86::TreeEvaluator::BNDCHKwithSpineCHKEvaluator(TR::Node *node
  *
  * Due to performance penalty of mfence, a faster lockor on RSP is used
  * it achieve the same functionality but runs faster.
+ *
+ * A storeFence node marked with canOmitSync() is generated only for
+ * jdk.internal.misc.Unsafe.storeStoreFence() (see
+ * TR_J9InlinerPolicy::createUnsafeFence). x86's TSO memory model already
+ * guarantees store-store ordering, so that fence is emitted as a no-op here.
+ * A genuine Unsafe.storeFence() (load/store -> store ordering) never carries
+ * this flag and still lowers to a real fence below.
  */
 TR::Register *J9::X86::TreeEvaluator::barrierFenceEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     TR::ILOpCodes opCode = node->getOpCodeValue();
-    if (opCode == TR::fullFence && node->canOmitSync()) {
+    if ((opCode == TR::fullFence || opCode == TR::storeFence) && node->canOmitSync()) {
         Inst_Label(OP::label, node, generateLabelSymbol(cg), cg);
     } else if (cg->comp()->getOption(TR_X86UseMFENCE)) {
         Inst(OP::MFENCE, node, cg);

--- a/test/functional/Java9andUp/src/org/openj9/test/varhandle/VarHandleFenceTests.java
+++ b/test/functional/Java9andUp/src/org/openj9/test/varhandle/VarHandleFenceTests.java
@@ -18,13 +18,20 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: Claude
  */
 package org.openj9.test.varhandle;
 
+import java.lang.invoke.VarHandle;
+
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = { "level.extended" })
 public class VarHandleFenceTests {
+	int intField;
+	long longField;
+
 	@Test
 	public void testFullFence() {
 
@@ -45,9 +52,19 @@ public class VarHandleFenceTests {
 
 	}
 
+	/**
+	 * @tests java.lang.invoke.VarHandle.storeStoreFence()
+	 */
 	@Test
 	public void testStoreStoreFence() {
-
+		intField = 1;
+		longField = 2L;
+		VarHandle.storeStoreFence();
+		intField = 3;
+		longField = 4L;
+		VarHandle.storeStoreFence();
+		Assert.assertEquals(intField, 3);
+		Assert.assertEquals(longField, 4L);
 	}
 
 }


### PR DESCRIPTION
## Summary
- `jdk.internal.misc.Unsafe.storeStoreFence()` was not recognized as a JIT intrinsic, so calls were compiled as ordinary calls to `storeFence()`, which emits an `MFENCE`. x86's TSO memory model already guarantees store-store ordering, making that `MFENCE` unnecessary for this particular fence.
- Adds `jdk_internal_misc_Unsafe_storeStoreFence` as a recognized method and, when inlining it, generates a `storeFence` IL node marked with `canOmitSync()`, reusing the existing mechanism already used by `fullFence` so x86 codegen can skip emitting the fence instruction.
- Power and aarch64 are unaffected, since their `storeFence` codegen does not check `canOmitSync()`.

Fixes #19042

## Test plan
- [ ] `test/functional/Java9andUp/src/org/openj9/test/varhandle/VarHandleFenceTests.java`: implemented `testStoreStoreFence()` (previously an empty stub) using the public `VarHandle.storeStoreFence()` API.
- [ ] CI build/test run on x86, Power, and aarch64 to confirm no regressions on non-x86 platforms.