### PR TITLE
(0.62) Improve performance slowdown from setting Thread.threadStatus

### DIFF
--- a/runtime/oti/VMHelpers.hpp
+++ b/runtime/oti/VMHelpers.hpp
@@ -2283,7 +2283,43 @@ exit:
 		indicateAsyncMessagePending(targetThread);
 	}
 
-	static U_32
+	/**
+	 * Set the Java thread state without reading or returning the old state.
+	 * Use this when the caller does not need to restore the previous state,
+	 * saving one barriered field read per call.
+	 *
+	 * @param[in] currentThread the current J9VMThread
+	 * @param[in] state the new thread state to set
+	 */
+	static VMINLINE void
+	setThreadStateNoSave(J9VMThread *currentThread, U_32 state)
+	{
+#if JAVA_SPEC_VERSION >= 19
+		j9object_t receiverObject = currentThread->carrierThreadObject;
+		if (NULL != receiverObject) {
+			/* Platform threads must have a non-null FieldHolder object. */
+			j9object_t threadHolder = J9VMJAVALANGTHREAD_HOLDER(currentThread, receiverObject);
+			if (NULL != threadHolder) {
+				J9VMJAVALANGTHREADFIELDHOLDER_SET_THREADSTATUS(currentThread, threadHolder, state);
+			}
+		}
+#else /* JAVA_SPEC_VERSION >= 19 */
+		j9object_t receiverObject = currentThread->threadObject;
+		if (NULL != receiverObject) {
+			J9VMJAVALANGTHREAD_SET_THREADSTATUS(currentThread, receiverObject, state);
+		}
+#endif /* JAVA_SPEC_VERSION >= 19 */
+	}
+
+	/**
+	 * Set the Java thread state and return the previous state.
+	 * Use this when the caller must later restore the original state.
+	 *
+	 * @param[in] currentThread the current J9VMThread
+	 * @param[in] state the new thread state to set
+	 * @return the previous thread state, or 0 if no thread object is available
+	 */
+	static VMINLINE U_32
 	setThreadState(J9VMThread *currentThread, U_32 state)
 	{
 		U_32 oldState = 0;

--- a/runtime/vm/ObjectMonitor.cpp
+++ b/runtime/vm/ObjectMonitor.cpp
@@ -188,7 +188,7 @@ objectMonitorEnterBlocking(J9VMThread *currentThread)
 
 		if (J9_EVENT_IS_HOOKED(vm->hookInterface, J9HOOK_VM_MONITOR_CONTENDED_ENTER)) {
 			bool frameBuilt = saveBlockingEnterObject(currentThread);
-			VM_VMHelpers::setThreadState(currentThread, J9VMTHREAD_STATE_BLOCKED);
+			VM_VMHelpers::setThreadStateNoSave(currentThread, J9VMTHREAD_STATE_BLOCKED);
 			VM_VMAccess::setPublicFlags(currentThread, J9_PUBLIC_FLAGS_THREAD_BLOCKED);
 			ALWAYS_TRIGGER_J9HOOK_VM_MONITOR_CONTENDED_ENTER(vm->hookInterface, currentThread, monitor);
 			restoreBlockingEnterObject(currentThread, frameBuilt);
@@ -201,7 +201,7 @@ objectMonitorEnterBlocking(J9VMThread *currentThread)
 			goto releasedAccess;
 		}
 restart:
-		VM_VMHelpers::setThreadState(currentThread, J9VMTHREAD_STATE_BLOCKED);
+		VM_VMHelpers::setThreadStateNoSave(currentThread, J9VMTHREAD_STATE_BLOCKED);
 		internalReleaseVMAccessSetStatus(currentThread, J9_PUBLIC_FLAGS_THREAD_BLOCKED);
 releasedAccess:
 		omrthread_monitor_enter_using_threadId(monitor, osThread);
@@ -291,7 +291,7 @@ releasedAccess:
 				J9_STORE_LOCKWORD(currentThread, lwEA, lock);
 				goto done;
 			}
-			VM_VMHelpers::setThreadState(currentThread, J9VMTHREAD_STATE_BLOCKED);
+			VM_VMHelpers::setThreadStateNoSave(currentThread, J9VMTHREAD_STATE_BLOCKED);
 			internalReleaseVMAccessSetStatus(currentThread, J9_PUBLIC_FLAGS_THREAD_BLOCKED);
 			SET_IGNORE_ENTER(monitor);
 			omrthread_monitor_wait_timed(monitor, (I_64)waitTime, 0);
@@ -303,7 +303,7 @@ releasedAccess:
 		}
 done:
 		clearEventFlag(currentThread, J9_PUBLIC_FLAGS_THREAD_BLOCKED);
-		VM_VMHelpers::setThreadState(currentThread, J9VMTHREAD_STATE_RUNNING);
+		VM_VMHelpers::setThreadStateNoSave(currentThread, J9VMTHREAD_STATE_RUNNING);
 
 		/* Clear the SUPPRESS_CONTENDED_EXITS bit in the monitor saying that CONTENDED EXIT can be sent again */
 		((J9ThreadMonitor*)monitor)->flags &= ~(UDATA)J9THREAD_MONITOR_SUPPRESS_CONTENDED_EXIT;

--- a/runtime/vm/vmthread.cpp
+++ b/runtime/vm/vmthread.cpp
@@ -461,7 +461,7 @@ void threadCleanup(J9VMThread * vmThread, UDATA forkedByVM)
 		/* Safe to call this whether handleUncaughtException clears the exception or not */
 		internalExceptionDescribe(vmThread);
 	}
-	VM_VMHelpers::setThreadState(vmThread, J9VMTHREAD_STATE_DEAD);
+	VM_VMHelpers::setThreadStateNoSave(vmThread, J9VMTHREAD_STATE_DEAD);
 	releaseVMAccess(vmThread);
 
 	/* Mark this thread as dead */


### PR DESCRIPTION
- inline setThreadState
- introduce setThreadStateNoSave to avoid extra Thread.threadStatus reads

Port from: https://github.com/eclipse-openj9/openj9/pull/24485