### PR TITLE
(0.62) Update recognition of Vector API types and methods for jdk27+

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -2821,6 +2821,12 @@ void TR_ResolvedJ9Method::construct()
         { x(TR::jdk_internal_util_Preconditions_checkIndex, "checkIndex", "(JJLjava/util/function/BiFunction;)J") },
         { TR::unknownMethod } };
 
+#if JAVA_SPEC_VERSION >= 27
+#define LANE_TYPE "I"
+#else /* JAVA_SPEC_VERSION >= 27 */
+#define LANE_TYPE "Ljava/lang/Class;"
+#endif /* JAVA_SPEC_VERSION >= 27 */
+
     static X VectorSupportMethods[] = {
 #if JAVA_SPEC_VERSION <= 21
         { x(TR::jdk_internal_vm_vector_VectorSupport_load, "load",
@@ -2829,87 +2835,87 @@ void TR_ResolvedJ9Method::construct()
             "VectorSupport$VectorPayload;") },
 #else
         { x(TR::jdk_internal_vm_vector_VectorSupport_load, "load",
-            "(Ljava/lang/Class;Ljava/lang/Class;ILjava/lang/Object;JZLjava/lang/Object;JLjdk/internal/vm/vector/"
+            "(Ljava/lang/Class;" LANE_TYPE "ILjava/lang/Object;JZLjava/lang/Object;JLjdk/internal/vm/vector/"
             "VectorSupport$VectorSpecies;Ljdk/internal/vm/vector/VectorSupport$LoadOperation;)Ljdk/internal/vm/vector/"
             "VectorSupport$VectorPayload;") },
 #endif
         { x(TR::jdk_internal_vm_vector_VectorSupport_binaryOp, "binaryOp",
-            "(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/"
+            "(ILjava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/"
             "VectorSupport$VectorPayload;Ljdk/internal/vm/vector/VectorSupport$VectorPayload;Ljdk/internal/vm/vector/"
             "VectorSupport$VectorMask;Ljdk/internal/vm/vector/VectorSupport$BinaryOperation;)Ljdk/internal/vm/vector/"
             "VectorSupport$VectorPayload;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_blend, "blend",
-            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
+            "(Ljava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
             "internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/"
             "vector/VectorSupport$VectorBlendOp;)Ljdk/internal/vm/vector/VectorSupport$Vector;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_broadcastInt, "broadcastInt",
-            "(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;ILjdk/"
+            "(ILjava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;ILjdk/"
             "internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/vector/"
             "VectorSupport$VectorBroadcastIntOp;)Ljdk/internal/vm/vector/VectorSupport$Vector;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_compare, "compare",
-            "(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
+            "(ILjava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
             "internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/"
             "vector/VectorSupport$VectorCompareOp;)Ljdk/internal/vm/vector/VectorSupport$VectorMask;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_compressExpandOp, "compressExpandOp",
-            "(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
+            "(ILjava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
             "internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/vector/"
             "VectorSupport$CompressExpandOperation;)Ljdk/internal/vm/vector/VectorSupport$VectorPayload;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_convert, "convert",
-            "(ILjava/lang/Class;Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/"
+            "(ILjava/lang/Class;" LANE_TYPE "ILjava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/"
             "VectorSupport$VectorPayload;Ljdk/internal/vm/vector/VectorSupport$VectorSpecies;Ljdk/internal/vm/vector/"
             "VectorSupport$VectorConvertOp;)Ljdk/internal/vm/vector/VectorSupport$VectorPayload;") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_extract, "extract",
-            "(Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$VectorPayload;ILjdk/internal/vm/"
+            "(Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$VectorPayload;ILjdk/internal/vm/"
             "vector/VectorSupport$VecExtractOp;)J") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_fromBitsCoerced, "fromBitsCoerced",
-            "(Ljava/lang/Class;Ljava/lang/Class;IJILjdk/internal/vm/vector/VectorSupport$VectorSpecies;Ljdk/internal/"
+            "(Ljava/lang/Class;" LANE_TYPE "IJILjdk/internal/vm/vector/VectorSupport$VectorSpecies;Ljdk/internal/"
             "vm/vector/VectorSupport$FromBitsCoercedOperation;)Ljdk/internal/vm/vector/VectorSupport$VectorPayload;") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_indexPartiallyInUpperRange, "indexPartiallyInUpperRange",
