### PR TITLE
Check recompilationInfo before inserting recompDueToPhaseChangeCode

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -3616,7 +3616,8 @@ void J9::CodeGenerator::insertRecompDueToPhaseChangeCode()
     TR::Compilation *comp = self()->comp();
 
     if (!comp->getOption(TR_EnableRecompDueToPatchedNopableGuards) || comp->getMethodHotness() < hot
-        || comp->getOptimizationPlan()->getDoNotInsertPhaseChangeRecomp() || comp->isProfilingCompilation())
+        || comp->getOptimizationPlan()->getDoNotInsertPhaseChangeRecomp() || comp->isProfilingCompilation()
+        || comp->getRecompilationInfo() == NULL)
         return;
 
     OMR::Logger *log = comp->log();


### PR DESCRIPTION
It is possible that the recompilationInfo is null in a compilation and it would cause segmentation fault if it tries to insert recompilation code in insertRecompDueToPhaseChangeCode() method.

Add a condition to check recompilationInfo before entering insertRecompDueToPhaseChangeCode() function.