### PR TITLE
Power: Check negative 2nd dimension for multianewarray

### DIFF
--- a/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
+++ b/runtime/compiler/p/codegen/J9TreeEvaluator.cpp
@@ -1996,7 +1996,10 @@ static TR::Register *generateMultianewArrayWithInlineAllocators(TR::Node *node, 
     generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, condReg, firstDimLenReg, 0);
     generateConditionalBranchInstruction(cg, TR::InstOpCode::bne, node, nonZeroFirstDimLabel, condReg);
 
-    // if we reach here, both dimensions are zero, just allocate a zero-length object array
+    // if we reach here, the first dimension is zero, just allocate a zero-length object array
+    generateTrg1Src1ImmInstruction(cg, TR::InstOpCode::cmpi4, node, condReg, secondDimLenReg, 0);
+    generateConditionalBranchInstruction(cg, TR::InstOpCode::blt, node, oolJumpLabel, condReg);
+
     generateTrg1MemInstruction(cg, TR::InstOpCode::Op_load, node, targetReg,
         TR::MemoryReference::createWithDisplacement(cg, vmThreadReg, offsetof(J9VMThread, heapAlloc), addrSize));
 


### PR DESCRIPTION
This commit adds a check for the second dimension size for multianewarray inlining on Power.
The second dimension needs to be checked for negative value even when the first dimension is 0.