### PR TITLE
Patchable JProfiler thread pool infrastructure

### DIFF
--- a/runtime/compiler/codegen/J9CodeGenPhase.cpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.cpp
@@ -55,6 +55,47 @@ void J9::CodeGenPhase::reportPhase(PhaseValue phase)
 
 int J9::CodeGenPhase::getNumPhases() { return static_cast<int>(TR::CodeGenPhase::LastJ9Phase); }
 
+void J9::CodeGenPhase::performBinaryEncodingPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
+{
+    OMR::CodeGenPhase::performBinaryEncodingPhase(cg, phase);
+    TR::Compilation *comp = cg->comp();
+    if (comp->getOptimizationPlan()->insertPatchableJProfiling() && comp->getRecompilationInfo() != NULL) {
+        uintptr_t key = reinterpret_cast<uintptr_t>(comp->getRecompilationInfo()->getJittedBodyInfo());
+        TR_BlockFrequencyInfo *info = TR_BlockFrequencyInfo::getCurrent(comp);
+        if (info != NULL) {
+            TR::list<TR::Instruction *> instrList = cg->getJProfilingCounterBumpInstructionList();
+            if (!instrList->empty()) {
+                TR::JProfBFPatchSites *sites = new (comp->trPersistentMemory())
+                    TR::JProfBFPatchSites(comp->trPersistentMemory(), instrList->size());
+                for (auto iter = instrList->begin(); itre != instrList->end(); ++iter) {
+                    uint8_t *location = (*iter)->getBinaryEncoding();
+                    uint8_t instrLength = (*iter)->getBinaryLength();
+                    // Need to pass the length of the instruction here.
+                    sites->add(location, instrLength);
+                }
+                TR_JProfBlockFrequencyCounterSites *patchSites = TR_JProfBlockFrequencyCounterSites::make(comp->fe(),
+                    comp->trPersistentMemory(), key, sites, comp->getMetadataAssumptionList());
+                info->addJProfBlockFrequencyCounterPatchSites(patchSites);
+            }
+        }
+        TR_ValueProfileInfo *valueInfo = TR_ValueProfileInfo::getCurrent(comp);
+        if (valueInfo != NULL) {
+            TR::list<TR::Instruction *> instrList = cg->getJProfValueBranchInstrList();
+            if (instrList != NULL && !instrList->empty()) {
+                TR::PatchSites *sites
+                    = new (comp->trPersistentMemory()) TR::PatchSites(comp->trPersistentMemory(), instrList->size());
+                for (auto iter = instrList->begin(); iter != instrList->end(); ++iter) {
+                    uint8_t *location = (*iter)->getBinaryEncoding();
+                    sites->add(location, 0);
+                }
+                TR_JProfValueSites *valueProfSites = TR_JProfValueSites::make(comp->fe(), comp->trPersistentMemory(),
+                    key, sites, comp->getMetadataAssumptionList());
+                valueInfo->addJProfValueSites(valueProfSites);
+            }
+        }
+    }
+}
+
 void J9::CodeGenPhase::performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *phase)
 {
     cg->fixUpProfiledInterfaceGuardTest();

--- a/runtime/compiler/codegen/J9CodeGenPhase.hpp
+++ b/runtime/compiler/codegen/J9CodeGenPhase.hpp
@@ -47,6 +47,7 @@ protected:
 
 public:
     void reportPhase(PhaseValue phase);
+    static void performBinaryEncodingPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performFixUpProfiledInterfaceGuardTestPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performAllocateLinkageRegistersPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);
     static void performPopulateOSRBufferPhase(TR::CodeGenerator *cg, TR::CodeGenPhase *);

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4387,6 +4387,30 @@ void J9::CodeGenerator::jitAdd32BitPicToPatchOnClassRedefinition(void *classPoin
     }
 }
 
