### PR TITLE
Fix jdk.jfr module resolution for JFR V2 startup and jcmd

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VM.java
@@ -774,6 +774,12 @@ public static native Module getUnnamedModuleForSystemLoader();
  * Native used to initialize internal JFR structures
  */
 public static native void initializeInternalJFRStructures();
+
+/**
+ * Native used to unregister the JFR V2 hooks when jdk.jfr
+ * could not be made available.
+ */
+public static native void disableJFRV2Support();
 /*[ENDIF] JFR_SUPPORT */
 
 /*[IF JAVA_SPEC_VERSION >= 24]*/

--- a/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/vm/VMLangAccess.java
@@ -224,6 +224,13 @@ public interface VMLangAccess {
 
 	/*[IF JAVA_SPEC_VERSION == 17]*/
 	/**
+	 * Get the message describing why Flight Recorder could not be enabled.
+	 *
+	 * @return the message lines, or null if jdk.jfr was available
+	 */
+	public String[] getJFRModuleUnavailableMessage();
+
+	/**
 	 * Invoke jdk.jfr.internal.dcmd.DCmdStart.execute().
 	 *
 	 * @param execArgs The string arguments separated by a delimiter

--- a/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
+++ b/jcl/src/java.base/share/classes/java/lang/ClassLoader.java
@@ -292,6 +292,7 @@ public abstract class ClassLoader {
 			System.bootLayer = jdk.internal.module.ModuleBootstrap.boot();
 		/*[IF JAVA_SPEC_VERSION >= 10]*/
 		} catch (Exception ex) {
+			System.out.println("Error occurred during initialization of boot layer"); //$NON-NLS-1$
 			System.out.println(ex);
 			Throwable t = ex.getCause();
 			while (t != null) {

--- a/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
+++ b/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
@@ -36,6 +36,12 @@ import jdk.internal.misc.Unsafe;
 
 @SuppressWarnings("nls")
 final class JFRHelpers {
+	/* Indices into logTagValues[] / logLevelValues[]; keep in sync with the enum
+	 * declaration order in jdk.jfr.internal.LogTag and jdk.jfr.internal.LogLevel.
+	 */
+	private static final int LOGTAG_JFR_START = 13; // LogTag.JFR_START
+	private static final int LOGLEVEL_INFO = 2; // LogLevel.INFO
+
 	private static Class<?> jfrjvmClass;
 	private static Class<?> logTagClass;
 	private static Class<?> logLeveLClass;
@@ -50,11 +56,40 @@ final class JFRHelpers {
 	private static Constructor<?> constructorEventWriter;
 	private static volatile boolean jfrClassesInitialized = false;
 	private static String jfrCMDLineOption = null;
+	// Non-null exactly when ensureJfrModuleAvailable() has run and failed.
+	private static String[] jfrModuleUnavailableMessage;
 
 	static {
 		if (VM.isJFREnabled() && VM.isJFRV2SupportEnabled()) {
-			VM.initializeInternalJFRStructures();
-			initJFRClasses();
+			if (ensureJfrModuleAvailable()) {
+				VM.initializeInternalJFRStructures();
+				initJFRClasses();
+			}
+		}
+	}
+
+	/**
+	 * Ensure jdk.jfr is resolved into the running module graph, loading it on
+	 * demand if the launched application never itself required it (e.g. a
+	 * --module launch, or a jcmd-triggered command with no -XX:StartFlightRecording
+	 * on the original command line).
+	 *
+	 * @return true if jdk.jfr is available, false if it could not be loaded
+	 */
+	private static boolean ensureJfrModuleAvailable() {
+		if (ModuleLayer.boot().findModule("jdk.jfr").isPresent()) {
+			return true;
+		}
+		try {
+			jdk.internal.module.Modules.loadModule("jdk.jfr");
+			return true;
+		} catch (Throwable t) {
+			jfrModuleUnavailableMessage = new String[] {
+				"Flight Recorder can not be enabled.",
+				t.toString() + "."
+			};
+			VM.disableJFRV2Support();
+			return false;
 		}
 	}
 
@@ -217,14 +252,14 @@ final class JFRHelpers {
 				null
 			);
 			if (null != results) {
-				logJFR(results, 0, 2);
+				logJFR(results, LOGTAG_JFR_START, LOGLEVEL_INFO);
 			}
 			/*[ELSE] JAVA_SPEC_VERSION == 11 */
 			String[] results = (String []) dcmdStart.getDcmdExecute().invoke(
 					dcmdStart.getDCmdInstance(), "internal", jfrCMDLineOption, ',');
 			if (null != results) {
 				for (String result : results) {
-					logJFR(result, 0, 2);
+					logJFR(result, LOGTAG_JFR_START, LOGLEVEL_INFO);
 				}
 			}
 			/*[ENDIF] JAVA_SPEC_VERSION == 11 */
@@ -497,6 +532,15 @@ final class JFRHelpers {
 			}
 		}
 		return dcmdInvocation;
+	}
+
+	/**
+	 * Get the message describing why Flight Recorder could not be enabled.
+	 *
+	 * @return the message lines, or null if jdk.jfr was available
+	 */
+	public static String[] getJFRModuleUnavailableMessage() {
+		return jfrModuleUnavailableMessage;
 	}
 
 	/**

--- a/jcl/src/java.base/share/classes/java/lang/VMAccess.java
+++ b/jcl/src/java.base/share/classes/java/lang/VMAccess.java
@@ -292,6 +292,16 @@ final class VMAccess implements VMLangAccess {
 
 	/*[IF JAVA_SPEC_VERSION == 17]*/
 	/**
+	 * Get the message describing why Flight Recorder could not be enabled.
+	 *
+	 * @return the message lines, or null if jdk.jfr was available
+	 */
+	@Override
+	public String[] getJFRModuleUnavailableMessage() {
+		return JFRHelpers.getJFRModuleUnavailableMessage();
+	}
+
+	/**
 	 * Invoke jdk.jfr.internal.dcmd.DCmdStart.execute().
 	 *
 	 * @param execArgs The string arguments separated by a delimiter

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/DiagnosticUtils.java
@@ -685,6 +685,21 @@ public class DiagnosticUtils {
 				commandTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR::doJFR);
 				helpTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR.DIAGNOSTICS_JFR_STOP_HELP);
 			}
+/*[IF JAVA_SPEC_VERSION == 17]*/
+		} else {
+			/* JFR unavailable: route JFR.* to a handler that reports why, instead of leaving them unrecognized. */
+			commandTable.put(JFR.DIAGNOSTICS_JFR_START, JFR::getJFRModuleUnavailableMessage);
+			helpTable.put(JFR.DIAGNOSTICS_JFR_START, JFR.DIAGNOSTICS_JFR_START_HELP);
+
+			commandTable.put(JFR.DIAGNOSTICS_JFR_DUMP, JFR::getJFRModuleUnavailableMessage);
+			helpTable.put(JFR.DIAGNOSTICS_JFR_DUMP, JFR.DIAGNOSTICS_JFR_DUMP_HELP);
+
+			commandTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR::getJFRModuleUnavailableMessage);
+			helpTable.put(JFR.DIAGNOSTICS_JFR_STOP, JFR.DIAGNOSTICS_JFR_STOP_HELP);
+
+			commandTable.put(JFR.DIAGNOSTICS_JFR_CONFIGURE, JFR::getJFRModuleUnavailableMessage);
+			helpTable.put(JFR.DIAGNOSTICS_JFR_CONFIGURE, JFR.DIAGNOSTICS_JFR_CONFIGURE_HELP);
+/*[ENDIF] JAVA_SPEC_VERSION == 17 */
 		}
 /*[ENDIF] JFR_SUPPORT */
 	}

