### PR TITLE
Fix captured call state handling for native downcalls

### DIFF
--- a/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/foreign/abi/InternalDowncallHandler.java
@@ -210,6 +210,9 @@ public class InternalDowncallHandler {
 	private static synchronized native void resolveRequiredFields();
 	private native void initCifNativeThunkData(String[] argLayouts, String retLayout, boolean newArgTypes, int varArgIndex);
 	private native long invokeNative(
+			/*[IF JAVA_SPEC_VERSION >= 25]*/
+			int capturedCallStateMask,
+			/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
 			/*[IF JAVA_SPEC_VERSION >= 24]*/
 			Object returnStateMemBase,
 			/*[ENDIF] JAVA_SPEC_VERSION >= 24 */
@@ -931,6 +934,9 @@ public class InternalDowncallHandler {
 		try (Arena arena = Arena.ofConfined()) {
 			setDependency(arena.scope());
 			returnVal = invokeNative(
+					/*[IF JAVA_SPEC_VERSION >= 25]*/
+					linkerOpts.capturedCallStateMask(),
+					/*[ENDIF] JAVA_SPEC_VERSION >= 25 */
 					/*[IF JAVA_SPEC_VERSION >= 24]*/
 					returnStateMemBase,
 					/*[ENDIF] JAVA_SPEC_VERSION >= 24 */

--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -23,17 +23,6 @@
 #if !defined(BYTECODEINTERPRETER_HPP_)
 #define BYTECODEINTERPRETER_HPP_
 
-#if JAVA_SPEC_VERSION >= 21
-#include <errno.h>
-#if defined(WIN32)
-/* Ignore the definition of UDATA as it is defined in <windows.h>. */
-#define UDATA UDATA_win32_
-#include <windows.h>
-#undef UDATA /* This is safe because our UDATA is a typedef rather than a macro. */
-#include <winsock2.h>
-#endif /* defined(WIN32) */
-#endif /* JAVA_SPEC_VERSION >= 21 */
-
 #include "bcnames.h"
 #define FFI_BUILDING /* Needed on Windows to link libffi statically */
 #include "ffi.h"
@@ -79,6 +68,7 @@
 #include "LayoutFFITypeHelpers.hpp"
 #endif /* JAVA_SPEC_VERSION >= 16 */
 #if JAVA_SPEC_VERSION >= 21
+#include "ForeignCallHelpers.hpp"
 #include "ContinuationHelpers.hpp"
 #endif /* JAVA_SPEC_VERSION >= 21 */
 #if JAVA_SPEC_VERSION >= 24
@@ -5481,7 +5471,11 @@ done:
 	}
 
 #if JAVA_SPEC_VERSION >= 16
-#if JAVA_SPEC_VERSION >= 24
+#if JAVA_SPEC_VERSION >= 25
+	/* openj9.internal.foreign.abi.InternalDowncallHandler:
+	 * private native long invokeNative(int capturedCallStateMask, Object returnStateMemBase, Object[] bases, long[] offsets, boolean isInCriticalDownCall, long returnStateMemAddr, long returnStructMemAddr, long functionAddr, long calloutThunk, long[] argValues);
+	 */
+#elif JAVA_SPEC_VERSION >= 24
 	/* openj9.internal.foreign.abi.InternalDowncallHandler:
 	 * private native long invokeNative(Object returnStateMemBase, Object[] bases, long[] offsets, boolean isInCriticalDownCall, long returnStateMemAddr, long returnStructMemAddr, long functionAddr, long calloutThunk, long[] argValues);
 	 */
@@ -5526,10 +5520,17 @@ done:
 		UDATA *returnStorage = &(_currentThread->returnValue);
 		U_64 *ffiArgs = _currentThread->ffiArgs;
 		U_64 sFfiArgs[16];
+#if JAVA_SPEC_VERSION >= 21
+		I_32 capturedCallStateMask = DowncallCapturableState::J9_CAPTURE_ALL_STATES;
+#endif /* JAVA_SPEC_VERSION >= 21 */
 #if JAVA_SPEC_VERSION >= 22
 #if JAVA_SPEC_VERSION >= 24
+#if JAVA_SPEC_VERSION >= 25
+		UDATA argSlots = 15;
+#else /* JAVA_SPEC_VERSION >= 25 */
 		UDATA argSlots = 14;
-		UDATA returnStateMemAddr;
+#endif /* JAVA_SPEC_VERSION >= 25 */
+		UDATA returnStateMemAddr = 0;
 		j9object_t returnStateMemBase = NULL;
 #else /* JAVA_SPEC_VERSION >= 24 */
 		UDATA argSlots = 13;
@@ -5572,6 +5573,9 @@ done:
 		} else {
 			returnState = (I_32 *)returnStateMemAddr;
 		}
+#if JAVA_SPEC_VERSION >= 25
+		capturedCallStateMask = *(I_32 *)(_sp + 13); /* capturedCallStateMask */
+#endif /* JAVA_SPEC_VERSION >= 25 */
 #else /* JAVA_SPEC_VERSION >= 24 */
 		returnState = (I_32 *)(UDATA)*(I_64 *)(_sp + 7); /* returnStateMemAddr */
 #endif /* JAVA_SPEC_VERSION >= 24 */
@@ -5715,11 +5719,21 @@ done:
 			VM_VMAccess::inlineExitVMToJNI(_currentThread);
 		}
 		VM_VMHelpers::beforeJNICall(_currentThread);
+
+#if JAVA_SPEC_VERSION >= 25
+		ForeignCallHelpers::restoreCapturedCallState(returnState, capturedCallStateMask);
+#endif /* JAVA_SPEC_VERSION >= 25 */
+
 #if FFI_NATIVE_RAW_API
 		ffiCallWithSetJmpForUpcall(_currentThread, cif, function, returnStorage, values, values_raw);
 #else /* FFI_NATIVE_RAW_API */
 		ffiCallWithSetJmpForUpcall(_currentThread, cif, function, returnStorage, values);
 #endif /* FFI_NATIVE_RAW_API */
+
+#if JAVA_SPEC_VERSION >= 21
+		ForeignCallHelpers::storeCapturedCallState(returnState, capturedCallStateMask);
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
 		VM_VMHelpers::afterJNICall(_currentThread);
 #if JAVA_SPEC_VERSION >= 21
 		/* Re-enter VM after non-critical downcalls. */
@@ -5765,21 +5779,6 @@ done:
 		}
 #endif /* JAVA_SPEC_VERSION >= 22 */
 
-#if JAVA_SPEC_VERSION >= 21
-		/* Set the execution state after the downcall as required in the linker options. */
-		if (NULL != returnState) {
-			/* The error code layout on Windows in JDK21 is changed to a segment for an array of integers
-			 * which saves the return value of GetLastError(), WSAGetLastError() and errno.
-			 */
-#if defined(WIN32)
-			returnState[0] = GetLastError();
-			returnState[1] = WSAGetLastError();
-			returnState[2] = (I_32)errno;
-#else /* defined(WIN32) */
-			*returnState = (I_32)errno;
-#endif /* defined(WIN32) */
-		}
-#endif /* JAVA_SPEC_VERSION >= 21 */
 		VM_VMHelpers::convertFFIReturnValue(_currentThread, returnType, returnTypeSize, returnStorage);
 		returnDoubleFromINL(REGISTER_ARGS, _currentThread->returnValue, argSlots);
 

--- a/runtime/vm/ForeignCallHelpers.hpp
+++ b/runtime/vm/ForeignCallHelpers.hpp
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Copyright IBM Corp. and others 2026
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ *******************************************************************************/
+
+#if !defined(FOREIGNCALLHELPERS_HPP_)
+#define FOREIGNCALLHELPERS_HPP_
+
+#include "j9cfg.h"
+
+#if JAVA_SPEC_VERSION >= 21
+#include <errno.h>
+#if defined(WIN32)
+/* Ignore the definition of UDATA as it is defined in <windows.h>. */
+#define UDATA UDATA_win32_
+#include <windows.h>
+#undef UDATA /* This is safe because our UDATA is a typedef rather than a macro. */
+#include <winsock2.h>
+#endif /* defined(WIN32) */
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
+#include "j9consts.h"
+
+/* These bit values must match the corresponding values defined by
+ * jdk.internal.foreign.abi.CapturableState.
+ */
+typedef enum {
+	J9_CAPTURE_GET_LAST_ERROR = 1 << 0,
+	J9_CAPTURE_WSA_LAST_ERROR = 1 << 1,
+	J9_CAPTURE_ERRNO = 1 << 2,
+#if defined(WIN32)
+	J9_CAPTURE_ALL_STATES = J9_CAPTURE_GET_LAST_ERROR | J9_CAPTURE_WSA_LAST_ERROR | J9_CAPTURE_ERRNO
+#else /* defined(WIN32) */
+	J9_CAPTURE_ALL_STATES = J9_CAPTURE_ERRNO
+#endif /* defined(WIN32) */
+} DowncallCapturableState;
+
+class ForeignCallHelpers
+{
+/*
+ * Function members
+ */
+public:
+
+#if JAVA_SPEC_VERSION >= 25
+	/**
+	 * Restore the selected native thread-local state values from the
+	 * capture state buffer before a native downcall.
+	 *
+	 * @param returnState[in] pointer to the capture state buffer
+	 * @param capturedCallStateMask[in] mask identifying the call state
+	 * values to restore
+	 */
+	static VMINLINE void
+	restoreCapturedCallState(I_32 *returnState, I_32 capturedCallStateMask)
+	{
+		if (NULL != returnState) {
+#if defined(WIN32)
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_GET_LAST_ERROR)) {
+				SetLastError((DWORD)returnState[0]);
+			}
+
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_WSA_LAST_ERROR)) {
+				WSASetLastError(returnState[1]);
+			}
+
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_ERRNO)) {
+				errno = returnState[2];
+			}
+#else /* defined(WIN32) */
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_ERRNO)) {
+				errno = returnState[0];
+			}
+#endif /* defined(WIN32) */
+		}
+	}
+#endif /* JAVA_SPEC_VERSION >= 25 */
+
+#if JAVA_SPEC_VERSION >= 21
+	/**
+	 * Store the selected native thread-local state values to the
+	 * capture state buffer after a native downcall.
+	 *
+	 * @param returnState[out] pointer to the capture state buffer
+	 * @param capturedCallStateMask[in] mask identifying the call state
+	 * values to save
+	 */
+	static VMINLINE void
+	storeCapturedCallState(I_32 *returnState, I_32 capturedCallStateMask)
+	{
+		if (NULL != returnState) {
+#if defined(WIN32)
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_GET_LAST_ERROR)) {
+				returnState[0] = (I_32)GetLastError();
+			}
+
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_WSA_LAST_ERROR)) {
+				returnState[1] = WSAGetLastError();
+			}
+
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_ERRNO)) {
+				returnState[2] = errno;
+			}
+#else /* defined(WIN32) */
+			if (J9_ARE_ANY_BITS_SET(capturedCallStateMask, J9_CAPTURE_ERRNO)) {
+				returnState[0] = errno;
+			}
+#endif /* defined(WIN32) */
+		}
+	}
+#endif /* JAVA_SPEC_VERSION >= 21 */
+
+};
+
+#endif /* !defined(FOREIGNCALLHELPERS_HPP_) */