+void J9::CodeGenerator::initJProfCounterBumpInstrList()
+{
+    TR::Compilation *comp = self()->comp();
+    _jProfilingCounterBumpInstructionList = new (comp->trHeapMemory()) TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
+}
+
+void J9::CodeGenerator::addInstrToJProfCounterBumpInstrList(TR::Instruction *instr)
+{
+    TR_ASSERT_FATAL(_jProfilingCounterBumpInstructionList != NULL, "Adding JProfiling Block counter increment instruction to list without initializing list\n");
+    _jProfilingCounterBumpInstructionList->push_front(instr);
+}
+
+void J9::CodeGenerator::initJProfValueBranchInstrList()
+{
+    TR::Compilation *comp = self()->comp();
+    __jProfilingValueProfilingBranchInstructions = new (comp->trHeapMemory()) TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
+}
+
+void J9::CodeGenerator::addInstrToJProfValueBranchInstrList(TR::Instruction *instr)
+{
+    TR_ASSERT_FATAL(__jProfilingValueProfilingBranchInstructions != NULL, "Adding JProfiling Value Branch instruction to list without initializing list\n");
+    __jProfilingValueProfilingBranchInstructions->push_front(instr);
+}
+
 void J9::CodeGenerator::createHWPRecords()
 {
     if (self()->comp()->getPersistentInfo()->isRuntimeInstrumentationEnabled()

--- a/runtime/compiler/codegen/J9CodeGenerator.cpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.cpp
@@ -4390,24 +4390,28 @@ void J9::CodeGenerator::jitAdd32BitPicToPatchOnClassRedefinition(void *classPoin
 void J9::CodeGenerator::initJProfCounterBumpInstrList()
 {
     TR::Compilation *comp = self()->comp();
-    _jProfilingCounterBumpInstructionList = new (comp->trHeapMemory()) TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
+    _jProfilingCounterBumpInstructionList = new (comp->trHeapMemory())
+        TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
 }
 
 void J9::CodeGenerator::addInstrToJProfCounterBumpInstrList(TR::Instruction *instr)
 {
-    TR_ASSERT_FATAL(_jProfilingCounterBumpInstructionList != NULL, "Adding JProfiling Block counter increment instruction to list without initializing list\n");
+    TR_ASSERT_FATAL(_jProfilingCounterBumpInstructionList != NULL,
+        "Adding JProfiling Block counter increment instruction to list without initializing list\n");
     _jProfilingCounterBumpInstructionList->push_front(instr);
 }
 
 void J9::CodeGenerator::initJProfValueBranchInstrList()
 {
     TR::Compilation *comp = self()->comp();
-    __jProfilingValueProfilingBranchInstructions = new (comp->trHeapMemory()) TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
+    __jProfilingValueProfilingBranchInstructions = new (comp->trHeapMemory())
+        TR::list<TR::Instruction *>(getTypedAllocator<TR::Instruction *>(comp->allocator()));
 }
 
 void J9::CodeGenerator::addInstrToJProfValueBranchInstrList(TR::Instruction *instr)
 {
-    TR_ASSERT_FATAL(__jProfilingValueProfilingBranchInstructions != NULL, "Adding JProfiling Value Branch instruction to list without initializing list\n");
+    TR_ASSERT_FATAL(__jProfilingValueProfilingBranchInstructions != NULL,
+        "Adding JProfiling Value Branch instruction to list without initializing list\n");
     __jProfilingValueProfilingBranchInstructions->push_front(instr);
 }
 

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -408,6 +408,7 @@ private:
 
     TR::list<TR::Instruction *> *_jProfilingCounterBumpInstructionList;
     TR::list<TR::Instruction *> *__jProfilingValueProfilingBranchInstructions;
+
 protected:
     // isTemporaryBased storageReferences just have a symRef but some other routines expect a node so use the below to
     // fill in this symRef on this node
@@ -432,11 +433,17 @@ public:
     // Patchable JProfiling
     void initJProfCounterBumpInstrList();
     void addInstrToJProfCounterBumpInstrList(TR::Instruction *instr);
-    TR::list<TR::Instruction *> *getJProfilingCounterBumpInstructionList() { return _jProfilingCounterBumpInstructionList; }
+
+    TR::list<TR::Instruction *> *getJProfilingCounterBumpInstructionList()
+    {
+        return _jProfilingCounterBumpInstructionList;
+    }
 
     void initJProfValueBranchInstrList();
     void addInstrToJProfValueBranchInstrList(TR::Instruction *instr);
+
     TR::list<TR::Instruction *> *getJProfValueBranchInstrList() { return __jProfilingValueProfilingBranchInstructions; }
+
     // --------------------------------------------------------------------------
     // GPU
     //

--- a/runtime/compiler/codegen/J9CodeGenerator.hpp
+++ b/runtime/compiler/codegen/J9CodeGenerator.hpp
@@ -406,6 +406,8 @@ private:
 
     TR_BitVector *_liveMonitors;
 
+    TR::list<TR::Instruction *> *_jProfilingCounterBumpInstructionList;
+    TR::list<TR::Instruction *> *__jProfilingValueProfilingBranchInstructions;
 protected:
     // isTemporaryBased storageReferences just have a symRef but some other routines expect a node so use the below to
     // fill in this symRef on this node
@@ -427,6 +429,14 @@ public:
     // J9
     int32_t getInternalPtrMapBit() { return 31; }
 
+    // Patchable JProfiling
+    void initJProfCounterBumpInstrList();
+    void addInstrToJProfCounterBumpInstrList(TR::Instruction *instr);
+    TR::list<TR::Instruction *> *getJProfilingCounterBumpInstructionList() { return _jProfilingCounterBumpInstructionList; }
+
+    void initJProfValueBranchInstrList();
+    void addInstrToJProfValueBranchInstrList(TR::Instruction *instr);
+    TR::list<TR::Instruction *> *getJProfValueBranchInstrList() { return __jProfilingValueProfilingBranchInstructions; }
     // --------------------------------------------------------------------------
     // GPU
     //

--- a/runtime/compiler/control/J9Options.cpp
+++ b/runtime/compiler/control/J9Options.cpp
@@ -265,6 +265,10 @@ TR_YesNoMaybe J9::Options::_hwProfilerEnabled = TR_maybe;
 TR_YesNoMaybe J9::Options::_perfToolEnabled = TR_no;
 int32_t J9::Options::_hwprofilerNumOutstandingBuffers = 256; // 1MB / 4KB buffers
 
+uint32_t J9::Options::_patchableJProfilingRecompilationFreq = 2000;
+uint32_t J9::Options::_patchableJProfilingPatchingAgeCutOff = 50000000;
+uint32_t J9::Options::_numOfMethodsToTriggerPatching = 10000;
+
 // These numbers are cast into floats divided by 10000
 uint32_t J9::Options::_hwprofilerWarmOptLevelThreshold = 1; // 0.0001
 uint32_t J9::Options::_hwprofilerReducedWarmOptLevelThreshold
@@ -1223,12 +1227,21 @@ TR::OptionTable OMR::Options::_feOptions[] = {
     { "numInterpCompReqToExitIdleMode=", "M<nnn>\tNumber of first time comp. req. that takes the JIT out of idle mode",
      TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_numFirstTimeCompilationsToExitIdleMode, 0, "F%d",
      NOT_IN_SUBSET },
+    { "numOfMethodsToTriggerPatching=", "O<nnn<\tNumber of methods in the patching list to trigger patching phase",
+     TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_numOfMethodsToTriggerPatching, 0, "F%d",
+     NOT_IN_SUBSET },
 #if defined(J9VM_OPT_JITSERVER)
     { "oldAge=", " \tDefines what an old JITServer cache entry means", TR::Options::setStaticNumeric,
      (intptr_t)&TR::Options::_oldAge, 0, "F%d" },
     { "oldAgeUnderLowMemory=", " \tDefines what an old JITServer cache entry means when memory is low",
      TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_oldAgeUnderLowMemory, 0, "F%d" },
 #endif  /* defined(J9VM_OPT_JITSERVER) */
+    { "patchableJProfilingPatchingAgeCutOff=",
+     "O<nnn<\tCutoff age in milliseconds for method to be patched to disable JProfiling", TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_patchableJProfilingPatchingAgeCutOff, 0, "F%d",
+     NOT_IN_SUBSET },
+    { "patchableJProfilingRecompilationFreq=", "O<nnn<\tFrequency to queue up method for recompilation",
+     TR::Options::setStaticNumeric, (intptr_t)&TR::Options::_patchableJProfilingRecompilationFreq, 0, "F%d",
+     NOT_IN_SUBSET },
     { "profileAllTheTime=", "R<nnn>\tInterpreter profiling will be on all the time", TR::Options::setStaticNumeric,
      (intptr_t)&TR::Options::_profileAllTheTime, 0, "F%d", NOT_IN_SUBSET },
     { "queuedInvReqThresholdToDowngradeOptLevel=", "M<nnn>\tDowngrade opt level if too many inv req",

--- a/runtime/compiler/control/J9Options.hpp
+++ b/runtime/compiler/control/J9Options.hpp
@@ -533,6 +533,9 @@ public:
 
     static int32_t _expensiveCompWeight; // weight of a comp request to be considered expensive
     static int32_t _jProfilingEnablementSampleThreshold;
+    static uint32_t _patchableJProfilingRecompilationFreq;
+    static uint32_t _patchableJProfilingPatchingAgeCutOff;
+    static uint32_t _numOfMethodsToTriggerPatching;
 
     static bool _aggressiveLockReservation;
 

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -51,6 +51,7 @@ enum TR_RuntimeAssumptionKind {
     RuntimeAssumptionOnStaticFinalFieldModification,
     RuntimeAssumptionOnMutableCallSiteChange,
     RuntimeAssumptionOnMethodBreakPoint,
+    RuntimeAssumptionOnPatchJProfBlockFreqCounters,
     LastAssumptionKind,
     // If you add another kind, add its name to the runtimeAssumptionKindNames array
     RuntimeAssumptionSentinel // This is special as there is no hashtable associated with it and we only create one of

--- a/runtime/compiler/env/RuntimeAssumptionTable.hpp
+++ b/runtime/compiler/env/RuntimeAssumptionTable.hpp
@@ -52,6 +52,7 @@ enum TR_RuntimeAssumptionKind {
     RuntimeAssumptionOnMutableCallSiteChange,
     RuntimeAssumptionOnMethodBreakPoint,
     RuntimeAssumptionOnPatchJProfBlockFreqCounters,
+    RuntimeAssumptionOnPatchJProfValueBranch,
     LastAssumptionKind,
     // If you add another kind, add its name to the runtimeAssumptionKindNames array
     RuntimeAssumptionSentinel // This is special as there is no hashtable associated with it and we only create one of

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -67,7 +67,9 @@
 #include "runtime/ExternalProfiler.hpp"
 #include "runtime/J9Runtime.hpp"
 #include "runtime/J9ValueProfiler.hpp"
-
+#if defined(TR_TARGET_X86)
+#include "x/runtime/X86Runtime.hpp"
+#endif
 //*************************************************************************
 //
 // Optimization passes to insert recompilation counters, etc
@@ -2762,4 +2764,84 @@ TR_PersistentProfileInfo *TR_JProfilerThread::deleteProfileInfo(TR_PersistentPro
     }
 
     return next;
+}
+
+TR_JProfBlockFrequencyCounterSites *TR_JProfBlockFrequencyCounterSites::make(TR_FrontEnd *fe, TR_PersistentMemory *pm,
+    uintptr_t key, TR::JProfBFPatchSites *sites, OMR::RuntimeAssumption **sentinel)
+{
+    TR_JProfBlockFrequencyCounterSites *res = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_JProfBlockFrequencyCounterSites));
+    if (mem) {
+        res = ::new (mem) TR_JProfBlockFrequencyCounterSites(pm, key, sites);
+        res->addToRAT(pm, RuntimeAssumptionOnPatchJProfBlockFreqCounters, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumptions");
+    }
+
+    return res;
+}
+
+void TR_JProfBlockFrequencyCounterSites::compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey)
+{
+    // Instead of patching flag, this routine will update the whole instruction
+    // (E.g, 6 Bytes on Z with NOP. PatchSites will hold two pointers, first one
+    // will have a location to update, second one is the original instruction
+    // which we would be caching. If modifying instruction to be NOP, the second
+    // entry would not be used, but in case if if we are enabling the profiling
+    // again, we will  update. NOP with the instruction to update counter which
+    // is already stored in the patch site second entry. _patchFlag zero means
+    // data collection is ON, in that case update all the increment code with
+    // NOP.
+    if (disableDataCollection && _patchFlag == 0) {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+            uint8_t instructionLength = *(uint8_t *)(_patchSites->getBumpInstructionPointer(i));
+#if defined(TR_TARGET_S390)
+            *(uint16_t *)cursor = 0xC004;
+#elif defined(TR_TARGET_X86)
+            if (instructionLength == 2) {
+                *(uint16_t *)cursor = 0x9066;
+            } else if (instructionLength == 3) {
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                // byte 2
+                cursor[2] = 0x00;
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = 0x1F0F
+            } else if (instructionLength == 4) {
+                *(uint32_t *)cursor = 0x00401F0F;
+            } else {
+                TR_ASSERT_FATAL(0, "Unexpected instruction lenght - Can not patch");
+            }
+#endif
+            _patchFlag = 1;
+        }
+    } else if (_patchFlag == 1) {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+            uint8_t *bumpInstruction = _patchSites->getBumpInstructionPointer(i);
+            uint8_t instructionLength = *bumpInstruction;
+            bumpInstruction += sizeof(uint8_t);
+#if defined(TR_TARGET_S390)
+            *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+#elif defined(TR_TARGET_X86)
+            if (instructionLength == 2) {
+                *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+            } else if (instructionLength == 3) {
+                *(uint16_t *)cursor = 0xfeeb;
+                patchingFence16(cursor);
+                cursor[2] = *(uint8_t *)(bumpInstruction + 2);
+                patchingFence16(cursor);
+                *(uint16_t *)cursor = *(uint16_t *)(bumpInstruction);
+            } else if (instructionLength == 4) {
+                *(uint32_t *)cursor = *(uint32_t *)(bumpInstruction);
+            } else {
+                TR_ASSERT_FATAL(0, "Unexpected instruction lenght - Can not patch");
+            }
+#endif
+            _patchFlag = 0;
+        }
+    }
 }

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2880,3 +2880,29 @@ void TR_JProfValueSites::compensate(TR_FrontEnd *vm, bool disableDataCollection,
         }
     }
 }
+
+uint32_t TR_JProfilerPatchingTask::patchAllMethods(TR_J9VMBase *vm)
+{
+    uint32_t numberOfPatchedMethods = 0;
+    TR_PersistentProfileInfo *info = _listOfMethodsToPatch.pop();
+    while (info != NULL) {
+        if (patchMethod(vm, info)) {
+            _listOfPatchedMethods.append(info);
+            numberOfPatchedMethods++;
+        }
+        info = _listOfMethodsToPatch.pop();
+    }
+    return numberOfPatchedMethods;
+}
+
+bool TR_JProfilerPatchingTask::patchMethod(TR_J9VMBase *vm, TR_PersistentProfileInfo *info)
+{
+    if (info->isActive()) {
+        if (info->getValueProfileInfo() != NULL && info->getValueProfileInfo()->getJProfValueProfSites() != NULL) {
+            info->getValueProfileInfo()->getJProfValueProfSites()->compensate(vm, true, 0);
+        }
+        info->getBlockFrequencyInfo()->getJProfBlockFrequencyCounterSites()->compensate(vm, true, 0);
+        return true;
+    }
+    return false;
+}

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -3127,3 +3127,302 @@ void TR_JProfilerAnalysisTask::printCounts()
            "inActive = %d\n\ttotal method recompiled to warm : %d\n\ttotal method set for patching : %d",
         _totalMethodsAddedForAnalysis, _infoInvalidatedAsInActive, _methodsRecompiledToWarm, _methodsAddedToPatchList);
 }
