### PR TITLE
(v0.62) AArch64: Check negative 2nd dimension for multianewarray

### DIFF
--- a/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/aarch64/codegen/J9TreeEvaluator.cpp
@@ -3611,7 +3611,10 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
 
     generateCompareBranchInstruction(cg, TR::InstOpCode::cbnzw, node, firstDimLenReg, nonZeroFirstDimLabel);
 
-    // if we reach here, both dimensions are zero, just allocate a zero-length object array
+    // if we reach here, the first dimension is zero, just allocate a zero-length object array
+    generateCompareImmInstruction(cg, node, secondDimLenReg, 0, /* is64bit */ false);
+    generateConditionalBranchInstruction(cg, node, oolFailLabel, TR::CC_LT);
+
     generateTrg1MemInstruction(cg, loadAddrOp, node, targetReg,
         MRef_disp(cg, vmThreadReg, offsetof(J9VMThread, heapAlloc)));
 


### PR DESCRIPTION
This commit adds a check for the second dimension size for multianewarray inlining on AArch64.  The second dimension needs to be checked for negative value even when the first dimension is 0.

Original PR in master: #24707