### PR TITLE
RCP: remove the setting of J9ClassIsLoadedFromSnapshot flag

### DIFF
--- a/runtime/vm/createramclass.cpp
+++ b/runtime/vm/createramclass.cpp
@@ -2489,13 +2489,6 @@ nativeOOM:
 		}
 #endif /* defined(J9VM_OPT_VALHALLA_FLATTENABLE_VALUE_TYPES) */
 
-#if defined(J9VM_OPT_SNAPSHOTS)
-		if (IS_RESTORE_RUN(javaVM)) {
-			/* This flag is needed to ensure class hooks are run only once. */
-			classFlags |= J9ClassIsLoadedFromSnapshot;
-		}
-#endif /* defined(J9VM_OPT_SNAPSHOTS) */
-
 		state->ramClass->classFlags = classFlags;
 
 		/* Ensure all previous writes have completed before making the new class visible. */


### PR DESCRIPTION
J9ClassIsLoadedFromSnapshot is used to set classFlags if a RAM class is persisted, loaded from RCP cache. The setting flags a RAM class created in restore run, as loaded from RCP cache.