### PR TITLE
Support more opcodes in InterpreterEmulator to inline DirectMethodHandleAccessor.isStatic

### DIFF
--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -628,6 +628,10 @@ bool InterpreterEmulator::maintainStack(TR_J9ByteCode bc)
             push(new (trStackMemory()) IconstOperand(0));
             maintainStackForIf(J9BCificmpeq);
             break;
+        case J9BCifacmpeq:
+        case J9BCifacmpne:
+            maintainStackForIf(bc);
+            break;
         case J9BCgoto:
             genTarget(bcIndex() + next2BytesSigned());
             break;
@@ -635,6 +639,12 @@ bool InterpreterEmulator::maintainStack(TR_J9ByteCode bc)
         case J9BCputfield:
         case J9BCputstatic:
             pop();
+            break;
+        case J9BCbipush:
+            push(new (trStackMemory()) IconstOperand(nextByte()));
+            break;
+        case J9BCsipush:
+            push(new (trStackMemory()) IconstOperand(next2Bytes()));
             break;
         case J9BCladd:
         case J9BCiadd:

--- a/runtime/compiler/optimizer/InterpreterEmulator.cpp
+++ b/runtime/compiler/optimizer/InterpreterEmulator.cpp
@@ -636,9 +636,11 @@ bool InterpreterEmulator::maintainStack(TR_J9ByteCode bc)
             genTarget(bcIndex() + next2BytesSigned());
             break;
         case J9BCpop:
-        case J9BCputfield:
         case J9BCputstatic:
             pop();
+            break;
+        case J9BCputfield:
+            popn(2);
             break;
         case J9BCbipush:
             push(new (trStackMemory()) IconstOperand(nextByte()));


### PR DESCRIPTION
Adds support for `ifacmpeq`, `ifacmpne`, `bipush`, `sipush` to `InterpreterEmulator.cpp`, allowing `DirectMethodHandleAccessor.isStatic()` to be folded to its result.

builds on changes in https://github.com/eclipse-openj9/openj9/pull/24504. These won't take effect until that PR is merged, since it relies on the `ifacmpeq` and `ifacmpne` support added there in `InterpreterEmulator::maintainStackForIf()`