+
+typedef struct jProfilerThreadInfoPerThread {
+    uint32_t jProfilerThreadID;
+    TR_JProfilerThreadsDispatcher *dispatcher;
+    J9JavaVM *javaVM;
+    uint32_t initializationComplete;
+} jProfilerThreadInfoPerThread;
+
+#define JPROFILER_THREAD_INIT 0
+#define JPROFILER_THREAD_INIT_SUCCESS 1
+
+static int32_t J9THREAD_PROC jProfilerDispatcherProc(void *entryArg)
+{
+    // Task of this function to -
+    // 1. Attach this thread to VM
+    // 2. Change the state to Run/Wait
+    jProfilerThreadInfoPerThread *info = reinterpret_cast<jProfilerThreadInfoPerThread *>(entryArg);
+    J9JavaVM *javaVM = info->javaVM;
+    TR_JProfilerThreadsDispatcher *dispatcher = info->dispatcher;
+    uint32_t jProfilerThreadID = info->jProfilerThreadID;
+    bool isMainThread = dispatcher->isMainThread(jProfilerThreadID);
+
+    J9VMThread *jProfilerVMThread = NULL;
+
+    PORT_ACCESS_FROM_JAVAVM(javaVM);
+
+    int rc = javaVM->internalVMFunctions->internalAttachCurrentThread(javaVM, &jProfilerVMThread, NULL,
+        J9_PRIVATE_FLAGS_DAEMON_THREAD | J9_PRIVATE_FLAGS_NO_OBJECT | J9_PRIVATE_FLAGS_SYSTEM_THREAD
+            | J9_PRIVATE_FLAGS_ATTACHED_THREAD,
+        dispatcher->getJProfilerOSThreadFromIndex(jProfilerThreadID));
+
+    if (rc == JNI_OK) {
+        info->initializationComplete = JPROFILER_THREAD_INIT_SUCCESS;
+        dispatcher->setJProfilerVMThread(jProfilerThreadID, jProfilerVMThread);
+        if (isMainThread)
+            dispatcher->analysisThreadEntryPoint(javaVM, jProfilerThreadID);
+        else
+            dispatcher->workerThreadEntryPoint(javaVM, jProfilerThreadID);
+    } else {
+        return JNI_ERR;
+    }
+    return 0;
+}
+
+void TR_JProfilerThreadsDispatcher::analysisThreadEntryPoint(J9JavaVM *javaVM, uint32_t threadID)
+{
+    completeThreadInitialization(threadID, true);
+    if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+        TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+            "Analysis Thread Entrypoint, recompilation freq. cut-off = %u, ageCutOff = %u",
+            task->getRecompilationCutOff(), task->getAgeCutOffForPatching());
+    }
+
+    J9VMThread *jProfilerMainThread = getJProfilerVMThread(threadID);
+    while (stateTable[threadID] == Run) {
+        j9thread_sleep(_analysisThreadSleepTime);
+        _workerThreadMonitor->enter();
+        if (_inShutdown || stateTable[threadID] == Stop) {
+            _workerThreadMonitor->exit();
+            break;
+        }
+        _workerThreadMonitor->exit();
+
+        task->performAnalysis(javaVM->jitConfig, jProfilerMainThread);
+
+        // TODO: Currently we check the size of the list containing methods to be patched to initiate patching
+        // Need to add parameters to track last time patching was done and size of active profile info list
+        // To trigger another patching phase.
+        if (task->inspectListOfMethodsToBePatchedAndPreparePatchingTask(patchingTaskList, _maxJProfilerThreadCount,
+                javaVM->jitConfig)) {
+            TR_J9VMBase *vm = TR_J9VMBase::get(javaVM->jitConfig, NULL);
+            bool threadHadNoVMAccess = (!(jProfilerMainThread->publicFlags & J9_PUBLIC_FLAGS_VM_ACCESS));
+            if (threadHadNoVMAccess)
+                javaVM->internalVMFunctions->internalAcquireVMAccess(jProfilerMainThread);
+            javaVM->internalVMFunctions->acquireExclusiveVMAccess(jProfilerMainThread);
+            _totalExclusivePatchPhase += 1;
+
+            _workerThreadMonitor->enter();
+            _threadsReservedForPatchingWork = true;
+            _numberOfThreadsToWakeUpForPatching = _maxJProfilerThreadCount - 1;
+            _totalThreadCountForSynchronization = _maxJProfilerThreadCount;
+            _synchronizationThreadCount = 0;
+            if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+                TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                    "Acquired Exclusive Access, waking up threads - _numberOfThreadsToWakeUpForPatching = %d, "
+                    "_totalThreadCountForSynchronization = %d",
+                    _numberOfThreadsToWakeUpForPatching, _totalThreadCountForSynchronization);
+            }
+            _workerThreadMonitor->notifyAll();
+            _workerThreadMonitor->exit();
+            if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+                TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                    "Patching started in Analysis Thread - Number of methods to patch = %d",
+                    patchingTaskList[threadID]->getSize());
+            }
+            uint32_t numberOfMethodsPatched
+                = patchingTaskList[threadID]->patchMethods(TR_J9VMBase::get(javaVM->jitConfig, NULL), threadID);
+            if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+                TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "JProfiler Analysis Thread Patched %d methods",
+                    numberOfMethodsPatched);
+            synchronizeJProfilerThreads(threadID);
+            _threadsReservedForPatchingWork = false;
+            _totalThreadCountForSynchronization = 0;
+            javaVM->internalVMFunctions->releaseExclusiveVMAccess(jProfilerMainThread);
+            if (threadHadNoVMAccess)
+                javaVM->internalVMFunctions->internalReleaseVMAccess(jProfilerMainThread);
+        }
+    }
+    task->printCounts();
+    cleanUpThread(javaVM, threadID);
+}
+
+void TR_JProfilerThreadsDispatcher::workerThreadEntryPoint(J9JavaVM *javaVM, uint32_t threadID)
+{
+    completeThreadInitialization(threadID, false);
+    _workerThreadMonitor->enter();
+    while (stateTable[threadID] != Stop) {
+        while (stateTable[threadID] == Wait) {
+            if (_threadsReservedForPatchingWork && _numberOfThreadsToWakeUpForPatching > 0) {
+                stateTable[threadID] = Reserve;
+                _numberOfThreadsToWakeUpForPatching -= 1;
+                if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+                    TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                        "JProfiler Worker Thread - %d reserved, threadsToWakeUpForPatching = %d", threadID,
+                        _numberOfThreadsToWakeUpForPatching);
+            } else {
+                _workerThreadMonitor->wait();
+            }
+        }
+
+        if (stateTable[threadID] == Reserve) {
+            _workerThreadMonitor->exit();
+            if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+                TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                    "Worker Thread - %d reserved for patching, Number of methods to patch = %d", threadID,
+                    patchingTaskList[threadID]->getSize());
+            }
+            uint32_t numberOfPatchedMethods
+                = patchingTaskList[threadID]->patchMethods(TR_J9VMBase::get(javaVM->jitConfig, NULL), threadID);
+            if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+                TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "JProfiler WorkerThread -%d Patched %d methods",
+                    threadID, numberOfPatchedMethods);
+            synchronizeJProfilerThreads(threadID);
+            _workerThreadMonitor->enter();
+            if (stateTable[threadID] != Stop)
+                stateTable[threadID] = Wait;
+        }
+    }
+    _workerThreadMonitor->exit();
+    cleanUpThread(javaVM, threadID);
+}
+
+void TR_JProfilerThreadsDispatcher::startThreads(J9JavaVM *javaVM)
+{
+    if (_dispatcherMonitor == NULL || _workerThreadMonitor == NULL || _synchronizationMonitor == NULL) {
+        if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                "FAILED TO START JPROFILER THREADS AS MONITOR OBJECTS ARE NOT INITIALIZED");
+        return;
+    }
+    _dispatcherMonitor->enter();
+    for (auto jProfilerThreadID = 0; jProfilerThreadID < _maxJProfilerThreadCount; ++jProfilerThreadID) {
+        jProfilerThreadInfoPerThread info;
+        info.dispatcher = this;
+        info.javaVM = javaVM;
+        info.jProfilerThreadID = jProfilerThreadID;
+        info.initializationComplete = JPROFILER_THREAD_INIT;
+        if (J9THREAD_SUCCESS
+            != javaVM->internalVMFunctions->createThreadWithCategory(&(jProfilerOSThreadList[jProfilerThreadID]),
+                TR::Options::_profilerStackSize << 10,
+                isMainThread(jProfilerThreadID) ? J9THREAD_PRIORITY_USER_MAX : J9THREAD_PRIORITY_USER_MIN, 0,
+                &jProfilerDispatcherProc, reinterpret_cast<void *>(&info), J9THREAD_CATEGORY_SYSTEM_JIT_THREAD)) {
+            if (isMainThread(jProfilerThreadID)) {
+                // We can not even start the main thread - Disable the Patcheable JProfiling.
+                if (TR::Options::getVerboseOption(TR_VerboseProfiling))
+                    TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                        "Can not start the JProfiling Analysis Thread - Disabling Patchable JProfiling");
+                TR::Options::getJITCmdLineOptions()->setOption(TR_EnablePatchableJProfiling, false);
+            }
+            _maxJProfilerThreadCount = jProfilerThreadID;
+            break;
+        } else {
+            do {
+                if (_inShutdown) {
+                    // If a shutdown is initiated while starting JProfiler Threads, then Set the
+                    // _maxJProfilerThreadCount to number of threads created so far and break out of the loop. This will
+                    // ensure that the _maxJProfilerThreadCount is set to the number of threads created so that the
+                    // shutdown routine can take care of cleaning up the threads.
+                    _maxJProfilerThreadCount = jProfilerThreadID + 1;
+                    break;
+                }
+                // printf("Started thread %d, waiting for initialization to complete\n",jProfilerThreadID);
+                _dispatcherMonitor->wait();
+            } while (info.initializationComplete == JPROFILER_THREAD_INIT);
+            // printf("Started thread %d, initialization complete\n",jProfilerThreadID);
+        }
+    }
+    _dispatcherMonitor->exit();
+}
+
+void TR_JProfilerThreadsDispatcher::stopThreads(J9JavaVM *javaVM)
+{
+    _inShutdown = true;
+    // printf("Dispatcher Shutdown threads Enter\n");
+    _dispatcherMonitor->enter();
+    _dispatcherMonitor->notifyAll();
+    _dispatcherMonitor->exit();
+    // printf("Dispatcher Shutdown threads - Notified all waiting on dispatcherMonitor\n");
+    //  Now Use the Worker Thread Monitor to set up the thread state to Stop
+    _workerThreadMonitor->enter();
+    for (auto threadID = 0; threadID < _maxJProfilerThreadCount; ++threadID) {
+        stateTable[threadID] = Stop;
+    }
+
+    // Main Thread will be stopped as it will continue to inspect the list of the methods with active profiling. So
+    // setting state to stop would stop the main thread. Worker threads would be either performing a patching work or
+    // waiting for the work, so we need to wake up the threads.
+    _workerThreadMonitor->notifyAll();
+    _workerThreadMonitor->exit();
+    // printf("Dispatcher Shutdown threads - All thread State changed to Stop\n");
+    _dispatcherMonitor->enter();
+    while (0 != _maxJProfilerThreadCount) {
+        // printf("Dispatcher Shutdown threads _maxJProfilerThreadCount = %d\n", _maxJProfilerThreadCount);
+        _dispatcherMonitor->wait();
+    }
+    _dispatcherMonitor->exit();
+}
+
+void TR_JProfilerThreadsDispatcher::cleanUpThread(J9JavaVM *javaVM, uint32_t threadID)
+{
+    javaVM->internalVMFunctions->DetachCurrentThread((JavaVM *)javaVM);
+    setJProfilerVMThread(threadID, NULL);
+    _dispatcherMonitor->enter();
+    _maxJProfilerThreadCount -= 1;
+    _dispatcherMonitor->notify();
+    j9thread_exit((J9ThreadMonitor *)_dispatcherMonitor->getVMMonitor());
+}
+
+void TR_JProfilerThreadsDispatcher::synchronizeJProfilerThreads(uint32_t threadID)
+{
+    if (1 < _totalThreadCountForSynchronization) {
+        _synchronizationMonitor->enter();
+
+        _synchronizationThreadCount += 1;
+        if (_synchronizationThreadCount == _totalThreadCountForSynchronization) {
+            _synchronizationThreadCount = 0;
+            _synchronizationThreadIndex += 1;
+            printf("Finished Sync On all threads, notifying others\n");
+            _synchronizationMonitor->notifyAll();
+        } else {
+            volatile uint32_t index = _synchronizationThreadIndex;
+            do {
+                _synchronizationMonitor->wait();
+            } while (index == _synchronizationThreadIndex);
+        }
+        _synchronizationMonitor->exit();
+    }
+}
+
+void TR_JProfilerThreadsDispatcher::completeThreadInitialization(uint32_t threadID, bool isAnalysisThread)
+{
+    _dispatcherMonitor->enter();
+    stateTable[threadID] = isAnalysisThread ? TR_JProfilerThreadsDispatcher::Run : TR_JProfilerThreadsDispatcher::Wait;
+    _dispatcherMonitor->notifyAll();
+    _dispatcherMonitor->exit();
+}
+
+TR_JProfilerThreadsDispatcher *TR_JProfilerThreadsDispatcher::allocate()
+{
+    TR_JProfilerThreadsDispatcher *dispatcher = new (PERSISTENT_NEW) TR_JProfilerThreadsDispatcher();
+    return dispatcher;
+}
+
+void TR_JProfilerThreadsDispatcher::initializeDispatcher(uint32_t numberOfJProfilerThreads)
+{
+    _dispatcherMonitor = TR::Monitor::create("JIT-JProfilerDispatcherMonitor");
+    _workerThreadMonitor = TR::Monitor::create("JIT-JProfilerWorkerThreadMonitor");
+    _synchronizationMonitor = TR::Monitor::create("JIT-JProfilerSynchronizationMonitor");
+    _inShutdown = false;
+    _threadsReservedForPatchingWork = false;
+    _numberOfThreadsToWakeUpForPatching = 0;
+    _totalThreadCountForSynchronization = 0;
+    _synchronizationThreadIndex = 0;
+    _synchronizationThreadCount = 0;
+    _totalExclusivePatchPhase = 0;
+    _maxJProfilerThreadCount = numberOfJProfilerThreads;
+    stateTable = static_cast<State *>(jitPersistentAlloc(numberOfJProfilerThreads * sizeof(State)));
+    jProfilerOSThreadList
+        = static_cast<j9thread_t *>(jitPersistentAlloc(numberOfJProfilerThreads * sizeof(j9thread_t)));
+    jProfilerVMThreadList
+        = static_cast<J9VMThread **>(jitPersistentAlloc(numberOfJProfilerThreads * sizeof(J9VMThread *)));
+    task = new (PERSISTENT_NEW) TR_JProfilerAnalysisTask();
+    patchingTaskList = static_cast<TR_JProfilerPatchingTask **>(
+        jitPersistentAlloc(numberOfJProfilerThreads * sizeof(TR_JProfilerPatchingTask *)));
+    for (auto threadID = 0; threadID < numberOfJProfilerThreads; ++threadID) {
+        patchingTaskList[threadID] = new (PERSISTENT_NEW) TR_JProfilerPatchingTask();
+    }
+    _analysisThreadSleepTime = 60000;
+}

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2845,3 +2845,38 @@ void TR_JProfBlockFrequencyCounterSites::compensate(TR_FrontEnd *vm, bool disabl
         }
     }
 }
