### PR TITLE
Dump JFR recording on crash

### DIFF
--- a/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
+++ b/runtime/jcl/common/jdk_jfr_internal_JVM_common.cpp
@@ -627,7 +627,22 @@ Java_jdk_jfr_internal_JVM_flush__Ljdk_jfr_internal_event_EventWriter_2II(JNIEnv 
 void JNICALL
 Java_jdk_jfr_internal_JVM_setRepositoryLocation(JNIEnv *env, jobject obj, jstring dirText)
 {
-	// TODO: implementation
+	J9VMThread *currentThread = (J9VMThread *)env;
+	J9JavaVM *vm = currentThread->javaVM;
+	J9InternalVMFunctions *vmFuncs = vm->internalVMFunctions;
+
+	if (NULL != dirText) {
+		vmFuncs->internalEnterVMFromJNI(currentThread);
+		j9object_t dirTextObject = J9_JNI_UNWRAP_REFERENCE(dirText);
+		char *dirText = vmFuncs->copyStringToUTF8WithMemAlloc(currentThread, dirTextObject, J9_STR_NULL_TERMINATE_RESULT, "", 0, NULL, 0, NULL);
+		if (NULL == dirText) {
+			vmFuncs->setNativeOutOfMemoryError(currentThread, 0, 0);
+		} else {
+			Assert_JCL_true(NULL == vm->jfrState.jfrRepositoryLocation);
+			vm->jfrState.jfrRepositoryLocation = dirText;
+		}
+		vmFuncs->internalExitVMToJNI(currentThread);
+	}
 }
 
 void JNICALL

--- a/runtime/oti/j9.h
+++ b/runtime/oti/j9.h
@@ -459,6 +459,7 @@ static_assert((LITERAL_STRLEN(J9_UNMODIFIABLE_CLASS_ANNOTATION) < (size_t)'/'), 
 #if defined(J9VM_OPT_JFR)
 
 #define DEFAULT_JFR_FILE_NAME "defaultJ9recording.jfr"
+#define JFR_EMERGENCY_DUMP_FILE_NAME "OpenJ9-error.jfr"
 
 #endif /* defined(J9VM_OPT_JFR) */
 

--- a/runtime/oti/j9nonbuilder.h
+++ b/runtime/oti/j9nonbuilder.h
@@ -6252,6 +6252,7 @@ typedef struct J9VMThread {
 
 typedef struct JFRState {
 	char *jfrFileName;
+	char *jfrRepositoryLocation;
 	const char *jfrCMDLineOption;
 	U_8 *metaDataBlobFile;
 	UDATA metaDataBlobFileSize;

--- a/runtime/vm/gphandle.c
+++ b/runtime/vm/gphandle.c
@@ -137,6 +137,7 @@ static UDATA writeJITInfo (J9VMThread* vmThread, char* s, UDATA length, void* gp
 #endif /* J9VM_INTERP_NATIVE_SUPPORT */
 
 static void printBacktrace(struct J9JavaVM *vm, void* gpInfo);
+static void writeJFREmergencyDump(struct J9JavaVM *vm, J9VMThread *vmThread);
 
 #if defined(J9VM_ARCH_X86) && defined(J9VM_ENV_DATA64)
 #define UNSAFE_TARGET_REGISTER J9PORT_SIG_GPR_AMD64_RDI
@@ -1155,6 +1156,7 @@ generateDiagnosticFiles(struct J9PortLibrary* portLibrary, void* userData)
 	if (vmThread) {
 		vmThread->gpInfo = gpInfo;
 		printBacktrace(vm, gpInfo);
+		writeJFREmergencyDump(vm, vmThread);
 	}
 
 	/* Trigger dump only if RASdump is activated */
@@ -1345,6 +1347,114 @@ printBacktrace(struct J9JavaVM *vm, void *gpInfo)
 	}
 
 	omrtty_printf("---------------------------------------\n");
+}
+
+static void
+writeJFREmergencyDump(struct J9JavaVM *vm, J9VMThread *vmThread)
+{
+	PORT_ACCESS_FROM_JAVAVM(vm);
+	OMRPORT_ACCESS_FROM_J9PORT(PORTLIB);
+	BOOLEAN failed = FALSE;
+
+	/* Dump to disk even if disk option is set to false. */
+	if (NULL == vm->jfrState.jfrFileName) {
+		if (-1 != vm->jfrState.blobFileDescriptor) {
+			j9file_close(vm->jfrState.blobFileDescriptor);
+		}
+		vm->jfrState.blobFileDescriptor = j9file_open(JFR_EMERGENCY_DUMP_FILE_NAME, EsOpenWrite | EsOpenCreate | EsOpenTruncate , 0666);
+
+		if (-1 == vm->jfrState.blobFileDescriptor) {
+			failed = TRUE;
+			goto done;
+		}
+	}
+
+	internalAcquireVMAccess(vmThread);
+	acquireExclusiveVMAccess(vmThread);
+
+	jfrDump(vmThread, FALSE);
+
+	releaseExclusiveVMAccess(vmThread);
+	internalReleaseVMAccess(vmThread);
+
+	if (NULL != vm->jfrState.jfrFileName) {
+		IDATA emergencyDumpDescriptor = j9file_open(JFR_EMERGENCY_DUMP_FILE_NAME, EsOpenWrite | EsOpenCreate | EsOpenTruncate, 0666);
+		if (-1 != emergencyDumpDescriptor) {
+			char *repositoryLocation = vm->jfrState.jfrRepositoryLocation;
+			if (NULL != repositoryLocation) {
+				char fileName[EsMaxPath];
+				UDATA findHandle = 0;
+				I_32 findResult = 0;
+
+				findHandle = j9file_findfirst(repositoryLocation, fileName);
+				if ((UDATA)-1 != findHandle) {
+					do {
+						/* Skip "." and "..". */
+						if ((0 != strcmp(fileName, ".")) && (0 != strcmp(fileName, ".."))) {
+							char fullPath[EsMaxPath];
+							IDATA srcDescriptor = -1;
+							UDATA repoLen = strlen(repositoryLocation);
+
+							/* Build full path. */
+							if (repoLen + strlen(fileName) + 2 < EsMaxPath) {
+								strcpy(fullPath, repositoryLocation);
+								if (fullPath[repoLen - 1] != '/' && fullPath[repoLen - 1] != '\\') {
+									strcat(fullPath, "/");
+								}
+								strcat(fullPath, fileName);
+
+								/* Open source JFR file. */
+								srcDescriptor = j9file_open(fullPath, EsOpenRead, 0);
+								if (-1 != srcDescriptor) {
+									char buffer[4096];
+									IDATA bytesRead = 0;
+
+									/* Copy file contents to emergency dump. */
+									while ((bytesRead = j9file_read(srcDescriptor, buffer, sizeof(buffer))) > 0) {
+										j9file_write(emergencyDumpDescriptor, buffer, bytesRead);
+									}
+
+									j9file_close(srcDescriptor);
+								}
+							}
+						}
+						findResult = j9file_findnext(findHandle, fileName);
+					} while (findResult >= 0);
+
+					j9file_findclose(findHandle);
+				}
+			}
+			j9file_close(emergencyDumpDescriptor);
+		} else {
+			failed = TRUE;
+		}
+	}
+done:
+	if (failed) {
+		omrtty_printf("JFR emergency dump file could not be created.\n");
+	} else {
+		char absolutePath[EsMaxPath];
+		char *cwd = NULL;
+#if defined(J9ZOS390)
+		cwd = atoe_getcwd(absolutePath, EsMaxPath);
+#else
+		cwd = getcwd(absolutePath, EsMaxPath);
+#endif
+		if (NULL != cwd) {
+			UDATA cwdLen = strlen(absolutePath);
+			if (cwdLen + strlen(JFR_EMERGENCY_DUMP_FILE_NAME) + 2 < EsMaxPath) {
+				if (absolutePath[cwdLen - 1] != '/' && absolutePath[cwdLen - 1] != '\\') {
+					strcat(absolutePath, "/");
+				}
+				strcat(absolutePath, JFR_EMERGENCY_DUMP_FILE_NAME);
+				omrtty_printf("JFR emergency dump file has been written to %s\n", absolutePath);
+			} else {
+				omrtty_printf("JFR emergency dump file has been written to %s\n", JFR_EMERGENCY_DUMP_FILE_NAME);
+			}
+		} else {
+			omrtty_printf("JFR emergency dump file has been written to %s\n", JFR_EMERGENCY_DUMP_FILE_NAME);
+		}
+	}
 }
 
 #if defined(J9VM_PORT_ZOS_CEEHDLRSUPPORT)

--- a/runtime/vm/jvminit.c
+++ b/runtime/vm/jvminit.c
@@ -784,9 +784,11 @@ freeJavaVM(J9JavaVM * vm)
 
 #if defined(J9VM_OPT_JFR)
 	j9mem_free_memory(vm->jfrState.jfrFileName);
+	j9mem_free_memory(vm->jfrState.jfrRepositoryLocation);
 	j9mem_free_memory(vm->jfrState.delay);
 	j9mem_free_memory(vm->jfrState.duration);
 	vm->jfrState.jfrFileName = NULL;
+	vm->jfrState.jfrRepositoryLocation = NULL;
 	vm->jfrState.delay = NULL;
 	vm->jfrState.duration = NULL;
 #endif /* defined(J9VM_OPT_JFR) */


### PR DESCRIPTION
When a crash happens, first dump unflushed JFR data to the repository
location and then assemble all the chunks in the repository location
into the final emergency dump file and write it to the current
directory. If disk option is set to false, directly dump unflushed data
to current directory.

Related to: https://github.com/eclipse-openj9/openj9/issues/23721