### PR TITLE
Skip unmapped autos when building monitor masks

### DIFF
--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -770,9 +770,13 @@ static void createMonitorMask(uint8_t *callSiteCursor, List<TR::RegisterMappedSy
         ListIterator<TR::RegisterMappedSymbol> iterator(autos);
         for (TR::RegisterMappedSymbol *a = iterator.getFirst(); a; a = iterator.getNext()) {
             int32_t bitNumber = a->getGCMapIndex();
-            // TODO: add this important assert in the future
-            // TR_ASSERT(bitNumber >= 0, "bitNumber is negative\n");
-            callSiteCursor[bitNumber >> 3] |= 1 << (bitNumber & 7);
+
+            // A monitor auto that did not get a GC slot assigned would have a GC map index
+            // of -1. Ensure bitNumber is non-negative to avoid out-of-bounds writes that can
+            // result from such unmapped autos.
+            if (bitNumber >= 0) {
+                callSiteCursor[bitNumber >> 3] |= 1 << (bitNumber & 7);
+            }
         }
     }
 }


### PR DESCRIPTION
In createMonitorMask(), indexing into the monitor mask was performed using GC map indices of autos. TR::RegisterMappedSymbol initializes autos with GC map index -1. For autos that were not assigned a GC slot, bitNumber would be set as -1 in createMonitorMask, which would eventually lead to unintended out-of-bounds writes.

The solution is to ensure that the bitNumber is non-negative, and that prevents the possibility of corrupting surrounding regions of memory.

Detailed explanation of the problem that is being fixed in this PR: https://github.com/eclipse-openj9/openj9/issues/23934#issuecomment-5285049801

Issue: #23934