+
+TR_JProfValueSites *TR_JProfValueSites::make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
+    TR::PatchSites *sites, OMR::RuntimeAssumption **sentinel)
+{
+    TR_JProfValueSites *res = NULL;
+    void *mem = TR_RuntimeAssumptionTable::allocateRAPersistentMemory(sizeof(TR_JProfValueSites));
+    if (mem) {
+        res = ::new (mem) TR_JProfValueSites(pm, key, sites);
+        res->addToRAT(pm, RuntimeAssumptionOnPatchJProfValueBranch, fe, sentinel);
+    } else {
+        TR::Compilation *comp = TR::comp();
+        if (comp)
+            comp->failCompilation<TR::CompilationException>("Out of persistent memory while creating assumption");
+    }
+    return res;
+}
+
+void TR_JProfValueSites::compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey)
+{
+    if (disableDataCollection) {
+        for (size_t i; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+#if defined(TR_TARGET_S390)
+            *(cursor + 1) &= 0x0F;
+#endif
+        }
+    } else {
+        for (size_t i = 0; i < _patchSites->getSize(); i++) {
+            uint8_t *cursor = _patchSites->getLocation(i);
+#if defined(TR_TARGET_S390)
+            *(cursor + 1) |= 0xF0;
+#endif
+        }
+    }
+}

--- a/runtime/compiler/runtime/J9Profiler.cpp
+++ b/runtime/compiler/runtime/J9Profiler.cpp
@@ -2906,3 +2906,224 @@ bool TR_JProfilerPatchingTask::patchMethod(TR_J9VMBase *vm, TR_PersistentProfile
     }
     return false;
 }
