### PR TITLE
Fix race condition after global buf alloc

### DIFF
--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -289,6 +289,7 @@ writeOutGlobalBuffer(J9VMThread *currentThread, bool finalWrite, bool dumpCalled
 {
 	J9JavaVM *vm = currentThread->javaVM;
 	Assert_VM_mustHaveVMAccess(currentThread);
+	Assert_VM_true((J9_XACCESS_EXCLUSIVE == vm->exclusiveAccessState) || (J9_XACCESS_EXCLUSIVE == vm->safePointState) || omrthread_monitor_owned_by_self(vm->jfrBufferMutex));
 	Trc_VM_jfr_writeOutGlobalBuffer(currentThread, vm->jfrBuffer.bufferSize - vm->jfrBuffer.bufferRemaining);
 
 	if (vm->jfrState.isCreated && (NULL != vm->jfrBuffer.bufferCurrent)) {
@@ -307,47 +308,45 @@ writeOutGlobalBuffer(J9VMThread *currentThread, bool finalWrite, bool dumpCalled
 }
 
 U_8 *
-allocateMemFromGlobalBuffer(J9VMThread *currentThread, UDATA size)
+allocateMemFromGlobalBuffer(J9VMThread *currentThread, UDATA size, bool *hasExclusive)
 {
 	J9JavaVM *vm = currentThread->javaVM;
 	Assert_VM_mustHaveVMAccess(currentThread);
 	U_8 *bytes = NULL;
 
-	bool hasExclusive = (J9_XACCESS_EXCLUSIVE == vm->exclusiveAccessState) || (J9_XACCESS_EXCLUSIVE == vm->safePointState);
+	*hasExclusive = (J9_XACCESS_EXCLUSIVE == vm->exclusiveAccessState) || (J9_XACCESS_EXCLUSIVE == vm->safePointState);
 
-	if (!hasExclusive) {
+	if (!*hasExclusive) {
 		internalReleaseVMAccess(currentThread);
 		omrthread_monitor_enter(vm->jfrBufferMutex);
 	}
 	if (vm->jfrBuffer.bufferRemaining < size) {
 		if (isJFRV2SupportEnabled(vm)) {
-			if (!hasExclusive) {
+			if (!*hasExclusive) {
 				omrthread_monitor_exit(vm->jfrBufferMutex);
 				internalAcquireVMAccess(currentThread);
 				notifyForChunkRotation(currentThread);
 			}
 			goto done;
 		} else {
-			if (!hasExclusive) {
+			if (!*hasExclusive) {
 				internalAcquireVMAccess(currentThread);
 			}
 			bool result = writeOutGlobalBuffer(currentThread, false, false);
-			if (!hasExclusive) {
+			if (!*hasExclusive) {
 				internalReleaseVMAccess(currentThread);
-				if (!result) {
+			}
+			if (!result) {
+				if (!*hasExclusive) {
 					omrthread_monitor_exit(vm->jfrBufferMutex);
-					goto done;
 				}
+				goto done;
 			}
 		}
 	}
 	bytes = vm->jfrBuffer.bufferCurrent;
 	vm->jfrBuffer.bufferCurrent += size;
 	vm->jfrBuffer.bufferRemaining -= size;
-	if (!hasExclusive) {
-		omrthread_monitor_exit(vm->jfrBufferMutex);
-		internalAcquireVMAccess(currentThread);
-	}
 
 done:
 	return bytes;
@@ -370,6 +369,7 @@ flushBufferToGlobal(J9VMThread *currentThread, J9VMThread *flushThread)
 	UDATA bufferSize = flushThread->jfrBuffer.bufferCurrent - flushThread->jfrBuffer.bufferStart;
 	bool success = true;
 	U_8 *allocStart = NULL;
+	bool hasExclusive = false;
 
 	Trc_VM_jfr_flushBufferToGlobal(currentThread, flushThread, (U_32)bufferSize, flushThread->jfrBuffer.bufferStart, flushThread->jfrBuffer.bufferCurrent);
 
@@ -377,13 +377,18 @@ flushBufferToGlobal(J9VMThread *currentThread, J9VMThread *flushThread)
 		goto done;
 	}
 
-	allocStart = allocateMemFromGlobalBuffer(currentThread, bufferSize);
+	allocStart = allocateMemFromGlobalBuffer(currentThread, bufferSize, &hasExclusive);
 
 	if (NULL == allocStart) {
 		success = false;
 		goto done;
 	}
 	memcpy(allocStart, flushThread->jfrBuffer.bufferStart, bufferSize);
+
+	if (!hasExclusive) {
+		omrthread_monitor_exit(flushThread->javaVM->jfrBufferMutex);
+		internalAcquireVMAccess(currentThread);
+	}
 
 	/* Reset the buffer */
 	flushThread->jfrBuffer.bufferRemaining = flushThread->jfrBuffer.bufferSize;
@@ -2595,7 +2600,7 @@ JfrPeriodicEventSet::requestThreadDump(J9VMThread *currentThread)
 
 	const U_64 bufferSize = VM_JFRUtils::THREAD_DUMP_EVENT_SIZE_PER_THREAD * vm->peakThreadCount;
 	const UDATA eventSize = bufferSize + sizeof(J9JFRThreadDump);
-	J9JFRThreadDump *jfrEvent = (J9JFRThreadDump *)allocateMemFromGlobalBuffer(currentThread, eventSize);
+	J9JFRThreadDump *jfrEvent = (J9JFRThreadDump *)reserveBuffer(currentThread, currentThread, eventSize);
 
 	if (NULL == jfrEvent) {
 		return;
@@ -2610,6 +2615,7 @@ JfrPeriodicEventSet::requestThreadDump(J9VMThread *currentThread)
 	jfrEvent->bufferSize = bufferSize;
 	jfrEvent->result = buffer;
 	jfrEvent->resultLength = length;
+
 	return;
 }
 

--- a/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
+++ b/test/functional/cmdLineTests/jfr/src/org/openj9/test/WorkLoad.java
@@ -81,9 +81,16 @@ public class WorkLoad {
 			vthreads = Boolean.parseBoolean(args[3]);
 		}
 
-		WorkLoad workload = new WorkLoad(numberOfThreads, sizeOfNumberList, repeats, vthreads);
-		workload.runWork();
-		System.gc();
+		try {
+			WorkLoad workload = new WorkLoad(numberOfThreads, sizeOfNumberList, repeats, vthreads);
+			workload.runWork();
+			System.gc();
+		} catch (Throwable t) {
+			t.printStackTrace();
+		} finally {
+			System.out.println("Test ended");
+		}
+
 	}
 
 	public void runWork() {


### PR DESCRIPTION
There is a gap after allocateMemFromGlobalBuffer returns memory from the
global buffer. Given the the lock is released in the allocation function
it is possible that a thread is writing to the buffer, while another is
reading from it. This PR makes a change such that the lock is only
released after the write is complete.

Also, fix JFR the failure path after attempting to write out the global
buffer.