### PR TITLE
Correct spelling of "nonstandard"

### DIFF
--- a/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
+++ b/jcl/src/java.base/share/classes/com/ibm/oti/util/ExternalMessages-MasterIndex.properties
@@ -487,7 +487,7 @@ K0B03="Setting a Security Manager is not supported"
 K0B04="A command line option has attempted to allow or enable the Security Manager. Enabling a Security Manager is not supported."
 
 #java.lang.Throwable
-K0C00="Non-standard List class not permitted in suppressedExceptions serial stream"
+K0C00="Nonstandard List class not permitted in suppressedExceptions serial stream"
 
 #java.lang.String
 K0D00="Invalid escape sequence detected: {0}"

--- a/jcl/src/java.base/share/classes/java/lang/Throwable.java
+++ b/jcl/src/java.base/share/classes/java/lang/Throwable.java
@@ -492,7 +492,7 @@ private void readObject(ObjectInputStream s)
 					}
 				}
 			} else {
-				/*[MSG "K0C00", "Non-standard List class not permitted in suppressedExceptions serial stream"]*/
+				/*[MSG "K0C00", "Nonstandard List class not permitted in suppressedExceptions serial stream"]*/
 				throw new java.io.StreamCorruptedException(com.ibm.oti.util.Msg.getString("K0C00")); //$NON-NLS-1$
 /*[IF JAVA_SPEC_VERSION >= 9]*/
 			}

--- a/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
+++ b/jcl/src/jdk.management/share/classes/com/ibm/lang/management/internal/PlatformMBeanProvider.java
@@ -48,7 +48,7 @@ import jdk.management.VirtualThreadSchedulerMXBean;
 /**
  * This class implements the service-provider interface to make OpenJ9-specific
  * MXBeans available. These beans are either in addition to the basic set or
- * implement non-standard interfaces.
+ * implement nonstandard interfaces.
  */
 public final class PlatformMBeanProvider extends sun.management.spi.PlatformMBeanProvider {
 

--- a/runtime/codert_vm/arm64nathelp.m4
+++ b/runtime/codert_vm/arm64nathelp.m4
@@ -472,13 +472,13 @@ END_RETURN_POINT(jitExitInterpreterD)
 	DECLARE_EXTERN(old_slow_jitInterpretNewInstanceMethod)
 	DECLARE_EXTERN(old_slow_jitTranslateNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitInterpretNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitInterpretNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitTranslateNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)

--- a/runtime/codert_vm/armnathelp.m4
+++ b/runtime/codert_vm/armnathelp.m4
@@ -461,13 +461,13 @@ END_RETURN_POINT(jitExitInterpreterD)
 	DECLARE_EXTERN(old_slow_jitInterpretNewInstanceMethod)
 	DECLARE_EXTERN(old_slow_jitTranslateNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitInterpretNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitInterpretNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitTranslateNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)

--- a/runtime/codert_vm/pnathelp.m4
+++ b/runtime/codert_vm/pnathelp.m4
@@ -524,13 +524,13 @@ END_RETURN_POINT(jitExitInterpreterD)
 	DECLARE_EXTERN(old_slow_jitInterpretNewInstanceMethod)
 	DECLARE_EXTERN(old_slow_jitTranslateNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitInterpretNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitInterpretNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitTranslateNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitTranslateNewInstanceMethod)
 	BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)

--- a/runtime/codert_vm/riscvnathelp.m4
+++ b/runtime/codert_vm/riscvnathelp.m4
@@ -453,13 +453,13 @@ END_RETURN_POINT(jitExitInterpreterD)
     DECLARE_EXTERN(old_slow_jitInterpretNewInstanceMethod)
     DECLARE_EXTERN(old_slow_jitTranslateNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitInterpretNewInstanceMethod)
     CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
     BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_PROC(jitInterpretNewInstanceMethod)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitTranslateNewInstanceMethod)
     CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
     BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)

--- a/runtime/codert_vm/xnathelp.m4
+++ b/runtime/codert_vm/xnathelp.m4
@@ -555,7 +555,7 @@ END_PROC(jitRunOnJavaStack)
 
 	FASTCALL_EXTERN(fast_jitAcquireVMAccess,1)
 
-dnl Non-standard - _RSP points to C stack when this is called
+dnl Nonstandard - _RSP points to C stack when this is called
 BEGIN_HELPER(jitAcquireVMAccess)
 dnl Ensure _rsp is pointing to the C interpreter stack frame
 	pop uword ptr J9TR_VMThread_jitReturnAddress[_rbp]
@@ -570,7 +570,7 @@ dnl currently declared by JIT, but could move here
 
 	FASTCALL_EXTERN(fast_jitReleaseVMAccess)
 
