### PR TITLE
Implement x86 CRC32C acceleration

### DIFF
--- a/runtime/compiler/runtime/Runtime.cpp
+++ b/runtime/compiler/runtime/Runtime.cpp
@@ -340,12 +340,13 @@ JIT_HELPER(doAESENCDecrypt);
 
 JIT_HELPER(methodHandleJ2IGlue);
 JIT_HELPER(methodHandleJ2I_unwrapper);
-
+JIT_HELPER(java_util_zip_CRC32C_updateBytes_impl);
 // --------------------------------------------------------------------------------
 //                                    IA32
 // --------------------------------------------------------------------------------
 
 #else /* TR_HOST_64BIT */
+JIT_HELPER(java_util_zip_CRC32C_updateBytes_impl);
 JIT_HELPER(longDivide);
 JIT_HELPER(longRemainder);
 
@@ -1195,6 +1196,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
     SET(TR_AMD64arrayTranslateTROT, (void *)arrayTranslateTROT, TR_Helper);
     SET(TR_AMD64encodeUTF16Big, (void *)encodeUTF16Big, TR_Helper);
     SET(TR_AMD64encodeUTF16Little, (void *)encodeUTF16Little, TR_Helper);
+    SET(TR_AMD64java_util_zip_CRC32C_updateBytes, (void *)java_util_zip_CRC32C_updateBytes_impl, TR_Helper);
 #ifdef J9VM_OPT_JAVA_CRYPTO_ACCELERATION
     SET(TR_AMD64doAESENCEncrypt, (void *)doAESENCEncrypt, TR_Helper);
     SET(TR_AMD64doAESENCDecrypt, (void *)doAESENCDecrypt, TR_Helper);
@@ -1245,7 +1247,7 @@ void initializeCodeRuntimeHelperTable(J9JITConfig *jitConfig, char isSMP)
     SET(TR_IA32arrayTranslateTROT, (void *)arrayTranslateTROT, TR_Helper);
     SET(TR_IA32encodeUTF16Big, (void *)encodeUTF16Big, TR_Helper);
     SET(TR_IA32encodeUTF16Little, (void *)encodeUTF16Little, TR_Helper);
-
+    SET(TR_IA32java_util_zip_CRC32C_updateBytes, (void *)java_util_zip_CRC32C_updateBytes_impl, TR_Helper);
     SET(TR_jitAddPicToPatchOnClassUnload, (void *)jitAddPicToPatchOnClassUnload, TR_Helper);
 
     SET(TR_IA32JitMonitorEnterReserved, (void *)jitMonitorEnterReserved, TR_CHelper);

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.cpp
@@ -12917,6 +12917,79 @@ TR::Register *J9::X86::TreeEvaluator::tabortEvaluator(TR::Node *node, TR::CodeGe
     return NULL;
 }
 
