### PR TITLE
Run a workload during TestRecording's recording

### DIFF
--- a/test/functional/cmdLineTests/jfr/jfrV2.xml
+++ b/test/functional/cmdLineTests/jfr/jfrV2.xml
@@ -110,7 +110,7 @@ SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-ex
 	</test>
 	-->
 	<test id="Test JFRv2 with Recording API">
-		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xshare:off -cp $RESJAR$ org.openj9.test.TestRecording</command>
+		<command>$EXE$ -XX:+EnableOpenJ9ExperimentalFlightRecording -Xshare:off --add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED -cp $RESJAR$ org.openj9.test.TestRecording</command>
 		<output type="success" caseSensitive="yes" regex="no">recording created</output>
 		<output type="required" caseSensitive="yes" regex="no">start test</output>
 		<output type="failure" caseSensitive="yes" regex="no">Found additional fields in mirror class</output>

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/TestRecording.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/TestRecording.java
@@ -32,6 +32,8 @@ public class TestRecording {
 		System.out.println("TestRecording: start test");
 		Recording r = new Recording(Configuration.getConfiguration("default"));
 		r.start();
+		WorkLoad workload = new WorkLoad(2, 2000, 3, false);
+		workload.runWork();
 		r.stop();
 		r.dump(Paths.get("testrecording.jfr"));
 		r.close();


### PR DESCRIPTION
`TestRecording` called `r.stop()` immediately after `r.start()`, likely 
too short for the native JFR sampler's periodic tick (~20ms) to fire 
even once. Added a small 2-thread `WorkLoad` during the recording so 
it stays open long enough for samples to be captured.

Also add `--add-opens jdk.jfr/jdk.jfr.internal=ALL-UNNAMED` to the 
test command, required by WorkLoad.runWork()'s `emitDataLoss()` call.

Fixes: https://github.com/eclipse-openj9/openj9/issues/24533