### PR TITLE
Fix constrefs RCP restore

### DIFF
--- a/runtime/vm/VMSnapshotImpl.cpp
+++ b/runtime/vm/VMSnapshotImpl.cpp
@@ -709,6 +709,8 @@ VMSnapshotImpl::fixupClass(J9Class *clazz)
 		}
 	}
 	omrthread_monitor_exit(_vm->memberNameListsMutex);
+	/* constRefArrays are only used when OpenJDK MethodHandles are enabled.	*/
+	clazz->constRefArrays = NULL;
 #else /* defined(J9VM_OPT_OPENJDK_METHODHANDLE) */
 	if (NULL != clazz->methodTypes) {
 		memset(clazz->methodTypes, 0, sizeof(UDATA) * clazz->romClass->methodTypeCount);


### PR DESCRIPTION
## Problem

On a snapshot restore run, classes loaded from the snapshot have ConstRef pointers that point into the old ConstRefPool from the previous run, which no longer exists. They would eventually get dereferenced and cause a crash.

## Fix

null clazz->constRefArrays in VMSnapshotImpl::fixupClass() at checkpoint time. fixupClass() is called for all classes before J9ClassIsFrozen is set, ensuring all classes have their constRefArrays cleared before the snapshot is written. constRefs (and thus constRefArrays) are only enabled with OpenJDK MethodHandles enabled, which is why they are nulled out only if MethodHandles are enabled.

## Testing

Reproduced the original crash and confirmed the server starts cleanly on every restore run with the fix applied.

Fixes: #24454