-dnl Non-standard - _RSP points to C stack when this is called
+dnl Nonstandard - _RSP points to C stack when this is called
 dnl Extra JNI arguments may be pushed on the stack, so the code
 dnl below is incorrect.
 BEGIN_HELPER(jitReleaseVMAccess)
@@ -586,13 +586,13 @@ END_HELPER(jitReleaseVMAccess,0)
 	FASTCALL_EXTERN(old_slow_jitInterpretNewInstanceMethod,1)
 	FASTCALL_EXTERN(old_slow_jitTranslateNewInstanceMethod,1)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitInterpretNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitInterpretNewInstanceMethod)
 	jmp uword ptr J9TR_VMThread_tempSlot[_rbp]
 END_HELPER(jitInterpretNewInstanceMethod,0)
 
-dnl Non-standard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
+dnl Nonstandard - Called via an invoke - arguments are reversed on stack and doesn't return to caller right away
 BEGIN_HELPER(jitTranslateNewInstanceMethod)
 	CALL_SLOW_PATH_ONLY_HELPER_NO_EXCEPTION_NO_RETURN_VALUE(jitTranslateNewInstanceMethod)
 	jmp uword ptr J9TR_VMThread_tempSlot[_rbp]

--- a/runtime/codert_vm/znathelp.m4
+++ b/runtime/codert_vm/znathelp.m4
@@ -558,7 +558,7 @@ BEGIN_RETURN_POINT(jitExitInterpreterD)
     ld fpr0,J9TR_VMThread_returnValue(J9VMTHREAD)
 END_RETURN_POINT
 
-dnl Non-standard - Called via an invoke
+dnl Nonstandard - Called via an invoke
 dnl Arguments are reversed on stack and doesn't
 dnl return to caller right away.
 
@@ -567,7 +567,7 @@ BEGIN_HELPER(jitInterpretNewInstanceMethod)
     BRANCH_VIA_VMTHREAD(J9TR_VMThread_tempSlot)
 END_CURRENT
 
-dnl Non-standard - Called via an invoke
+dnl Nonstandard - Called via an invoke
 dnl Arguments are reversed on stack and doesn't
 dnl return to caller right away.
 

--- a/runtime/compiler/ilgen/Walker.cpp
+++ b/runtime/compiler/ilgen/Walker.cpp
@@ -3946,7 +3946,7 @@ TR::Node *TR_J9ByteCodeIlGenerator::genOrFindAdjunct(TR::Node *node)
         }                                    \
     }
 
-// Definition of operation to be executed when converting the non standard lengths
+// Definition of operation to be executed when converting the nonstandard lengths
 struct OperationDescriptor {
     int32_t shiftDistance; // distance to shift, the direction depends on load or store
     int32_t offsetAdjustment; // adjustment of the memory offset

--- a/runtime/gc_base/ObjectAccessBarrier.cpp
+++ b/runtime/gc_base/ObjectAccessBarrier.cpp
@@ -63,7 +63,7 @@ MM_ObjectAccessBarrier::initialize(MM_EnvironmentBase *env)
 		 */
 		if (_extensions->isMetronomeGC()) {
 			if (DEFAULT_LOW_MEMORY_HEAP_CEILING_SHIFT < omrVM->_compressedPointersShift) {
-				/* Non-standard NLS message required */
+				/* Nonstandard NLS message required */
 				_extensions->heapInitializationFailureReason = MM_GCExtensionsBase::HEAP_INITIALIZATION_FAILURE_REASON_METRONOME_DOES_NOT_SUPPORT_4BIT_SHIFT;
 				return false;
 			}

--- a/runtime/gc_vlhgc/CopyForwardScheme.cpp
+++ b/runtime/gc_vlhgc/CopyForwardScheme.cpp
@@ -306,7 +306,7 @@ MM_CopyForwardScheme::initialize(MM_EnvironmentVLHGC *env)
 		}
 	}
 
-	/* Set the min/max sizes for copy scan cache allocation when allocating a general purpose area (does not include non-standard sized objects) */
+	/* Set the min/max sizes for copy scan cache allocation when allocating a general purpose area (does not include nonstandard sized objects) */
 	_minCacheSize = _extensions->scavengerScanCacheMinimumSize;
 	_maxCacheSize = _extensions->scavengerScanCacheMaximumSize;
 