+
+static void logVerboseProfilingMessage(const char *message, TR_PersistentProfileInfo *info)
+{
+    if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+        J9UTF8 *className;
+        J9UTF8 *name;
+        J9UTF8 *signature;
+        J9Method *method = (J9Method *)TR::Recompilation::getJittedBodyInfoFromPC(
+            info->getBlockFrequencyInfo()->getStartPCOfBodyCollectingProfilingData())
+                               ->getMethodInfo()
+                               ->getMethodInfo();
+        getClassNameSignatureFromMethod(method, className, name, signature);
+        TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "%s : %.*s.%.*s%.*s", message, J9UTF8_LENGTH(className),
+            (char *)J9UTF8_DATA(className), J9UTF8_LENGTH(name), (char *)J9UTF8_DATA(name), J9UTF8_LENGTH(signature),
+            (char *)J9UTF8_DATA(signature));
+    }
+}
+
+void TR_JProfilerAnalysisTask::addProfilingInfoToListOfActiveProfilingInfo(TR_PersistentProfileInfo *info)
+{
+    // TODO: As we are adding a PersistentProfileInfo to the list of active profiling info,
+    // Increase the reference count
+    // When the information is not referenced by the JProfiling anymore, decrement reference count
+    // To get the memory reclaimed.
+    // There is a possibility that, the info is marked inactive and gets cleaned up. In that case,
+    // We may have stale copy of the info which is not active anymore and reclaimed.
+    _listUpdateMonitor->enter();
+    _activeProfilingList.insertAfter(_activeProfilingListTail, info);
+    _activeProfilingListTail = info;
+    _totalMethodsAddedForAnalysis++;
+    char message[128];
+    sprintf(message, "Added method to list of active profiling info - current size = %d",
+        _activeProfilingList.getSize());
+    logVerboseProfilingMessage(message, info);
+    _listUpdateMonitor->exit();
+}
+
+void TR_JProfilerAnalysisTask::removeProfilingInfoFromListOfActiveProfilingInfo(TR_PersistentProfileInfo *prev,
+    TR_PersistentProfileInfo *info)
+{
+    _listUpdateMonitor->enter();
+    if (info == _activeProfilingListTail)
+        _activeProfilingListTail = prev;
+    _activeProfilingList.removeAfter(prev, info);
+    char message[128];
+    sprintf(message, "Removed method to list of active profiling info - current size = %d",
+        _activeProfilingList.getSize());
+    logVerboseProfilingMessage(message, info);
+    _listUpdateMonitor->exit();
+}
+
+bool TR_JProfilerAnalysisTask::recompileMethod(J9JITConfig *jitConfig, TR_PersistentProfileInfo *info,
+    J9VMThread *vmThread, TR_Hotness recompHotness)
+{
+    void *startPC = info->getBlockFrequencyInfo()->getStartPCOfBodyCollectingProfilingData();
+    TR_PersistentJittedBodyInfo *bodyInfo = TR::Recompilation::getJittedBodyInfoFromPC(startPC);
+
+    TR_Hotness methodHotness = bodyInfo->getHotness();
+
+    TR_MethodEvent event;
+
+    event._eventType = TR_MethodEvent::JProfilerRecompilationTrigger;
+    event._j9method = reinterpret_cast<J9Method *>(bodyInfo->getMethodInfo()->getMethodInfo());
+    event._samplePC = NULL;
+    event._vmThread = vmThread;
+    event._classNeedingThunk = 0;
+    event._oldStartPC = startPC;
+    event._nextOptLevel = recompHotness;
+
+    bool newPlanCreated;
+
+    TR_OptimizationPlan *plan
+        = TR::CompilationController::getCompilationStrategy()->processEvent(&event, &newPlanCreated);
+
+    bool queued = false;
+    if (plan) {
+        TR_FrontEnd *fe = TR_J9VMBase::get(jitConfig, vmThread);
+        plan->setInducedByPatchableJProfiling(true);
+        bool rc = TR::Recompilation::induceRecompilation(fe, startPC, &queued, plan);
+        if (!queued && plan != NULL)
+            TR_OptimizationPlan::freeOptimizationPlan(plan);
+
+        if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+            J9UTF8 *className;
+            J9UTF8 *name;
+            J9UTF8 *signature;
+            J9Method *method = (J9Method *)TR::Recompilation::getJittedBodyInfoFromPC(
+                info->getBlockFrequencyInfo()->getStartPCOfBodyCollectingProfilingData())
+                                   ->getMethodInfo()
+                                   ->getMethodInfo();
+            getClassNameSignatureFromMethod(method, className, name, signature);
+            TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                "%s in queuing %.*s.%.*s%.*s for recompilation, optLevel = %d", rc ? "Success" : "Failure",
+                J9UTF8_LENGTH(className), (char *)J9UTF8_DATA(className), J9UTF8_LENGTH(name),
+                (char *)J9UTF8_DATA(name), J9UTF8_LENGTH(signature), (char *)J9UTF8_DATA(signature), recompHotness);
+        }
+        return rc;
+    }
+    return false;
+}
+
+void TR_JProfilerAnalysisTask::performAnalysis(J9JITConfig *jitConfig, J9VMThread *vmThread)
+{
+    if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+        TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+            "Starting the analysis of the profile info list, elapsed Time = %lu, currentActiveListSize = %d, "
+            "patchCandidateSize = %d",
+            TR::CompilationInfo::get(jitConfig)->getPersistentInfo()->getElapsedTime(), _activeProfilingList.getSize(),
+            _listOfProfileInfoToBePatched.getSize());
+    }
+
+    uint32_t processedNodes = 0;
+    TR_PersistentProfileInfo *prev = NULL;
+    TR_PersistentProfileInfo *current = _activeProfilingList.getFirst();
+    while (current != NULL && processedNodes < _analysisCutOff) {
+        TR_PersistentProfileInfo *next = current->getNext();
+        TR_PersistentProfileInfo *nextPrev = current;
+        if (current->isActive()) {
+            if (!current->getBlockFrequencyInfo()->isQueuedForRecompilation()) {
+                TR_BlockFrequencyInfo *bfi = current->getBlockFrequencyInfo();
+                int32_t maxFreq = bfi->getMaxRawCount();
+                if (maxFreq >= _recompilationCutOff) {
+                    removeProfilingInfoFromListOfActiveProfilingInfo(prev, current);
+                    nextPrev = prev;
+                    static bool patchRecompCandidate = feGetEnv("TR_PatchRecompCandidateFirst") != NULL;
+                    if (patchRecompCandidate) {
+                        TR_JProfilerPatchingTask::patchMethod(TR_J9VMBase::get(jitConfig, NULL), current, false);
+                    }
+                    bool rc = recompileMethod(jitConfig, current, vmThread, warm);
+                    _methodsRecompiledToWarm++;
+                    if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+                        J9UTF8 *className;
+                        J9UTF8 *name;
+                        J9UTF8 *signature;
+                        J9Method *method = (J9Method *)TR::Recompilation::getJittedBodyInfoFromPC(
+                            current->getBlockFrequencyInfo()->getStartPCOfBodyCollectingProfilingData())
+                                               ->getMethodInfo()
+                                               ->getMethodInfo();
+                        getClassNameSignatureFromMethod(method, className, name, signature);
+                        TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+                            "Called recompile Method for %.*s.%.*s%.*s with %s", J9UTF8_LENGTH(className),
+                            (char *)J9UTF8_DATA(className), J9UTF8_LENGTH(name), (char *)J9UTF8_DATA(name),
+                            J9UTF8_LENGTH(signature), (char *)J9UTF8_DATA(signature), rc ? "Success" : "Failure");
+                    }
+                } else {
+                    uint64_t ageOfMethod = TR::Compiler->vm.getUSecClock() - bfi->getTimestampDataCollectionStarted();
+                    if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+                        J9UTF8 *className;
+                        J9UTF8 *name;
+                        J9UTF8 *signature;
+                        J9Method *method = (J9Method *)TR::Recompilation::getJittedBodyInfoFromPC(
+                            current->getBlockFrequencyInfo()->getStartPCOfBodyCollectingProfilingData())
+                                               ->getMethodInfo()
+                                               ->getMethodInfo();
+                        getClassNameSignatureFromMethod(method, className, name, signature);
+                        TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING, "Age of method %.*s.%.*s%.*s : %lu",
+                            J9UTF8_LENGTH(className), (char *)J9UTF8_DATA(className), J9UTF8_LENGTH(name),
+                            (char *)J9UTF8_DATA(name), J9UTF8_LENGTH(signature), (char *)J9UTF8_DATA(signature),
+                            ageOfMethod);
+                    }
+                    if (ageOfMethod > _ageCutOffForPatching) {
+                        removeProfilingInfoFromListOfActiveProfilingInfo(prev, current);
+                        nextPrev = prev;
+                        // TR_JProfilerPatchingTask::patchMethod(TR_J9VMBase::get(jitConfig, NULL), current, true);
+                        _listOfProfileInfoToBePatched.add(current);
+                        _methodsAddedToPatchList++;
+                    }
+                }
+            }
+        } else {
+            // If the method has been redefined / class is unloaded, profiling info would be marked inactive.
+            // Do not patch or even recompile method using JProfiling, let the new method reach proper invocation count
+            // to get compiled, for now remove the information from Active Profiling Info List.
+            _infoInvalidatedAsInActive++;
+            removeProfilingInfoFromListOfActiveProfilingInfo(prev, current);
+            nextPrev = prev;
+        }
+        current = next;
+        prev = nextPrev;
+        processedNodes++;
+    }
+    if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+        TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+            "Finished the analysis of the profile info list, elapsed Time = %lu, currentActiveListSize = %d, "
+            "patchCandidateSize = %d",
+            TR::CompilationInfo::get(jitConfig)->getPersistentInfo()->getElapsedTime(), _activeProfilingList.getSize(),
+            _listOfProfileInfoToBePatched.getSize());
+    }
+}
+
+bool TR_JProfilerAnalysisTask::inspectListOfMethodsToBePatchedAndPreparePatchingTask(
+    TR_JProfilerPatchingTask **patchingTaskList, uint32_t numberOfThreadsToUse, J9JITConfig *jitConfig)
+{
+    if (TR::Options::getVerboseOption(TR_VerboseProfiling)) {
+        TR_VerboseLog::writeLineLocked(TR_Vlog_PROFILING,
+            "Inspecting the list of methods to Patch, elapsed Time = %lu, patchCandidateSize = %d",
+            TR::CompilationInfo::get(jitConfig)->getPersistentInfo()->getElapsedTime(),
+            _listOfProfileInfoToBePatched.getSize());
+    }
+    if (_listOfProfileInfoToBePatched.getSize() >= _numOfMethodsToTriggerPatching) {
+        TR_PersistentProfileInfo *info = _listOfProfileInfoToBePatched.pop();
+        uint32_t numberOfMethodInfoPoppedFromList = 0;
+        while (info != NULL) {
+            TR_JProfilerPatchingTask::patchMethod(TR_J9VMBase::get(jitConfig, NULL), info, true);
+            /*
+            patchingTaskList[numberOfMethodInfoPoppedFromList %
+            numberOfThreadsToUse]->addProfilingInfoToListOfMethodsToPatch(info); numberOfMethodInfoPoppedFromList++;
+            */
+            info = _listOfProfileInfoToBePatched.pop();
+        }
+        return false;
+    }
+    return false;
+}
+
+void TR_JProfilerAnalysisTask::printCounts()
+{
+    printf("In the run\n\ttotal methods added for analysis : %d\n\ttotal methods invalidated as info was marked "
+           "inActive = %d\n\ttotal method recompiled to warm : %d\n\ttotal method set for patching : %d",
+        _totalMethodsAddedForAnalysis, _infoInvalidatedAsInActive, _methodsRecompiledToWarm, _methodsAddedToPatchList);
+}

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -39,6 +39,7 @@
 #include "env/VMJ9.h"
 #include "infra/TRlist.hpp"
 #include "runtime/J9ValueProfiler.hpp"