--- a/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/JFR.java
+++ b/jcl/src/java.base/share/classes/openj9/internal/tools/attach/target/JFR.java
@@ -386,5 +386,19 @@ public class JFR {
 
 		return result;
 	}
+
+	/**
+	 * Handle a JFR.* command when Flight Recorder is unavailable, reporting the reason.
+	 *
+	 * @param diagnosticCommand the full command string (ignored)
+	 * @return a result carrying the unavailability message
+	 */
+	static DiagnosticProperties getJFRModuleUnavailableMessage(String diagnosticCommand) {
+		String[] message = VM.getVMLangAccess().getJFRModuleUnavailableMessage();
+		if (null == message) {
+			return DiagnosticProperties.makeStringResult("Flight Recorder can not be enabled.");
+		}
+		return DiagnosticProperties.makeStringResult(Stream.of(message).collect(Collectors.joining("\n")));
+	}
 /*[ENDIF] JAVA_SPEC_VERSION == 17 */
 }

--- a/runtime/jcl/common/jclcinit.c
+++ b/runtime/jcl/common/jclcinit.c
@@ -516,6 +516,42 @@ done:
 }
 
 #define ADDMODS_PROPERTY_BASE "jdk.module.addmods."
+
+/* Add moduleName as an implicit --add-modules entry via a numbered
+ * jdk.module.addmods.<n> system property. Returns 0 on success, 1 on failure.
+ */
+static UDATA
+addRequiredModuleProperty(J9VMThread *vmThread, const char *moduleName)
+{
+	J9JavaVM *vm = vmThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	J9VMSystemProperty *systemProperty = NULL;
+
+	Trc_JCL_initializeRequiredClasses_addAgentModuleEntry(vmThread, moduleName);
+	/* Handle the case where there are no user-specified modules. In this case, there
+	 * is typically one system property but no user-set "add-modules" arguments.
+	 */
+	if ((0 == vm->addModulesCount)
+		&& (J9SYSPROP_ERROR_NONE == vmFuncs->getSystemProperty(vm, ADDMODS_PROPERTY_BASE "0", &systemProperty)))
+	{
+		/* this is implicitly an unused property */
+		vmFuncs->setSystemProperty(vm, systemProperty, moduleName);
+	} else {
+		UDATA indexLen = j9str_printf(NULL, 0, "%zu", vm->addModulesCount); /* get the length of the number string */
+		char *propNameBuffer = j9mem_allocate_memory(sizeof(ADDMODS_PROPERTY_BASE) + indexLen, OMRMEM_CATEGORY_VM);
+		if (NULL == propNameBuffer) {
+			Trc_JCL_initializeRequiredClasses_addAgentModuleOutOfMemory(vmThread);
+			return 1;
+		}
+		j9str_printf(propNameBuffer, sizeof(ADDMODS_PROPERTY_BASE) + indexLen, ADDMODS_PROPERTY_BASE "%zu", vm->addModulesCount);
+		Trc_JCL_initializeRequiredClasses_addAgentModuleSetProperty(vmThread, propNameBuffer, moduleName);
+		vmFuncs->addSystemProperty(vm, propNameBuffer, moduleName, J9SYSPROP_FLAG_NAME_ALLOCATED);
+	}
+	vm->addModulesCount += 1;
+	return 0;
+}
+
 UDATA
 initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 {
@@ -532,7 +568,6 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 	J9ClassWalkState state;
 	J9NativeLibrary* nativeLibrary = NULL;
 	j9object_t oom;
-	PORT_ACCESS_FROM_JAVAVM(vm);
 	static UDATA requiredClasses[] = {
 			J9VMCONSTANTPOOL_JAVALANGTHREAD,
 			J9VMCONSTANTPOOL_JAVALANGCLASSLOADER,
@@ -777,28 +812,9 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 		} else
 #endif /* JAVA_SPEC_VERSION < 26 */
 		{
-			J9VMSystemProperty *systemProperty = NULL;
-			Trc_JCL_initializeRequiredClasses_addAgentModuleEntry(vmThread, moduleName);
-			/* Handle the case where there are no user-specified modules. In this case, there
-			 * is typically one system property but no user-set "add-modules" arguments.
-			 */
-			if ((0 == vm->addModulesCount)
-				&& (J9SYSPROP_ERROR_NONE == vmFuncs->getSystemProperty(vm, ADDMODS_PROPERTY_BASE "0", &systemProperty)))
-			{
-				/* this is implicitly an unused property */
-				vmFuncs->setSystemProperty(vm, systemProperty, moduleName);
-			} else {
-				UDATA indexLen = j9str_printf(NULL, 0, "%zu", vm->addModulesCount); /* get the length of the number string */
-				char *propNameBuffer = j9mem_allocate_memory(sizeof(ADDMODS_PROPERTY_BASE) + indexLen, OMRMEM_CATEGORY_VM);
-				if (NULL == propNameBuffer) {
-					Trc_JCL_initializeRequiredClasses_addAgentModuleOutOfMemory(vmThread);
-					return 1;
-				}
-				j9str_printf(propNameBuffer, sizeof(ADDMODS_PROPERTY_BASE) + indexLen, ADDMODS_PROPERTY_BASE "%zu", vm->addModulesCount);
-				Trc_JCL_initializeRequiredClasses_addAgentModuleSetProperty(vmThread, propNameBuffer, moduleName);
-				vmFuncs->addSystemProperty(vm, propNameBuffer, moduleName, J9SYSPROP_FLAG_NAME_ALLOCATED);
+			if (0 != addRequiredModuleProperty(vmThread, moduleName)) {
+				return 1;
 			}
-			vm->addModulesCount += 1;
 		}
 	}
 
@@ -819,30 +835,26 @@ initializeRequiredClasses(J9VMThread *vmThread, char* dllName)
 		} else
 #endif /* JAVA_SPEC_VERSION < 26 */
 		{
-			J9VMSystemProperty *systemProperty = NULL;
-			Trc_JCL_initializeRequiredClasses_addAgentModuleEntry(vmThread, moduleName);
-			/* Handle the case where there are no user-specified modules. In this case, there
-			 * is typically one system property but no user-set "add-modules" arguments.
-			 */
-			if ((0 == vm->addModulesCount)
-				&& (J9SYSPROP_ERROR_NONE == vmFuncs->getSystemProperty(vm, ADDMODS_PROPERTY_BASE "0", &systemProperty)))
-			{
-				/* this is implicitly an unused property */
-				vmFuncs->setSystemProperty(vm, systemProperty, moduleName);
-			} else {
-				UDATA indexLen = j9str_printf(NULL, 0, "%zu", vm->addModulesCount); /* get the length of the number string */
-				char *propNameBuffer = j9mem_allocate_memory(sizeof(ADDMODS_PROPERTY_BASE) + indexLen, OMRMEM_CATEGORY_VM);
-				if (NULL == propNameBuffer) {
-					Trc_JCL_initializeRequiredClasses_addAgentModuleOutOfMemory(vmThread);
-					return 1;
-				}
-				j9str_printf(propNameBuffer, sizeof(ADDMODS_PROPERTY_BASE) + indexLen, ADDMODS_PROPERTY_BASE "%zu", vm->addModulesCount);
-				Trc_JCL_initializeRequiredClasses_addAgentModuleSetProperty(vmThread, propNameBuffer, moduleName);
-				vmFuncs->addSystemProperty(vm, propNameBuffer, moduleName, J9SYSPROP_FLAG_NAME_ALLOCATED);
+			if (0 != addRequiredModuleProperty(vmThread, moduleName)) {
+				return 1;
 			}
-			vm->addModulesCount += 1;
 		}
 	}
