### PR TITLE
Use VM helper for unresolved fields with value type flattening

### DIFF
--- a/runtime/compiler/compile/J9SymbolReferenceTable.cpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.cpp
@@ -253,16 +253,16 @@ TR::SymbolReference *J9::SymbolReferenceTable::findOrCreateGetFlattenableFieldSy
     return findOrCreateRuntimeHelper(TR_getFlattenableField, true, true, true);
 }
 
-TR::SymbolReference *J9::SymbolReferenceTable::findOrCreateWithFlattenableFieldSymbolRef(
-    TR::ResolvedMethodSymbol *owningMethodSymbol)
-{
-    return findOrCreateRuntimeHelper(TR_withFlattenableField, true, true, true);
-}
-
 TR::SymbolReference *J9::SymbolReferenceTable::findOrCreatePutFlattenableFieldSymbolRef(
     TR::ResolvedMethodSymbol *owningMethodSymbol)
 {
     return findOrCreateRuntimeHelper(TR_putFlattenableField, true, true, true);
+}
+
+TR::SymbolReference *J9::SymbolReferenceTable::findOrCreateResolveFlattenableFieldSymbolRef(
+    TR::ResolvedMethodSymbol *owningMethodSymbol)
+{
+    return findOrCreateRuntimeHelper(TR_resolveFlattenableField, true, true, true);
 }
 
 TR::SymbolReference *J9::SymbolReferenceTable::findOrCreateGetFlattenableStaticFieldSymbolRef(

--- a/runtime/compiler/compile/J9SymbolReferenceTable.hpp
+++ b/runtime/compiler/compile/J9SymbolReferenceTable.hpp
@@ -168,8 +168,9 @@ public:
     // these helpers are guaranteed to never throw if the receiving object is not null,
     // so we explicit generate NULLCHKs and assume the helpers will never throw
     TR::SymbolReference *findOrCreateGetFlattenableFieldSymbolRef(TR::ResolvedMethodSymbol *owningMethodSymbol = NULL);
-    TR::SymbolReference *findOrCreateWithFlattenableFieldSymbolRef(TR::ResolvedMethodSymbol *owningMethodSymbol = NULL);
     TR::SymbolReference *findOrCreatePutFlattenableFieldSymbolRef(TR::ResolvedMethodSymbol *owningMethodSymbol = NULL);
+    TR::SymbolReference *findOrCreateResolveFlattenableFieldSymbolRef(
+        TR::ResolvedMethodSymbol *owningMethodSymbol = NULL);
     TR::SymbolReference *findOrCreateGetFlattenableStaticFieldSymbolRef(
         TR::ResolvedMethodSymbol *owningMethodSymbol = NULL);
     TR::SymbolReference *findOrCreatePutFlattenableStaticFieldSymbolRef(

--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -9471,33 +9471,28 @@ void TR_J9ByteCodeIlGenerator::packReferenceChainOffsets(TR::Node *node, std::ve
 
 bool TR_ResolvedJ9Method::isFieldNullRestricted(TR::Compilation *comp, int32_t cpIndex, bool isStatic, bool isStore)
 {
-    if (!TR::Compiler->om.areFlattenableValueTypesEnabled() || (-1 == cpIndex))
+    if (!TR::Compiler->om.areFlattenableValueTypesEnabled() || (-1 == cpIndex)) {
         return false;
+    }
 
     J9VMThread *vmThread = fej9()->vmThread();
     J9ROMFieldShape *fieldShape = NULL;
 
-    bool failCompilation = false;
     {
         TR::VMAccessCriticalSection isFieldNullRestricted(fej9());
         if (isStatic) {
             void *staticAddress
                 = jitCTResolveStaticFieldRefWithMethod(vmThread, ramMethod(), cpIndex, isStore, &fieldShape);
             if (!staticAddress) {
-                failCompilation = true;
+                return false;
             }
         } else {
             IDATA fieldOffset
                 = jitCTResolveInstanceFieldRefWithMethod(vmThread, ramMethod(), cpIndex, isStore, &fieldShape);
             if (fieldOffset == -1) {
-                failCompilation = true;
+                return false;
             }
         }
-    }
-
-    if (failCompilation) {
-        comp->failCompilation<TR::CompilationException>(
-            isStatic ? "jitCTResolveStaticFieldRefWithMethod failed" : "jitCTResolveInstanceFieldRefWithMethod failed");
     }
 
     return vmThread->javaVM->internalVMFunctions->isFieldNullRestricted(fieldShape);

--- a/runtime/compiler/env/j9method.h
+++ b/runtime/compiler/env/j9method.h
@@ -556,7 +556,8 @@ public:
     virtual void makeParameterList(TR::ResolvedMethodSymbol *methodSym);
 
     /**
-     * @brief Check if a field has the NullRestricted attribute.
+     * @brief Check if a field has the NullRestricted attribute.  Should only be called
+     *        for a field that is already resolved.
      *
      * @param[in] comp : The current compilation object
      * @param[in] cpIndex : the constant pool index of the field

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -1825,8 +1825,9 @@ U_16 TR_ResolvedJ9JITServerMethod::archetypeArgPlaceholderSlot()
 bool TR_ResolvedJ9JITServerMethod::isFieldNullRestricted(TR::Compilation *comp, int32_t cpIndex, bool isStatic,
     bool isStore)
 {
-    if (!TR::Compiler->om.areFlattenableValueTypesEnabled() || (-1 == cpIndex))
+    if (!TR::Compiler->om.areFlattenableValueTypesEnabled() || (-1 == cpIndex)) {
         return false;
+    }
 
     _stream->write(JITServer::MessageType::ResolvedMethod_isFieldNullRestricted, _remoteMirror, cpIndex, isStatic,
         isStore);

--- a/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
+++ b/runtime/compiler/ilgen/J9ByteCodeIlGenerator.hpp
@@ -229,7 +229,7 @@ private:
     void loadInstance(int32_t);
     void loadInstance(TR::SymbolReference *);
     void loadFlattenableInstance(int32_t);
-    void loadFlattenableInstanceWithHelper(int32_t cpIndex);
+    void loadFlattenableInstanceWithHelper(TR_ResolvedJ9Method *owningMethod, int32_t cpIndex, bool isResolved);
     void loadStatic(int32_t);
     void loadAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);
     TR::Node *loadSymbol(TR::ILOpCodes, TR::SymbolReference *);
@@ -255,7 +255,7 @@ private:
     void storeInstance(int32_t);
     void storeInstance(TR::SymbolReference *);
     void storeFlattenableInstance(int32_t);
-    void storeFlattenableInstanceWithHelper(int32_t);
+    void storeFlattenableInstanceWithHelper(TR_ResolvedJ9Method *owningMethod, int32_t cpIndex, bool isResolved);
     void storeStatic(int32_t);
     TR::Node *narrowIntStoreIfRequired(TR::Node *value, TR::SymbolReference *symRef);
     void storeAuto(TR::DataType type, int32_t slot, bool isAdjunct = false);

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -5293,44 +5293,65 @@ void TR_J9ByteCodeIlGenerator::loadAuto(TR::DataType type, int32_t slot, bool is
     push(load);
 }
 
-/**
- * @brief Returns whether a field ref in the constant pool resolved
- *
- * Importantly, when this function returns false, a ResolveCHK is guarenteed to be needed.
- *
- * @param comp is a pointer the current compilation object
- * @param owningMethod is the method that owns the constant pool
- * @param cpIndex is the index into the constant pool of the field
- * @param isStore specifies whether the check is done for a store of the field
- * @return true when the constant pool entry for the field is resolved, false otherwise
- */
-static bool isFieldResolved(TR::Compilation *comp, TR_ResolvedJ9Method *owningMethod, int32_t cpIndex, bool isStore)
-{
-    uint32_t offset = 0;
-    TR::DataType type = TR::NoType;
-    bool isVolatile = true, isFinal = false, isPrivate = false, isUnresolvedInCP;
-    return owningMethod->fieldAttributes(comp, cpIndex, &offset, &type, &isVolatile, &isFinal, &isPrivate, isStore,
-        &isUnresolvedInCP, true /* needsAOTValidation */);
-}
-
 void TR_J9ByteCodeIlGenerator::loadInstance(int32_t cpIndex)
 {
     if (_generateReadBarriersForFieldWatch && comp()->compileRelocatableCode())
         comp()->failCompilation<J9::AOTNoSupportForAOTFailure>("NO support for AOT in field watch");
 
     TR_ResolvedJ9Method *owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
+    TR::SymbolReference *symRef = symRefTab()->findOrCreateShadowSymbol(_methodSymbol, cpIndex, false);
 
-    if (owningMethod->isFieldNullRestricted(comp(), cpIndex, false /* isStatic */, false /* isStore */)) {
-        if (!isFieldResolved(comp(), owningMethod, cpIndex, false)) {
-            abortForUnresolvedValueTypeOp("getfield", "field");
-        } else if (owningMethod->isFieldFlattened(comp(), cpIndex, false /* isStatic */)) {
-            return comp()->getOption(TR_UseFlattenedFieldRuntimeHelpers) ? loadFlattenableInstanceWithHelper(cpIndex)
-                                                                         : loadFlattenableInstance(cpIndex);
+    TR_YesNoMaybe isNullRestrictedField = TR_no;
+    bool useSymRefLoad = true;
+
+    if (TR::Compiler->om.areValueTypesEnabled()) {
+        TR::Symbol *symbol = symRef->getSymbol();
+        TR::DataType type = symbol->getDataType();
+
+        bool isResolved = !symRef->isUnresolved();
+
+        // Null-restricted fields must be reference fields.  We only know for certain whether such a
+        // field is null-restricted if it is resolved.
+        //
+        if (type == TR::Address) {
+            if (isResolved) {
+                isNullRestrictedField
+                    = owningMethod->isFieldNullRestricted(comp(), cpIndex, false /* isStatic */, false /* isStore */)
+                    ? TR_yes
+                    : TR_no;
+            } else {
+                isNullRestrictedField = TR_maybe;
+            }
+        }
+
+        // If null-restricted types are never flattened, there's no need to do anything special
+        // for a load of a reference type field that is null-restricted.  Determine whether
+        // flattening is a possibility in this case - if the field might be null-restricted
+        //
+        if ((isNullRestrictedField != TR_no) && TR::Compiler->om.isValueTypeFlatteningEnabled()
+            && (!isResolved || owningMethod->isFieldFlattened(comp(), cpIndex, false /* isStatic */))) {
+            // If the field is not resolved, the JIT doesn't have any information about the layout of the field,
+            // so it needs to call JVM helpers to load the instance.  Otherwise, create a new instance
+            // from the flattened field
+            //
+            if (!isResolved || comp()->getOption(TR_UseFlattenedFieldRuntimeHelpers)) {
+                loadFlattenableInstanceWithHelper(owningMethod, cpIndex, isResolved);
+            } else {
+                loadFlattenableInstance(cpIndex);
+            }
+
+            useSymRefLoad = false;
         }
     }
 
-    TR::SymbolReference *symRef = symRefTab()->findOrCreateShadowSymbol(_methodSymbol, cpIndex, false);
-    loadInstance(symRef);
+    if (useSymRefLoad) {
+        loadInstance(symRef);
+    }
+
+    // If the field is known to be null-restricted, the value loaded from it must be non-null
+    if (isNullRestrictedField == TR_yes) {
+        top()->setIsNonNull(true);
+    }
 }
 
 void TR_J9ByteCodeIlGenerator::loadInstance(TR::SymbolReference *symRef)
@@ -5400,20 +5421,47 @@ void TR_J9ByteCodeIlGenerator::loadInstance(TR::SymbolReference *symRef)
     push(dummyLoad);
 }
 
-void TR_J9ByteCodeIlGenerator::loadFlattenableInstanceWithHelper(int32_t cpIndex)
+void TR_J9ByteCodeIlGenerator::loadFlattenableInstanceWithHelper(TR_ResolvedJ9Method *owningMethod, int32_t cpIndex,
+    bool isResolved)
 {
     TR::Node *address = pop();
+
+    // If it's needed, the test of resolution must happen before any NULLCHK of the object that's being dereferenced
+    //
+    if (!isResolved) {
+        // Ensure address calculation is anchored before the call to resolve the field
+        //
+        genTreeTop(TR::Node::create(TR::treetop, 1, address));
+        TR::SymbolReference *resolveFieldCallSymRef
+            = comp()->getSymRefTab()->findOrCreateResolveFlattenableFieldSymbolRef();
+        TR::Node *getFieldFlagNode = TR::Node::iconst(J9TR_FLAT_RESOLVE_GETFIELD);
+        TR::Node *cpIndexNode = TR::Node::iconst(cpIndex);
+        TR::Node *j9MethodPtrNode = TR::Node::aconst((uintptr_t)owningMethod->getPersistentIdentifier());
+        j9MethodPtrNode->setIsMethodPointerConstant(true);
+        TR::Node *resolveCallNode = TR::Node::createWithSymRef(TR::call, 3, 3, getFieldFlagNode, cpIndexNode,
+            j9MethodPtrNode, resolveFieldCallSymRef);
+
+        genTreeTop(resolveCallNode);
+    }
+
     if (!address->isNonNull()) {
-        auto *nullchk = TR::Node::create(TR::PassThrough, 1, address);
+        TR::Node *nullchk = TR::Node::create(TR::PassThrough, 1, address);
         nullchk = genNullCheck(nullchk);
         genTreeTop(nullchk);
     }
-    auto *j9ResolvedMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
-    auto *ramFieldRef = reinterpret_cast<J9RAMFieldRef *>(j9ResolvedMethod->cp()) + cpIndex;
-    auto *ramFieldRefNode = TR::Node::aconst(reinterpret_cast<uintptr_t>(ramFieldRef));
-    auto *receiverNode = address;
-    auto *helperCallNode = TR::Node::createWithSymRef(TR::acall, 2, 2, receiverNode, ramFieldRefNode,
+
+    TR::SymbolReference *cpSymRef = comp()->getSymRefTab()->findOrCreateConstantPoolAddressSymbolRef(_methodSymbol);
+
+    TR::Node *cpLoadNode = TR::Node::createWithSymRef(TR::loadaddr, 0, cpSymRef);
+    TR::Node *cpIndexOffsetNode = comp()->target().is64Bit() ? TR::Node::lconst(cpIndex * sizeof(J9RAMFieldRef))
+                                                             : TR::Node::iconst(cpIndex * sizeof(J9RAMFieldRef));
+    TR::ILOpCodes addrAddOp = comp()->target().is64Bit() ? TR::aladd : TR::aiadd;
+
+    TR::Node *ramFieldAddrNode = TR::Node::create(addrAddOp, 2, cpLoadNode, cpIndexOffsetNode);
+
+    TR::Node *helperCallNode = TR::Node::createWithSymRef(TR::acall, 2, 2, address, ramFieldAddrNode,
         comp()->getSymRefTab()->findOrCreateGetFlattenableFieldSymbolRef());
+
     handleSideEffect(helperCallNode);
     genTreeTop(helperCallNode);
     push(helperCallNode);
@@ -6100,8 +6148,9 @@ void TR_J9ByteCodeIlGenerator::loadArrayElement(TR::DataType dataType, TR::ILOpC
     // we won't have flattening, so no call to flattenable array element access
     // helper is needed.
     //
-    if (mayBeValueType && TR::Compiler->om.isValueTypeArrayFlatteningEnabled()
-        && // isValueTypeArrayFlatteningEnabled() checks areFlattenableValueTypesEnabled()
+    if (mayBeValueType && TR::Compiler->om.isValueTypeFlatteningEnabled()
+        && TR::Compiler->om.isValueTypeArrayFlatteningEnabled()
+        && // isNullRestrictedArrayFlatteningEnabled() checks areNullRestrictedTypesEnabled()
         !TR::Compiler->om.canGenerateArraylets() && dataType == TR::Address
         && !_methodSymbol->skipFlattenableArrayElementNonHelperCall()) {
         TR::Node *elementIndex = pop();
@@ -6750,29 +6799,60 @@ void TR_J9ByteCodeIlGenerator::storeInstance(int32_t cpIndex)
         comp()->failCompilation<J9::AOTNoSupportForAOTFailure>("NO support for AOT in field watch");
 
     TR_ResolvedJ9Method *owningMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
+    TR::SymbolReference *symRef = symRefTab()->findOrCreateShadowSymbol(_methodSymbol, cpIndex, false);
 
-    if (owningMethod->isFieldNullRestricted(comp(), cpIndex, false /* isStatic */, true /* isStore */)) {
-        if (!isFieldResolved(comp(), owningMethod, cpIndex, true)) {
-            abortForUnresolvedValueTypeOp("putfield", "field");
-        } else if (owningMethod->isFieldFlattened(comp(), cpIndex, false /* isStatic */)) {
-            return comp()->getOption(TR_UseFlattenedFieldRuntimeHelpers) ? storeFlattenableInstanceWithHelper(cpIndex)
-                                                                         : storeFlattenableInstance(cpIndex);
+    if (TR::Compiler->om.areValueTypesEnabled()) {
+        TR::Symbol *symbol = symRef->getSymbol();
+        TR::DataType type = symbol->getDataType();
+
+        bool isResolved = !symRef->isUnresolved();
+        TR_YesNoMaybe isNullRestrictedField;
+
+        // Null-restricted fields must be reference fields.  We only know for certain whether such a
+        // field is null-restricted if it is resolved.
+        //
+        if (type != TR::Address) {
+            isNullRestrictedField = TR_no;
+        } else if (isResolved) {
+            isNullRestrictedField
+                = owningMethod->isFieldNullRestricted(comp(), cpIndex, false /* isStatic */, false /* isStore */)
+                ? TR_yes
+                : TR_no;
         } else {
-            TR::Node *value = pop();
-            logprintf(comp()->getOption(TR_TraceILGen), comp()->log(),
-                "%s: cpIndex %d isFieldFlattened 0 value n%dn isNonNull %d\n", __FUNCTION__, cpIndex,
-                value->getGlobalIndex(), value->isNonNull());
+            isNullRestrictedField = TR_maybe;
+        }
 
-            if (!value->isNonNull()) {
-                TR::Node *passThruNode = TR::Node::create(TR::PassThrough, 1, value);
-                genTreeTop(genNullCheck(passThruNode));
+        if (isNullRestrictedField != TR_no) {
+            // If a field is unresolved and it could be null-restricted, the JIT will need to
+            // use helpers if the field could be flattened or if the value assigned to the field
+            // could be null.  As the JIT doesn't have enough information to determine whether a
+            // NULLCHK actually is required for an unresolved field when null-restricted types are
+            // enabled, helper calls are still needed even if flattening is not enabled.
+            //
+            bool isFlatteningEnabled = TR::Compiler->om.isValueTypeFlatteningEnabled();
+            bool mustUseHelpersForUnresolvedField = !isResolved && (isFlatteningEnabled || !top()->isNonNull());
+
+            if (mustUseHelpersForUnresolvedField
+                || (isFlatteningEnabled && owningMethod->isFieldFlattened(comp(), cpIndex, false /* isStatic */))) {
+                return (!isResolved || comp()->getOption(TR_UseFlattenedFieldRuntimeHelpers))
+                    ? storeFlattenableInstanceWithHelper(owningMethod, cpIndex, isResolved)
+                    : storeFlattenableInstance(cpIndex);
+            } else {
+                TR::Node *value = pop();
+                logprintf(comp()->getOption(TR_TraceILGen), comp()->log(),
+                    "%s: cpIndex %d isFieldFlattened 0 value n%dn isNonNull %d\n", __FUNCTION__, cpIndex,
+                    value->getGlobalIndex(), value->isNonNull());
+
+                if (!value->isNonNull()) {
+                    TR::Node *passThruNode = TR::Node::create(TR::PassThrough, 1, value);
+                    genTreeTop(genNullCheck(passThruNode));
+                }
+
+                push(value);
             }
-
-            push(value);
         }
     }
 
-    TR::SymbolReference *symRef = symRefTab()->findOrCreateShadowSymbol(_methodSymbol, cpIndex, true);
     storeInstance(symRef);
 }
 
@@ -6927,20 +7007,50 @@ void TR_J9ByteCodeIlGenerator::storeInstance(TR::SymbolReference *symRef)
     }
 }
 
-void TR_J9ByteCodeIlGenerator::storeFlattenableInstanceWithHelper(int32_t cpIndex)
+void TR_J9ByteCodeIlGenerator::storeFlattenableInstanceWithHelper(TR_ResolvedJ9Method *owningMethod, int32_t cpIndex,
+    bool isResolved)
 {
     TR::Node *value = pop();
     TR::Node *address = pop();
+
+    // If it's needed, the test of resolution must happen before any NULLCHK of the object that's being dereferenced
+    //
+    if (!isResolved) {
+        // Ensure address and value calculations are anchored before the call to resolve the field
+        //
+        genTreeTop(TR::Node::create(TR::treetop, 1, address));
+        genTreeTop(TR::Node::create(TR::treetop, 1, value));
+
+        TR::SymbolReference *resolveFieldCallSymRef
+            = comp()->getSymRefTab()->findOrCreateResolveFlattenableFieldSymbolRef();
+        TR::Node *getFieldFlagNode = TR::Node::iconst(J9TR_FLAT_RESOLVE_PUTFIELD);
+        TR::Node *cpIndexNode = TR::Node::iconst(cpIndex);
+        TR::Node *j9MethodPtrNode = TR::Node::aconst((uintptr_t)owningMethod->getPersistentIdentifier());
+        j9MethodPtrNode->setIsMethodPointerConstant(true);
+        TR::Node *resolveCallNode = TR::Node::createWithSymRef(TR::call, 3, 3, getFieldFlagNode, cpIndexNode,
+            j9MethodPtrNode, resolveFieldCallSymRef);
+
+        genTreeTop(TR::Node::create(TR::treetop, 1, resolveCallNode));
+    }
+
     if (!address->isNonNull()) {
         auto *nullchk = TR::Node::create(TR::PassThrough, 1, address);
         nullchk = genNullCheck(nullchk);
         genTreeTop(nullchk);
     }
-    auto *j9ResolvedMethod = static_cast<TR_ResolvedJ9Method *>(_methodSymbol->getResolvedMethod());
-    auto *ramFieldRef = reinterpret_cast<J9RAMFieldRef *>(j9ResolvedMethod->cp()) + cpIndex;
-    auto *ramFieldRefNode = TR::Node::aconst(reinterpret_cast<uintptr_t>(ramFieldRef));
-    auto *helperCallNode = TR::Node::createWithSymRef(TR::acall, 3, 3, value, address, ramFieldRefNode,
+
+    TR::SymbolReference *cpSymRef = comp()->getSymRefTab()->findOrCreateConstantPoolAddressSymbolRef(_methodSymbol);
+
+    TR::Node *cpLoadNode = TR::Node::createWithSymRef(TR::loadaddr, 0, cpSymRef);
+    TR::Node *cpIndexOffsetNode = comp()->target().is64Bit() ? TR::Node::lconst(cpIndex * sizeof(J9RAMFieldRef))
+                                                             : TR::Node::iconst(cpIndex * sizeof(J9RAMFieldRef));
+    TR::ILOpCodes addrAddOp = comp()->target().is64Bit() ? TR::aladd : TR::aiadd;
+
+    TR::Node *ramFieldAddrNode = TR::Node::create(addrAddOp, 2, cpLoadNode, cpIndexOffsetNode);
+
+    TR::Node *helperCallNode = TR::Node::createWithSymRef(TR::acall, 3, 3, value, address, ramFieldAddrNode,
         comp()->getSymRefTab()->findOrCreatePutFlattenableFieldSymbolRef());
+
     handleSideEffect(helperCallNode);
     genTreeTop(helperCallNode);
 }
@@ -7265,8 +7375,9 @@ void TR_J9ByteCodeIlGenerator::storeArrayElement(TR::DataType dataType, TR::ILOp
 
     if (TR::Compiler->om.areFlattenableValueTypesEnabled() && !TR::Compiler->om.canGenerateArraylets()
         && dataType == TR::Address) {
-        generateNonHelper = (TR::Compiler->om.isValueTypeArrayFlatteningEnabled()
-                                && !_methodSymbol->skipFlattenableArrayElementNonHelperCall())
+        generateNonHelper
+            = (TR::Compiler->om.isValueTypeFlatteningEnabled() && TR::Compiler->om.isValueTypeArrayFlatteningEnabled()
+                  && !_methodSymbol->skipFlattenableArrayElementNonHelperCall())
             || !_methodSymbol->skipNonNullableArrayNullStoreCheck();
     }
 

--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -1016,8 +1016,8 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
     SET(TR_newValueNoZeroInit, (void *)jitNewValueNoZeroInit, TR_CHelper);
 
     SET(TR_getFlattenableField, (void *)jitGetFlattenableField, TR_Helper);
-    SET(TR_withFlattenableField, (void *)jitWithFlattenableField, TR_Helper);
     SET(TR_putFlattenableField, (void *)jitPutFlattenableField, TR_Helper);
+    SET(TR_resolveFlattenableField, (void *)jitResolveFlattenableField, TR_Helper);
     SET(TR_getFlattenableStaticField, (void *)jitGetFlattenableStaticField, TR_Helper);
     SET(TR_putFlattenableStaticField, (void *)jitPutFlattenableStaticField, TR_Helper);
     SET(TR_ldFlattenableArrayElement, (void *)jitLoadFlattenableArrayElement, TR_Helper);


### PR DESCRIPTION
If null-restricted value type support is enabled, the JIT compiler currently fails to compile or inline methods that contain unresolved references to reference type fields.
    
Define the `jitResolveFlattenableField` VM helper, and a `SymbolReferenceTable` method for creating symbol references for it, and modify IL Generation to generate calls to that helper as well as the` jit{Get|Put}FlattenableField` helpers to load from or store to unresolved reference fields.  Note that despite the names, those helpers will be used even if the field turns out to be an identity field, as the JIT will not have enough information at compile time.
    
The `jitGetFlattenableField` helper is only needed if flattening of null- restricted value types is enabled.  The `jitPutFlattenableField` helper is needed if null-restricted values types are enabled, even if flattening is not enabled, as a check for assigning a null reference to a null-restricted field might be needed.
    
As special cases, when generating IL to load a field that is known to be null-restricted, mark the node as isNonNull.  Also, if null-restricted field flattening is not enabled, and the value that's being stored to an unresolved field is known to be non-null, there's no need to use VM helpers to perform the store.
    
Also remove the `jitWithFlattenableField` helper, as it's no longer needed.


Marking this as a draft pull request as it depends on pull requests #24623 and eclipse-omr/omr#8413.