### PR TITLE
Compare settings of value types options for AOT compile and run time

### DIFF
--- a/runtime/compiler/control/JITClientCompilationThread.cpp
+++ b/runtime/compiler/control/JITClientCompilationThread.cpp
@@ -462,6 +462,7 @@ static bool handleResponse(JITServer::MessageType response, JITServer::ClientStr
             fe->getNurserySpaceBounds(&vmInfo._nurserySpaceBoundsBase, &vmInfo._nurserySpaceBoundsTop);
             vmInfo._lowTenureAddress = fe->getLowTenureAddress();
             vmInfo._highTenureAddress = fe->getHighTenureAddress();
+            vmInfo._valueFlatteningThreshold = TR::Compiler->om.valueTypesFlatteningThreshold();
 
             {
                 TR::VMAccessCriticalSection getVMInfo(fe);
@@ -479,6 +480,7 @@ static bool handleResponse(JITServer::MessageType response, JITServer::ClientStr
                     vmInfo._srConstructorAccessorClass = NULL;
 #endif // J9VM_OPT_SIDECAR
                 vmInfo._extendedRuntimeFlags2 = javaVM->extendedRuntimeFlags2;
+                vmInfo._extendedRuntimeFlags3 = javaVM->extendedRuntimeFlags3;
 #if defined(J9VM_OPT_OPENJDK_METHODHANDLE)
                 // These offsets are initialized later on
                 vmInfo._vmtargetOffset = 0;

--- a/runtime/compiler/env/J9ObjectModel.cpp
+++ b/runtime/compiler/env/J9ObjectModel.cpp
@@ -127,6 +127,45 @@ bool J9::ObjectModel::areFlattenableValueTypesEnabled()
     return javaVM->internalVMFunctions->areFlattenableValueTypesEnabled(javaVM);
 }
 
+bool J9::ObjectModel::isValueTypeFlatteningEnabled()
+{
+#if defined(J9VM_OPT_JITSERVER)
+    if (auto stream = TR::CompilationInfo::getStream()) {
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+        auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+        return J9_ARE_ANY_BITS_SET(vmInfo->_extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_ENABLE_VT_FLATTENING);
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+        return false;
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+    }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+    J9JavaVM *javaVM = TR::Compiler->javaVM;
+
+    if (javaVM->internalVMFunctions->areFlattenableValueTypesEnabled(javaVM))
+        return J9_ARE_ALL_BITS_SET(javaVM->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_ENABLE_VT_FLATTENING);
+    else
+        return false;
+}
+
+uintptr_t J9::ObjectModel::valueTypesFlatteningThreshold()
+{
+#if defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES)
+#if defined(J9VM_OPT_JITSERVER)
+    if (auto stream = TR::CompilationInfo::getStream()) {
+        auto *vmInfo = TR::compInfoPT->getClientData()->getOrCacheVMInfo(stream);
+        return vmInfo->_valueFlatteningThreshold;
+    }
+#endif /* defined(J9VM_OPT_JITSERVER) */
+
+    J9JavaVM *javaVM = TR::Compiler->javaVM;
+
+    return javaVM->valueFlatteningThreshold;
+#else /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+    return 0;
+#endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
+}
+
 bool J9::ObjectModel::areValueBasedMonitorChecksEnabled()
 {
 #if defined(J9VM_OPT_JITSERVER)

--- a/runtime/compiler/env/J9ObjectModel.hpp
+++ b/runtime/compiler/env/J9ObjectModel.hpp
@@ -75,6 +75,17 @@ public:
     bool areFlattenableValueTypesEnabled();
 
     /**
+     * @brief Indicates whether support for flattening of null-restricted types is enabled
+     */
+    bool isValueTypeFlatteningEnabled();
+
+    /**
+     * @brief Indicates the maximum length in bytes for which flattening of a null-restricted type might be
+     *        permitted.  The result only has meaning if the result of @ref isNullRestrictedFlatteningEnabled() is true.
+     */
+    uintptr_t valueTypesFlatteningThreshold();
+
+    /**
      * @brief Whether the check is enabled on monitor object being value based class type
      */
     bool areValueBasedMonitorChecksEnabled();

--- a/runtime/compiler/net/CommunicationStream.hpp
+++ b/runtime/compiler/net/CommunicationStream.hpp
@@ -140,7 +140,7 @@ protected:
     // likely to lose an increment when merging/rebasing/etc.
     //
     static const uint8_t MAJOR_NUMBER = 1;
-    static const uint16_t MINOR_NUMBER = 105; // ID: etwSOwaRRyEiXWkBxSiP
+    static const uint16_t MINOR_NUMBER = 106; // ID: P6Kt3H1ppWJDxgYxaDx6
     static const uint8_t PATCH_NUMBER = 0;
     static uint32_t CONFIGURATION_FLAGS;
 

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -337,6 +337,7 @@ public:
         uint32_t _enableGlobalLockReservation;
         uintptr_t _nurserySpaceBoundsBase;
         uintptr_t _nurserySpaceBoundsTop;
+        uintptr_t _valueFlatteningThreshold;
         UDATA _lowTenureAddress;
         UDATA _highTenureAddress;
 #if defined(J9VM_OPT_SIDECAR)
@@ -344,6 +345,7 @@ public:
         TR_OpaqueClassBlock *_srConstructorAccessorClass;
 #endif // J9VM_OPT_SIDECAR
         U_32 _extendedRuntimeFlags2;
+        U_32 _extendedRuntimeFlags3;
 #if defined(TR_HOST_POWER)
         void *_helperAddresses[TR_numRuntimeHelpers];
 #endif

--- a/runtime/compiler/runtime/RelocationRuntime.cpp
+++ b/runtime/compiler/runtime/RelocationRuntime.cpp
@@ -885,6 +885,10 @@ void TR_RelocationRuntime::fillAOTHeader(J9JavaVM *vm, TR_FrontEnd *fe, TR_AOTHe
         vm->internalVMFunctions->currentVMThread(vm));
     aotHeader->processorDescription = TR::Compiler->relocatableTarget.cpu.getProcessorDescription();
 
+#if JAVA_SPEC_VERSION >= 28
+    aotHeader->valueTypesFlatteningThreshold = TR::Compiler->om.valueTypesFlatteningThreshold();
+#endif /* JAVA_SPEC_VERSION >= 28 */
+
     // Set up other feature flags
     aotHeader->featureFlags = generateFeatureFlags(fe);
 
@@ -976,6 +980,24 @@ uintptr_t TR_RelocationRuntime::generateFeatureFlags(TR_FrontEnd *fe)
     if (!TR::Options::getAOTCmdLineOptions()->getOption(TR_DisableCHOpts) && cht && cht->isActive()) {
         featureFlags |= TR_FeatureFlag_CHTableEnabled;
     }
+
+#if JAVA_SPEC_VERSION >= 28
+    if (TR::Compiler->om.areValueTypesEnabled()) {
+        featureFlags |= TR_FeatureFlag_ValueTypesEnabled;
+
+        if (TR::Compiler->om.areFlattenableValueTypesEnabled()) {
+            featureFlags |= TR_FeatureFlag_FlattenableValueTypesEnabled;
+
+            if (TR::Compiler->om.isValueTypeFlatteningEnabled()) {
+                featureFlags |= TR_FeatureFlag_ValueTypesFlatteningEnabled;
+            }
+
+            if (TR::Compiler->om.isValueTypeArrayFlatteningEnabled()) {
+                featureFlags |= TR_FeatureFlag_ValueTypesArrayFlatteningEnabled;
+            }
+        }
+    }
+#endif /* JAVA_SPEC_VERSION >= 28 */
 
     return featureFlags;
 }
@@ -1222,6 +1244,29 @@ void TR_SharedCacheRelocationRuntime::checkAOTHeaderFlags(const TR_AOTHeader *hd
         defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_END_SANITY_BIT_MANGLED,
             "AOT header validation failed: Trailing sanity bit mismatch.");
 
+#if JAVA_SPEC_VERSION >= 28
+    if ((featureFlags & TR_FeatureFlag_ValueTypesEnabled)
+        != (hdrInCache->featureFlags & TR_FeatureFlag_ValueTypesEnabled)) {
+        defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ENABLED_MISMATCH,
+            "AOT header validation failed: Value types feature mismatch.");
+    }
+    if ((featureFlags & TR_FeatureFlag_FlattenableValueTypesEnabled)
+        != (hdrInCache->featureFlags & TR_FeatureFlag_FlattenableValueTypesEnabled)) {
+        defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_FLATTENABLE_VALUE_TYPES_ENABLED_MISMATCH,
+            "AOT header validation failed: Null-restricted types feature mismatch.");
+    }
+    if ((featureFlags & TR_FeatureFlag_ValueTypesFlatteningEnabled)
+        != (hdrInCache->featureFlags & TR_FeatureFlag_ValueTypesFlatteningEnabled)) {
+        defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_ENABLED_MISMATCH,
+            "AOT header validation failed: Null-restricted flattening feature mismatch.");
+    }
+    if ((featureFlags & TR_FeatureFlag_ValueTypesArrayFlatteningEnabled)
+        != (hdrInCache->featureFlags & TR_FeatureFlag_ValueTypesArrayFlatteningEnabled)) {
+        defaultMessage = generateError(J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ARRAY_FLATTENING_ENABLED_MISMATCH,
+            "AOT header validation failed: Null-restricted array element flattening feature mismatch.");
+    }
+#endif /* JAVA_SPEC_VERSION >= 28 */
+
     if (defaultMessage)
         generateError(J9NLS_RELOCATABLE_CODE_UNKNOWN_PROBLEM,
             "AOT header validation failed: Unkown problem with processor features.");
