### PR TITLE
JDK Event Support

### DIFF
--- a/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
+++ b/jcl/src/java.base/share/classes/java/lang/JFRHelpers.java
@@ -258,6 +258,7 @@ final class JFRHelpers {
 				jdkJFR.implAddExports("jdk.jfr.internal.dcmd", javabase);
 				jdkJFR.implAddExports("jdk.jfr.internal.handlers", systemUnnamedModule);
 				jdkJFR.implAddExportsToAllUnnamed("jdk.jfr.internal.handlers");
+				jdkJFR.implAddExportsToAllUnnamed("jdk.jfr.internal");
 				VM.getUnnamedModuleForSystemLoader().implAddReads(jdkJFR);
 
 				logTagValues = (Object[])logTagClass.getDeclaredMethod("values", (Class[])null).invoke(logTagClass);

--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -37,7 +37,8 @@ extern "C" {
 #define LOG_LEVEL_WARN 4
 #define LOG_LEVEL_ERROR 5
 
-#define JFR_STRING_BUFFER 256
+#define JFR_STRING_BUFFER_SIZE 256
+#define JFR_CLASS_BUFFER_SIZE 32
 
 void JNICALL
 Java_jdk_jfr_internal_JVM_registerNatives(JNIEnv *env, jclass clazz)
@@ -280,9 +281,9 @@ logJFRMessage(J9VMThread *currentThread, j9object_t stringMessage)
 {
 	PORT_ACCESS_FROM_VMC(currentThread);
 	J9InternalVMFunctions *vmFuncs = currentThread->javaVM->internalVMFunctions;
-	char buf[JFR_STRING_BUFFER];
+	char buf[JFR_STRING_BUFFER_SIZE];
 
-	J9UTF8* utf8Message = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, stringMessage, J9_STR_NONE, "", 0, buf, JFR_STRING_BUFFER);
+	J9UTF8* utf8Message = vmFuncs->copyStringToJ9UTF8WithMemAlloc(currentThread, stringMessage, J9_STR_NONE, "", 0, buf, JFR_STRING_BUFFER_SIZE);
 	if (NULL == utf8Message) {
 		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
 	} else {
@@ -374,7 +375,47 @@ Java_jdk_jfr_internal_JVM_subscribeLogLevel(JNIEnv *env, jclass clazz, jobject l
 void JNICALL
 Java_jdk_jfr_internal_JVM_retransformClasses(JNIEnv *env, jobject obj, jobjectArray classes)
 {
-	// TODO: implementation
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	jvmtiEnv *jvmtiAgent = vm->jfrState.jvmtiAgent;
+	jclass buf[JFR_CLASS_BUFFER_SIZE];
+	jsize arrayLength = env->GetArrayLength(classes);
+	jclass *classesPtr = buf;
+
+	if (arrayLength > (jsize)(sizeof(buf)/sizeof(jclass))) {
+		classesPtr = (jclass *)j9mem_allocate_memory(arrayLength, J9MEM_CATEGORY_JFR);
+		if (NULL == classesPtr) {
+			vmFuncs->internalEnterVMFromJNI(currentThread);
+			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+			vmFuncs->internalExitVMToJNI(currentThread);
+			goto done;
+		}
+	}
+
+	for (jsize i = 0; i < arrayLength; i++) {
+		classesPtr[i] = (jclass)env->GetObjectArrayElement(classes, i);
+	}
+
+	if (JVMTI_ERROR_NONE != jvmtiAgent->SetEventNotificationMode(JVMTI_ENABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)) {
+		throwNewInternalError(env, (char *)"Unable to retransform JFR event classes.");
+		goto done;
+	}
+
+	if (JVMTI_ERROR_NONE != jvmtiAgent->RetransformClasses(arrayLength, classesPtr)) {
+		throwNewInternalError(env, (char *)"Unable to retransform JFR event classes.");
+	}
+
+	if (JVMTI_ERROR_NONE != jvmtiAgent->SetEventNotificationMode(JVMTI_DISABLE, JVMTI_EVENT_CLASS_FILE_LOAD_HOOK, NULL)) {
+		throwNewInternalError(env, (char *)"Unable to retransform JFR event classes.");
+		goto done;
+	}
+
+done:
+	if (classesPtr != buf) {
+		j9mem_free_memory(classesPtr);
+	}
 }
 
 void JNICALL
@@ -492,8 +533,84 @@ done:
 jboolean JNICALL
 Java_jdk_jfr_internal_JVM_getAllowedToDoEventRetransforms(JNIEnv *env, jobject obj)
 {
-	// TODO: implementation
-	return JNI_FALSE;
+	return JNI_TRUE;
+}
+
+static void JNICALL
+jfrClassFileLoadHook(jvmtiEnv *jvmtiEnv,
+            JNIEnv *jniEnv,
+            jclass classBeingRedefined,
+            jobject loader,
+            const char *name,
+            jobject protectionDomain,
+            jint classDataLen,
+            const unsigned char *classData,
+            jint *newClassDataLen,
+            unsigned char **newClassData)
+{
+	J9VMThread *currentThread = (J9VMThread *)jniEnv;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	vmFuncs->internalEnterVMFromJNI(currentThread);
+	vmFuncs->jvmUpcallsOnRetransform(jvmtiEnv, jniEnv, classBeingRedefined, loader, name, protectionDomain, classDataLen, classData, newClassDataLen, newClassData);
+	vmFuncs->internalExitVMToJNI(currentThread);
+}
+
+static bool
+setupJFRAgent(JNIEnv *env)
+{
+	bool result = true;
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	jvmtiCapabilities capabilities;
+	jvmtiEventCallbacks callbacks;
+	JavaVM *jniVM = NULL;
+	jvmtiEnv *jvmtiAgent = NULL;
+
+	if (NULL != vm->jfrState.jvmtiAgent) {
+		goto done;
+	}
+
+	env->GetJavaVM(&jniVM);
+
+	if (NULL == jniVM) {
+		result = false;
+		goto done;
+	}
+
+	if (JNI_ERR == jniVM->GetEnv((void **)&jvmtiAgent, JVMTI_VERSION_1_2)) {
+		result = false;
+		goto done;
+	}
+
+	vm->jfrState.jvmtiAgent = jvmtiAgent;
+
+	memset(&capabilities, 0, sizeof(capabilities));
+	capabilities.can_retransform_classes = 1;
+
+	if (JVMTI_ERROR_NONE != jvmtiAgent->AddCapabilities(&capabilities)) {
+		result = false;
+		goto disposeEnv;
+	}
+
+	memset(&callbacks, 0, sizeof(callbacks));
+	callbacks.ClassFileLoadHook = &jfrClassFileLoadHook;
+
+	if (JVMTI_ERROR_NONE != jvmtiAgent->SetEventCallbacks(&callbacks, sizeof(jvmtiEventCallbacks))) {
+		result = false;
+		goto disposeEnv;
+	}
+
+done:
+	return result;
+
+disposeEnv:
+	if (NULL != vm->jfrState.jvmtiAgent) {
+		vm->jfrState.jvmtiAgent->DisposeEnvironment();
+		vm->jfrState.jvmtiAgent = NULL;
+	}
+	goto done;
 }
 
 jboolean JNICALL
@@ -509,16 +626,27 @@ Java_jdk_jfr_internal_JVM_createJFR(JNIEnv *env, jobject obj, jboolean simulateF
 		throwNewIllegalStateException(env, (char *)"Unable to start Jfr");
 		goto done;
 	}
+
+	if (!setupJFRAgent(env)) {
+		rc = JNI_FALSE;
+		throwNewIllegalStateException(env, (char *)"Unable to setup JFR agent");
+		goto done;
+	}
+
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	if (JNI_OK != vmFuncs->initializeJFR(vm)) {
 		rc = JNI_FALSE;
-		goto done;
+		vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+		goto exit;
 	}
 
 	if (!vmFuncs->setupChunkMonitor(currentThread)) {
 		rc = JNI_FALSE;
-		goto done;
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto exit;
 	}
+
+exit:
 	vmFuncs->internalExitVMToJNI(currentThread);
 
 done:
@@ -532,6 +660,11 @@ Java_jdk_jfr_internal_JVM_destroyJFR(JNIEnv *env, jobject obj)
 	J9VMThread *currentThread = (J9VMThread*) env;
 	J9JavaVM *vm = currentThread->javaVM;
 	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	if (NULL != vm->jfrState.jvmtiAgent) {
+		vm->jfrState.jvmtiAgent->DisposeEnvironment();
+		vm->jfrState.jvmtiAgent = NULL;
+	}
 
 	vmFuncs->internalEnterVMFromJNI(currentThread);
 	vmFuncs->tearDownJFR(vm);

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -5736,6 +5736,7 @@ typedef struct J9InternalVMFunctions {
 	jlong (*getTypeIdUTF8)(struct J9VMThread *currentThread, struct J9ClassLoader *classLoader, struct J9UTF8 *className, BOOLEAN freeName);
 	jlong (*getTypeId)(struct J9VMThread *currentThread, struct J9Class *clazz);
 	void (*jvmUpcallsEagerByteInstrumentation)(struct J9VMThread *currentThread, struct J9Class *superClass, U_8 *className, U_16 classNameLength, struct J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
+	void (*jvmUpcallsOnRetransform)(jvmtiEnv *jvmtiEnv, JNIEnv *jniEnv, jclass classBeingRedefined, jobject loader, const char *name, jobject protectionDomain, jint classDataLen, const unsigned char *classData, jint *newClassDataLen, unsigned char **newClassData);
 	j9object_t (*jvmUpcallTransformArrayToList)(struct J9VMThread *currentThread, j9object_t array);
 	void (*jvmUpcallsTransformJFREventClass)(struct J9VMThread *currentThread, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 	jobject (*createNewEventWriter)(struct J9VMThread *currentThread);
@@ -6278,6 +6279,7 @@ typedef struct JFRState {
 	jclass jfrInternalEventClassRef;
 	jclass jfrEventClassRef;
 	J9Method *onRetransformUpcallMethod;
+	J9Method *bytesForEagerInstrumentation;
 	J9Method *transformToListMethod;
 	J9Method *transformJFREventClassMethod;
 	J9Method *constructorEventWriterMethod;
@@ -6296,6 +6298,7 @@ typedef struct JFRState {
 	IDATA startPositionAddressOffset;
 	IDATA currentPositionOffset;
 	IDATA maxPositionOffset;
+	jvmtiEnv *jvmtiAgent;
 } JFRState;
 
 typedef struct J9ReflectFunctionTable {

--- a/runtime/oti/vm_api.h
+++ b/runtime/oti/vm_api.h
@@ -5991,6 +5991,22 @@ shutdownJFRIDs(J9JavaVM *vm);
 void
 jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClass, U_8 *className, U_16 classNameLength, J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength);
 
+/**
+ * Call the JFR retransform method to modify the JFR event class. Current exception will
+ * be set if there is a failure.
+ *
+ * @param jvmtiEnv[in] the jvmtienv
+ * @param classBeingRedefined[in] the class being redefined
+ * @param loader[in] the classloader
+ * @param className[in] the name of the class
+ * @param protectionDomain[in] the protection domain
+ * @param classDataLength[in] the length of the class data
+ * @param classData[in] the class data
+ * @param newClassDataLength[out] the new class data length
+ * @param newClassData[out] the new class data
+ */
+void
+jvmUpcallsOnRetransform(jvmtiEnv *jvmtiEnv, JNIEnv *jniEnv, jclass classBeingRedefined, jobject loader, const char *name, jobject protectionDomain, jint classDataLen, const unsigned char *classData, jint *newClassDataLen, unsigned char **newClassData);
 
 /**
  * Call the JFR transformJFREventClass method to transform the jdk.jfr.Event class.

--- a/runtime/vm/classallocation.c
+++ b/runtime/vm/classallocation.c
@@ -336,6 +336,11 @@ freeClassLoader(J9ClassLoader *classLoader, J9JavaVM *javaVM, J9VMThread *vmThre
 		classLoader->outlivingLoaders = NULL;
 	}
 
+	if (NULL != classLoader->redefinedClasses) {
+		hashTableFree(classLoader->redefinedClasses);
+		classLoader->redefinedClasses = NULL;
+	}
+
 #ifdef J9VM_NEEDS_JNI_REDIRECTION
 	if (classLoader->jniRedirectionBlocks != NULL) {
 		J9JNIRedirectionBlock* block = classLoader->jniRedirectionBlocks;

--- a/runtime/vm/intfunc.c
+++ b/runtime/vm/intfunc.c
@@ -492,6 +492,7 @@ J9InternalVMFunctions J9InternalFunctions = {
 	getTypeIdUTF8,
 	getTypeId,
 	jvmUpcallsEagerByteInstrumentation,
+	jvmUpcallsOnRetransform,
 	jvmUpcallTransformArrayToList,
 	jvmUpcallsTransformJFREventClass,
 	createNewEventWriter,

--- a/runtime/vm/jfr.cpp
+++ b/runtime/vm/jfr.cpp
@@ -61,7 +61,10 @@ J9_DECLARE_CONSTANT_UTF8(jfrEventWriterClassUTF8, "jdk/jfr/internal/EventWriter"
 J9_DECLARE_CONSTANT_UTF8(constructorEventWriterUTF8, "constructorEventWriter");
 J9_DECLARE_CONSTANT_UTF8(constructorEventWriterSigUTF8, "(JJJJZ)Ljava/lang/Object;");
 J9_DECLARE_CONSTANT_NAS(constructorEventWriterNAS, constructorEventWriterUTF8, constructorEventWriterSigUTF8);
-
+J9_DECLARE_CONSTANT_UTF8(jvmUpcallClassUTF8, "jdk/jfr/internal/JVMUpcalls");
+J9_DECLARE_CONSTANT_UTF8(onRetransformUTF8, "onRetransform");
+J9_DECLARE_CONSTANT_UTF8(onRetransformSigUTF8, "(JZLjava/lang/Class;[B)[B");
+J9_DECLARE_CONSTANT_NAS(onRetransformNAS, onRetransformUTF8, onRetransformSigUTF8);
 
 // TODO: allow configureable values
 #define J9JFR_THREAD_BUFFER_SIZE (128 * 1024)
@@ -91,6 +94,21 @@ static void checkAvailableSpaceInGlobalBuffer(J9VMThread *currentThread);
 static void jfrClassInitialize(J9HookInterface **hook, UDATA eventNum, void *eventData, void *userData);
 static bool isChunkRotationMonitor(J9VMThread *currentThread, omrthread_monitor_t monitor);
 static J9JFREvent *reserveBufferWithStackTrace(J9VMThread *currentThread, J9VMThread *sampleThread, UDATA eventType, UDATA eventFixedSize, I_32 frameSkipCount);
+
+static bool
+isJFRHostEventClass(const char *name)
+{
+	UDATA nameLength = strlen(name);
+	return J9UTF8_LITERAL_EQUALS(name, nameLength, "sun/nio/ch/FileChannelImpl")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "java/io/FileInputStream")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "java/io/FileOutputStream")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "java/io/RandomAccessFile")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "java/net/Socket$SocketInputStream")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "java/net/Socket$SocketOutputStream")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "sun/nio/ch/SocketChannelImpl")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "java/lang/Throwable")
+		|| J9UTF8_LITERAL_EQUALS(name, nameLength, "java/lang/Error");
+}
 
 U_32
 emitStackTrace(J9VMThread *currentThread, I_32 skipCount)
@@ -2171,6 +2189,147 @@ jfrCheckJFRCMDLineOptions(J9HookInterface **hook, UDATA eventNum, void *eventDat
 	internalReleaseVMAccess(currentThread);
 }
 
+static bool
+canRetransformClass(J9VMThread *currentThread, const char *name, jclass classBeingRedefined)
+{
+	J9JavaVM *vm = currentThread->javaVM;
+	bool result = true;
+	J9Class *clazz = NULL;
+
+	if (isJFRHostEventClass(name)) {
+		goto done;
+	}
+
+	if (NULL == classBeingRedefined) {
+		result = false;
+		goto done;
+	}
+
+	clazz = J9VMJAVALANGCLASS_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(classBeingRedefined));
+
+	if (!isSameOrSuperClassOf(J9VMJAVALANGCLASS_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(vm->jfrState.jfrEventClassRef)), clazz)
+		|| J9_ARE_ANY_BITS_SET(clazz->romClass->modifiers, J9AccAbstract)
+	) {
+		result = false;
+		goto done;
+	}
+
+done:
+	return result;
+}
+
+void
+jvmUpcallsOnRetransform(jvmtiEnv *jvmtiEnv,
+            JNIEnv *jniEnv,
+            jclass classBeingRedefined,
+            jobject classLoaderRef,
+            const char *name,
+            jobject protectionDomain,
+            jint classDataLen,
+            const unsigned char *classData,
+            jint *newClassDataLen,
+            unsigned char **newClassData)
+{
+	J9VMThread *currentThread = (J9VMThread *)jniEnv;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+	J9MemoryManagerFunctions *mmfns = vm->memoryManagerFunctions;
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	jlong traceID = 0;
+	j9object_t inputByteArray = NULL;
+	j9object_t outputByteArray = NULL;
+	UDATA args[5];
+	jint classNameLength = (jint)strlen(name);
+	const char *className = name;
+	jint classDataLength = classDataLen;
+	jint newClassDataLength = 0;
+	J9ClassLoader *loader = vm->systemClassLoader;
+	U_8 buf[J9JFR_CLASSNAME_BUFFER_SIZE + sizeof(U_16)];
+	J9UTF8 *nameUTF8 = (J9UTF8 *)buf;
+
+	if (!canRetransformClass(currentThread, name, classBeingRedefined)) {
+		goto done;
+	}
+
+	if (classNameLength > J9JFR_CLASSNAME_BUFFER_SIZE) {
+		nameUTF8 = (J9UTF8 *)j9mem_allocate_memory(classNameLength + sizeof(U_16), OMRMEM_CATEGORY_VM);
+		if (NULL == nameUTF8) {
+			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+			goto done;
+		}
+	}
+
+	J9UTF8_SET_LENGTH(nameUTF8, (U_16)classNameLength);
+	memcpy(J9UTF8_DATA(nameUTF8), className, classNameLength);
+
+	if (NULL != classLoaderRef) {
+		loader = J9VMJAVALANGCLASSLOADER_VMREF(currentThread, J9_JNI_UNWRAP_REFERENCE(classLoaderRef));
+	}
+
+	traceID = getTypeIdUTF8(currentThread, loader, nameUTF8, FALSE);
+
+	inputByteArray = mmfns->J9AllocateIndexableObject(currentThread, vm->byteReflectClass->arrayClass, (U_32)classDataLength, J9_GC_ALLOCATE_OBJECT_NON_INSTRUMENTABLE);
+	if (NULL == inputByteArray) {
+		vmFuncs->setHeapOutOfMemoryError(currentThread);
+		goto done;
+	}
+
+	VM_ArrayCopyHelpers::memcpyToArray(currentThread, inputByteArray, (UDATA)0, classDataLength, (void *)classData);
+
+	if (NULL == vm->jfrState.onRetransformUpcallMethod) {
+		PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, inputByteArray);
+		J9Class *jvmUpCallsClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jvmUpcallClassUTF8), J9UTF8_LENGTH(&jvmUpcallClassUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
+		if (NULL == jvmUpCallsClass) {
+			goto popInputArrayAndDone;
+		}
+		vm->jfrState.onRetransformUpcallMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jvmUpCallsClass, (J9ROMNameAndSignature *)&onRetransformNAS, jvmUpCallsClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
+		if (NULL == vm->jfrState.onRetransformUpcallMethod) {
+			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
+			goto popInputArrayAndDone;
+		}
+		vmFuncs->initializeClass(currentThread, jvmUpCallsClass);
+		inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+
+		if (VM_VMHelpers::exceptionPending(currentThread)) {
+			goto done;
+		}
+	}
+
+	args[0] = 0;
+	args[1] = (UDATA)traceID;
+	args[2] = (UDATA)FALSE;
+	args[3] = (UDATA)J9_JNI_UNWRAP_REFERENCE(classBeingRedefined);
+	args[4] = (UDATA)inputByteArray;
+
+	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.onRetransformUpcallMethod, TRUE, 5, args);
+	outputByteArray = (j9object_t)currentThread->returnValue;
+
+	if (VM_VMHelpers::exceptionPending(currentThread) || (NULL == outputByteArray)) {
+		goto done;
+	}
+
+	newClassDataLength = (jint)J9INDEXABLEOBJECT_SIZE(currentThread, outputByteArray);
+	*newClassData = (U_8 *)j9mem_allocate_memory(newClassDataLength, OMRMEM_CATEGORY_VM);
+	if (NULL == *newClassData) {
+		vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		goto done;
+	}
+	*newClassDataLen = newClassDataLength;
+
+	VM_ArrayCopyHelpers::memcpyFromArray(currentThread, outputByteArray, (UDATA)0, (UDATA)0, newClassDataLength, *newClassData);
+
+done:
+	if (nameUTF8 != (J9UTF8 *)buf) {
+		j9mem_free_memory(nameUTF8);
+	}
+
+	return;
+
+popInputArrayAndDone:
+	inputByteArray = POP_OBJECT_IN_SPECIAL_FRAME(currentThread);
+	goto done;
+}
+
 void
 jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClass, U_8 *className, U_16 classNameLength, J9ClassLoader *loader, U_8 *classData, UDATA classDataLength, U_8 **newClassData, UDATA *newClassDataLength)
 {
@@ -2191,7 +2350,7 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 	}
 	freeName = TRUE;
 
-	J9UTF8_LENGTH(nameUTF8) = (U_16)classNameLength;
+	J9UTF8_SET_LENGTH(nameUTF8, (U_16)classNameLength);
 	memcpy(J9UTF8_DATA(nameUTF8), className, classNameLength);
 
 	traceID = getTypeIdUTF8(currentThread, loader, nameUTF8, freeName);
@@ -2206,14 +2365,14 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 
 	VM_ArrayCopyHelpers::memcpyToArray(currentThread, inputByteArray, (UDATA)0, classDataLength, (void *)classData);
 
-	if (NULL == vm->jfrState.onRetransformUpcallMethod) {
+	if (NULL == vm->jfrState.bytesForEagerInstrumentation) {
 		PUSH_OBJECT_IN_SPECIAL_FRAME(currentThread, inputByteArray);
 		J9Class *jfrClassTransformerClass = vmFuncs->internalFindClassUTF8(currentThread, (U_8 *)J9UTF8_DATA(&jfrClassTransformerUTF8), J9UTF8_LENGTH(&jfrClassTransformerUTF8), vm->systemClassLoader, J9_FINDCLASS_FLAG_THROW_ON_FAIL);
 		if (NULL == jfrClassTransformerClass) {
 			goto popInputArrayAndDone;
 		}
-		vm->jfrState.onRetransformUpcallMethod = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrClassTransformerClass, (J9ROMNameAndSignature *)&bytesForEagerInstrumentationNAS, jfrClassTransformerClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
-		if (NULL == vm->jfrState.onRetransformUpcallMethod) {
+		vm->jfrState.bytesForEagerInstrumentation = (J9Method *)vmFuncs->javaLookupMethodImpl(currentThread, jfrClassTransformerClass, (J9ROMNameAndSignature *)&bytesForEagerInstrumentationNAS, jfrClassTransformerClass, J9_LOOK_STATIC | J9_LOOK_DIRECT_NAS, NULL);
+		if (NULL == vm->jfrState.bytesForEagerInstrumentation) {
 			vmFuncs->setCurrentException(currentThread, J9VMCONSTANTPOOL_JAVALANGINTERNALERROR, NULL);
 			goto popInputArrayAndDone;
 		}
@@ -2230,7 +2389,7 @@ jvmUpcallsEagerByteInstrumentation(J9VMThread *currentThread, J9Class *superClas
 	args[3] = (UDATA)superClass->classObject;
 	args[4] = (UDATA)inputByteArray;
 
-	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.onRetransformUpcallMethod, TRUE, 5, args);
+	vmFuncs->internalRunStaticMethod(currentThread, vm->jfrState.bytesForEagerInstrumentation, TRUE, 5, args);
 	outputByteArray = (j9object_t)currentThread->returnValue;
 
 	if (VM_VMHelpers::exceptionPending(currentThread) || (NULL == outputByteArray)) {
@@ -2412,7 +2571,8 @@ createNewEventWriter(J9VMThread *currentThread)
 		currentThread->jfrJavaEventBuffer.bufferStart = buffer;
 		currentThread->jfrJavaEventBuffer.bufferCurrent = buffer + sizeof(I_64);
 		currentThread->jfrJavaEventBuffer.bufferSize = J9JFR_THREAD_BUFFER_SIZE;
-		currentThread->jfrJavaEventBuffer.bufferRemaining = J9JFR_THREAD_BUFFER_SIZE - sizeof(I_64);
+		currentThread->jfrJavaEventBuffer.bufferRemaining = J9JFR_THREAD_BUFFER_SIZE;
+		*(I_64 *)currentThread->jfrJavaEventBuffer.bufferStart = (I_64)currentThread->jfrJavaEventBuffer.bufferCurrent;
 #if defined(DEBUG)
 		memset(currentThread->jfrJavaEventBuffer.bufferStart, 0, J9JFR_THREAD_BUFFER_SIZE);
 #endif /* defined(DEBUG) */
@@ -2485,7 +2645,7 @@ done:
 void
 asyncflushJavaJFRBuffer(J9VMThread *currentThread, J9VMThread *flushThread)
 {
-	I_64 currentPosition = *(I_64 *)currentThread->jfrJavaEventBuffer.bufferStart;
+	I_64 currentPosition = *(I_64 *)flushThread->jfrJavaEventBuffer.bufferStart;
 
 	/* The Java thread will be writing events between currentPosition and maxPosition so anything up to
 	 * currentPosition is safe to read. Start the reading from the internal currentPosition and not the start
@@ -2561,8 +2721,9 @@ flushJavaJFRBuffer(J9VMThread *currentThread, jobject eventWriterRef, I_32 uncom
 	/* Reset the buffer variables and move uncommited data back to the start of the new buffer. */
 	currentThread->jfrJavaEventBuffer.bufferCurrent = currentThread->jfrJavaEventBuffer.bufferStart + sizeof(I_64);
 	memmove(currentThread->jfrJavaEventBuffer.bufferCurrent, (const void *)(UDATA)currentPosition, uncommited);
+	*(I_64 *)currentThread->jfrJavaEventBuffer.bufferStart = (I_64)currentThread->jfrJavaEventBuffer.bufferCurrent;
 	objectAccessBarrier.inlineMixedObjectStoreI64(currentThread, eventWriter, jfrState->startPositionOffset, (I_64)currentThread->jfrJavaEventBuffer.bufferCurrent, TRUE);
-	objectAccessBarrier.inlineMixedObjectStoreI64(currentThread, eventWriter, jfrState->currentPositionOffset, (I_64)currentThread->jfrJavaEventBuffer.bufferCurrent, TRUE);
+	objectAccessBarrier.inlineMixedObjectStoreI64(currentThread, eventWriter, jfrState->currentPositionOffset, (I_64)currentThread->jfrJavaEventBuffer.bufferCurrent + uncommited, TRUE);
 
 	j9mem_free_memory(oldBuffer);
 done:


### PR DESCRIPTION
There are certain events that are created by JCL code, particularly the
ones that invole Files and sockets. These events require the
retransformation JFR capability which is enabled by
Java_jdk_jfr_internal_JVM_getAllowedToDoEventRetransforms.

When retransformations are enabled JCL classes (JFRHostEventClass) like
FileInputStream are transformed to emit an event when certain APIs are
used. To facilitate this, Java_jdk_jfr_internal_JVM_retransformClasses
is called and the JVM passes uses the JVMUpcalls::retransformationClass
API to modify the class. This requires that a jvmti Agent is setup when
JFRv2 is enabled in setupJFRAgent.

JVM_getAllowedToDoEventRetransforms also enables more optimal code to be
emitted for custom events. When this is turned off, custom events are
emitted with runtime checks to see if they are enable. When retransform
is enabled, there are no runtime checks. Instead, the class is modified
to emit the events.

The retransform call checks canRetransformClass to ensure that only
host event classes or actual event classes and be retransformed.

Related to https://github.com/eclipse-openj9/openj9/issues/23732

Other fixes:
1. jdk.jfr.internal is exported to unnamed classes
2. bytesForEagerInstrumentation upcall method is appropriately named
3. asyncflushJavaJFRBuffer uses flush thread instead of current thread
4. flushJavaJFRBuffer now correctly resets the current position