+#include "runtime/J9RuntimeAssumptions.hpp"
 
 #define PROFILING_INVOCATION_COUNT (2)
 
@@ -714,6 +715,20 @@ public:
         _counterDerivationInfo = counterDerivationInfo;
     }
 
+    void addJProfBlockFrequencyCounterPatchSites(TR_JProfBlockFrequencyCounterSites *patchSites)
+    {
+        _jProfilingBlockFrequencyCounterPatchSites = patchSites;
+    }
+
+    TR_JProfBlockFrequencyCounterSites *getJProfBlockFrequencyCounterPatchSites()
+    {
+        return _jProfilingBlockFrequencyCounterPatchSites;
+    }
+
+    void setTimestampDataCollectionStarted(uint64_t timeStamp) { _timeStampWhenDataCollectionStarted = timeStamp; }
+
+    uint64_t getTimestampDataCollectionStarted() { return _timeStampWhenDataCollectionStarted; }
+
     void setEntryBlockNumber(int32_t number) { _entryBlockNumber = number; }
 
     bool isJProfilingData() { return _counterDerivationInfo != NULL; }
@@ -820,6 +835,9 @@ private:
     // Following flag is checked at runtime to know if we have queued this method for recompilation and skip the
     // profiling code
     int32_t _isQueuedForRecompilation;
+    void *_startPCOfBodyCollectingProfilingData;
+    uint64_t _timeStampWhenDataCollectionStarted;
+    TR_JProfBlockFrequencyCounterSites *_jProfilingBlockFrequencyCounterPatchSites;
 };
 
 TR_BlockFrequencyInfo *TR_BlockFrequencyInfo::get(TR_PersistentProfileInfo *profileInfo)

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -1186,4 +1186,143 @@ protected:
     TR_LinkHeadAndTail<TR_PersistentProfileInfo> _listOfPatchedMethods;
 };
 
+/**
+ * @brief A work-unit that analyzes the frequency information of various methods and based on the information takes one
+ * of the following decision for the method.
+ *  1. If it is executed a lot (can be decided based on high max-raw count) by
+ *     the application, recompile it at warm
+ *  2. If it is not executed a lot and application has already spend good amount
+ *     of CPU Time since the method is compiled, patch the method to disable the
+ *     profiling data collection as at this point, recompilation is not needed.
+ *  3. If application has not executed enough since the method started profiling
+ *     data collection, let it profile and check other methods.
+ */
+class TR_JProfilerAnalysisTask {
+public:
+    TR_PERSISTENT_ALLOC(TR_Memory::TR_JProfiler);
+
+    TR_JProfilerAnalysisTask()
+        : _methodsAddedToPatchList(0)
+        , _methodsRecompiledToWarm(0)
+        , _infoInvalidatedAsInActive(0)
+        , _totalMethodsAddedForAnalysis(0)
+        , _activeProfilingListTail(NULL)
+    {
+        _recompilationCutOff = TR::Options::_patchableJProfilingRecompilationFreq;
+        _ageCutOffForPatching = TR::Options::_patchableJProfilingPatchingAgeCutOff;
+        _numOfMethodsToTriggerPatching = TR::Options::_numOfMethodsToTriggerPatching;
+        _listUpdateMonitor = TR::Monitor::create("JIT-JProfilerAnalysisTaskListMonitor");
+        _analysisCutOff = 256;
+    }
+
+    /**
+     * @brief Add the Persistent Profile Info of a method to list of active profiling methods.
+     *
+     * @param info TR_PersistentProfileInfo of the method
+     */
+    void addProfilingInfoToListOfActiveProfilingInfo(TR_PersistentProfileInfo *info);
+
+    /**
+     * @brief Remove the Persistent Profile Info of a method to list of active profiling methods.
+     *
+     * @param prev TR_PersistentProfileInfo of the previous method in the list
+     * @param info TR_PersistentProfileInfo of the method to remove from list
+     */
+    void removeProfilingInfoFromListOfActiveProfilingInfo(TR_PersistentProfileInfo *prev,
+        TR_PersistentProfileInfo *info);
+
+    /**
+     * @brief Creates a new optimization plan for the method and induces recompilation
+     *
+     * @param jitConfig J9JITConfig object
+     * @param info TR_PersistentProfileInfo of the method that will be recompiled
+     * @param vmThread J9VMThread of the threads that is performing analysis
+     * @param recompHotness TR_Hotness at which recompilation will be induced
+     * @return true If it was queued for recompilation successfully
+     * @return false If it failed to queue the method for recompilation
+     */
+    bool recompileMethod(J9JITConfig *jitConfig, TR_PersistentProfileInfo *info, J9VMThread *vmThread,
+        TR_Hotness recompHotness);
+
+    /**
+     * @brief Function works as a core-engine that does the analysis and decides
+     * if method will be patched or recompiled.
+     *
+     * @param jitConfig J9JITConfig object
+     * @param vmThread J9VMThread of the thread performing analysis
+     */
+    void performAnalysis(J9JITConfig *jitConfig, J9VMThread *vmThread);
+
+    /**
+     * @brief Inspect the list of methods to be patched an divides it between
+     * different JProfilerPatchingTask work-unit so that it can be passed to
+     * worker thread to perform patching.
+     *
+     * @param patchingTaskList TR_JProfilerPatchingTask array of the Patching Task
+     * @param numberOfThreadsToUse Number of threads amongst which the work will be divided
+     * @param jitConfig J9JITConfig object
+     * @return true If we have gathered significant amount of work to trigger
+     * patching function will distribute methods through multiple patching
+     * work-unit and returns true so that main thread can signal worker thread
+     * that there is a work available
+     * @return false If there is not many methods to patch - returns false
+     */
+    bool inspectListOfMethodsToBePatchedAndPreparePatchingTask(TR_JProfilerPatchingTask **patchingTaskList,
+        uint32_t numberOfThreadsToUse, J9JITConfig *jitConfig);
+
+    void printCounts();
+
+    /**
+     * @brief Get the Recompilation Cut Off count
+     *
+     * @return uint32_t recompilationCutOff count
+     */
+    uint32_t getRecompilationCutOff() { return _recompilationCutOff; }
+
+    /**
+     * @brief Get the Age Cut Off For Patching
+     *
+     * @return uint32_t Age at which method will be patched
+     */
+    uint32_t getAgeCutOffForPatching() { return _ageCutOffForPatching; }
+
+    /**
+     * @brief Set the Number Of Methods To Trigger Patching object
+     *
+     * @param numbersOfMethodsToTriggerPatching
+     */
+
+    void setNumberOfMethodsToTriggerPatching(uint32_t numbersOfMethodsToTriggerPatching)
+    {
+        _numOfMethodsToTriggerPatching = numbersOfMethodsToTriggerPatching;
+    }
+
+    /**
+     * @brief Set the Analysis Cut Off object
+     *
+     * @param val
+     */
+    void setAnalysisCutOff(uint32_t val) { _analysisCutOff = val; }
+
+protected:
+    TR_LinkHead<TR_PersistentProfileInfo> _activeProfilingList;
+    TR_PersistentProfileInfo *_activeProfilingListTail;
+
+    TR_LinkHead<TR_PersistentProfileInfo> _listOfProfileInfoToBePatched;
+
+    TR_LinkHead<TR_PersistentProfileInfo> _listOfPatchedMethodProfileInfo;
+
+    TR::Monitor *_listUpdateMonitor;
+
+    uint32_t _recompilationCutOff;
+    uint32_t _ageCutOffForPatching;
+    uint32_t _numOfMethodsToTriggerPatching;
+    uint32_t _analysisCutOff;
+
+    uint32_t _totalMethodsAddedForAnalysis;
+    uint32_t _infoInvalidatedAsInActive;
+    uint32_t _methodsRecompiledToWarm;
+    uint32_t _methodsAddedToPatchList;
+};
+
 #endif

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -745,6 +745,16 @@ public:
     TR::Node *generateBlockRawCountCalculationSubTree(TR::Compilation *comp, TR::Node *node, bool trace);
     void dumpInfo(OMR::Logger *log);
 
+    void setJProfBlockFrequencyCounterSites(TR_JProfBlockFrequencyCounterSites *patchSites)
+    {
+        _jProfilingBlockFrequencyCounterPatchSites = patchSites;
+    }
+
+    TR_JProfBlockFrequencyCounterSites *getJProfBlockFrequencyCounterSites()
+    {
+        return _jProfilingBlockFrequencyCounterPatchSites;
+    }
+
     int32_t getCallCount();
     int32_t getMaxRawCount(int32_t callerIndex);
     int32_t getMaxRawCount();

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -1325,4 +1325,213 @@ protected:
     uint32_t _methodsAddedToPatchList;
 };
 