-            "(Ljava/lang/Class;Ljava/lang/Class;IJJLjdk/internal/vm/vector/"
+            "(Ljava/lang/Class;" LANE_TYPE "IJJLjdk/internal/vm/vector/"
             "VectorSupport$IndexPartiallyInUpperRangeOperation;)Ljdk/internal/vm/vector/VectorSupport$VectorMask;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_indexVector, "indexVector",
-            "(Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;ILjdk/internal/vm/vector/"
+            "(Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;ILjdk/internal/vm/vector/"
             "VectorSupport$VectorSpecies;Ljdk/internal/vm/vector/VectorSupport$IndexOperation;)Ljdk/internal/vm/vector/"
             "VectorSupport$Vector;") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_insert, "insert",
-            "(Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;IJLjdk/internal/vm/"
+            "(Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;IJLjdk/internal/vm/"
             "vector/VectorSupport$VecInsertOp;)Ljdk/internal/vm/vector/VectorSupport$Vector;") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_loadMasked, "loadMasked",
-            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjava/lang/Object;JZLjdk/internal/vm/vector/"
+            "(Ljava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjava/lang/Object;JZLjdk/internal/vm/vector/"
             "VectorSupport$VectorMask;ILjava/lang/Object;JLjdk/internal/vm/vector/VectorSupport$VectorSpecies;Ljdk/"
             "internal/vm/vector/VectorSupport$LoadVectorMaskedOperation;)Ljdk/internal/vm/vector/"
             "VectorSupport$Vector;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_loadWithMap, "loadWithMap",
-            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/Object;JLjdk/internal/vm/"
+            "(Ljava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjava/lang/Class;Ljava/lang/Object;JLjdk/internal/vm/"
             "vector/VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$VectorMask;Ljava/lang/Object;I[IILjdk/"
             "internal/vm/vector/VectorSupport$VectorSpecies;Ljdk/internal/vm/vector/"
             "VectorSupport$LoadVectorOperationWithMap;)Ljdk/internal/vm/vector/VectorSupport$Vector;") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_maskReductionCoerced, "maskReductionCoerced",
-            "(ILjava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/"
+            "(ILjava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/"
             "vector/VectorSupport$VectorMaskOp;)J") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_rearrangeOp, "rearrangeOp",
-            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/"
+            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/"
             "VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$VectorShuffle;Ljdk/internal/vm/vector/"
             "VectorSupport$VectorMask;Ljdk/internal/vm/vector/VectorSupport$VectorRearrangeOp;)Ljdk/internal/vm/vector/"
             "VectorSupport$Vector;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_reductionCoerced, "reductionCoerced",
-            "(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
+            "(ILjava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
             "internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/vector/"
             "VectorSupport$ReductionOperation;)J") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_selectFromOp, "selectFromOp",
-            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
+            "(Ljava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
             "internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/"
             "vector/VectorSupport$VectorSelectFromOp;)Ljdk/internal/vm/vector/VectorSupport$Vector;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_selectFromTwoVectorOp, "selectFromTwoVectorOp",
-            "(Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/"
+            "(Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/"
             "VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/"
             "VectorSupport$SelectFromTwoVector;)Ljdk/internal/vm/vector/VectorSupport$Vector;") },
 
@@ -2922,25 +2928,25 @@ void TR_ResolvedJ9Method::construct()
             "internal/vm/vector/VectorSupport$Vector;") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_storeMasked, "storeMasked",
