### PR TITLE
Strengthen field name pointers to const

### DIFF
--- a/runtime/compiler/env/VMJ9.cpp
+++ b/runtime/compiler/env/VMJ9.cpp
@@ -2363,7 +2363,7 @@ bool TR_MarkHotField::markHotField(J9Class *clazz, bool rootClass)
     if (_comp->getOption(TR_TraceMarkingOfHotFields)) {
         if (rootClass) {
             int32_t len;
-            char *s = _symRef->getOwningMethod(_comp)->fieldName(_symRef->getCPIndex(), len, _comp->trMemory());
+            const char *s = _symRef->getOwningMethod(_comp)->fieldName(_symRef->getCPIndex(), len, _comp->trMemory());
             printf("hot field %*s with bitValue=%" OMR_PRIuPTR " and slotIndex=%" OMR_PRIuPTR
                    " found while compiling \n   %s\n",
                 len, s, _bitValue, _slotIndex, _comp->signature());

--- a/runtime/compiler/env/annotations/AnnotationBase.cpp
+++ b/runtime/compiler/env/annotations/AnnotationBase.cpp
@@ -320,7 +320,8 @@ J9AnnotationInfoEntry *TR_AnnotationBase::getAnnotationInfoEntry(TR::SymbolRefer
             // will return a string of the form "prefix.fieldname signature"
             // need to remove
             // replace space with a null and we'll have two strings
-            char *name = symRef->getOwningMethod(_comp)->fieldName(symRef->getCPIndex(), length, _comp->trMemory());
+            const char *name
+                = symRef->getOwningMethod(_comp)->fieldName(symRef->getCPIndex(), length, _comp->trMemory());
             nameBuf = (char *)j9mem_allocate_memory(length + 2 * sizeof(char), J9MEM_CATEGORY_JIT);
             if (!nameBuf)
                 return NULL;

--- a/runtime/compiler/il/J9Symbol.cpp
+++ b/runtime/compiler/il/J9Symbol.cpp
@@ -254,7 +254,7 @@ TR::Symbol::RecognizedField J9::Symbol::searchRecognizedField(TR::Compilation *c
     // So check if the field is final and check if it is this special field
     if (isStatic) {
         int32_t totalLen;
-        char *fieldName;
+        const char *fieldName;
         fieldName = owningMethod->staticName(cpIndex, totalLen,
             comp->trMemory()); // totalLen = strlen("<class>" + "<field>" + "<sig>") + 3
         static const char *assertionsDisabledStr = "$assertionsDisabled Z";

--- a/runtime/compiler/optimizer/EscapeAnalysis.cpp
+++ b/runtime/compiler/optimizer/EscapeAnalysis.cpp
@@ -2660,7 +2660,7 @@ bool TR_EscapeAnalysis::checkAllNewsOnRHSInLoopWithAliasing(int32_t defIndex, TR
                         TR::Node *underlyingArray = addr->getFirstChild();
 
                         int32_t fieldNameLen = -1;
-                        char *fieldName = NULL;
+                        const char *fieldName = NULL;
                         if (underlyingArray && underlyingArray->getOpCode().hasSymbolReference()
                             && underlyingArray->getSymbolReference()->getSymbol()->isStaticField()) {
                             fieldName = underlyingArray->getSymbolReference()->getOwningMethod(comp())->staticName(

--- a/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
+++ b/runtime/compiler/optimizer/InterProceduralAnalyzer.cpp
@@ -721,7 +721,7 @@ bool TR::InterProceduralAnalyzer::addSingleClassThatShouldNotBeNewlyExtended(TR_
 
 bool TR::InterProceduralAnalyzer::addWrittenGlobal(TR::SymbolReference *symRef)
 {
-    char *sig = NULL;
+    const char *sig = NULL;
     int32_t length = 0;
     if (symRef->getSymbol()->isStaticField())
         sig = symRef->getOwningMethod(comp())->staticName(symRef->getCPIndex(), length, trMemory());
@@ -732,7 +732,7 @@ bool TR::InterProceduralAnalyzer::addWrittenGlobal(TR::SymbolReference *symRef)
     for (ListElement<TR::GlobalSymbol> *currSymRef = _globalsWrittenInCurrentPeek.getListHead();
          currSymRef != _prevSymRef; currSymRef = currSymRef->getNextElement()) {
         TR::SymbolReference *currSymReference = currSymRef->getData()->_symRef;
-        char *currSig = NULL;
+        const char *currSig = NULL;
         int32_t currLength = 0;
         if (currSymReference->getSymbol()->isStaticField())
             currSig = currSymReference->getOwningMethod(comp())->staticName(currSymReference->getCPIndex(), currLength,
@@ -752,7 +752,7 @@ bool TR::InterProceduralAnalyzer::addWrittenGlobal(TR::SymbolReference *symRef)
 
     for (TR::GlobalSymbol *currSym = _globalsWritten.getFirst(); currSym; currSym = currSym->getNext()) {
         TR::SymbolReference *currSymReference = currSym->_symRef;
-        char *currSig = NULL;
+        const char *currSig = NULL;
         int32_t currLength = 0;
         if (currSymReference->getSymbol()->isStaticField())
             currSig = currSymReference->getOwningMethod(comp())->staticName(currSymReference->getCPIndex(), currLength,

--- a/runtime/compiler/optimizer/J9TransformUtil.cpp
+++ b/runtime/compiler/optimizer/J9TransformUtil.cpp
@@ -1345,7 +1345,8 @@ bool J9::TransformUtil::attemptStaticFinalFieldFoldingImpl(TR::Optimization *opt
     }
 
     int32_t fieldNameLen;
-    char *fieldName = symRef->getOwningMethod(comp)->fieldName(cpIndex, fieldNameLen, comp->trMemory(), stackAlloc);
+    const char *fieldName
+        = symRef->getOwningMethod(comp)->fieldName(cpIndex, fieldNameLen, comp->trMemory(), stackAlloc);
     int32_t fieldSigLength;
     char *fieldSignature = symRef->getOwningMethod(comp)->staticSignatureChars(cpIndex, fieldSigLength);
 

--- a/runtime/compiler/optimizer/MonitorElimination.cpp
+++ b/runtime/compiler/optimizer/MonitorElimination.cpp
@@ -4553,7 +4553,7 @@ bool TR::MonitorElimination::treesAllowCoarsening(TR::TreeTop *startTree, TR::Tr
                         TR::SymbolReference *symRef = symRefTab->getSymRef(symRefNum);
                         if (symRef->getSymbol()->isStatic()
                             || (symRef->getSymbol()->isShadow() && !symRef->getSymbol()->isArrayShadowSymbol())) {
-                            char *sig = NULL;
+                            const char *sig = NULL;
                             int32_t length = 0;
                             if (symRef->getSymbol()->isStatic()) {
                                 if (symRef->getSymbol()->isConstObjectRef())
@@ -4566,7 +4566,7 @@ bool TR::MonitorElimination::treesAllowCoarsening(TR::TreeTop *startTree, TR::Tr
                                     trMemory());
                             }
 
-                            char *currSig = NULL;
+                            const char *currSig = NULL;
                             int32_t currLength = 0;
                             if (currSymReference->getSymbol()->isStatic()) {
                                 if (currSymReference->getSymbol()->isConstObjectRef())


### PR DESCRIPTION
Strengthen local field-name and static-name pointers to const to reflect that the returned strings are not modified.