+
+#if defined(J9VM_OPT_JFR)
+	if (J9_ARE_ANY_BITS_SET(vm->extendedRuntimeFlags3, J9_EXTENDED_RUNTIME3_JFR_V2_SUPPORT)
+		&& (NULL != vm->jfrState.jfrCMDLineOption))
+	{
+		/* -XX:StartFlightRecording implies jdk.jfr even if the launched application
+		 * doesn't itself require it (e.g. a --module launch with no such requires).
+		 * No pre-check here: if jdk.jfr isn't in the image, resolution below fails
+		 * with the standard FindException, which is the expected behaviour.
+		 */
+		if (0 != addRequiredModuleProperty(vmThread, "jdk.jfr")) {
+			return 1;
+		}
+	}
+#endif /* defined(J9VM_OPT_JFR) */
 
 	vmThread->privateFlags &= (~J9_PRIVATE_FLAGS_REPORT_ERROR_LOADING_CLASS);
 

--- a/runtime/jcl/common/jclvm.c
+++ b/runtime/jcl/common/jclvm.c
@@ -652,6 +652,18 @@ Java_com_ibm_oti_vm_VM_initializeInternalJFRStructures(JNIEnv *env, jclass clazz
 	vmFuncs->internalExitVMToJNI(currentThread);
 }
 
