### PR TITLE
Use full length for ArraysSupport.vectorizedMismatch on JDK28+

### DIFF
--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -2799,11 +2799,7 @@ bool J9::RecognizedCallTransformer::isInlineable(TR::TreeTop *treetop)
                     && !node->isSafeForCGToInlineStringIntrinsic() && !node->isSkippedInRecognizedCallTransformation());
 #endif /* JAVA_SPEC_VERSION < 25 */
             case TR::jdk_internal_util_ArraysSupport_vectorizedMismatch:
-#if JAVA_SPEC_VERSION >= 28
-                return false;
-#else /* JAVA_SPEC_VERSION >= 28 */
                 return cg()->getSupportsInlineVectorizedMismatch();
-#endif /* JAVA_SPEC_VERSION >= 28 */
 #if JAVA_SPEC_VERSION >= 21
             case TR::java_lang_foreign_MemorySegment_get_OfByte:
             case TR::java_lang_foreign_MemorySegment_get_OfChar:

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.cpp
@@ -1643,18 +1643,22 @@ void J9::RecognizedCallTransformer::process_jdk_internal_util_ArraysSupport_vect
         }
     }
 #endif /* defined(J9VM_GC_SPARSE_HEAP_ALLOCATION) */
-
-    TR::Node *log2ArrayIndexScale64Bits = TR::Node::create(node, TR::iu2l, 1, log2ArrayIndexScale);
-
     TR::Node *lengthInBytes
         = TR::Node::create(node, TR::lshl, 2, TR::Node::create(node, TR::iu2l, 1, length), log2ArrayIndexScale);
+    TR::Node *lengthToCompare = NULL;
+
+#if JAVA_SPEC_VERSION < 28
+    TR::Node *log2ArrayIndexScale64Bits = TR::Node::create(node, TR::iu2l, 1, log2ArrayIndexScale);
 
     TR::Node *mask = TR::Node::create(node, TR::lor, 2,
         TR::Node::create(node, TR::lshl, 2, log2ArrayIndexScale64Bits, TR::Node::iconst(node, 1)),
         TR::Node::lconst(node, 3));
 
