### PR TITLE
Fix FFM downcall exception stack frame handling

### DIFF
--- a/runtime/vm/BytecodeInterpreter.hpp
+++ b/runtime/vm/BytecodeInterpreter.hpp
@@ -5752,6 +5752,7 @@ done:
 #endif /* JAVA_SPEC_VERSION >= 19 */
 		if (VM_VMHelpers::exceptionPending(_currentThread)) {
 			rc = GOTO_THROW_CURRENT_EXCEPTION;
+			goto done;
 		}
 		bp = _arg0EA - argSlots;
 		recordJNIReturn(REGISTER_ARGS, bp);
@@ -5799,6 +5800,7 @@ done:
 		return rc;
 
 ffi_OOM:
+		buildInternalNativeStackFrame(REGISTER_ARGS);
 		updateVMStruct(REGISTER_ARGS);
 		setNativeOutOfMemoryError(_currentThread, J9NLS_VM_NATIVE_OOM);
 		VMStructHasBeenUpdated(REGISTER_ARGS);


### PR DESCRIPTION
When an exception is pending after an FFM downcall, avoid executing
the normal JNI return path. That path removes the special stack frame
before exception dispatch, leaving the VM to walk an invalid frame
and potentially crash.

For allocation failures before the native invocation, construct an
internal native stack frame before raising the native `OutOfMemoryError`
so the stack remains walkable during exception dispatch.

Related: #24654