### PR TITLE
(0.63) Propogate StackOVerflow errors from cfreader

### DIFF
--- a/runtime/bcutil/defineclass.c
+++ b/runtime/bcutil/defineclass.c
@@ -1006,6 +1006,9 @@ createROMClassFromClassFile(J9VMThread *currentThread, J9LoadROMClassData *loadD
 			/* This case is handled below */
 			break;
 
+		case BCT_ERR_STACK_OVERFLOW:
+			exceptionNumber = J9VMCONSTANTPOOL_JAVALANGSTACKOVERFLOWERROR;
+			break;
 		/*
 		 * Error messages are contents of vm->dynamicLoadBuffers->classFileError if anything is assigned
 		 * otherwise just the classname.


### PR DESCRIPTION
Currently, all stack overflow failures thrown in cfreader are incorrectly converted to ClassFormatErrors. This is because the code required to build the SO error is missing. This PR rectifies the issue and correctly builds the SO error.

Backport of https://github.com/eclipse-openj9/openj9/pull/24698