### PR TITLE
(0.62.0) Update to OpenSSL 3.5.8 to fix several CVEs

### DIFF
--- a/buildenv/jenkins/variables/defaults.yml
+++ b/buildenv/jenkins/variables/defaults.yml
@@ -143,7 +143,7 @@ jitserver:
 # OpenSSL
 #========================================#
 openssl:
-  extra_getsource_options: '-openssl-branch=openssl-3.5.7'
+  extra_getsource_options: '-openssl-branch=openssl-3.5.8'
   extra_configure_options: '--with-openssl=fetched'
 #========================================#
 # OpenSSL Bundling


### PR DESCRIPTION
* CVE-2026-14456
* CVE-2026-14457
* CVE-2026-18798
* CVE-2026-54874
* CVE-2026-63072
* CVE-2026-63073
* CVE-2026-63074
* CVE-2026-63075
* CVE-2026-63076
* CVE-2026-75803

Cherry-pick https://github.com/eclipse-openj9/openj9/pull/24636 for the 0.62.0 release.