### PR TITLE
Fix incorrect faulting instruction update in BNDCHK implicit null check

### DIFF
--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -3065,7 +3065,16 @@ void setImplicitNULLCHKExceptionInfo(TR::Node *node, TR::CodeGenerator *cg)
         // The last instruction is a branch, the comparison is before.
         TR::Instruction *cmpInstruction = cg->getAppendInstruction()->getPrev();
         OP::Mnemonic mnemonic = cmpInstruction->getOpCodeValue();
-        bool isComparisonMemForm = mnemonic == OP::CMP4MemReg || mnemonic == OP::CMP4RegMem;
+
+        // CMP4MemReg: cmp [arr+4], idx_reg
+        // The memory operand loads the array length from the array.
+        // This instruction can fault if arr is null, making it the correct faulting instruction.
+        //
+        // CMP4RegMem: cmp arraylength_reg, [this+idx_offset]
+        // The memory operand loads idx from 'this', not from the array.
+        // This instruction cannot fault due to a null array access, so it
+        // shouldn't be selected as the faulting instruction.
+        bool isComparisonMemForm = mnemonic == OP::CMP4MemReg;
         if (comp->useCompressedPointers() && faultingInstruction != cmpInstruction && isComparisonMemForm) {
             logprintf(isTraceCG, comp->log(), "Faulting instruction (previously %p) updated to %p\n",
                 faultingInstruction, cmpInstruction);


### PR DESCRIPTION
When a `BNDCHK` has a `foldedImplicitNULLCHK`, the function `setImplicitNULLCHKExceptionInfo` attempts to correctly identify the faulting instruction. The condition checked for both `CMP4MemReg` and `CMP4RegMem`, but `CMP4RegMem` is only used if the array length is held in a register, so the memory access will not be the faulting instruction for a null array access. Including that instruction as potentially raising an implicit `NULLCHK` caused the stack walker to fail to find the stack map, hitting a fatal assertion in jswalk.c.

The fix removes `CMP4RegMem` from the condition, keeping only `CMP4MemReg` which correctly identifies a cmp that loads array length from the array.

Fixes #24569 