-    TR::Node *lengthToCompare = TR::Node::create(node, TR::land, 2, lengthInBytes,
+    lengthToCompare = TR::Node::create(node, TR::land, 2, lengthInBytes,
         TR::Node::create(node, TR::lxor, 2, mask, TR::Node::lconst(node, -1)));
+#else /* JAVA_SPEC_VERSION < 28 */
+    lengthToCompare = lengthInBytes;
+#endif /* JAVA_SPEC_VERSION < 28 */
 
     TR::Node *mismatchByteIndex = TR::Node::create(node, TR::arraycmplen, 3);
 
@@ -1671,22 +1675,28 @@ void J9::RecognizedCallTransformer::process_jdk_internal_util_ArraysSupport_vect
     TR::Node *arraycmplenAnchorNode = TR::Node::create(TR::treetop, 1, mismatchByteIndex);
     TR::TreeTop *arraycmplenTreeTop = TR::TreeTop::create(comp(), treetop->getPrevTreeTop(), arraycmplenAnchorNode);
 
-    TR::Node *invertedRemainder = TR::Node::create(node, TR::ixor, 2,
+    TR::Node *noMatchResult = NULL;
+#if JAVA_SPEC_VERSION < 28
+    // inverted remainder (complement of the number of elements left unchecked)
+    noMatchResult = TR::Node::create(node, TR::ixor, 2,
         TR::Node::create(node, TR::l2i, 1,
             TR::Node::create(node, TR::lshr, 2, TR::Node::create(node, TR::land, 2, lengthInBytes, mask),
                 log2ArrayIndexScale)),
         TR::Node::iconst(node, -1));
+#else /* JAVA_SPEC_VERSION < 28 */
+    noMatchResult = TR::Node::iconst(node, -1);
+#endif /* JAVA_SPEC_VERSION < 28 */
 
     TR::Node *mismatchElementIndex = TR::Node::create(node, TR::l2i, 1,
         TR::Node::create(node, TR::lshr, 2, mismatchByteIndex, log2ArrayIndexScale));
-    TR::Node *noMismatchFound = TR::Node::create(node, TR::lcmpeq, 2, mismatchByteIndex, lengthToCompare);
+    TR::Node *isNoMismatchFound = TR::Node::create(node, TR::lcmpeq, 2, mismatchByteIndex, lengthToCompare);
 
     prepareToReplaceNode(node);
 
     TR::Node::recreate(node, TR::iselect);
     node->setNumChildren(3);
-    node->setAndIncChild(0, noMismatchFound);
-    node->setAndIncChild(1, invertedRemainder);
+    node->setAndIncChild(0, isNoMismatchFound);
+    node->setAndIncChild(1, noMatchResult);
     node->setAndIncChild(2, mismatchElementIndex);
 
     TR::TransformUtil::removeTree(comp(), treetop);

--- a/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
+++ b/runtime/compiler/optimizer/J9RecognizedCallTransformer.hpp
@@ -284,7 +284,8 @@ private:
      *     \endcode
      *
      *  \details
-     *     The call node is transformed to the following shape:
+     *     The call node is transformed to the following shape (where \c <lengthToCompare> and \c <noMatchResult>
+     *     differ between JDK versions):
      *
      *     \code
      *     iselect ()
@@ -296,19 +297,37 @@ private:
      *           aladd
      *             <b>
      *             <bOffset>
-     *           land
+     *           <lengthToCompare>
+     *         ==>arraycmplen
+     *       <noMatchResult>
+     *       l2i
+     *         lshr
+     *           ==>arraycmplen
+     *           <log2ArrayIndexScale>
+     *     \endcode
+     *
+     *     On JDK < 28, \c <lengthToCompare> expands to  the following:
+     *
+     *     \code
+     *     <lengthToCompare> :=
+     *       land
+     *         lshl
+     *           iu2l
+     *             <length>
+     *           <log2ArrayIndexScale>
+     *         lxor
+     *           lor
      *             lshl
-     *               i2l
-     *                 <length>
-     *               <log2ArrayIndexScale>
-     *             lxor
-     *               lor
-     *                 lshl
-     *                   ==>i2l
-     *                   iconst 1
-     *                 lconst 3
-     *               lconst -1
-     *         ==>land
+     *               ==>iu2l
+     *               iconst 1
+     *             lconst 3
+     *           lconst -1
+     *     \endcode
+     *
+     *     And \c <noMatchResult> expands to:
+     *
+     *     \code
+     *     <noMatchResult> :=
      *       ixor
      *         l2i
      *           lshr
@@ -317,10 +336,6 @@ private:
      *               ==>lor
      *             <log2ArrayIndexScale>
      *         iconst -1
-     *       l2i
-     *         lshr
-     *           ==>arraycmplen
-     *           <log2ArrayIndexScale>
      *     \endcode
      *
      *     This transformation is valid because vectorizedMismatch is functionally equivalent to the following
@@ -343,6 +358,24 @@ private:
      * converted from byte-wise index to element-wise index else // mismatch found return mismatchIndex >>
      * log2ArrayIndexScale                    // convert byte-wise index to element-wise index
      *     }
+     *     \endcode
+     *
+     *     On JDK >= 28, we always use the full length, so all we need is the number of elements
+     *     shifted by the element size scale to get the number of bytes
+     *
+     *     \code
+     *     <lengthToCompare> :=
+     *       lshl
+     *         iu2l
+     *           <length>
+     *         <log2ArrayIndexScale>
+     *     \endcode
+     *
+     *     On JDK >= 28 all elements are checked, so when no mismatch is found the result is simply \c -1:
+     *
+     *     \code
+     *     <noMatchResult> :=
+     *       iconst -1
      *     \endcode
      */
     void process_jdk_internal_util_ArraysSupport_vectorizedMismatch(TR::TreeTop *treetop, TR::Node *node);


### PR DESCRIPTION
On Java < 28, `ArraysSupport.vectorizedMismatch()` only checks 16-byte chunks and returns the complement of the remaining number of elements when no match is found. Callers of this method typically use an additional loop to check the remaining elements. The intrinsic implementation takes this into account and only multiples of 16 are given to `arraycmplen`. However, in JDK 28 `ArraysSupport.vectorizedMismatch()` was changed to check all elements. 

This commit modifies the calculation of the number of bytes to check so that `arraycmplen` always receives the full length. This works since arraycmplen supports a remainder of < 16 bytes on all platforms.

The changes are conditionally compiled to only apply to Java 28+.

Fixes: #24523