### PR TITLE
Run git clean to avoid unwanted files

### DIFF
--- a/buildenv/jenkins/common/build.groovy
+++ b/buildenv/jenkins/common/build.groovy
@@ -309,8 +309,9 @@ def fetchRef (REF1, REF2) {
 
 def checkoutRef (REF) {
     // Remove git's index file, forcing all files to be checked out and
-    // encoded according to any .gitattributes files in the new branch.
-    sh "rm -f .git/index && git checkout -f refs/remotes/origin/${REF}"
+    // encoded according to any .gitattributes files in the new branch,
+    // then "clean" to remove any unwanted files.
+    sh "rm -f .git/index && git checkout -f refs/remotes/origin/${REF} && git clean -fdx"
 }
 
 def build() {


### PR DESCRIPTION
This improves on https://github.com/eclipse-openj9/openj9/pull/24639 to avoid unwanted files present on the original branch but not on the target branch.

