### PR TITLE
(0.63) Propogate StackOVerflow errors from cfreader v2

### DIFF
--- a/runtime/bcutil/ClassFileParser.cpp
+++ b/runtime/bcutil/ClassFileParser.cpp
@@ -95,6 +95,9 @@ ClassFileParser::parseClassFile(ROMClassCreationContext *context, UDATA *initial
 		context->recordCFRError(buffer);
 		Trc_BCU_createRomClassEndian_Error(result, I_32(ClassRead));
 		buildResult = ClassRead;
+	} else if (BCT_ERR_STACK_OVERFLOW == result) {
+		Trc_BCU_createRomClassEndian_Error(result, I_32(StackOverflow));
+		buildResult = StackOverflow;
 	} else {
 		Trc_BCU_createRomClassEndian_Error(result, I_32(GenericError));
 		buildResult = GenericError;

--- a/runtime/bcutil/cfreader.c
+++ b/runtime/bcutil/cfreader.c
@@ -486,8 +486,10 @@ readAttributes(J9CfrClassFile * classfile, J9CfrAttribute *** pAttributes, U_32 
 				result = readAnnotations(classfile, annotations->annotations, annotations->numberOfAnnotations, data, dataEnd, segment, segmentEnd, &index, &freePointer, flags, availableOSStackSpace, startingSP);
 			}
 
-			if (BCT_ERR_OUT_OF_ROM == result) {
-				/* Return out of memory error code to allocate larger buffer for classfile */
+			if ((BCT_ERR_OUT_OF_ROM == result) || (BCT_ERR_STACK_OVERFLOW == result)) {
+				/* Return out of memory error code to allocate larger buffer for classfile
+				 * or bail if we run out of stack space.
+				 */
 				return result;
 			} else if ((BCT_ERR_NO_ERROR != result) || (0 == length) || (index != end)) {
 				U_32 cursor = 0;


### PR DESCRIPTION
Currently, all stack overflow failures thrown in cfreader are incorrectly converted to ClassFormatErrors. This is because the code required to build the SO error is missing. This PR rectifies the issue and correctly builds the SO error.

This adds some of the support that
https://github.com/eclipse-openj9/openj9/pull/24698 was missing.

Backport of https://github.com/eclipse-openj9/openj9/pull/24738