+void JNICALL
+Java_com_ibm_oti_vm_VM_disableJFRV2Support(JNIEnv *env, jclass clazz)
+{
+	J9VMThread *currentThread = (J9VMThread *) env;
+	J9JavaVM *javaVM = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = javaVM->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->jfrDisableJFRV2Support(currentThread);
+	vmFuncs->internalExitVMToJNI(currentThread);
+}
+
 #endif /* defined(J9VM_OPT_JFR) */
 
 /*

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -30,12 +30,15 @@
 
 extern "C" {
 
-/* Make sure these logging levels lineup with jdk/jfr/internal/LogLevel.java */
+/* Make sure these logging levels line up with jdk/jfr/internal/LogLevel.java. */
 #define LOG_LEVEL_TRACE 1
 #define LOG_LEVEL_DEBUG 2
 #define LOG_LEVEL_INFO 3
 #define LOG_LEVEL_WARN 4
 #define LOG_LEVEL_ERROR 5
+
+/* Must match JFR_START's id in jdk/jfr/internal/LogTag.java. */
+#define J9JFR_LOGTAG_JFR_START 13
 
 #define JFR_STRING_BUFFER_SIZE 256
 #define JFR_CLASS_BUFFER_SIZE 32
@@ -363,8 +366,13 @@ Java_jdk_jfr_internal_JVM_subscribeLogLevel(JNIEnv *env, jclass clazz, jobject l
 	if (-1 != tagSetLevelOffset) {
 		MM_ObjectAccessBarrierAPI objectAccessBarrier = MM_ObjectAccessBarrierAPI(currentThread);
 
-		/* TODO for now we will use warn as the default, in the future we will parse -Xlog to determine actual level */
-		objectAccessBarrier.inlineMixedObjectStoreI32(currentThread, logTagInstance, tagSetLevelOffset, LOG_LEVEL_WARN, TRUE);
+		/* TODO: For now WARN is the default for most tags; eventually -Xlog will be
+		 * parsed to determine the actual level. JFR_START is special-cased to INFO so
+		 * the -XX:StartFlightRecording banner ("Started recording ...") is visible by
+		 * default.
+		 */
+		I_32 defaultLevel = (J9JFR_LOGTAG_JFR_START == tagSetId) ? LOG_LEVEL_INFO : LOG_LEVEL_WARN;
+		objectAccessBarrier.inlineMixedObjectStoreI32(currentThread, logTagInstance, tagSetLevelOffset, defaultLevel, TRUE);
 	} else {
 		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 	}

--- a/runtime/jcl/exports.cmake
+++ b/runtime/jcl/exports.cmake
@@ -695,6 +695,7 @@ endif()
 
 if(J9VM_OPT_JFR)
 	omr_add_exports(jclse
+		Java_com_ibm_oti_vm_VM_disableJFRV2Support
 		Java_com_ibm_oti_vm_VM_getjfrCMDLineOption
 		Java_com_ibm_oti_vm_VM_getJfrDelay
 		Java_com_ibm_oti_vm_VM_getJfrDuration

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5753,6 +5753,7 @@ typedef struct J9InternalVMFunctions {
 	void (*jvmUpcallsTransformJFREventClass)(struct J9VMThread *currentThread, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 	jobject (*createNewEventWriter)(struct J9VMThread *currentThread);
 	void (*jfrInitializeInternalStructures)(struct J9VMThread *currentThread);
+	void (*jfrDisableJFRV2Support)(struct J9VMThread *currentThread);
 	void (*jfrEmitDataLoss)(struct J9VMThread *currentThread, U_64 bytes);
 	jboolean (*requestJFREvent)(struct J9VMThread *currentThread, jlong id);
 	BOOLEAN (*setupChunkMonitor)(struct J9VMThread *currentThread);

--- a/runtime/oti/jclprots.h
+++ b/runtime/oti/jclprots.h
@@ -1305,6 +1305,8 @@ jobject JNICALL
 Java_com_ibm_oti_vm_VM_getUnnamedModuleForSystemLoader(JNIEnv *env, jclass clazz);
 void JNICALL
 Java_com_ibm_oti_vm_VM_initializeInternalJFRStructures(JNIEnv *env, jclass clazz);
+void JNICALL
+Java_com_ibm_oti_vm_VM_disableJFRV2Support(JNIEnv *env, jclass clazz);
 jboolean JNICALL
 Java_com_ibm_oti_vm_VM_isStartFlightRecordingSpecified(JNIEnv *env, jclass clazz);
 jboolean JNICALL

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -6048,6 +6048,15 @@ void
 jfrInitializeInternalStructures(J9VMThread *currentThread);
 
 /**
+ * Disable JFR V2 when jdk.jfr could not be made available: clear the JFR
+ * enablement flags and unregister the hooks registered by initializeJFRv2().
+ *
+ * @param currentThread[in] the current J9VMThread
+ */
+void
+jfrDisableJFRV2Support(J9VMThread *currentThread);
+
+/**
  * Emit a jdk.DataLoss event for the specified number of bytes lost.
  *
  * @param currentThread[in] the current J9VMThread

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -497,6 +497,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	jvmUpcallsTransformJFREventClass,
 	createNewEventWriter,
 	jfrInitializeInternalStructures,
+	jfrDisableJFRV2Support,
 	jfrEmitDataLoss,
 	requestJFREvent,
 	setupChunkMonitor,

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -2156,6 +2156,24 @@ jfrInitializeInternalStructures(J9VMThread *currentThread)
 	return;
 }
 
+/**
+ * Disable JFR V2 when jdk.jfr could not be made available: clear the JFR
+ * enablement flags and unregister the hooks registered by initializeJFRv2().
+ */
+void
+jfrDisableJFRV2Support(J9VMThread *currentThread)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	J9HookInterface **vmHooks = getVMHookInterface(vm);
+
+	vm->extendedRuntimeFlags2 &= ~J9_EXTENDED_RUNTIME2_JFR_ENABLED;
+	vm->extendedRuntimeFlags3 &= ~J9_EXTENDED_RUNTIME3_JFR_V2_SUPPORT;
+
+	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_INITIALIZED, jfrCheckJFRCMDLineOptions, NULL);
+	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_SHUTTING_DOWN, jfrShutdownInternalStructures, NULL);
+	(*vmHooks)->J9HookUnregister(vmHooks, J9HOOK_VM_CLASS_INITIALIZE, jfrClassInitialize, NULL);
+}
+
 static void
 jfrShutdownInternalStructures(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData)
 {
@@ -2178,6 +2196,7 @@ jfrShutdownInternalStructures(J9HookInterface **hook, UDATA eventNum, void *even
 		(*hook)->J9HookUnregister(hook, J9HOOK_VM_CLASS_INITIALIZE, jfrClassInitialize, NULL);
 		if (NULL != vm->jfrState.metaDataBlobFile) {
 			j9mem_free_memory(vm->jfrState.metaDataBlobFile);
+			vm->jfrState.metaDataBlobFile = NULL;
 		}
 	}
 }


### PR DESCRIPTION
JFR V2 (gated behind `-XX:+EnableOpenJ9ExperimentalFlightRecording`
on JDK17) assumed `jdk.jfr` was always resolved before touching any
of its classes. That breaks for a `--module` launch whose module
declares no "requires jdk.jfr", and for a jcmd `JFR.start` with no
`-XX:StartFlightRecording` on the command line. Both exercised by
`test/jdk/jdk/jfr/jvm/TestModularImage.java`, which failed several
ways: the "Started recording" print was silently dropped, a native
assertion crashed the VM when jdk.jfr was not resolved already
(e.g. -`-add-mods jdk.jfr` not given at launch), and a module-resolution
failure printed the wrong text.

This introduces the following changes:

- Default `LogTag.JFR_START` to INFO instead of WARN, and tag the
  startup banner with it (was tagged as plain LogTag.JFR), so it
  is no longer filtered by the default logging threshold.

- Inject `jdk.jfr` into the root module set at boot when
  `-XX:StartFlightRecording` is given with JFR V2 enabled, via a
  synthesized `jdk.module.addmods.<n>` property. Extracted the
  shared injection logic into one `addRequiredModuleProperty()`
  helper, reused by two other existing call sites.

- Add `ensureJfrModuleAvailable()`: for `jcmd` with no
  `-XX:StartFlightRecording` on the command line, checks the boot
  layer, then loads `jdk.jfr` on demand since nothing requested it
  at startup. JFR internal structures now only initialize on
  success, removing a native assertion crash. jcmd DCmd entry
  points check this and return a clean error instead of failing
  in reflection.

- Print a leading error line in `ClassLoader.java`'s module
  bootstrap catch block, matching the boot-layer error text
  TestModularImage.java expects.
  
Fixes: https://github.com/eclipse-openj9/openj9/issues/23708