### PR TITLE
(0.62) Account for required signal handler space in copied OSR stack frame

### DIFF
--- a/runtime/codert_vm/decomp.cpp
+++ b/runtime/codert_vm/decomp.cpp
@@ -140,7 +140,7 @@ static UDATA performOSR(J9VMThread *currentThread, J9StackWalkState *walkState, 
 static UDATA* jitLocalSlotAddress(J9VMThread * currentThread, J9StackWalkState *walkState, UDATA slot, UDATA inlineDepth);
 static void jitResetAllMethods(J9VMThread *currentThread);
 static void fixStackForNewDecompilation(J9VMThread * currentThread, J9StackWalkState * walkState, J9JITDecompilationInfo *info, UDATA reason, J9JITDecompilationInfo **link);
-static UDATA roundedOSRScratchBufferSize(J9VMThread * currentThread, J9JITExceptionTable *metaData, void *jitPC);
+static UDATA roundedOSRScratchBufferSize(UDATA scratchBufferSize);
 static j9object_t* getObjectSlotAddress(J9OSRData *osrData, U_16 slot);
 static UDATA createMonitorEnterRecords(J9VMThread *currentThread, J9OSRData *osrData);
 static UDATA initializeOSRFrame(J9VMThread *currentThread, J9OSRData *osrData);
@@ -1200,7 +1200,7 @@ addDecompilationHelper(J9VMThread * currentThread, J9StackWalkState * walkState,
 	}
 
 	if (osrFrame) {
-		UDATA scratchBufferSize = roundedOSRScratchBufferSize(currentThread, metaData, walkState->pc);
+		UDATA scratchBufferSize = roundedOSRScratchBufferSize(osrScratchBufferSize(currentThread, metaData, walkState->pc));
 		UDATA jitStackFrameSize = (UDATA)(walkState->arg0EA + 1) - (UDATA)walkState->unwindSP;
 		void *osrScratchBuffer = j9mem_allocate_memory(scratchBufferSize + jitStackFrameSize, OMRMEM_CATEGORY_JIT);
 		UDATA mustDecompile = FALSE;
@@ -2160,24 +2160,25 @@ jitLocalSlotAddress(J9VMThread * currentThread, J9StackWalkState *walkState, UDA
 /**
  * Compute the required size of the OSR scratch buffer.
  *
- * @param[in] *currentThread current thread
- * @param[in] *metadata JIT metadata for this compilation
- * @param[in] *jitPC compiled PC at which to OSR
+ * @param[in] scratchBufferSize OSR scratch buffer size
  *
- * @return the scratch buffer size
+ * @return the extended aand rounded scratch buffer size
  */
 static UDATA
-roundedOSRScratchBufferSize(J9VMThread * currentThread, J9JITExceptionTable *metaData, void *jitPC)
+roundedOSRScratchBufferSize(UDATA scratchBufferSize)
 {
-	J9JavaVM *vm = currentThread->javaVM;
-	UDATA scratchBufferSize = osrScratchBufferSize(currentThread, metaData, jitPC);
-
 	/* Ensure a minimum size for the scratch buffer to allow for possible calls while the stack is active
 	 * (in particular, Linux on x86 performs a call in order to compute the GOT).  Currently, the minimum
 	 * size is 8 UDATAs.  Round the size of the scratch buffer up to UDATA.
 	 */
 	scratchBufferSize = OMR_MAX(scratchBufferSize, (8 * sizeof(UDATA)));
 	scratchBufferSize = ROUND_TO(sizeof(UDATA), scratchBufferSize);
+
+#if defined(J9VM_ARCH_X86)
+	/* Account for any space required by a signal handler running while the native SP points to the OSR area. */
+	scratchBufferSize += (J9_EXTRA_STACK_SPACE_FOR_SIGNALS + J9_STACK_OVERFLOW_RESERVED_SIZE);
+#endif /* J9VM_ARCH_X86 */
+
 	return scratchBufferSize;
 }
 
@@ -2439,7 +2440,7 @@ induceOSROnCurrentThread(J9VMThread * currentThread)
 	 */
 	decompRecordSize = osrAllFramesSize(currentThread, metaData, jitPC, walkState.resolveFrameFlags);
 	decompRecordSize += sizeof(J9JITDecompilationInfo);
-	scratchBufferSize = roundedOSRScratchBufferSize(currentThread, metaData, jitPC);
+	scratchBufferSize = roundedOSRScratchBufferSize(osrScratchBufferSize(currentThread, metaData, jitPC));
 	jitStackFrameSize = (UDATA)(walkState.arg0EA + 1) - (UDATA)walkState.unwindSP;
 	totalSize = decompRecordSize + scratchBufferSize + jitStackFrameSize;
 	Assert_CodertVM_true(totalSize <= vm->osrGlobalBufferSize);
@@ -2500,7 +2501,7 @@ ensureOSRBufferSize(J9JavaVM *vm, UDATA osrFramesByteSize, UDATA osrScratchBuffe
 	UDATA result = TRUE;
 	UDATA osrGlobalBufferSize = sizeof(J9JITDecompilationInfo);
 	osrGlobalBufferSize += ROUND_TO(sizeof(UDATA), osrFramesByteSize);
-	osrGlobalBufferSize += ROUND_TO(sizeof(UDATA), osrScratchBufferByteSize);
+	osrGlobalBufferSize += roundedOSRScratchBufferSize(osrScratchBufferByteSize);
 	osrGlobalBufferSize += ROUND_TO(sizeof(UDATA), osrStackFrameByteSize);
 	if (osrGlobalBufferSize > vm->osrGlobalBufferSize) {
 		omrthread_monitor_enter(vm->osrGlobalBufferLock);

--- a/runtime/oti/j9consts.h
+++ b/runtime/oti/j9consts.h
@@ -76,6 +76,17 @@ extern "C" {
  * Extra space is added to the stack on windows x86 in allocateJavaStack to account for
  * the additional space required for AMX.
  */
+
+#if defined(WIN32)
+/* Extra space is needed for the XSAVE buffer when the processor has AMX capabilities. The amount
+ * amount of space needed in XSAVE for AMX is 8K. TODO in the future we should detect AMX
+ * capabilities and selectively increase the buffer size.
+ */
+#define J9_EXTRA_STACK_SPACE_FOR_SIGNALS (8 * 1024)
+#else /* defined(WIN32) */
+#define J9_EXTRA_STACK_SPACE_FOR_SIGNALS 0
+#endif /* defined(WIN32) */
+
 #if defined(J9VM_ENV_DATA64)
 #if defined(J9VM_ARCH_X86)
 #define J9_STACK_OVERFLOW_RESERVED_SIZE 0x2000

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -1580,22 +1580,12 @@ allocateJavaStack(J9JavaVM * vm, UDATA stackSize, J9JavaStack * previousStack)
 	UDATA pageSize = vm->defaultPageSize;
 	bool pageGuards = J9_ARE_ALL_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_JAVA_STACK_GUARD_PAGES);
 	UDATA stackMemory = 0;
-	UDATA extraRegisterSpace = 0;
 
 	/* Allocate the stack, adding the header and overflow area size.
 	 * Add one slot for possible double-slot alignment.
 	 * If stagger is in use, add the maximum stagger value to account for that alignment.
 	 */
-
-#if defined(WIN32)
-	/* Extra space is needed for the XSAVE buffer when the processor has AMX capabilities. The amount
-	 * amount of space needed in XSAVE for AMX is 8K. TODO in the future we should detect AMX
-	 * capabilities and selectively increase the buffer size.
-	 */
-	extraRegisterSpace += (8 * 1024);
-#endif /* defined(WIN32) */
-
-	mallocSize = J9_STACK_OVERFLOW_AND_HEADER_SIZE + (stackSize + sizeof(UDATA)) + vm->thrStaggerMax + extraRegisterSpace;
+	mallocSize = J9_STACK_OVERFLOW_AND_HEADER_SIZE + (stackSize + sizeof(UDATA)) + vm->thrStaggerMax + J9_EXTRA_STACK_SPACE_FOR_SIGNALS;
 	if (pageGuards) {
 		mallocSize += (pageSize * 2);
 	}
@@ -1636,7 +1626,7 @@ allocateJavaStack(J9JavaVM * vm, UDATA stackSize, J9JavaStack * previousStack)
 		UDATA end = 0;
 		UDATA stagger = vm->thrStagger;
 
-		end = ((UDATA) stack) + J9_STACK_OVERFLOW_AND_HEADER_SIZE + stackSize + extraRegisterSpace;
+		end = ((UDATA) stack) + J9_STACK_OVERFLOW_AND_HEADER_SIZE + stackSize + J9_EXTRA_STACK_SPACE_FOR_SIGNALS;
 		if (pageGuards) {
 			end += (pageSize * 2);
 		}


### PR DESCRIPTION
Allocate larger OSR scratch buffer for possible signal handler invocation.

Fixes: #24487

Port https://github.com/eclipse-openj9/openj9/pull/24518