--- a/runtime/include/zip_api.h
+++ b/runtime/include/zip_api.h
@@ -61,7 +61,7 @@ extern "C" {
 /* Do extra work to read the data pointer. If false the dataPointer will be 0. */
 #define J9ZIP_GETENTRY_READ_DATA_POINTER 2
 
-/* Look for the entry using the central directory without a cache.  This handles non-standard ZIP files. */
+/* Look for the entry using the central directory without a cache.  This handles nonstandard ZIP files. */
 #define J9ZIP_GETENTRY_USE_CENTRAL_DIRECTORY 4
 
 typedef struct J9ZipFunctionTable {

--- a/runtime/j9vm/jvm.h
+++ b/runtime/j9vm/jvm.h
@@ -96,7 +96,7 @@ extern "C" {
 #endif
 
 #ifndef O_TEMPORARY
-#define O_TEMPORARY 0x10000 /* non-standard flag on Unix */
+#define O_TEMPORARY 0x10000 /* nonstandard flag on Unix */
 #endif
 
 /*

--- a/runtime/nls/exel/exelib.nls
+++ b/runtime/nls/exel/exelib.nls
@@ -45,7 +45,7 @@ J9NLS.HEADER=j9exelibnls.h
 
 # J9SourceExeLibArgumentsParsing - describeInternalOptions
 
-J9NLS_EXELIB_INTERNAL_HELP_1_1=The following options are non-standard and subject to change without notice.\n
+J9NLS_EXELIB_INTERNAL_HELP_1_1=The following options are nonstandard and subject to change without notice.\n
 # START NON-TRANSLATABLE
 J9NLS_EXELIB_INTERNAL_HELP_1_1.explanation=NOTAG
 J9NLS_EXELIB_INTERNAL_HELP_1_1.system_action=

--- a/test/functional/VM_Test/src/com/ibm/j9/test/tools/classfilecompare/ClassFileCompare.java
+++ b/test/functional/VM_Test/src/com/ibm/j9/test/tools/classfilecompare/ClassFileCompare.java
@@ -119,7 +119,7 @@ public class ClassFileCompare {
 		new ClassReader(classFile2).accept(classNode2, debugMode);
 		
 		/*
-		 * Non-standard attributes and runtime invisible annotations are stripped by the JVM - don't compare them.
+		 * Nonstandard attributes and runtime invisible annotations are stripped by the JVM - don't compare them.
 		 * Constant pools are reordered by the JVM - don't compare them.
 		 * BootstrapMethods attribute is referenced by invokedynamic instructions 
 		 * - BSM entries are compared in the case of INVOKE_DYNAMIC_INSN in the method "compareInstructions"
@@ -254,7 +254,7 @@ public class ClassFileCompare {
 				FieldNode field1 = iter.next();
 
 				/*
-				 * Non-standard attributes and runtime invisible annotations are stripped by the JVM - don't compare them.
+				 * Nonstandard attributes and runtime invisible annotations are stripped by the JVM - don't compare them.
 				 * ACC_SYNTHETIC or Synthetic attribute is part of access flag computed as a composition value.
 				 */
 				compareAccessFlag(field1.access, field2.access, "Field (" + field1.name + ") access flags", true);
@@ -479,7 +479,7 @@ public class ClassFileCompare {
 				MethodNode method1 = iter.next();
 
 				/*
-				 * Non-standard attributes and runtime invisible annotations are stripped by the JVM - don't compare them.
+				 * Nonstandard attributes and runtime invisible annotations are stripped by the JVM - don't compare them.
 				 * LocalVariableTypeTable is implicitly checked by local variable comparison.
 				 * LineNumberTable attribute is stripped out with SKIP_DEBUG specified
 				 * ACC_SYNTHETIC or Synthetic attribute is part of access flag computed as a composition value 

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java8.xml
@@ -32,9 +32,9 @@
  <test id="X">
   <command>$EXE$ $CP$ -X $TARGET$</command>
   <!-- Java 7 and prior -->
-  <output type="success">.*following.options.are.non.standard.*</output>
+  <output type="success">.*following.options.are.nonstandard.*</output>
   <!-- Java 8 -->
-  <output type="success">.*The.-X.options.are.non-standard.and.subject.to.change.without.notice.*</output>
+  <output type="success">.*The.-X.options.are.nonstandard.and.subject.to.change.without.notice.*</output>
  </test>
 
  <test id="Xbootclasspath">

--- a/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java9.xml
+++ b/test/functional/cmdLineTests/cmdLineTest_J9tests/j9tests_Java9.xml
@@ -29,7 +29,7 @@
  
  <test id="X">
   <command>$EXE$ $CP$ -X $TARGET$</command>
-  <output type="success">.*options.are.non.standard.and.subject.to.change.without.notice.*</output>
+  <output type="success">.*options.are.nonstandard.and.subject.to.change.without.notice.*</output>
   <output type="success">.*These.extra.options.are.subject.to.change.without.notice.*</output>
  </test>
 </suite>


### PR DESCRIPTION
https://github.com/eclipse-openj9/openj9-docs/pull/1712 includes a similar correction.

I'm not sure the translation in `port_fr.nls` is correct, but hopefully that will get fixed automatically.