### PR TITLE
Fail getResolved[Virtual/Interface]Method lookups for obsolete classes

### DIFF
--- a/runtime/compiler/env/j9method.cpp
+++ b/runtime/compiler/env/j9method.cpp
@@ -7484,6 +7484,18 @@ TR_OpaqueMethodBlock *TR_J9VMBase::getResolvedVirtualMethod(TR_OpaqueClassBlock 
 
     TR::Compilation *comp = _compInfoPT->getCompilation();
 
+    // It is possible to end up attempting to look up the vtable of an obsolete class in some scenarios,
+    // such as during peeking ILGen. Under fast HCR, the obsolete class vtable would be empty. However,
+    // under extended HCR, it is possible for obsolete classes to have a non-empty vtable, so the check
+    // below that would terminate when vftHeader size is 0 is not sufficient on its own.
+    if (J9_IS_CLASS_OBSOLETE(j9class)) {
+        OMR::Logger *log = comp->log();
+        logprintf(comp->getOption(TR_TraceOptDetails), log,
+            "getResolvedVirtualMethod: class %p is obsolete; failing query for virtualCallOffset=%d\n", (void *)j9class,
+            virtualCallOffset);
+        return 0;
+    }
+
     // virtualCallOffset is a vtable slot computed against the class the call was resolved
     // against, while classObject is the receiver's (possibly refined) type.  When those
     // differ, such as when an interface accessor whose vtable slot was taken from one
@@ -7526,12 +7538,22 @@ TR_OpaqueMethodBlock *TR_J9VMBase::getResolvedInterfaceMethod(J9ConstantPool *ow
 
     // the classObject is the fixed type of the this pointer.  The result of this method is going to be
     // used to call the interface function directly.
-    //
-    J9Method *ramMethod = jitGetInterfaceMethodFromCP(vmThread(), ownerCP, cpIndex,
-        TR::Compiler->cls.convertClassOffsetToClassPtr(classObject));
+
+    TR::Compilation *comp = _compInfoPT->getCompilation();
+    J9Class *j9class = (J9Class *)TR::Compiler->cls.convertClassOffsetToClassPtr(classObject);
+
+    // A redefined class is never a valid target for a direct interface dispatch.
+    if (J9_IS_CLASS_OBSOLETE(j9class)) {
+        OMR::Logger *log = comp->log();
+        logprintf(comp->getOption(TR_TraceOptDetails), log,
+            "getResolvedInterfaceMethod: class %p is obsolete; failing query for cpIndex=%d\n", (void *)j9class,
+            cpIndex);
+        return 0;
+    }
+
+    J9Method *ramMethod = jitGetInterfaceMethodFromCP(vmThread(), ownerCP, cpIndex, j9class);
 
     // ramMethod might have been inherited from a superclass
-    TR::Compilation *comp = _compInfoPT->getCompilation();
     comp->constProvenanceGraph()->addEdge(classObject, ramMethod);
 
     return (TR_OpaqueMethodBlock *)ramMethod;


### PR DESCRIPTION
For interface method case, under fast HCR, the superseding class shares the same iTable as the obsolete class, but the obsolete class would have an empty vTable. Therefore, an iTable lookup will succeed, and the vtable offset obtained would be valid for only the live class, so accessing the obsolete class's vtable using that is going to be an out of bounds access. Under extended HCR, the vtable for an obsolete class is not empty, but accessing an entry in it based on the obtained vtable offset is still incorrect for the same reasons and should be prevented.

For virtual method case, under extended HCR, an obsolete class can have a non-empty vtable, meaning the existing size-zero guard is not sufficient on its own as it would be for fast HCR, where obsolete classes have empty vtables.

One path that can reach these lookups with an obsolete classes is peeking ILGen, which may attemptvirtual/interface method dispatch resolution on a class that has already been redefined.

This commit addresses these problems by adding an explicit J9_IS_CLASS_OBSOLETE check in classObject-based getResolvedVirtualMethod and getResolvedInterfaceMethod helpers.