@@ -1315,6 +1360,13 @@ bool TR_SharedCacheRelocationRuntime::validateAOTHeader(TR_FrontEnd *fe, J9VMThr
         } else if (hdrInCache->compressedPointerShift != TR::Compiler->om.compressedReferenceShift()) {
             incompatibleCache(J9NLS_RELOCATABLE_CODE_CMPRS_REF_SHIFT_MISMATCH,
                 "AOT header validation failed: incompatible compressed pointer shift");
+#if JAVA_SPEC_VERSION >= 28
+        } else if (TR::Compiler->om.areValueTypesEnabled() && TR::Compiler->om.areFlattenableValueTypesEnabled()
+            && TR::Compiler->om.isValueTypeFlatteningEnabled()
+            && (hdrInCache->valueTypesFlatteningThreshold != TR::Compiler->om.valueTypesFlatteningThreshold())) {
+            incompatibleCache(J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_THRESHOLD_MISMATCH,
+                "AOT header validation failed: incompatible null-restricted type flattening threshold amounts");
+#endif /* JAVA_SPEC_VERSION >= 28 */
         } else {
             static_cast<TR_JitPrivateConfig *>(jitConfig()->privateConfig)->aotValidHeader = TR_yes;
             return true;

--- a/runtime/compiler/runtime/RelocationRuntime.hpp
+++ b/runtime/compiler/runtime/RelocationRuntime.hpp
@@ -59,10 +59,19 @@ extern "C" {
  *    3.1    Java7.1
  *    4.1    Java8 (828)
  *    5.0    Java9 (929 AND 829)
+ *    5.1    Relaxed AOT processor check to permit superset of processor features rather than requiring exact match
+ *    6.0    Introduction of variable heap base
+ *    7.0    Java 28 (Value types support)
  */
 
+#if JAVA_SPEC_VERSION >= 28
+#define TR_AOTHeaderMajorVersion 7
+#define TR_AOTHeaderMinorVersion 0
+#else /* JAVA_SPEC_VERSION >= 28 */
 #define TR_AOTHeaderMajorVersion 6
 #define TR_AOTHeaderMinorVersion 0
+#endif /* JAVA_SPEC_VERSION >= 28 */
+
 #define TR_AOTHeaderEyeCatcher 0xA0757A27
 
 /* AOT Header Flags */
@@ -85,6 +94,12 @@ typedef enum TR_AOTFeatureFlags {
     TR_FeatureFlag_IsVariableHeapSizeForBarrierRange0 = 0x00008000,
     TR_FeatureFlag_IsVariableActiveCardTableBase = 0x00010000,
     TR_FeatureFlag_CHTableEnabled = 0x00020000,
+#if JAVA_SPEC_VERSION >= 28
+    TR_FeatureFlag_ValueTypesEnabled = 0x00040000,
+    TR_FeatureFlag_FlattenableValueTypesEnabled = 0x00080000,
+    TR_FeatureFlag_ValueTypesFlatteningEnabled = 0x00100000,
+    TR_FeatureFlag_ValueTypesArrayFlatteningEnabled = 0x00200000,
+#endif /* JAVA_SPEC_VERSION >= 28 */
     TR_FeatureFlag_SanityCheckEnd = 0x80000000
 } TR_AOTFeatureFlags;
 
@@ -106,6 +121,9 @@ typedef struct TR_AOTHeader {
     uintptr_t vendorId;
     uintptr_t gcPolicyFlag;
     uintptr_t compressedPointerShift;
+#if JAVA_SPEC_VERSION >= 28
+    uintptr_t valueTypesFlatteningThreshold;
+#endif /* JAVA_SPEC_VERSION >= 28 */
     uint32_t lockwordOptionHashValue;
     int32_t arrayLetLeafSize;
     OMRProcessorDesc processorDescription;

--- a/runtime/nls/jitm/j9jit.nls
+++ b/runtime/nls/jitm/j9jit.nls
@@ -438,3 +438,43 @@ J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.explanation=The JVM was
 J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
 J9NLS_JIT_CHECKPOINT_RESTORE_AOT_DISABLED_PRE_CHECKPOINT.user_response=Remove any (pre-checkpoint) option that would have resulted in this behaviour.
 # END NON-TRANSLATABLE
+
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ENABLED_MISMATCH=Value types feature mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ENABLED_MISMATCH.explanation=The JVM is not running with the value types feature in the same state as the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ENABLED_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ENABLED_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ENABLED_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE
+
+J9NLS_RELOCATABLE_CODE_HEADER_FLATTENABLE_VALUE_TYPES_ENABLED_MISMATCH=Null-restricted types feature mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_HEADER_FLATTENABLE_VALUE_TYPES_ENABLED_MISMATCH.explanation=The JVM is not running with the null-restricted types feature in the same state as the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_HEADER_FLATTENABLE_VALUE_TYPES_ENABLED_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_HEADER_FLATTENABLE_VALUE_TYPES_ENABLED_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_HEADER_FLATTENABLE_VALUE_TYPES_ENABLED_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE
+
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_ENABLED_MISMATCH=Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_ENABLED_MISMATCH.explanation=The JVM is not running with the null-restricted types flattening feature in the same state as the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_ENABLED_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_ENABLED_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_ENABLED_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE
+
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ARRAY_FLATTENING_ENABLED_MISMATCH=Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ARRAY_FLATTENING_ENABLED_MISMATCH.explanation=The JVM is not running with the null-restricted array element flattening feature in the same state as the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ARRAY_FLATTENING_ENABLED_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ARRAY_FLATTENING_ENABLED_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_ARRAY_FLATTENING_ENABLED_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE
+
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_THRESHOLD_MISMATCH=Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.
+# START NON-TRANSLATABLE
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_THRESHOLD_MISMATCH.explanation=The JVM is not running with the same threshold setting for flattening of null-restricted types as the one that generated the code in the SCC.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_THRESHOLD_MISMATCH.system_action=The compiler will not generate AOT code. AOT code from the shared class cache will not be used.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_THRESHOLD_MISMATCH.user_response=Destroy and recreate the AOT code in the shared class cache for the current platform using the -Xshareclasses:reset option.
+J9NLS_RELOCATABLE_CODE_HEADER_VALUE_TYPES_FLATTENING_THRESHOLD_MISMATCH.link=dita:///diag/appendixes/cmdline/cmdline_x.dita#cmdline_x/xshareclasses-reset
+# END NON-TRANSLATABLE

--- a/test/functional/Valhalla/AOTValhallaFeaturesTests.xml
+++ b/test/functional/Valhalla/AOTValhallaFeaturesTests.xml
@@ -41,12 +41,26 @@
 	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:+EnableArrayFlattening org.openj9.test.jep401.Sample" quiet="false"/>
 	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.thr4,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=4 org.openj9.test.jep401.Sample" quiet="false"/>
 	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr.thr4,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:+EnableArrayFlattening -XX:ValueTypeFlatteningThreshold=4 org.openj9.test.jep401.Sample" quiet="false"/>
+	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.thr8,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=8 org.openj9.test.jep401.Sample" quiet="false"/>
+	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr.thr8,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:+EnableArrayFlattening -XX:ValueTypeFlatteningThreshold=8 org.openj9.test.jep401.Sample" quiet="false"/>
 
 	<!--
 	   - Set variables indicating whether tests should be run with value types flattening
 	   - enabled, array element flattening enabled and the flattening threshold option.
 	   - The array element flattening and flattening threshold only take effect if value
 	   - types flattening itself is enabled.
+	   -
+	   - VALHFLATMODE=310 sets -XX:-EnableFlattening
+	   - VALHFLATMODE=311 sets -XX:+EnableFlattening
+	   -
+	   - VALHARRFLATMODE=320 sets -XX:-EnableArrayFlattening
+	   - VALHARRFLATMODE=321 sets -XX:+EnableArrayFlattening
+	   -
+	   - VALHARRFLATMODE=330 uses the default -XX:ValueTypeFlatteningThreshold setting
+	   - VALHARRFLATMODE=334 sets -XX:ValueTypeFlatteningThreshold=4
+	   - VALHARRFLATMODE=338 sets -XX:ValueTypeFlatteningThreshold=8
+	   -
+	   - If VALHFLATMODE is 310, the -XX:-EnableArrayFlattening option and default -XX:ValueTypeFlatteningThreshold take effect
 	  -->
 	<if testVariable="VALHFLATMODE" testValue="310" resultVariable="ENABLEFLATTENING" resultValue="no"/>
 	<if testVariable="VALHFLATMODE" testValue="311" resultVariable="ENABLEFLATTENING" resultValue="yes"/>
@@ -56,7 +70,8 @@
 	<if testVariable="VALHFLATMODE" testValue="310" resultVariable="ENABLEARRAYFLATTENING" resultValue="no"/>
 
 	<if testVariable="VALHFLATTHRESHMODE" testValue="330" resultVariable="USEFLATTENINGTHREHSOLD" resultValue="no"/>
-	<if testVariable="VALHFLATTHRESHMODE" testValue="331" resultVariable="USEFLATTENINGTHREHSOLD" resultValue="yes"/>
+	<if testVariable="VALHFLATTHRESHMODE" testValue="334" resultVariable="USEFLATTENINGTHREHSOLD" resultValue="4"/>
+	<if testVariable="VALHFLATTHRESHMODE" testValue="338" resultVariable="USEFLATTENINGTHREHSOLD" resultValue="8"/>
 	<if testVariable="VALHFLATMODE" testValue="310" resultVariable="USEFLATTENINGTHRESHOLD" resultValue="no"/>
 
 	<!--
@@ -68,8 +83,9 @@
 	<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="ARRAYFLATTENINGOPT" resultValue="-XX:-EnableArrayFlattening"/>
 	<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="ARRAYFLATTENINGOPT" resultValue="-XX:+EnableArrayFlattening"/>
 
+
+	<variable name="FLATTENINGTHRESHOLDOPT" value="-XX:ValueTypeFlatteningThreshold=$USEFLATTENINGTHREHSOLD$"/>
 	<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="FLATTENINGTHRESHOLDOPT" resultValue=""/>
-	<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="FLATTENINGTHRESHOLDOPT" resultValue="-XX:ValueTypeFlatteningThreshold=4"/>
 
 	<echo value=" "/>
 	<echo value="###########################################################################"/>
@@ -123,7 +139,7 @@
 		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
 
 		<!-- If flattening threshold option is specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
-		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
+		<variable name="EXPECTFLATTENINGTHRESHOLDMISMATCH" value="required"/>
 		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
 
 		<!-- Flattening threshold mismatch should only be reported if flattening was enabled, but array flattening was not -->
@@ -161,7 +177,7 @@
 		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
 
 		<!-- If flattening threshold option is specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
-		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
+		<variable name="EXPECTFLATTENINGTHRESHOLDMISMATCH" value="required"/>
 		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
 
 		<!-- Flattening threshold mismatch should only be reported if flattening and array flattening were both enabled -->
@@ -198,9 +214,9 @@
 		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
 		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
 
-		<!-- If flattening threshold option is not specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
-		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
-		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<!-- If flattening threshold option is not specified or does not have a value of 4, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<variable name="EXPECTFLATTENINGTHRESHOLDMISMATCH" value="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="4" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
 
 		<!-- Flattening threshold mismatch should only be reported if flattening was enabled, but array flattening was not -->
 		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
@@ -236,9 +252,9 @@
 		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
 		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
 
-		<!-- If flattening threshold option is not specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
-		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
-		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<!-- If flattening threshold option is not specified or does not have a value of 4, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<variable name="EXPECTFLATTENINGTHRESHOLDMISMATCH" value="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="4" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
 
 		<!-- Flattening threshold mismatch should only be reported if flattening and array flattening were both enabled -->
 		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
@@ -246,6 +262,82 @@
 
 		<!-- Run the test and look for warning messages -->
 		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr.thr4,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
+
+		<!-- Ignore regularly seen AOT messages -->
+		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>
+		<output type="success" caseSensitive="yes" regex="yes">JVMSHRC.*</output>
+		<output type="success" caseSensitive="yes" regex="yes">AOT for ROMMethod 0x[0-9a-f]* in shared cache</output>
+
+		<!-- Verify test actually runs -->
+		<output type="required" caseSensitive="yes" regex="no">In Sample.sub</output>
+		<output type="required" caseSensitive="yes" regex="no">In Sample.main</output>
+		<output type="required" caseSensitive="yes" regex="no">Leaving Sample.main</output>
+
+		<!-- These are the messages we're interested in -->
+		<output type="$EXPECTFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTARRFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTFLATTENINGTHRESHOLDMISMATCH$" caseSensitive="yes" regex="no">Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.</output>
+	</test>
+
+	<test id="testAOTFieldFlatteningThreshold8SCC">
+		<!-- Test with SCC built with flattening enabled and flattening threshold of four -->
+
+		<!-- If flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If array element flattening is enabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If flattening threshold option is not specified or does not have a value of 8, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<variable name="EXPECTFLATTENINGTHRESHOLDMISMATCH" value="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="8" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Flattening threshold mismatch should only be reported if flattening was enabled, but array flattening was not -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Run the test and look for warning messages -->
+		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.thr8,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
+
+		<!-- Ignore regularly seen AOT messages -->
+		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>
+		<output type="success" caseSensitive="yes" regex="yes">JVMSHRC.*</output>
+		<output type="success" caseSensitive="yes" regex="yes">AOT for ROMMethod 0x[0-9a-f]* in shared cache</output>
+
+		<!-- Verify test actually runs -->
+		<output type="required" caseSensitive="yes" regex="no">In Sample.sub</output>
+		<output type="required" caseSensitive="yes" regex="no">In Sample.main</output>
+		<output type="required" caseSensitive="yes" regex="no">Leaving Sample.main</output>
+
+		<!-- These are the messages we're interested in -->
+		<output type="$EXPECTFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTARRFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTFLATTENINGTHRESHOLDMISMATCH$" caseSensitive="yes" regex="no">Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.</output>
+	</test>
+
+	<test id="testAOTFieldAndArrayFlatteningThreshold8SCC">
+		<!-- Test with SCC built with flattening enabled, array element flattening enabled and flattening threshold of four -->
+
+		<!-- If flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If array element flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If flattening threshold option is not specified or does not have a value of 8, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<variable name="EXPECTFLATTENINGTHRESHOLDMISMATCH" value="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="8" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Flattening threshold mismatch should only be reported if flattening and array flattening were both enabled -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Run the test and look for warning messages -->
+		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr.thr8,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
 
 		<!-- Ignore regularly seen AOT messages -->
 		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>

--- a/test/functional/Valhalla/AOTValhallaFeaturesTests.xml
+++ b/test/functional/Valhalla/AOTValhallaFeaturesTests.xml
@@ -1,0 +1,268 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Copyright IBM Corp. and others 2026
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+
+<!DOCTYPE suite SYSTEM "cmdlinetester.dtd">
+<suite id="AOTValhallaFeatures">
+
+	<exec command="$JAVA_EXE$ -Xshareclasses:destroyAll" quiet="false"/>
+
+	<!--
+	   - Build shared classes caches with various settings of value types features enabled:
+	   -
+	   -   Flattening enabled or disabled:  -XX:{+|-}EnableFlattening
+	   -   Array element flattening enabled or disabled:  -XX:{+|-}EnableArrayFlattening
+	   -   Flattening threshold size specified or default (0):  -XX:ValueTypeFlatteningThreshold
+	   -
+	   - If OpenJ9 ever has an option that controls whether value type are enabled or disabled or
+	   - null-restricted types are enabled or disabled, we can add tests for those options as well.
+	  -->
+	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=noflat,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} org.openj9.test.jep401.Sample" quiet="false"/>
+	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening org.openj9.test.jep401.Sample" quiet="false"/>
+	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:+EnableArrayFlattening org.openj9.test.jep401.Sample" quiet="false"/>
+	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.thr4,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:ValueTypeFlatteningThreshold=4 org.openj9.test.jep401.Sample" quiet="false"/>
+	<exec command="$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr.thr4,reset -Xscminaot10K -Xscmaxaot100K -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} -XX:+EnableFlattening -XX:+EnableArrayFlattening -XX:ValueTypeFlatteningThreshold=4 org.openj9.test.jep401.Sample" quiet="false"/>
+
+	<!--
+	   - Set variables indicating whether tests should be run with value types flattening
+	   - enabled, array element flattening enabled and the flattening threshold option.
+	   - The array element flattening and flattening threshold only take effect if value
+	   - types flattening itself is enabled.
+	  -->
+	<if testVariable="VALHFLATMODE" testValue="310" resultVariable="ENABLEFLATTENING" resultValue="no"/>
+	<if testVariable="VALHFLATMODE" testValue="311" resultVariable="ENABLEFLATTENING" resultValue="yes"/>
+
+	<if testVariable="VALHARRFLATMODE" testValue="320" resultVariable="ENABLEARRAYFLATTENING" resultValue="no"/>
+	<if testVariable="VALHARRFLATMODE" testValue="321" resultVariable="ENABLEARRAYFLATTENING" resultValue="yes"/>
+	<if testVariable="VALHFLATMODE" testValue="310" resultVariable="ENABLEARRAYFLATTENING" resultValue="no"/>
+
+	<if testVariable="VALHFLATTHRESHMODE" testValue="330" resultVariable="USEFLATTENINGTHREHSOLD" resultValue="no"/>
+	<if testVariable="VALHFLATTHRESHMODE" testValue="331" resultVariable="USEFLATTENINGTHREHSOLD" resultValue="yes"/>
+	<if testVariable="VALHFLATMODE" testValue="310" resultVariable="USEFLATTENINGTHRESHOLD" resultValue="no"/>
+
+	<!--
+	   - Set variables that contain the settings of the various options with which to run the tests.
+	  -->
+	<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="FLATTENINGOPT" resultValue="-XX:-EnableFlattening"/>
+	<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="FLATTENINGOPT" resultValue="-XX:+EnableFlattening"/>
+
+	<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="ARRAYFLATTENINGOPT" resultValue="-XX:-EnableArrayFlattening"/>
+	<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="ARRAYFLATTENINGOPT" resultValue="-XX:+EnableArrayFlattening"/>
+
+	<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="FLATTENINGTHRESHOLDOPT" resultValue=""/>
+	<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="FLATTENINGTHRESHOLDOPT" resultValue="-XX:ValueTypeFlatteningThreshold=4"/>
+
+	<echo value=" "/>
+	<echo value="###########################################################################"/>
+	<echo value="Running AOT tests with various combinations of value types features enabled"/>
+	<echo value="$FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$"/>
+	<echo value="###########################################################################"/>
+	<echo value=" "/>
+
+	<test id="testAOTNoFlatteningSCC">
+		<!-- Test with SCC that was built with flattening disabled -->
+
+		<!-- If flattening is enabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If array element flattening is enabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- Flattening threshold mismatch should never be reported; mismatches will only occur for flattening enablement settings -->
+		<variable name="EXPECTFLATTENINGTHRESHOLDMISMATCH" value="failure"/>
+
+		<!-- Run the test and look for warning messages -->
+		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=noflat,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
+
+		<!-- Ignore regularly seen AOT messages -->
+		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>
+		<output type="success" caseSensitive="yes" regex="yes">JVMSHRC.*</output>
+		<output type="success" caseSensitive="yes" regex="yes">AOT for ROMMethod 0x[0-9a-f]* in shared cache</output>
+
+		<!-- Verify test actually runs -->
+		<output type="required" caseSensitive="yes" regex="no">In Sample.sub</output>
+		<output type="required" caseSensitive="yes" regex="no">In Sample.main</output>
+		<output type="required" caseSensitive="yes" regex="no">Leaving Sample.main</output>
+
+		<!-- These are the messages we're interested in -->
+		<output type="$EXPECTFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTARRFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTFLATTENINGTHRESHOLDMISMATCH$" caseSensitive="yes" regex="no">Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.</output>
+	</test>
+
+	<test id="testAOTFieldFlatteningSCC">
+		<!-- Test with SCC built with flattening enabled -->
+
+		<!-- If flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If array element flattening is enabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If flattening threshold option is specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Flattening threshold mismatch should only be reported if flattening was enabled, but array flattening was not -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Run the test and look for warning messages -->
+		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
+
+		<!-- Ignore regularly seen AOT messages -->
+		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>
+		<output type="success" caseSensitive="yes" regex="yes">JVMSHRC.*</output>
+		<output type="success" caseSensitive="yes" regex="yes">AOT for ROMMethod 0x[0-9a-f]* in shared cache</output>
+
+		<!-- Verify test actually runs -->
+		<output type="required" caseSensitive="yes" regex="no">In Sample.sub</output>
+		<output type="required" caseSensitive="yes" regex="no">In Sample.main</output>
+		<output type="required" caseSensitive="yes" regex="no">Leaving Sample.main</output>
+
+		<!-- These are the messages we're interested in -->
+		<output type="$EXPECTFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTARRFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTFLATTENINGTHRESHOLDMISMATCH$" caseSensitive="yes" regex="no">Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.</output>
+	</test>
+
+	<test id="testAOTFieldAndArrayFlatteningSCC">
+		<!-- Test with SCC built with flattening enabled and array element flattening enabled -->
+
+		<!-- If flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If array element flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If flattening threshold option is specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Flattening threshold mismatch should only be reported if flattening and array flattening were both enabled -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Run the test and look for warning messages -->
+		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
+
+		<!-- Ignore regularly seen AOT messages -->
+		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>
+		<output type="success" caseSensitive="yes" regex="yes">JVMSHRC.*</output>
+		<output type="success" caseSensitive="yes" regex="yes">AOT for ROMMethod 0x[0-9a-f]* in shared cache</output>
+
+		<!-- Verify test actually runs -->
+		<output type="required" caseSensitive="yes" regex="no">In Sample.sub</output>
+		<output type="required" caseSensitive="yes" regex="no">In Sample.main</output>
+		<output type="required" caseSensitive="yes" regex="no">Leaving Sample.main</output>
+
+		<!-- These are the messages we're interested in -->
+		<output type="$EXPECTFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTARRFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTFLATTENINGTHRESHOLDMISMATCH$" caseSensitive="yes" regex="no">Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.</output>
+	</test>
+
+	<test id="testAOTFieldFlatteningThreshold4SCC">
+		<!-- Test with SCC built with flattening enabled and flattening threshold of four -->
+
+		<!-- If flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If array element flattening is enabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If flattening threshold option is not specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Flattening threshold mismatch should only be reported if flattening was enabled, but array flattening was not -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Run the test and look for warning messages -->
+		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.thr4,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
+
+		<!-- Ignore regularly seen AOT messages -->
+		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>
+		<output type="success" caseSensitive="yes" regex="yes">JVMSHRC.*</output>
+		<output type="success" caseSensitive="yes" regex="yes">AOT for ROMMethod 0x[0-9a-f]* in shared cache</output>
+
+		<!-- Verify test actually runs -->
+		<output type="required" caseSensitive="yes" regex="no">In Sample.sub</output>
+		<output type="required" caseSensitive="yes" regex="no">In Sample.main</output>
+		<output type="required" caseSensitive="yes" regex="no">Leaving Sample.main</output>
+
+		<!-- These are the messages we're interested in -->
+		<output type="$EXPECTFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTARRFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTFLATTENINGTHRESHOLDMISMATCH$" caseSensitive="yes" regex="no">Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.</output>
+	</test>
+
+	<test id="testAOTFieldAndArrayFlatteningThreshold4SCC">
+		<!-- Test with SCC built with flattening enabled, array element flattening enabled and flattening threshold of four -->
+
+		<!-- If flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEFLATTENING" testValue="yes" resultVariable="EXPECTFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If array element flattening is disabled, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="required"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="yes" resultVariable="EXPECTARRFLATTENINGMISMATCH" resultValue="failure"/>
+
+		<!-- If flattening threshold option is not specified, expect a mismatch warning; otherwise, fail if the warning is produced -->
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="required"/>
+		<if testVariable="USEFLATTENINGTHREHSOLD" testValue="yes" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Flattening threshold mismatch should only be reported if flattening and array flattening were both enabled -->
+		<if testVariable="ENABLEFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+		<if testVariable="ENABLEARRAYFLATTENING" testValue="no" resultVariable="EXPECTFLATTENINGTHRESHOLDMISMATCH" resultValue="failure"/>
+
+		<!-- Run the test and look for warning messages -->
+		<command>$JAVA_EXE$ -cp $TESTSJARPATH$ --enable-preview -Xshareclasses:name=flat.arr.thr4,verbose -Xaot:forceaot,limit={org/openj9/test/jep401/Sample.sub*} $FLATTENINGOPT$ $ARRAYFLATTENINGOPT$ $FLATTENINGTHRESHOLDOPT$ org.openj9.test.jep401.Sample</command>
+
+		<!-- Ignore regularly seen AOT messages -->
+		<output type="success" caseSensitive="yes" regex="yes">\[-Xshareclasses .* enabled\]</output>
+		<output type="success" caseSensitive="yes" regex="yes">JVMSHRC.*</output>
+		<output type="success" caseSensitive="yes" regex="yes">AOT for ROMMethod 0x[0-9a-f]* in shared cache</output>
+
+		<!-- Verify test actually runs -->
+		<output type="required" caseSensitive="yes" regex="no">In Sample.sub</output>
+		<output type="required" caseSensitive="yes" regex="no">In Sample.main</output>
+		<output type="required" caseSensitive="yes" regex="no">Leaving Sample.main</output>
+
+		<!-- These are the messages we're interested in -->
+		<output type="$EXPECTFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted types feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTARRFLATTENINGMISMATCH$" caseSensitive="yes" regex="no">Flattening of null-restricted array elements feature mismatch. Ignoring AOT code in shared class cache.</output>
+		<output type="$EXPECTFLATTENINGTHRESHOLDMISMATCH$" caseSensitive="yes" regex="no">Null-restricted types flattening threshold mismatch. Ignoring AOT code in shared class cache.</output>
+	</test>
+
+	<!-- Get rid of the shared classes caches that were created at the start of testing above -->
+	<exec command="$JAVA_EXE$ -Xshareclasses:destroyAll" quiet="false"/>
+</suite>

--- a/test/functional/Valhalla/build.xml
+++ b/test/functional/Valhalla/build.xml
@@ -38,6 +38,7 @@
 	<property name="transformerListener" location="${TEST_ROOT}/Utils/src"/>
 	<property name="LIB" value="asm,jcommander,testng"/>
 	<import file="${TEST_ROOT}/TKG/scripts/getDependencies.xml"/>
+	<import file="${TEST_ROOT}/functional/cmdLineTests/buildTools.xml" />
 
 	<target name="init">
 		<mkdir dir="${DEST}" />
@@ -82,7 +83,7 @@
 		</copy>
 	</target>
 
-	<target name="build" >
+	<target name="build" depends="buildCmdLineTestTools" >
 		<condition property="is_JDK_VERSION_Valhalla">
 			<equals arg1="${JDK_VERSION}" arg2="Valhalla"/>
 		</condition>

--- a/test/functional/Valhalla/exclude.xml
+++ b/test/functional/Valhalla/exclude.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!--
+  Copyright IBM Corp. and others 2026
+
+  This program and the accompanying materials are made available under
+  the terms of the Eclipse Public License 2.0 which accompanies this
+  distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+  or the Apache License, Version 2.0 which accompanies this distribution and
+  is available at https://www.apache.org/licenses/LICENSE-2.0.
+
+  This Source Code may also be made available under the following
+  Secondary Licenses when the conditions for such availability set
+  forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+  General Public License, version 2 with the GNU Classpath
+  Exception [1] and GNU General Public License, version 2 with the
+  OpenJDK Assembly Exception [2].
+
+  [1] https://www.gnu.org/software/classpath/license.html
+  [2] https://openjdk.org/legal/assembly-exception.html
+
+  SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+-->
+<!DOCTYPE suite SYSTEM "excludes.dtd">
+<?xml:stylesheet type="text/xsl" href="excludes.xsl" ?>
+<suite id="AOT Value Types Features Consistent Excluded Test Case List">
+</suite>

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -451,4 +451,37 @@
 			<impl>ibm</impl>
 		</impls>
 	</test>
+	<test>
+		<testCaseName>AOTValhallaFeaturesTests</testCaseName>
+		<variations>
+			<variation>-DVALHFLATMODE=310 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=330</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=330</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=321 -DVALHFLATTHRESHMODE=330</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=331</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=321 -DVALHFLATTHRESHMODE=331</variation>
+		</variations>
+		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
+		$(JVM_OPTIONS) \
+		-DJAVA_EXE=$(SQ)$(JAVA_COMMAND) $(JVM_OPTIONS)$(SQ) \
+		-DTESTSJARPATH=$(Q)$(TEST_RESROOT)$(D)ValhallaTests.jar$(Q) \
+		-DRESJAR=$(CMDLINETESTER_RESJAR) -jar $(CMDLINETESTER_JAR) \
+		-config $(Q)$(TEST_RESROOT)$(D)AOTValhallaFeaturesTests.xml$(Q) \
+		-outputLimit 1000 -explainExcludes -xids all,$(PLATFORM),$(VARIATION) -plats all,$(PLATFORM),$(VARIATION) \
+		-xlist $(Q)$(TEST_RESROOT)$(D)exclude.xml$(Q) \
+		-nonZeroExitWhenError; \
+		$(TEST_STATUS)</command>
+		<levels>
+			<level>sanity</level>
+		</levels>
+		<groups>
+			<group>functional</group>
+		</groups>
+		<versions>
+			<version>Valhalla</version>
+		</versions>
+		<impls>
+			<impl>openj9</impl>
+			<impl>ibm</impl>
+		</impls>
+	</test>
 </playlist>

--- a/test/functional/Valhalla/playlist.xml
+++ b/test/functional/Valhalla/playlist.xml
@@ -454,11 +454,24 @@
 	<test>
 		<testCaseName>AOTValhallaFeaturesTests</testCaseName>
 		<variations>
+			<!--
+			   - VALHFLATMODE=310 sets -XX:-EnableFlattening
+			   - VALHFLATMODE=311 sets -XX:+EnableFlattening
+			   -
+			   - VALHARRFLATMODE=320 sets -XX:-EnableArrayFlattening
+			   - VALHARRFLATMODE=321 sets -XX:+EnableArrayFlattening
+			   -
+			   - VALHARRFLATMODE=330 uses the default -XX:ValueTypeFlatteningThreshold setting
+			   - VALHARRFLATMODE=334 sets -XX:ValueTypeFlatteningThreshold=4
+			   - VALHARRFLATMODE=338 sets -XX:ValueTypeFlatteningThreshold=8
+			  -->
 			<variation>-DVALHFLATMODE=310 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=330</variation>
 			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=330</variation>
 			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=321 -DVALHFLATTHRESHMODE=330</variation>
-			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=331</variation>
-			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=321 -DVALHFLATTHRESHMODE=331</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=334</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=321 -DVALHFLATTHRESHMODE=334</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=320 -DVALHFLATTHRESHMODE=338</variation>
+			<variation>-DVALHFLATMODE=311 -DVALHARRFLATMODE=321 -DVALHFLATTHRESHMODE=338</variation>
 		</variations>
 		<command>$(JAVA_COMMAND) $(CMDLINETESTER_JVM_OPTIONS) \
 		$(JVM_OPTIONS) \

--- a/test/functional/Valhalla/src/org/openj9/test/jep401/Sample.java
+++ b/test/functional/Valhalla/src/org/openj9/test/jep401/Sample.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright IBM Corp. and others 2023
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the Eclipse Public License 2.0 which accompanies this
+ * distribution and is available at https://www.eclipse.org/legal/epl-2.0/
+ * or the Apache License, Version 2.0 which accompanies this distribution and
+ * is available at https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * This Source Code may also be made available under the following
+ * Secondary Licenses when the conditions for such availability set
+ * forth in the Eclipse Public License, v. 2.0 are satisfied: GNU
+ * General Public License, version 2 with the GNU Classpath
+ * Exception [1] and GNU General Public License, version 2 with the
+ * OpenJDK Assembly Exception [2].
+ *
+ * [1] https://www.gnu.org/software/classpath/license.html
+ * [2] https://openjdk.org/legal/assembly-exception.html
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR Apache-2.0 OR GPL-2.0-only WITH Classpath-exception-2.0 OR GPL-2.0-only WITH OpenJDK-assembly-exception-1.0
+ */
+package org.openj9.test.jep401;
+
+/**
+ * Simple test used to verify whether an AOT-compiled method is loaded successfully, based
+ * on compatible or incompatible settings of various value types-related features.
+ */
+public class Sample {
+	public static final void sub(Object[] arr, boolean print) {
+		arr[0] = null;
+		if (print) {
+			System.out.println("In Sample.sub");
+		}
+	}
+
+	public static final void main(String[] args) {
+		final int maxIters = 1000000;
+		System.out.println("In Sample.main");
+		for (int i = 1; i <= maxIters; i++) {
+			sub(new Object[1], i == 1 || i == maxIters);
+		}
+		System.out.println("Leaving Sample.main");
+	}
+}

--- a/test/functional/Valhalla/testng.xml
+++ b/test/functional/Valhalla/testng.xml
@@ -82,4 +82,9 @@
 			</class>
 		</classes>
 	</test>
+	<test name="AOTValhallaFeaturesTests">
+		<classes>
+			<class name="org.openj9.test.jep401.Sample"/>
+		</classes>
+	</test>
 </suite> <!-- Suite -->


### PR DESCRIPTION
Some compiler code generation will differ based on whether value types support is enabled, whether null-restricted types are enabled, and whether flattening of fields or arrays of such types is enabled.  Add support in AOT Relocation to determine whether the features have been enabled in a consistent fashion with those that were enabled at compile time.

Also add new Valhalla tests to test that warnings are produced as expected for inconsistent settings of those options.