### PR TITLE
Verifier updates for strict fields

### DIFF
--- a/runtime/bcverify/bcverify.c
+++ b/runtime/bcverify/bcverify.c
@@ -122,12 +122,23 @@ setInitializedThisStatus(J9BytecodeVerificationData *verifyData)
 			 * which means 'Locals' starts from 0 to stackBaseIndex while 'Stacks' starts from stackBaseIndex
 			 * to stackTopIndex.
 			 *
+			 * Before Java 27:
 			 * The JVM Spec at 4.10.1.4 Stack Map Frame Representation says that if any local variable in 'Locals'
 			 * has the type 'uninitializedThis', then 'Flags' has the single element 'flagThisUninit'; otherwise
 			 * 'Flags' is an empty list. That is to say, we only check the elements of 'Locals' rather than the
 			 * whole operation stack frame to determine whether to set the flags.
+			 *
+			 * In Java 27 the spec changed so that flagThisUninit must be set when
+			 * uninitializedThis appears in either locals or the stack. While this
+			 * change appears in the JVMS for Java 27 it was not enforced in the ri
+			 * until Java 28. To match this behavior OpenJ9 also will not enforce
+			 * this until Java 28.
 			 */
+#if JAVA_SPEC_VERSION >= 28
+			for (; i < currentStack->stackTopIndex; i++) {
+#else /* JAVA_SPEC_VERSION >= 28 */
 			for (; i < currentStack->stackBaseIndex; i++) {
+#endif /* JAVA_SPEC_VERSION >= 28 */
 				if (J9_ARE_ALL_BITS_SET(currentStack->stackElements[i], BCV_SPECIAL_INIT)) {
 					flag_uninitialized = TRUE;
 					break;

--- a/runtime/bcverify/rtverify.c
+++ b/runtime/bcverify/rtverify.c
@@ -245,20 +245,22 @@ findAndMatchStack (J9BytecodeVerificationData *verifyData, IDATA targetPC, IDATA
 		if (J9_CLASSFILE_OR_ROMCLASS_SUPPORTS_STRICT_FIELDS(verifyData->romClass)
 			&& liveStack->uninitializedThis
 			&& (hashTableGetCount(verifyData->strictFields) > 0)
-			&& (hashTableGetCount(verifyData->earlyLarvalFrames) > 0)
 		) {
-			J9EarlyLarvalFrame query = {0};
-			query.baseFramePC = targetPC;
-			J9EarlyLarvalFrame *earlyLarvalFrame = hashTableFind(verifyData->earlyLarvalFrames, &query);
-			if (NULL == earlyLarvalFrame) {
-				earlyLarvalFrame = verifyData->earlyLarvalFramePrevious;
-			} else {
-				verifyData->earlyLarvalFramePrevious = earlyLarvalFrame;
+			/* If there is no early larval frame for this pc the unset fields
+			 * are inferred from the previous frame.
+			 */
+			J9EarlyLarvalFrame *earlyLarvalFrame = verifyData->earlyLarvalFramePrevious;
+			if (hashTableGetCount(verifyData->earlyLarvalFrames) > 0) {
+				J9EarlyLarvalFrame query = {0};
+				query.baseFramePC = targetPC;
+				J9EarlyLarvalFrame *earlyLarvalFrameTemp = hashTableFind(verifyData->earlyLarvalFrames, &query);
+				if (NULL != earlyLarvalFrameTemp) {
+					earlyLarvalFrame = earlyLarvalFrameTemp;
+					verifyData->earlyLarvalFramePrevious = earlyLarvalFrame;
+				}
 			}
 
 			if (NULL != earlyLarvalFrame) {
-				J9ROMClass *romClass = verifyData->romClass;
-				J9ROMConstantPoolItem *constantPool = J9_ROM_CP_FROM_ROM_CLASS(romClass);
 				U_16 unsetFieldIndex = 0;
 				J9StrictFieldEntry *entry = NULL;
 				/* Mark each strict field that is in the target frame unset field list as referenced. */
@@ -274,35 +276,36 @@ findAndMatchStack (J9BytecodeVerificationData *verifyData, IDATA targetPC, IDATA
 					}
 					entry->isReferenced = TRUE;
 				}
+			}
 
-				/* The unset fields list is used to track which fields are guaranteed to be
-				 * set. If a field appears in the list it is either unset or it might be
-				 * unset on this new branch.
-				 * For fields that are in the unset list make sure they are tracked as unset
-				 * so we can verify whether they will be set in the new path.
-				 * For fields that are not in the unset list make sure they were set, otherwise
-				 * throw an error.
-				*/
-				J9HashTableState hashTableState = {0};
-				entry = (J9StrictFieldEntry *)hashTableStartDo(verifyData->strictFields, &hashTableState);
-				while (NULL != entry) {
-					if (entry->isReferenced) {
-						if (entry->isSet) {
-							entry->isSet = FALSE;
-							verifyData->strictFieldsUnsetCount++;
-						}
-						/* Reset for the next stack map frame match. */
-						entry->isReferenced = FALSE;
-					} else {
-						if (!entry->isSet) {
-							verifyData->errorDetailCode = BCV_ERR_STRICT_FIELD_STACK_MAP_INCONSISTENT;
-							rc = BCV_FAIL;
-							goto exit;
-						}
+			/* The unset fields list is used to track which fields are guaranteed to be
+			 * set. If a field appears in the list it is either unset or it might be
+			 * unset on this new branch.
+			 * For fields that are in the unset list make sure they are tracked as unset
+			 * so we can verify whether they will be set in the new path.
+			 * For fields that are not in the unset list make sure they were set, otherwise
+			 * throw an error.
+			 */
+			J9HashTableState hashTableState = {0};
+			J9StrictFieldEntry *entry = (J9StrictFieldEntry *)hashTableStartDo(verifyData->strictFields, &hashTableState);
+			while (NULL != entry) {
+				/* The implicit first frame of a strict instance initialization
+				 * method (NULL == earlyLarvalFrame) treats all strict fields as unset.
+				 */
+				if ((NULL == earlyLarvalFrame) || entry->isReferenced) {
+					if (entry->isSet) {
+						entry->isSet = FALSE;
+						verifyData->strictFieldsUnsetCount++;
 					}
-
-					entry = hashTableNextDo(&hashTableState);
+					/* Reset for the next stack map frame match. */
+					entry->isReferenced = FALSE;
+				} else if (!entry->isSet) {
+					verifyData->errorDetailCode = BCV_ERR_STRICT_FIELD_STACK_MAP_INCONSISTENT;
+					rc = BCV_FAIL;
+					goto exit;
 				}
+
+				entry = hashTableNextDo(&hashTableState);
 			}
 		}
 #endif /* defined(J9VM_OPT_VALHALLA_STRICT_FIELDS) */


### PR DESCRIPTION
This change fixes two new test failures in runtime/valhalla/inlinetypes/verifier/StrictInstanceFieldsTest.java, ControlFlowAlias and UninitThisOnStack.

### ControlFlowAlias
In an uninitialized state a stack map frame with no early larval
entry is assumed to have the same list as the previous frame. If
no previous frame exists all strict fields should be treated as
unset. Previously this case was skipped over.

### UninitThisOnStack
Previously flagThisUninit was only set if uninitializedThis was
found in the list of locals.

Starting in Java 27 the spec changed to include that flagThisUninit
should also be set if uninitializedThis is on the operand stack.

The ri does not enforce this until Java 28 so I have also included
this starting in Java 28.

This fixes the UninitThisOnStack test case in StrictInstanceFieldsTest
however it is not specific to strict fields.

Fixes: https://github.com/eclipse-openj9/openj9/issues/24512
Related: https://github.com/eclipse-openj9/openj9/issues/24520