### PR TITLE
Reduce ResolvedMethod_stringConstant messages with per-client session cache

### DIFF
--- a/runtime/compiler/control/JITServerCompilationThread.cpp
+++ b/runtime/compiler/control/JITServerCompilationThread.cpp
@@ -289,7 +289,7 @@ TR::CompilationInfoPerThreadRemote::CompilationInfoPerThreadRemote(TR::Compilati
     , _fieldAttributesCache(NULL)
     , _staticAttributesCache(NULL)
     , _nullClassSignatureCache(NULL)
-    , _isUnresolvedStrCache(NULL)
+    , _stringConstantCache(NULL)
     , _classUnloadReadMutexDepth(0)
     , _aotCacheStore(false)
     , _methodIndex((uint32_t)-1)
@@ -1705,32 +1705,16 @@ bool TR::CompilationInfoPerThreadRemote::classIsInNullClassSignatureCache(const 
     return _nullClassSignatureCache->find(clsp) != _nullClassSignatureCache->end();
 }
 
-/**
- * @brief Method executed by JITServer to cache unresolved string
- *
- * @param ramClass The ramClass of interest as part of the key
- * @param cpIndex The cpIndex of interest as part of the key
- * @param stringAttrs The value we are going to cache
- * @return void
- */
-void TR::CompilationInfoPerThreadRemote::cacheIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
-    const TR_IsUnresolvedString &stringAttrs)
+void TR::CompilationInfoPerThreadRemote::cacheStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
+    const TR_StringConstantData &data)
 {
-    cacheToPerCompilationMap(_isUnresolvedStrCache, std::make_pair(ramClass, cpIndex), stringAttrs);
+    cacheToPerCompilationMap(_stringConstantCache, std::make_pair(ramClass, cpIndex), data);
 }
 
