### PR TITLE
Fix warning in VerboseEventMetronomeSynchronousGCEnd

### DIFF
--- a/runtime/gc_verbose_old_events/VerboseEventMetronomeSynchronousGCEnd.cpp
+++ b/runtime/gc_verbose_old_events/VerboseEventMetronomeSynchronousGCEnd.cpp
@@ -19,6 +19,7 @@
  * [2] https://openjdk.org/legal/assembly-exception.html
  *
  * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ * Assisted-by: IBM Bob
  *******************************************************************************/
 
 #include "VerboseEventMetronomeSynchronousGCEnd.hpp"
@@ -77,7 +78,8 @@ MM_VerboseEventMetronomeSynchronousGCEnd::consumeEvents(void)
 		/* Copy over all relevant attributes from SyncGC start event, to be used later in formattedOutput */
 		_heapFreeBefore = eventSyncGCStart->getHeapFree();
 		_startTime = eventSyncGCStart->getTimeStamp();
-		strncpy(_timestamp, eventSyncGCStart->getTimestamp(), 32);		
+		strncpy(_timestamp, eventSyncGCStart->getTimestamp(), sizeof(_timestamp) - 1);
+		_timestamp[sizeof(_timestamp) - 1] = '\0';
 		_reason = eventSyncGCStart->getReason();
 		_reasonParameter = eventSyncGCStart->getReasonParameter();
 		_classLoadersUnloadedStart = eventSyncGCStart->getClassLoadersUnloaded();


### PR DESCRIPTION
strncpy(_timestamp, ..., 32) was called with a bound equal to the destination buffer size (char _timestamp[32]). GCC's -Werror=stringop-truncation rejects this because strncpy does not null-terminate when the source fills all n bytes.

Fix by copying at most sizeof(_timestamp) - 1 bytes and explicitly null-terminating the last byte, guaranteeing a valid C-string regardless of source length.

Assisted-by: IBM Bob