+/**
+ * @brief Central coordinator for the JProfiler thread pool which manages set of
+ *  native JVM threads which collectively performs following two distinct jobs.
+ * 1. Analysis - Main thread designed to perform analyze the profiling data and
+ *    decide if it requires recompilation or patched to enable or disable the data
+ *    collection.
+ * 2. Patching - Worker threads desinged to carry out mechanical work of
+ *    patching the methods.
+ *
+ * Each thread in the pool follows simple finite-state machine, declared as the nested enum State.
+ * 1. Initial - Thread has been created but not ready
+ * 2. Wait - Thread is idle - waiting for work
+ * 3. Reserve - Thread is reserved by dispatcher to perform the work
+ * 4. Run - Thread is actively executing the work-unit
+ * 5. Stop Thread is shutting down
+ */
+class TR_JProfilerThreadsDispatcher {
+public:
+    TR_PERSISTENT_ALLOC(TR_Memory::TR_JProfiler);
+
+    enum State {
+        Initial,
+        Wait,
+        Reserve,
+        Run,
+        Stop
+    };
+
+    TR_JProfilerThreadsDispatcher() {}
+
+    ~TR_JProfilerThreadsDispatcher();
+
+    /**
+     * @brief Allocates a Dispatcher object
+     *
+     * @return TR_JProfilerThreadsDispatcher* constructed JProfiler Thread Pool disaptcher
+     */
+    static TR_JProfilerThreadsDispatcher *allocate();
+
+    /**
+     * @brief Checks if the thread is main thread
+     *
+     * @param threadID Integer ID of the thread
+     * @return true If it is main thread
+     * @return false If it is worker thread
+     */
+    bool isMainThread(uint32_t threadID) { return threadID == 0; }
+
+    /**
+     * @brief Analysis thread's run loop
+     *
+     * @param javaVM J9JavaVM object
+     * @param threadID Thread ID
+     */
+    void analysisThreadEntryPoint(J9JavaVM *javaVM, uint32_t threadID);
+
+    /**
+     * @brief Worker thread's run loop
+     *
+     * @param javaVM J9JavaVM object
+     * @param threadID Thread ID
+     */
+    void workerThreadEntryPoint(J9JavaVM *javaVM, uint32_t threadID);
+
+    /**
+     * @brief Initializes various field of the JProfiler Thread Pool dispatcher
+     * object
+     *
+     * @param numberOfJProfilerThreads - Number of JProfiler Threads to create
+     * in this thread pool
+     */
+    void initializeDispatcher(uint32_t numberOfJProfilerThreads);
+
+    /**
+     * @brief Start all threads in the thread pool
+     *
+     * @param javaVM J9JavaVM object
+     */
+    void startThreads(J9JavaVM *javaVM);
+
+    /**
+     * @brief Stop all threads in the thread pool
+     *
+     * @param javaVM J9JavaVM object
+     */
+    void stopThreads(J9JavaVM *javaVM);
+
+    /**
+     * @brief A cyclic counting barrier for synchronizing between active threads
+     * in the pool
+     *
+     * @param threadID ID of the thread calling this rendezvous point
+     */
+    void synchronizeJProfilerThreads(uint32_t threadID);
+
+    /**
+     * @brief Returns native OS thread that is backing up the thread
+     *
+     * @param threadID Thread ID
+     * @return j9thread_t native j9thread_t object backing this JVM thread
+     */
+    j9thread_t getJProfilerOSThreadFromIndex(int32_t threadID) { return jProfilerOSThreadList[threadID]; }
+
+    /**
+     * @brief Returns the Analysis Work-Unit object
+     *
+     * @return TR_JProfilerAnalysisTask*
+     */
+    TR_JProfilerAnalysisTask *getJProfilerAnalysisTask() { return task; }
+
+    /**
+     * @brief Sets the JVM Thread that represents the Thread ID in the thread pool
+     *
+     * @param threadID ID of the thread
+     * @param vmThread JVM thread object
+     */
+    void setJProfilerVMThread(int32_t threadID, J9VMThread *vmThread) { jProfilerVMThreadList[threadID] = vmThread; }
+
+    /**
+     * @brief Returns the J9VMThread of the threadID thread
+     *
+     * @param threadID ID of the thread in the pool
+     * @return J9VMThread*
+     */
+    J9VMThread *getJProfilerVMThread(int32_t threadID) { return jProfilerVMThreadList[threadID]; }
+
+    /**
+     * @brief Get the Total JProfiler Threads in the thread pool
+     *
+     * @return int32_t number of threads in the thread pool
+     */
+    int32_t getTotalJProfilerThreads() { return _maxJProfilerThreadCount; }
+
+    /**
+     * @brief Performs the clean-up task for threadID
+     *
+     * @param javaVM J9JavaVM object
+     * @param threadID Thread ID
+     */
+    void cleanUpThread(J9JavaVM *javaVM, uint32_t threadID);
+
+    /**
+     * @brief Sets the state of the thread once the intialization work for
+     * threadID in the thread pool is finished.
+     *
+     * @param threadID Thread ID
+     * @param isAnalysisThread Boolean flag that conveys that this threadID
+     * contains an analysis work-unit
+     */
+    void completeThreadInitialization(uint32_t threadID, bool isAnalysisThread = false);
+
+    /**
+     * @brief Set the Analysis Thread Sleep Time
+     *
+     * @param sleepTime time in milliseconds at which analysis thread will be
+     * woken-up to perform analysis
+     */
+    void setAnalysisThreadSleepTime(int32_t sleepTime) { _analysisThreadSleepTime = sleepTime; }
+
+    /**
+     * @brief Set the Analysis Task List Size To Trigger Patching object
+     *
+     * @param val Number of methods held by analysis task for patching to start patching
+     */
+    void setAnalysisTaskListSizeToTriggerPatching(uint32_t val) { task->setNumberOfMethodsToTriggerPatching(val); }
+
+    /**
+     * @brief Set the Analysis Cut Off
+     *
+     * @param val Number of methods to inspect when analysis thread in the thread pool is woken up.
+     */
+    void setAnalysisCutOff(uint32_t val) { task->setAnalysisCutOff(val); }
+
+protected:
+    j9thread_t *jProfilerOSThreadList;
+
+    J9VMThread **jProfilerVMThreadList;
+
+    State *stateTable;
+
+    uint32_t _maxJProfilerThreadCount;
+
+    TR_JProfilerAnalysisTask *task;
+
+    TR_JProfilerPatchingTask **patchingTaskList;
+
+private:
+    volatile bool _inShutdown;
+
+    volatile bool _threadsReservedForPatchingWork;
+
+    volatile uint32_t _analysisThreadSleepTime;
+
+    uint32_t _numberOfThreadsToWakeUpForPatching;
+
+    TR::Monitor *_dispatcherMonitor;
+
+    TR::Monitor *_workerThreadMonitor;
+
+    TR::Monitor *_synchronizationMonitor;
+
+    uint32_t _synchronizationThreadCount;
+
+    uint32_t _synchronizationThreadIndex;
+
+    uint32_t _totalThreadCountForSynchronization;
+
+    uint32_t _totalExclusivePatchPhase;
+};
 #endif

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -521,9 +521,14 @@ public:
 
     void dumpInfo(OMR::Logger *log);
 
+    void addJProfValueSites(TR_JProfValueSites *patchSites) { _jProfValueProfSites = patchSites; }
+
+    TR_JProfValueSites *getJProfValueSites() { return _jProfValueProfSites; }
+
 private:
     TR_AbstractProfilerInfo *_values[LastProfiler];
     TR_CallSiteInfo *_callSiteInfo;
+    TR_JProfValueSites *_jProfValueProfSites;
 };
 
 TR_ValueProfileInfo *TR_ValueProfileInfo::get(TR_PersistentProfileInfo *profileInfo)

--- a/runtime/compiler/runtime/J9Profiler.hpp
+++ b/runtime/compiler/runtime/J9Profiler.hpp
@@ -1124,4 +1124,66 @@ protected:
     static const uint32_t _waitMillis = 500;
 };
 
+/**
+ * @brief A work-unit class that contains the list of compiled methods that
+ * needs their profiling code patches and performs patching. Depending number of
+ * worker threads created for Patchable JProfiler, functionality provided by
+ * this task allows infrastructure to differentiate analaysis and code patching
+ * execution.
+ *
+ */
+class TR_JProfilerPatchingTask {
+public:
+    TR_PERSISTENT_ALLOC(TR_Memory::TR_JProfiler);
+
+    TR_JProfilerPatchingTask() {}
+
+    ~TR_JProfilerPatchingTask();
+
+    /**
+     * @brief Add the Persistent Method Info to the list of methods that will be
+     * patched by this work-unit when worker thread holing this work-unit will
+     * be scheduled.
+     *
+     * @param info TR_PersistentProfileInfo to add to the list
+     */
+    void addProfilingInfoToListOfMethodsToPatch(TR_PersistentProfileInfo *info) { _listOfMethodsToPatch.append(info); }
+
+    /**
+     * @brief Goes through the list of methods to patch and patch the methods.
+     * This function will patch all the methods in the list.
+     *
+     * @param vm TR_J9VMBase vm object
+     * @return uint32_t Returns number of methods patches by this work-unit in this pass.
+     */
+    uint32_t patchAllMethods(TR_J9VMBase *vm);
+
+    /**
+     * @brief Patch the method represented by info.
+     *
+     * @param vm TR_J9VMBase vm object
+     * @param info TR_PersistentProfileInfo of the method to patch
+     * @return true If the method was patches
+     * @return false If the method was not patched (When it is inactive)
+     */
+    static bool patchMethod(TR_J9VMBase *vm, TR_PersistentProfileInfo *info);
+
+    /**
+     * @brief Get the Size of the list
+     *
+     * @return uint32_t Size of the listOfMethodsToPatch
+     */
+    uint32_t getSize() { return _listOfMethodsToPatch.getSize(); }
+
+protected:
+    /**
+     * @brief List contains a method to patch by this work-unit
+     */
+    TR_LinkHeadAndTail<TR_PersistentProfileInfo> _listOfMethodsToPatch;
+    /**
+     * @brief List contains method patched by this work-unit
+     */
+    TR_LinkHeadAndTail<TR_PersistentProfileInfo> _listOfPatchedMethods;
+};
+
 #endif