-            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjava/lang/Object;JZLjdk/internal/vm/vector/"
+            "(Ljava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjava/lang/Object;JZLjdk/internal/vm/vector/"
             "VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$VectorMask;Ljava/lang/Object;JLjdk/internal/vm/"
             "vector/VectorSupport$StoreVectorMaskedOperation;)V") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_storeWithMap, "storeWithMap",
-            "(Ljava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjava/lang/Class;Ljava/lang/Object;JLjdk/internal/vm/"
+            "(Ljava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjava/lang/Class;Ljava/lang/Object;JLjdk/internal/vm/"
             "vector/VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/"
             "VectorSupport$VectorMask;Ljava/lang/Object;I[IILjdk/internal/vm/vector/"
             "VectorSupport$StoreVectorOperationWithMap;)V") },
 
         { x(TR::jdk_internal_vm_vector_VectorSupport_ternaryOp, "ternaryOp",
-            "(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
+            "(ILjava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
             "internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/vector/VectorSupport$Vector;Ljdk/internal/vm/"
             "vector/VectorSupport$VectorMask;Ljdk/internal/vm/vector/VectorSupport$TernaryOperation;)Ljdk/internal/vm/"
             "vector/VectorSupport$Vector;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_test, "test",
-            "(ILjava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/"
+            "(ILjava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/"
             "vector/VectorSupport$VectorMask;Ljava/util/function/BiFunction;)Z") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_unaryOp, "unaryOp",
-            "(ILjava/lang/Class;Ljava/lang/Class;Ljava/lang/Class;ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
+            "(ILjava/lang/Class;Ljava/lang/Class;" LANE_TYPE "ILjdk/internal/vm/vector/VectorSupport$Vector;Ljdk/"
             "internal/vm/vector/VectorSupport$VectorMask;Ljdk/internal/vm/vector/VectorSupport$UnaryOperation;)Ljdk/"
             "internal/vm/vector/VectorSupport$Vector;") },
         { x(TR::jdk_internal_vm_vector_VectorSupport_wrapShuffleIndexes, "wrapShuffleIndexes",
@@ -2954,12 +2960,14 @@ void TR_ResolvedJ9Method::construct()
             "VectorSupport$StoreVectorOperation;)V") },
 #else
         { x(TR::jdk_internal_vm_vector_VectorSupport_store, "store",
-            "(Ljava/lang/Class;Ljava/lang/Class;ILjava/lang/Object;JZLjdk/internal/vm/vector/"
+            "(Ljava/lang/Class;" LANE_TYPE "ILjava/lang/Object;JZLjdk/internal/vm/vector/"
             "VectorSupport$VectorPayload;Ljava/lang/Object;JLjdk/internal/vm/vector/"
             "VectorSupport$StoreVectorOperation;)V") },
 #endif
         { TR::unknownMethod }
     };
+
+#undef LANE_TYPE
 
     static X ArrayMethods[]
         = { { x(TR::java_lang_reflect_Array_getLength, "getLength", "(Ljava/lang/Object;)I") }, { TR::unknownMethod } };

