### PR TITLE
(0.62) Enable immutable JCL classes

### DIFF
--- a/runtime/compiler/compile/J9AliasBuilder.cpp
+++ b/runtime/compiler/compile/J9AliasBuilder.cpp
@@ -38,7 +38,7 @@ J9::AliasBuilder::AliasBuilder(TR::SymbolReferenceTable *symRefTab, size_t sizeH
     , _tenantDataMetaSymRefs(sizeHint, c->trMemory(), heapAlloc, growable)
     , _callSiteTableEntrySymRefs(sizeHint, c->trMemory(), heapAlloc, growable)
     , _unresolvedShadowSymRefs(sizeHint, c->trMemory(), heapAlloc, growable)
-    , _immutableConstructorDefAliases(c->trMemory(), _numImmutableClasses)
+    , _immutableConstructorDefAliases(c->trMemory(), TR::SymbolReferenceTable::_numImmutableClasses)
     , _methodTypeTableEntrySymRefs(sizeHint, c->trMemory(), heapAlloc, growable)
 {
     for (int32_t i = 0; i < _numNonUserFieldClasses; i++)
@@ -158,7 +158,7 @@ void J9::AliasBuilder::createAliasInfo()
 
     int32_t i;
 
-    for (i = 0; i < _numImmutableClasses; i++) {
+    for (i = 0; i < TR::SymbolReferenceTable::_numImmutableClasses; i++) {
         symRefTab()->immutableSymRefNumbers()[i]->pack();
     }
 
@@ -208,7 +208,7 @@ void J9::AliasBuilder::createAliasInfo()
 
     defaultMethodDefAliasesWithoutImmutable() |= defaultMethodDefAliases();
 
-    for (i = 0; i < _numImmutableClasses; i++) {
+    for (i = 0; i < TR::SymbolReferenceTable::_numImmutableClasses; i++) {
         defaultMethodDefAliasesWithoutImmutable() -= *(symRefTab()->immutableSymRefNumbers()[i]);
     }
 
@@ -219,7 +219,7 @@ void J9::AliasBuilder::createAliasInfo()
         immutableClassInfoElem = immutableClassInfoElem->getNextElement();
     }
 
-    for (i = 0; i < _numImmutableClasses; i++) {
+    for (i = 0; i < TR::SymbolReferenceTable::_numImmutableClasses; i++) {
         immutableConstructorDefAliases()[i]
             = new (trHeapMemory()) TR_BitVector(symRefTab()->getNumSymRefs(), comp()->trMemory(), heapAlloc, growable);
         *(immutableConstructorDefAliases()[i]) = defaultMethodDefAliasesWithoutImmutable();

--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -59,6 +59,25 @@
 #include "env/j9methodServer.hpp"
 #endif /* defined(J9VM_OPT_JITSERVER) */
 
+// Static definitions for built-in immutable class name table.
+// _numImmutableClasses is derived at compile time from the array size, so adding or
+// removing a class name here is the only change needed (no enum arithmetic required).
+const char * const J9::SymbolReferenceTable::_immutableClassNames[] = {
+    "java/lang/Boolean",
+    "java/lang/Character",
+    "java/lang/Byte",
+    "java/lang/Short",
+    "java/lang/Integer",
+    "java/lang/Long",
+    "java/lang/Float",
+    "java/lang/Double",
+    "java/lang/String",
+    "jdk/internal/foreign/AbstractMemorySegmentImpl",
+};
+
+const int32_t J9::SymbolReferenceTable::_numImmutableClasses = sizeof(J9::SymbolReferenceTable::_immutableClassNames)
+    / sizeof(J9::SymbolReferenceTable::_immutableClassNames[0]);
+
 namespace J9 {
 enum NonUserMethod {
     unknownNonUserMethod,
@@ -2150,16 +2169,15 @@ void J9::SymbolReferenceTable::checkImmutable(TR::SymbolReference *symRef)
     if (name == NULL || length == 0)
         return;
 
-    static struct N {
-        const char *name;
-    } names[] = { "java/lang/Boolean", "java/lang/Character", "java/lang/Byte", "java/lang/Short", "java/lang/Integer",
-        "java/lang/Long", "java/lang/Float", "java/lang/Double", "java/lang/String" };
-
     if (!comp()->getOption(TR_DisableImmutableFieldAliasing)) {
-        TR_ASSERT(sizeof(names) / sizeof(char *) == _numImmutableClasses, "Size of names array is not correct\n");
+        OMR::Logger *log = comp()->log();
+        bool trace = comp()->getOption(TR_TraceAliases);
+
         int32_t i;
         for (i = 0; i < _numImmutableClasses; i++) {
-            if (strcmp(names[i].name, name) == 0) {
+            if (strncmp(_immutableClassNames[i], name, length) == 0) {
+                logprintf(trace, log, "Found immutable #%d: class %.*s in %s\n", symRef->getReferenceNumber(), length,
+                    name, comp()->signature());
                 _hasImmutable = true;
                 _immutableSymRefNumbers[i]->set(symRef->getReferenceNumber());
                 break;

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -531,6 +531,17 @@ public:
 
     TR_Array<TR_BitVector *> &immutableSymRefNumbers() { return _immutableSymRefNumbers; }
 
+    /** \brief
+     *     Names of the built-in immutable classes whose fields are tracked for alias analysis.
+     *     One entry per class; the array is defined in J9SymbolReferenceTable.cpp.
+     */
+    static const char * const _immutableClassNames[];
+
+    /** \brief
+     *     Number of built-in immutable classes, derived from the size of \c _immutableClassNames.
+     */
+    static const int32_t _numImmutableClasses;
+
     int userFieldMethodId(TR::MethodSymbol *);
 
     bool hasUserField() { return _hasUserField; }
@@ -671,7 +682,5 @@ private:
 };
 
 } // namespace J9
-
-#define _numImmutableClasses (TR::java_lang_String_init - TR::java_lang_Boolean_init + 1)
 
 #endif


### PR DESCRIPTION
- fix strcmp typo that prevented immutable classes from being recognized
- add jdk/internal/foreign/AbstractMemorySegmentImpl to the list
- improve _numInvariantClasses initialization

Double deliver of https://github.com/eclipse-openj9/openj9/pull/24401