### PR TITLE
Clean up stale monitor autos and fix empty monitor list check at inlined call sites

### DIFF
--- a/runtime/compiler/compile/J9Compilation.cpp
+++ b/runtime/compiler/compile/J9Compilation.cpp
@@ -1151,6 +1151,27 @@ void J9::Compilation::addAsMonitorAuto(TR::SymbolReference *symRef, bool dontAdd
     }
 }
 
+void J9::Compilation::removeMonitorAuto(TR::RegisterMappedSymbol *sym)
+{
+    TR_Array<List<TR::RegisterMappedSymbol> *> &monitorAutos = self()->getMonitorAutos();
+    for (uint32_t i = 0; i < monitorAutos.size(); i++) {
+        List<TR::RegisterMappedSymbol> *autos = monitorAutos.element(i);
+        if (autos && autos->remove(sym) != NULL) {
+            // remove all possible duplicates that may have been added
+            while (autos->remove(sym) != NULL) {
+            }
+
+            if (self()->getOption(TR_TraceLiveMonitorMetadata)) {
+                self()->log()->printf("removed monitor auto %p from caller index %d\n", sym, (int32_t)i - 1);
+            }
+
+            if (autos->isEmpty()) {
+                monitorAutos.element(i) = NULL;
+            }
+        }
+    }
+}
+
 TR_OpaqueClassBlock *J9::Compilation::getClassClassPointer(bool isVettedForAOT)
 {
     if (!isVettedForAOT || self()->getOption(TR_UseSymbolValidationManager)) {

--- a/runtime/compiler/compile/J9Compilation.hpp
+++ b/runtime/compiler/compile/J9Compilation.hpp
@@ -336,6 +336,18 @@ public:
     void addMonitorAuto(TR::RegisterMappedSymbol *, int32_t callerIndex);
     void addAsMonitorAuto(TR::SymbolReference *symRef, bool dontAddIfDLT);
 
+    /**
+     * \brief Removes a monitor auto symbol from all callerIndex buckets in the
+     *        monitor autos table.
+     *
+     * Iterates over every per-call-site list stored in _monitorAutos and
+     * removes all occurrences of sym (duplicates included).  If a list
+     * becomes empty after removal its slot is set to NULL.
+     *
+     * \param sym The RegisterMappedSymbol to remove
+     */
+    void removeMonitorAuto(TR::RegisterMappedSymbol *sym);
+
     TR::list<TR::SymbolReference *> *getMonitorAutoSymRefsInCompiledMethod()
     {
         return &_monitorAutoSymRefsInCompiledMethod;

--- a/runtime/compiler/runtime/MetaData.cpp
+++ b/runtime/compiler/runtime/MetaData.cpp
@@ -1105,12 +1105,11 @@ static void populateInlineCalls(TR::Compilation *comp, TR_J9VMBase *vm, TR_Metho
         TR_InlinedCallSite *inlinedCallSite = &comp->getInlinedCallSite(i);
 
         List<TR::RegisterMappedSymbol> *autos = (i + 1 < monitorAutos.size()) ? monitorAutos[i + 1] : 0;
-        bool hasLiveMonitors = (i + 1 < monitorAutos.size() && monitorAutos[i + 1]);
 
         // _isSameReceiver is an overloaded bit that in this context means that the live monitor data for this
         // inlined call site contains some nonzero bits
         //
-        if (autos != 0)
+        if (autos && !autos->isEmpty())
             inlinedCallSite->_byteCodeInfo.setIsSameReceiver(1);
 
         if (vm->isAOT_DEPRECATED_DO_NOT_USE()) {


### PR DESCRIPTION
This pull request addresses two related issues with the synchronization, cleanup, and validation of live monitor data during JIT compilations and method metadata creation. 

Together, these changes prevent stale or empty monitor autos from persisting into final code generation and metadata creation steps, avoiding cases of monitor autos persisting with no GC slots assigned, or marking call sites as having live monitor data when they do not.

For further details, see the commit messages. This work utilizes the OMR-side changes contributed in https://github.com/eclipse-omr/omr/pull/8408.

Closes: #23934