### PR TITLE
AArch64: Check negative 2nd dimension for multianewarray

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3563,7 +3563,10 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
 
     Inst_CompareBranch(cg, OP::cbnzw, node, firstDimLenReg, nonZeroFirstDimLabel);
 
-    // if we reach here, both dimensions are zero, just allocate a zero-length object array
+    // if we reach here, the first dimension is zero, just allocate a zero-length object array
+    Inst_CompareImm(cg, node, secondDimLenReg, 0, /* is64bit */ false);
+    Inst_ConditionalBranch(cg, node, oolFailLabel, TR::CC_LT);
+
     Inst_Trg1Mem(cg, loadAddrOp, node, targetReg, MRef_disp(cg, vmThreadReg, offsetof(J9VMThread, heapAlloc)));
 
     // see if we will have a heap overflow, if so go back to the ool call


### PR DESCRIPTION
This commit adds a check for the second dimension size for multianewarray inlining on AArch64.  The second dimension needs to be checked for negative value even when the first dimension is 0.