--- a/runtime/vm/bindnatv.cpp
+++ b/runtime/vm/bindnatv.cpp
@@ -312,7 +312,9 @@ static inlMapping mappings[] = {
 	{ "Java_sun_reflect_Reflection_getClassAccessFlags__Ljava_lang_Class_2", J9_BCLOOP_SEND_TARGET_INL_REFLECTION_GETCLASSACCESSFLAGS },
 #endif /* JAVA_SPEC_VERSION >= 11 */
 
-#if JAVA_SPEC_VERSION >= 24
+#if JAVA_SPEC_VERSION >= 25
+	{ "Java_openj9_internal_foreign_abi_InternalDowncallHandler_invokeNative__ILjava_lang_Object_2_3Ljava_lang_Object_2_3JZJJJJ_3J", J9_BCLOOP_SEND_TARGET_INL_INTERNALDOWNCALLHANDLER_INVOKENATIVE },
+#elif JAVA_SPEC_VERSION >= 24 /* JAVA_SPEC_VERSION >= 25 */
 	{ "Java_openj9_internal_foreign_abi_InternalDowncallHandler_invokeNative__Ljava_lang_Object_2_3Ljava_lang_Object_2_3JZJJJJ_3J", J9_BCLOOP_SEND_TARGET_INL_INTERNALDOWNCALLHANDLER_INVOKENATIVE },
 #elif JAVA_SPEC_VERSION >= 22 /* JAVA_SPEC_VERSION >= 24 */
 	{ "Java_openj9_internal_foreign_abi_InternalDowncallHandler_invokeNative___3Ljava_lang_Object_2_3JZJJJJ_3J", J9_BCLOOP_SEND_TARGET_INL_INTERNALDOWNCALLHANDLER_INVOKENATIVE },


### PR DESCRIPTION
JDK 25+ requires captured native thread-local state to be restored
from the capture state buffer immediately before a native downcall
and saved back to the buffer after the call.

OpenJ9 previously only saved the state after the downcall. This
caused values such as `errno` from an earlier native call to be
preserved when the target function did not update them.

Pass the captured call state mask to `invokeNative` and use it to
restore and save only the requested state values around the native
call.

Related: https://github.com/eclipse-openj9/openj9/issues/24463