### PR TITLE
OpenJ9 jimage header adopts JDK27+ MAJOR_VERSION update

### DIFF
--- a/runtime/oti/jimage.h
+++ b/runtime/oti/jimage.h
@@ -35,7 +35,11 @@ extern "C" {
 #define JIMAGE_HEADER_MAGIC 0xCAFEDADA
 
 /* Major and minor versions in jimage header */
+#if JAVA_SPEC_VERSION < 27
 #define JIMAGE_MAJOR_VERSION 0
+#else /* JAVA_SPEC_VERSION < 27 */
+#define JIMAGE_MAJOR_VERSION 1
+#endif /* JAVA_SPEC_VERSION < 27 */
 #define JIMAGE_MINOR_VERSION 1
 
 /* Macros to get type and length from "type" byte in attribute */


### PR DESCRIPTION
OpenJ9 `jimage` header adopts JDK27+ `MAJOR_VERSION` update

JDK27+ `jimage` header `MAJOR_VERSION` is `1`.

https://github.com/ibmruntimes/openj9-openjdk-jdk27/blob/d922afdca3e4fa74037cb9ada2f1b7ed1cc67221/src/java.base/share/classes/jdk/internal/jimage/ImageHeader.java#L58-L59
```
public final class ImageHeader {
    public static final int MAGIC = 0xCAFEDADA;
    public static final int MAJOR_VERSION = 1;
    public static final int MINOR_VERSION = 1;
```

closes https://github.com/eclipse-openj9/openj9/issues/24536

Signed-off-by: Jason Feng <fengj@ca.ibm.com>