--- a/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
@@ -101,4 +101,127 @@ public:
     virtual uintptr_t hashCode() { return TR_RuntimeAssumptionTable::hashCode((uintptr_t)getPicLocation()); }
 };
 
+/**
+ * @brief
+ *    A runtime assumption for patching the block frequency counter increment
+ *    instructions in the compiled body that is collecting JProfiling data.
+ *    It provides means to patch the instruction to turn off / turn on profiling
+ *    data collection.
+ */
+class TR_JProfBlockFrequencyCounterSites : public OMR::ValueModifyRuntimeAssumption {
+protected:
+    /**
+     * @brief Construct a new tr TR_JProfBlockFrequencyCounterSites object
+     *
+     * @param pm TR_PersistentMemory object for allocating the runtime assumption
+     * @param key key against which this runtime assumption is stored in table
+     * @param sites TR::JProfBFPatchSites object that contains the information to
+     *              accommodate patching instructons in the compiled method with JProfiling
+     *              to turn-on / turn off data collection.
+     */
+    TR_JProfBlockFrequencyCounterSites(TR_PersistentMemory *pm, uintptr_t key, TR::JProfBFPatchSites *sites)
+        : OMR::ValueModifyRuntimeAssumption(pm, key)
+        , _patchSites(sites)
+        , _patchFlag(Enabled)
+    {}
+
+    enum State {
+        Enabled,
+        Disabled
+    };
+
+public:
+    /**
+     * @brief Get the first instruction in the _patchSites for patching
+     *
+     * @return uint8_t* first instruction pointer in the _patchSites
+     */
+    virtual uint8_t *getFirstAssumingPC() { return _patchSites->getFirstLocation(); }
+
+    /**
+     * @brief Get the last instruction in the _patchSites for patching
+     *
+     * @return uint8_t* last instruction pointer in the _patchSites
+     */
+    virtual uint8_t *getLastAssumingPC() { return _patchSites->getLastLocation(); }
+
+    /**
+     * @brief
+     *    Goes through the instruction list for the compiled method which
+     *    increments static counters in JProfiling Data for block frequencies,
+     *    and patches them to diasble / enable Profiling Data Collection.
+     *
+     * @param vm TR_FrontEnd vm object
+     * @param disableDataCollection boolean flag to disable / enable data collection
+     * @param newKey
+     */
+    virtual void compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey);
+
+    virtual void dumpInfo() { return; }
+
+    /**
+     * @brief Get the Runtime Assumption Kind
+     *
+     * @return TR_RuntimeAssumptionKind
+     */
+    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnPatchJProfBlockFreqCounters; }
+
+    /**
+     * @brief Construct a new TR_JProfBlockFrequencyCounterSites runtime assumption for the method
+     *
+     * @param fe TR_FrontEnd object to facilitate adding constructed runtime assumption to RAT
+     * @param pm TR_PersistentMemory Persistent Memory object to allocate the persistent object
+     * @param key key using which the runtime assumption will be added in the RAT
+     * @param sites TR::JProfBFPatchSites object containing information about
+     *                instructions to be patched in method
+     * @param sentinel Setinnel node for the RAT
+     * @return TR_JProfBlockFrequencyCounterSites* returns constructed TR_JProfBlockFrequencyCounterSites object for
+     * this method.
+     */
+    static TR_JProfBlockFrequencyCounterSites *make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key,
+        TR::JProfBFPatchSites *sites, OMR::RuntimeAssumption **sentinel);
+
+    /**
+     * @brief Cleans up data structure associated with this runtime assumption.
+     *
+     */
+    void reclaim() { TR::JProfBFPatchSites::reclaim(_patchSites); }
+
+    /**
+     * @brief Get TR::JProfBFPatchSites object containing information about instructions to be patched in method.
+     *
+     * @return TR::JProfBFPatchSites*
+     */
+    TR::JProfBFPatchSites *getPatchSites() { return _patchSites; }
+
+    /**
+     * @brief Compares this runtime assumption with another one.
+     *
+     * @param other Other Runtime Assumption agains which this one will be compared.alignas
+     * @return true if equal
+     * @return false if not equal
+     */
+    virtual bool equals(OMR::RuntimeAssumption &other)
+    {
+        if (other.getAssumptionKind() != RuntimeAssumptionOnPatchJProfBlockFreqCounters)
+            return false;
+
+        TR_JProfBlockFrequencyCounterSites *otherSite = reinterpret_cast<TR_JProfBlockFrequencyCounterSites *>(&other);
+        return _patchSites->equals(otherSite->getPatchSites());
+    }
+
+private:
+    /**
+     * @brief TR::JProfBFPatchSites object containing list of instruction addresses in this compiled code and the
+     * instruciton itself that updates static counters to facilitate patching of the sites to turn on / off profiling
+     * data collection.
+     */
+    TR::JProfBFPatchSites *_patchSites;
+
+    /**
+     * @brief A flag to indicate the current status of body associated with this runtime assumption.
+     *
+     */
+    uint8_t _patchFlag;
+};
 #endif

--- a/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
+++ b/runtime/compiler/runtime/J9RuntimeAssumptions.hpp
@@ -224,4 +224,105 @@ private:
      */
     uint8_t _patchFlag;
 };
+
+/**
+ * @brief A runtime assumption for patching guards that controls execution of
+ * JProfiling Value code. This assumption can patch the branch both ways - From
+ * unconditional Jump to NOP and vice-versa.
+ */
+class TR_JProfValueSites : public OMR::LocationRedirectRuntimeAssumption {
+protected:
+    /**
+     * @brief Construct a new TR_JProfValueSites assumption for the method.
+     *
+     * @param pm TR_PersistentMemory object for allocating the runtime assumption
+     * @param key key against which this runtime assumption is stored in table
+     * @param sites TR::PatchSites object that contains the list of location and
+     *              destination pairs.
+     */
+    TR_JProfValueSites(TR_PersistentMemory *pm, uintptr_t key, TR::PatchSites *sites)
+        : OMR::LocationRedirectRuntimeAssumption(pm, key)._patchSites(sites)
+    {}
+
+public:
+    /**
+     * @brief Get the location of first instruction in _patchsites for patching
+     *
+     * @return uint8_t* First instruction pointer in _patchsites
+     */
+    virtual uint8_t *getFirstAssumingPC() { return _patchSites->getFirstLocation(); }
+
+    /**
+     * @brief Get the location of last instruction in _patchsites for patching
+     *
+     * @return uint8_t*  Last instruction pointer in _patchsites
+     */
+    virtual uint8_t *getLastAssumingPC() { return _patchSites->getLastLocation(); }
+
+    /**
+     * @brief Goes through the list of instruction and location pair in the
+     * _patchSites and based on the passed boolean, patches the instruction from
+     * unconditional jump to NOP and vice-versa.
+     *
+     * @param vm TR_FrontEnd vm object
+     * @param disableDataCollection boolean flag to disable / enable data collection
+     * @param newKey
+     */
+    virtual void compensate(TR_FrontEnd *vm, bool disableDataCollection, void *newKey);
+
+    virtual void dumpInfo() { return; }
+
+    /**
+     * @brief Get the Assumption Kind object
+     *
+     * @return TR_RuntimeAssumptionKind
+     */
+    virtual TR_RuntimeAssumptionKind getAssumptionKind() { return RuntimeAssumptionOnPatchJProfValueBranch; }
+
+    /**
+     * @brief Construct a new TR_JProfValueSites runtime assumption for the method
+     *
+     * @param fe TR_FrontEnd object to facilitate adding constructed runtime assumption to RAT
+     * @param pm TR_PersistentMemory Persistent Memory object to allocate the persistent object
+     * @param key key using which the runtime assumption will be added in the RAT
+     * @param sites TR::PatchSites object containing information about
+     *                instructions to be patched in method
+     * @param sentinel Setinnel node for the RAT
+     * @return TR_JProfValueSites* returns constructed TR_JProfValueSites object for
+     * this method.
+     */
+    static TR_JProfValueSites *make(TR_FrontEnd *fe, TR_PersistentMemory *pm, uintptr_t key, TR::PatchSites *sites,
+        OMR::RuntimeAssumption **sentinel);
+
+    /**
+     * @brief Cleans up data structure associated with this runtime assumption.
+     */
+    void reclaim() { TR::PatchSites::reclaim(_patchSites); }
+
+    /**
+     * @brief et TR::PatchSites object containing information about instructions to be patched in method.
+     *
+     * @return TR::PatchSites*
+     */
+    TR::PatchSites *getPatchSites() { return _patchSites; }
+
+    /**
+     * @brief Compares this runtime assumption with another one.
+     *
+     * @param other Other Runtime Assumption agains which this one will be compared.alignas
+     * @return true if equal
+     * @return false if not equal
+     */
+    virtual bool equals(OMR::RuntimeAssumption &other)
+    {
+        if (other.getAssumptionKind() != RuntimeAssumptionOnPatchJProfValueBranch)
+            return false;
+
+        TR_JProfValueSites *otherSite = reinterpret_cast<TR_JProfValueSites *>(&other);
+        return _patchSites->equals(otherSite->getPatchSites());
+    }
+
+private:
+    TR::PatchSites *_patchSites;
+};
 #endif


### PR DESCRIPTION
Introduces the infrastructure for a patchable JProfiler: a thread-pool-based
design that separates profiling analysis from the mechanical work of patching
compiled method bodies to disable/enable data collection.

The core of the change is three cooperating components — a patching work-unit,
an analysis work-unit, and a thread-pool dispatcher — along with the JIT options
needed to tune their behavior at runtime. Together they allow the JProfiler to
offload patching to dedicated worker threads while keeping analysis on a single
coordinator thread.