### PR TITLE
JDK28 restores Access API Override annotation after Vahalla updates

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/Access.java
+++ b/jcl/src/java.base/share/classes/java/lang/Access.java
@@ -1044,16 +1044,12 @@ final class Access implements JavaLangAccess {
 	/*[ENDIF] JAVA_SPEC_VERSION >= 27 */
 
 	/*[IF JAVA_SPEC_VERSION >= 28]*/
-	// @Override
-	// To be restored after Valhalla extension repo has JavaLangAccess.getConfinedMemoryPools() as well.
-	// https://github.com/eclipse-openj9/openj9/issues/24710
+	@Override
 	public long[] getConfinedMemoryPools(Thread thread) {
 		return thread.confinedMemoryPools();
 	}
 
-	// @Override
-	// To be restored after Valhalla extension repo has JavaLangAccess.getOrCreateConfinedMemoryPools() as well.
-	// https://github.com/eclipse-openj9/openj9/issues/24710
+	@Override
 	public long[] getOrCreateConfinedMemoryPools(Thread thread, int poolSlots) {
 		return thread.getOrCreateConfinedMemoryPools(poolSlots);
 	}


### PR DESCRIPTION
JDK28 restores Access API @Override annotation after [Vahalla updates](https://github.com/ibmruntimes/openj9-openjdk-jdk.valuetypes/commit/ab489789de13bcc9051769699ebaaab1c7fa4607)

Related to
* https://github.com/eclipse-openj9/openj9/issues/24710

Signed-off-by: Jason Feng <fengj@ca.ibm.com>