--- a/runtime/compiler/optimizer/VectorAPIExpansion.cpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.cpp
@@ -176,7 +176,7 @@ void TR_VectorAPIExpansion::getElementTypeAndNumLanes(TR::Node *node, TR::DataTy
 
     int32_t i = getElementTypeIndex(methodSymbol);
     TR::Node *elementTypeNode = node->getChild(i);
-    elementType = getDataTypeFromClassNode(comp(), elementTypeNode);
+    elementType = getDataTypeFromNode(comp(), elementTypeNode);
 
     i = getNumLanesIndex(methodSymbol);
     TR::Node *numLanesNode = node->getChild(i);
@@ -519,7 +519,7 @@ void TR_VectorAPIExpansion::visitNodeToBuildVectorAliases(TR::Node *node, bool v
             // Update method element type and vector length
             if (i == getElementTypeIndex(methodSymbol)) {
                 TR::Node *elementTypeNode = node->getChild(i);
-                methodElementType = getDataTypeFromClassNode(comp(), elementTypeNode);
+                methodElementType = getDataTypeFromNode(comp(), elementTypeNode);
                 _aliasTable[methodRefNum]._vinfo._elementType = methodElementType;
                 _nodeTable[nodeIndex]._vinfo._elementType = methodElementType;
             } else if (i == getNumLanesIndex(methodSymbol)) {
@@ -846,15 +846,38 @@ TR_OpaqueClassBlock *TR_VectorAPIExpansion::getOpaqueClassBlockFromClassNode(TR:
     return clazz;
 }
 
-TR::DataType TR_VectorAPIExpansion::getDataTypeFromClassNode(TR::Compilation *comp, TR::Node *classNode)
+TR::DataType TR_VectorAPIExpansion::getDataTypeFromNode(TR::Compilation *comp, TR::Node *elementTypeNode)
 {
-    TR_OpaqueClassBlock *clazz = getOpaqueClassBlockFromClassNode(comp, classNode);
+#if JAVA_SPEC_VERSION >= 27
+    if (elementTypeNode->getOpCodeValue() != TR::iconst)
+        return TR::NoType;
+
+    switch (elementTypeNode->getConstValue()) {
+        case LT_FLOAT:
+            return TR::Float;
+        case LT_DOUBLE:
+            return TR::Double;
+        case LT_BYTE:
+            return TR::Int8;
+        case LT_SHORT:
+            return TR::Int16;
+        case LT_INT:
+            return TR::Int32;
+        case LT_LONG:
+            return TR::Int64;
+        case LT_FLOAT16: // TODO: add support for Float16
+        default:
+            return TR::NoType;
+    }
+#else /* JAVA_SPEC_VERSION >= 27 */
+    TR_OpaqueClassBlock *clazz = getOpaqueClassBlockFromClassNode(comp, elementTypeNode);
 
     if (!clazz)
         return TR::NoType;
 
     TR_J9VMBase *fej9 = comp->fej9();
     return fej9->getClassPrimitiveDataType(clazz);
+#endif /* JAVA_SPEC_VERSION >= 27 */
 }
 
 TR_VectorAPIExpansion::vapiObjType TR_VectorAPIExpansion::getObjectTypeFromClassNode(TR::Compilation *comp,
@@ -884,19 +907,13 @@ TR_VectorAPIExpansion::vapiObjType TR_VectorAPIExpansion::getObjectTypeFromClass
 
     char *cursor = classNameChars + length;
 
-    if (!strncmp(cursor - 6, "Vector", 6)) {
-        objectType = Vector;
-        cursor -= 6;
-    } else if (!strncmp(cursor - 4, "Mask", 4)) {
-        objectType = Mask;
-        cursor -= 4;
-    } else if (!strncmp(cursor - 7, "Shuffle", 7)) {
-        objectType = Shuffle;
-        cursor -= 7;
-    } else {
-        return Unknown;
-    }
-
+#if JAVA_SPEC_VERSION >= 27
+    /*
+     * In jdk27+, the vector length is at the end of the type name, for example:
+     *   DoubleVector512
+     *   DoubleVector512$DoubleMask512
+     *   DoubleVector512$DoubleShuffle512
+     */
     if (!strncmp(cursor - 2, "64", 2)) {
         vectorLength = TR::VectorLength64;
         cursor -= 2;
@@ -916,6 +933,44 @@ TR_VectorAPIExpansion::vapiObjType TR_VectorAPIExpansion::getObjectTypeFromClass
     } else {
         return Unknown;
     }
+#endif /* JAVA_SPEC_VERSION >= 27 */
+
+    if (!strncmp(cursor - 6, "Vector", 6)) {
+        objectType = Vector;
+        cursor -= 6;
+    } else if (!strncmp(cursor - 4, "Mask", 4)) {
+        objectType = Mask;
+        cursor -= 4;
+    } else if (!strncmp(cursor - 7, "Shuffle", 7)) {
+        objectType = Shuffle;
+        cursor -= 7;
+    } else {
+        return Unknown;
+    }
+
+#if JAVA_SPEC_VERSION < 27
+    /*
+     * Before jdk27, the vector length is at the end of the species name, for example:
+     *   Double512Vector
+     *   Double512Vector$Double512Mask
+     *   Double512Vector$Double512Shuffle
+     */
+    if (!strncmp(cursor - 2, "64", 2)) {
+        vectorLength = TR::VectorLength64;
+        cursor -= 2;
+    } else if (!strncmp(cursor - 3, "128", 3)) {
+        vectorLength = TR::VectorLength128;
+        cursor -= 3;
+    } else if (!strncmp(cursor - 3, "256", 3)) {
+        vectorLength = TR::VectorLength256;
+        cursor -= 3;
+    } else if (!strncmp(cursor - 3, "512", 3)) {
+        vectorLength = TR::VectorLength512;
+        cursor -= 3;
+    } else {
+        return Unknown;
+    }
+#endif /* JAVA_SPEC_VERSION < 27 */
 
     if (!strncmp(cursor - 4, "Byte", 4)) {
         elementType = TR::Int8;
@@ -2653,7 +2708,7 @@ bool TR_VectorAPIExpansion::getConvertSourceType(TR_VectorAPIExpansion *opt, TR:
 
     // For convert, source vector type info is in children 2 and 3
     TR::Node *sourceElementTypeNode = node->getChild(2);
-    sourceElementType = getDataTypeFromClassNode(comp, sourceElementTypeNode);
+    sourceElementType = getDataTypeFromNode(comp, sourceElementTypeNode);
 
     TR::Node *sourceNumLanesNode = node->getChild(3);
 

--- a/runtime/compiler/optimizer/VectorAPIExpansion.hpp
+++ b/runtime/compiler/optimizer/VectorAPIExpansion.hpp
@@ -94,7 +94,7 @@ private:
     static int32_t const _maxNumberOperands = 5;
 
 public:
-    // Start of opcodes from VectorSupport.java (have to be kept up-to-date)
+    // Start of constants from VectorSupport.java (have to be kept up-to-date)
 
     // Unary
     static int32_t const VECTOR_OP_ABS = 0;
@@ -192,7 +192,10 @@ public:
     static int32_t const MODE_BROADCAST = 0;
     static int32_t const MODE_BITS_COERCED_LONG_TO_MASK = 1;
 
-    // End of opcodes from VectorSupport.java
+    static int32_t const LT_FLOAT = 0, LT_DOUBLE = 1, LT_BYTE = 2, LT_SHORT = 3, LT_INT = 4, LT_LONG = 5;
+    static int32_t const LT_FLOAT16 = 6; // Float16 is in VectorSupport in jdk27+ but not supported by openj9 yet
+
+    // End of opcodes and constants from VectorSupport.java
 
     // Position of the parameters in the intrinsics.
     static int32_t const BROADCAST_TYPE_CHILD = 4;
@@ -957,10 +960,10 @@ public:
      *  \param comp
      *     Compilation
      *
-     *  \param classNode
-     *     Node that loads SPECIES object
+     *  \param elementTypeNode
+     *     Class object before JDK27, iconst after
      */
-    static TR::DataType getDataTypeFromClassNode(TR::Compilation *comp, TR::Node *classNode);
+    static TR::DataType getDataTypeFromNode(TR::Compilation *comp, TR::Node *elementTypeNode);
 
     /** \brief
      *     Anchors all node's children before transforming it into a new node


### PR DESCRIPTION
- starting with JDK27, VectorSupport intrinsic's element type parameter is int instead of Class
- class names are ByteVector128, IntVector128, etc. instead of Byte128Vector, Int128Vector...

Co-authored-by:: @keithc-ca
Co-authored-by:: @midronij

Double deliver of https://github.com/eclipse-openj9/openj9/pull/24496