+TR::Register *J9::X86::TreeEvaluator::callCRC32CUpdateHelper(TR::Node *node, TR::CodeGenerator *cg, bool isDirectBuffer)
+{
+    TR::Register *crc = cg->gprClobberEvaluate(node->getChild(0), TR::InstOpCode::MOV4RegReg);
+    TR::Register *buf = cg->gprClobberEvaluate(node->getChild(1), OP::MOVRegReg());
+    TR::Register *off = cg->gprClobberEvaluate(node->getChild(2), TR::InstOpCode::MOV4RegReg);
+    TR::Register *end = cg->evaluate(node->getChild(3));
+
+    if (!isDirectBuffer) {
+        TR::MemoryReference *memRef = MRef_Bdisp32(buf, TR::Compiler->om.contiguousArrayHeaderSizeInBytes(), cg);
+        Inst_RegMem(OP::LEARegMem(), node, buf, memRef, cg);
+    }
+
+    TR::Register *result;
+#if defined(TR_TARGET_64BIT)
+    {
+        /*
+        AMD64 helper calling convention:
+          edi = initial CRC (in)
+          rsi = buffer pointer (in)
+          edx = start offset (in)
+          ecx = exclusive end offset (in)
+          r8  = clobbered scratch (dummy)
+          eax = result CRC (out)
+        */
+        TR::Register *dummy = cg->allocateRegister(TR_GPR);
+        result = cg->allocateRegister();
+        TR::RegisterDependencyConditions *dependencies = RegDeps((uint8_t)0, 6, cg);
+        dependencies->addPostCondition(crc, TR::RealRegister::edi, cg);
+        dependencies->addPostCondition(buf, TR::RealRegister::esi, cg);
+        dependencies->addPostCondition(off, TR::RealRegister::edx, cg);
+        dependencies->addPostCondition(end, TR::RealRegister::ecx, cg);
+        dependencies->addPostCondition(dummy, TR::RealRegister::r8, cg);
+        dependencies->addPostCondition(result, TR::RealRegister::eax, cg);
+
+        dependencies->stopAddingConditions();
+
+        Inst_HelperCall(node, TR_AMD64java_util_zip_CRC32C_updateBytes, dependencies, cg);
+        cg->stopUsingRegister(dummy);
+    }
+#else
+    {
+        /*
+        IA32 helper calling convention:
+          eax = initial CRC (in) / result CRC (out) — same register
+          edx = buffer pointer (in)
+          ecx = start offset (in)
+          ebx = exclusive end offset (in)
+          esi = clobbered scratch (dummy)
+        */
+        TR::Register *dummy = cg->allocateRegister(TR_GPR);
+        result = crc; /* helper overwrites eax in-place; use the crc register as result */
+        TR::RegisterDependencyConditions *dependencies = RegDeps((uint8_t)0, 5, cg);
+        dependencies->addPostCondition(crc, TR::RealRegister::eax, cg);
+        dependencies->addPostCondition(buf, TR::RealRegister::edx, cg);
+        dependencies->addPostCondition(off, TR::RealRegister::ecx, cg);
+        dependencies->addPostCondition(end, TR::RealRegister::ebx, cg);
+        dependencies->addPostCondition(dummy, TR::RealRegister::esi, cg);
+
+        dependencies->stopAddingConditions();
+
+        Inst_HelperCall(node, TR_IA32java_util_zip_CRC32C_updateBytes, dependencies, cg);
+        cg->stopUsingRegister(dummy);
+    }
+#endif
+
+    for (uint16_t i = 0; i < node->getNumChildren(); i++) {
+        cg->decReferenceCount(node->getChild(i));
+    }
+
+    node->setRegister(result);
+    return result;
+}
+
 TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg)
 {
     static bool useJapaneseCompression = (feGetEnv("TR_JapaneseComp") != NULL);
@@ -13037,6 +13110,16 @@ TR::Register *J9::X86::TreeEvaluator::directCallEvaluator(TR::Node *node, TR::Co
                 return NULL;
             } else
                 break;
+        }
+        case TR::java_util_zip_CRC32C_updateBytes:
+        case TR::java_util_zip_CRC32C_updateDirectByteBuffer: {
+            static const bool disableCRC32C = feGetEnv("TR_DisableCRC32CAcceleration") != NULL;
+            if (!disableCRC32C && !TR::Compiler->om.canGenerateArraylets()
+                && comp->target().cpu.supportsFeature(OMR_FEATURE_X86_SSE4_2)) {
+                return callCRC32CUpdateHelper(node, cg,
+                    symbol->getRecognizedMethod() == TR::java_util_zip_CRC32C_updateDirectByteBuffer);
+            }
+            break;
         }
 #if JAVA_SPEC_VERSION < 19
         case TR::java_lang_StringCoding_hasNegatives:

--- a/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
+++ b/runtime/compiler/x/codegen/J9TreeEvaluator.hpp
@@ -144,6 +144,7 @@ public:
     static void generateFillInDataBlockSequenceForUnresolvedField(TR::CodeGenerator *cg, TR::Node *node,
         TR::Snippet *dataSnippet, bool isWrite, TR::Register *sideEffectRegister, TR::Register *dataSnippetRegister);
     static TR::Register *directCallEvaluator(TR::Node *node, TR::CodeGenerator *cg);
+    static TR::Register *callCRC32CUpdateHelper(TR::Node *node, TR::CodeGenerator *cg, bool isDirectBuffer);
     static TR::Register *encodeUTF16Evaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *toUpperIntrinsicUTF16Evaluator(TR::Node *node, TR::CodeGenerator *cg);
     static TR::Register *toLowerIntrinsicUTF16Evaluator(TR::Node *node, TR::CodeGenerator *cg);

--- a/runtime/compiler/x/runtime/X86Codert.nasm
+++ b/runtime/compiler/x/runtime/X86Codert.nasm
@@ -146,6 +146,8 @@ segment .text
         DECLARE_EXTERN jProfile64BitValue
 %endif
 
+        DECLARE_GLOBAL java_util_zip_CRC32C_updateBytes_impl
+
         align 16
 jitFPHelpersBegin:
 
