### PR TITLE
JDK28 Adopts OpenJDK JavaLangAccess updates

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1042,4 +1042,20 @@ final class Access implements JavaLangAccess {
 		Thread.currentThread().setNativeThreadID(id);
 	}
 	/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
+
+	/*[IF JAVA_SPEC_VERSION >= 28]*/
+	// @Override
+	// To be restored after Valhalla extension repo has JavaLangAccess.getConfinedMemoryPools() as well.
+	// https://github.com/eclipse-openj9/openj9/issues/24710
+	public long[] getConfinedMemoryPools(Thread thread) {
+		return thread.confinedMemoryPools();
+	}
+
+	// @Override
+	// To be restored after Valhalla extension repo has JavaLangAccess.getOrCreateConfinedMemoryPools() as well.
+	// https://github.com/eclipse-openj9/openj9/issues/24710
+	public long[] getOrCreateConfinedMemoryPools(Thread thread, int poolSlots) {
+		return thread.getOrCreateConfinedMemoryPools(poolSlots);
+	}
+	/*[ENDIF] JAVA_SPEC_VERSION >= 28 */
 }


### PR DESCRIPTION
JDK28 Adopts OpenJDK JavaLangAccess updates

Added `getConfinedMemoryPools()` and `getOrCreateConfinedMemoryPools()`.

Required by
* https://github.com/ibmruntimes/openj9-openjdk-jdk/pull/1266

Signed-off-by: Jason Feng <fengj@ca.ibm.com>

