### PR TITLE
Fix gettext build in mkdocker.sh

### DIFF
--- a/buildenv/docker/mkdocker.sh
+++ b/buildenv/docker/mkdocker.sh
@@ -481,9 +481,6 @@ if [ $arch = x86_64 ] ; then
   echo " && $wget_O gettext.tar.gz http://ftp.gnu.org/gnu/gettext/gettext-$gettext_version.tar.gz \\"
   echo " && tar -xzf gettext.tar.gz \\"
   echo " && cd gettext-$gettext_version \\"
-if [ $version != 6 ] ; then
-  echo " && ./autogen.sh --skip-gnulib \\"
-fi
   echo " && ./configure --disable-nls \\"
   echo " && make \\"
   echo " && make install \\"


### PR DESCRIPTION
The autgen.sh script doesn't need to be called because we are fetching a release tarball that has all the resulting files already present.

The autogen.sh script needs to fetch files from an external host that may not be reachable.