@@ -452,7 +454,7 @@ doSSEdoubleRemainder:
         ; note, the sign of the divisor has no affect on the final result
         andpd xmm1, oword  [_rel ABSMASK]                            ; xmm1 = {|a|, |b|}
         movapd xmm2, [_rel NULL_INF_MASK]                            ; xmm2 = {+inf, 0.0}
-        
+
         cmppd xmm2, xmm1, 4                             ; compare xmm2 != xmm1, leave mask in xmm1
 
         ; xmm1 = {(|a| != +inf ? |a| : 0, |b| != 0.0 ? |b| : 0}
@@ -787,6 +789,100 @@ SSEd2l_NaN:                         ; if the number is a NaN, return 0 (note: no
 
 jitFPHelpersEnd:
 
+%ifdef TR_HOST_64BIT
+; java_util_zip_CRC32C_updateBytes_impl
+;
+; This algorithm uses the crc32 instruction to accumulate the checksum in three sections. The first section is unrolled
+; to process 64 bytes at a time. Next, we process 8 bytes at a time. The residue is then processed using a duff device,
+; which uses 7 inline crc32b instructions and jumps to the correct spot in the instruction sequence, depending on the
+; number of bytes left.
+;
+; Arguments:
+; rdi - initial CRC32C value
+; rsi - pointer to the address of the buffer's first byte
+; rdx - starting offset
+; rcx - exclusive ending offset
+;
+; Return:
+; eax - updated CRC32C value
+        align 16
+java_util_zip_CRC32C_updateBytes_impl:
+        mov eax, edi ; Copy current crc value into rax (result register)
+crc32c_64byte_loop:
+        lea r8, [rdx + 64]
+        cmp r8, rcx
+        ja crc32c_8byte_loop ;Skip loop if less than 64 bytes in buffer
+
+        crc32 rax, qword [rsi+rdx] ; else go into 64 byte unrolled crc32c loop body to process words
+        crc32 rax, qword [rsi+rdx+8]
+        crc32 rax, qword [rsi+rdx+16]
+        crc32 rax, qword [rsi+rdx+24]
+        crc32 rax, qword [rsi+rdx+32]
+        crc32 rax, qword [rsi+rdx+40]
+        crc32 rax, qword [rsi+rdx+48]
+        crc32 rax, qword [rsi+rdx+56]
+        add rdx, 0x00000040
+        jmp crc32c_64byte_loop
+
+crc32c_8byte_loop: ; crc 8 bytes at a time in loop
+        lea r8, [rdx+8]
+        cmp r8, rcx
+        ja crc32c_residue
+
+        crc32 rax, qword [rsi+rdx]
+        add rdx, 8
+        jmp crc32c_8byte_loop
+
+crc32c_residue: ; one byte loop as Duff device implementation for residue bytes processing
+        cmp rdx, rcx
+        jae crc32c_done
+
+        crc32 eax, byte [rsi+rdx]
+        inc rdx
+        jmp crc32c_residue
+
+crc32c_done:
+        ret
+
+%else ; TR_HOST_32BIT
+; Arguments:
+; eax - CRC accumulator result
+; edx - data pointer to first byte of the buffer
+; ecx - starting offset
+; ebx - exclusive ending offset
+; esi - dummy register
+
+        align 16
+java_util_zip_CRC32C_updateBytes_impl:
+crc32c_4byte_loop:
+        lea esi, [ecx+4]
+        cmp esi, ebx
+        ja crc32c_2byte_loop
+
+        crc32 eax, dword [edx+ecx]
+        add ecx, 4
+        jmp crc32c_4byte_loop
+
+crc32c_2byte_loop:
+        lea esi, [ecx+2]
+        cmp esi, ebx
+        ja crc32c_residue
+
+        crc32 eax, word [edx+ecx]
+        add ecx, 2
+
+crc32c_residue:
+        cmp ecx, ebx
+        jae crc32c_done
+
+        crc32 eax, byte [edx+ecx]
+        inc ecx
+        jmp crc32c_residue
+
+crc32c_done:
+        ret
+
+%endif ; TR_HOST_64BIT
 
 eq_J9VMThread_heapAlloc      equ J9TR_VMThread_heapAlloc
 eq_J9VMThread_heapTop        equ J9TR_VMThread_heapTop


### PR DESCRIPTION
- Implement the call to fast crc32c helper evaluators, current version supports both 32-bit and 64-bit.
- Implement the actual crc32c algorithms to handle different byte lengths from the buffer.
- The related helper declaration for crc32 is in this PR: https://github.com/eclipse-omr/omr/pull/8428

Issue: https://github.ibm.com/runtimes/openj9-jit-xopt/issues/595