-/**
- * @brief Method executed by JITServer to retrieve unresolved string
- *
- * @param ramClass The ramClass of interest as part of the key
- * @param cpIndex The cpIndex of interest as part of the key
- * @param attrs The value to be set by the API
- * @return returns true if found in cache else false
- */
-bool TR::CompilationInfoPerThreadRemote::getCachedIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
-    TR_IsUnresolvedString &stringAttrs)
+bool TR::CompilationInfoPerThreadRemote::getCachedStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex,
+    TR_StringConstantData &data)
 {
-    return getCachedValueFromPerCompilationMap(_isUnresolvedStrCache, std::make_pair(ramClass, cpIndex), stringAttrs);
+    return getCachedValueFromPerCompilationMap(_stringConstantCache, std::make_pair(ramClass, cpIndex), data);
 }
 
 /**
@@ -1745,7 +1729,7 @@ void TR::CompilationInfoPerThreadRemote::clearPerCompilationCaches()
     clearPerCompilationCache(_fieldAttributesCache);
     clearPerCompilationCache(_staticAttributesCache);
     clearPerCompilationCache(_nullClassSignatureCache);
-    clearPerCompilationCache(_isUnresolvedStrCache);
+    clearPerCompilationCache(_stringConstantCache);
 }
 
 /**

--- a/runtime/compiler/control/JITServerCompilationThread.hpp
+++ b/runtime/compiler/control/JITServerCompilationThread.hpp
@@ -128,8 +128,8 @@ public:
     void addClassToNullClassSignatureCache(const ClassLoaderStringPair &clsp);
     bool classIsInNullClassSignatureCache(const ClassLoaderStringPair &clsp);
 
-    void cacheIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, const TR_IsUnresolvedString &stringAttrs);
-    bool getCachedIsUnresolvedStr(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_IsUnresolvedString &stringAttrs);
+    void cacheStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, const TR_StringConstantData &data);
+    bool getCachedStringConstantData(TR_OpaqueClassBlock *ramClass, int32_t cpIndex, TR_StringConstantData &data);
 
     void clearPerCompilationCaches();
     void deleteClientSessionData(uint64_t clientId, TR::CompilationInfo *compInfo, J9VMThread *compThread);
@@ -226,7 +226,7 @@ private:
     FieldOrStaticAttrTable_t *_fieldAttributesCache;
     FieldOrStaticAttrTable_t *_staticAttributesCache;
     NullClassSignatureCache_t *_nullClassSignatureCache;
-    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_IsUnresolvedString> *_isUnresolvedStrCache;
+    UnorderedMap<std::pair<TR_OpaqueClassBlock *, int32_t>, TR_StringConstantData> *_stringConstantCache;
     int32_t _classUnloadReadMutexDepth;
     bool _aotCacheStore; // True if the result of this compilation will be stored in AOT cache
     uint32_t _methodIndex; // Index of the method being compiled in the array of methods of its defining class

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -987,12 +987,27 @@ void *TR_ResolvedJ9JITServerMethod::stringConstant(I_32 cpIndex)
     TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
     auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
     TR_StringConstantData data;
+    // Check the fast per-compilation cache first (no locking needed)
     if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data))
         return data._stringConstant;
+    // Check the per-client ClassInfo cache (survives across compilations)
+    {
+        OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
+        auto &perClientCache = JITServerHelpers::getJ9ClassInfo(compInfoPT, _ramClass)._stringConstantCache;
+        auto it = perClientCache.find(cpIndex);
+        if (it != perClientCache.end()) {
+            compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, it->second);
+            return it->second._stringConstant;
+        }
+    }
     _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
     auto recv = _stream->read<void *, bool, bool>();
-    compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex,
-        TR_StringConstantData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv)));
+    TR_StringConstantData newData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv));
+    {
+        OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
+        JITServerHelpers::getJ9ClassInfo(compInfoPT, _ramClass)._stringConstantCache.insert({ cpIndex, newData });
+    }
+    compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, newData);
     return std::get<0>(recv);
 }
 
@@ -1000,15 +1015,28 @@ bool TR_ResolvedJ9JITServerMethod::isUnresolvedString(I_32 cpIndex, bool optimiz
 {
     auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
     TR_StringConstantData data;
-    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data)) {
+    // Check the fast per-compilation cache first (no locking needed)
+    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data))
         return optimizeForAOT ? data._optimizeForAOTTrueResult : data._optimizeForAOTFalseResult;
-    } else {
-        _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
-        auto recv = _stream->read<void *, bool, bool>();
-        compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex,
-            TR_StringConstantData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv)));
-        return optimizeForAOT ? std::get<1>(recv) : std::get<2>(recv);
+    // Check the per-client ClassInfo cache (survives across compilations)
+    {
+        OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
+        auto &perClientCache = JITServerHelpers::getJ9ClassInfo(compInfoPT, _ramClass)._stringConstantCache;
+        auto it = perClientCache.find(cpIndex);
+        if (it != perClientCache.end()) {
+            compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, it->second);
+            return optimizeForAOT ? it->second._optimizeForAOTTrueResult : it->second._optimizeForAOTFalseResult;
+        }
     }
+    _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
+    auto recv = _stream->read<void *, bool, bool>();
+    TR_StringConstantData newData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv));
+    {
+        OMR::CriticalSection getRemoteROMClass(compInfoPT->getClientData()->getROMMapMonitor());
+        JITServerHelpers::getJ9ClassInfo(compInfoPT, _ramClass)._stringConstantCache.insert({ cpIndex, newData });
+    }
+    compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, newData);
+    return optimizeForAOT ? std::get<1>(recv) : std::get<2>(recv);
 }
 
 bool TR_ResolvedJ9JITServerMethod::isSubjectToPhaseChange(TR::Compilation *comp)

--- a/runtime/compiler/env/j9methodServer.cpp
+++ b/runtime/compiler/env/j9methodServer.cpp
@@ -985,25 +985,29 @@ TR_ResolvedMethod *TR_ResolvedJ9JITServerMethod::getResolvedVirtualMethod(TR::Co
 void *TR_ResolvedJ9JITServerMethod::stringConstant(I_32 cpIndex)
 {
     TR_ASSERT(cpIndex != -1, "cpIndex shouldn't be -1");
+    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
+    TR_StringConstantData data;
+    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data))
+        return data._stringConstant;
     _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
     auto recv = _stream->read<void *, bool, bool>();
-
-    auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
-    compInfoPT->cacheIsUnresolvedStr((TR_OpaqueClassBlock *)_ramClass, cpIndex,
-        TR_IsUnresolvedString(std::get<1>(recv), std::get<2>(recv)));
+    compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex,
+        TR_StringConstantData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv)));
     return std::get<0>(recv);
 }
 
 bool TR_ResolvedJ9JITServerMethod::isUnresolvedString(I_32 cpIndex, bool optimizeForAOT)
 {
     auto compInfoPT = static_cast<TR::CompilationInfoPerThreadRemote *>(_fe->_compInfoPT);
-    TR_IsUnresolvedString stringAttrs;
-    if (compInfoPT->getCachedIsUnresolvedStr((TR_OpaqueClassBlock *)_ramClass, cpIndex, stringAttrs)) {
-        return optimizeForAOT ? stringAttrs._optimizeForAOTTrueResult : stringAttrs._optimizeForAOTFalseResult;
+    TR_StringConstantData data;
+    if (compInfoPT->getCachedStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex, data)) {
+        return optimizeForAOT ? data._optimizeForAOTTrueResult : data._optimizeForAOTFalseResult;
     } else {
-        _stream->write(JITServer::MessageType::ResolvedMethod_isUnresolvedString, _remoteMirror, cpIndex,
-            optimizeForAOT);
-        return std::get<0>(_stream->read<bool>());
+        _stream->write(JITServer::MessageType::ResolvedMethod_stringConstant, _remoteMirror, cpIndex);
+        auto recv = _stream->read<void *, bool, bool>();
+        compInfoPT->cacheStringConstantData((TR_OpaqueClassBlock *)_ramClass, cpIndex,
+            TR_StringConstantData(std::get<0>(recv), std::get<1>(recv), std::get<2>(recv)));
+        return optimizeForAOT ? std::get<1>(recv) : std::get<2>(recv);
     }
 }
 

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -104,24 +104,6 @@ struct TR_IsUnresolvedString {
     bool _optimizeForAOTFalseResult;
 };
 
-struct TR_StringConstantData {
-    TR_StringConstantData()
-        : _stringConstant(NULL)
-        , _optimizeForAOTTrueResult(false)
-        , _optimizeForAOTFalseResult(false)
-    {}
-
-    TR_StringConstantData(void *stringConstant, bool optimizeForAOTTrueResult, bool optimizeForAOTFalseResult)
-        : _stringConstant(stringConstant)
-        , _optimizeForAOTTrueResult(optimizeForAOTTrueResult)
-        , _optimizeForAOTFalseResult(optimizeForAOTFalseResult)
-    {}
-
-    void *_stringConstant;
-    bool _optimizeForAOTTrueResult;
-    bool _optimizeForAOTFalseResult;
-};
-
 // define a hash function for TR_ResolvedMethodKey
 namespace std {
 template<> struct hash<TR_ResolvedMethodKey> {

--- a/runtime/compiler/env/j9methodServer.hpp
+++ b/runtime/compiler/env/j9methodServer.hpp
@@ -104,6 +104,24 @@ struct TR_IsUnresolvedString {
     bool _optimizeForAOTFalseResult;
 };
 
+struct TR_StringConstantData {
+    TR_StringConstantData()
+        : _stringConstant(NULL)
+        , _optimizeForAOTTrueResult(false)
+        , _optimizeForAOTFalseResult(false)
+    {}
+
+    TR_StringConstantData(void *stringConstant, bool optimizeForAOTTrueResult, bool optimizeForAOTFalseResult)
+        : _stringConstant(stringConstant)
+        , _optimizeForAOTTrueResult(optimizeForAOTTrueResult)
+        , _optimizeForAOTFalseResult(optimizeForAOTFalseResult)
+    {}
+
+    void *_stringConstant;
+    bool _optimizeForAOTTrueResult;
+    bool _optimizeForAOTFalseResult;
+};
+
 // define a hash function for TR_ResolvedMethodKey
 namespace std {
 template<> struct hash<TR_ResolvedMethodKey> {

--- a/runtime/compiler/runtime/JITClientSession.cpp
+++ b/runtime/compiler/runtime/JITClientSession.cpp
@@ -1485,6 +1485,7 @@ ClientSessionData::ClassInfo::ClassInfo(TR_PersistentMemory *persistentMemory)
           decltype(_fieldOrStaticDefiningClassCache)::allocator_type(persistentMemory->_persistentAllocator.get()))
     , _J9MethodNameCache(decltype(_J9MethodNameCache)::allocator_type(persistentMemory->_persistentAllocator.get()))
     , _isStableCache(decltype(_isStableCache)::allocator_type(persistentMemory->_persistentAllocator.get()))
+    , _stringConstantCache(decltype(_stringConstantCache)::allocator_type(persistentMemory->_persistentAllocator.get()))
     , _referencingClassLoaders(
           decltype(_referencingClassLoaders)::allocator_type(persistentMemory->_persistentAllocator.get()))
     , _referenceSlotsInClass(

--- a/runtime/compiler/runtime/JITClientSession.hpp
+++ b/runtime/compiler/runtime/JITClientSession.hpp
@@ -173,6 +173,24 @@ struct J9MethodNameAndSignature {
     std::string _methodSignatureStr;
 };
 
+struct TR_StringConstantData {
+    TR_StringConstantData()
+        : _stringConstant(NULL)
+        , _optimizeForAOTTrueResult(false)
+        , _optimizeForAOTFalseResult(false)
+    {}
+
+    TR_StringConstantData(void *stringConstant, bool optimizeForAOTTrueResult, bool optimizeForAOTFalseResult)
+        : _stringConstant(stringConstant)
+        , _optimizeForAOTTrueResult(optimizeForAOTTrueResult)
+        , _optimizeForAOTFalseResult(optimizeForAOTFalseResult)
+    {}
+
+    void *_stringConstant;
+    bool _optimizeForAOTTrueResult;
+    bool _optimizeForAOTFalseResult;
+};
+
 /**
    @class ClientSessionData
    @brief Data structure that holds data specific to a client
@@ -248,6 +266,8 @@ public:
         PersistentUnorderedMap<int32_t, J9MethodNameAndSignature> _J9MethodNameCache; // key is a cpIndex
         PersistentUnorderedMap<int32_t, bool>
             _isStableCache; // Store the presence of the Stable annotation for the field indicated by a cpIndex
+        PersistentUnorderedMap<int32_t, TR_StringConstantData>
+            _stringConstantCache; // Cache for stringConstant/isUnresolvedString keyed by cpIndex
         PersistentUnorderedSet<J9ClassLoader *> _referencingClassLoaders;
         // The following vector caches information about the offsets of the reference slots in the class.
         // An empty vector means I don't have any information yet.


### PR DESCRIPTION
I added a per-client session cache for `stringConstant` and `isUnresolvedString` results so the same `(ramClass, cpIndex)` pair only sends a message once per client session. Both functions now share the same cache, so whichever is called first populates it for the other. A fast per-compilation cache is checked first before acquiring the lock for the per-client cache.

Benchmark results (AcmeAirEE8):
Master: ~10,000 `stringConstant` messages, ~231,109 total
This PR: ~3,800 `stringConstant` messages, ~224,000 total (~62% reduction)

Issue: https://github.ibm.com/runtimes/rt-tr-common-repo/issues/30

Continued off of: #24448 